### PR TITLE
fix ConfirmSubscription access to SNS store

### DIFF
--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -114,8 +114,8 @@ class SnsStore(BaseStore):
     # maps subscription ARN to SnsSubscription
     subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)
 
-    # maps topic Arn to subscription validation token to subscription ARN
-    subscription_tokens: Dict[str, Dict[str, str]] = LocalAttribute(default=dict)
+    # maps confirmation token to subscription ARN
+    subscription_tokens: Dict[str, str] = LocalAttribute(default=dict)
 
     # maps topic ARN to list of tags
     sns_tags: Dict[str, List[Dict]] = LocalAttribute(default=dict)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -404,14 +404,33 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         authenticate_on_unsubscribe: authenticateOnUnsubscribe = None,
     ) -> ConfirmSubscriptionResponse:
         # TODO: validate format on the token (seems to be 288 hex chars)
-        store = self.get_store(account_id=context.account_id, region=context.region)
-        topic_tokens = store.subscription_tokens.get(topic_arn, {})
+        # this request can come from any http client, it might not be signed (we would need to implement
+        # `authenticate_on_unsubscribe` to force a signing client to do this request.
+        # so, the region and account_id might not be in the request. Use the ones from the topic_arn
+        try:
+            parsed_arn = parse_arn(topic_arn)
+        except InvalidArnException:
+            raise InvalidParameterException("Invalid parameter: Topic")
 
-        subscription_arn = topic_tokens.pop(token, None)
+        store = self.get_store(account_id=parsed_arn["account"], region=parsed_arn["region"])
+
+        # it seems SNS is able to know what the region of the topic should be, even though a wrong topic is accepted
+        if parsed_arn["region"] != get_region_from_subscription_token(token):
+            raise InvalidParameterException("Invalid parameter: Topic")
+
+        subscription_arn = store.subscription_tokens.get(token)
         if not subscription_arn:
             raise InvalidParameterException("Invalid parameter: Token")
 
         subscription = store.subscriptions.get(subscription_arn)
+        if not subscription:
+            # subscription could have been deleted in the meantime
+            raise InvalidParameterException("Invalid parameter: Token")
+
+        # ConfirmSubscription is idempotent
+        if subscription.get("PendingConfirmation") == "false":
+            return ConfirmSubscriptionResponse(SubscriptionArn=subscription_arn)
+
         subscription["PendingConfirmation"] = "false"
         subscription["ConfirmationWasAuthenticated"] = "true"
 
@@ -495,7 +514,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if subscription["Protocol"] in ["http", "https"]:
             # TODO: actually validate this (re)subscribe behaviour somehow (localhost.run?)
             #  we might need to save the sub token in the store
