### PR TITLE
fix tag updates of AWS::SSM::Parameter

### DIFF
--- a/tests/integration/cloudformation/resources/test_ssm.py
+++ b/tests/integration/cloudformation/resources/test_ssm.py
@@ -52,3 +52,59 @@ def test_update_ssm_parameters(deploy_cfn_template, aws_client):
     parameter_name = stack.outputs["CustomParameterOutput"]
     param = aws_client.ssm.get_parameter(Name=parameter_name)
     assert param["Parameter"]["Value"] == ssm_parameter_value
+
+
+@pytest.mark.aws_validated
+def test_update_ssm_parameter_tag(deploy_cfn_template, aws_client):
+    ssm_parameter_value = f"custom-{short_uid()}"
+    tag_value = f"tag-{short_uid()}"
+
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/ssm_parameter_defaultname_withtags.yaml"
+        ),
+        parameters={
+            "Input": ssm_parameter_value,
+            "TagValue": tag_value,
+        },
+    )
+    parameter_name = stack.outputs["CustomParameterOutput"]
+    ssm_tags = aws_client.ssm.list_tags_for_resource(
+        ResourceType="Parameter", ResourceId=parameter_name
+    )["TagList"]
+    tags_pre_update = {tag["Key"]: tag["Value"] for tag in ssm_tags}
+    assert tags_pre_update["A"] == tag_value
+
+    tag_value_new = f"tag-{short_uid()}"
+    deploy_cfn_template(
+        is_update=True,
+        stack_name=stack.stack_name,
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/ssm_parameter_defaultname_withtags.yaml"
+        ),
+        parameters={
+            "Input": ssm_parameter_value,
+            "TagValue": tag_value_new,
+        },
+    )
+
+    ssm_tags = aws_client.ssm.list_tags_for_resource(
+        ResourceType="Parameter", ResourceId=parameter_name
+    )["TagList"]
+    tags_post_update = {tag["Key"]: tag["Value"] for tag in ssm_tags}
+    assert tags_post_update["A"] == tag_value_new
+
+    # TODO: re-enable after fixing updates in general
+    # deploy_cfn_template(
+    #     is_update=True,
+    #     stack_name=stack.stack_name,
+    #     template_path=os.path.join(
+    #         os.path.dirname(__file__), "../../templates/ssm_parameter_defaultname.yaml"
+    #     ),
+    #     parameters={
+    #         "Input": ssm_parameter_value,
+    #     },
+    # )
+    #
+    # ssm_tags = aws_client.ssm.list_tags_for_resource(ResourceType="Parameter", ResourceId=parameter_name)['TagList']
+    # assert ssm_tags == []

--- a/tests/integration/templates/ssm_parameter_defaultname_withtags.yaml
+++ b/tests/integration/templates/ssm_parameter_defaultname_withtags.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  Input:
+    Type: String
+  TagValue:
+    Type: String
+
+Resources:
+  CustomParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !Ref Input
+      Tags:
+        A: !Ref TagValue
+
+Outputs:
+  CustomParameterOutput:
+    Value: !Ref CustomParameter


### PR DESCRIPTION
This issue was encountered by a user when updating an `AWS::SSM::Parameter` resource which included a tag and resulted in the following exception:

```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the PutParameter operation: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.
```
