### PR TITLE
add quality gate for entrypoints to make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,15 @@ install: install-dev entrypoints  ## Install full dependencies into venv
 
 entrypoints:              ## Run setup.py develop to build entry points
 	$(VENV_RUN); python setup.py plugins egg_info
+	# make sure that the entrypoints were correctly created and are non-empty
+	test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 
 dist: entrypoints        ## Build source and built (wheel) distributions of the current version
 	$(VENV_RUN); pip install --upgrade twine; python setup.py sdist bdist_wheel
 
 publish: clean-dist dist  ## Publish the library to the central PyPi repository
+	# make sure the dist archive contains a non-empty entry_points.txt file before uploading
+	tar --wildcards --to-stdout -xf dist/localstack-core*.tar.gz "localstack-core*/localstack_core.egg-info/entry_points.txt" | grep . > /dev/null 2>&1 || (echo "Refusing upload, localstack-core dist does not contain entrypoints." && exit 1)
 	$(VENV_RUN); twine upload dist/*
 
 coveralls:         		  ## Publish coveralls metrics


### PR DESCRIPTION
With the release of `localstack-core==2.0.0`, we had a slight hiccup where the entrypoints were missing in the distribution (hence the `2.0.0.post1` release on PyPi).

This PR adds some simple quality gates to avoid publishing distributions without entrypoints.