### PR TITLE
fix APIGW RestAPI minimumCompressionSize

### DIFF
--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -338,7 +338,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_optional_params": {
-    "recorded-date": "01-02-2023, 23:48:05",
+    "recorded-date": "04-04-2023, 17:58:40",
     "recorded-content": {
       "create-only-name": {
         "apiKeySource": "HEADER",
@@ -398,6 +398,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      },
+      "string-compression-size": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }
@@ -2504,6 +2515,100 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_compression": {
+    "recorded-date": "04-04-2023, 17:35:05",
+    "recorded-content": {
+      "enable-compression": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "minimumCompressionSize": 10,
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "disable-compression": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-compression-zero": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "minimumCompressionSize": 0,
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-negative-compression": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "set-string-compression": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "unsupported-operation": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch operation specified. Must be 'add'|'remove'|'replace'"
+        },
+        "message": "Invalid patch operation specified. Must be 'add'|'remove'|'replace'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }


### PR DESCRIPTION
As reported in https://github.com/localstack/localstack/issues/7975#issuecomment-1495698212, we have an issue while returning a `minimumCompressionSize` when set to an empty string. The docs states:
> To enable compression, apply a replace operation with the accompanying value property set to a non-negative integer between 0 and 10485760. To disable compression, apply a replace operation with the value property set to null or omit the value property.

https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html#UpdateRestApi-Patch

Apparently, an empty string works as well. I've added the validation + type casting of either `int` or `None` when disabled, but we're not actually enforcing this as a feature, only mocking this value, so no changes down the line.

If we updated the RestAPI with an empty string, we would return it in the response and the client would fail parse that response. This is now fixed. 

_fix #7975_