### PR TITLE
add boto3-stubs to development deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ install-test-only: venv
 	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[test]"
 
 install-dev: venv         ## Install developer requirements into venv
+	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[cli,runtime,test,dev]"
+
+install-dev-types: venv   ## Install developer requirements incl. type hints into venv
 	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[cli,runtime,test,dev,typehint]"
 
 install: install-dev entrypoints  ## Install full dependencies into venv

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install-test-only: venv
 	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[test]"
 
 install-dev: venv         ## Install developer requirements into venv
-	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[cli,runtime,test,dev]"
+	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -e ".[cli,runtime,test,dev,typehint]"
 
 install: install-dev entrypoints  ## Install full dependencies into venv
 

--- a/scripts/generate_minimal_boto3stubs_install.py
+++ b/scripts/generate_minimal_boto3stubs_install.py
@@ -1,12 +1,17 @@
+"""
+A simple script to generate a pip install command for all boto3-stubs packages we're currently using in LocalStack
+"""
+
 import os
 import re
 
 if __name__ == "__main__":
     with open(
-        os.path.join(os.path.dirname(__file__), "../localstack/testing/pytest/fixtures.py")
+        os.path.join(os.path.dirname(__file__), "../localstack/utils/aws/client_types.py")
     ) as fd:
         content = fd.read()
-        result = re.findall(r"\smypy_boto3_([a-z]+)\s", content)
+        result = re.findall(r"\smypy_boto3_([a-z0-9_]+)\s", content)
+        result = [r.replace("_", "-") for r in set(result)]
         result.sort()
 
         print(f'pip install "boto3-stubs[{",".join(result)}]"', end="")

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,3 +129,7 @@ dev =
     # enables flake8 configuration through pyproject.toml
     pyproject-flake8>=6.0.0.post1
     rstr>=3.2.0
+
+# not strictly necessary for development, but provides type hint support for a better developer experience
+typehint =
+    boto3-stubs[acm,amplify,apigateway,apigatewayv2,appconfig,appsync,athena,autoscaling,backup,batch,ce,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,es,events,firehose,fis,glacier,glue,iam,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,stepfunctions,sts,timestream-query,timestream-write,transcribe,xray]


### PR DESCRIPTION
Adds the types we're using for our typed client factory as dev dependencies

Packages have been extracted from this file here:
https://github.com/localstack/localstack/blob/2e86662f01a450396027982aadceac0006f89bd6/localstack/utils/aws/client_types.py#L4-L10


They're now also installed when running `make install` but I'm also open to move it to a separate target instead :thinking: 


/cc @pinzon 