### PR TITLE
fix invalid error message for decrypt with incorrect key

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -53,6 +53,7 @@ from localstack.aws.api.kms import (
     GrantTokenList,
     GrantTokenType,
     ImportKeyMaterialResponse,
+    IncorrectKeyException,
     InvalidCiphertextException,
     InvalidGrantIdException,
     InvalidKeyUsageException,
@@ -664,11 +665,10 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         key = self._get_key(context, key_id)
         key_id = key.metadata["KeyId"]
         if key_id != ciphertext.key_id:
-            # Haven't checked if this is the exception being raised by AWS in such cases.
-            ValidationError(
-                f"The supplied KeyId {key_id} doesn't match the KeyId {ciphertext.key_id} present in "
-                f"ciphertext. Keep in mind that LocalStack currently doesn't perform asymmetric encryption"
+            raise IncorrectKeyException(
+                "The key ID in the request does not identify a CMK that can perform this operation."
             )
+
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1247,7 +1247,7 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_error_messaging_for_invalid_keys": {
-    "recorded-date": "06-04-2023, 16:59:05",
+    "recorded-date": "07-04-2023, 14:16:00",
     "recorded-content": {
       "generate-mac-invalid-key-id": {
         "Error": {
@@ -1288,6 +1288,17 @@
           "Message": "<key-arn> key usage is SIGN_VERIFY which is not valid for Encrypt."
         },
         "message": "<key-arn> key usage is SIGN_VERIFY which is not valid for Encrypt.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "decrypt-invalid-key-id": {
+        "Error": {
+          "Code": "IncorrectKeyException",
+          "Message": "The key ID in the request does not identify a CMK that can perform this operation."
+        },
+        "message": "The key ID in the request does not identify a CMK that can perform this operation.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400


### PR DESCRIPTION
- Fixed error message for decrypt when the key id is different from the one used in encryption
- Added a test case to verify the changes
- Removed old AWS client for test case: `test_error_messaging_for_invalid_keys`