### PR TITLE
fix returned security options for opensearch domain

### DIFF
--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -357,9 +357,8 @@ def get_domain_status(domain_key: DomainKey, deleted=False) -> DomainStatus:
             TLSSecurityPolicy=TLSSecurityPolicy.Policy_Min_TLS_1_0_2019_07,
             CustomEndpointEnabled=False,
         ),
-        AdvancedSecurityOptions=AdvancedSecurityOptions(
-            Enabled=False, InternalUserDatabaseEnabled=False
-        ),
+        AdvancedSecurityOptions=stored_status.get("AdvancedSecurityOptions")
+        or AdvancedSecurityOptions(Enabled=False, InternalUserDatabaseEnabled=False),
         AutoTuneOptions=AutoTuneOptionsOutput(State=AutoTuneState.ENABLE_IN_PROGRESS),
     )
     if stored_status.get("Endpoint"):

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -575,6 +575,21 @@ class TestOpensearchProvider:
         domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
         assert domain_name in domain_names
 
+    def test_advanced_security_options(self, opensearch_create_domain, aws_client):
+        advanced_security_options = AdvancedSecurityOptionsInput(
+            Enabled=True,
+            InternalUserDatabaseEnabled=True,
+            MasterUserOptions=MasterUserOptions(
+                MasterUserName="master-user",
+                MasterUserPassword="12345678Aa!",
+            ),
+        )
+        domain_name = opensearch_create_domain(
+            EngineVersion="OpenSearch_2.3", AdvancedSecurityOptions=advanced_security_options
+        )
+        describe_domain = aws_client.opensearch.describe_domain(DomainName=domain_name)
+        assert describe_domain["DomainStatus"]["AdvancedSecurityOptions"]["Enabled"] is True
+
 
 @pytest.mark.skip_offline
 class TestEdgeProxiedOpensearchCluster:


### PR DESCRIPTION
Fixes a user-reported issue where the returned security options for the `describe_domain` call were always set to `Enabled=False`.
