### PR TITLE
Fix server stop errors when restoring a snapshot

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -84,6 +84,8 @@ class DynamodbServer(Server):
         """Stop the DynamoDB server."""
         import psutil
 
+        if self._thread is None:
+            return
         self._thread.auto_restart = False
         self.shutdown()
         self.join(timeout=10)

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -94,7 +94,7 @@ def wait_for_stepfunctions():
 
 
 def stop_stepfunctions():
-    if PROCESS_THREAD or not PROCESS_THREAD.process:
+    if not PROCESS_THREAD or not PROCESS_THREAD.process:
         return
     LOG.debug("Restarting StepFunctions process ...")
 


### PR DESCRIPTION
In the persistence test logs, we have a few errors calling the `on_before_state_load`. In these hooks, we usually try to stop a server before loading the state. However, we did not check for threads and processes not being `None` (which is the case when we just started the container).

The following issue was present for DDB and StepFunctions:
```
line 87, in stop_dynamodb
docker-run.sh: self._thread.auto_restart = False
docker-run.sh: AttributeError: 'NoneType' object has no attribute 'auto_restart'

line 97, in stop_stepfunctions
docker-run.sh: if PROCESS_THREAD or not PROCESS_THREAD.process:
docker-run.sh: AttributeError: 'NoneType' object has no attribute 'process'
```

Could be replicated by:
- starting LocalStack with `PERSISTENCE=1`;
- create a DDB table;
- restart again with `PERSISTENCE=1`;
- call any DDB operation.