### PR TITLE
fix: Adding validation on kms plaintext based on the key type

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -58,6 +58,7 @@ from localstack.aws.api.kms import (
     InvalidGrantIdException,
     InvalidKeyUsageException,
     KeyIdType,
+    KeySpec,
     KeyState,
     KmsApi,
     KMSInvalidStateException,
@@ -629,6 +630,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> EncryptResponse:
         key = self._get_key(context, key_id)
         self._validate_plaintext_length(plaintext)
+        self._validate_plaintext_key_type_based(plaintext, key, encryption_algorithm)
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 
@@ -1018,6 +1020,50 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                     f" constraint: [Member must satisfy enum value set: {VALID_OPERATIONS}]"
                 )
 
+    def _validate_plaintext_key_type_based(
+        self,
+        plaintext: PlaintextType,
+        key: KmsKey,
+        encryption_algorithm: EncryptionAlgorithmSpec = None,
+    ):
+        # max size values extracted from AWS boto3 documentation
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html
+        max_size_bytes = 4096  # max allowed size
+        if (
+            key.metadata["KeySpec"] == KeySpec.RSA_2048
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
+            max_size_bytes = 214
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_2048
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
+            max_size_bytes = 190
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_3072
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
+            max_size_bytes = 342
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_3072
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
+            max_size_bytes = 318
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_4096
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_1
+        ):
+            max_size_bytes = 470
+        elif (
+            key.metadata["KeySpec"] == KeySpec.RSA_4096
+            and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
+        ):
+            max_size_bytes = 446
+            
+        if len(plaintext) > max_size_bytes:
+            raise ValidationException(
+                f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_size_bytes} bytes."
+            )
 
 # ---------------
 # UTIL FUNCTIONS

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1059,11 +1059,12 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             and encryption_algorithm == EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
         ):
             max_size_bytes = 446
-            
+
         if len(plaintext) > max_size_bytes:
             raise ValidationException(
                 f"Algorithm {encryption_algorithm} and key spec {key.metadata['KeySpec']} cannot encrypt data larger than {max_size_bytes} bytes."
             )
+
 
 # ---------------
 # UTIL FUNCTIONS

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -44,6 +44,96 @@
       }
     }
   },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_2048 cannot encrypt data larger than 214 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_2048-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_2048 cannot encrypt data larger than 190 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_3072-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_3072 cannot encrypt data larger than 342 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_3072-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_3072 cannot encrypt data larger than 318 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_4096-RSAES_OAEP_SHA_1]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_1 and key spec RSA_4096 cannot encrypt data larger than 470 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_validate_plaintext_size_per_key_type[RSA_4096-RSAES_OAEP_SHA_256]": {
+    "recorded-date": "06-04-2023, 14:50:19",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Algorithm RSAES_OAEP_SHA_256 and key spec RSA_4096 cannot encrypt data larger than 446 bytes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
     "recorded-date": "25-10-2022, 19:27:20",
     "recorded-content": {


### PR DESCRIPTION
The issue was partially fixed here #8083, but I also need to check the context based on the key type, not only the max allowed plaintext size.
* Added method to validate the plaintext size based on the key type, all those extracted numbers are from [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/encrypt.html)
* Add tests cases to the written function
