### PR TITLE
Replace (incorrect) regex with filter pattern

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -15,7 +15,7 @@ on:
       - "bin/**"
     branches:
       - master
-      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
+      - release/*
   push:
     paths:
       - ".github/workflows/cli-tests.yml"
@@ -30,7 +30,7 @@ on:
       - "bin/**"
     branches:
       - master
-      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
+      - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -20,7 +20,7 @@ on:
     branches:
       - master
       - 'v[0-9]+'
-      - release\/v[0-9]+(\.[0-9]+){0,2}  # e.g. release/v2.1.0 or release/v2.1
+      - release/*
   push:
     paths:
       - ".github/workflows/pro-integration.yml"


### PR DESCRIPTION
I had thought from the `v[0-9]+` entry above that this filter pattern is
a regex, but it isn't. It's annoyingly close though. The effect is that
CI was _not_ being run against the `release/v2.1` branch.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
