### PR TITLE
SNS test and add deduplication for FIFO topic

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -289,6 +289,10 @@ class SqsTopicPublisher(TopicPublisher):
             # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
             content = msg_context.message_content("sqs")
             kwargs["MessageDeduplicationId"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+        # TODO: for message deduplication, we are using the underlying features of the SQS queue
+        # however, SQS queue only deduplicate on the MessageGroupId, where the SNS topic deduplicate on the topic level
+        # we will need to implement this
         return kwargs
 
 

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -291,7 +291,7 @@ class SqsTopicPublisher(TopicPublisher):
             kwargs["MessageDeduplicationId"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
 
         # TODO: for message deduplication, we are using the underlying features of the SQS queue
-        # however, SQS queue only deduplicate on the MessageGroupId, where the SNS topic deduplicate on the topic level
+        # however, SQS queue only deduplicate at the Queue level, where the SNS topic deduplicate on the topic level
         # we will need to implement this
         return kwargs
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1349,6 +1349,8 @@ class TestSNSProvider:
             "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
             "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
             "$.sub-attrs-raw-true.Attributes.SubscriptionPrincipal",
+            "$.republish-batch-response-fifo.Successful..MessageId",  # TODO: SNS doesnt keep track of duplicate
+            "$.republish-batch-response-fifo.Successful..SequenceNumber",  # TODO: SNS doesnt keep track of duplicate
         ]
     )
     @pytest.mark.parametrize("content_based_deduplication", [True, False])
@@ -1467,11 +1469,24 @@ class TestSNSProvider:
 
         retry(get_messages, retries=5, sleep=1)
         snapshot.match("messages", {"Messages": messages})
-        # todo add test for deduplication
-        # https://docs.aws.amazon.com/cli/latest/reference/sns/publish-batch.html
-        # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
-        # > The SQS FIFO queue consumer processes the message and deletes it from the queue before the visibility
-        # > timeout expires.
+
+        publish_batch_response = aws_client.sns.publish_batch(
+            TopicArn=topic_arn,
+            PublishBatchRequestEntries=publish_batch_request_entries,
+        )
+
+        snapshot.match("republish-batch-response-fifo", publish_batch_response)
+        get_deduplicated_messages = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            AttributeNames=["All"],
+            MaxNumberOfMessages=10,
+            WaitTimeSeconds=3,
+            VisibilityTimeout=0,
+        )
+        # there should not be any messages here, as they are duplicate
+        # see https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
+        snapshot.match("duplicate-messages", get_deduplicated_messages)
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
@@ -1688,8 +1703,6 @@ class TestSNSProvider:
             )
         snapshot.match("no-dedup-id", e.value.response)
 
-        # todo add test and implement behaviour for ContentBasedDeduplication or MessageDeduplicationId
-
     @pytest.mark.aws_validated
     def test_subscribe_to_sqs_with_queue_url(
         self, sns_create_topic, sqs_create_queue, sns_subscription, snapshot
@@ -1823,31 +1836,34 @@ class TestSNSProvider:
             QueueName=queue_name,
             Attributes=queue_attributes,
         )
-        # todo check both ContentBasedDeduplication and MessageDeduplicationId when implemented
-        # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
 
         sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
         message = "Test"
-        if content_based_deduplication:
-            aws_client.sns.publish(
-                TopicArn=topic_arn, Message=message, MessageGroupId="message-group-id-1"
-            )
-        else:
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=message,
-                MessageGroupId="message-group-id-1",
-                MessageDeduplicationId="message-deduplication-id-1",
-            )
+        kwargs = {"MessageGroupId": "message-group-id-1"}
+        if not content_based_deduplication:
+            kwargs["MessageDeduplicationId"] = "message-deduplication-id-1"
+
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
 
         response = aws_client.sqs.receive_message(
             QueueUrl=queue_url,
-            VisibilityTimeout=0,
             WaitTimeSeconds=10,
             AttributeNames=["All"],
         )
         snapshot.match("messages", response)
