### PR TITLE
add OpenSearch 2.5, remove Firehose limitation

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -136,7 +136,7 @@ ELASTICSEARCH_PLUGIN_LIST = [
 ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
 
 # the version of opensearch which is used by default
-OPENSEARCH_DEFAULT_VERSION = "OpenSearch_2.3"
+OPENSEARCH_DEFAULT_VERSION = "OpenSearch_2.5"
 
 # See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
 OPENSEARCH_PLUGIN_LIST = [

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -59,7 +59,6 @@ from localstack.aws.api.firehose import (
     S3DestinationConfiguration,
     S3DestinationDescription,
     S3DestinationUpdate,
-    ServiceUnavailableException,
     SplunkDestinationConfiguration,
     SplunkDestinationUpdate,
     TagDeliveryStreamInputTagList,
@@ -84,7 +83,6 @@ from localstack.services.firehose.mappers import (
     convert_source_config_to_desc,
 )
 from localstack.services.firehose.models import FirehoseStore, firehose_stores
-from localstack.services.opensearch import versions
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import (
     extract_region_from_arn,
@@ -237,21 +235,6 @@ class FirehoseProvider(FirehoseApi):
             db_description = convert_opensearch_config_to_desc(
                 amazonopensearchservice_destination_configuration
             )
-
-            domain_arn = db_description.get("DomainARN")
-            domain_name = opensearch_domain_name(domain_arn)
-
-            domain = aws_stack.connect_to_service("opensearch").describe_domain(
-                DomainName=domain_name
-            )
-            engine_version = domain["DomainStatus"]["EngineVersion"]
-
-            if versions.get_install_version(engine_version).startswith("2.3"):
-                # See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html
-                raise ServiceUnavailableException(
-                    "Delivery stream destination is not supported: OpenSearch 2.3"
-                )
-
             destinations.append(
                 DestinationDescription(
                     DestinationId=short_uid(),

--- a/localstack/services/opensearch/versions.py
+++ b/localstack/services/opensearch/versions.py
@@ -17,8 +17,9 @@ _opensearch_install_versions = {
     "1.0": "1.0.0",
     "1.1": "1.1.0",
     "1.2": "1.2.4",
-    "1.3": "1.3.6",
+    "1.3": "1.3.9",
     "2.3": "2.3.0",
+    "2.5": "2.5.0",
 }
 # Internal representation of the Elasticsearch versions (without the "Elasticsearch_" prefix)
 _elasticsearch_install_versions = {
@@ -210,7 +211,11 @@ compatible_versions = [
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_1.3",
-        TargetVersions=["OpenSearch_2.3"],
+        TargetVersions=["OpenSearch_2.3", "OpenSearch_2.5"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.3",
+        TargetVersions=["OpenSearch_2.5"],
     ),
 ]
 

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -83,7 +83,7 @@ class TestElasticsearchProvider:
 
         versions = response["CompatibleElasticsearchVersions"]
 
-        assert len(versions) == 21
+        assert len(versions) == 22
 
         assert {
             "SourceVersion": "OpenSearch_1.0",

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -97,6 +97,7 @@ class TestOpensearchProvider:
         versions = response["Versions"]
 
         expected_versions = [
+            "OpenSearch_2.5",
             "OpenSearch_2.3",
             "OpenSearch_1.3",
             "OpenSearch_1.2",
@@ -134,6 +135,10 @@ class TestOpensearchProvider:
         assert len(compatible_versions) >= 20
         expected_compatible_versions = [
             {
+                "SourceVersion": "OpenSearch_2.3",
+                "TargetVersions": ["OpenSearch_2.5"],
+            },
+            {
                 "SourceVersion": "OpenSearch_1.0",
                 "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
             },
@@ -147,7 +152,7 @@ class TestOpensearchProvider:
             },
             {
                 "SourceVersion": "OpenSearch_1.3",
-                "TargetVersions": ["OpenSearch_2.3"],
+                "TargetVersions": ["OpenSearch_2.3", "OpenSearch_2.5"],
             },
             {
                 "SourceVersion": "Elasticsearch_7.10",
@@ -333,7 +338,8 @@ class TestOpensearchProvider:
     @pytest.mark.only_localstack
     @pytest.mark.parametrize(
         "engine_version",
-        ["OpenSearch_1.0", "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3", "OpenSearch_2.3"],
+        # Test once per major version
+        ["OpenSearch_1.3", "OpenSearch_2.5"],
     )
     def test_security_plugin(self, opensearch_create_domain, engine_version, aws_client):
         master_user_auth = ("master-user", "12345678Aa!")
@@ -590,7 +596,7 @@ class TestEdgeProxiedOpensearchCluster:
 
             response = requests.get(cluster_url)
             assert response.ok, f"cluster endpoint returned an error: {response.text}"
-            assert response.json()["version"]["number"] == "2.3.0"
+            assert response.json()["version"]["number"] == "2.5.0"
 
             response = requests.get(f"{cluster_url}/_cluster/health")
             assert response.ok, f"cluster health endpoint returned an error: {response.text}"


### PR DESCRIPTION
This PR contains the following changes:
- It adds OpenSearch 2.5 to the list of supported OpenSearch versions.
- It changes the default version of OpenSearch from 2.3 to 2.5 (as it is currently for AWS).
- It removes a previous limitation of AWS Kinesis Data Firehose which was initially not compatible with OpenSearch 2+.
  - This was previously stated in the upgrade docs but has now vanished: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html
  - The docs of AWS Kinesis Data Firehose also don't show any limitations: https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-elasticsearch

