### PR TITLE
SQS fix deduplication at queue level and deleted messages

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2220,7 +2220,7 @@ class TestSNSProvider:
             _get_snapshot_requests_response(broken_token_confirm_subscribe_request),
         )
 
-        # a topic with a different region will fail than the subscription
+        # using the right topic name with a different region will fail when confirming the subscription
         parsed_arn = parse_arn(topic_arn)
         different_region = "eu-central-1" if parsed_arn["region"] != "eu-central-1" else "us-east-1"
         different_region_topic = topic_arn.replace(parsed_arn["region"], different_region)

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -2108,6 +2108,50 @@ class TestSqsProvider:
         snapshot.match("get-messages-duplicate", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.parametrize("content_based_deduplication", [True, False])
+    def test_fifo_deduplication_not_on_message_group_id(
+        self,
+        sqs_create_queue,
+        aws_client,
+        content_based_deduplication,
+        snapshot,
+    ):
+        attributes = {"FifoQueue": "true"}
+        if content_based_deduplication:
+            attributes["ContentBasedDeduplication"] = "true"
+        queue_url = sqs_create_queue(
+            QueueName=f"test-queue-{short_uid()}.fifo",
+            Attributes=attributes,
+        )
+        item = '{"foo": "bar"}'
+        kwargs = {}
+        if not content_based_deduplication:
+            kwargs["MessageDeduplicationId"] = "dedup1"
+
+        aws_client.sqs.send_message(
+            QueueUrl=queue_url, MessageBody=item, MessageGroupId="group-1", **kwargs
+        )
+
+        aws_client.sqs.send_message(
+            QueueUrl=queue_url, MessageBody=item, MessageGroupId="group-2", **kwargs
+        )
+
+        # first receive has the item
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=2
+        )
+        assert len(response["Messages"]) == 1
+        assert response["Messages"][0]["Body"] == item
+        snapshot.match("get-messages", response)
+
+        # second doesn't since the message has the same content
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=1
+        )
+        assert response.get("Messages", []) == []
+        snapshot.match("get-dedup-messages", response)
+
+    @pytest.mark.aws_validated
     @pytest.mark.xfail(
         reason="localstack allows queue names with slashes, but this should be deprecated"
     )

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -2062,6 +2062,52 @@ class TestSqsProvider:
         assert response.get("Messages", []) == []
 
     @pytest.mark.aws_validated
+    @pytest.mark.parametrize("content_based_deduplication", [True, False])
+    def test_fifo_deduplication_arrives_once_after_delete(
+        self,
+        sqs_create_queue,
+        aws_client,
+        content_based_deduplication,
+        snapshot,
+    ):
+        attributes = {"FifoQueue": "true"}
+        if content_based_deduplication:
+            attributes["ContentBasedDeduplication"] = "true"
+        queue_url = sqs_create_queue(
+            QueueName=f"test-queue-{short_uid()}.fifo",
+            Attributes=attributes,
+        )
+        item = '{"foo": "bar"}'
+        group = "group-1"
+        kwargs = {}
+        if not content_based_deduplication:
+            kwargs["MessageDeduplicationId"] = "dedup1"
+        aws_client.sqs.send_message(
+            QueueUrl=queue_url, MessageBody=item, MessageGroupId=group, **kwargs
+        )
+
+        # first receive has the item
+        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=3)
+        snapshot.match("get-messages", response)
+        assert len(response["Messages"]) == 1
+        assert response["Messages"][0]["Body"] == item
+        # delete the item, we want to check that we don't receive a duplicate even after deletion
+        # see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+
+        # republish the same message
+        aws_client.sqs.send_message(
+            QueueUrl=queue_url, MessageBody=item, MessageGroupId=group, **kwargs
+        )
+
+        # second doesn't receive anything since the message has the same content
+        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert response.get("Messages", []) == []
+        snapshot.match("get-messages-duplicate", response)
+
+    @pytest.mark.aws_validated
     @pytest.mark.xfail(
         reason="localstack allows queue names with slashes, but this should be deprecated"
     )

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -2102,7 +2102,7 @@ class TestSqsProvider:
             QueueUrl=queue_url, MessageBody=item, MessageGroupId=group, **kwargs
         )
 
-        # second doesn't receive anything since the message has the same content
+        # second doesn't receive anything the deduplication id is the same
         response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert response.get("Messages", []) == []
         snapshot.match("get-messages-duplicate", response)

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -651,5 +651,59 @@
         }
       }
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[True]": {
+    "recorded-date": "14-04-2023, 19:30:06",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[False]": {
+    "recorded-date": "14-04-2023, 19:30:08",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -705,5 +705,59 @@
         }
       }
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[True]": {
+    "recorded-date": "14-04-2023, 20:25:10",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[False]": {
+    "recorded-date": "14-04-2023, 20:25:12",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
While working on #8144 and #8145 I've spotted 2 issues with deduplication on FIFO SQS queues.

First, it seemed we did not deduplicate deleted messages when the SQS documentation says they do.
See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html

While reading this, I've also realised that what I thought was a feature of SQS was actually a bug, and that we should deduplicate on the queue level and not the `MessageGroupId`. However, this means breaking persistence as we're changing the structure of the `FifoQueue` object. Is this acceptable for 2.1?

I've added 2 AWS validated tests, and #8144 is building on this PR. 