-            subscription_token = short_uid()
+            subscription_token = encode_subscription_token_with_region(region=context.region)
             message_ctx = SnsMessage(
                 type="UnsubscribeConfirmation",
                 token=subscription_token,
@@ -732,9 +751,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store.topic_subscriptions[topic_arn].append(subscription_arn)
 
         # store the token and subscription arn
-        subscription_token = short_uid()
-        topic_tokens = store.subscription_tokens.setdefault(topic_arn, {})
-        topic_tokens[subscription_token] = subscription_arn
+        # TODO: the token is a 288 hex char string
+        subscription_token = encode_subscription_token_with_region(region=context.region)
+        store.subscription_tokens[subscription_token] = subscription_arn
 
         # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
         if protocol in ["http", "https"]:
@@ -798,7 +817,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             store.subscriptions.pop(topic_sub, None)
 
         store.sns_tags.pop(topic_arn, None)
-        store.subscription_tokens.pop(topic_arn, None)
 
     def create_topic(
         self,
@@ -961,6 +979,29 @@ def extract_tags(
             if is_create_topic_request and existing_tags is not None and tag not in existing_tags:
                 return False
     return True
+
+
+def encode_subscription_token_with_region(region: str) -> str:
+    """
+    Create a 64 characters Subscription Token with the region encoded
+    :param region:
+    :return: a subscription token with the region encoded
+    """
+    return ((region.encode() + b"/").hex() + short_uid() * 8)[:64]
+
+
+def get_region_from_subscription_token(token: str) -> str:
+    """
+    Try to decode and return the region from a subscription token
+    :param token:
+    :return: the region if able to decode it
+    :raises: InvalidParameterException if the token is invalid
+    """
+    try:
+        region = token.split("2f", maxsplit=1)[0]
+        return bytes.fromhex(region).decode("utf-8")
+    except (IndexError, ValueError, TypeError, UnicodeDecodeError):
+        raise InvalidParameterException("Invalid parameter: Token")
 
 
 def register_sns_api_resource(router: Router):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -590,8 +590,7 @@ class TestSNSProvider:
         assert sub_attr["Attributes"]["PendingConfirmation"] == "true"
 
         def check_subscription():
-            topic_tokens = store.subscription_tokens.get(topic_arn, {})
-            for token, sub_arn in topic_tokens.items():
+            for token, sub_arn in store.subscription_tokens.items():
                 if sub_arn == subscription_arn:
                     aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=token)
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2146,8 +2146,28 @@ class TestSNSProvider:
     @pytest.mark.aws_validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     def test_subscribe_external_http_endpoint(
-        self, sns_create_http_endpoint, raw_message_delivery, aws_client
+        self, sns_create_http_endpoint, raw_message_delivery, aws_client, snapshot
     ):
+        def _get_snapshot_requests_response(response: requests.Response) -> dict:
+            parsed_xml_body = xmltodict.parse(response.content)
+            for root_tag, fields in parsed_xml_body.items():
+                fields.pop("@xmlns", None)
+                if "ResponseMetadata" in fields:
+                    fields["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
+                    fields["ResponseMetadata"]["HTTPStatusCode"] = response.status_code
+            return parsed_xml_body
+
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("RequestId"),
+                snapshot.transform.key_value("Token"),
+                snapshot.transform.regex(
+                    r"(?<=(?i)SubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=ConfirmSubscription)",
+                    replacement="<subscribe-domain>",
+                ),
+            ]
+        )
+
         # Necessitate manual set up to allow external access to endpoint, only in local testing
         topic_arn, subscription_arn, endpoint_url, server = sns_create_http_endpoint(
             raw_message_delivery
@@ -2158,6 +2178,7 @@ class TestSNSProvider:
         )
         sub_request, _ = server.log[0]
         payload = sub_request.get_json(force=True)
+        snapshot.match("subscription-confirmation", payload)
         assert payload["Type"] == "SubscriptionConfirmation"
         assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
         assert "Signature" in payload
@@ -2167,8 +2188,56 @@ class TestSNSProvider:
         subscribe_url = payload["SubscribeURL"]
         service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
         assert subscribe_url == (
-            f"{service_url}/?Action=ConfirmSubscription" f"&TopicArn={topic_arn}&Token={token}"
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
         )
+
+        test_broken_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn=not-an-arn&Token={token}"
+        )
+        broken_confirm_subscribe_request = requests.get(test_broken_confirm_url)
+        snapshot.match(
+            "broken-topic-arn-confirm",
+            _get_snapshot_requests_response(broken_confirm_subscribe_request),
+        )
+
+        test_broken_token_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token=abc123"
+        )
+        broken_token_confirm_subscribe_request = requests.get(test_broken_token_confirm_url)
+        snapshot.match(
+            "broken-token-confirm",
+            _get_snapshot_requests_response(broken_token_confirm_subscribe_request),
+        )
+
+        # a topic with a different region will fail than the subscription
+        parsed_arn = parse_arn(topic_arn)
+        different_region = "eu-central-1" if parsed_arn["region"] != "eu-central-1" else "us-east-1"
+        different_region_topic = topic_arn.replace(parsed_arn["region"], different_region)
+        different_region_topic_confirm_url = f"{service_url}/?Action=ConfirmSubscription&TopicArn={different_region_topic}&Token={token}"
+        region_topic_confirm_subscribe_request = requests.get(different_region_topic_confirm_url)
+        snapshot.match(
+            "different-region-arn-confirm",
+            _get_snapshot_requests_response(region_topic_confirm_subscribe_request),
+        )
+
+        # but a nonexistent topic in the right region will succeed
+        last_fake_topic_char = "a" if topic_arn[-1] != "a" else "b"
+        nonexistent = topic_arn[:-1] + last_fake_topic_char
+        assert nonexistent != topic_arn
+        test_wrong_topic_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={nonexistent}&Token={token}"
+        )
+        wrong_topic_confirm_subscribe_request = requests.get(test_wrong_topic_confirm_url)
+        snapshot.match(
+            "nonexistent-token-confirm",
+            _get_snapshot_requests_response(wrong_topic_confirm_subscribe_request),
+        )
+
+        # weirdly, even with a wrong topic, SNS will confirm the topic
+        subscription_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
 
         confirm_subscribe_request = requests.get(subscribe_url)
         confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
