### PR TITLE
fix invalid SQS message decoding

### DIFF
--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -293,6 +293,14 @@ class TestSqsProvider:
         assert result["Messages"][0]["Body"] == "message"
 
     @pytest.mark.aws_validated
+    def test_send_receive_message_encoded_content(self, sqs_create_queue, aws_client):
+        queue = sqs_create_queue()
+        aws_client.sqs.send_message(QueueUrl=queue, MessageBody='"&quot;&quot;\r')
+        result = aws_client.sqs.receive_message(QueueUrl=queue)
+        assert len(result["Messages"]) == 1
+        assert result["Messages"][0]["Body"] == '"&quot;&quot;\r'
+
+    @pytest.mark.aws_validated
     def test_send_message_batch(self, sqs_queue, aws_client):
         aws_client.sqs.send_message_batch(
             QueueUrl=sqs_queue,


### PR DESCRIPTION
This PR slightly adjusts the special message encoding for SQS which has been introduced with #5298.

With #5298, an SQS specific serializer has been introduced which performs a special escaping logic for the node text content in the XML responses. This is only done by SQS, and since it's a very rare practice, it's not supported by any popular XML serialization libraries.

#8002 raised the issue that this behavior causes issues when these escaping sequences are used in the sent message itself.
A message `"&quot;&quot;"` sent would be received as `""""`.

This was due to the nature of the initial implementation:
- These special characters have been escaped before the ElementTree serialization was performed: `"&quot;&quot;"` ==> `&quot;&quot;&quot;&quot;`
- The escape sequence itself contains characters which are escaped in XML (specifically `&`): `&quot;` ==> `&amp;quot;&amp;quot;&amp;quot;&amp;quot;`
- A post-serialization step removed the double-escaping: `&amp;quot;&amp;quot;&amp;quot;&amp;quot;` ==> `&quot;&quot;&quot;&quot;`
- The client performs the unescape: `&quot;&quot;&quot;&quot;` ==> `""""`

With this PR, the special escaping is done after the XML node is serialized:
- The special characters in the text are "marked" (which is just another form of internal escaping): `"&quot;&quot;"` ==> `__marker__"__marker__&quot;&quot;__marker__"__marker__`
  - The "marking" is necessary to identify exactly those special characters within the completely serialized message, without taking any other occurrences of these special characters into account.
- The message is serialized by the XML serializer: `__marker__"__marker__&quot;&quot;__marker__"__marker__` ==> `__marker__"__marker__&amp;quot;&amp;quot;__marker__"__marker__`
- A post-serialization step replaces the marked special characters with their escape sequence: `__marker__"__marker__&amp;quot;&amp;quot;__marker__"__marker__` ==> `&quot;&amp;quot;&amp;quot;&quot;`
- The client performs the unescape: `&quot;&amp;quot;&amp;quot;&quot;` ==> `"&quot;&quot;"`

This approach now would not work if the "marked" / internally escaped representation of the character is used in the raw message. f.e. a message `"__marker__"__marker"` would be received as `"""`.
However, the only approach I can think of right now to properly implement this would be to avoid the specific pre- and post-processing and this could only be done by fixing the serialization itself (i.e. implementing our own XML serialization).
I'm happy for any feedback or ideas!

Fixes #8002.