### PR TITLE
add SNS validation of JSON fields type for MessageStructure json

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -598,12 +598,10 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 # Keys in the JSON object that correspond to supported transport protocols must have
                 # simple JSON string values.
                 # Non-string values will cause the key to be ignored.
-                filtered_message = {
-                    key: field for key, field in message.items() if isinstance(field, str)
-                }
+                message = {key: field for key, field in message.items() if isinstance(field, str)}
                 # TODO: check no default key for direct TargetArn endpoint publish, need credentials
                 # see example: https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
-                if "default" not in filtered_message and not is_endpoint_publish:
+                if "default" not in message and not is_endpoint_publish:
                     raise InvalidParameterException(
                         "Invalid parameter: Message Structure - No default entry in JSON message body"
                     )

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -595,9 +595,15 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if message_structure == "json":
             try:
                 message = json.loads(message)
+                # Keys in the JSON object that correspond to supported transport protocols must have
+                # simple JSON string values.
+                # Non-string values will cause the key to be ignored.
+                filtered_message = {
+                    key: field for key, field in message.items() if isinstance(field, str)
+                }
                 # TODO: check no default key for direct TargetArn endpoint publish, need credentials
                 # see example: https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
-                if "default" not in message and not is_endpoint_publish:
+                if "default" not in filtered_message and not is_endpoint_publish:
                     raise InvalidParameterException(
                         "Invalid parameter: Message Structure - No default entry in JSON message body"
                     )

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2876,6 +2876,15 @@ class TestSNSProvider:
         )
         snapshot.match("duplicate-json-keys", resp)
 
+        with pytest.raises(ClientError) as e:
+            message = json.dumps({"default": {"object": "test"}})
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                MessageStructure="json",
+            )
+        snapshot.match("key-is-not-string", e.value.response)
+
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_set_subscription_filter_policy_scope(

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2886,6 +2886,41 @@ class TestSNSProvider:
         snapshot.match("key-is-not-string", e.value.response)
 
     @pytest.mark.aws_validated
+    def test_message_structure_json_to_sqs(
+        self, aws_client, sns_create_topic, sqs_create_queue, snapshot, sns_create_sqs_subscription
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_name = f"test-queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        message = json.dumps({"default": "default field", "sqs": json.dumps({"field": "value"})})
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageStructure="json",
+        )
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
+        )
+        snapshot.match("get-msg-json-sqs", response)
+        receipt_handle = response["Messages"][0]["ReceiptHandle"]
+        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+
+        # don't json dumps the SQS field, it will be ignored, and the message received will be the `default`
+        message = json.dumps({"default": "default field", "sqs": {"field": "value"}})
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageStructure="json",
+        )
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
+        )
+        snapshot.match("get-msg-json-default", response)
+
+    @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_set_subscription_filter_policy_scope(
         self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2361,7 +2361,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_structure_json_exc": {
-    "recorded-date": "25-11-2022, 18:42:09",
+    "recorded-date": "03-04-2023, 21:23:54",
     "recorded-content": {
       "missing-default-key": {
         "Error": {
@@ -2390,6 +2390,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "key-is-not-string": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message Structure - No default entry in JSON message body",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3516,5 +3516,58 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_message_structure_json_to_sqs": {
+    "recorded-date": "03-04-2023, 21:52:04",
+    "recorded-content": {
+      "get-msg-json-sqs": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"field\": \"value\"}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-msg-json-default": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "default field",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
As reported in #8034, there would be an error down the line when trying to publish delivery logs when using `MessageStructure="json"`. It's because we would pass a `dict` instead of `str` to calculate the md5 hash of the body, because we didn't filter the fields of the received JSON message. In the docs, it's specified that if the field isn't a string, it will be ignored by AWS: https://docs.aws.amazon.com/sns/latest/api/API_Publish.html

This PR now properly filters the fields, and add some tests to validate the behaviour with AWS.

_fixes #8034_