### PR TITLE
fix: add check on plaintext size to kms encrypt operation 

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -627,6 +627,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         encryption_algorithm: EncryptionAlgorithmSpec = None,
     ) -> EncryptResponse:
         key = self._get_key(context, key_id)
+        self._validate_plaintext_length(plaintext)
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 
@@ -998,6 +999,13 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 raise InvalidKeyUsageException(
                     f"Algorithm {algorithm} is incompatible with key spec {key_spec}."
                 )
+
+    def _validate_plaintext_length(self, plaintext: bytes):
+        if len(plaintext) > 4096:
+            raise ValidationException(
+                "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: "
+                "Member must have length less than or equal to 4096"
+            )
 
     def _validate_grant_request(self, data: Dict, store: KmsStore):
         if "KeyId" not in data or "GranteePrincipal" not in data or "Operations" not in data:

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1083,3 +1083,12 @@ class TestKMS:
         with pytest.raises(ClientError) as e:
             kms_client.encrypt(Plaintext="test message 123!@#", KeyId=sign_verify_key_id)
         snapshot.match("encrypt-invalid-key-id", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_plaintext_size_for_encrypt(self, kms_create_key, snapshot, aws_client):
+        key_id = kms_create_key()["KeyId"]
+        message = b"test message 123 !%$@ 1234567890"
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.encrypt(KeyId=key_id, Plaintext=base64.b64encode(message * 100))
+        snapshot.match("invalid-plaintext-size-encrypt", e.value.response)

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1294,5 +1294,20 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_plaintext_size_for_encrypt": {
+    "recorded-date": "07-04-2023, 10:52:32",
+    "recorded-content": {
+      "invalid-plaintext-size-encrypt": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length less than or equal to 4096"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- validate length of data to be encrypted 
- add test case to check this condition 

Related issue #8083 