### PR TITLE
Configure CI on release branches

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -15,6 +15,7 @@ on:
       - "bin/**"
     branches:
       - master
+      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
   push:
     paths:
       - ".github/workflows/cli-tests.yml"
@@ -29,6 +30,7 @@ on:
       - "bin/**"
     branches:
       - master
+      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - master
       - 'v[0-9]+'
+      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
   push:
     paths:
       - ".github/workflows/pro-integration.yml"


### PR DESCRIPTION
We have a release branch `release/v2.1` which was not being tested.

Companion PR in ext: https://github.com/localstack/localstack-ext/pull/1573
