### PR TITLE
include link to service coverage page on not implemented error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   <br/>
   <a href="https://docs.localstack.cloud" target="_blank">📖 Docs</a> •
   <a href="https://app.localstack.cloud" target="_blank">💻 Pro version</a> •
-  <a href="https://docs.localstack.cloud/user-guide/aws/feature-coverage/" target="_blank">☑️ Feature coverage</a>
+  <a href="https://docs.localstack.cloud/references/coverage/" target="_blank">☑️ LocalStack coverage</a>
 </p>
 
 ---
@@ -109,7 +109,7 @@ To use SQS, a fully managed distributed message queuing service, on LocalStack, 
 }
 ```
 
-Learn more about [LocalStack AWS services](https://docs.localstack.cloud/user-guide/aws/feature-coverage/) and using them with LocalStack's `awslocal` CLI.
+Learn more about [LocalStack AWS services](https://docs.localstack.cloud/references/coverage/) and using them with LocalStack's `awslocal` CLI.
 
 ## Running
 

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -9,6 +9,7 @@ from botocore.model import OperationModel, ServiceModel
 
 from localstack import config
 from localstack.http import Response
+from localstack.utils.coverage_docs import get_coverage_link_for_service
 
 from ..api import CommonServiceException, RequestContext, ServiceException
 from ..api.core import ServiceOperation
@@ -184,10 +185,7 @@ class ServiceExceptionSerializer(ExceptionHandler):
 
         if operation and isinstance(exception, NotImplementedError):
             action_name = operation.name
-            message = (
-                f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/references/coverage/coverage_{service_name}/ for further information"
-            )
+            message = get_coverage_link_for_service(service_name, action_name)
             LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)
             context.service_exception = error

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -186,7 +186,7 @@ class ServiceExceptionSerializer(ExceptionHandler):
             action_name = operation.name
             message = (
                 f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+                f" - check https://docs.localstack.cloud/references/coverage/coverage_{service_name}/ for further information"
             )
             LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -203,7 +203,7 @@ class Skeleton:
         service_name = operation.service_model.service_name
         message = (
             f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-            f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+            f" - check https://docs.localstack.cloud/references/coverage/coverage_{service_name}/ for further information"
         )
         LOG.info(message)
         error = CommonServiceException("InternalFailure", message, status_code=501)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -16,6 +16,7 @@ from localstack.aws.protocol.parser import create_parser
 from localstack.aws.protocol.serializer import create_serializer
 from localstack.aws.spec import load_service
 from localstack.utils import analytics
+from localstack.utils.coverage_docs import get_coverage_link_for_service
 
 LOG = logging.getLogger(__name__)
 
@@ -201,10 +202,7 @@ class Skeleton:
 
         action_name = operation.name
         service_name = operation.service_model.service_name
-        message = (
-            f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-            f" - check https://docs.localstack.cloud/references/coverage/coverage_{service_name}/ for further information"
-        )
+        message = get_coverage_link_for_service(service_name, action_name)
         LOG.info(message)
         error = CommonServiceException("InternalFailure", message, status_code=501)
         # record event

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -17,6 +17,7 @@ from localstack.utils.aws.aws_responses import (
     requests_response,
     requests_to_flask_response,
 )
+from localstack.utils.coverage_docs import get_coverage_link_for_service
 from localstack.utils.patch import patch
 from localstack.utils.strings import snake_to_camel_case
 from localstack.utils.threads import FuncThread
@@ -181,10 +182,7 @@ def patch_moto_request_handling():
                 if match:
                     action = snake_to_camel_case(match.group(1))
             service = extract_service_name_from_auth_header(request.headers)
-            msg = (
-                f"API action '{action}' for service '{service}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/references/coverage/coverage_{service}/ for further information"
-            )
+            msg = get_coverage_link_for_service(service, action)
             response = requests_error_response(request.headers, msg, code=501)
             if config.MOCK_UNIMPLEMENTED:
                 is_json = is_json_request(request.headers)

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -183,7 +183,7 @@ def patch_moto_request_handling():
             service = extract_service_name_from_auth_header(request.headers)
             msg = (
                 f"API action '{action}' for service '{service}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+                f" - check https://docs.localstack.cloud/references/coverage/coverage_{service}/ for further information"
             )
             response = requests_error_response(request.headers, msg, code=501)
             if config.MOCK_UNIMPLEMENTED:

--- a/localstack/utils/coverage_docs.py
+++ b/localstack/utils/coverage_docs.py
@@ -6,12 +6,12 @@ MESSAGE_TEMPLATE = (
     f" - please check {COVERAGE_LINK_BASE}%s for further information"
 )
 
+
 def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
     available_services = SERVICE_PLUGINS.list_available()
 
     if service_name not in available_services:
-      return MESSAGE_TEMPLATE % (f"action {action_name} ", service_name, "")
+        return MESSAGE_TEMPLATE % (f"action {action_name} ", service_name, "")
 
     else:
-      return MESSAGE_TEMPLATE % (action_name, service_name, f"coverage_{service_name}/")
-
+        return MESSAGE_TEMPLATE % (action_name, service_name, f"coverage_{service_name}/")

--- a/localstack/utils/coverage_docs.py
+++ b/localstack/utils/coverage_docs.py
@@ -1,17 +1,21 @@
-from localstack.services.plugins import SERVICE_PLUGINS
-
 COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage/"
 MESSAGE_TEMPLATE = (
-    f"API '%s'for service '%s' not yet implemented or pro feature"
+    f"API %sfor service '%s' not yet implemented or pro feature"
     f" - please check {COVERAGE_LINK_BASE}%s for further information"
 )
 
 
 def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
+    from localstack.services.plugins import SERVICE_PLUGINS
+
     available_services = SERVICE_PLUGINS.list_available()
 
     if service_name not in available_services:
-        return MESSAGE_TEMPLATE % (f"action {action_name} ", service_name, "")
+        return MESSAGE_TEMPLATE % ("", service_name, "")
 
     else:
-        return MESSAGE_TEMPLATE % (action_name, service_name, f"coverage_{service_name}/")
+        return MESSAGE_TEMPLATE % (
+            f"action '{action_name}' ",
+            service_name,
+            f"coverage_{service_name}/",
+        )

--- a/localstack/utils/coverage_docs.py
+++ b/localstack/utils/coverage_docs.py
@@ -1,0 +1,17 @@
+from localstack.services.plugins import SERVICE_PLUGINS
+
+COVERAGE_LINK_BASE = "https://docs.localstack.cloud/references/coverage/"
+MESSAGE_TEMPLATE = (
+    f"API '%s'for service '%s' not yet implemented or pro feature"
+    f" - please check {COVERAGE_LINK_BASE}%s for further information"
+)
+
+def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
+    available_services = SERVICE_PLUGINS.list_available()
+
+    if service_name not in available_services:
+      return MESSAGE_TEMPLATE % (f"action {action_name} ", service_name, "")
+
+    else:
+      return MESSAGE_TEMPLATE % (action_name, service_name, f"coverage_{service_name}/")
+

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -220,7 +220,7 @@ def test_skeleton_e2e_sqs_send_message_not_implemented():
     assert "Error" in parsed_response
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
-        "Message": "API action 'SendMessage' for service 'sqs' not yet implemented or pro feature - check "
+        "Message": "API action 'SendMessage' for service 'sqs' not yet implemented or pro feature - please check "
         "https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
     }
 
@@ -290,7 +290,7 @@ def test_dispatch_missing_method_returns_internal_failure():
     assert "Error" in parsed_response
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
-        "Message": "API action 'DeleteQueue' for service 'sqs' not yet implemented or pro feature - check "
+        "Message": "API action 'DeleteQueue' for service 'sqs' not yet implemented or pro feature - please check "
         "https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
     }
 

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -221,7 +221,7 @@ def test_skeleton_e2e_sqs_send_message_not_implemented():
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
         "Message": "API action 'SendMessage' for service 'sqs' not yet implemented or pro feature - check "
-        "https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information",
+        "https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
     }
 
 
@@ -291,7 +291,7 @@ def test_dispatch_missing_method_returns_internal_failure():
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
         "Message": "API action 'DeleteQueue' for service 'sqs' not yet implemented or pro feature - check "
-        "https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information",
+        "https://docs.localstack.cloud/references/coverage/coverage_sqs/ for further information",
     }
 
 

--- a/tests/unit/utils/test_coverage_docs.py
+++ b/tests/unit/utils/test_coverage_docs.py
@@ -2,7 +2,7 @@ from localstack.utils.coverage_docs import get_coverage_link_for_service
 
 
 def test_coverage_link_for_existing_service():
-    coverage_link = get_coverage_link_for_service("random_action", "s3")
+    coverage_link = get_coverage_link_for_service("s3", "random_action")
     assert (
         coverage_link
         == "API action 'random_action' for service 's3' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information"
@@ -10,7 +10,7 @@ def test_coverage_link_for_existing_service():
 
 
 def test_coverage_link_for_non_existing_service():
-    coverage_link = get_coverage_link_for_service("random_action", "dummy_service")
+    coverage_link = get_coverage_link_for_service("dummy_service", "random_action")
     assert (
         coverage_link
         == "API for service 'dummy_service' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information"

--- a/tests/unit/utils/test_coverage_docs.py
+++ b/tests/unit/utils/test_coverage_docs.py
@@ -2,9 +2,16 @@ from localstack.utils.coverage_docs import get_coverage_link_for_service
 
 
 def test_coverage_link_for_existing_service():
-  coverage_link = get_coverage_link_for_service("random_action", "s3")
-  assert coverage_link == "API action 'random_action' for service 's3' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information"
+    coverage_link = get_coverage_link_for_service("random_action", "s3")
+    assert (
+        coverage_link
+        == "API action 'random_action' for service 's3' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information"
+    )
+
 
 def test_coverage_link_for_non_existing_service():
-  coverage_link = get_coverage_link_for_service("random_action", "dummy_service")
-  assert coverage_link == "API for service 'dummy_service' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information"
+    coverage_link = get_coverage_link_for_service("random_action", "dummy_service")
+    assert (
+        coverage_link
+        == "API for service 'dummy_service' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information"
+    )

--- a/tests/unit/utils/test_coverage_docs.py
+++ b/tests/unit/utils/test_coverage_docs.py
@@ -1,0 +1,10 @@
+from localstack.utils.coverage_docs import get_coverage_link_for_service
+
+
+def test_coverage_link_for_existing_service():
+  coverage_link = get_coverage_link_for_service("random_action", "s3")
+  assert coverage_link == "API action 'random_action' for service 's3' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/coverage_s3/ for further information"
+
+def test_coverage_link_for_non_existing_service():
+  coverage_link = get_coverage_link_for_service("random_action", "dummy_service")
+  assert coverage_link == "API for service 'dummy_service' not yet implemented or pro feature - please check https://docs.localstack.cloud/references/coverage/ for further information"


### PR DESCRIPTION
This PR adjusts the links that are printed for `not implemented` errors. 

Instead of pointing to our general feature coverage https://docs.localstack.cloud/user-guide/aws/feature-coverage/ they now point to the specific service page of our docs, e.g. https://docs.localstack.cloud/references/coverage/coverage_sqs/ for `sqs`.


question: 
do all our services have a related page on the docs?
based on the fact that the docs are auto-generated, I'm assuming that the answer to the question is yes, hence allowing us to link directly to the coverage page of each service 🙂 