### PR TITLE
wip: fix S3 CopyObject copying or returning Checksum

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import re
-from typing import Dict, Literal, Union
+from typing import Dict, Literal, Optional, Union
+from urllib.parse import parse_qs, unquote, urlparse
 
 import moto.s3.models as moto_s3_models
 from botocore.exceptions import ClientError
@@ -120,6 +121,15 @@ def is_valid_canonical_id(canonical_id: str) -> bool:
         return int(canonical_id, 16) and len(canonical_id) == 64
     except ValueError:
         return False
+
+
+def extract_bucket_key_version_id_from_copy_source(
+    copy_source: str,
+) -> tuple[BucketName, ObjectKey, Optional[str]]:
+    copy_source_parsed = urlparse(copy_source)
+    src_bucket, src_key = unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
+    src_version_id = parse_qs(copy_source_parsed.query).get("versionId", [None])[0]
+    return src_bucket, src_key, src_version_id
 
 
 def forwarded_from_virtual_host_addressed_request(headers: Dict[str, str]) -> bool:

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5854,5 +5854,101 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place": {
+    "recorded-date": "20-04-2023, 21:51:53",
+    "recorded-content": {
+      "put_object": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "application/json",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {
+          "key": "value"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-no-change": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-object-in-place-with-storage-class": {
+        "CopyObjectResult": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "LastModified": "datetime",
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "aws-sandbox-benjamin-simon-001",
+              "ID": "c32ee542628cfb38f348c508a38f7e82a38b79b25f728d7e262c1d90441b608a",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name>",
+          "ID": "<owner-id>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-acl": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5950,5 +5950,59 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum": {
+    "recorded-date": "21-04-2023, 19:58:51",
+    "recorded-content": {
+      "put-object-no-checksum": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "Checksum": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U="
+        },
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-to-dest-keep-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This partially addresses #8172

It appeared S3 was not returning a checksum when requested, or would not copy the source object's checksum if not provided. This PR fixes that.

That is not enough for #8172 as moto's check when copying objects are wrong. There's a test in this PR that is xfail demonstrating the behaviour. This is not fixable by patching, so I'll open a PR upstream with the change I'm already working on, and will open new PR then here de-xfailing the test and adding more cases.

edit: this is a temporary fix, as moto has been working on adding and saving checksum in `FakeKey`, which will allow us to remove our own fixes in the provider. Until then (and until we update moto too, I'm going to open the PR for the `CopyObject` overhaul upstream), our fix here will provide this functionality.