### PR TITLE
fix ASF operation signature mismatches

### DIFF
--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -64,6 +64,7 @@ from localstack.aws.api.lambda_ import (
     InvocationResponse,
     InvocationType,
     InvokeAsyncResponse,
+    InvokeMode,
     LambdaApi,
     LastUpdateStatus,
     LayerName,
@@ -1675,6 +1676,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         auth_type: FunctionUrlAuthType,
         qualifier: FunctionUrlQualifier = None,
         cors: Cors = None,
+        invoke_mode: InvokeMode = None,
     ) -> CreateFunctionUrlConfigResponse:
         state = lambda_stores[context.account_id][context.region]
 
@@ -1787,6 +1789,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         qualifier: FunctionUrlQualifier = None,
         auth_type: FunctionUrlAuthType = None,
         cors: Cors = None,
+        invoke_mode: InvokeMode = None,
     ) -> UpdateFunctionUrlConfigResponse:
         state = lambda_stores[context.account_id][context.region]
 

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -19,10 +19,12 @@ from localstack.aws.api.events import (
     ConnectionDescription,
     ConnectionName,
     CreateConnectionAuthRequestParameters,
+    CreateConnectionResponse,
     EventBusNameOrArn,
     EventPattern,
     EventsApi,
     PutRuleResponse,
+    PutTargetsResponse,
     RoleArn,
     RuleDescription,
     RuleName,
@@ -177,7 +179,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         authorization_type: ConnectionAuthorizationType,
         auth_parameters: CreateConnectionAuthRequestParameters,
         description: ConnectionDescription = None,
-    ):
+    ) -> CreateConnectionResponse:
         errors = []
 
         if not CONNECTION_NAME_PATTERN.match(name):
@@ -207,7 +209,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule: RuleName,
         targets: TargetList,
         event_bus_name: EventBusNameOrArn = None,
-    ):
+    ) -> PutTargetsResponse:
         validation_errors = []
 
         id_regex = re.compile(r"^[\.\-_A-Za-z0-9]+$")

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -207,7 +207,7 @@ class FirehoseProvider(FirehoseApi):
         self,
         context: RequestContext,
         delivery_stream_name: DeliveryStreamName,
-        delivery_stream_type: DeliveryStreamType = DeliveryStreamType.DirectPut,
+        delivery_stream_type: DeliveryStreamType = None,
         kinesis_stream_source_configuration: KinesisStreamSourceConfiguration = None,
         delivery_stream_encryption_configuration_input: DeliveryStreamEncryptionConfigurationInput = None,
         s3_destination_configuration: S3DestinationConfiguration = None,