+
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+        # republish the message, to check deduplication
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=1,
+            AttributeNames=["All"],
+        )
+        snapshot.match("dedup-messages", response)
 
     @pytest.mark.aws_validated
     def test_validations_for_fifo(
@@ -3311,21 +3327,108 @@ class TestSNSProvider:
 
         # Topic has ContentBasedDeduplication set to true, the queue should receive only one message
         # SNS will create a MessageDeduplicationId for the SQS queue, as it does not have ContentBasedDeduplication
+        for _ in range(2):
+            aws_client.sns.publish(
+                TopicArn=topic_arn, Message="Test single", MessageGroupId="message-group-id-1"
+            )
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "MessageGroupId": "message-group-id-1",
+                        "Message": "Test batched",
+                    }
+                ],
+            )
+
+        messages = []
+        message_ids_received = set()
+
+        def get_messages():
+            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
+            # MaxNumberOfMessages could return less than 2 messages
+            sqs_response = aws_client.sqs.receive_message(
+                QueueUrl=queue_url,
+                MessageAttributeNames=["All"],
+                AttributeNames=["All"],
+                MaxNumberOfMessages=10,
+                WaitTimeSeconds=1,
+                VisibilityTimeout=10,
+            )
+
+            for message in sqs_response["Messages"]:
+                if message["MessageId"] in message_ids_received:
+                    continue
+
+                message_ids_received.add(message["MessageId"])
+                messages.append(message)
+                aws_client.sqs.delete_message(
+                    QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
+                )
+
+            assert len(messages) == 2
+
+        retry(get_messages, retries=5, sleep=1)
+        messages.sort(key=lambda x: x["Attributes"]["MessageDeduplicationId"])
+        snapshot.match("messages", {"Messages": messages})
+
+    @pytest.mark.aws_validated
+    @pytest.mark.xfail(reason="SNS provider does not deduplicate on topic level yet")
+    def test_publish_to_fifo_topic_deduplication_on_topic_level(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sns_create_sqs_subscription,
+        snapshot,
+        aws_client,
+    ):
+        topic_name = f"topic-{short_uid()}.fifo"
+        queue_name = f"queue-{short_uid()}.fifo"
+        topic_attributes = {"FifoTopic": "true", "ContentBasedDeduplication": "true"}
+        queue_attributes = {"FifoQueue": "true"}
+
+        topic_arn = sns_create_topic(
+            Name=topic_name,
+            Attributes=topic_attributes,
+        )["TopicArn"]
+        queue_url = sqs_create_queue(
+            QueueName=queue_name,
+            Attributes=queue_attributes,
+        )
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        # TODO: for message deduplication, we are using the underlying features of the SQS queue
+        # however, SQS queue only deduplicate on the MessageGroupId, where the SNS topic deduplicate on the topic level
+        # we will need to implement this
         message = "Test"
         aws_client.sns.publish(
             TopicArn=topic_arn, Message=message, MessageGroupId="message-group-id-1"
         )
         aws_client.sns.publish(
-            TopicArn=topic_arn, Message=message, MessageGroupId="message-group-id-1"
+            TopicArn=topic_arn, Message=message, MessageGroupId="message-group-id-2"
         )
 
+        # get the deduplicated message and delete it
         response = aws_client.sqs.receive_message(
             QueueUrl=queue_url,
-            VisibilityTimeout=0,
+            VisibilityTimeout=10,
             WaitTimeSeconds=10,
             AttributeNames=["All"],
         )
         snapshot.match("messages", response)
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+        # assert there are no more messages in the queue
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            VisibilityTimeout=10,
+            WaitTimeSeconds=1,
+            AttributeNames=["All"],
+        )
+        snapshot.match("dedup-messages", response)
 
     @pytest.mark.aws_validated
     def test_publish_to_fifo_with_target_arn(self, sns_create_topic, aws_client):

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -1753,7 +1753,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[True]": {
-    "recorded-date": "14-04-2023, 19:13:18",
+    "recorded-date": "14-04-2023, 19:17:55",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -1924,11 +1924,41 @@
             "ReceiptHandle": "<receipt-handle:3>"
           }
         ]
+      },
+      "republish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "duplicate-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[False]": {
-    "recorded-date": "14-04-2023, 19:13:21",
+    "recorded-date": "14-04-2023, 19:18:02",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -2099,11 +2129,41 @@
             "ReceiptHandle": "<receipt-handle:3>"
           }
         ]
+      },
+      "republish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "duplicate-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_to_fifo_sqs[True]": {
-    "recorded-date": "27-01-2023, 19:44:21",
+    "recorded-date": "14-04-2023, 19:38:46",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2135,11 +2195,17 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_to_fifo_sqs[False]": {
-    "recorded-date": "27-01-2023, 19:44:23",
+    "recorded-date": "14-04-2023, 19:38:59",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2167,6 +2233,12 @@
             "ReceiptHandle": "<receipt-handle:1>"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3196,7 +3268,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[True]": {
-    "recorded-date": "27-01-2023, 19:39:16",
+    "recorded-date": "14-04-2023, 19:57:05",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -3204,27 +3276,38 @@
             "Attributes": {
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
               "MessageGroupId": "message-group-id-1",
               "SenderId": "<sender-id>",
               "SentTimestamp": "timestamp",
               "SequenceNumber": "<sequence-number:1>"
             },
-            "Body": "Test",
+            "Body": "Test single",
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:1>",
             "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:2>"
+            },
+            "Body": "Test batched",
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+        ]
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[False]": {
-    "recorded-date": "27-01-2023, 19:39:19",
+    "recorded-date": "14-04-2023, 19:57:07",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -3232,7 +3315,7 @@
             "Attributes": {
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
               "MessageGroupId": "message-group-id-1",
               "SenderId": "<sender-id>",
               "SentTimestamp": "timestamp",
@@ -3243,19 +3326,38 @@
               "MessageId": "<uuid:1>",
               "SequenceNumber": "<sequence-number:2>",
               "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test",
+              "Message": "Test single",
               "Timestamp": "date",
               "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",
             "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:3>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "SequenceNumber": "<sequence-number:4>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test batched",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+        ]
       }
     }
   },
@@ -3639,6 +3741,48 @@
             "ReceiptHandle": "<receipt-handle:2>"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_deduplication_on_topic_level": {
+    "recorded-date": "14-04-2023, 20:03:27",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
This is building on top of #8144 and #8146, and adds test and implement the deduplication for FIFO topics. Right now, we are just properly using the SQS deduplication features, but SNS one is a bit different regarding the `MessageGroupId`, see https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html, the deduplication is at the topic level. 
We are also not storing the deduplication ID yet, so we cannot return the proper `MessageId` and `SequenceNumber` from the publishing call, which we should do. 