### PR TITLE
Update to Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2004:2022.04.1"
+    default: "ubuntu-2004:2023.02.1"
   ubuntu-arm64-machine-image:
     type: string
-    default: "ubuntu-2004:2022.04.1"
+    default: "ubuntu-2004:2023.02.1"
 
 executors:
   ubuntu-machine-amd64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2004:2023.02.1"
+    default: "ubuntu-2204:2023.02.1"
   ubuntu-arm64-machine-image:
     type: string
-    default: "ubuntu-2004:2023.02.1"
+    default: "ubuntu-2204:2023.02.1"
 
 executors:
   ubuntu-machine-amd64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,6 @@ jobs:
       - restore_cache:
           key: python-requirements-{{ checksum "setup.cfg" }}
       - run:
-          name: Install prerequisites
-          command: |
-            # fix for: https://discuss.circleci.com/t/heroku-gpg-issues-in-ubuntu-images/43834/3
-            sudo rm -rf /etc/apt/sources.list.d/heroku.list
-            sudo apt-get update
-            sudo apt-get install -y libsasl2-dev
-      - run:
           name: Setup environment
           command: |
             make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,14 @@ jobs:
           at: /tmp/workspace
       - prepare-pytest-tinybird
       - run:
+          # legacy tests are executed locally, new runners ship with Java 17, downgrade to Java 11 for stepfunctions
+          name: Install OpenJDK 11
+          command: |
+            sudo apt-get update && sudo apt-get install openjdk-11-jdk
+            sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+            sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+            java -version
+      - run:
           name: Test 'local' Lambda executor
           environment:
             LAMBDA_EXECUTOR: "local"

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up system wide dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libsasl2-dev jq
+          sudo apt-get install jq
 
       - name: Set up Python 3.11
         id: setup-python

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -19,11 +19,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install libsasl2-dev jq
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Cache LocalStack community dependencies (venv)
         uses: actions/cache@v3

--- a/.github/workflows/marker-report-issue.yml
+++ b/.github/workflows/marker-report-issue.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: make install-dev

--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -23,7 +23,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Cache LocalStack community dependencies (venv)
         uses: actions/cache@v3

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install podman and test dependencies
         run: |

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14=14.9-0ubuntu0* postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.9-0ubuntu0* postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -154,7 +154,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Set up Node 18.x
         uses: actions/setup-node@v3

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -150,7 +150,7 @@ jobs:
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           path: localstack-ext
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         id: setup-python
         uses: actions/setup-python@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder: Stage to build a custom JRE (with jlink)
-FROM python:3.10.13-slim-bullseye@sha256:5277d9d2e03ced08b332eb2a8fb86bb0800b45ac9bf16c235b9e63d532b9ca38 as java-builder
+FROM python:3.11.5-slim-buster@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -37,7 +37,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java,...)
-FROM python:3.10.13-slim-bullseye@sha256:5277d9d2e03ced08b332eb2a8fb86bb0800b45ac9bf16c235b9e63d532b9ca38 as base
+FROM python:3.11.5-slim-buster@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies
@@ -167,9 +167,9 @@ RUN --mount=type=cache,target=/root/.cache \
     chmod -R 777 /usr/lib/localstack
 
 # link the python package installer virtual environments into the localstack venv
-RUN echo /var/lib/localstack/lib/python-packages/lib/python3.10/site-packages > localstack-var-python-packages-venv.pth && \
+RUN echo /var/lib/localstack/lib/python-packages/lib/python3.11/site-packages > localstack-var-python-packages-venv.pth && \
     mv localstack-var-python-packages-venv.pth .venv/lib/python*/site-packages/
-RUN echo /usr/lib/localstack/python-packages/lib/python3.10/site-packages > localstack-static-python-packages-venv.pth && \
+RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > localstack-static-python-packages-venv.pth && \
     mv localstack-static-python-packages-venv.pth .venv/lib/python*/site-packages/
 
 # Install the latest version of the LocalStack Persistence Plugin

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ docker-run:        		  ## Run Docker image locally
 
 docker-mount-run:
 	MOTO_DIR=$$(echo $$(pwd)/.venv/lib/python*/site-packages/moto | awk '{print $$NF}'); echo MOTO_DIR $$MOTO_DIR; \
