### PR TITLE
KMS HMAC support

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -184,8 +184,7 @@ class KmsCryptoKey:
             self.key_material = os.urandom(random.randint(minimum_length, maximum_length))
             return
         else:
-            # Currently we do not support HMAC keys - symmetric keys that are used for GenerateMac / VerifyMac.
-            # We also do not support SM2 - asymmetric keys both suitable for ENCRYPT_DECRYPT and SIGN_VERIFY,
+            # We do not support SM2 - asymmetric keys both suitable for ENCRYPT_DECRYPT and SIGN_VERIFY,
             # but only used in China AWS regions.
             raise UnsupportedOperationException(f"KeySpec {key_spec} is not supported")
 
@@ -503,10 +502,8 @@ class KmsKey:
                     f"failed to satisfy constraint: Member must satisfy enum value set: "
                     f"[ENCRYPT_DECRYPT, SIGN_VERIFY, GENERATE_VERIFY_MAC]"
                 )
-            else:
-                return request_key_usage
         else:
-            return "ENCRYPT_DECRYPT"
+            return request_key_usage or "ENCRYPT_DECRYPT"
 
 
 class KmsGrant:

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import random
 import re
 import struct
 import uuid
@@ -11,7 +12,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa, utils
 
@@ -24,8 +25,10 @@ from localstack.aws.api.kms import (
     DisabledException,
     EncryptionContextType,
     KeyMetadata,
+    KMSInvalidMacException,
     KMSInvalidSignatureException,
     KMSInvalidStateException,
+    MacAlgorithmSpec,
     MessageType,
     NotFoundException,
     SigningAlgorithmSpec,
@@ -56,6 +59,13 @@ ECC_CURVES = {
     "ECC_NIST_P384": ec.SECP384R1(),
     "ECC_NIST_P521": ec.SECP521R1(),
     "ECC_SECG_P256K1": ec.SECP256K1(),
+}
+
+HMAC_RANGE_KEY_LENGTHS = {
+    "HMAC_224": (28, 64),
+    "HMAC_256": (32, 64),
+    "HMAC_384": (48, 128),
+    "HMAC_512": (64, 128),
 }
 
 
@@ -162,6 +172,17 @@ class KmsCryptoKey:
         elif key_spec.startswith("ECC"):
             curve = ECC_CURVES.get(key_spec)
             self.key = ec.generate_private_key(curve)
+        elif key_spec.startswith("HMAC"):
+            if key_spec not in HMAC_RANGE_KEY_LENGTHS:
+                raise ValidationException(
+                    f"1 validation error detected: Value '{key_spec}' at 'keySpec' "
+                    f"failed to satisfy constraint: Member must satisfy enum value set: "
+                    f"[RSA_2048, ECC_NIST_P384, ECC_NIST_P256, ECC_NIST_P521, HMAC_384, RSA_3072, "
+                    f"ECC_SECG_P256K1, RSA_4096, SYMMETRIC_DEFAULT, HMAC_256, HMAC_224, HMAC_512]"
+                )
+            minimum_length, maximum_length = HMAC_RANGE_KEY_LENGTHS.get(key_spec)
+            self.key_material = os.urandom(random.randint(minimum_length, maximum_length))
+            return
         else:
             # Currently we do not support HMAC keys - symmetric keys that are used for GenerateMac / VerifyMac.
             # We also do not support SM2 - asymmetric keys both suitable for ENCRYPT_DECRYPT and SIGN_VERIFY,
@@ -212,6 +233,20 @@ class KmsKey:
     def calculate_and_set_arn(self, account_id, region):
         self.metadata["Arn"] = kms_key_arn(self.metadata.get("KeyId"), account_id, region)
 
+    def generate_mac(self, msg: bytes, mac_algorithm: MacAlgorithmSpec) -> bytes:
+        h = self._get_hmac_context(mac_algorithm)
+        h.update(msg)
+        return h.finalize()
+
+    def verify_mac(self, msg: bytes, mac: bytes, mac_algorithm: MacAlgorithmSpec) -> bool:
+        h = self._get_hmac_context(mac_algorithm)
+        h.update(msg)
+        try:
+            h.verify(mac)
+            return True
+        except InvalidSignature:
+            raise KMSInvalidMacException()
+
     # Encrypt is a method of KmsKey and not of KmsCryptoKey only because it requires KeyId, and KmsCryptoKeys do not
     # hold KeyIds. Maybe it would be possible to remodel this better.
     def encrypt(self, plaintext: bytes) -> bytes:
@@ -253,6 +288,17 @@ class KmsKey:
         except InvalidSignature:
             # AWS itself raises this exception without any additional message.
             raise KMSInvalidSignatureException()
+
+    def _get_hmac_context(self, mac_algorithm: MacAlgorithmSpec):
+        if mac_algorithm == "HMAC_SHA_224":
+            h = hmac.HMAC(self.crypto_key.key_material, hashes.SHA224())
+        elif mac_algorithm == "HMAC_SHA_256":
+            h = hmac.HMAC(self.crypto_key.key_material, hashes.SHA256())
+        elif mac_algorithm == "HMAC_SHA_384":
+            h = hmac.HMAC(self.crypto_key.key_material, hashes.SHA384())
+        elif mac_algorithm == "HMAC_SHA_512":
+            h = hmac.HMAC(self.crypto_key.key_material, hashes.SHA512())
+        return h
 
     def _construct_sign_verify_kwargs(
         self, signing_algorithm: SigningAlgorithmSpec, message_type: MessageType
@@ -318,7 +364,6 @@ class KmsKey:
         # "DescribeKey does not return the following information: ... Tags on the KMS key."
 
         self.metadata["Description"] = create_key_request.get("Description") or ""
-        self.metadata["KeyUsage"] = create_key_request.get("KeyUsage") or "ENCRYPT_DECRYPT"
         self.metadata["MultiRegion"] = create_key_request.get("MultiRegion") or False
         self.metadata["Origin"] = create_key_request.get("Origin") or "AWS_KMS"
         # https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html#KMS-CreateKey-request-CustomerMasterKeySpec
@@ -330,6 +375,9 @@ class KmsKey:
             or "SYMMETRIC_DEFAULT"
         )
         self.metadata["CustomerMasterKeySpec"] = self.metadata.get("KeySpec")
+        self.metadata["KeyUsage"] = self._populate_key_usage(
+            create_key_request.get("KeyUsage"), self.metadata.get("KeySpec")
+        )
 
         # Metadata fields AWS introduces automatically
         self.metadata["AWSAccountId"] = account_id or get_aws_account_id()
@@ -353,6 +401,7 @@ class KmsKey:
         self._populate_signing_algorithms(
             self.metadata.get("KeyUsage"), self.metadata.get("KeySpec")
         )
+        self._populate_mac_algorithms(self.metadata.get("KeyUsage"), self.metadata.get("KeySpec"))
 
     def add_tags(self, tags: List) -> None:
         # Just in case we get None from somewhere.
@@ -401,7 +450,7 @@ class KmsKey:
         # The two main usages for KMS keys are encryption/decryption and signing/verification.
         # Doesn't make sense to populate fields related to encryption/decryption unless the key is created with that
         # goal in mind.
-        if key_usage != "ENCRYPT_DECRYPT":
+        if key_usage != "ENCRYPT_DECRYPT" or key_usage != "GENERATE_VERIFY_MAC":
             return
         if key_spec == "SYMMETRIC_DEFAULT":
             self.metadata["EncryptionAlgorithms"] = ["SYMMETRIC_DEFAULT"]
@@ -429,6 +478,35 @@ class KmsKey:
                 "RSASSA_PSS_SHA_384",
                 "RSASSA_PSS_SHA_512",
             ]
