### PR TITLE
Fix containerd detection for host mode

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -311,9 +311,17 @@ def in_docker():
                 if not line:
                     continue
 
+                # skip comments
+                if line[0] == "#":
+                    continue
+
                 # format (man 5 fstab)
                 # <spec> <mount point> <type> <options> <rest>...
                 parts = line.split()
+                if len(parts) < 4:
+                    # badly formatted line
+                    continue
+
                 mount_point = parts[1]
                 options = parts[3]
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -9,6 +9,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Tuple, TypeVar
 
+import psutil
+
 from localstack import constants
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
@@ -302,9 +304,10 @@ def in_docker():
             return True
 
     # containerd does not set any specific file or config, but does use
-    # io.containerd.snapshotter.v1.overlayfs as the overlay filesystem
-    with open("/proc/1/mountinfo", "rt") as infile:
-        if "io.containerd" in infile.read():
+    # io.containerd.snapshotter.v1.overlayfs as the overlay filesystem for `/`.
+    partitions = psutil.disk_partitions(all=True)
+    for partition in partitions:
+        if partition.mountpoint == "/" and "io.containerd" in partition.opts:
             return True
 
     return False


### PR DESCRIPTION
Previously, if _any_ containerd container was running on the host, and LocalStack was started in host mode then it would detect the `containerd` string in the disk partitions, and return True. This is not a great default for host mode, as it binds LocalStack to 0.0.0.0.

This change searches through the `/proc/1/mountinfo` virtual file system looking for mount options that include `containerd`. This means that only the root mount point is considered, rather than any host mounts that correspond to other containers. After this update, while running a containerd container in the background and starting LocalStack in host mode, the docker status is correctly determined to be False, and LocalStack is bound to 127.0.0.1.