-		DOCKER_FLAGS="$(DOCKER_FLAGS) -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/plugins.py:/opt/code/localstack/localstack/plugins.py -v `pwd`/localstack/plugin:/opt/code/localstack/localstack/plugin -v `pwd`/localstack/runtime:/opt/code/localstack/localstack/runtime -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/http:/opt/code/localstack/localstack/http -v `pwd`/localstack/contrib:/opt/code/localstack/localstack/contrib -v `pwd`/tests:/opt/code/localstack/tests -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.10/site-packages/moto/" make docker-run
+		DOCKER_FLAGS="$(DOCKER_FLAGS) -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/plugins.py:/opt/code/localstack/localstack/plugins.py -v `pwd`/localstack/plugin:/opt/code/localstack/localstack/plugin -v `pwd`/localstack/runtime:/opt/code/localstack/localstack/runtime -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/http:/opt/code/localstack/localstack/http -v `pwd`/localstack/contrib:/opt/code/localstack/localstack/contrib -v `pwd`/tests:/opt/code/localstack/tests -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/" make docker-run
 
 docker-cp-coverage:
 	@echo 'Extracting .coverage file from Docker image'; \
@@ -194,13 +194,13 @@ test-docker-mount:		  ## Run automated tests in Docker (mounting local code)
 	# TODO: find a cleaner way to mount/copy the dependencies into the container...
 	VENV_DIR=$$(pwd)/.venv/; \
 		PKG_DIR=$$(echo $$VENV_DIR/lib/python*/site-packages | awk '{print $$NF}'); \
-		PKG_DIR_CON=/opt/code/localstack/.venv/lib/python3.10/site-packages; \
+		PKG_DIR_CON=/opt/code/localstack/.venv/lib/python3.11/site-packages; \
 		echo "#!/usr/bin/env python" > /tmp/pytest.ls.bin; cat $$VENV_DIR/bin/pytest >> /tmp/pytest.ls.bin; chmod +x /tmp/pytest.ls.bin; \
 		DOCKER_FLAGS="-v `pwd`/tests:/opt/code/localstack/tests -v /tmp/pytest.ls.bin:/opt/code/localstack/.venv/bin/pytest -v $$PKG_DIR/deepdiff:$$PKG_DIR_CON/deepdiff -v $$PKG_DIR/ordered_set:$$PKG_DIR_CON/ordered_set -v $$PKG_DIR/py:$$PKG_DIR_CON/py -v $$PKG_DIR/pluggy:$$PKG_DIR_CON/pluggy -v $$PKG_DIR/iniconfig:$$PKG_DIR_CON/iniconfig -v $$PKG_DIR/jsonpath_ng:$$PKG_DIR_CON/jsonpath_ng -v $$PKG_DIR/packaging:$$PKG_DIR_CON/packaging -v $$PKG_DIR/pytest:$$PKG_DIR_CON/pytest -v $$PKG_DIR/pytest_httpserver:$$PKG_DIR_CON/pytest_httpserver -v $$PKG_DIR/_pytest:$$PKG_DIR_CON/_pytest -v $$PKG_DIR/_pytest:$$PKG_DIR_CON/orjson" make test-docker-mount-code
 
 test-docker-mount-code:
 	PACKAGES_DIR=$$(echo $$(pwd)/.venv/lib/python*/site-packages | awk '{print $$NF}'); \
-		DOCKER_FLAGS="$(DOCKER_FLAGS) --entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/aws:/opt/code/localstack/localstack/aws -v `pwd`/Makefile:/opt/code/localstack/Makefile -v $$PACKAGES_DIR/moto:/opt/code/localstack/.venv/lib/python3.10/site-packages/moto/ -e TEST_PATH=\\'$(TEST_PATH)\\' -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS) $(ENTRYPOINT)" CMD="make test" make docker-run
+		DOCKER_FLAGS="$(DOCKER_FLAGS) --entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/aws:/opt/code/localstack/localstack/aws -v `pwd`/Makefile:/opt/code/localstack/Makefile -v $$PACKAGES_DIR/moto:/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ -e TEST_PATH=\\'$(TEST_PATH)\\' -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS) $(ENTRYPOINT)" CMD="make test" make docker-run
 
 lint:              		  ## Run code linter to check code style
 	($(VENV_RUN); python -m pflake8 --show-source)

--- a/localstack/dev/run/paths.py
+++ b/localstack/dev/run/paths.py
@@ -38,7 +38,7 @@ class ContainerPaths:
     """Important paths in the container"""
 
     project_dir: str = "/opt/code/localstack"
