### PR TITLE
Enhance parity for ACM certificates for wildcard subdomains

### DIFF
--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -1,22 +1,42 @@
+from moto import settings as moto_settings
 from moto.acm import models as acm_models
 
 from localstack.aws.api import RequestContext, handler
-from localstack.aws.api.acm import AcmApi, RequestCertificateRequest, RequestCertificateResponse
+from localstack.aws.api.acm import (
+    AcmApi,
+    ListCertificatesRequest,
+    ListCertificatesResponse,
+    RequestCertificateRequest,
+    RequestCertificateResponse,
+)
 from localstack.services import moto
 from localstack.utils.objects import singleton_factory
 from localstack.utils.patch import patch
 
+# reduce the validation wait time from 60 (default) to 10 seconds
+moto_settings.ACM_VALIDATION_WAIT = 10
+
 
 @patch(acm_models.CertBundle.describe)
 def describe(describe_orig, self):
-    result = describe_orig(self)
+
+    # Terrible hack (for parity). Moto adds certain required fields only if status is PENDING_VALIDATION. TODO fix!
+    cert_status = self.status
+    self.status = "PENDING_VALIDATION"
+    try:
+        result = describe_orig(self)
+    finally:
+        self.status = cert_status
+
     cert = result.get("Certificate", {})
-    sans = cert.get("SubjectAlternativeNames", [])
+    cert["Status"] = cert_status
+    sans = cert.setdefault("SubjectAlternativeNames", [])
+    sans_summaries = cert.setdefault("SubjectAlternativeNameSummaries", [])
 
     # add missing attributes in ACM certs that cause Terraform to fail
     addenda = {
         "RenewalEligibility": "INELIGIBLE",
-        "KeyUsages": [{"Name": "DIGITAL_SIGNATURE"}],
+        "KeyUsages": [{"Name": "DIGITAL_SIGNATURE"}, {"Name": "KEY_ENCIPHERMENT"}],
         "ExtendedKeyUsages": [],
         "Options": {"CertificateTransparencyLoggingPreference": "ENABLED"},
     }
@@ -33,26 +53,62 @@ def describe(describe_orig, self):
                     "ValidationMethod": cert.get("ValidationMethod"),
                 }
             )
+
     for option in options:
         option["DomainName"] = domain_name = option.get("DomainName") or cert.get("DomainName")
-        option["ValidationDomain"] = option.get("ValidationDomain") or option["DomainName"]
+        validation_domain = option.get("ValidationDomain") or f"test.{domain_name.lstrip('*.')}"
+        option["ValidationDomain"] = validation_domain
         option["ValidationMethod"] = option.get("ValidationMethod") or "DNS"
         status = option.get("ValidationStatus")
-        option["ValidationStatus"] = "SUCCESS" if status in [None, "PENDING_VALIDATION"] else status
-        option["ValidationEmails"] = option.get("ValidationEmails") or [
-            "admin@%s" % self.common_name
-        ]
+        option["ValidationStatus"] = (
+            "SUCCESS" if (status is None or cert_status == "ISSUED") else status
+        )
+        if option["ValidationMethod"] == "EMAIL":
+            option["ValidationEmails"] = option.get("ValidationEmails") or [
+                f"admin@{self.common_name}"
+            ]
         test_record = {
-            "Name": "test.%s" % domain_name,
+            "Name": validation_domain,
             "Type": "CNAME",
             "Value": "test123",
         }
         option["ResourceRecord"] = option.get("ResourceRecord") or test_record
+        option["ResourceRecord"]["Name"] = option["ResourceRecord"]["Name"].replace(".*.", ".")
 
     for key, value in addenda.items():
         if not cert.get(key):
             cert[key] = value
     cert["Serial"] = str(cert.get("Serial") or "")
