### PR TITLE
upgrade werkzeug to 2.2.3

### DIFF
--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -28,8 +28,8 @@ def push_request_context(_chain: HandlerChain, context: RequestContext, _respons
 
     from localstack.utils.aws import request_context
 
-    quart.globals._request_ctx_stack.push(context)
-    flask.globals._request_ctx_stack.push(context)
+    context._legacy_flask_cv_request_token = flask.globals._cv_request.set(context)
+    context._legacy_quart_cv_request_token = quart.globals._cv_request.set(context)
     request_context.THREAD_LOCAL.request_context = context.request
 
 
@@ -40,8 +40,8 @@ def pop_request_context(_chain: HandlerChain, _context: RequestContext, _respons
 
     from localstack.utils.aws import request_context
 
-    quart.globals._request_ctx_stack.pop()
-    flask.globals._request_ctx_stack.pop()
+    flask.globals._cv_request.reset(_context._legacy_flask_cv_request_token)
+    quart.globals._cv_request.reset(_context._legacy_quart_cv_request_token)
     request_context.THREAD_LOCAL.request_context = None
 
 

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -20,6 +20,11 @@ class GreedyPathConverter(PathConverter):
 
     regex = ".*?"
 
+    part_isolating = False
+    """From the werkzeug docs: If a custom converter can match a forward slash, /, it should have the
+    attribute part_isolating set to False. This will ensure that rules using the custom converter are
+    correctly matched."""
+
 
 class _HttpOperation(NamedTuple):
     """Useful intermediary representation of the 'http' block of an operation to make code cleaner"""

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -258,7 +258,7 @@ def _create_service_map(service: ServiceModel) -> Map:
         rules=rules,
         strict_slashes=False,
         merge_slashes=False,
-        converters={"path": GreedyPathConverter},
+        # converters={"path": GreedyPathConverter},
     )
 
 

--- a/localstack/http/adapters.py
+++ b/localstack/http/adapters.py
@@ -1,3 +1,4 @@
+# TODO: remove with 2.1, this is defunct/dead code.
 """Adapters and other utilities to use the HTTP framework together with the edge proxy. These tools facilitate the
 migration from the edge proxy to the new HTTP framework, and will be removed in the future. """
 from urllib.parse import urlsplit

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -402,30 +402,3 @@ class ASGIAdapter:
                 return
             else:
                 return
-
-
-def patch_werkzeug():
-    from werkzeug.wsgi import LimitedStream
-
-    from localstack.utils.patch import patch
-
-    @patch(LimitedStream.read, pass_target=False)
-    def _read(self, size: t.Optional[int] = None):
-        # FIXME: This is a bandaid for https://github.com/pallets/werkzeug/issues/2558 and should be removed once the
-        #  issue is fixed
-        if self._pos >= self.limit:
-            return self.on_exhausted()
-        if size is None or size == -1:
-            size = self.limit
-        to_read = min(self.limit - self._pos, size)
-        try:
-            read = self._read(to_read)
-        except (OSError, ValueError):
-            return self.on_disconnect()
-        if to_read and not len(read):  # this line is affected by the original code
-            return self.on_disconnect()
-        self._pos += len(read)
-        return read
-
-
-patch_werkzeug()

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -32,6 +32,7 @@ RequestArguments = Mapping[str, Any]
 class RegexConverter(BaseConverter):
     """
     A converter that can be used to inject a regex as parameter, e.g., ``path=/<regex('[a-z]+'):my_var>``.
+    When using groups in regex, make sure they are non-capturing ``(?:[a-z]+)``
     """
 
     def __init__(self, map: "Map", *args: Any, **kwargs: Any) -> None:
@@ -46,7 +47,7 @@ class PortConverter(BaseConverter):
     The converter converts the port to an int, or returns None if there's no port in the input string.
     """
 
-    regex = r"(:[0-9]{1,5})?"
+    regex = r"(?::[0-9]{1,5})?"
 
     def to_python(self, value: str) -> Any:
         if value:

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -171,7 +171,10 @@ class Router(Generic[E]):
             converters = {**self.default_converters, **converters}
 
         self.url_map = Map(
-            host_matching=True, strict_slashes=False, converters=converters, redirect_defaults=False
+            host_matching=True,
+            strict_slashes=False,
+            converters=converters,
+            redirect_defaults=False,
         )
         self.dispatcher = dispatcher or call_endpoint
         self._mutex = threading.RLock()

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -244,14 +244,14 @@ def register_cluster(
             ROUTER.add(
                 path=path,
                 endpoint=endpoint,
-                host=f'{host}<regex("(:.*)?"):port>',
+                host=f"{host}<port:port>",
             )
         )
         rules.append(
             ROUTER.add(
                 f"{path}/<path:path>",
                 endpoint=endpoint,
-                host=f'{host}<regex("(:.*)?"):port>',
+                host=f"{host}<port:port>",
             )
         )
     elif strategy == "domain":
@@ -263,14 +263,14 @@ def register_cluster(
             ROUTER.add(
                 "/",
                 endpoint=endpoint,
-                host=f"{host}<regex('(:.*)?'):port>",
+                host=f"{host}<port:port>",
             )
         )
         rules.append(
             ROUTER.add(
                 "/<path:path>",
                 endpoint=endpoint,
-                host=f"{host}<regex('(:.*)?'):port>",
+                host=f"{host}<port:port>",
             )
         )
     elif strategy == "path":

--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -35,7 +35,7 @@ class S3VirtualHostProxyHandler:
         self.proxy = proxy or Proxy(
             forward_base_url=config.get_edge_url(),
             preserve_host=False,
-            client=SimpleStreamingRequestsClient()
+            client=SimpleStreamingRequestsClient(),
         )
 
     def __call__(self, request: Request, **kwargs) -> Response:

--- a/localstack/services/s3/website_hosting.py
+++ b/localstack/services/s3/website_hosting.py
@@ -154,7 +154,7 @@ def _serve_key(request: Request, bucket_name: BucketName, path: str = None) -> R
         not key_name or is_folder
     ):  # the path automatically remove the trailing slash, even with strict_slashes=False
         index_key = website_config["IndexDocument"]["Suffix"]
-        key_name = f"{key_name}/{index_key}" if key_name else index_key
+        key_name = f"{key_name}{index_key}" if key_name else index_key
 
     key = _get_key_from_moto_bucket(bucket, key_name)
     if not key:

--- a/localstack/services/s3/website_hosting.py
+++ b/localstack/services/s3/website_hosting.py
@@ -28,9 +28,7 @@ from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
 
-STATIC_WEBSITE_HOST_REGEX = (
-    '<regex(".*"):bucket_name>.%s<regex("(:[0-9]{2,5})?"):port>' % S3_STATIC_WEBSITE_HOSTNAME
-)
+STATIC_WEBSITE_HOST_REGEX = f'<regex(".*"):bucket_name>.{S3_STATIC_WEBSITE_HOSTNAME}<port:port>'
 
 _leading_whitespace_re = re.compile("(^[ \t]*)(?:[ \t\n])", re.MULTILINE)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ runtime =
     dnslib>=0.9.10
     dnspython>=1.16.0
     docker==6.0.1
-    flask==2.1.3
+    flask>=2.2.3
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
     hypercorn==0.14.2
@@ -89,12 +89,11 @@ runtime =
     pproxy>=2.7.0
     pymongo>=4.2.0
     pyopenssl>=23.0.0
-    Quart==0.17
+    Quart>=0.18
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
     vosk==0.3.43
-    # TODO: remove werkzeug&flask version pins once we can upgrade to latest versions
-    Werkzeug==2.1.2
+    Werkzeug>=2.2.3
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3035,6 +3035,7 @@ class TestS3:
 
         key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
         proxied_response = requests.get(key_url)
+        assert proxied_response.ok
         assert proxied_response.headers["server"] == response.headers["server"]
         assert len(proxied_response.headers["server"].split(",")) == 1
         assert len(proxied_response.headers["date"].split(",")) == 2  # coma in the date

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -27,9 +27,6 @@ def test_create_op_router_works_for_every_service(service):
         pass
 
 
-@pytest.mark.skip(
-    reason="this is mostly for documentation behavior of the old greedy path converter that is no longer in use"
-)
 def test_greedy_path_converter():
     # this test is mostly to document behavior
 
@@ -104,3 +101,10 @@ def test_s3_bucket_operation_with_trailing_slashes():
 
     op, _ = router.match(Request("Get", "/mybucket/"))
     assert op.name == "ListObjects"
+
+
+def test_s3_bucket_operation_with_double_slashes():
+    router = RestServiceOperationRouter(load_service("s3"))
+
+    op, _ = router.match(Request("GET", "/mybucket//mykey"))
+    assert op.name == "GetObject"

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -27,6 +27,9 @@ def test_create_op_router_works_for_every_service(service):
         pass
 
 
+@pytest.mark.skip(
+    reason="this is mostly for documentation behavior of the old greedy path converter that is no longer in use"
+)
 def test_greedy_path_converter():
     # this test is mostly to document behavior
 

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -75,3 +75,29 @@ def test_trailing_slashes_are_not_strict():
 
     op, _ = router.match(Request("POST", "/2015-03-31/functions/"))
     assert op.name == "CreateFunction"
+
+
+def test_s3_query_args_routing():
+    router = RestServiceOperationRouter(load_service("s3"))
+
+    op, _ = router.match(Request("DELETE", "/mybucket?delete"))
+    assert op.name == "DeleteBucket"
+
+    op, _ = router.match(Request("DELETE", "/mybucket/?delete"))
+    assert op.name == "DeleteBucket"
+
+    op, _ = router.match(Request("DELETE", "/mybucket/mykey?delete"))
+    assert op.name == "DeleteObject"
+
+    op, _ = router.match(Request("DELETE", "/mybucket/mykey/?delete"))
+    assert op.name == "DeleteObject"
+
+
+def test_s3_bucket_operation_with_trailing_slashes():
+    router = RestServiceOperationRouter(load_service("s3"))
+
+    op, _ = router.match(Request("GET", "/mybucket"))
+    assert op.name == "ListObjects"
+
+    op, _ = router.match(Request("Get", "/mybucket/"))
+    assert op.name == "ListObjects"

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -188,7 +188,7 @@ class TestRouter:
         router.add(path="/<path:path>", endpoint=echo_params_json)
 
         assert router.dispatch(Request(path="/my")).json == {"path": "my"}
-        assert router.dispatch(Request(path="/my/")).json == {"path": "my"}
+        assert router.dispatch(Request(path="/my/")).json == {"path": "my/"}
         assert router.dispatch(Request(path="/my/path foobar")).json == {"path": "my/path foobar"}
 
     def test_path_converter_with_args(self):
@@ -203,7 +203,7 @@ class TestRouter:
         # removes trailing slash
         assert router.dispatch(Request(path="/with-args/123456/my/")).json == {
             "some_id": "123456",
-            "path": "my",
+            "path": "my/",
         }
 
         # works with sub paths
@@ -223,7 +223,7 @@ class TestRouter:
         router = Router()
         router.add(
             path="/<path:path>",
-            host="foobar.us-east-1.opensearch.localhost.localstack.cloud<regex('(:.*)?'):port>",
+            host="foobar.us-east-1.opensearch.localhost.localstack.cloud<regex('(?::.*)?'):port>",
             endpoint=echo_params_json,
         )
         assert router.dispatch(

--- a/tests/unit/services/s3/test_virtual_host.py
+++ b/tests/unit/services/s3/test_virtual_host.py
@@ -1,0 +1,201 @@
+from queue import Queue
+
+import pytest
+from werkzeug.exceptions import NotFound
+
+from localstack.http import Request, Response, Router
+from localstack.http.client import HttpClient
+from localstack.http.dispatcher import handler_dispatcher
+from localstack.services.s3.virtual_host import S3VirtualHostProxyHandler, add_s3_vhost_rules
+
+
+class _RequestCollectingClient(HttpClient):
+    requests: Queue
+
+    def __init__(self):
+        self.requests = Queue()
+
+    def request(self, request: Request, server: str | None = None) -> Response:
+        self.requests.put((request, server))
+        return Response()
+
+
+class TestS3VirtualHostProxyHandler:
+    def test_vhost_without_region(self):
+        # create mock environment
+        router = Router(dispatcher=handler_dispatcher())
+        collector = _RequestCollectingClient()
+        handler = S3VirtualHostProxyHandler()
+        handler.proxy.client = collector
+        # add rules
+        add_s3_vhost_rules(router, handler)
+
+        # test key with path
+        router.dispatch(
+            Request(path="/my/key", headers={"Host": "abucket.s3.localhost.localstack.cloud:4566"})
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
+        assert server == "http://localhost:4566"
+
+        # test root key
+        router.dispatch(
+            Request(path="/", headers={"Host": "abucket.s3.localhost.localstack.cloud:4566"})
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/"
+
+        # test different host without port
+        router.dispatch(Request(path="/key", headers={"Host": "abucket.s3.amazonaws.com"}))
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/key"
+
+    def test_vhost_with_region(self):
+        # create mock environment
+        router = Router(dispatcher=handler_dispatcher())
+        collector = _RequestCollectingClient()
+        handler = S3VirtualHostProxyHandler()
+        handler.proxy.client = collector
+        # add rules
+        add_s3_vhost_rules(router, handler)
+
+        # test key with path
+        router.dispatch(
+            Request(
+                path="/my/key",
+                headers={"Host": "abucket.s3.eu-central-1.localhost.localstack.cloud:4566"},
+            )
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
+        assert server == "http://localhost:4566"
+
+        # test key with path (gov cloud
+        router.dispatch(
+            Request(
+                path="/my/key",
+                headers={"Host": "abucket.s3.us-gov-east-1a.localhost.localstack.cloud:4566"},
+            )
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
+        assert server == "http://localhost:4566"
+
+        # test root key
+        router.dispatch(
+            Request(
+                path="/",
+                headers={"Host": "abucket.s3.eu-central-1.localhost.localstack.cloud:4566"},
+            )
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/"
+
+        # test different host without port
+        router.dispatch(
+            Request(path="/key", headers={"Host": "abucket.s3.eu-central-1.amazonaws.com"})
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/key"
+
+    def test_path_without_region(self):
+        # create mock environment
+        router = Router(dispatcher=handler_dispatcher())
+        collector = _RequestCollectingClient()
+        handler = S3VirtualHostProxyHandler()
+        handler.proxy.client = collector
+        # add rules
+        add_s3_vhost_rules(router, handler)
+
+        with pytest.raises(NotFound):
+            # test key with path
+            router.dispatch(
+                Request(
+                    path="/abucket/my/key", headers={"Host": "s3.localhost.localstack.cloud:4566"}
+                )
+            )
+
+    def test_path_with_region(self):
+        # create mock environment
+        router = Router(dispatcher=handler_dispatcher())
+        collector = _RequestCollectingClient()
+        handler = S3VirtualHostProxyHandler()
+        handler.proxy.client = collector
+        # add rules
+        add_s3_vhost_rules(router, handler)
+
+        # test key with path
+        router.dispatch(
+            Request(
+                path="/abucket/my/key",
+                headers={"Host": "s3.eu-central-1.localhost.localstack.cloud:4566"},
+            )
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
+        assert server == "http://localhost:4566"
+
+        # test root key
+        router.dispatch(
+            Request(
+                path="/abucket", headers={"Host": "s3.eu-central-1.localhost.localstack.cloud:4566"}
+            )
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket"
+
+        # test different host without port
+        router.dispatch(
+            Request(path="/abucket/key", headers={"Host": "s3.eu-central-1.amazonaws.com"})
+        )
+        request, server = collector.requests.get()
+        assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/key"
+
+
+def test_vhost_rule_matcher():
+    def echo_params(request, params):
+        r = Response()
+        r.set_json(params)
+        return r
+
+    router = Router()
+    add_s3_vhost_rules(router, echo_params)
+
+    # path-based with region
+    assert router.dispatch(
+        Request(
+            path="/abucket/key",
+            headers={"Host": "s3.eu-central-1.amazonaws.com"},
+        )
+    ).json == {
+        "bucket": "abucket",
+        "region": "eu-central-1.",
+        "domain": "amazonaws.com",
+        "path": "key",
+    }
+
+    # vhost with region
+    assert router.dispatch(
+        Request(
+            path="/my/key",
+            headers={"Host": "abucket.s3.eu-central-1.localhost.localstack.cloud:4566"},
+        )
+    ).json == {
+        "bucket": "abucket",
+        "region": "eu-central-1.",
+        "domain": "localhost.localstack.cloud:4566",
+        "path": "my/key",
+    }
+
+    # vhost without region
+    assert router.dispatch(
+        Request(
+            path="/my/key",
+            headers={"Host": "abucket.s3.localhost.localstack.cloud:4566"},
+        )
+    ).json == {
+        "bucket": "abucket",
+        "region": "",
+        "domain": "localhost.localstack.cloud:4566",
+        "path": "my/key",
+    }


### PR DESCRIPTION
## Motivation
This PR upgrades werkzeug to 2.2.3, and the dependents flask and quart, that were pinned in https://github.com/localstack/localstack/pull/6514

The changes since werkzeug 2.1.2 had the following effects:
* groups in regex host matchers must be non-capturing, otherwise they break. this was a problem in opensearch and s3, and also the `PortConverter` regex. things like `(.*).` in rules matchers need to be changed to `(?:.*).`
* `_request_ctx_stack` used to set the request context for flask and quart was removed
* `/<path:path>` matchers no longer remove trailing slashes. previously `/foo/` and `/foo` would both lead to the `path` being passed to be `foo`, now it is `foo/` and `foo` respectively.

## Changes
The PR does the following:
* adds several tests that cover the changed behavior
* fixes our request context handlers to the flask/quart refactoring (thanks to @alexrashed for his solution in #7274, mine was wrong)
* simplifies the opensearch endpoint matchers using the corrected `PortConverter`, to review by @alexrashed 
* reworked the `S3VirtualHostProxyHandler` a bit, and made some other minor s3 changes, to review by @bentsku 
  * changes the `AWS_REGION_REGEX` to use non-capturing groups
  * simplifies the regex to match domains and ports
  * inject the `Proxy` instance as dependency so we can unit test the implementation
* use `PortConverter` for s3-website regex
* `rstrip("/")` the path before it goes into the op router matcher so we get the old behavior
* tiny fix in s3 website to remove a redundant trailing slash

## Learnings for the next time slashes come back to haunt us

* `GreedyPathConverter` is needed to make `/mybucket//mykey` match the rule `/<Bucket>/<path:Key>`, such that `Key=/mykey`. 
* the line `path = path.rstrip("/")` in `RestServiceOperationRouter.match` is needed because without it, in combination with the `GreedyPathConverter`, `/mybucket/` would match the rule `/<Bucket>/<path:Key>` instead of `/<Bucket>`, which lead to calls like `GET /mybucket/` being detected as `GetObject` with `Key=''` instead of `ListObjects` (bucket operation)
* URI matching in smithy is explained in https://smithy.io/2.0/spec/http-bindings.html#uri, but there are no examples for the greedy labels for the special cases with trailing slashes or prefix slashes in patterns (like the first example `/mybucket//mykey`). however it states that "trailing slashes are ignored", which substantiates that the `rstrip` call in match is OK
