### PR TITLE
Fix publishing versions if package type is image

### DIFF
--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -385,16 +385,23 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
                 Type="User",
             )
-        current_hash = current_latest_version.config.code.code_sha256
-        if (
-            code_sha256
-            and current_hash != code_sha256
-            and not current_latest_version.config.code.is_hot_reloading()
-        ):
+
+        # check if code hashes match if they are specified
+        current_hash = (
+            current_latest_version.config.code.code_sha256
+            if current_latest_version.config.package_type == PackageType.Zip
+            else current_latest_version.config.image.code_sha256
+        )
+        is_hot_reloading = (
+            current_latest_version.config.package_type == PackageType.Zip
+            and current_latest_version.config.code.is_hot_reloading()
+        )
+        if code_sha256 and current_hash != code_sha256 and not is_hot_reloading:
             raise InvalidParameterValueException(
                 f"CodeSHA256 ({code_sha256}) is different from current CodeSHA256 in $LATEST ({current_hash}). Please try again with the CodeSHA256 in $LATEST.",
                 Type="User",
             )
+
         state = lambda_stores[account_id][region]
         function = state.functions.get(function_name)
         changes = {}

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -392,11 +392,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             if current_latest_version.config.package_type == PackageType.Zip
             else current_latest_version.config.image.code_sha256
         )
-        is_hot_reloading = (
+        # if the code is a zip package and hot reloaded (hot reloading is currently only supported for zip packagetypes)
+        # we cannot enforce the codesha256 check
+        is_hot_reloaded_zip_package = (
             current_latest_version.config.package_type == PackageType.Zip
             and current_latest_version.config.code.is_hot_reloading()
         )
-        if code_sha256 and current_hash != code_sha256 and not is_hot_reloading:
+        if code_sha256 and current_hash != code_sha256 and not is_hot_reloaded_zip_package:
             raise InvalidParameterValueException(
                 f"CodeSHA256 ({code_sha256}) is different from current CodeSHA256 in $LATEST ({current_hash}). Please try again with the CodeSHA256 in $LATEST.",
                 Type="User",

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -811,8 +811,7 @@ class TestLambdaImages:
             Environment={"Variables": {"CUSTOM_ENV": "test"}},
             Publish=True,
         )
-        snapshot.match("create-image-response", create_image_response)
-        aws_client.awslambda.get_waiter("function_active_v2").wait(FunctionName=function_name)
+        snapshot.match("create_image_response", create_image_response)
 
         get_function_result = aws_client.awslambda.get_function(FunctionName=function_name)
         snapshot.match("get_function_result", get_function_result)
@@ -838,7 +837,7 @@ class TestLambdaImages:
                 Description="Second version description :)",
                 CodeSha256="a" * 64,
             )
-        snapshot.match("invalid-sha-publish", e.value.response)
+        snapshot.match("invalid_sha_publish", e.value.response)
 
         # publish with correct codesha256
         first_publish_response = aws_client.awslambda.publish_version(

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -593,7 +593,7 @@ class TestLambdaImages:
             )
 
     @pytest.fixture(scope="class")
-    def test_image(self, aws_client):
+    def test_image(self, aws_client, login_docker_client):
         repository_names = []
         image_names = []
 
@@ -793,6 +793,75 @@ class TestLambdaImages:
         snapshot.match(
             "get-function-config-response-after-delete-imageconfig", get_function_config_response
         )