+
+    def _populate_mac_algorithms(self, key_usage: str, key_spec: str) -> None:
+        if key_usage != "GENERATE_VERIFY_MAC":
+            return
+        if key_spec == "HMAC_224":
+            self.metadata["MacAlgorithms"] = ["HMAC_SHA_224"]
+        elif key_spec == "HMAC_256":
+            self.metadata["MacAlgorithms"] = ["HMAC_SHA_256"]
+        elif key_spec == "HMAC_384":
+            self.metadata["MacAlgorithms"] = ["HMAC_SHA_384"]
+        elif key_spec == "HMAC_512":
+            self.metadata["MacAlgorithms"] = ["HMAC_SHA_512"]
+
+    def _populate_key_usage(self, request_key_usage: str, key_spec: str) -> str:
+        if key_spec in ["HMAC_224", "HMAC_256", "HMAC_384", "HMAC_512"]:
+            if request_key_usage is None:
+                raise ValidationException(
+                    "You must specify a KeyUsage value for all KMS keys except for symmetric encryption keys."
+                )
+            elif request_key_usage != "GENERATE_VERIFY_MAC":
+                raise ValidationException(
+                    f"1 validation error detected: Value '{request_key_usage}' at 'keyUsage' "
+                    f"failed to satisfy constraint: Member must satisfy enum value set: "
+                    f"[ENCRYPT_DECRYPT, SIGN_VERIFY, GENERATE_VERIFY_MAC]"
+                )
+            else:
+                return request_key_usage
+        else:
+            return "ENCRYPT_DECRYPT"
 
 
 class KmsGrant:

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -502,6 +502,8 @@ class KmsKey:
                     f"failed to satisfy constraint: Member must satisfy enum value set: "
                     f"[ENCRYPT_DECRYPT, SIGN_VERIFY, GENERATE_VERIFY_MAC]"
                 )
+            else:
+                return request_key_usage
         else:
             return request_key_usage or "ENCRYPT_DECRYPT"
 

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -449,7 +449,7 @@ class KmsKey:
         # The two main usages for KMS keys are encryption/decryption and signing/verification.
         # Doesn't make sense to populate fields related to encryption/decryption unless the key is created with that
         # goal in mind.
-        if key_usage != "ENCRYPT_DECRYPT" or key_usage != "GENERATE_VERIFY_MAC":
+        if key_usage != "ENCRYPT_DECRYPT":
             return
         if key_spec == "SYMMETRIC_DEFAULT":
             self.metadata["EncryptionAlgorithms"] = ["SYMMETRIC_DEFAULT"]

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -9,7 +9,7 @@ import struct
 import uuid
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, hmac
@@ -288,7 +288,7 @@ class KmsKey:
             # AWS itself raises this exception without any additional message.
             raise KMSInvalidSignatureException()
 
-    def _get_hmac_context(self, mac_algorithm: MacAlgorithmSpec) -> Any:
+    def _get_hmac_context(self, mac_algorithm: MacAlgorithmSpec) -> hmac.HMAC:
         if mac_algorithm == "HMAC_SHA_224":
             h = hmac.HMAC(self.crypto_key.key_material, hashes.SHA224())
         elif mac_algorithm == "HMAC_SHA_256":

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -540,9 +540,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
     @handler("GenerateMac", expand=False)
     def generate_mac(
-            self,
-            context: RequestContext,
-            request: GenerateMacRequest,
+        self,
+        context: RequestContext,
+        request: GenerateMacRequest,
     ) -> GenerateMacResponse:
         msg = request.get("Message")
         self._validate_mac_msg_length(msg)
@@ -559,9 +559,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
     @handler("VerifyMac", expand=False)
     def verify_mac(
-            self,
-            context: RequestContext,
-            request: VerifyMacRequest,
+        self,
+        context: RequestContext,
+        request: VerifyMacRequest,
     ) -> VerifyMacResponse:
         msg = request.get("Message")
         self._validate_mac_msg_length(msg)
@@ -574,7 +574,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
         mac_valid = key.verify_mac(msg, request.get("Mac"), algorithm)
 
-        return VerifyMacResponse(KeyId=key.metadata.get("Arn"), MacValid=mac_valid, MacAlgorithm=algorithm)
+        return VerifyMacResponse(
+            KeyId=key.metadata.get("Arn"), MacValid=mac_valid, MacAlgorithm=algorithm
+        )
 
     @handler("Sign", expand=False)
     def sign(self, context: RequestContext, request: SignRequest) -> SignResponse:
@@ -955,7 +957,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
         key_spec = key.metadata["KeySpec"]
         if x := algorithm.split("_"):
