### PR TITLE
SQS: Add cross-account support

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -169,9 +169,13 @@ try:
 except Exception:
     MAX_POOL_CONNECTIONS = 150
 
-# test credentials used for generating signature for S3 presigned URLs (to be used by external clients)
+# credentials used in the test suite
 TEST_AWS_ACCESS_KEY_ID = "test"
 TEST_AWS_SECRET_ACCESS_KEY = "test"
+
+# additional credentials used in the test suite (mainly for cross-account access)
+SECONDARY_TEST_AWS_ACCESS_KEY_ID = "test2"
+SECONDARY_TEST_AWS_SECRET_ACCESS_KEY = "test2"
 
 # credentials being used for internal calls
 INTERNAL_AWS_ACCESS_KEY_ID = "__internal_call__"

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -447,7 +447,7 @@ class SqsDeveloperEndpoints:
             raise QueueDoesNotExist()
 
         try:
-            region, account_id, queue_name = parse_queue_url(request.values["QueueUrl"])
+            account_id, region, queue_name = parse_queue_url(request.values["QueueUrl"])
         except ValueError:
             LOG.exception("Error while parsing Queue URL from request values: %s", request.values)
             raise InvalidAddress()
@@ -1288,10 +1288,14 @@ def resolve_queue_location(
     :return: tuple of account id, region and queue_name
     """
     if not queue_name:
-        if queue_url:
-            return parse_queue_url(queue_url)
-        else:
-            return parse_queue_url(context.request.base_url)
+        try:
+            if queue_url:
+                return parse_queue_url(queue_url)
+            else:
+                return parse_queue_url(context.request.base_url)
+        except ValueError:
+            # should work if queue name is passed in QueueUrl
+            return context.account_id, context.region, queue_url
 
     return context.account_id, context.region, queue_name
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -605,7 +605,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         :raises QueueDoesNotExist: if the queue does not exist
         """
         account_id, region_name, name = resolve_queue_location(context, queue_name, queue_url)
-        return self._require_queue(account_id, region_name, name)
+        return self._require_queue(account_id, region_name or context.region, name)
 
     def create_queue(
         self,

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -539,6 +539,19 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         - Pagination of results (NextToken)
         - Delivery guarantees
         - The region is not encoded in the queue URL
+
+    CROSS-ACCOUNT ACCESS:
+    LocalStack permits cross-account access for all operations. However, AWS
+    disallows the same for following operations:
+        - AddPermission
+        - CreateQueue
+        - DeleteQueue
+        - ListQueues
+        - ListQueueTags
+        - RemovePermission
+        - SetQueueAttributes
+        - TagQueue
+        - UntagQueue
     """
 
     queues: Dict[str, SqsQueue]

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -7,7 +7,7 @@ import threading
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from queue import Empty
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from moto.sqs.models import BINARY_TYPE_FIELD_INDEX, STRING_TYPE_FIELD_INDEX
 from moto.sqs.models import Message as MotoMessage
@@ -568,7 +568,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         self._cloudwatch_publish_worker.stop()
         self._cloudwatch_dispatcher.shutdown()
 
-    def _require_queue(self, context: RequestContext, name: str) -> SqsQueue:
+    def _require_queue(self, account_id: str, region_name: str, name: str) -> SqsQueue:
         """
         Returns the queue for the given name, or raises QueueDoesNotExist if it does not exist.
 
@@ -577,7 +577,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         :returns: the queue
         :raises QueueDoesNotExist: if the queue does not exist
         """
-        store = self.get_store(context.account_id, context.region)
+        store = self.get_store(account_id, region_name)
         with self._mutex:
             if name not in store.queues.keys():
                 raise QueueDoesNotExist("The specified queue does not exist for this wsdl version.")
@@ -586,7 +586,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     def _require_queue_by_arn(self, context: RequestContext, queue_arn: str) -> SqsQueue:
         arn = parse_arn(queue_arn)
-        return self._require_queue(context, arn["resource"])
+        return self._require_queue(arn.account, arn.region, arn["resource"])
 
     def _resolve_queue(
         self,
@@ -604,8 +604,8 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         :returns: the queue
         :raises QueueDoesNotExist: if the queue does not exist
         """
-        name = resolve_queue_name(context, queue_name, queue_url)
-        return self._require_queue(context, name)
+        account_id, region_name, name = resolve_queue_location(context, queue_name, queue_url)
+        return self._require_queue(account_id, region_name, name)
 
     def create_queue(
         self,
@@ -1276,28 +1276,24 @@ def _create_message_attribute_hash(message_attributes) -> Optional[str]:
     return hash.hexdigest()
 
 
-def get_queue_name_from_url(queue_url: str) -> str:
-    return queue_url.rstrip("/").split("/")[-1]
-
-
-def resolve_queue_name(
+def resolve_queue_location(
     context: RequestContext, queue_name: Optional[str] = None, queue_url: Optional[str] = None
-) -> str:
+) -> Tuple[str, Optional[str], str]:
     """
-    Resolves a queue name from the given information.
+    Resolves a queue location from the given information.
 
     :param context: the request context, used for getting region and account_id, and optionally the queue_url
     :param queue_name: the queue name (if this is set, then this will be used for the key)
     :param queue_url: the queue url (if name is not set, this will be used to determine the queue name)
-    :return: the queue name describing the queue being requested
+    :return: tuple of account id, region and queue_name
     """
     if not queue_name:
         if queue_url:
-            queue_name = get_queue_name_from_url(queue_url)
+            return parse_queue_url(queue_url)
         else:
-            queue_name = get_queue_name_from_url(context.request.base_url)
+            return parse_queue_url(context.request.base_url)
 
-    return queue_name
+    return context.account_id, context.region, queue_name
 
 
 def message_filter_attributes(message: Message, names: Optional[AttributeNameList]):

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -586,7 +586,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     def _require_queue_by_arn(self, context: RequestContext, queue_arn: str) -> SqsQueue:
         arn = parse_arn(queue_arn)
-        return self._require_queue(arn.account, arn.region, arn["resource"])
+        return self._require_queue(arn["account"], arn["region"], arn["resource"])
 
     def _resolve_queue(
         self,

--- a/localstack/services/sqs/utils.py
+++ b/localstack/services/sqs/utils.py
@@ -24,7 +24,7 @@ def is_sqs_queue_url(url):
 
 def parse_queue_url(queue_url: str) -> Tuple[str, Optional[str], str]:
     """
-    Parses an SQS Queue URL and returns a triple of region, account_id, and queue_name.
+    Parses an SQS Queue URL and returns a triple of account_id, region and queue_name.
 
     :param queue_url: the queue URL
     :return: account_id, region (may be None), queue_name

--- a/localstack/services/sqs/utils.py
+++ b/localstack/services/sqs/utils.py
@@ -22,12 +22,12 @@ def is_sqs_queue_url(url):
     return re.match(r"^/(queue|%s)/[a-zA-Z0-9_-]+(.fifo)?$" % get_aws_account_id(), path)
 
 
-def parse_queue_url(queue_url: str) -> Tuple[Optional[str], str, str]:
+def parse_queue_url(queue_url: str) -> Tuple[str, Optional[str], str]:
     """
     Parses an SQS Queue URL and returns a triple of region, account_id, and queue_name.
 
     :param queue_url: the queue URL
-    :return: region (may be None), account_id, queue_name
+    :return: account_id, region (may be None), queue_name
     """
     url = urlparse(queue_url.rstrip("/"))
     path_parts = url.path.lstrip("/").split("/")
@@ -55,7 +55,7 @@ def parse_queue_url(queue_url: str) -> Tuple[Optional[str], str, str]:
     else:
         region = None
 
-    return region, account_id, queue_name
+    return account_id, region, queue_name
 
 
 def parse_message_attributes(

--- a/tests/integration/test_sqs_backdoor.py
+++ b/tests/integration/test_sqs_backdoor.py
@@ -179,7 +179,7 @@ class TestSqsDeveloperEdpoints:
         aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-1")
         aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-2")
 
-        region, account, name = parse_queue_url(queue_url)
+        account, region, name = parse_queue_url(queue_url)
         # sometimes the region cannot be determined from the queue url, we make no assumptions about this in this test
         region = region or aws_client.sqs.meta.region_name
 

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -69,40 +69,40 @@ def test_check_message_size():
 
 def test_parse_queue_url_valid():
     assert parse_queue_url("http://localhost:4566/queue/eu-central-2/000000000001/my-queue") == (
-        "eu-central-2",
         "000000000001",
+        "eu-central-2",
         "my-queue",
     )
     assert parse_queue_url("http://localhost:4566/000000000001/my-queue") == (
-        None,
         "000000000001",
+        None,
         "my-queue",
     )
     assert parse_queue_url("http://localhost/000000000001/my-queue") == (
-        None,
         "000000000001",
+        None,
         "my-queue",
     )
 
     assert parse_queue_url("http://localhost/queue/eu-central-2/000000000001/my-queue") == (
-        "eu-central-2",
         "000000000001",
+        "eu-central-2",
         "my-queue",
     )
 
     assert parse_queue_url(
         "http://queue.localhost.localstack.cloud:4566/000000000001/my-queue"
     ) == (
-        "us-east-1",
         "000000000001",
+        "us-east-1",
         "my-queue",
     )
 
     assert parse_queue_url(
         "http://eu-central-2.queue.localhost.localstack.cloud:4566/000000000001/my-queue"
     ) == (
-        "eu-central-2",
         "000000000001",
+        "eu-central-2",
         "my-queue",
     )
 
@@ -110,8 +110,8 @@ def test_parse_queue_url_valid():
     assert parse_queue_url(
         "http://eu-central-2.foobar.localhost.localstack.cloud:4566/000000000001/my-queue"
     ) == (
-        None,
         "000000000001",
+        None,
         "my-queue",
     )
 


### PR DESCRIPTION
This PR makes SQS queues resolve based on the account ID and region in the queue URL.

Previously this was based on request context.