### PR TITLE
fix CFn s3 CORS configuration for optional parameters

### DIFF
--- a/tests/integration/cloudformation/resources/test_s3.py
+++ b/tests/integration/cloudformation/resources/test_s3.py
@@ -56,6 +56,7 @@ def test_bucket_versioning(deploy_cfn_template, aws_client):
     assert bucket_version["Status"] == "Enabled"
 
 
+@pytest.mark.aws_validated
 def test_cors_configuration(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
     snapshot.add_transformer(snapshot.transform.s3_api())
@@ -65,7 +66,10 @@ def test_cors_configuration(deploy_cfn_template, snapshot, aws_client):
             os.path.dirname(__file__), "../../templates/s3_cors_bucket.yaml"
         ),
     )
-    bucket_name = result.outputs["BucketName"]
-    cors_info = aws_client.s3.get_bucket_cors(Bucket=bucket_name)
+    bucket_name_optional = result.outputs["BucketNameAllParameters"]
+    cors_info = aws_client.s3.get_bucket_cors(Bucket=bucket_name_optional)
+    snapshot.match("cors-info-optional", cors_info)
 
-    snapshot.match("cors_info", cors_info)
+    bucket_name_required = result.outputs["BucketNameOnlyRequired"]
+    cors_info = aws_client.s3.get_bucket_cors(Bucket=bucket_name_required)
+    snapshot.match("cors-info-only-required", cors_info)

--- a/tests/integration/cloudformation/resources/test_s3.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_s3.snapshot.json
@@ -1,8 +1,8 @@
 {
   "tests/integration/cloudformation/resources/test_s3.py::test_cors_configuration": {
-    "recorded-date": "16-03-2023, 10:22:58",
+    "recorded-date": "20-04-2023, 20:17:17",
     "recorded-content": {
-      "cors_info": {
+      "cors-info-optional": {
         "CORSRules": [
           {
             "AllowedHeaders": [
@@ -20,6 +20,22 @@
             ],
             "ID": "test-cors-id",
             "MaxAgeSeconds": 3600
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "cors-info-only-required": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ]
           }
         ],
         "ResponseMetadata": {

--- a/tests/integration/templates/s3_cors_bucket.yaml
+++ b/tests/integration/templates/s3_cors_bucket.yaml
@@ -15,6 +15,20 @@ Resources:
               - Date
             Id: "test-cors-id"
             MaxAge: 3600
+
+  LocalBucket2:
+    Type: AWS::S3::Bucket
+    Properties:
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - '*'
+
+
 Outputs:
-  BucketName:
+  BucketNameAllParameters:
     Value: !Ref LocalBucket
+  BucketNameOnlyRequired:
+    Value: !Ref LocalBucket2


### PR DESCRIPTION
Follow up from #7866, we now allow optional parameters to not be present for a bucket CORS configuration. Validated against AWS.

fixes #8173 