### PR TITLE
Fix lambda init xray telemetry initialization

### DIFF
--- a/localstack/services/awslambda/invocation/runtime_environment.py
+++ b/localstack/services/awslambda/invocation/runtime_environment.py
@@ -153,6 +153,8 @@ class RuntimeEnvironment:
             env_vars["LOCALSTACK_USER"] = ""
         if config.LAMBDA_INIT_USER:
             env_vars["LOCALSTACK_USER"] = config.LAMBDA_INIT_USER
+        if config.DEBUG:
+            env_vars["LOCALSTACK_INIT_LOG_LEVEL"] = "debug"
         if config.LAMBDA_INIT_POST_INVOKE_WAIT_MS:
             env_vars["LOCALSTACK_POST_INVOKE_WAIT_MS"] = int(config.LAMBDA_INIT_POST_INVOKE_WAIT_MS)
         return env_vars

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.16-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.17-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -325,6 +325,7 @@ class TestLambdaBehavior:
             "$..Payload.paths._var_task_uid",
         ],
     )
+    # TODO: fix arch compatibility detection for supported emulations
     @pytest.mark.skipif(get_arch() == "arm64", reason="Cannot inspect x86 runtime on arm")
     @pytest.mark.aws_validated
     def test_runtime_introspection_x86(self, create_lambda_function, snapshot, aws_client):


### PR DESCRIPTION
Ships a new Lambda init release: https://github.com/localstack/lambda-runtime-init/releases/tag/v0.1.17-pre

* Addresses a support case where the optional X-Ray daemon telemetry crashed the Lambda Docker container: https://github.com/localstack/lambda-runtime-init/pull/18
* Improves Lambda init logging: https://github.com/localstack/lambda-runtime-init/pull/19


