### PR TITLE
Replace SES Client In SNS Publisher

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -493,7 +493,8 @@ class EmailJsonTopicPublisher(TopicPublisher):
     """
 
     def _publish(self, context: SnsPublishContext, subscriber: SnsSubscription):
-        ses_client = aws_stack.connect_to_service("ses")
+        region = extract_region_from_arn(subscriber["Endpoint"])
+        ses_client = connect_to(region_name=region).ses
         if endpoint := subscriber.get("Endpoint"):
             ses_client.verify_email_address(EmailAddress=endpoint)
             ses_client.verify_email_address(EmailAddress="admin@localstack.com")


### PR DESCRIPTION
This PR adds a small change to use the new AWS Internal Client.
It does not call `request_metadata` due to the Publisher being able to just send emails without needing an Identity Policy on the address.