### PR TITLE
Add basic lambda performance tests

### DIFF
--- a/tests/integration/awslambda/test_lambda_performance.py
+++ b/tests/integration/awslambda/test_lambda_performance.py
@@ -1,0 +1,97 @@
+"""
+Basic opt-in performance tests for Lambda. Usage:
+1) Set TEST_PERFORMANCE=1
+2) Set TEST_PERFORMANCE_RESULTS_DIR=$HOME/Downloads if you want to export performance results as CSV
+3) Adjust repeat=1000 to configure the number of repetitions
+"""
+
+import csv
+import os
+import pathlib
+import statistics
+import timeit
+from datetime import datetime
+
+import pytest
+
+from localstack import config
+from localstack.aws.api.lambda_ import Runtime
+from localstack.config import is_env_true
+from localstack.utils.strings import short_uid
+from tests.integration.awslambda.test_lambda import TEST_LAMBDA_PYTHON_ECHO
+
+# These performance tests are opt-in because we currently do not track performance systematically.
+if not is_env_true("TEST_PERFORMANCE"):
+    pytest.skip("Skip slow and resource-intensive tests", allow_module_level=True)
+
+
+def test_invoke_warm_start(create_lambda_function, aws_client):
+    function_name = f"echo-func-{short_uid()}"
+    create_lambda_function(
+        handler_file=TEST_LAMBDA_PYTHON_ECHO,
+        func_name=function_name,
+        runtime=Runtime.python3_9,
+    )
+
+    def invoke():
+        aws_client.awslambda.invoke(FunctionName=function_name)
+
+    # Cold start
+    invoke()
+
+    # Warm starts
+    repeat = 100
+    timings = timeit.repeat(invoke, number=1, repeat=repeat)
+    print("")
+    print(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
+    print(format_summary(timings))
+    export_csv(timings, "test_invoke_warm_start")
+
+
+def test_invoke_cold_start(create_lambda_function, aws_client, monkeypatch):
+    monkeypatch.setattr(config, "LAMBDA_KEEPALIVE_MS", 0)
+    function_name = f"echo-func-{short_uid()}"
+    create_lambda_function(
+        handler_file=TEST_LAMBDA_PYTHON_ECHO,
+        func_name=function_name,
+        runtime=Runtime.python3_9,
+    )
+
+    def invoke():
+        aws_client.awslambda.invoke(FunctionName=function_name)
+
+    # Cold starts caused by keep alive 0
+    repeat = 100
+    # Optionally sleep in between repetitions
+    sleep_s = 4
+    timings = timeit.repeat(
+        invoke, number=1, repeat=repeat, setup=f"import time; time.sleep({sleep_s})"
+    )
+    print("")
+    print(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
+    print(format_summary(timings))
+    export_csv(timings, "test_invoke_cold_start")
+
+
+def format_summary(timings: [float]) -> str:
+    """Format summary statistics in seconds."""
+    stats = [
+        f"{min(timings)} (min)",
+        f"{statistics.median(timings)} (median)",
+        f"""{statistics.quantiles(timings, n=100, method="inclusive")[98]} (p99)""",
+        f"{max(timings)} (max)",
+    ]
+    return ", ".join(stats)
+
+
+def export_csv(timings: [float], label: str = "") -> None:
+    """Export the given timings into a csv file if the environment variable TEST_PERFORMANCE_RESULTS_DIR is set."""
+    if results_dir := os.environ.get("TEST_PERFORMANCE_RESULTS_DIR"):
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        file_name = f"{timestamp}_{label}.csv"
+        file_path = pathlib.Path(results_dir) / file_name
+        file = open(file_path, "w")
+        data = [[value] for value in timings]
+        with file:
+            write = csv.writer(file)
+            write.writerows(data)

--- a/tests/integration/awslambda/test_lambda_performance.py
+++ b/tests/integration/awslambda/test_lambda_performance.py
@@ -60,6 +60,9 @@ def test_invoke_cold_start(create_lambda_function, aws_client, monkeypatch):
     def invoke():
         aws_client.awslambda.invoke(FunctionName=function_name)
 
+    # Initial cold start could be even slower due to init downloading
+    invoke()
+
     # Cold starts caused by keep alive 0
     repeat = 100
     # Optionally sleep in between repetitions

--- a/tests/integration/awslambda/test_lambda_performance.py
+++ b/tests/integration/awslambda/test_lambda_performance.py
@@ -6,6 +6,7 @@ Basic opt-in performance tests for Lambda. Usage:
 """
 
 import csv
+import logging
 import os
 import pathlib
 import statistics
@@ -25,6 +26,9 @@ if not is_env_true("TEST_PERFORMANCE"):
     pytest.skip("Skip slow and resource-intensive tests", allow_module_level=True)
 
 
+LOG = logging.getLogger(__name__)
+
+
 def test_invoke_warm_start(create_lambda_function, aws_client):
     function_name = f"echo-func-{short_uid()}"
     create_lambda_function(
@@ -42,9 +46,8 @@ def test_invoke_warm_start(create_lambda_function, aws_client):
     # Test warm starts
     repeat = 100
     timings = timeit.repeat(invoke, number=1, repeat=repeat)
-    print("")
-    print(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
-    print(format_summary(timings))
+    LOG.info(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
+    LOG.info(format_summary(timings))
     export_csv(timings, "test_invoke_warm_start")
 
 
@@ -70,9 +73,8 @@ def test_invoke_cold_start(create_lambda_function, aws_client, monkeypatch):
     timings = timeit.repeat(
         invoke, number=1, repeat=repeat, setup=f"import time; time.sleep({sleep_s})"
     )
-    print("")
-    print(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
-    print(format_summary(timings))
+    LOG.info(f" EXECUTION TIME (s) for {repeat} repetitions ".center(80, "="))
+    LOG.info(format_summary(timings))
     export_csv(timings, "test_invoke_cold_start")
 
 


### PR DESCRIPTION
Add basic performance tests for Lambda. The main idea is to have an initial version of reproducible tests within the IDE.
I looked into the dedicated `performance` directory under tests but they do not integrate with pytest nor can they leverage the convenient test utils such as fixtures, running against external LocalStack, etc.

## Initial results

Initial results and basic plotting scripts are available at https://github.com/joe4dev/localstack-performance-testing/

The preliminary results support that warm starts are pretty fast around 17ms (min) to 77ms (p99) on macOS but even faster on Linux.
Cold starts seem pretty slow 3.3s (min) to 7.5s (p99) on macOS with Docker compared to 700ms (min) to 870ms (p99) on Linux in host mode. Daniel's summary of `tests.integration.awslambda.test_lambda_performance.test_invoke_cold_start`:

```
==================== EXECUTION TIME (s) for 100 repetitions ====================
0.6990477449999162 (min), 0.7632910385000287 (median), 0.8729619503100002 (p99), 0.8846987280003304 (max)
```

* Something makes cold starts slow on macOS with Docker compared to host mode, where the execution time goes back to normal ~880 ms. Maybe copying causes slowdown, maybe particularly in multi-arch environments 🤔 
* Related to the invocation loop rework, when using `LAMBDA_KEEPALIVE_MS=0` to trigger cold starts, it appears that no new environments are spawned while the previous environment de-provisions. Therefore, the cold start test adds a setup delay `sleep_s = 4` between invocations. This slows down the cold start test, making it run for ~13 min.

## Published numbers

* [LocalStack release blog](https://localstack.cloud/blog/2023-03-29-announcing-localstack-2.0-general-availability/): "800 - 1000ms from the old docker executor to around 10ms for a simple Lambda invocation with an Echo function."
* [Lambda Provider Behavioral Changes](https://docs.localstack.cloud/references/lambda-provider-v2/): "10ms warm-start and 600ms cold-start for an Echo Python Lambda"

These numbers are based on Daniel's benchmarking before the v2 release (see [Lambda Knowledge Base](https://www.notion.so/localstack/Lambda-Knowledge-Base-73d652ded2bd45cf9545860ca3d8764f?pvs=4#5448da714ad14ea8a3166ff4ffdd4fc0)).

```
Old without pro:
docker: 1.2s
docker-reuse: Cold 1s, warm 400ms
docker-reuse hot: Cold 1s, warm 80ms
local: cold 400ms, warm 60ms

New:
cold 600ms, warm 10ms
```

## Preliminary Plot initial results

> **Disclaimer:** This plot mainly shows a limitation for investigation on macOS with Docker and is not representative of the actual performance LocalStack can achieve!

![invoke_time](https://user-images.githubusercontent.com/8161292/231809338-6168920b-33d6-4014-aee3-51efd5cc5923.png)

|    | label                   |   level_1 |   time_seconds |
|---:|:------------------------|----------:|---------------:|
|  0 | v1_docker               |      0    |      1.73869   |
|  1 | v1_docker               |      0.5  |      1.81394   |
|  2 | v1_docker               |      0.95 |      1.91334   |
|  3 | v1_docker               |      0.99 |      2.51415   |
|  4 | v1_docker               |      1    |      2.68338   |
|  5 | v2_docker_cold          |      0    |      3.84627   |
|  6 | v2_docker_cold          |      0.5  |      4.94845   |
|  7 | v2_docker_cold          |      0.95 |      5.81013   |
|  8 | v2_docker_cold          |      0.99 |      6.47774   |
|  9 | v2_docker_cold          |      1    |      6.9414    |
| 10 | v2_docker_cold_arm64    |      0    |      4.77397   |
| 11 | v2_docker_cold_arm64    |      0.5  |      5.20489   |
| 12 | v2_docker_cold_arm64    |      0.95 |      6.15666   |
| 13 | v2_docker_cold_arm64    |      0.99 |      7.23966   |
| 14 | v2_docker_cold_arm64    |      1    |      7.56599   |
| 15 | v2_docker_cold_virtiofs |      0    |      4.1032    |
| 16 | v2_docker_cold_virtiofs |      0.5  |      4.98274   |
| 17 | v2_docker_cold_virtiofs |      0.95 |      6.54635   |
| 18 | v2_docker_cold_virtiofs |      0.99 |      8.11454   |
| 19 | v2_docker_cold_virtiofs |      1    |      8.20455   |
| 20 | v2_docker_warm          |      0    |      0.0184816 |
| 21 | v2_docker_warm          |      0.5  |      0.0330957 |
| 22 | v2_docker_warm          |      0.95 |      0.0498648 |
| 23 | v2_docker_warm          |      0.99 |      0.0772281 |
| 24 | v2_docker_warm          |      1    |      0.0792853 |
| 25 | v2_docker_warm_arm64    |      0    |      0.0178109 |
| 26 | v2_docker_warm_arm64    |      0.5  |      0.0293759 |
| 27 | v2_docker_warm_arm64    |      0.95 |      0.0434178 |
| 28 | v2_docker_warm_arm64    |      0.99 |      0.0632035 |
| 29 | v2_docker_warm_arm64    |      1    |      0.0748119 |
| 30 | v2_host_cold_arm64      |      0    |      0.736802  |
| 31 | v2_host_cold_arm64      |      0.5  |      0.804289  |
| 32 | v2_host_cold_arm64      |      0.95 |      0.925292  |
| 33 | v2_host_cold_arm64      |      0.99 |      1.00363   |
| 34 | v2_host_cold_arm64      |      1    |      1.08274   |
| 35 | v2_host_cold_linux      |      0    |      0.680633  |
| 36 | v2_host_cold_linux      |      0.5  |      0.768912  |
| 37 | v2_host_cold_linux      |      0.95 |      0.853735  |
| 38 | v2_host_cold_linux      |      0.99 |      0.893655  |
| 39 | v2_host_cold_linux      |      1    |      1.09164   |