-            if len(x) == 3 and x[0]+"_"+x[2] != key_spec:
+            if len(x) == 3 and x[0] + "_" + x[2] != key_spec:
                 raise InvalidKeyUsageException(
                     f"Algorithm {algorithm} is incompatible with key spec {key_spec}."
                 )

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -39,6 +39,8 @@ from localstack.aws.api.kms import (
     GenerateDataKeyResponse,
     GenerateDataKeyWithoutPlaintextRequest,
     GenerateDataKeyWithoutPlaintextResponse,
+    GenerateMacRequest,
+    GenerateMacResponse,
     GenerateRandomRequest,
     GenerateRandomResponse,
     GetKeyPolicyRequest,
@@ -68,6 +70,7 @@ from localstack.aws.api.kms import (
     ListKeysResponse,
     ListResourceTagsRequest,
     ListResourceTagsResponse,
+    MacAlgorithmSpec,
     MarkerType,
     NotFoundException,
     PlaintextType,
@@ -84,6 +87,8 @@ from localstack.aws.api.kms import (
     UntagResourceRequest,
     UpdateAliasRequest,
     UpdateKeyDescriptionRequest,
+    VerifyMacRequest,
+    VerifyMacResponse,
     VerifyRequest,
     VerifyResponse,
     WrappingKeySpec,
@@ -533,6 +538,44 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         result.pop("Plaintext")
         return GenerateDataKeyWithoutPlaintextResponse(**result)
 
+    @handler("GenerateMac", expand=False)
+    def generate_mac(
+            self,
+            context: RequestContext,
+            request: GenerateMacRequest,
+    ) -> GenerateMacResponse:
+        msg = request.get("Message")
+        self._validate_mac_msg_length(msg)
+
+        key = self._get_key(context, request.get("KeyId"))
+        self._validate_key_for_generate_verify_mac(key)
+
+        algorithm = request.get("MacAlgorithm")
+        self._validate_mac_algorithm(key, algorithm)
+
+        mac = key.generate_mac(msg, algorithm)
+
+        return GenerateMacResponse(Mac=mac, MacAlgorithm=algorithm, KeyId=key.metadata.get("Arn"))
+
+    @handler("VerifyMac", expand=False)
+    def verify_mac(
+            self,
+            context: RequestContext,
+            request: VerifyMacRequest,
+    ) -> VerifyMacResponse:
+        msg = request.get("Message")
+        self._validate_mac_msg_length(msg)
+
+        key = self._get_key(context, request.get("KeyId"))
+        self._validate_key_for_generate_verify_mac(key)
+
+        algorithm = request.get("MacAlgorithm")
+        self._validate_mac_algorithm(key, algorithm)
+
+        mac_valid = key.verify_mac(msg, request.get("Mac"), algorithm)
+
+        return VerifyMacResponse(KeyId=key.metadata.get("Arn"), MacValid=mac_valid, MacAlgorithm=algorithm)
+
     @handler("Sign", expand=False)
     def sign(self, context: RequestContext, request: SignRequest) -> SignResponse:
         key = self._get_key(context, request.get("KeyId"))
@@ -888,6 +931,34 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             raise InvalidKeyUsageException(
                 "KeyUsage for signing / verification key should be SIGN_VERIFY"
             )
+
+    def _validate_key_for_generate_verify_mac(self, key: KmsKey):
+        if key.metadata["KeyUsage"] != "GENERATE_VERIFY_MAC":
+            raise InvalidKeyUsageException(
+                "KeyUsage for generate / verify mac should be GENERATE_VERIFY_MAC"
+            )
+
+    def _validate_mac_msg_length(self, msg: bytes):
+        if len(msg) > 4096:
+            raise ValidationException(
+                "1 validation error detected: Value at 'message' failed to satisfy constraint: "
+                "Member must have length less than or equal to 4096"
+            )
+
+    def _validate_mac_algorithm(self, key: KmsKey, algorithm: str):
+        if not hasattr(MacAlgorithmSpec, algorithm):
+            raise ValidationException(
+                f"1 validation error detected: Value '{algorithm}' at 'macAlgorithm' "
+                f"failed to satisfy constraint: Member must satisfy enum value set: "
+                f"[HMAC_SHA_384, HMAC_SHA_256, HMAC_SHA_224, HMAC_SHA_512]"
+            )
+
+        key_spec = key.metadata["KeySpec"]
+        if x := algorithm.split("_"):
+            if len(x) == 3 and x[0]+"_"+x[2] != key_spec:
+                raise InvalidKeyUsageException(
+                    f"Algorithm {algorithm} is incompatible with key spec {key_spec}."
+                )
 
     def _validate_grant_request(self, data: Dict, store: KmsStore):
         if "KeyId" not in data or "GranteePrincipal" not in data or "Operations" not in data:

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -906,13 +906,13 @@ class TestKMS:
         )
         snapshot.match("generate-mac", generate_mac_response)
 
-        verify__mac_response = kms_client.verify_mac(
+        verify_mac_response = kms_client.verify_mac(
             KeyId=key_id,
             Message="some important message",
             MacAlgorithm=mac_algo,
             Mac=generate_mac_response["Mac"],
         )
-        snapshot.match("verify-mac", verify__mac_response)
+        snapshot.match("verify-mac", verify_mac_response)
 
         # test generate mac with invalid key-id
         with pytest.raises(ClientError) as e:

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -832,3 +832,167 @@ class TestKMS:
         with pytest.raises(ClientError) as e:
             kms_client.schedule_key_deletion(KeyId=key_id)
         e.match("KMSInvalidStateException")
+
+    @pytest.mark.aws_validated
+    def test_hmac_create_key(self, kms_client_for_region, kms_create_key, snapshot):
+        region = "us-east-1"
+        kms_client = kms_client_for_region(region)
+        key_ids_before = _get_all_key_ids(kms_client)
+
+        response = kms_create_key(
+            region=region,
+            Description="test key",
+            KeySpec="HMAC_256",
+            KeyUsage="GENERATE_VERIFY_MAC",
+        )
+        key_id = response["KeyId"]
+        snapshot.match("create-hmac-key", response)
+
+        assert key_id not in key_ids_before
+        key_ids_after = _get_all_key_ids(kms_client)
+        assert key_id in key_ids_after
+
+        response = kms_client.describe_key(KeyId=key_id)["KeyMetadata"]
+        snapshot.match("describe-key", response)
+
+    @pytest.mark.aws_validated
+    def test_hmac_create_key_invalid_operations(self, kms_create_key, snapshot):
+        with pytest.raises(ClientError) as e:
+            kms_create_key(Description="test HMAC key without key usage", KeySpec="HMAC_256")
+        snapshot.match("create-hmac-key-without-key-usage", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            kms_create_key(Description="test invalid HMAC spec", KeySpec="HMAC_random")
+        snapshot.match("create-hmac-key-invalid-spec", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            kms_create_key(
+                region="us-east-1",
+                Description="test invalid HMAC spec",
+                KeySpec="HMAC_256",
+                KeyUsage="RANDOM",
+            )
+        snapshot.match("create-hmac-key-invalid-key-usage", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..KeyId",
+            "$..Mac",
+        ]
+    )
+    @pytest.mark.parametrize(
+        "key_spec,mac_algo",
+        [
+            ("HMAC_224", "HMAC_SHA_224"),
+            ("HMAC_256", "HMAC_SHA_256"),
+            ("HMAC_384", "HMAC_SHA_384"),
+            ("HMAC_512", "HMAC_SHA_512"),
+        ],
+    )
+    def test_generate_and_verify_mac(
+        self, kms_client, kms_create_key, key_spec, mac_algo, snapshot
+    ):
+        key_id = kms_create_key(
+            Description="test hmac key",
+            KeySpec=key_spec,
+            KeyUsage="GENERATE_VERIFY_MAC",
+        )["KeyId"]
+
+        generate_mac_response = kms_client.generate_mac(
+            KeyId=key_id,
+            Message="some important message",
+            MacAlgorithm=mac_algo,
+        )
+        snapshot.match("generate-mac", generate_mac_response)
+
+        verify__mac_response = kms_client.verify_mac(
+            KeyId=key_id,
+            Message="some important message",
+            MacAlgorithm=mac_algo,
+            Mac=generate_mac_response["Mac"],
+        )
+        snapshot.match("verify-mac", verify__mac_response)
+
+        # test generate mac with invalid key-id
+        with pytest.raises(ClientError) as e:
+            kms_client.generate_mac(
+                KeyId="key_id",
+                Message="some important message",
+                MacAlgorithm=mac_algo,
+            )
+        snapshot.match("generate-mac-invalid-key-id", e.value.response)
+
+        # test verify mac with invalid key-id
+        with pytest.raises(ClientError) as e:
+            kms_client.verify_mac(
+                KeyId="key_id",
+                Message="some important message",
+                MacAlgorithm=mac_algo,
+                Mac=generate_mac_response["Mac"],
+            )
+        snapshot.match("verify-mac-invalid-key-id", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..KeyId",
+            "$..Mac",
+        ]
+    )
+    @pytest.mark.parametrize(
+        "key_spec,mac_algo",
+        [
+            ("HMAC_224", "HMAC_SHA_256"),
+            ("HMAC_256", "INVALID"),
+        ],
+    )
+    def test_invalid_generate_mac(self, kms_client, kms_create_key, key_spec, mac_algo, snapshot):
+        key_id = kms_create_key(
+            Description="test hmac key",
+            KeySpec=key_spec,
+            KeyUsage="GENERATE_VERIFY_MAC",
+        )["KeyId"]
+
+        with pytest.raises(ClientError) as e:
+            kms_client.generate_mac(
+                KeyId=key_id,
+                Message="some important message",
+                MacAlgorithm=mac_algo,
+            )
+        snapshot.match("generate-mac", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..KeyId", "$..Mac", "$..message"])
+    @pytest.mark.parametrize(
+        "key_spec,mac_algo,verify_msg",
+        [
+            ("HMAC_256", "HMAC_SHA_256", "some different important message"),
+            ("HMAC_256", "HMAC_SHA_512", "some important message"),
+            ("HMAC_256", "INVALID", "some important message"),
+        ],
+    )
+    def test_invalid_verify_mac(
+        self, kms_client, kms_create_key, key_spec, mac_algo, verify_msg, snapshot
+    ):
+        key_id = kms_create_key(
+            Description="test hmac key",
+            KeySpec=key_spec,
+            KeyUsage="GENERATE_VERIFY_MAC",
+        )["KeyId"]
+
+        generate_mac_response = kms_client.generate_mac(
+            KeyId=key_id,
+            Message="some important message",
+            MacAlgorithm="HMAC_SHA_256",
+        )
+        snapshot.match("generate-mac", generate_mac_response)
+
+        with pytest.raises(ClientError) as e:
+            kms_client.verify_mac(
+                KeyId=key_id,
+                Message=verify_msg,
+                MacAlgorithm=mac_algo,
+                Mac=generate_mac_response["Mac"],
+            )
+        snapshot.match("verify-mac", e.value.response)

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -663,10 +663,6 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P256-ECDSA_SHA_384]": {
-    "recorded-date": "16-03-2023, 18:57:59",
-    "recorded-content": {}
-  },
   "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_256]": {
     "recorded-date": "16-03-2023, 19:16:44",
     "recorded-content": {
@@ -710,10 +706,6 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_512]": {
-    "recorded-date": "16-03-2023, 18:58:07",
-    "recorded-content": {}
-  },
   "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P384-ECDSA_SHA_384]": {
     "recorded-date": "16-03-2023, 19:16:39",
     "recorded-content": {
@@ -749,6 +741,366 @@
         "Error": {
           "Code": "KMSInvalidSignatureException",
           "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_hmac_create_key": {
+    "recorded-date": "03-04-2023, 22:50:44",
+    "recorded-content": {
+      "create-hmac-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "CreationDate": "datetime",
+        "CustomerMasterKeySpec": "HMAC_256",
+        "Description": "test key",
+        "Enabled": true,
+        "KeyId": "<uuid:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "HMAC_256",
+        "KeyState": "Enabled",
+        "KeyUsage": "GENERATE_VERIFY_MAC",
+        "MacAlgorithms": [
+          "HMAC_SHA_256"
+        ],
+        "MultiRegion": false,
+        "Origin": "AWS_KMS"
+      },
+      "describe-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "CreationDate": "datetime",
+        "CustomerMasterKeySpec": "HMAC_256",
+        "Description": "test key",
+        "Enabled": true,
+        "KeyId": "<uuid:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "HMAC_256",
+        "KeyState": "Enabled",
+        "KeyUsage": "GENERATE_VERIFY_MAC",
+        "MacAlgorithms": [
+          "HMAC_SHA_256"
+        ],
+        "MultiRegion": false,
+        "Origin": "AWS_KMS"
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_hmac_create_key_invalid_operations": {
+    "recorded-date": "03-04-2023, 22:50:48",
+    "recorded-content": {
+      "create-hmac-key-without-key-usage": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "You must specify a KeyUsage value for all KMS keys except for symmetric encryption keys."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-hmac-key-invalid-spec": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'HMAC_random' at 'keySpec' failed to satisfy constraint: Member must satisfy enum value set: [RSA_2048, ECC_NIST_P384, ECC_NIST_P256, ECC_NIST_P521, HMAC_384, RSA_3072, ECC_SECG_P256K1, RSA_4096, SYMMETRIC_DEFAULT, HMAC_256, HMAC_224, HMAC_512]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-hmac-key-invalid-key-usage": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'RANDOM' at 'keyUsage' failed to satisfy constraint: Member must satisfy enum value set: [ENCRYPT_DECRYPT, SIGN_VERIFY, GENERATE_VERIFY_MAC]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_224-HMAC_SHA_224]": {
+    "recorded-date": "03-04-2023, 22:50:53",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/9a06e397-7c23-4072-8cb6-678139c5dac2",
+        "Mac": "b'\\x00\\xee\\xf7\\x10a\\xba)lL\\x94E\\x1a}s\\x11\\xb0\\xdd\\x99_\\xc3_\\xaeHf)\\xfeZ{'",
+        "MacAlgorithm": "HMAC_SHA_224",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/9a06e397-7c23-4072-8cb6-678139c5dac2",
+        "MacAlgorithm": "HMAC_SHA_224",
+        "MacValid": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "generate-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "verify-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_256-HMAC_SHA_256]": {
+    "recorded-date": "03-04-2023, 22:51:09",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/c64a71b7-f615-4fc4-9d0e-dac17a854d71",
+        "Mac": "b'z\\xe4)\\xe7\\xd1)\\xb5\\xbb\\xab\\x95\\xe6\\xcaNA!Ur\\xa3~\\x1b\\x96\\xc1I\\x04\\xf9\\n\\x96\\x057\\xb6\\x0f\\xb7'",
+        "MacAlgorithm": "HMAC_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/c64a71b7-f615-4fc4-9d0e-dac17a854d71",
+        "MacAlgorithm": "HMAC_SHA_256",
+        "MacValid": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "generate-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "verify-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_384-HMAC_SHA_384]": {
+    "recorded-date": "03-04-2023, 22:51:12",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/cb408051-6c85-48da-9314-58eaafcd5bf1",
+        "Mac": "b'N\\x0f0\\x8a\\x07\\xd1\\x1b\\xc1\\xeb\\x8d\\xd0\\x18h\\xecDU\\x10U\\x15\\xae\\x19\\xd3\\xd1\\xee\\xf1\\x87k\\x99|\\xe7\\x86gf\\xd5\\xf4\\xa4\\x01\\x0c`\\x08Y\\xf2.a<7\\xbc\\x99'",
+        "MacAlgorithm": "HMAC_SHA_384",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/cb408051-6c85-48da-9314-58eaafcd5bf1",
+        "MacAlgorithm": "HMAC_SHA_384",
+        "MacValid": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "generate-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "verify-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_512-HMAC_SHA_512]": {
+    "recorded-date": "03-04-2023, 22:51:17",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/8dc7ebfa-8f3a-46cc-8630-6efb6c4343cc",
+        "Mac": "b\"\\xeb\\x87\\xdf\\xe2\\x88\\x95-\\x1f\\xfe\\xdb<\\x82\\xa5&|x'\\xd4\\x15\\x08\\x8cL<\\xaf\\xb0QT\\xba\\x13}\\xc3\\x11\\x8a\\x84\\xa7\\x8bB\\x15N\\xb6F\\xef1VJ~\\x05\\x82V\\xff\\xd4\\xf9\\xda\\xd3\\xaa\\x14\\xeb\\x99&\\xb4\\x16\\xec\\xfc\\xba\"",
+        "MacAlgorithm": "HMAC_SHA_512",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/8dc7ebfa-8f3a-46cc-8630-6efb6c4343cc",
+        "MacAlgorithm": "HMAC_SHA_512",
+        "MacValid": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "generate-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "verify-mac-invalid-key-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid keyId key_id"
+        },
+        "message": "Invalid keyId key_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_generate_mac[HMAC_224-HMAC_SHA_256]": {
+    "recorded-date": "03-04-2023, 22:51:22",
+    "recorded-content": {
+      "generate-mac": {
+        "Error": {
+          "Code": "InvalidKeyUsageException",
+          "Message": "Algorithm HMAC_SHA_256 is incompatible with key spec HMAC_224."
+        },
+        "message": "Algorithm HMAC_SHA_256 is incompatible with key spec HMAC_224.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_generate_mac[HMAC_256-INVALID]": {
+    "recorded-date": "03-04-2023, 22:51:25",
+    "recorded-content": {
+      "generate-mac": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'INVALID' at 'macAlgorithm' failed to satisfy constraint: Member must satisfy enum value set: [HMAC_SHA_384, HMAC_SHA_256, HMAC_SHA_224, HMAC_SHA_512]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-HMAC_SHA_256-some different important message]": {
+    "recorded-date": "03-04-2023, 22:51:28",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/d57a080a-aa39-4929-8220-a3247e07fd9c",
+        "Mac": "b'\\x8f?\\xfbr\\x98G\\x11\\x94;s!O\\xaa\\xd3\\xf2cU\\xde\\xe1+\\x1b9V\\xeb\\xa8P=\\xdc\\xb5\\xcaT\\\\'",
+        "MacAlgorithm": "HMAC_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "Error": {
+          "Code": "KMSInvalidMacException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-HMAC_SHA_512-some important message]": {
+    "recorded-date": "03-04-2023, 22:51:30",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/d9c7e9a7-b035-4440-b06f-f578403b0662",
+        "Mac": "b';u\\x12\\x00!\\x87\\xbd\\x99<\\x03\\rh\\xa2\\x82\\xf8a\\xba\\xe7\\xe0\\xf0\\xa8\\xfaj\\xbbqm\\x93>\\x13\\xe1\\xe9\\xfb'",
+        "MacAlgorithm": "HMAC_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "Error": {
+          "Code": "InvalidKeyUsageException",
+          "Message": "Algorithm HMAC_SHA_512 is incompatible with key spec HMAC_256."
+        },
+        "message": "Algorithm HMAC_SHA_512 is incompatible with key spec HMAC_256.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-INVALID-some important message]": {
+    "recorded-date": "03-04-2023, 22:51:33",
+    "recorded-content": {
+      "generate-mac": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/ef770e0e-ffb0-4e56-bbc5-444961ac36a5",
+        "Mac": "b'&\\x88t\\xd95\\xf3_\\xa8{r\\x8d\\x00\\xb3I#<\\xd7\\x8d\\xf7]\\xd1\\xc0-Uw\\xe8\\xcc\\x19\\xaf\\xb4\\xda\\xb2'",
+        "MacAlgorithm": "HMAC_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verify-mac": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'INVALID' at 'macAlgorithm' failed to satisfy constraint: Member must satisfy enum value set: [HMAC_SHA_384, HMAC_SHA_256, HMAC_SHA_224, HMAC_SHA_512]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -757,8 +757,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_hmac_create_key": {
-    "recorded-date": "03-04-2023, 22:50:44",
+  "tests/integration/test_kms.py::TestKMS::test_hmac_create_key": {
+    "recorded-date": "04-04-2023, 14:21:34",
     "recorded-content": {
       "create-hmac-key": {
         "AWSAccountId": "111111111111",
@@ -798,8 +798,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_hmac_create_key_invalid_operations": {
-    "recorded-date": "03-04-2023, 22:50:48",
+  "tests/integration/test_kms.py::TestKMS::test_hmac_create_key_invalid_operations": {
+    "recorded-date": "04-04-2023, 14:21:46",
     "recorded-content": {
       "create-hmac-key-without-key-usage": {
         "Error": {
@@ -833,12 +833,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_224-HMAC_SHA_224]": {
-    "recorded-date": "03-04-2023, 22:50:53",
+  "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_224-HMAC_SHA_224]": {
+    "recorded-date": "04-04-2023, 14:21:59",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/9a06e397-7c23-4072-8cb6-678139c5dac2",
-        "Mac": "b'\\x00\\xee\\xf7\\x10a\\xba)lL\\x94E\\x1a}s\\x11\\xb0\\xdd\\x99_\\xc3_\\xaeHf)\\xfeZ{'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/7adef49f-2edb-4755-a202-afb6000c1673",
+        "Mac": "b'\\x86\\xe9a\\xee\\xd2*p\\xb5\\xd8om[\\x1d\\xc9\\xdb\\x83)\\xe96X\\x82D\\xad\\xe1\\x83\\xf8\\xbc\\xe9'",
         "MacAlgorithm": "HMAC_SHA_224",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -846,7 +846,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/9a06e397-7c23-4072-8cb6-678139c5dac2",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/7adef49f-2edb-4755-a202-afb6000c1673",
         "MacAlgorithm": "HMAC_SHA_224",
         "MacValid": true,
         "ResponseMetadata": {
@@ -878,12 +878,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_256-HMAC_SHA_256]": {
-    "recorded-date": "03-04-2023, 22:51:09",
+  "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_256-HMAC_SHA_256]": {
+    "recorded-date": "04-04-2023, 14:21:59",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/c64a71b7-f615-4fc4-9d0e-dac17a854d71",
-        "Mac": "b'z\\xe4)\\xe7\\xd1)\\xb5\\xbb\\xab\\x95\\xe6\\xcaNA!Ur\\xa3~\\x1b\\x96\\xc1I\\x04\\xf9\\n\\x96\\x057\\xb6\\x0f\\xb7'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/96d5546b-4c0b-409b-aa17-982226608c91",
+        "Mac": "b'l\\xb9h\\x1c\\xff\\xd0\\x19R\\x82\\x83\\x8a\\x9d\\x86\\x16nS\\x0fO\\xf8Y\\xe5_\\x89\\xd2\\xc1#l\\x97\\xe3\\xad`l'",
         "MacAlgorithm": "HMAC_SHA_256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -891,7 +891,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/c64a71b7-f615-4fc4-9d0e-dac17a854d71",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/96d5546b-4c0b-409b-aa17-982226608c91",
         "MacAlgorithm": "HMAC_SHA_256",
         "MacValid": true,
         "ResponseMetadata": {
@@ -923,12 +923,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_384-HMAC_SHA_384]": {
-    "recorded-date": "03-04-2023, 22:51:12",
+  "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_384-HMAC_SHA_384]": {
+    "recorded-date": "04-04-2023, 14:21:59",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/cb408051-6c85-48da-9314-58eaafcd5bf1",
-        "Mac": "b'N\\x0f0\\x8a\\x07\\xd1\\x1b\\xc1\\xeb\\x8d\\xd0\\x18h\\xecDU\\x10U\\x15\\xae\\x19\\xd3\\xd1\\xee\\xf1\\x87k\\x99|\\xe7\\x86gf\\xd5\\xf4\\xa4\\x01\\x0c`\\x08Y\\xf2.a<7\\xbc\\x99'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/7d09d39d-9cb6-459e-b72f-5a97351921ba",
+        "Mac": "b'tVW\\xd3\\x9b\\xdc\\xc5\\x7f\\x9b\\xf8\\t\\xb9fo\\xda\\xd9\\nE\\x03\\xba\\xa1\\xfc\\x85\\x8a\\xf7\\xcc\\x1e\\x87\\x8b\\xfe\\n\\xf5\\x83\\x96\\xbc\\xd0B\\x9b\\x9aY\\xb2\\x02as\\xb8\\xca\\xb8\\xfb'",
         "MacAlgorithm": "HMAC_SHA_384",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -936,7 +936,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/cb408051-6c85-48da-9314-58eaafcd5bf1",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/7d09d39d-9cb6-459e-b72f-5a97351921ba",
         "MacAlgorithm": "HMAC_SHA_384",
         "MacValid": true,
         "ResponseMetadata": {
@@ -968,12 +968,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_generate_and_verify_mac[HMAC_512-HMAC_SHA_512]": {
-    "recorded-date": "03-04-2023, 22:51:17",
+  "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_512-HMAC_SHA_512]": {
+    "recorded-date": "04-04-2023, 14:21:59",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/8dc7ebfa-8f3a-46cc-8630-6efb6c4343cc",
-        "Mac": "b\"\\xeb\\x87\\xdf\\xe2\\x88\\x95-\\x1f\\xfe\\xdb<\\x82\\xa5&|x'\\xd4\\x15\\x08\\x8cL<\\xaf\\xb0QT\\xba\\x13}\\xc3\\x11\\x8a\\x84\\xa7\\x8bB\\x15N\\xb6F\\xef1VJ~\\x05\\x82V\\xff\\xd4\\xf9\\xda\\xd3\\xaa\\x14\\xeb\\x99&\\xb4\\x16\\xec\\xfc\\xba\"",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/2a068ba0-4163-4fd4-8035-adf89eeb1994",
+        "Mac": "b'T\\xabF\\xa5\\xcbd\\xe3\\xc2|T\\x1c\\xa5\\x88J>w\\xde\\xe7C\"\\xf9\\x0c}:\\x9eVc\\x1b\\xc80\\xe4!#\\xce$\\xb0x\\x02\\x91\\x83\\x87B\\xb3xX\\xec\\xb0)\\xc7jg)\\xc3\\xb9\\x13\\t\\xbdO\\xd4oPV\\xac\\xa1'",
         "MacAlgorithm": "HMAC_SHA_512",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -981,7 +981,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/8dc7ebfa-8f3a-46cc-8630-6efb6c4343cc",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/2a068ba0-4163-4fd4-8035-adf89eeb1994",
         "MacAlgorithm": "HMAC_SHA_512",
         "MacValid": true,
         "ResponseMetadata": {
@@ -1013,8 +1013,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_generate_mac[HMAC_224-HMAC_SHA_256]": {
-    "recorded-date": "03-04-2023, 22:51:22",
+  "tests/integration/test_kms.py::TestKMS::test_invalid_generate_mac[HMAC_224-HMAC_SHA_256]": {
+    "recorded-date": "04-04-2023, 14:22:21",
     "recorded-content": {
       "generate-mac": {
         "Error": {
@@ -1029,8 +1029,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_generate_mac[HMAC_256-INVALID]": {
-    "recorded-date": "03-04-2023, 22:51:25",
+  "tests/integration/test_kms.py::TestKMS::test_invalid_generate_mac[HMAC_256-INVALID]": {
+    "recorded-date": "04-04-2023, 14:22:21",
     "recorded-content": {
       "generate-mac": {
         "Error": {
@@ -1044,12 +1044,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-HMAC_SHA_256-some different important message]": {
-    "recorded-date": "03-04-2023, 22:51:28",
+  "tests/integration/test_kms.py::TestKMS::test_invalid_verify_mac[HMAC_256-HMAC_SHA_256-some different important message]": {
+    "recorded-date": "04-04-2023, 14:22:30",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/d57a080a-aa39-4929-8220-a3247e07fd9c",
-        "Mac": "b'\\x8f?\\xfbr\\x98G\\x11\\x94;s!O\\xaa\\xd3\\xf2cU\\xde\\xe1+\\x1b9V\\xeb\\xa8P=\\xdc\\xb5\\xcaT\\\\'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/d7a7f540-75a3-476c-9d7b-dc1ba976f10b",
+        "Mac": "b'\\x0c\\x96=\\x97\\x10\\xd4\\xa2\\xb7\\x08\\xd0w%\\xa6\\x1eT\\xf5Z\\xa00bx\\x02\\x90\\xe2\\x0f-\\x8c\\xf0\\xf9hQ\\x00'",
         "MacAlgorithm": "HMAC_SHA_256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1061,6 +1061,7 @@
           "Code": "KMSInvalidMacException",
           "Message": ""
         },
+        "message": "",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1068,12 +1069,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-HMAC_SHA_512-some important message]": {
-    "recorded-date": "03-04-2023, 22:51:30",
+  "tests/integration/test_kms.py::TestKMS::test_invalid_verify_mac[HMAC_256-HMAC_SHA_512-some important message]": {
+    "recorded-date": "04-04-2023, 14:22:30",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/d9c7e9a7-b035-4440-b06f-f578403b0662",
-        "Mac": "b';u\\x12\\x00!\\x87\\xbd\\x99<\\x03\\rh\\xa2\\x82\\xf8a\\xba\\xe7\\xe0\\xf0\\xa8\\xfaj\\xbbqm\\x93>\\x13\\xe1\\xe9\\xfb'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/6432fbe6-c58f-48d6-a22d-35ba55ea11c5",
+        "Mac": "b'\\x9d\\xbeEj<\\xbc9\\x9a -\\x9a3\\x99\\xb2\\x15V\\xc6\\xbc\\xe7\\xbbj\\x95\\xf9\\rU\\xff\\xae+g\\xb0\\xdcP'",
         "MacAlgorithm": "HMAC_SHA_256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1093,12 +1094,12 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMSHmac::test_invalid_verify_mac[HMAC_256-INVALID-some important message]": {
-    "recorded-date": "03-04-2023, 22:51:33",
+  "tests/integration/test_kms.py::TestKMS::test_invalid_verify_mac[HMAC_256-INVALID-some important message]": {
+    "recorded-date": "04-04-2023, 14:22:30",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/ef770e0e-ffb0-4e56-bbc5-444961ac36a5",
-        "Mac": "b'&\\x88t\\xd95\\xf3_\\xa8{r\\x8d\\x00\\xb3I#<\\xd7\\x8d\\xf7]\\xd1\\xc0-Uw\\xe8\\xcc\\x19\\xaf\\xb4\\xda\\xb2'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/2a6d424a-b285-49ff-aed2-f691cad346ab",
+        "Mac": "b'\\xbe\\xa2\\xa3*cE\\xf8\\xc5\\x84I\\x9f\\xe2\\xb4\\xa9p\\x15%(\\xe6\\x9e\\x1b\\xb7;d;\\x0cp\\t:\\xca;c'",
         "MacAlgorithm": "HMAC_SHA_256",
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -834,11 +834,11 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_224-HMAC_SHA_224]": {
-    "recorded-date": "04-04-2023, 14:21:59",
+    "recorded-date": "04-04-2023, 16:01:36",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/7adef49f-2edb-4755-a202-afb6000c1673",
-        "Mac": "b'\\x86\\xe9a\\xee\\xd2*p\\xb5\\xd8om[\\x1d\\xc9\\xdb\\x83)\\xe96X\\x82D\\xad\\xe1\\x83\\xf8\\xbc\\xe9'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/e851f07d-5645-46e4-aabd-b036ead86b44",
+        "Mac": "b'\\xdeD\\xa5\\xeeDd\\x0e\\xfdO[\\x8ci\\x12\\x84\\xde\\xdd\\xac,,\\xb9\\xc8C\\xe7\\x00\\xba2\\xdb+'",
         "MacAlgorithm": "HMAC_SHA_224",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -846,7 +846,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/7adef49f-2edb-4755-a202-afb6000c1673",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/e851f07d-5645-46e4-aabd-b036ead86b44",
         "MacAlgorithm": "HMAC_SHA_224",
         "MacValid": true,
         "ResponseMetadata": {
@@ -879,11 +879,11 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_256-HMAC_SHA_256]": {
-    "recorded-date": "04-04-2023, 14:21:59",
+    "recorded-date": "04-04-2023, 16:01:39",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/96d5546b-4c0b-409b-aa17-982226608c91",
-        "Mac": "b'l\\xb9h\\x1c\\xff\\xd0\\x19R\\x82\\x83\\x8a\\x9d\\x86\\x16nS\\x0fO\\xf8Y\\xe5_\\x89\\xd2\\xc1#l\\x97\\xe3\\xad`l'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/b86adf68-f057-4140-9619-23c474f11c5e",
+        "Mac": "b\"\\xe8\\t\\xe1y& \\xe7S_\\xe2\\xca\\xbb\\xb3F'-R\\xa8\\xa3\\x85\\xea\\xd9zn\\x0fQ\\x8ab\\xa6\\xef\\x9b:\"",
         "MacAlgorithm": "HMAC_SHA_256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -891,7 +891,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/96d5546b-4c0b-409b-aa17-982226608c91",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/b86adf68-f057-4140-9619-23c474f11c5e",
         "MacAlgorithm": "HMAC_SHA_256",
         "MacValid": true,
         "ResponseMetadata": {
@@ -924,11 +924,11 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_384-HMAC_SHA_384]": {
-    "recorded-date": "04-04-2023, 14:21:59",
+    "recorded-date": "04-04-2023, 16:01:42",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/7d09d39d-9cb6-459e-b72f-5a97351921ba",
-        "Mac": "b'tVW\\xd3\\x9b\\xdc\\xc5\\x7f\\x9b\\xf8\\t\\xb9fo\\xda\\xd9\\nE\\x03\\xba\\xa1\\xfc\\x85\\x8a\\xf7\\xcc\\x1e\\x87\\x8b\\xfe\\n\\xf5\\x83\\x96\\xbc\\xd0B\\x9b\\x9aY\\xb2\\x02as\\xb8\\xca\\xb8\\xfb'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/5ad42559-2de9-493b-9571-ebd702f1836e",
+        "Mac": "b'\\xfb\\xb0m\\xecG\\x86\\xd0\\xe1eu\\xfc\\x0c_`\\r\\x1b\\x0fK\\xa8u\\xac\\xb0\\xb1\\xadn\\x88e\\xe1\\x82\\xc2\\xf8jU#q`QS\\x9e\\xad\\x19\\xad\\xfe<0\\xc8Sb'",
         "MacAlgorithm": "HMAC_SHA_384",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -936,7 +936,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/7d09d39d-9cb6-459e-b72f-5a97351921ba",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/5ad42559-2de9-493b-9571-ebd702f1836e",
         "MacAlgorithm": "HMAC_SHA_384",
         "MacValid": true,
         "ResponseMetadata": {
@@ -969,11 +969,11 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_512-HMAC_SHA_512]": {
-    "recorded-date": "04-04-2023, 14:21:59",
+    "recorded-date": "04-04-2023, 16:01:44",
     "recorded-content": {
       "generate-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/2a068ba0-4163-4fd4-8035-adf89eeb1994",
-        "Mac": "b'T\\xabF\\xa5\\xcbd\\xe3\\xc2|T\\x1c\\xa5\\x88J>w\\xde\\xe7C\"\\xf9\\x0c}:\\x9eVc\\x1b\\xc80\\xe4!#\\xce$\\xb0x\\x02\\x91\\x83\\x87B\\xb3xX\\xec\\xb0)\\xc7jg)\\xc3\\xb9\\x13\\t\\xbdO\\xd4oPV\\xac\\xa1'",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/b6d050b9-7e03-4db8-921b-6cb95baf32d5",
+        "Mac": "b'\\xdc/\\xe4\\x05\\x08\\xeaGB\\xa2.%\\xa0T\\x1e\\x80>\\xf8\\x11\\x95\\x0f\\x8d\\x07\\x06I\\x98\\xa5\\x97\\xf7O\\xdf\\x1b\\xb3^3rW\\xcbV0c/h\\\\\\xa1\\x8a\\xdf\\xa4\\x98.\\xec\\xc5V5zM\\x95\\xe0\\xb4X\\xa6\\n\\xbd\\xf1x'",
         "MacAlgorithm": "HMAC_SHA_512",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -981,7 +981,7 @@
         }
       },
       "verify-mac": {
-        "KeyId": "arn:aws:kms:<region>:111111111111:key/2a068ba0-4163-4fd4-8035-adf89eeb1994",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/b6d050b9-7e03-4db8-921b-6cb95baf32d5",
         "MacAlgorithm": "HMAC_SHA_512",
         "MacValid": true,
         "ResponseMetadata": {

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -663,6 +663,10 @@
       }
     }
   },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P256-ECDSA_SHA_384]": {
+    "recorded-date": "16-03-2023, 18:57:59",
+    "recorded-content": {}
+  },
   "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_256]": {
     "recorded-date": "16-03-2023, 19:16:44",
     "recorded-content": {
@@ -705,6 +709,10 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_512]": {
+    "recorded-date": "16-03-2023, 18:58:07",
+    "recorded-content": {}
   },
   "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P384-ECDSA_SHA_384]": {
     "recorded-date": "16-03-2023, 19:16:39",


### PR DESCRIPTION
- Added support for key specs - HMAC_224, HMAC_256, HMAC_384 and HMAC_512
- Implemented `CreateKey` for hmac, `GenerateMac` and `VerifyMac`
- Write test cases for them 

Related issue #7736 