### PR TITLE
add Docker SDK default timeout config

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -582,6 +582,9 @@ EDGE_FORWARD_URL = os.environ.get("EDGE_FORWARD_URL", "").strip()
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
 
+# Default timeout for Docker API calls sent by the Docker SDK client, in seconds.
+DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS") or 60)
+
 # whether to enable API-based updates of configuration variables at runtime
 ENABLE_CONFIG_UPDATES = is_env_true("ENABLE_CONFIG_UPDATES")
 
@@ -992,6 +995,7 @@ CONFIG_ENV_VARS = [
     "DISABLE_CUSTOM_CORS_S3",
     "DISABLE_EVENTS",
     "DOCKER_BRIDGE_IP",
+    "DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS",
     "DYNAMODB_ERROR_PROBABILITY",
     "DYNAMODB_HEAP_SIZE",
     "DYNAMODB_IN_MEMORY",

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -42,7 +42,9 @@ class SdkDockerClient(ContainerClient):
 
     def __init__(self):
         try:
-            self.docker_client = docker.from_env()
+            from localstack.config import DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS
+
+            self.docker_client = docker.from_env(timeout=DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS)
             logging.getLogger("urllib3").setLevel(logging.INFO)
         except DockerException:
             self.docker_client = None

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -26,6 +26,7 @@ from localstack.utils.container_utils.container_client import (
     VolumeInfo,
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
+from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient
 from localstack.utils.docker_utils import (
     container_ports_can_be_bound,
     is_container_port_reserved,
@@ -1328,6 +1329,16 @@ class TestDockerNetworking:
             docker_client.start_container(
                 container_name_or_id=container_2.container_id, attach=True
             )
+
+    def test_docker_sdk_timeout_seconds(self, monkeypatch):
+        # check that the timeout seconds are defined by the config variable
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS", 1337)
+        sdk_client = SdkDockerClient()
+        assert sdk_client.docker_client.api.timeout == 1337
+        # check that the config variable is reloaded when the client is recreated
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS", 987)
+        sdk_client = SdkDockerClient()
+        assert sdk_client.docker_client.api.timeout == 987
 
 
 class TestDockerPermissions:


### PR DESCRIPTION
We have recently seen flaky tests (on a new test environment which uses private GitHub runners). These tests failed due to request timeout errors within the Docker SDK client.

Some research led to an issue report in `docker-py`: https://github.com/docker/docker-py/issues/2266
According to these reports, these issues might be associated with the Docker daemon on the machine, and that it sometimes can happen that spawning a container takes a long time (i.e. longer than the default timeout of 60 seconds).

Since the Docker client is quite essential, and maybe some users are also facing issues like this in high-load scenarios, this PR introduces a config variable which allows globally setting the default timeout (in seconds) for the Docker SDK client.