-    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.10/site-packages"
+    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.11/site-packages"
     docker_entrypoint: str = "/usr/local/bin/docker-entrypoint.sh"
     localstack_supervisor: str = "/usr/local/bin/localstack-supervisor"
     localstack_source_dir: str

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -1,11 +1,17 @@
 import logging
+import os
 import select
 import socket
+import ssl
+from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
 from localstack.constants import BIND_HOST, LOCALHOST_IP
+from localstack.utils.files import new_tmp_file, save_file
 from localstack.utils.functions import run_safe
 from localstack.utils.numbers import is_number
+from localstack.utils.serving import Server
+from localstack.utils.ssl import create_ssl_cert
 from localstack.utils.threads import start_worker_thread
 
 LOG = logging.getLogger(__name__)
@@ -73,3 +79,98 @@ def start_tcp_proxy(src, dst, handler, **kwargs):
             start_worker_thread(lambda *args, _thread: handle_request(src_socket, _thread))
         except socket.timeout:
             pass
+
+
+def _save_cert_keys(client_cert_key: tuple[str, str]) -> tuple[str, str]:
+    """
+    Save the given cert / key into files and returns their filename
+    :param client_cert_key: tuple with (client_cert, client_key)
+    :return: tuple of paths to files containing (client_cert, client_key)
+    """
+    cert_file = client_cert_key[0]
+    if not os.path.exists(cert_file):
+        cert_file = new_tmp_file()
+        save_file(cert_file, client_cert_key[0])
+    key_file = client_cert_key[1]
+    if not os.path.exists(key_file):
+        key_file = new_tmp_file()
+        save_file(key_file, client_cert_key[1])
+    return cert_file, key_file
+
+
+class TLSProxyServer(Server):
+    thread_pool: ThreadPoolExecutor
+    client_certs: tuple[str, str]
+    socket: socket.socket | None
+    target_host: str
+    target_port: str
+
+    def __init__(
+        self,
+        port: int,
+        target: str,
+        host: str = "localhost",
+        client_certs: tuple[str, str] | None = None,
+    ):
+        super().__init__(port, host)
+        self.target_host, _, self.target_port = target.partition(":")
+        self.thread_pool = ThreadPoolExecutor()
+        self.client_certs = client_certs
+        self.socket = None
+
+    def _handle_socket(self, source_socket: ssl.SSLSocket, client_address: str) -> None:
+        LOG.debug(
+            "Handling connection from %s to %s:%s",
+            client_address,
+            self.target_host,
+            self.target_port,
+        )
+        try:
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+            if self.client_certs:
+                LOG.debug("Configuring ssl proxy to use client certs")
+                cert_file, key_file = _save_cert_keys(client_cert_key=self.client_certs)
+                context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+            with socket.create_connection((self.target_host, int(self.target_port))) as sock:
+                with context.wrap_socket(sock, server_hostname=self.target_host) as target_socket:
+                    sockets = [source_socket, target_socket]
+                    while not self._stopped.is_set():
+                        s_read, _, _ = select.select(sockets, [], [])
+
+                        for s in s_read:
+                            data = s.recv(BUFFER_SIZE)
+                            if not data:
+                                return
+
+                            if s == source_socket:
+                                target_socket.sendall(data)
+                            elif s == target_socket:
+                                source_socket.sendall(data)
+        except Exception as e:
+            LOG.warning(
+                "Error while proxying SSL request: %s", e, exc_info=LOG.isEnabledFor(logging.DEBUG)
+            )
+
+    def do_run(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+        _, cert_file_name, key_file_name = create_ssl_cert()
+        context.load_cert_chain(cert_file_name, key_file_name)
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
+            self.socket = sock
+            sock.bind((self.host, self.port))
+            sock.listen()
+            with context.wrap_socket(sock, server_side=True) as ssock:
+                while not self._stopped.is_set():
+                    try:
+                        conn, addr = ssock.accept()
+                        self.thread_pool.submit(self._handle_socket, conn, addr)
+                    except Exception as e:
+                        LOG.exception("Error accepting socket: %s", e)
+
+    def do_shutdown(self):
+        if self.socket:
+            self.socket.close()

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -1,17 +1,11 @@
 import logging
-import os
 import select
 import socket
-import ssl
-from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
 from localstack.constants import BIND_HOST, LOCALHOST_IP
-from localstack.utils.files import new_tmp_file, save_file
 from localstack.utils.functions import run_safe
 from localstack.utils.numbers import is_number
-from localstack.utils.serving import Server
-from localstack.utils.ssl import create_ssl_cert
 from localstack.utils.threads import start_worker_thread
 
 LOG = logging.getLogger(__name__)
@@ -79,98 +73,3 @@ def start_tcp_proxy(src, dst, handler, **kwargs):
             start_worker_thread(lambda *args, _thread: handle_request(src_socket, _thread))
         except socket.timeout:
             pass
-
-
-def _save_cert_keys(client_cert_key: tuple[str, str]) -> tuple[str, str]:
-    """
-    Save the given cert / key into files and returns their filename
-    :param client_cert_key: tuple with (client_cert, client_key)
-    :return: tuple of paths to files containing (client_cert, client_key)
-    """
-    cert_file = client_cert_key[0]
-    if not os.path.exists(cert_file):
-        cert_file = new_tmp_file()
-        save_file(cert_file, client_cert_key[0])
-    key_file = client_cert_key[1]
-    if not os.path.exists(key_file):
-        key_file = new_tmp_file()
-        save_file(key_file, client_cert_key[1])
-    return cert_file, key_file
-
-
-class TLSProxyServer(Server):
-    thread_pool: ThreadPoolExecutor
-    client_certs: tuple[str, str]
-    socket: socket.socket | None
-    target_host: str
-    target_port: str
-
-    def __init__(
-        self,
-        port: int,
-        target: str,
-        host: str = "localhost",
-        client_certs: tuple[str, str] | None = None,
-    ):
-        super().__init__(port, host)
-        self.target_host, _, self.target_port = target.partition(":")
-        self.thread_pool = ThreadPoolExecutor()
-        self.client_certs = client_certs
-        self.socket = None
-
-    def _handle_socket(self, source_socket: ssl.SSLSocket, client_address: str) -> None:
-        LOG.debug(
-            "Handling connection from %s to %s:%s",
-            client_address,
-            self.target_host,
-            self.target_port,
-        )
-        try:
-            context = ssl.create_default_context()
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
-            if self.client_certs:
-                LOG.debug("Configuring ssl proxy to use client certs")
-                cert_file, key_file = _save_cert_keys(client_cert_key=self.client_certs)
-                context.load_cert_chain(certfile=cert_file, keyfile=key_file)
-            with socket.create_connection((self.target_host, int(self.target_port))) as sock:
-                with context.wrap_socket(sock, server_hostname=self.target_host) as target_socket:
-                    sockets = [source_socket, target_socket]
-                    while not self._stopped.is_set():
-                        s_read, _, _ = select.select(sockets, [], [])
-
-                        for s in s_read:
-                            data = s.recv(BUFFER_SIZE)
-                            if not data:
-                                return
-
-                            if s == source_socket:
-                                target_socket.sendall(data)
-                            elif s == target_socket:
-                                source_socket.sendall(data)
-        except Exception as e:
-            LOG.warning(
-                "Error while proxying SSL request: %s", e, exc_info=LOG.isEnabledFor(logging.DEBUG)
-            )
-
-    def do_run(self):
-        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-
-        _, cert_file_name, key_file_name = create_ssl_cert()
-        context.load_cert_chain(cert_file_name, key_file_name)
-
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
-            self.socket = sock
-            sock.bind((self.host, self.port))
-            sock.listen()
-            with context.wrap_socket(sock, server_side=True) as ssock:
-                while not self._stopped.is_set():
-                    try:
-                        conn, addr = ssock.accept()
-                        self.thread_pool.submit(self._handle_socket, conn, addr)
-                    except Exception as e:
-                        LOG.exception("Error accepting socket: %s", e)
-
-    def do_shutdown(self):
-        if self.socket:
-            self.socket.close()

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -17,7 +17,6 @@ from localstack.utils.threads import start_worker_thread
 LOG = logging.getLogger(__name__)
 
 BUFFER_SIZE = 2**10  # 1024
-TLS_BUFFER_SIZE = 16384  # 16 KB, max TLS record size
 
 PortOrUrl = Union[str, int]
 
@@ -141,7 +140,7 @@ class TLSProxyServer(Server):
                         s_read, _, _ = select.select(sockets, [], [])
 
                         for s in s_read:
-                            data = s.recv(TLS_BUFFER_SIZE)
+                            data = s.recv(BUFFER_SIZE)
                             if not data:
                                 return
 
@@ -153,9 +152,6 @@ class TLSProxyServer(Server):
             LOG.warning(
                 "Error while proxying SSL request: %s", e, exc_info=LOG.isEnabledFor(logging.DEBUG)
             )
-        finally:
-            source_socket.close()
-            LOG.debug("Connection finished!")
 
     def do_run(self):
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -172,8 +168,6 @@ class TLSProxyServer(Server):
                     try:
                         conn, addr = ssock.accept()
                         self.thread_pool.submit(self._handle_socket, conn, addr)
-                    except ssl.SSLZeroReturnError:
-                        pass
                     except Exception as e:
                         LOG.exception("Error accepting socket: %s", e)
 

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -115,7 +115,7 @@ class TLSProxyServer(Server):
     ):
         super().__init__(port, host)
         self.target_host, _, self.target_port = target.partition(":")