@@ -390,10 +390,7 @@ class FirehoseProvider(FirehoseApi):
         )
 
     def put_record(
-        self,
-        context: RequestContext,
-        delivery_stream_name: DeliveryStreamName,
-        record: Record,
+        self, context: RequestContext, delivery_stream_name: DeliveryStreamName, record: Record
     ) -> PutRecordOutput:
         record = self._reencode_record(record)
         return self._put_record(delivery_stream_name, record)

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -13,6 +13,7 @@ from localstack.aws.api.kinesis import (
     KinesisApi,
     PartitionKey,
     ProvisionedThroughputExceededException,
+    PutRecordOutput,
     PutRecordsOutput,
     PutRecordsRequestEntryList,
     PutRecordsResultEntry,
@@ -146,7 +147,7 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
         explicit_hash_key: HashKey = None,
         sequence_number_for_ordering: SequenceNumber = None,
         stream_arn: StreamARN = None,
-    ):
+    ) -> PutRecordOutput:
         if random() < config.KINESIS_ERROR_PROBABILITY:
             raise ProvisionedThroughputExceededException(
                 "Rate exceeded for shard X in stream Y under account Z."

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -62,6 +62,7 @@ from localstack.aws.api.route53resolver import (
     NextToken,
     Priority,
     ResolverEndpointDirection,
+    ResolverEndpointType,
     ResolverQueryLogConfig,
     ResolverQueryLogConfigAssociation,
     ResolverQueryLogConfigName,
@@ -540,6 +541,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         ip_addresses: IpAddressesRequest,
         name: Name = None,
         tags: TagList = None,
+        resolver_endpoint_type: ResolverEndpointType = None,
     ) -> CreateResolverEndpointResponse:
         create_resolver_endpoint_resp = call_moto(context)
         create_resolver_endpoint_resp["ResolverEndpoint"][

--- a/localstack/testing/aws/asf_utils.py
+++ b/localstack/testing/aws/asf_utils.py
@@ -1,0 +1,131 @@
+import importlib
+import importlib.util
+import inspect
+import pkgutil
+import re
+from types import FunctionType, ModuleType
+from typing import Optional, Pattern
+
+
+def _import_submodules(
+    package_name: str, module_regex: Optional[Pattern] = None, recursive: bool = True
+) -> dict[str, ModuleType]:
+    """
+    Imports all submodules of the given package with the defined (optional) module_suffix.
+
+    :param package_name: To start the loading / importing at
+    :param module_regex: Optional regex to filter the module names for
+    :param recursive: True if the package should be loaded recursively
+    :return:
+    """
+    package = importlib.import_module(package_name)
+    results = {}
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+        if not module_regex or module_regex.match(name):
+            results[name] = importlib.import_module(name)
+        if recursive and is_pkg:
+            results.update(_import_submodules(name, module_regex, recursive))
+    return results
+
+
+def _collect_provider_classes(
+    provider_module: str, provider_module_regex: Pattern, provider_class_regex: Pattern
+) -> list[type]:
+    """
+    Collects all provider implementation classes which should be tested.
+    :param provider_module: module to start collecting in
+    :param provider_module_regex: Regex to filter the module names for
+    :param provider_class_regex: Regex to filter the provider class names for
+    :return: list of classes to check the operation signatures of
+    """
+    provider_classes = []
+    provider_modules = _import_submodules(provider_module, provider_module_regex)
+    # check that all these files don't import any encrypted code
+    for _, mod in provider_modules.items():
+        # get all classes of the module which end with "Provider"
+        classes = [
+            cls_obj
+            for cls_name, cls_obj in inspect.getmembers(mod)
+            if inspect.isclass(cls_obj) and provider_class_regex.match(cls_name)
+        ]
+        provider_classes.extend(classes)
+    return provider_classes
+
+
+def collect_implemented_provider_operations(
+    provider_module: str = "localstack.services",
+    provider_module_regex: Pattern = re.compile(r".*\.provider[A-Za-z_0-9]*$"),
+    provider_class_regex: Pattern = re.compile(r".*Provider$"),
+    asf_api_module: str = "localstack.aws.api",
+) -> list[tuple[type, type, str]]:
+    """
+    Collects all implemented operations on all provider classes together with their base classes (generated API classes).
+    :param provider_module: module to start collecting in
+    :param provider_module_regex: Regex to filter the module names for
+    :param provider_class_regex: Regex to filter the provider class names for
+    :param asf_api_module: module which contains the generated ASF APIs
+    :return: list of tuple, where each tuple is (provider_class: type, base_class: type, provider_function: str)
+    """
+    results = []
+    provider_classes = _collect_provider_classes(
+        provider_module, provider_module_regex, provider_class_regex
+    )
+    for provider_class in provider_classes:
+        for base_class in provider_class.__bases__:
+            base_parent_module = ".".join(base_class.__module__.split(".")[:-1])
+            if base_parent_module == asf_api_module:
+                # find all functions on the provider class which are also defined in the super class and are not dunder functions
+                provider_functions = [
+                    method
+                    for method in dir(provider_class)
+                    if hasattr(base_class, method)
+                    and isinstance(getattr(base_class, method), FunctionType)
+                    and method.startswith("__") is False
+                ]
+                for provider_function in provider_functions:
+                    results.append((provider_class, base_class, provider_function))
+    return results
+
+
+def check_provider_signature(sub_class: type, base_class: type, method_name: str) -> None:
+    """
+    Checks if the signature of a given provider method is equal to the signature of the function with the same name on the base class.
+
+    :param sub_class: provider class to check the given method's signature of
+    :param base_class: API class to check the given method's signature against
+    :param method_name: name of the method on the sub_class and base_class to compare
+    :raise: AssertionError if the two signatures are not equal
+    """
+    try:
+        sub_function = getattr(sub_class, method_name)
+    except AttributeError:
+        raise AttributeError(
+            f"Given method name ('{method_name}') is not a method of the sub class ('{sub_class.__name__}')."
+        )
+
+    if not isinstance(sub_function, FunctionType):
+        raise AttributeError(
+            f"Given method name ('{method_name}') is not a method of the sub class ('{sub_class.__name__}')."
+        )
+
+    if not getattr(sub_function, "expand_parameters", True):
+        # if the operation on the subclass has the "expand_parameters" attribute (it has a handler decorator) set to False, we don't care
+        return
+
+    if wrapped := getattr(sub_function, "__wrapped__", False):
+        # if the operation on the subclass has a decorator, unwrap it
+        sub_function = wrapped
+
+    try:
+        base_function = getattr(base_class, method_name)
+        # unwrap from the handler decorator
+        base_function = getattr(base_function, "__wrapped__")
+
+        sub_spec = inspect.getfullargspec(sub_function)
+        base_spec = inspect.getfullargspec(base_function)
+        assert (
+            sub_spec == base_spec
+        ), f"{sub_class.__name__}#{method_name} breaks with {base_class.__name__}#{method_name}"
+    except AttributeError:
+        # the function is not defined in the superclass
+        pass

--- a/tests/unit/aws/api/test_asf_providers.py
+++ b/tests/unit/aws/api/test_asf_providers.py
@@ -1,0 +1,14 @@
+import pytest
+
+from localstack.testing.aws.asf_utils import (
+    check_provider_signature,
+    collect_implemented_provider_operations,
+)
+
+
+@pytest.mark.parametrize(
+    "sub_class,base_class,method_name",
+    collect_implemented_provider_operations(),
+)
+def test_provider_signatures(sub_class: type, base_class: type, method_name: str):
+    check_provider_signature(sub_class, base_class, method_name)


### PR DESCRIPTION
One of the core foundations of ASF are the generated API classes based on the service specifications contained in the latest `botocore` package. These generated APIs are contained in the `localstack.aws.api` module and are updated on a weekly basis by the ["Update ASF APIs"](https://github.com/localstack/localstack/actions/workflows/asf-updates.yml) workflow.

Unfortunately, these updates can cause problems if the signature of the generated APIs change, but the corresponding provider method signatures - implementing the abstract generated API methods - are not adjusted.
This also caused issues with our parity metric collection in the past. /cc @steffyP 

For example, the latest run of the [Update ASF APIs last Monday](https://github.com/localstack/localstack/actions/runs/4654646951) created PR #8106 with recent API changes related to the Lambda Response Streaming (as mentioned by @joe4dev in the PR). This changes the signature of `LambdaApi.create_function_url_config` by adding a new parameter called `invoke_mode`:
https://github.com/localstack/localstack/blob/9debbcc15c83727a560c78f336b0cc44dc516cec/localstack/aws/api/lambda_/__init__.py#L1831

This breaks the invocation of the implementing provider function in `LambdaProvider.create_function_url_config` if this new parameter is used by a client.

This PR contains the following changes:
- b50c0a1db990f53836787160aacc530cfae7581f adds a new unit test which tries to discover all provider classes based on our conventions (classes where the name is ending with `Provider`, contained in modules called `provider`).
  - I was playing around with discovering the provider classes based on the Plux entrypoints, but I was having a hard time collecting _all_ available provider classes. I'm happy for any feedback concerning the simplification of the provider and base class detection.
  - The current approach detects a total of 2383 operation signatures / tests.
  - The execution time seems to be ~15 seconds for all these tests (comparing [the current run of this branch - 2m48s](https://app.circleci.com/pipelines/github/localstack/localstack/14134/workflows/f2de07a1-1a3c-43ae-98c3-1ccd6fd1237d/jobs/105027) - with the [latest run on master - 2m33s](https://app.circleci.com/pipelines/github/localstack/localstack/14129/workflows/96c4e38f-1f84-4ad7-a0d4-de5e2e1fa224/jobs/104994)).
- 7a7f96307d4c8e0767299de9101875ba6f77486d fixes current issues with the provider signatures detected with the unit test.