### PR TITLE
Disable HTTPS(S) proxies for internal calls

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -647,7 +647,7 @@ FORCE_SHUTDOWN = is_env_not_false("FORCE_SHUTDOWN")
 MOCK_UNIMPLEMENTED = is_env_true("MOCK_UNIMPLEMENTED")
 
 # set variables no_proxy, i.e., run internal service calls directly
-no_proxy = ",".join([LOCALSTACK_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]"])
+no_proxy = ",".join([constants.LOCALHOST_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]"])
 if os.environ.get("no_proxy"):
     os.environ["no_proxy"] += "," + no_proxy
 elif os.environ.get("NO_PROXY"):

--- a/localstack/services/awslambda/invocation/executor_endpoint.py
+++ b/localstack/services/awslambda/invocation/executor_endpoint.py
@@ -124,7 +124,9 @@ class ExecutorEndpoint:
         if not self.container_address:
             raise ValueError("Container address not set, but got an invoke.")
         invocation_url = f"http://{self.container_address}:{self.container_port}/invoke"
-        response = requests.post(url=invocation_url, json=payload)
+        # disable proxies for internal requests
+        proxies = {"http": "", "https": ""}
+        response = requests.post(url=invocation_url, json=payload, proxies=proxies)
         if not response.ok:
             raise InvokeSendError(
                 f"Error while sending invocation {payload} to {invocation_url}. Error Code: {response.status_code}"

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -22,6 +22,7 @@ from localstack.aws.api.lambda_ import (
     ResourceNotFoundException,
     State,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.awslambda import api_utils
 from localstack.services.awslambda.api_utils import (
     lambda_arn,
@@ -45,7 +46,6 @@ from localstack.services.awslambda.invocation.models import lambda_stores
 from localstack.services.awslambda.invocation.version_manager import LambdaVersionManager
 from localstack.services.awslambda.lambda_utils import HINT_LOG
 from localstack.utils.archives import get_unzipped_size, is_zip_file
-from localstack.utils.aws import aws_stack
 from localstack.utils.container_utils.container_client import ContainerException
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import to_str
@@ -536,7 +536,7 @@ def store_lambda_archive(
             Type="User",
         )
     # store all buckets in us-east-1 for now
-    s3_client: "S3Client" = aws_stack.connect_to_service("s3", region_name="us-east-1")
+    s3_client: "S3Client" = connect_to(region_name="us-east-1").s3
     bucket_name = f"awslambda-{region_name}-tasks"
     # s3 create bucket is idempotent
     s3_client.create_bucket(Bucket=bucket_name)
@@ -584,7 +584,7 @@ def store_s3_bucket_archive(
     """
     if archive_bucket == config.BUCKET_MARKER_LOCAL:
         return create_hot_reloading_code(path=archive_key)
-    s3_client: "S3Client" = aws_stack.connect_to_service("s3")
+    s3_client: "S3Client" = connect_to().s3
     kwargs = {"VersionId": archive_version} if archive_version else {}
     archive_file = s3_client.get_object(Bucket=archive_bucket, Key=archive_key, **kwargs)[
         "Body"

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -14,6 +14,7 @@ from flask import Response
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import FilterCriteria, Runtime
+from localstack.aws.connect import connect_to
 from localstack.services.awslambda.lambda_models import AwsLambdaStore, awslambda_stores
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
@@ -245,7 +246,7 @@ def get_zip_bytes(function_code):
     """
     function_code = function_code or {}
     if "S3Bucket" in function_code:
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = connect_to().s3
         bytes_io = BytesIO()
         try:
             s3_client.download_fileobj(function_code["S3Bucket"], function_code["S3Key"], bytes_io)

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -134,6 +134,7 @@ from localstack.aws.api.lambda_ import (
     UpdateFunctionUrlConfigResponse,
     Version,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.awslambda import api_utils
 from localstack.services.awslambda import hooks as lambda_hooks
 from localstack.services.awslambda.api_utils import STATEMENT_ID_REGEX
@@ -184,7 +185,6 @@ from localstack.services.awslambda.urlrouter import FunctionUrlRouter
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import StateVisitor
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_service_from_arn
 from localstack.utils.collections import PaginatedList
 from localstack.utils.files import load_file
@@ -1193,7 +1193,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     ),
                     mode="rb",
                 )
-                lambda_client = aws_stack.connect_to_service("lambda")
+                lambda_client = connect_to().awslambda
                 lambda_client.create_function(
                     FunctionName="localstack-internal-awssdk",
                     Runtime=Runtime.nodejs16_x,


### PR DESCRIPTION
Enterprise environments often use HTTP(S) proxies but LocalStack-internal AWS clients fail since boto3 migrated from requests to urllib3 and dropped support for `NO_PROXY` (https://github.com/boto/boto3/issues/3179).

This PR disables proxies for LocalStack-internal AWS calls and migrates Lambda (new provider) to the new AWS client (introduced in https://github.com/localstack/localstack/pull/7240).

## Issue

The following minimal configuration now fails against LocalStack:

```
HTTP_PROXY=http://mycompany.us-east-1.mycorp.com:3587
NO_PROXY = .s3.localhost.localstack.cloud,127.0.0.1,*.localhost
```

For example when trying to create any Lambda function via `awslocal lambda create-function ...`, an exception occurs:
**Hint:** For testing the setup, use [mitmproxy](https://mitmproxy.org/) and `HTTP_PROXY=http://localhost:8080`

```
botocore.exceptions.ProxyConnectionError: Failed to connect to proxy URL: "http://mycompany.us-east-1.mycorp.com:3587"
```

* We recommend `NO_PROXY` in our FAQ to fix connectivity issues in the BigData image: https://docs.localstack.cloud/getting-started/faq/#how-do-i-resolve-connection-issues-with-proxy-blocking-access-to-localstacks-bigdata-image

The issue came up in LocalStack Pro support.

## Explored Solutions

`NO_PROXY` supports a list of hosts to selectively disable any proxy configured through HTTP_PROXY
Example:
`NO_PROXY = .s3.localhost.localstack.cloud,127.0.0.1,*.localhost`

However,  we can only disable proxies entirely through botocore configuration: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html

AFIAK, the underlying urllib3 also does not offer a configuration to disable selected hosts from active proxies: https://urllib3.readthedocs.io/en/stable/advanced-usage.html

## Implemented Solution

Disable all proxies for LocalStack-internal calls because proxying them never makes sense for customers.
If we want to use mitmproxy for debugging LocalStack-internal AWS calls, we would need to add `"http": "http://localhost:4566"` to the proxies config. We could make this configurable if there is high demand among LocalStack developers.

## Workaround

I tested the `NO_PROXY` configuration from our [FAQ](https://docs.localstack.cloud/getting-started/faq/#how-do-i-resolve-connection-issues-with-proxy-blocking-access-to-localstacks-bigdata-image) documentation again and discovered that even a more generic version (without the s3 subdomain) `NO_PROXY=localhost.localstack.cloud,127.0.0.1,*.localhost` works against both, the old stack and new AWS client without this fix 🤔 

I don't know exactly why because it got removed from [boto3](https://github.com/boto/boto3/issues/3179#issuecomment-1069709605) and is not implemented in [urllib3](https://github.com/search?q=repo%3Aurllib3%2Furllib3+no_proxy&type=code) used by boto3.