+
+    if cert.get("KeyAlgorithm") in ["RSA_1024", "RSA_2048"]:
+        cert["KeyAlgorithm"] = cert["KeyAlgorithm"].replace("RSA_", "RSA-")
+
+    if "InUse" not in cert:
+        cert["InUse"] = False
+
+    # add subject alternative names
+    if cert["DomainName"] not in sans:
+        sans.append(cert["DomainName"])
+    if cert["DomainName"] not in sans_summaries:
+        sans_summaries.append(cert["DomainName"])
+
+    if "HasAdditionalSubjectAlternativeNames" not in cert:
+        cert["HasAdditionalSubjectAlternativeNames"] = False
+
+    if not cert.get("ExtendedKeyUsages"):
+        cert["ExtendedKeyUsages"] = [
+            {"Name": "TLS_WEB_SERVER_AUTHENTICATION", "OID": "1.3.6.1.0.1.2.3.0"},
+            {"Name": "TLS_WEB_CLIENT_AUTHENTICATION", "OID": "1.3.6.1.0.1.2.3.4"},
+        ]
+
+    # remove attributes prior to validation
+    attrs = ["CertificateAuthorityArn", "IssuedAt", "NotAfter", "NotBefore", "Serial"]
+    if not cert.get("Status") == "ISSUED":
+        for attr in attrs:
+            cert.pop(attr, None)
+        cert["KeyUsages"] = []
+        cert["ExtendedKeyUsages"] = []
+
     return result
 
 
@@ -97,4 +153,23 @@ class AcmProvider(AcmApi):
         if not hasattr(cert, "domain_validation_options"):
             cert.domain_validation_options = request.get("DomainValidationOptions")
 
+        return response
+
+    @handler("ListCertificates", expand=False)
+    def list_certificates(
+        self,
+        context: RequestContext,
+        request: ListCertificatesRequest,
+    ) -> ListCertificatesResponse:
+        response = moto.call_moto(context)
+        summaries = response.get("CertificateSummaryList") or []
+        for summary in summaries:
+            if "KeyUsages" in summary:
+                summary["KeyUsages"] = [
+                    k["Name"] if isinstance(k, dict) else k for k in summary["KeyUsages"]
+                ]
+            if "ExtendedKeyUsages" in summary:
+                summary["ExtendedKeyUsages"] = [
+                    k["Name"] if isinstance(k, dict) else k for k in summary["ExtendedKeyUsages"]
+                ]
         return response

--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -14,7 +14,7 @@ from localstack.utils.objects import singleton_factory
 from localstack.utils.patch import patch
 
 # reduce the validation wait time from 60 (default) to 10 seconds
-moto_settings.ACM_VALIDATION_WAIT = 10
+moto_settings.ACM_VALIDATION_WAIT = min(10, moto_settings.ACM_VALIDATION_WAIT)
 
 
 @patch(acm_models.CertBundle.describe)

--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -20,7 +20,7 @@ moto_settings.ACM_VALIDATION_WAIT = min(10, moto_settings.ACM_VALIDATION_WAIT)
 @patch(acm_models.CertBundle.describe)
 def describe(describe_orig, self):
 
-    # Terrible hack (for parity). Moto adds certain required fields only if status is PENDING_VALIDATION. TODO fix!
+    # TODO fix! Terrible hack (for parity). Moto adds certain required fields only if status is PENDING_VALIDATION.
     cert_status = self.status
     self.status = "PENDING_VALIDATION"
     try:
@@ -102,8 +102,8 @@ def describe(describe_orig, self):
         ]
 
     # remove attributes prior to validation
-    attrs = ["CertificateAuthorityArn", "IssuedAt", "NotAfter", "NotBefore", "Serial"]
     if not cert.get("Status") == "ISSUED":
+        attrs = ["CertificateAuthorityArn", "IssuedAt", "NotAfter", "NotBefore", "Serial"]
         for attr in attrs:
             cert.pop(attr, None)
         cert["KeyUsages"] = []

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1447,7 +1447,7 @@ def acm_request_certificate(aws_client_factory):
         response = acm_client.request_certificate(**kwargs)
         created_certificate_arn = response["CertificateArn"]
         certificate_arns.append((created_certificate_arn, region_name))
-        return created_certificate_arn
+        return response
 
     yield factory
 

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -107,8 +107,14 @@ class TestACM:
         snapshot.match("describe-cert", response)
 
         if is_aws_cloud():
-            # wait until DNS entry has been added (needs to be done manually!)
-            input()
+            # Wait until DNS entry has been added (needs to be done manually!)
+            # Note: When running parity tests against AWS, we need to add the CNAME record to our DNS
+            #  server (currently with gandi.net), to enable validation of the certificate.
+            prompt = (
+                f"Please add the following CNAME entry to the LocalStack DNS server, then hit [ENTER] once "
+                f"the certificate has been validated in AWS: {dns_options['Name']} = {dns_options['Value']}"
+            )
+            input(prompt)
 
         def _get_cert_issued():
             response = aws_client.acm.describe_certificate(CertificateArn=cert_arn)

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -1,8 +1,12 @@
 import pytest