@@ -2177,6 +2246,10 @@ class TestSNSProvider:
                 "SubscriptionArn"
             ]
             == subscription_arn
+        )
+        # also confirm that ConfirmSubscription is idempotent
+        snapshot.match(
+            "confirm-subscribe", _get_snapshot_requests_response(confirm_subscribe_request)
         )
 
         subscription_attributes = aws_client.sns.get_subscription_attributes(
@@ -2207,10 +2280,12 @@ class TestSNSProvider:
             assert "SigningCertURL" in payload
             assert payload["Message"] == message
             assert payload["UnsubscribeURL"] == expected_unsubscribe_url
+            snapshot.match("http-message", payload)
 
         unsub_request = requests.get(expected_unsubscribe_url)
         unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
         assert "UnsubscribeResponse" in unsubscribe_confirmation
+        snapshot.match("unsubscribe-response", _get_snapshot_requests_response(unsub_request))
 
         assert poll_condition(
             lambda: len(server.log) >= 3,
@@ -2227,6 +2302,7 @@ class TestSNSProvider:
         assert payload["SubscribeURL"] == (
             f"{service_url}/?" f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
         )
+        snapshot.match("unsubscribe-request", payload)
 
     @pytest.mark.only_localstack
     @pytest.mark.parametrize("raw_message_delivery", [True, False])

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3569,5 +3569,194 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_subscribe_external_http_endpoint[True]": {
+    "recorded-date": "13-04-2023, 02:58:36",
+    "recorded-content": {
+      "subscription-confirmation": {
+        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
+        "Timestamp": "date",
+        "Token": "<token:1>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "SubscriptionConfirmation"
+      },
+      "broken-topic-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "broken-token-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Token",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "different-region-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "nonexistent-token-confirm": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "confirm-subscribe": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-response": {
+        "UnsubscribeResponse": {
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-request": {
+        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:2>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
+        "Timestamp": "date",
+        "Token": "<token:2>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "UnsubscribeConfirmation"
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_subscribe_external_http_endpoint[False]": {
+    "recorded-date": "13-04-2023, 02:58:52",
+    "recorded-content": {
+      "subscription-confirmation": {
+        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
+        "Timestamp": "date",
+        "Token": "<token:1>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "SubscriptionConfirmation"
+      },
+      "broken-topic-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "broken-token-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Token",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "different-region-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "nonexistent-token-confirm": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "confirm-subscribe": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "http-message": {
+        "Message": "test_external_http_endpoint",
+        "MessageId": "<uuid:2>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "Timestamp": "date",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "Notification",
+        "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+      },
+      "unsubscribe-response": {
+        "UnsubscribeResponse": {
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-request": {
+        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:3>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
+        "Timestamp": "date",
+        "Token": "<token:2>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "UnsubscribeConfirmation"
+      }
+    }
   }
 }

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -6,6 +6,7 @@ from base64 import b64encode
 import dateutil.parser
 import pytest
 
+from localstack.aws.api.sns import InvalidParameterException
 from localstack.services.sns.models import SnsMessage
 from localstack.services.sns.provider import (
     encode_subscription_token_with_region,
@@ -595,7 +596,7 @@ class TestSns:
         "token", ["abcdef123", "mynothexstring", "us-west-2", b"test", b"test2f", "test2f"]
     )
     def test_decode_token_with_no_region_encoded(self, token):
-        with pytest.raises(Exception) as e:
+        with pytest.raises(InvalidParameterException) as e:
             get_region_from_subscription_token(token)
 
         assert e.match("Invalid parameter: Token")


### PR DESCRIPTION
As reported in #8118, there was an issue with confirming a subscription from a simple http client, because we would use the region from the context, which was using the default region of LocalStack (set from the auth handler `MissingAuthHeaderInjector`). However, we should use the region from the `TopicARN`. I've re-validated the tests against AWS with a local setup with https://localhost.run, and could validate different behaviours that were untested. This adds more parity into our HTTP subscriptions, and fix the linked issue. 

Also, I've sneaked a little store change to get the parity needed. This should not break persistence nor cloud pods as tokens are usually short lived, and it is more additive. We won't try to get a topic ARN anymore from this dict, so it would not create error per se. 

_fixes #8118_