### PR TITLE
switch from feature coverage to API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   <br/>
   <a href="https://docs.localstack.cloud" target="_blank">📖 Docs</a> •
   <a href="https://app.localstack.cloud" target="_blank">💻 Pro version</a> •
-  <a href="https://docs.localstack.cloud/user-guide/aws/feature-coverage/" target="_blank">☑️ Feature coverage</a>
+  <a href="https://docs.localstack.cloud/references/coverage/" target="_blank">☑️ LocalStack coverage</a>
 </p>
 
 ---
@@ -109,7 +109,7 @@ To use SQS, a fully managed distributed message queuing service, on LocalStack, 
 }
 ```
 
-Learn more about [LocalStack AWS services](https://docs.localstack.cloud/user-guide/aws/feature-coverage/) and using them with LocalStack's `awslocal` CLI.
+Learn more about [LocalStack AWS services](https://docs.localstack.cloud/references/coverage/) and using them with LocalStack's `awslocal` CLI.
 
 ## Running
 

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -186,7 +186,7 @@ class ServiceExceptionSerializer(ExceptionHandler):
             action_name = operation.name
             message = (
                 f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+                f" - check https://docs.localstack.cloud/references/coverage for further information"
             )
             LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -203,7 +203,7 @@ class Skeleton:
         service_name = operation.service_model.service_name
         message = (
             f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
-            f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+            f" - check https://docs.localstack.cloud/references/coverage for further information"
         )
         LOG.info(message)
         error = CommonServiceException("InternalFailure", message, status_code=501)

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -183,7 +183,7 @@ def patch_moto_request_handling():
             service = extract_service_name_from_auth_header(request.headers)
             msg = (
                 f"API action '{action}' for service '{service}' not yet implemented or pro feature"
-                f" - check https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information"
+                f" - check https://docs.localstack.cloud/references/coverage for further information"
             )
             response = requests_error_response(request.headers, msg, code=501)
             if config.MOCK_UNIMPLEMENTED:

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -221,7 +221,7 @@ def test_skeleton_e2e_sqs_send_message_not_implemented():
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
         "Message": "API action 'SendMessage' for service 'sqs' not yet implemented or pro feature - check "
-        "https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information",
+        "https://docs.localstack.cloud/references/coverage for further information",
     }
 
 
@@ -291,7 +291,7 @@ def test_dispatch_missing_method_returns_internal_failure():
     assert parsed_response["Error"] == {
         "Code": "InternalFailure",
         "Message": "API action 'DeleteQueue' for service 'sqs' not yet implemented or pro feature - check "
-        "https://docs.localstack.cloud/user-guide/aws/feature-coverage for further information",
+        "https://docs.localstack.cloud/references/coverage for further information",
     }
 
 


### PR DESCRIPTION
## Description

This PR switches from the [feature coverage](https://docs.localstack.cloud/user-guide/aws/feature-coverage/) page to the [API coverage](https://docs.localstack.cloud/references/coverage/) to make more sense to the users!