+from moto import settings as moto_settings
 from moto.ec2 import utils as ec2_utils
 
 from localstack.aws.accounts import get_aws_account_id
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import aws_stack
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
 
 DIGICERT_ROOT_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -53,12 +57,67 @@ class TestACM:
                 aws_client.acm.delete_certificate(CertificateArn=result["CertificateArn"])
 
     def test_domain_validation(self, acm_request_certificate, aws_client):
-        certificate_arn = acm_request_certificate()
+        certificate_arn = acm_request_certificate()["CertificateArn"]
         result = aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
         options = result["Certificate"]["DomainValidationOptions"]
         assert len(options) == 1
 
     def test_boto_wait_for_certificate_validation(self, acm_request_certificate, aws_client):
-        certificate_arn = acm_request_certificate()
+        certificate_arn = acm_request_certificate()["CertificateArn"]
         waiter = aws_client.acm.get_waiter("certificate_validated")
         waiter.wait(CertificateArn=certificate_arn, WaiterConfig={"Delay": 0, "MaxAttempts": 1})
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..Certificate.SignatureAlgorithm"])
+    def test_certificate_for_subdomain_wildcard(
+        self, acm_request_certificate, aws_client, snapshot, monkeypatch
+    ):
+        snapshot.add_transformer(snapshot.transform.key_value("OID"))
+        snapshot.add_transformer(snapshot.transform.key_value("Serial"))
+        monkeypatch.setattr(moto_settings, "ACM_VALIDATION_WAIT", 3)
+
+        # request certificate for subdomain
+        domain_name = f"test-domain-{short_uid()}.localhost.localstack.cloud"
+        subdomain_pattern = f"*.{domain_name}"
+        create_response = acm_request_certificate(
+            ValidationMethod="DNS", DomainName=subdomain_pattern
+        )
+        cert_arn = create_response["CertificateArn"]
+
+        snapshot.add_transformer(snapshot.transform.regex(domain_name, "<domain-name>"))
+        cert_id = cert_arn.split("certificate/")[-1]
+        snapshot.add_transformer(snapshot.transform.regex(cert_id, "<cert-id>"))
+        snapshot.match("request-cert", create_response)
+
+        def _get_cert_with_records():
+            response = aws_client.acm.describe_certificate(CertificateArn=cert_arn)
+            assert response["Certificate"]["DomainValidationOptions"][0]["ResourceRecord"]
+            return response
+
+        # wait for cert with ResourceRecord CNAME entry
+        response = retry(_get_cert_with_records, sleep=1, retries=30)
+        dns_options = response["Certificate"]["DomainValidationOptions"][0]["ResourceRecord"]
+        snapshot.add_transformer(
+            snapshot.transform.regex(dns_options["Name"].split(".")[0], "<record-prefix>")
+        )
+        snapshot.add_transformer(snapshot.transform.regex(dns_options["Value"], "<record-value>"))
+        snapshot.match("describe-cert", response)
+
+        if is_aws_cloud():
+            # wait until DNS entry has been added (needs to be done manually!)
+            input()
+
+        def _get_cert_issued():
+            response = aws_client.acm.describe_certificate(CertificateArn=cert_arn)
+            assert response["Certificate"]["Status"] == "ISSUED"
+            return response
+
+        # get cert again after validation
+        response = retry(_get_cert_issued, sleep=1, retries=30)
+        snapshot.match("describe-cert-2", response)
+
+        # also snapshot response of cert summaries via list_certificates
+        response = aws_client.acm.list_certificates()
+        summaries = response.get("CertificateSummaryList") or []
+        matching = [cert for cert in summaries if cert["CertificateArn"] == cert_arn]
+        snapshot.match("list-cert", matching)

