### PR TITLE
fix wrong service mapping to s3 vhost bucket

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -344,7 +344,8 @@ def determine_aws_service_name(request: Request, services: ServiceCatalog = None
     if host:
         # iterate over the service spec's endpoint prefix
         for prefix, services_per_prefix in services.endpoint_prefix_index.items():
-            if host.startswith(prefix):
+            # this prevents a virtual host addressed bucket to be wrongly recognized
+            if host.startswith(f"{prefix}.") and ".s3." not in host:
                 if len(services_per_prefix) == 1:
                     return services_per_prefix[0]
                 candidates.update(services_per_prefix)

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -200,3 +200,19 @@ def test_endpoint_prefix_based_routing():
         )
     )
     assert detected_service_name == "chime-sdk-identity"
+
+
+def test_endpoint_prefix_based_routing_s3_virtual_host():
+    detected_service_name = determine_aws_service_name(
+        Request(method="GET", path="/", headers={"Host": "pictures.s3.localhost.localstack.cloud"})
+    )
+    assert detected_service_name == "s3"
+
+    detected_service_name = determine_aws_service_name(
+        Request(
+            method="POST",
+            path="/app-instances",
+            headers={"Host": "kms.s3.localhost.localstack.cloud"},
+        )
+    )
+    assert detected_service_name == "s3"


### PR DESCRIPTION
This PR fixes the issue reported in #8090.

### Issue

The flow is the following:
- request received as virtual host addressed : Host = `pictures.s3.localhost.localstack.cloud`
- the S3 CORS handler does its job correctly
- service name parser wrongly attributes this request to the service named `pi` because the host starts with `pi`
- the general CORS handler thinks it's not an S3 request and reject the request without taking into account S3 CORS config


Note that this issue could arise as well with any bucket name starting with an AWS service with an endpoint prefix, like `kmstest` or anything (you can play with the added test to see everything that would break). This did not affect functionality directly, as the request would be correctly routed to the right service in the end because it would be matched on the service router, but it greatly interfere with the CORS handler.

### Solution

I've added some checks in the service name parser, to verify that the request is not an S3 request when trying to match on the host. I'm not fond of the `".s3." not in host`, but the only other solution would be to forbid the creation of any S3 bucket with a conflictual name with any AWS service endpoint prefix (which is possible to do too).
I'm open to suggestion as to how to make this better, but it seems to fix the issue for now.

_fix #8090_

