### PR TITLE
fix auto decoding of gzip for s3 vhost proxied requests

### DIFF
--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit, urlunsplit
 from localstack import config
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.http import Request, Response
+from localstack.http.client import SimpleStreamingRequestsClient
 from localstack.http.proxy import Proxy
 from localstack.runtime import hooks
 from localstack.services.edge import ROUTER
@@ -45,6 +46,7 @@ class S3VirtualHostProxyHandler:
         with Proxy(
             forward_base_url=config.get_edge_url(),
             preserve_host=False,
+            client=SimpleStreamingRequestsClient(),
         ) as proxy:
             forwarded = proxy.forward(
                 request=request, forward_path=forward_to_url.path, headers=copied_headers


### PR DESCRIPTION
As reported in #8139, the new S3 provider will decode gzip encoded requests before returning the data.
This was due to our Proxy and more specifically our `SimpleHttpClient`, which uses `requests` under the hood. Requests automatically decode the response, and we need the raw data underneath. I've duplicated our http client to not do a drastic change and only use it in the virtual host part of S3, we can then see if it creates issues or not 😄

I didn't add unit tests as I believe it could be added on top of #8104, and don't want to create too many conflicts. 

About requests and decoding gzip:
https://docs.python-requests.org/en/latest/community/faq/#encoded-data

_fixes #8139_