### PR TITLE
Add kms DeleteImportedKeyMaterial operation

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -25,12 +25,14 @@ from localstack.aws.api.kms import (
     DisabledException,
     EncryptionContextType,
     KeyMetadata,
+    KeyState,
     KMSInvalidMacException,
     KMSInvalidSignatureException,
     KMSInvalidStateException,
     MacAlgorithmSpec,
     MessageType,
     NotFoundException,
+    OriginType,
     SigningAlgorithmSpec,
     UnsupportedOperationException,
 )
@@ -387,9 +389,13 @@ class KmsKey:
         # Metadata fields AWS introduces automatically
         self.metadata["AWSAccountId"] = account_id or get_aws_account_id()
         self.metadata["CreationDate"] = datetime.datetime.now()
-        self.metadata["Enabled"] = True
+        self.metadata["Enabled"] = create_key_request.get("Origin") != OriginType.EXTERNAL
         self.metadata["KeyManager"] = "CUSTOMER"
-        self.metadata["KeyState"] = "Enabled"
+        self.metadata["KeyState"] = (
+            KeyState.Enabled
+            if create_key_request.get("Origin") != OriginType.EXTERNAL
+            else KeyState.PendingImport
+        )
         # https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html
         # "Notice that multi-Region keys have a distinctive key ID that begins with mrk-. You can use the mrk- prefix to
         # identify MRKs programmatically."

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -628,6 +628,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> EncryptResponse:
         key = self._get_key(context, key_id)
         self._validate_key_for_encryption_decryption(key)
+        self._validate_key_state_not_pending_import(key)
         ciphertext_blob = key.encrypt(plaintext)
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
         # encrypts with symmetric encryption no matter the key settings.
@@ -667,6 +668,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 f"ciphertext. Keep in mind that LocalStack currently doesn't perform asymmetric encryption"
             )
         self._validate_key_for_encryption_decryption(key)
+        self._validate_key_state_not_pending_import(key)
 
         plaintext = key.decrypt(ciphertext)
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
@@ -747,11 +749,27 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 f"Unsupported padding, requested wrapping algorithm:'{import_state.wrapping_algo}'"
             )
 
+        # TODO check if there was already a key imported for this kms key
+        # if so, it has to be identical. We cannot change keys by reimporting after deletion/expiry
         key_material = import_state.key.crypto_key.key.decrypt(
             encrypted_key_material, decrypt_padding
         )
         key_to_import_material_to.crypto_key.key_material = key_material
+        key_to_import_material_to.metadata["Enabled"] = True
+        if not valid_to:
+            key_to_import_material_to.metadata[
+                "ExpirationModel"
+            ] = ExpirationModelType.KEY_MATERIAL_DOES_NOT_EXPIRE
+        key_to_import_material_to.metadata["KeyState"] = KeyState.Enabled
         return ImportKeyMaterialResponse()
+
+    def delete_imported_key_material(self, context: RequestContext, key_id: KeyIdType) -> None:
+        store = self._get_store(context)
+        key = store.get_key(key_id, enabled_key_allowed=True, disabled_key_allowed=True)
+        key.crypto_key.key_material = None
+        key.metadata["Enabled"] = False
+        key.metadata["KeyState"] = KeyState.PendingImport
+        key.metadata.pop("ExpirationModel", None)
 
     @handler("CreateAlias", expand=False)
     def create_alias(self, context: RequestContext, request: CreateAliasRequest) -> None:
@@ -921,6 +939,10 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         for tag_key in request.get("TagKeys"):
             # AWS doesn't seem to mind removal of a non-existent tag, so we do not raise any exception.
             key.tags.pop(tag_key, None)
+
+    def _validate_key_state_not_pending_import(self, key: KmsKey):
+        if key.metadata["KeyState"] == KeyState.PendingImport:
+            raise KMSInvalidStateException(f"{key.metadata['Arn']} is pending import.")
 
     def _validate_key_for_encryption_decryption(self, key: KmsKey):
         if key.metadata["KeyUsage"] != "ENCRYPT_DECRYPT":

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -756,7 +756,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         )
         key_to_import_material_to.crypto_key.key_material = key_material
         key_to_import_material_to.metadata["Enabled"] = True
-        if not valid_to:
+        if expiration_model:
+            key_to_import_material_to.metadata["ExpirationModel"] = expiration_model
+        else:
             key_to_import_material_to.metadata[
                 "ExpirationModel"
             ] = ExpirationModelType.KEY_MATERIAL_DOES_NOT_EXPIRE

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -556,9 +556,18 @@ class TestKMS:
         assert key_id in _get_all_key_ids(aws_client.kms)
 
     @pytest.mark.aws_validated
-    def test_import_key(self, kms_create_key, aws_client):
+    def test_import_key(self, kms_create_key, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("KeyId"))
+        snapshot.add_transformer(snapshot.transform.key_value("Description"))
         key = kms_create_key(Origin="EXTERNAL")
