### PR TITLE
fix default ProvisionedThroughput in DynamoDB

### DIFF
--- a/tests/integration/cloudformation/resources/test_dynamodb.py
+++ b/tests/integration/cloudformation/resources/test_dynamodb.py
@@ -81,6 +81,9 @@ def test_default_name_for_table(deploy_cfn_template, snapshot, aws_client):
         "$..Table.ProvisionedThroughput.LastDecreaseDateTime",
         "$..Table.ProvisionedThroughput.LastIncreaseDateTime",
         "$..Table.Replicas",
+        "$..Table.DeletionProtectionEnabled",
+        "$..Table.LatestStreamArn",
+        "$..Table.LatestStreamLabel",
     ]
 )
 @pytest.mark.parametrize("billing_mode", ["PROVISIONED", "PAY_PER_REQUEST"])

--- a/tests/integration/cloudformation/resources/test_dynamodb.py
+++ b/tests/integration/cloudformation/resources/test_dynamodb.py
@@ -73,3 +73,26 @@ def test_default_name_for_table(deploy_cfn_template, snapshot, aws_client):
 
     response = aws_client.dynamodb.describe_table(TableName=stack.outputs["TableName"])
     snapshot.match("table_description", response)
+
+
+@pytest.mark.aws_validated
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        "$..Table.ProvisionedThroughput.LastDecreaseDateTime",
+        "$..Table.ProvisionedThroughput.LastIncreaseDateTime",
+        "$..Table.Replicas",
+    ]
+)
+@pytest.mark.parametrize("billing_mode", ["PROVISIONED", "PAY_PER_REQUEST"])
+def test_billing_mode_as_conditional(deploy_cfn_template, snapshot, aws_client, billing_mode):
+    snapshot.add_transformer(snapshot.transform.dynamodb_api())
+    snapshot.add_transformer(snapshot.transform.key_value("TableName", "table-name"))
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/dynamodb_billing_conditional.yml"
+        ),
+        parameters={"BillingModeParameter": billing_mode},
+    )
+
+    response = aws_client.dynamodb.describe_table(TableName=stack.outputs["TableName"])
+    snapshot.match("table_description", response)

--- a/tests/integration/cloudformation/resources/test_dynamodb.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_dynamodb.snapshot.json
@@ -35,5 +35,97 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_dynamodb.py::test_billing_mode_as_conditional[PROVISIONED]": {
+    "recorded-date": "18-04-2023, 10:44:47",
+    "recorded-content": {
+      "table_description": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/2023-04-18T15:44:18.287",
+          "LatestStreamLabel": "2023-04-18T15:44:18.287",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "ACTIVE"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/cloudformation/resources/test_dynamodb.py::test_billing_mode_as_conditional[PAY_PER_REQUEST]": {
+    "recorded-date": "18-04-2023, 10:45:28",
+    "recorded-content": {
+      "table_description": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST",
+            "LastUpdateToPayPerRequestDateTime": "datetime"
+          },
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/2023-04-18T15:45:01.056",
+          "LatestStreamLabel": "2023-04-18T15:45:01.056",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "ACTIVE"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/dynamodb_billing_conditional.yml
+++ b/tests/integration/templates/dynamodb_billing_conditional.yml
@@ -1,0 +1,34 @@
+Parameters:
+  BillingModeParameter:
+    Type: String
+
+Resources:
+  DynamoDBTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        Fn::If:
+          - ShouldUsePayPerRequestBilling
+          - !Ref "AWS::NoValue"
+          - ReadCapacityUnits: 5
+            WriteCapacityUnits: 5
+      BillingMode:
+        Fn::If:
+          - ShouldUsePayPerRequestBilling
+          - PAY_PER_REQUEST
+          - !Ref "AWS::NoValue"
+      StreamSpecification:
+        StreamViewType: "NEW_AND_OLD_IMAGES"
+
+Conditions:
+  ShouldUsePayPerRequestBilling: !Equals [!Ref BillingModeParameter, "PAY_PER_REQUEST"]
+
+Outputs:
+  TableName:
+    Value: !Ref DynamoDBTable


### PR DESCRIPTION
Conditional attributes are not completely/correctly resolved during the execution of `add_defaults` method of a GenericBaeseModel. The current patch allows to have a DynamoDB table that has multiple conditional attributes to be deployed.

There's more work required to completely fix the issue but with these small changes the amplify-localstack plugin can finally deploy a API stack to LocalStack.


Changes:
- [x] Test with a small example of what amplify tries to deploy.
- [x] Move the addition of default parameters to another phase where conditionals are resolved.