+
+    @pytest.mark.aws_validated
+    def test_lambda_image_versions(
+        self, create_lambda_function_aws, lambda_su_role, test_image, snapshot, aws_client
+    ):
+        """Test lambda versions with package type image"""
+        image = test_image("alpine")
+        repo_uri = image.rpartition(":")[0]
+        snapshot.add_transformer(snapshot.transform.regex(repo_uri, "<repo_uri>"))
+        function_name = f"test-function-{short_uid()}"
+        create_image_response = create_lambda_function_aws(
+            FunctionName=function_name,
+            Role=lambda_su_role,
+            Code={"ImageUri": image},
+            PackageType="Image",
+            Environment={"Variables": {"CUSTOM_ENV": "test"}},
+            Publish=True,
+        )
+        snapshot.match("create-image-response", create_image_response)
+        aws_client.awslambda.get_waiter("function_active_v2").wait(FunctionName=function_name)
+
+        get_function_result = aws_client.awslambda.get_function(FunctionName=function_name)
+        snapshot.match("get_function_result", get_function_result)
+
+        list_versions_result = aws_client.awslambda.list_versions_by_function(
+            FunctionName=function_name
+        )
+        snapshot.match("list_versions_result", list_versions_result)
+
+        first_update_response = aws_client.awslambda.update_function_configuration(
+            FunctionName=function_name, Description="Second version :)"
+        )
+        snapshot.match("first_update_response", first_update_response)
+        waiter = aws_client.awslambda.get_waiter("function_updated_v2")
+        waiter.wait(FunctionName=function_name)
+        first_update_get_function = aws_client.awslambda.get_function(FunctionName=function_name)
+        snapshot.match("first_update_get_function", first_update_get_function)
+
+        # Try publishing with wrong codesha256
+        with pytest.raises(ClientError) as e:
+            aws_client.awslambda.publish_version(
+                FunctionName=function_name,
+                Description="Second version description :)",
+                CodeSha256="a" * 64,
+            )
+        snapshot.match("invalid-sha-publish", e.value.response)
+
+        # publish with correct codesha256
+        first_publish_response = aws_client.awslambda.publish_version(
+            FunctionName=function_name,
+            Description="Second version description :)",
+            CodeSha256=get_function_result["Configuration"]["CodeSha256"],
+        )
+        snapshot.match("first_publish_response", first_publish_response)
+
+        second_update_response = aws_client.awslambda.update_function_configuration(
+            FunctionName=function_name, Description="Third version :)"
+        )
+        snapshot.match("second_update_response", second_update_response)
+        waiter = aws_client.awslambda.get_waiter("function_updated_v2")
+        waiter.wait(FunctionName=function_name)
+        second_update_get_function = aws_client.awslambda.get_function(FunctionName=function_name)
+        snapshot.match("second_update_get_function", second_update_get_function)
+
+        # publish without codesha256
+        second_publish_response = aws_client.awslambda.publish_version(
+            FunctionName=function_name, Description="Third version description :)"
+        )
+        snapshot.match("second_publish_response", second_publish_response)
 
 
 @pytest.mark.skipif(is_old_provider(), reason="focusing on new provider")

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -12062,5 +12062,424 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_versions": {
+    "recorded-date": "21-04-2023, 11:58:36",
+    "recorded-content": {
+      "create-image-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_function_result": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_versions_result": {
+        "Versions": [
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "",
+            "Environment": {
+              "Variables": {
+                "CUSTOM_ENV": "test"
+              }
+            },
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+            "FunctionName": "<function-name:1>",
+            "LastModified": "date",
+            "MemorySize": 128,
+            "PackageType": "Image",
+            "RevisionId": "<uuid:2>",
+            "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "$LATEST"
+          },
+          {
+            "Architectures": [
+              "x86_64"
+            ],
+            "CodeSha256": "<code-sha256:1>",
+            "CodeSize": "<code-size>",
+            "Description": "",
+            "Environment": {
+              "Variables": {
+                "CUSTOM_ENV": "test"
+              }
+            },
+            "EphemeralStorage": {
+              "Size": 512
+            },
+            "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+            "FunctionName": "<function-name:1>",
+            "LastModified": "date",
+            "MemorySize": 128,
+            "PackageType": "Image",
+            "RevisionId": "<uuid:3>",
+            "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
+            "Timeout": 3,
+            "TracingConfig": {
+              "Mode": "PassThrough"
+            },
+            "Version": "1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_update_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "Second version :)",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:4>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_update_get_function": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "Second version :)",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:5>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-sha-publish": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "CodeSHA256 (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) is different from current CodeSHA256 in $LATEST (<code-sha256:1>). Please try again with the CodeSHA256 in $LATEST."
+        },
+        "Type": "User",
+        "message": "CodeSHA256 (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) is different from current CodeSHA256 in $LATEST (<code-sha256:1>). Please try again with the CodeSHA256 in $LATEST.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "first_publish_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "Second version description :)",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:2",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:6>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "2",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "second_update_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "Third version :)",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:7>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_update_get_function": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "Third version :)",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:8>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_publish_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "Third version description :)",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:3",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:9>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -12064,9 +12064,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_versions": {
-    "recorded-date": "21-04-2023, 11:58:36",
+    "recorded-date": "21-04-2023, 17:05:08",
     "recorded-content": {
-      "create-image-response": {
+      "create_image_response": {
         "Architectures": [
           "x86_64"
         ],
@@ -12307,7 +12307,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "invalid-sha-publish": {
+      "invalid_sha_publish": {
         "Error": {
           "Code": "InvalidParameterValueException",
           "Message": "CodeSHA256 (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) is different from current CodeSHA256 in $LATEST (<code-sha256:1>). Please try again with the CodeSHA256 in $LATEST."


### PR DESCRIPTION
## Motivation

Publishing image versions from image lambdas is currently broken, as we access the wrong code object.

## Changes
* Fix access to codesha256
* Add test for versioning image lambdas
* Add dependency of `test_image` fixture to `login_docker_client` fixture, to correctly login (login fixture was previously unused, it seems)