+        snapshot.match("created-key", key)
         key_id = key["KeyId"]
+
+        # try key before importing
+        plaintext = b"test content 123 !#"
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.encrypt(Plaintext=plaintext, KeyId=key_id)
+        snapshot.match("encrypt-before-import-error", e.value.response)
 
         # get key import params
         params = aws_client.kms.get_parameters_for_import(
@@ -576,20 +585,31 @@ class TestKMS:
         # import symmetric key (key material) into KMS
         public_key = load_der_public_key(params["PublicKey"])
         encrypted_key = public_key.encrypt(symmetric_key, PKCS1v15())
+        describe_key_before_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-before-import", describe_key_before_import)
         aws_client.kms.import_key_material(
             KeyId=key_id,
             ImportToken=params["ImportToken"],
             EncryptedKeyMaterial=encrypted_key,
             ExpirationModel="KEY_MATERIAL_DOES_NOT_EXPIRE",
         )
+        describe_key_after_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-after-import", describe_key_after_import)
 
         # use key to encrypt/decrypt data
-        plaintext = b"test content 123 !#"
         encrypt_result = aws_client.kms.encrypt(Plaintext=plaintext, KeyId=key_id)
         api_decrypted = aws_client.kms.decrypt(
             CiphertextBlob=encrypt_result["CiphertextBlob"], KeyId=key_id
         )
         assert api_decrypted["Plaintext"] == plaintext
+
+        aws_client.kms.delete_imported_key_material(KeyId=key_id)
+        describe_key_after_deleted_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-after-deleted-import", describe_key_after_deleted_import)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.encrypt(Plaintext=plaintext, KeyId=key_id)
+        snapshot.match("encrypt-after-delete-error", e.value.response)
 
     @pytest.mark.aws_validated
     def test_list_aliases_of_key(self, kms_create_key, kms_create_alias, aws_client):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -587,6 +587,14 @@ class TestKMS:
         encrypted_key = public_key.encrypt(symmetric_key, PKCS1v15())
         describe_key_before_import = aws_client.kms.describe_key(KeyId=key_id)
         snapshot.match("describe-key-before-import", describe_key_before_import)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.import_key_material(
+                KeyId=key_id,
+                ImportToken=params["ImportToken"],
+                EncryptedKeyMaterial=encrypted_key,
+            )
+        snapshot.match("import-expiring-key-without-valid-to", e.value.response)
         aws_client.kms.import_key_material(
             KeyId=key_id,
             ImportToken=params["ImportToken"],

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1119,7 +1119,7 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_import_key": {
-    "recorded-date": "05-04-2023, 15:22:20",
+    "recorded-date": "06-04-2023, 11:45:39",
     "recorded-content": {
       "created-key": {
         "AWSAccountId": "111111111111",
@@ -1172,6 +1172,16 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "import-expiring-key-without-valid-to": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "A validTo date must be set if the ExpirationModel is KEY_MATERIAL_EXPIRES"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       },
       "describe-key-after-import": {

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1117,5 +1117,123 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_import_key": {
+    "recorded-date": "05-04-2023, 15:22:20",
+    "recorded-content": {
+      "created-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+        "CreationDate": "datetime",
+        "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+        "Description": "<description:1>",
+        "Enabled": false,
+        "EncryptionAlgorithms": [
+          "SYMMETRIC_DEFAULT"
+        ],
+        "KeyId": "<key-id:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "KeyState": "PendingImport",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "MultiRegion": false,
+        "Origin": "EXTERNAL"
+      },
+      "encrypt-before-import-error": {
+        "Error": {
+          "Code": "KMSInvalidStateException",
+          "Message": "arn:aws:kms:<region>:111111111111:key/<key-id:1> is pending import."
+        },
+        "message": "arn:aws:kms:<region>:111111111111:key/<key-id:1> is pending import.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "describe-key-before-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "<description:1>",
+          "Enabled": false,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "PendingImport",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-key-after-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "<description:1>",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "ExpirationModel": "KEY_MATERIAL_DOES_NOT_EXPIRE",
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-key-after-deleted-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "<description:1>",
+          "Enabled": false,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "PendingImport",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "encrypt-after-delete-error": {
+        "Error": {
+          "Code": "KMSInvalidStateException",
+          "Message": "arn:aws:kms:<region>:111111111111:key/<key-id:1> is pending import."
+        },
+        "message": "arn:aws:kms:<region>:111111111111:key/<key-id:1> is pending import.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
Until now, the DeleteImportedKeyMaterial operation was missing.

## Changes
* Add, at least for External origin keys, some state handling. Keys with External origin are per default in `PendingImport` state (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-create-cmk.html). Encrypt/decrypt operation cannot be done while in this state (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
* Set ExpirationModel correctly
* When deleting the key material, set the state to PendingImport again, and remove the key. (Any operation with that key will fail as it will be none, but this should be guarded by the state handling).