-        self.thread_pool = ThreadPoolExecutor(32)
+        self.thread_pool = ThreadPoolExecutor()
         self.client_certs = client_certs
         self.socket = None
 
@@ -141,12 +141,9 @@ class TLSProxyServer(Server):
                         s_read, _, _ = select.select(sockets, [], [])
 
                         for s in s_read:
-                            data = s.recv(1024)
+                            data = s.recv(TLS_BUFFER_SIZE)
                             if not data:
                                 return
-                            pending_data = s.pending()
-                            if pending_data:
-                                data += s.recv(pending_data)
 
                             if s == source_socket:
                                 target_socket.sendall(data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = LocalStack Contributors
 author_email = info@localstack.cloud
 license = Apache License 2.0
 classifiers =
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: Apache Software License
     Topic :: Internet
     Topic :: Software Development :: Testing

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,6 @@ runtime =
     localstack-client>=2.0
     moto-ext[all]==4.2.4.post1
     opensearch-py==2.1.1
-    pproxy>=2.7.0
     pymongo>=4.2.0
     pyopenssl>=23.0.0
     Quart>=0.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     click>=7.0
     cachetools~=5.0.0
     cryptography
-    dill==0.3.2
+    dill==0.3.6
     dnslib>=0.9.10
     dnspython>=1.16.0
     plux>=1.3.1

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -108,7 +108,7 @@ TEST_LAMBDA_CONTEXT_REQID = os.path.join(THIS_FOLDER, "functions/lambda_context.
 PYTHON_TEST_RUNTIMES = (
     RUNTIMES_AGGREGATED["python"]
     if (not is_old_provider() or use_docker()) and get_arch() != Arch.arm64
-    else [Runtime.python3_10]
+    else [Runtime.python3_11]
 )
 NODE_TEST_RUNTIMES = (
     RUNTIMES_AGGREGATED["nodejs"]


### PR DESCRIPTION
## Motivation
This PR contains all changes necessary to upgrade our Python version for the runtime from 3.10 to 3.11.

## Changes
- Update all CircleCI runners (which use Python 3.11 by default).
- Update all GitHub actions to install Python 3.11 instead of Python 3.10.
- Install `libsnappy-dev` instead of `libsasl2-dev` when running against Pro (see changes there for a detailed explanation).
- Update the dockerfile base image to the latest sha digest of Python 3.11.5.
- Update all references to virtual environments which contain the Python version (f.e. `/usr/lib/localstack/python-packages/lib/python3.11/site-packages`).
- Remove the SSL proxy (it's not used in Community anymore and the used library - `python-proxy` - is not maintained and not compatible with 3.11).
- Update dill to a Python 3.11 compatible version.
- Update the Lambda Runtime version used for local execution (in the runtime of LocalStack itself) from 3.10 to 3.11.

## Impact
This PR only updates the runtime version of LocalStack itself. The LocalStack CLI will still be compatible with Python 3.7+.
However, [Python Initialization Hooks](https://docs.localstack.cloud/references/init-hooks/) and [LocalStack Extensions](https://docs.localstack.cloud/references/localstack-extensions/) will then run in a Python 3.11 environment instead of Python 3.10.

## TODO:
- [x] Analyze Podman tests (unrelated)
- [x] Ensure compatibility with LocalStack Pro before merging this PR.