--- a/tests/integration/test_acm.snapshot.json
+++ b/tests/integration/test_acm.snapshot.json
@@ -1,0 +1,141 @@
+{
+  "tests/integration/test_acm.py::TestACM::test_certificate_for_subdomain_wildcard": {
+    "recorded-date": "18-04-2023, 19:01:27",
+    "recorded-content": {
+      "request-cert": {
+        "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-cert": {
+        "Certificate": {
+          "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+          "CreatedAt": "datetime",
+          "DomainName": "*.<domain-name>",
+          "DomainValidationOptions": [
+            {
+              "DomainName": "*.<domain-name>",
+              "ResourceRecord": {
+                "Name": "<record-prefix>.<domain-name>.",
+                "Type": "CNAME",
+                "Value": "<record-value>"
+              },
+              "ValidationDomain": "*.<domain-name>",
+              "ValidationMethod": "DNS",
+              "ValidationStatus": "PENDING_VALIDATION"
+            }
+          ],
+          "ExtendedKeyUsages": [],
+          "InUseBy": [],
+          "Issuer": "Amazon",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [],
+          "Options": {
+            "CertificateTransparencyLoggingPreference": "ENABLED"
+          },
+          "RenewalEligibility": "INELIGIBLE",
+          "SignatureAlgorithm": "SHA256WITHRSA",
+          "Status": "PENDING_VALIDATION",
+          "Subject": "CN=*.<domain-name>",
+          "SubjectAlternativeNames": [
+            "*.<domain-name>"
+          ],
+          "Type": "AMAZON_ISSUED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-cert-2": {
+        "Certificate": {
+          "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+          "CreatedAt": "datetime",
+          "DomainName": "*.<domain-name>",
+          "DomainValidationOptions": [
+            {
+              "DomainName": "*.<domain-name>",
+              "ResourceRecord": {
+                "Name": "<record-prefix>.<domain-name>.",
+                "Type": "CNAME",
+                "Value": "<record-value>"
+              },
+              "ValidationDomain": "*.<domain-name>",
+              "ValidationMethod": "DNS",
+              "ValidationStatus": "SUCCESS"
+            }
+          ],
+          "ExtendedKeyUsages": [
+            {
+              "Name": "TLS_WEB_SERVER_AUTHENTICATION",
+              "OID": "<o-i-d:1>"
+            },
+            {
+              "Name": "TLS_WEB_CLIENT_AUTHENTICATION",
+              "OID": "<o-i-d:2>"
+            }
+          ],
+          "InUseBy": [],
+          "IssuedAt": "datetime",
+          "Issuer": "Amazon",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [
+            {
+              "Name": "DIGITAL_SIGNATURE"
+            },
+            {
+              "Name": "KEY_ENCIPHERMENT"
+            }
+          ],
+          "NotAfter": "datetime",
+          "NotBefore": "datetime",
+          "Options": {
+            "CertificateTransparencyLoggingPreference": "ENABLED"
+          },
+          "RenewalEligibility": "INELIGIBLE",
+          "Serial": "<serial:1>",
+          "SignatureAlgorithm": "SHA256WITHRSA",
+          "Status": "ISSUED",
+          "Subject": "CN=*.<domain-name>",
+          "SubjectAlternativeNames": [
+            "*.<domain-name>"
+          ],
+          "Type": "AMAZON_ISSUED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-cert": [
+        {
+          "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+          "DomainName": "*.<domain-name>",
+          "SubjectAlternativeNameSummaries": [
+            "*.<domain-name>"
+          ],
+          "HasAdditionalSubjectAlternativeNames": false,
+          "Status": "ISSUED",
+          "Type": "AMAZON_ISSUED",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [
+            "DIGITAL_SIGNATURE",
+            "KEY_ENCIPHERMENT"
+          ],
+          "ExtendedKeyUsages": [
+            "TLS_WEB_SERVER_AUTHENTICATION",
+            "TLS_WEB_CLIENT_AUTHENTICATION"
+          ],
+          "InUse": false,
+          "RenewalEligibility": "INELIGIBLE",
+          "NotBefore": "datetime",
+          "NotAfter": "datetime",
+          "CreatedAt": "datetime",
+          "IssuedAt": "datetime"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Enhance parity for ACM certificates issued for wildcard subdomains . Addresses https://github.com/localstack/localstack/issues/8156

With the changes in this PR, the following TF script deploys successfully (confirmed that it was hanging indefinitely before):
```
resource "aws_route53_zone" "this" {
  name = "example.com"
}

module "acm" {
  source  = "terraform-aws-modules/acm/aws"
  version = "4.3.2"

  domain_name         = "*.example.com"
  wait_for_validation = true
  zone_id             = aws_route53_zone.this.zone_id
}

data "aws_acm_certificate" "this" {
  depends_on = [module.acm]

  domain = "*.example.com"
}
```

The changes are covered by a snapshot test. Overall, the amount of patching we're performing in ACM is becoming a bit ridiculous ;) - probably a candidate for decoupling from moto in the near future as well.