### PR TITLE
Move test client creation logic into util package for re-use across repos

### DIFF
--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -265,7 +265,7 @@ class ClientFactory(ABC):
     def get_client(
         self,
         service_name: str,
-        region_name: Optional[str],
+        region_name: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
@@ -373,7 +373,7 @@ class InternalClientFactory(ClientFactory):
     def get_client(
         self,
         service_name: str,
-        region_name: Optional[str],
+        region_name: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
@@ -428,7 +428,7 @@ class ExternalClientFactory(ClientFactory):
     def get_client(
         self,
         service_name: str,
-        region_name: Optional[str],
+        region_name: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
@@ -484,12 +484,12 @@ class ExternalAwsClientFactory(ClientFactory):
     def get_client(
         self,
         service_name: str,
-        region_name: Optional[str],
+        region_name: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        endpoint_url: str = None,
-        config: Config = None,
+        endpoint_url: Optional[str] = None,
+        config: Optional[Config] = None,
     ) -> BaseClient:
         """
         Build and return client for connections originating outside LocalStack and targeting AWS.

--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -269,8 +269,8 @@ class ClientFactory(ABC):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        endpoint_url: str = None,
-        config: Config = None,
+        endpoint_url: Optional[str] = None,
+        config: Optional[Config] = None,
     ):
         raise NotImplementedError()
 
@@ -377,8 +377,8 @@ class InternalClientFactory(ClientFactory):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        endpoint_url: str = None,
-        config: Config = None,
+        endpoint_url: Optional[str] = None,
+        config: Optional[Config] = None,
     ) -> BaseClient:
         """
         Build and return client for connections originating within LocalStack.
@@ -432,8 +432,8 @@ class ExternalClientFactory(ClientFactory):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        endpoint_url: str = None,
-        config: Config = None,
+        endpoint_url: Optional[str] = None,
+        config: Optional[Config] = None,
     ) -> BaseClient:
         """
         Build and return client for connections originating outside LocalStack and targeting Localstack.

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -24,7 +24,6 @@ from werkzeug import Request, Response
 
 from localstack import config, constants
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.connect import ExternalAwsClientFactory, ExternalClientFactory
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -52,30 +51,6 @@ LOG = logging.getLogger(__name__)
 
 # URL of public HTTP echo server, used primarily for AWS parity/snapshot testing
 PUBLIC_HTTP_ECHO_SERVER_URL = "http://httpbin.org"
-
-
-@pytest.fixture(scope="session")
-def aws_session():
-    return boto3.Session()
-
-
-@pytest.fixture(scope="session")
-def aws_client_factory(aws_session):
-    config = None
-    if os.environ.get("TEST_DISABLE_RETRIES_AND_TIMEOUTS"):
-        config = botocore.config.Config(
-            connect_timeout=1_000, read_timeout=1_000, retries={"total_max_attempts": 1}
-        )
-
-    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
-        return ExternalAwsClientFactory(session=aws_session, config=config)
-    else:
-        return ExternalClientFactory(session=aws_session, config=config)
-
-
-@pytest.fixture(scope="session")
-def aws_client(aws_client_factory):
-    return aws_client_factory()
 
 
 def _resource(service):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from localstack.config import is_env_true
 from localstack.constants import ENV_INTERNAL_TEST_RUN
 from localstack.runtime import events
 from localstack.services import infra
+from localstack.testing.aws.util import base_aws_client, base_aws_client_factory, base_aws_session
 from localstack.utils.common import safe_requests
 from tests.integration.apigateway.apigateway_fixtures import delete_rest_api, import_rest_api
 from tests.integration.test_es import install_async as es_install_async
@@ -192,3 +193,18 @@ def import_apigw(apigateway_client):
 
     for rest_api_id in rest_api_ids:
         delete_rest_api(apigateway_client, restApiId=rest_api_id)
+
+
+@pytest.fixture(scope="session")
+def aws_session():
+    return base_aws_session()
+
+
+@pytest.fixture(scope="session")
+def aws_client_factory(aws_session):
+    return base_aws_client_factory(aws_session)
+
+
+@pytest.fixture(scope="session")
+def aws_client(aws_client_factory):
+    return base_aws_client(aws_client_factory)


### PR DESCRIPTION
Since PyCharm still can't properly detect the imported pytest plugins from localstack, we'll just duplicate the actual fixture definition across the two repos.

The core logic behind the client creation has been moved to `util.py` and is re-used across these client fixture definitions.