### PR TITLE
fix DockerHub description update action

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml
+  pull_request:
+    paths:
+      - .github/workflows/dockerhub-description.yml
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   dockerHubDescription:


### PR DESCRIPTION
This PR is used to debug current issues with the "Update Docker Hub Description" action, which is currently failling.