### PR TITLE
Fix firehose / s3 client creation of clients with role

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -437,7 +437,10 @@ def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> st
     function will resolve the SSM parameter with name `test-param` and return the SSM parameter's value.
     """
     # TODO: support different parameter value types
-    if parameter_type == "AWS::SSM::Parameter::Value<String>":
+    if (
+        parameter_type == "AWS::SSM::Parameter::Value<String>"
+        or parameter_type == "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    ):
         ssm_client = aws_stack.connect_to_service("ssm")
         return ssm_client.get_parameter(Name=parameter_value)["Parameter"]["Value"]
     raise Exception(f"Unsupported parameter value type {parameter_type}")

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -437,10 +437,7 @@ def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> st
     function will resolve the SSM parameter with name `test-param` and return the SSM parameter's value.
     """
     # TODO: support different parameter value types
-    if (
-        parameter_type == "AWS::SSM::Parameter::Value<String>"
-        or parameter_type == "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    ):
+    if parameter_type == "AWS::SSM::Parameter::Value<String>":
         ssm_client = aws_stack.connect_to_service("ssm")
         return ssm_client.get_parameter(Name=parameter_value)["Parameter"]["Value"]
     raise Exception(f"Unsupported parameter value type {parameter_type}")

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -106,6 +106,7 @@ class SnsSubscription(TypedDict):
     FilterPolicyScope: Literal["MessageAttributes", "MessageBody"]
     RawMessageDelivery: Literal["true", "false"]
     ConfirmationWasAuthenticated: Literal["true", "false"]
+    SubscriptionRoleArn: Optional[str]
 
 
 class SnsStore(BaseStore):

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -34,6 +34,7 @@ from localstack.utils.aws.arns import (
     sqs_queue_url_for_arn,
 )
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes
+from localstack.utils.aws.client_types import ServicePrincipal
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.objects import not_none_or
@@ -578,8 +579,14 @@ class FirehoseTopicPublisher(TopicPublisher):
         message_body = self.prepare_message(context.message, subscriber)
         try:
             region = extract_region_from_arn(subscriber["Endpoint"])
-            firehose_client = connect_to(region_name=region).firehose.request_metadata(
-                source_arn=subscriber["TopicArn"], service_principal="sns"
+            if role_arn := subscriber.get("SubscriptionRoleArn"):
+                factory = connect_to.with_assumed_role(
+                    role_arn=role_arn, service_principal=ServicePrincipal.sns, region_name=region
+                )
+            else:
+                factory = connect_to(region_name=region)
+            firehose_client = factory.firehose.request_metadata(
+                source_arn=subscriber["TopicArn"], service_principal=ServicePrincipal.sns
             )
             endpoint = subscriber["Endpoint"]
             if endpoint:

--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -228,5 +228,6 @@ class ServicePrincipal(str):
 
     awslambda = "lambda"
     apigateway = "apigateway"
+    firehose = "firehose"
     sqs = "sqs"
     sns = "sns"


### PR DESCRIPTION
## Motivation
Currently, we completely ignore the roles provided with the sns subscription or firehose s3 records integration.

## Changes
This PR uses the roles where provided. If it is not provided, we will just fallback to the service principal. This is to remain non-breaking, but we need to increase parity for this at a later point.