### PR TITLE
fix: Adding validation on kms plaintext based on the key type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,21 +115,21 @@ Learn more about [LocalStack AWS services](https://docs.localstack.cloud/referen
 
 You can run LocalStack through the following options:
 
-- [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli)
-- [Docker](https://docs.localstack.cloud/getting-started/installation/#docker)
-- [Docker Compose](https://docs.localstack.cloud/getting-started/installation/#docker-compose)
-- [Helm](https://docs.localstack.cloud/getting-started/installation/#helm)
+* [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli)
+* [Docker](https://docs.localstack.cloud/getting-started/installation/#docker)
+* [Docker Compose](https://docs.localstack.cloud/getting-started/installation/#docker-compose)
+* [Helm](https://docs.localstack.cloud/getting-started/installation/#helm)
 
 ## Usage
 
 To start using LocalStack, check out our documentation at <https://docs.localstack.cloud>.
 
-- [LocalStack Configuration](https://docs.localstack.cloud/references/configuration/)
-- [LocalStack in CI](https://docs.localstack.cloud/user-guide/ci/)
-- [LocalStack Integrations](https://docs.localstack.cloud/user-guide/integrations/)
-- [LocalStack Tools](https://docs.localstack.cloud/user-guide/tools/)
-- [Understanding LocalStack](https://docs.localstack.cloud/references/)
-- [Troubleshoot](doc/troubleshoot/README.md)
+* [LocalStack Configuration](https://docs.localstack.cloud/references/configuration/)
+* [LocalStack in CI](https://docs.localstack.cloud/user-guide/ci/)
+* [LocalStack Integrations](https://docs.localstack.cloud/user-guide/integrations/)
+* [LocalStack Tools](https://docs.localstack.cloud/user-guide/tools/)
+* [Understanding LocalStack](https://docs.localstack.cloud/references/)
+* [Troubleshoot](doc/troubleshoot/README.md)
 
 To use LocalStack with a graphical user interface, you can use the following UI clients:
 
@@ -144,9 +144,9 @@ Please refer to [GitHub releases](https://github.com/localstack/localstack/relea
 
 If you are interested in contributing to LocalStack:
 
-- Start by reading our [contributing guide](CONTRIBUTING.md).
-- Check out our [developer guide](https://docs.localstack.cloud/contributing/).
-- Navigate our codebase and [open issues](https://github.com/localstack/localstack/issues).
+* Start by reading our [contributing guide](CONTRIBUTING.md).
+* Check out our [developer guide](https://docs.localstack.cloud/contributing/).
+* Navigate our codebase and [open issues](https://github.com/localstack/localstack/issues).
 
 We are thankful for all the contributions and feedback we receive.
 
@@ -154,9 +154,9 @@ We are thankful for all the contributions and feedback we receive.
 
 To get in touch with LocalStack team for bugs/feature requests, support questions or general discussions, please use:
 
-- [LocalStack Slack Community](https://localstack.cloud/contact/)
-- [LocalStack Discussion Page](https://discuss.localstack.cloud/)
-- [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
+* [LocalStack Slack Community](https://localstack.cloud/contact/)
+* [LocalStack Discussion Page](https://discuss.localstack.cloud/)
+* [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ LocalStack also provides additional features to make your life as a cloud develo
 
 ## Requirements
 
-- `python` (Python 3.7 up to 3.11 supported)
-- `pip` (Python package manager)
-- `Docker`
+* `python` (Python 3.7 up to 3.11 supported)
+* `pip` (Python package manager)
+* `Docker`
 
 ## Installing
 
@@ -133,8 +133,8 @@ To start using LocalStack, check out our documentation at <https://docs.localsta
 
 To use LocalStack with a graphical user interface, you can use the following UI clients:
 
-- [Commandeer desktop app](https://getcommandeer.com)
-- [DynamoDB Admin Web UI](https://www.npmjs.com/package/dynamodb-admin)
+* [Commandeer desktop app](https://getcommandeer.com)
+* [DynamoDB Admin Web UI](https://www.npmjs.com/package/dynamodb-admin)
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ LocalStack also provides additional features to make your life as a cloud develo
 
 ## Requirements
 
-* `python` (Python 3.7 up to 3.11 supported)
-* `pip` (Python package manager)
-* `Docker`
+- `python` (Python 3.7 up to 3.11 supported)
+- `pip` (Python package manager)
+- `Docker`
 
 ## Installing
 
@@ -115,26 +115,26 @@ Learn more about [LocalStack AWS services](https://docs.localstack.cloud/referen
 
 You can run LocalStack through the following options:
 
-* [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli)
-* [Docker](https://docs.localstack.cloud/getting-started/installation/#docker)
-* [Docker Compose](https://docs.localstack.cloud/getting-started/installation/#docker-compose)
-* [Helm](https://docs.localstack.cloud/getting-started/installation/#helm)
+- [LocalStack CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli)
+- [Docker](https://docs.localstack.cloud/getting-started/installation/#docker)
+- [Docker Compose](https://docs.localstack.cloud/getting-started/installation/#docker-compose)
+- [Helm](https://docs.localstack.cloud/getting-started/installation/#helm)
 
 ## Usage
 
 To start using LocalStack, check out our documentation at <https://docs.localstack.cloud>.
 
-* [LocalStack Configuration](https://docs.localstack.cloud/references/configuration/)
-* [LocalStack in CI](https://docs.localstack.cloud/user-guide/ci/)
-* [LocalStack Integrations](https://docs.localstack.cloud/user-guide/integrations/)
-* [LocalStack Tools](https://docs.localstack.cloud/user-guide/tools/)
-* [Understanding LocalStack](https://docs.localstack.cloud/references/)
-* [Troubleshoot](doc/troubleshoot/README.md)
+- [LocalStack Configuration](https://docs.localstack.cloud/references/configuration/)
+- [LocalStack in CI](https://docs.localstack.cloud/user-guide/ci/)
+- [LocalStack Integrations](https://docs.localstack.cloud/user-guide/integrations/)
+- [LocalStack Tools](https://docs.localstack.cloud/user-guide/tools/)
+- [Understanding LocalStack](https://docs.localstack.cloud/references/)
+- [Troubleshoot](doc/troubleshoot/README.md)
 
 To use LocalStack with a graphical user interface, you can use the following UI clients:
 
-* [Commandeer desktop app](https://getcommandeer.com)
-* [DynamoDB Admin Web UI](https://www.npmjs.com/package/dynamodb-admin)
+- [Commandeer desktop app](https://getcommandeer.com)
+- [DynamoDB Admin Web UI](https://www.npmjs.com/package/dynamodb-admin)
 
 ## Releases
 
@@ -144,9 +144,9 @@ Please refer to [GitHub releases](https://github.com/localstack/localstack/relea
 
 If you are interested in contributing to LocalStack:
 
-* Start by reading our [contributing guide](CONTRIBUTING.md).
-* Check out our [developer guide](https://docs.localstack.cloud/contributing/).
-* Navigate our codebase and [open issues](https://github.com/localstack/localstack/issues).
+- Start by reading our [contributing guide](CONTRIBUTING.md).
+- Check out our [developer guide](https://docs.localstack.cloud/contributing/).
+- Navigate our codebase and [open issues](https://github.com/localstack/localstack/issues).
 
 We are thankful for all the contributions and feedback we receive.
 
@@ -154,9 +154,9 @@ We are thankful for all the contributions and feedback we receive.
 
 To get in touch with LocalStack team for bugs/feature requests, support questions or general discussions, please use:
 
-* [LocalStack Slack Community](https://localstack.cloud/contact/)
-* [LocalStack Discussion Page](https://discuss.localstack.cloud/)
-* [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
+- [LocalStack Slack Community](https://localstack.cloud/contact/)
+- [LocalStack Discussion Page](https://discuss.localstack.cloud/)
+- [LocalStack GitHub Issue tracker](https://github.com/localstack/localstack/issues)
 
 ### Contributors
 

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -131,8 +131,6 @@ VALID_OPERATIONS = [
     "GenerateDataKeyPair",
     "GenerateDataKeyPairWithoutPlaintext",
 ]
-# maximum size allowed by AWS
-PLAINTEXT_MAX_SIZE_BYTES = 4096
 
 
 class ValidationError(CommonServiceException):

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1027,7 +1027,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ):
         # max size values extracted from AWS boto3 documentation
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
-        max_size_bytes = 4096
+        max_size_bytes = 4096 # max allowed size
         if key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_1":
             max_size_bytes = 214
         elif key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_256":

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -631,6 +631,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> EncryptResponse:
         key = self._get_key(context, key_id)
         self._validate_plaintext_length(plaintext)
+        self._validate_plaintext_key_type_based(plaintext, key, encryption_algorithm)
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 
@@ -1020,7 +1021,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                     f" constraint: [Member must satisfy enum value set: {VALID_OPERATIONS}]"
                 )
 
-    def _validate_content_size(
+    def _validate_plaintext_key_type_based(
         self,
         plaintext: PlaintextType,
         key: KmsKey,
@@ -1045,14 +1046,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         if len(plaintext) > max_size_bytes:
             raise ValidationException(
                 f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_size_bytes} bytes."
-            )
-
-    def _validate_plaintext_max_size(self, plaintext: PlaintextType):
-        # Check if any plaintext are smaller than 4096 bytes independent of they key type.
-        if len(plaintext) > PLAINTEXT_MAX_SIZE_BYTES:
-            raise ValidationException(
-                "1 validation error detected: Value at 'plaintext' failed to satisfy constraint:"
-                " Member must have length less than or equal to 4096."
             )
 
 

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1052,7 +1052,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         if len(plaintext) > PLAINTEXT_MAX_SIZE_BYTES:
             raise ValidationException(
                 "1 validation error detected: Value at 'plaintext' failed to satisfy constraint:"
-                "Member must have length less than or equal to 4096."
+                " Member must have length less than or equal to 4096."
             )
 
 

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -131,6 +131,8 @@ VALID_OPERATIONS = [
     "GenerateDataKeyPair",
     "GenerateDataKeyPairWithoutPlaintext",
 ]
+# maximum size allowed by AWS
+PLAINTEXT_MAX_SIZE_BYTES = 4096
 
 
 class ValidationError(CommonServiceException):
@@ -1026,28 +1028,28 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ):
         # max size values extracted from AWS boto3 documentation
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
-        max_bytes_size = 0
+        max_size_bytes = PLAINTEXT_MAX_SIZE_BYTES
         if key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_1":
-            max_bytes_size = 214
+            max_size_bytes = 214
         elif key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_256":
-            max_bytes_size = 190
+            max_size_bytes = 190
         elif key.metadata["KeySpec"] == "RSA_3072" and encryption_algorithm == "RSAES_OAEP_SHA_1":
-            max_bytes_size = 342
+            max_size_bytes = 342
         elif key.metadata["KeySpec"] == "RSA_3072" and encryption_algorithm == "RSAES_OAEP_SHA_256":
-            max_bytes_size = 318
+            max_size_bytes = 318
         elif key.metadata["KeySpec"] == "RSA_4096" and encryption_algorithm == "RSAES_OAEP_SHA_1":
-            max_bytes_size = 470
+            max_size_bytes = 470
         elif key.metadata["KeySpec"] == "RSA_4096" and encryption_algorithm == "RSAES_OAEP_SHA_256":
-            max_bytes_size = 446
+            max_size_bytes = 446
 
-        if len(plaintext) > max_bytes_size:
+        if len(plaintext) > max_size_bytes:
             raise ValidationException(
-                f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_bytes_size} bytes."
+                f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_size_bytes} bytes."
             )
 
     def _validate_plaintext_max_size(self, plaintext: PlaintextType):
-        # Check if all plaintext are smaller than 4096 bytes independent of they key type.
-        if len(plaintext) > 4096:
+        # Check if any plaintext are smaller than 4096 bytes independent of they key type.
+        if len(plaintext) > PLAINTEXT_MAX_SIZE_BYTES:
             raise ValidationException(
                 "1 validation error detected: Value at 'plaintext' failed to satisfy constraint:"
                 "Member must have length less than or equal to 4096."

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -58,6 +58,7 @@ from localstack.aws.api.kms import (
     InvalidGrantIdException,
     InvalidKeyUsageException,
     KeyIdType,
+    KeySpec,
     KeyState,
     KmsApi,
     KMSInvalidStateException,
@@ -1028,19 +1029,37 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         # max size values extracted from AWS boto3 documentation
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
         max_size_bytes = 4096  # max allowed size
-        if key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_1":
+        if (
+            key.metadata["KeySpec"] == KeySpec.RSA_2048
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
             max_size_bytes = 214
-        elif key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_256":
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_2048
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
             max_size_bytes = 190
-        elif key.metadata["KeySpec"] == "RSA_3072" and encryption_algorithm == "RSAES_OAEP_SHA_1":
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_3072
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
             max_size_bytes = 342
-        elif key.metadata["KeySpec"] == "RSA_3072" and encryption_algorithm == "RSAES_OAEP_SHA_256":
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_3072
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
             max_size_bytes = 318
-        elif key.metadata["KeySpec"] == "RSA_4096" and encryption_algorithm == "RSAES_OAEP_SHA_1":
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_4096
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
             max_size_bytes = 470
-        elif key.metadata["KeySpec"] == "RSA_4096" and encryption_algorithm == "RSAES_OAEP_SHA_256":
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_4096
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
             max_size_bytes = 446
-
+            
         if len(plaintext) > max_size_bytes:
             raise ValidationException(
                 f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_size_bytes} bytes."

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1027,7 +1027,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ):
         # max size values extracted from AWS boto3 documentation
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
-        max_size_bytes = 4096 # max allowed size
+        max_size_bytes = 4096  # max allowed size
         if key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_1":
             max_size_bytes = 214
         elif key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_256":

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1027,7 +1027,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ):
         # max size values extracted from AWS boto3 documentation
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
-        max_size_bytes = PLAINTEXT_MAX_SIZE_BYTES
+        max_size_bytes = 4096
         if key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_1":
             max_size_bytes = 214
         elif key.metadata["KeySpec"] == "RSA_2048" and encryption_algorithm == "RSAES_OAEP_SHA_256":

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -554,26 +554,26 @@ class TestKMS:
         ],
     )
     def test_encrypt_validate_plaintext_size_per_key_type(
-        self, kms_create_key, key_spec, algo, aws_client
+        self, kms_create_key, key_spec, algo, snapshot, aws_client
     ):
         key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec=key_spec)["KeyId"]
-        message = b"more than 500 bytes and less than 4096" * 20
-        with pytest.raises(ClientError) as exc:
+        message = b"more than 500 bytes and less than 4096 bytes" * 20
+        with pytest.raises(ClientError) as e:
             aws_client.kms.encrypt(
                 KeyId=key_id, Plaintext=base64.b64encode(message), EncryptionAlgorithm=algo
             )
-        assert exc.match("ValidationException")
+        snapshot.match("generate-random-exc", e.value.response)
 
-    def test_encrypt_validate_plaintext_max_size(self, kms_create_key, aws_client):
+    def test_encrypt_validate_plaintext_max_size(self, kms_create_key, snapshot, aws_client):
         key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")["KeyId"]
-        message = b"more than 4096" * 400
-        with pytest.raises(ClientError) as exc:
+        message = b"more than 4096 bytes" * 400
+        with pytest.raises(ClientError) as e:
             aws_client.kms.encrypt(
                 KeyId=key_id,
                 Plaintext=base64.b64encode(message),
                 EncryptionAlgorithm="RSAES_OAEP_SHA_1",
             )
-        assert exc.match("ValidationException")
+        snapshot.match("generate-random-exc", e.value.response)
 
     @pytest.mark.aws_validated
     def test_get_public_key(self, kms_create_key, aws_client):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -542,6 +542,39 @@ class TestKMS:
         )["Plaintext"]
         assert base64.b64decode(plaintext) == message
 
+    @pytest.mark.parametrize(
+        "key_spec,algo",
+        [
+            ("RSA_2048", "RSAES_OAEP_SHA_1"),
+            ("RSA_2048", "RSAES_OAEP_SHA_256"),
+            ("RSA_3072", "RSAES_OAEP_SHA_1"),
+            ("RSA_3072", "RSAES_OAEP_SHA_256"),
+            ("RSA_4096", "RSAES_OAEP_SHA_1"),
+            ("RSA_4096", "RSAES_OAEP_SHA_256"),
+        ],
+    )
+    def test_encrypt_validate_plaintext_size_per_key_type(
+        self, kms_create_key, key_spec, algo, aws_client
+    ):
+        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec=key_spec)["KeyId"]
+        message = b"more than 500 bytes and less than 4096" * 20
+        with pytest.raises(ClientError) as exc:
+            aws_client.kms.encrypt(
+                KeyId=key_id, Plaintext=base64.b64encode(message), EncryptionAlgorithm=algo
+            )
+        assert exc.match("ValidationException")
+
+    def test_encrypt_validate_plaintext_max_size(self, kms_create_key, aws_client):
+        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")["KeyId"]
+        message = b"more than 4096" * 400
+        with pytest.raises(ClientError) as exc:
+            aws_client.kms.encrypt(
+                KeyId=key_id,
+                Plaintext=base64.b64encode(message),
+                EncryptionAlgorithm="RSAES_OAEP_SHA_1",
+            )
+        assert exc.match("ValidationException")
+
     @pytest.mark.aws_validated
     def test_get_public_key(self, kms_create_key, aws_client):
         key = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -542,6 +542,7 @@ class TestKMS:
         )["Plaintext"]
         assert base64.b64decode(plaintext) == message
 
+    @pytest.mark.aws_validated
     @pytest.mark.parametrize(
         "key_spec,algo",
         [

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -564,17 +564,6 @@ class TestKMS:
             )
         snapshot.match("generate-random-exc", e.value.response)
 
-    def test_encrypt_validate_plaintext_max_size(self, kms_create_key, snapshot, aws_client):
-        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")["KeyId"]
-        message = b"more than 4096 bytes" * 400
-        with pytest.raises(ClientError) as e:
-            aws_client.kms.encrypt(
-                KeyId=key_id,
-                Plaintext=base64.b64encode(message),
-                EncryptionAlgorithm="RSAES_OAEP_SHA_1",
-            )
-        snapshot.match("generate-random-exc", e.value.response)
-
     @pytest.mark.aws_validated
     def test_get_public_key(self, kms_create_key, aws_client):
         key = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -44,21 +44,6 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_max_size": {
-    "recorded-date": "06-04-2023, 14:50:19",
-    "recorded-content": {
-      "generate-random-exc": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length less than or equal to 4096."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_1]": {
     "recorded-date": "06-04-2023, 14:50:19",
     "recorded-content": {

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -44,6 +44,111 @@
       }
     }
   },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_max_size": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length less than or equal to 4096."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_2048 cannot encrypt data larger than 214 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_2048 cannot encrypt data larger than 190 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_3072-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_3072 cannot encrypt data larger than 342 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_3072-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_3072 cannot encrypt data larger than 318 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_4096-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_4096 cannot encrypt data larger than 470 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_4096-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_4096 cannot encrypt data larger than 446 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
     "recorded-date": "25-10-2022, 19:27:20",
     "recorded-content": {


### PR DESCRIPTION
The issue was partially fixed here #8083, but I also need to check the context based on the key type, not only the max allowed plaintext size.
* Added method to validate the plaintext size based on the key type, all those extracted numbers are from [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html)
* Add tests cases to the written function
