### PR TITLE
add support for python3.10 lambda runtime, now that it's officially a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.iml
 .coverage.*
 htmlcov
+*.orig
 
 .cache
 .filesystem

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -220,6 +220,7 @@ class Runtime(str):
     python3_7 = "python3.7"
     python3_8 = "python3.8"
     python3_9 = "python3.9"
+    python3_10 = "python3.10"
     dotnetcore1_0 = "dotnetcore1.0"
     dotnetcore2_0 = "dotnetcore2.0"
     dotnetcore2_1 = "dotnetcore2.1"

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -220,7 +220,6 @@ class Runtime(str):
     python3_7 = "python3.7"
     python3_8 = "python3.8"
     python3_9 = "python3.9"
-    python3_10 = "python3.10"
     dotnetcore1_0 = "dotnetcore1.0"
     dotnetcore2_0 = "dotnetcore2.0"
     dotnetcore2_1 = "dotnetcore2.1"

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -602,7 +602,7 @@ def validate_layer_runtimes_and_architectures(
     validations = []
 
     if compatible_runtimes and set(compatible_runtimes).difference(RUNTIMES):
-        constraint = "Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]"
+        constraint = "Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]"
         validation_msg = f"Value '[{', '.join([s for s in compatible_runtimes])}]' at 'compatibleRuntimes' failed to satisfy constraint: {constraint}"
         validations.append(validation_msg)
 

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -66,6 +66,7 @@ IMAGE_MAPPING = {
     "python3.7": "python:3.7",
     "python3.8": "python:3.8",
     "python3.9": "python:3.9",
+    "python3.10": "python:3.10",
     "nodejs12.x": "nodejs:12",
     "nodejs14.x": "nodejs:14",
     "nodejs16.x": "nodejs:16",

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -676,7 +676,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         runtime = request.get("Runtime")
         if package_type == PackageType.Zip and runtime not in IMAGE_MAPPING:
             raise InvalidParameterValueException(
-                f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+                f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
                 Type="User",
             )
         if snap_start := request.get("SnapStart"):
@@ -865,7 +865,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if "Runtime" in request:
             if request["Runtime"] not in IMAGE_MAPPING:
                 raise InvalidParameterValueException(
-                    f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+                    f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
                     Type="User",
                 )
             replace_kwargs["runtime"] = request["Runtime"]

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -3010,7 +3010,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if not layer_version_parts.get("layer_version"):
             raise ValidationException(
                 f"1 validation error detected: Value '{arn}' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: "
-                + "arn:[a-zA-Z0-9-]+:lambda:[a-zA-Z0-9-]+:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
+                + "arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
             )
 
         layer_name = layer_version_parts["layer_name"]

--- a/tests/integration/awslambda/conftest.py
+++ b/tests/integration/awslambda/conftest.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 
 
 RUNTIMES_AGGREGATED = {
-    "python": [Runtime.python3_7, Runtime.python3_8, Runtime.python3_9],
+    "python": [Runtime.python3_7, Runtime.python3_8, Runtime.python3_9, Runtime.python3_10],
     "nodejs": [Runtime.nodejs12_x, Runtime.nodejs14_x, Runtime.nodejs16_x, Runtime.nodejs18_x],
     "ruby": [Runtime.ruby2_7],
     "java": [Runtime.java8, Runtime.java8_al2, Runtime.java11],

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -96,6 +96,7 @@ PYTHON_TEST_RUNTIMES = (
         Runtime.python3_7,
         Runtime.python3_8,
         Runtime.python3_9,
+        Runtime.python3_10,
     ]
     if (not is_old_provider() or use_docker()) and get_arch() != "arm64"
     else [Runtime.python3_9]
@@ -913,8 +914,12 @@ class TestLambdaPermissions:
 
 class TestLambdaFeatures:
     @pytest.fixture(
-        params=[("python3.9", TEST_LAMBDA_PYTHON_ECHO), ("nodejs16.x", TEST_LAMBDA_NODEJS_ECHO)],
-        ids=["python3.9", "nodejs16.x"],
+        params=[
+            ("python3.9", TEST_LAMBDA_PYTHON_ECHO),
+            ("nodejs16.x", TEST_LAMBDA_NODEJS_ECHO),
+            ("python3.10", TEST_LAMBDA_PYTHON_ECHO),
+        ],
+        ids=["python3.9", "nodejs16.x", "python3.10"],
     )
     def invocation_echo_lambda(self, create_lambda_function, request):
         function_name = f"echo-func-{short_uid()}"

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -915,11 +915,10 @@ class TestLambdaPermissions:
 class TestLambdaFeatures:
     @pytest.fixture(
         params=[
-            ("python3.9", TEST_LAMBDA_PYTHON_ECHO),
             ("nodejs16.x", TEST_LAMBDA_NODEJS_ECHO),
             ("python3.10", TEST_LAMBDA_PYTHON_ECHO),
         ],
-        ids=["python3.9", "nodejs16.x", "python3.10"],
+        ids=["nodejs16.x", "python3.10"],
     )
     def invocation_echo_lambda(self, create_lambda_function, request):
         function_name = f"echo-func-{short_uid()}"
@@ -1019,7 +1018,7 @@ class TestLambdaFeatures:
         creation_response = create_lambda_function(
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_UNHANDLED_ERROR,
-            runtime="python3.9",
+            runtime=Runtime.python3_10,
         )
         snapshot.match("creation_response", creation_response)
         invocation_response = aws_client.awslambda.invoke(
@@ -1071,14 +1070,14 @@ class TestLambdaFeatures:
         zip_file = create_lambda_archive(
             load_file(TEST_LAMBDA_PYTHON),
             get_content=True,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
         aws_client.s3.upload_fileobj(BytesIO(zip_file), s3_bucket, bucket_key)
 
         # create lambda function
         response = create_lambda_function_aws(
             FunctionName=function_name,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Role=lambda_su_role,
             Publish=True,
             Handler="handler.handler",
@@ -1125,14 +1124,14 @@ class TestLambdaFeatures:
         zip_file = testutil.create_lambda_archive(
             load_file(TEST_LAMBDA_PYTHON),
             get_content=True,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
         aws_client.s3.upload_fileobj(BytesIO(zip_file), s3_bucket, bucket_key)
 
         # create lambda function
         create_response = create_lambda_function_aws(
             FunctionName=function_name,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Handler="handler.handler",
             Role=lambda_su_role,
             Code={"S3Bucket": s3_bucket, "S3Key": bucket_key},

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -152,7 +152,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[nodejs]": {
-    "recorded-date": "17-02-2023, 14:00:08",
+    "recorded-date": "30-04-2023, 18:55:41",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -179,7 +179,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[python]": {
-    "recorded-date": "17-02-2023, 14:00:12",
+    "recorded-date": "30-04-2023, 18:55:43",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -206,7 +206,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_with_timeout": {
-    "recorded-date": "17-02-2023, 14:20:09",
+    "recorded-date": "30-04-2023, 18:55:49",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -268,7 +268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {
-    "recorded-date": "17-02-2023, 14:00:29",
+    "recorded-date": "30-04-2023, 18:55:56",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -327,7 +327,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_function_state": {
-    "recorded-date": "17-02-2023, 13:59:50",
+    "recorded-date": "30-04-2023, 18:55:24",
     "recorded-content": {
       "create-fn-response": {
         "Architectures": [
@@ -415,7 +415,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_large_payloads": {
-    "recorded-date": "17-02-2023, 13:59:47",
+    "recorded-date": "30-04-2023, 18:55:22",
     "recorded-content": {
       "invocation_response": {
         "ExecutedVersion": "$LATEST",
@@ -449,7 +449,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.10]": {
-    "recorded-date": "26-04-2023, 19:26:27",
+    "recorded-date": "30-04-2023, 18:56:32",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -467,7 +467,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[nodejs16.x]": {
-    "recorded-date": "17-02-2023, 14:01:30",
+    "recorded-date": "30-04-2023, 18:56:30",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -499,7 +499,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[python3.10]": {
-    "recorded-date": "26-04-2023, 19:38:02",
+    "recorded-date": "30-04-2023, 18:56:36",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -513,7 +513,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[nodejs16.x]": {
-    "recorded-date": "17-02-2023, 14:01:37",
+    "recorded-date": "30-04-2023, 18:56:34",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -540,7 +540,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[python3.10]": {
-    "recorded-date": "26-04-2023, 19:39:23",
+    "recorded-date": "30-04-2023, 18:56:40",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -553,7 +553,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[nodejs16.x]": {
-    "recorded-date": "17-02-2023, 14:01:43",
+    "recorded-date": "30-04-2023, 18:56:38",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -697,7 +697,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_qualifier": {
-    "recorded-date": "17-02-2023, 14:02:08",
+    "recorded-date": "30-04-2023, 18:56:51",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -717,7 +717,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -773,7 +773,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_upload_lambda_from_s3": {
-    "recorded-date": "17-02-2023, 14:02:21",
+    "recorded-date": "30-04-2023, 18:56:57",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -793,7 +793,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1019,7 +1019,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaVersions::test_lambda_versions_with_code_changes": {
-    "recorded-date": "17-02-2023, 14:02:41",
+    "recorded-date": "30-04-2023, 18:57:27",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1309,7 +1309,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_lambda_alias_moving": {
-    "recorded-date": "17-02-2023, 14:02:51",
+    "recorded-date": "30-04-2023, 18:57:31",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1530,7 +1530,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_alias_routingconfig": {
-    "recorded-date": "17-02-2023, 14:03:03",
+    "recorded-date": "30-04-2023, 18:57:41",
     "recorded-content": {
       "create_alias_response": {
         "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
@@ -1551,7 +1551,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_lambda_different_iam_keys_environment": {
-    "recorded-date": "17-02-2023, 13:59:57",
+    "recorded-date": "30-04-2023, 18:55:31",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -2088,7 +2088,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_timed_out_environment_reuse": {
-    "recorded-date": "17-02-2023, 14:00:37",
+    "recorded-date": "30-04-2023, 18:56:00",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -2212,7 +2212,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
-    "recorded-date": "17-02-2023, 14:01:22",
+    "recorded-date": "30-04-2023, 18:56:28",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -2292,7 +2292,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
-    "recorded-date": "17-02-2023, 14:02:25",
+    "recorded-date": "30-04-2023, 18:57:01",
     "recorded-content": {
       "get_function_concurrency_default": {
         "ResponseMetadata": {
@@ -2331,7 +2331,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[dict]": {
-    "recorded-date": "17-02-2023, 14:00:42",
+    "recorded-date": "30-04-2023, 18:56:04",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2374,7 +2374,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response]": {
-    "recorded-date": "17-02-2023, 14:00:47",
+    "recorded-date": "30-04-2023, 18:56:07",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2415,7 +2415,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response-json]": {
-    "recorded-date": "17-02-2023, 14:00:51",
+    "recorded-date": "30-04-2023, 18:56:09",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2458,7 +2458,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[list-mixed]": {
-    "recorded-date": "17-02-2023, 14:00:56",
+    "recorded-date": "30-04-2023, 18:56:11",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2499,7 +2499,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[string]": {
-    "recorded-date": "17-02-2023, 14:01:00",
+    "recorded-date": "30-04-2023, 18:56:13",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2540,7 +2540,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[integer]": {
-    "recorded-date": "17-02-2023, 14:01:04",
+    "recorded-date": "30-04-2023, 18:56:16",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2581,7 +2581,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[float]": {
-    "recorded-date": "17-02-2023, 14:01:09",
+    "recorded-date": "30-04-2023, 18:56:18",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2622,7 +2622,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[boolean]": {
-    "recorded-date": "17-02-2023, 14:01:13",
+    "recorded-date": "30-04-2023, 18:56:22",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2663,7 +2663,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_echo_invoke": {
-    "recorded-date": "17-02-2023, 14:01:18",
+    "recorded-date": "30-04-2023, 18:56:26",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2696,7 +2696,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
-    "recorded-date": "08-03-2023, 14:18:06",
+    "recorded-date": "30-04-2023, 18:55:37",
     "recorded-content": {
       "invoke_runtime_arm_introspection": {
         "ExecutedVersion": "$LATEST",
@@ -2735,7 +2735,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_x86": {
-    "recorded-date": "08-03-2023, 14:16:54",
+    "recorded-date": "30-04-2023, 18:55:33",
     "recorded-content": {
       "invoke_runtime_x86_introspection": {
         "ExecutedVersion": "$LATEST",
@@ -2774,7 +2774,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_ulimits": {
-    "recorded-date": "15-03-2023, 00:11:15",
+    "recorded-date": "30-04-2023, 18:55:39",
     "recorded-content": {
       "invoke_runtime_ulimits": {
         "ExecutedVersion": "$LATEST",
@@ -2829,7 +2829,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_reserved_concurrency": {
-    "recorded-date": "15-03-2023, 16:44:20",
+    "recorded-date": "30-04-2023, 18:57:10",
     "recorded-content": {
       "fn": {
         "Architectures": [
@@ -2940,7 +2940,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_reserved_concurrency_async_queue": {
-    "recorded-date": "20-03-2023, 22:33:56",
+    "recorded-date": "30-04-2023, 19:41:56",
     "recorded-content": {
       "fn": {
         "Architectures": [
@@ -3192,11 +3192,11 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_format": {
-    "recorded-date": "31-03-2023, 10:33:20",
+    "recorded-date": "30-04-2023, 18:57:41",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_invoke": {
-    "recorded-date": "31-03-2023, 10:33:43",
+    "recorded-date": "30-04-2023, 18:57:53",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -3215,7 +3215,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_async_invoke_with_retry": {
-    "recorded-date": "31-03-2023, 10:36:02",
+    "recorded-date": "30-04-2023, 19:00:04",
     "recorded-content": {
       "invoke_result": {
         "Payload": "",
@@ -3232,7 +3232,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_invoke_url": {
-    "recorded-date": "31-03-2023, 10:33:57",
+    "recorded-date": "30-04-2023, 18:58:00",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -448,6 +448,24 @@
       }
     }
   },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.10]": {
+    "recorded-date": "26-04-2023, 19:26:27",
+    "recorded-content": {
+      "invoke": {
+        "ExecutedVersion": "$LATEST",
+        "LogResult": "log-result",
+        "Payload": {},
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "logs": {
+        "logs": "START RequestId: <request-id> Version: $LATEST\n{}\nEND RequestId: <request-id>\nREPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
+      }
+    }
+  },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[nodejs16.x]": {
     "recorded-date": "17-02-2023, 14:01:30",
     "recorded-content": {
@@ -468,6 +486,20 @@
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[python3.9]": {
     "recorded-date": "17-02-2023, 14:01:34",
+    "recorded-content": {
+      "invoke-result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {},
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[python3.10]": {
+    "recorded-date": "26-04-2023, 19:38:02",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -507,6 +539,19 @@
       }
     }
   },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[python3.10]": {
+    "recorded-date": "26-04-2023, 19:39:23",
+    "recorded-content": {
+      "invoke-result": {
+        "Payload": "",
+        "StatusCode": 202,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
+  },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[nodejs16.x]": {
     "recorded-date": "17-02-2023, 14:01:43",
     "recorded-content": {
@@ -522,6 +567,19 @@
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_dry_run[python3.9]": {
     "recorded-date": "09-09-2022, 19:15:23",
+    "recorded-content": {
+      "invoke-result": {
+        "Payload": "",
+        "StatusCode": 204,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_dry_run[python3.10]": {
+    "recorded-date": "26-04-2023, 19:37:23",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "recorded-date": "17-02-2023, 11:33:32",
+    "recorded-date": "27-04-2023, 20:34:59",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -303,7 +303,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "recorded-date": "17-02-2023, 11:33:39",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -574,7 +574,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "recorded-date": "17-02-2023, 11:33:39",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -603,7 +603,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "recorded-date": "17-02-2023, 11:33:40",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -632,7 +632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "recorded-date": "17-02-2023, 11:33:40",
+    "recorded-date": "27-04-2023, 20:35:05",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -661,7 +661,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "recorded-date": "17-02-2023, 11:33:43",
+    "recorded-date": "27-04-2023, 20:35:07",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -678,7 +678,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "recorded-date": "17-02-2023, 11:33:46",
+    "recorded-date": "27-04-2023, 20:35:09",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -695,7 +695,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "recorded-date": "17-02-2023, 11:33:49",
+    "recorded-date": "27-04-2023, 20:35:11",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -712,7 +712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "recorded-date": "17-02-2023, 11:33:53",
+    "recorded-date": "27-04-2023, 20:35:13",
     "recorded-content": {
       "delete_function_response_non_existent": {
         "Error": {
@@ -741,7 +741,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "recorded-date": "17-02-2023, 11:33:53",
+    "recorded-date": "27-04-2023, 20:35:13",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -758,7 +758,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "recorded-date": "17-02-2023, 11:33:54",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -775,7 +775,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "recorded-date": "17-02-2023, 11:33:54",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -792,7 +792,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "recorded-date": "17-02-2023, 11:33:54",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -809,7 +809,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "recorded-date": "17-02-2023, 11:33:54",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -826,7 +826,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "recorded-date": "17-02-2023, 11:33:55",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -843,7 +843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "recorded-date": "17-02-2023, 11:33:55",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -860,7 +860,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "recorded-date": "17-02-2023, 11:33:58",
+    "recorded-date": "27-04-2023, 20:35:16",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -877,7 +877,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "recorded-date": "17-02-2023, 11:34:01",
+    "recorded-date": "27-04-2023, 20:35:18",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -894,7 +894,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "recorded-date": "17-02-2023, 11:34:04",
+    "recorded-date": "27-04-2023, 20:35:20",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -911,7 +911,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "recorded-date": "17-02-2023, 11:34:07",
+    "recorded-date": "27-04-2023, 20:35:22",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -928,7 +928,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "recorded-date": "17-02-2023, 11:34:10",
+    "recorded-date": "27-04-2023, 20:35:24",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -945,7 +945,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "recorded-date": "17-02-2023, 11:34:13",
+    "recorded-date": "27-04-2023, 20:35:26",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -962,7 +962,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "recorded-date": "17-02-2023, 11:34:16",
+    "recorded-date": "27-04-2023, 20:35:28",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -979,7 +979,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "recorded-date": "17-02-2023, 11:34:19",
+    "recorded-date": "27-04-2023, 20:35:30",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -996,7 +996,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "recorded-date": "15-02-2023, 19:51:39",
+    "recorded-date": "27-04-2023, 20:35:32",
     "recorded-content": {
       "create-response-zip-file": {
         "Architectures": [
@@ -1170,7 +1170,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "recorded-date": "15-02-2023, 19:51:47",
+    "recorded-date": "27-04-2023, 20:35:37",
     "recorded-content": {
       "create_response_s3": {
         "Architectures": [
@@ -7459,7 +7459,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "17-02-2023, 11:34:21",
+    "recorded-date": "27-04-2023, 20:35:38",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7474,10 +7474,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7486,10 +7486,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7531,7 +7531,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "17-02-2023, 11:34:23",
+    "recorded-date": "27-04-2023, 20:35:39",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7546,10 +7546,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7558,10 +7558,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7570,7 +7570,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "recorded-date": "17-02-2023, 11:34:38",
+    "recorded-date": "27-04-2023, 20:35:52",
     "recorded-content": {
       "create_response_1": {
         "CreateEventSourceMappingResponse": null,
@@ -7843,7 +7843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "17-02-2023, 11:43:48",
+    "recorded-date": "27-04-2023, 20:39:18",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -7945,7 +7945,7 @@
       "get_layer_version_by_arn_exc_invalidarn": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:[a-zA-Z0-9-]+:lambda:[a-zA-Z0-9-]+:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
+          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8021,7 +8021,7 @@
       "publish_layer_version_exc_invalid_runtime_arch": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8031,7 +8031,7 @@
       "publish_layer_version_exc_partially_invalid_values": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs16.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs16.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8041,7 +8041,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_lifecycle": {
-    "recorded-date": "17-02-2023, 11:44:11",
+    "recorded-date": "27-04-2023, 20:40:59",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -8445,7 +8445,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_exceptions": {
-    "recorded-date": "17-02-2023, 11:44:25",
+    "recorded-date": "27-04-2023, 20:41:04",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8628,7 +8628,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_lifecycle": {
-    "recorded-date": "17-02-2023, 11:44:31",
+    "recorded-date": "27-04-2023, 20:41:09",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8756,7 +8756,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_s3_content": {
-    "recorded-date": "17-02-2023, 11:44:18",
+    "recorded-date": "27-04-2023, 21:01:08",
     "recorded-content": {
       "publish_layer_result": {
         "Content": {
@@ -8777,7 +8777,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
-    "recorded-date": "27-02-2023, 21:43:54",
+    "recorded-date": "27-04-2023, 20:39:58",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -11766,7 +11766,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_quota_exception": {
-    "recorded-date": "26-01-2023, 22:52:19",
+    "recorded-date": "27-04-2023, 20:40:38",
     "recorded-content": {
       "create_function_with_six_layers": {
         "Error": {

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs12.x]": {
-    "recorded-date": "27-02-2023, 15:49:15",
+    "recorded-date": "30-04-2023, 18:45:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -137,7 +137,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs14.x]": {
-    "recorded-date": "27-02-2023, 15:49:18",
+    "recorded-date": "30-04-2023, 18:45:07",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -274,7 +274,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "27-02-2023, 15:49:21",
+    "recorded-date": "30-04-2023, 18:45:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -411,7 +411,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.7]": {
-    "recorded-date": "27-02-2023, 15:49:06",
+    "recorded-date": "30-04-2023, 18:44:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -542,7 +542,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "27-02-2023, 15:49:09",
+    "recorded-date": "30-04-2023, 18:44:58",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -679,7 +679,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "27-02-2023, 15:49:12",
+    "recorded-date": "30-04-2023, 18:45:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -816,7 +816,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby2.7]": {
-    "recorded-date": "27-02-2023, 15:49:28",
+    "recorded-date": "30-04-2023, 18:45:14",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -957,13 +957,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8]": {
-    "recorded-date": "27-02-2023, 15:49:51",
+    "recorded-date": "30-04-2023, 18:45:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
+        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1094,13 +1094,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "27-02-2023, 15:50:00",
+    "recorded-date": "30-04-2023, 18:45:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
+        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1229,13 +1229,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "27-02-2023, 15:50:19",
+    "recorded-date": "30-04-2023, 18:45:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
+        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1364,7 +1364,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[go1.x]": {
-    "recorded-date": "27-02-2023, 15:50:42",
+    "recorded-date": "30-04-2023, 18:45:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1503,13 +1503,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "27-02-2023, 15:50:26",
+    "recorded-date": "30-04-2023, 18:45:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "pPNT1m9LVvHF5KD5w6+6D/DiPlGL//7uJyhOHcHcoOE=",
+        "CodeSha256": "auaig2ijl0r9T1HOo69YonJ2lGt47J3InDMMtIEywKI=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1644,13 +1644,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnetcore3.1]": {
-    "recorded-date": "27-02-2023, 15:50:23",
+    "recorded-date": "30-04-2023, 18:45:40",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "6kJ/nxnpFtFFnAfxqgjvQuueIKv4aH2qFl8qhr3o2Vo=",
+        "CodeSha256": "grKQ2jWhrYPgzcO8fDu2mhmQXUeHHWzOIy81E+/sdzg=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1777,13 +1777,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided]": {
-    "recorded-date": "27-02-2023, 15:50:46",
+    "recorded-date": "30-04-2023, 18:45:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "AwbdeLHglRbrp3WlhEE3stQ1MNXdw/2UsN8tYC262as=",
+        "CodeSha256": "N1Uy0eAVXHKaOp+CHxsuXmEsXD//FFGMBZhwppNdTTs=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1906,13 +1906,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "27-02-2023, 15:50:50",
+    "recorded-date": "30-04-2023, 18:45:52",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "AwbdeLHglRbrp3WlhEE3stQ1MNXdw/2UsN8tYC262as=",
+        "CodeSha256": "N1Uy0eAVXHKaOp+CHxsuXmEsXD//FFGMBZhwppNdTTs=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -2035,7 +2035,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.7]": {
-    "recorded-date": "27-02-2023, 15:50:53",
+    "recorded-date": "30-04-2023, 18:45:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2093,7 +2093,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "27-02-2023, 15:50:56",
+    "recorded-date": "30-04-2023, 18:45:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2151,7 +2151,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "27-02-2023, 15:50:58",
+    "recorded-date": "30-04-2023, 18:45:59",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2210,7 +2210,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs12.x]": {
-    "recorded-date": "27-02-2023, 15:51:01",
+    "recorded-date": "30-04-2023, 18:46:02",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2268,7 +2268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs14.x]": {
-    "recorded-date": "27-02-2023, 15:51:04",
+    "recorded-date": "30-04-2023, 18:46:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2326,7 +2326,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "27-02-2023, 15:51:06",
+    "recorded-date": "30-04-2023, 18:46:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2384,13 +2384,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8]": {
-    "recorded-date": "27-02-2023, 15:51:22",
+    "recorded-date": "30-04-2023, 18:46:18",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
+        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2442,13 +2442,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "27-02-2023, 15:51:30",
+    "recorded-date": "30-04-2023, 18:46:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
+        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2500,13 +2500,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "27-02-2023, 15:51:39",
+    "recorded-date": "30-04-2023, 18:46:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
+        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2558,7 +2558,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby2.7]": {
-    "recorded-date": "27-02-2023, 15:51:12",
+    "recorded-date": "30-04-2023, 18:46:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2616,7 +2616,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[go1.x]": {
-    "recorded-date": "27-02-2023, 15:52:45",
+    "recorded-date": "30-04-2023, 18:46:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2673,13 +2673,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided]": {
-    "recorded-date": "27-02-2023, 15:52:49",
+    "recorded-date": "30-04-2023, 18:46:46",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "mdyx6lX3eKXegmh4CuAtIYkz2zQio3aJPab0U7RUi+g=",
+        "CodeSha256": "HZO/38cx+0gOKUr19lI2upfd7j2O54SmOzIgneWYqQo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2730,13 +2730,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "27-02-2023, 15:52:52",
+    "recorded-date": "30-04-2023, 18:46:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "mdyx6lX3eKXegmh4CuAtIYkz2zQio3aJPab0U7RUi+g=",
+        "CodeSha256": "HZO/38cx+0gOKUr19lI2upfd7j2O54SmOzIgneWYqQo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2787,13 +2787,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "27-02-2023, 15:51:45",
+    "recorded-date": "30-04-2023, 18:46:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "RMNx39qSLuPzRpcE2Zo1OTMltH+9HJZ5LISmiqSukB0=",
+        "CodeSha256": "EHUV3FF9Y50HzjCFzJ2KlPXQPvPCcC0YoeqGOftrMLM=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2845,13 +2845,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnetcore3.1]": {
-    "recorded-date": "27-02-2023, 15:51:42",
+    "recorded-date": "30-04-2023, 18:46:35",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "evIqWg7Cz43b2UaEV0G1j2bm0dAVkDzyRRlBK5OY0lY=",
+        "CodeSha256": "ZuL/R1kGyXQ4eVGJq+w9teGyyK/5UOgchVjG6o8OK5M=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2903,71 +2903,71 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.7]": {
-    "recorded-date": "27-02-2023, 15:45:48",
+    "recorded-date": "30-04-2023, 18:43:14",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "27-02-2023, 15:45:55",
+    "recorded-date": "30-04-2023, 18:43:18",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "27-02-2023, 15:46:02",
+    "recorded-date": "30-04-2023, 18:43:22",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs12.x]": {
-    "recorded-date": "27-02-2023, 15:46:09",
+    "recorded-date": "30-04-2023, 18:43:32",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs14.x]": {
-    "recorded-date": "27-02-2023, 15:46:20",
+    "recorded-date": "30-04-2023, 18:43:37",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "27-02-2023, 15:46:28",
+    "recorded-date": "30-04-2023, 18:43:42",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby2.7]": {
-    "recorded-date": "27-02-2023, 15:46:42",
+    "recorded-date": "30-04-2023, 18:43:52",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8]": {
-    "recorded-date": "27-02-2023, 15:47:00",
+    "recorded-date": "30-04-2023, 18:44:02",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "27-02-2023, 15:47:11",
+    "recorded-date": "30-04-2023, 18:44:12",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "27-02-2023, 15:47:23",
+    "recorded-date": "30-04-2023, 18:44:21",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnetcore3.1]": {
-    "recorded-date": "27-02-2023, 15:47:29",
+    "recorded-date": "30-04-2023, 18:44:26",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "27-02-2023, 15:47:36",
+    "recorded-date": "30-04-2023, 18:44:31",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[go1.x]": {
-    "recorded-date": "27-02-2023, 15:48:42",
+    "recorded-date": "30-04-2023, 18:44:39",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided]": {
-    "recorded-date": "27-02-2023, 15:48:52",
+    "recorded-date": "30-04-2023, 18:44:47",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "27-02-2023, 15:49:03",
+    "recorded-date": "30-04-2023, 18:44:55",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "27-02-2023, 15:46:35",
+    "recorded-date": "30-04-2023, 18:43:47",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "27-02-2023, 15:49:24",
+    "recorded-date": "30-04-2023, 18:45:13",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3043,7 +3043,7 @@
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
           "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
-          "NODE_EXTRA_CA_CERTS": "/etc/pki/tls/certs/ca-bundle.crt",
+          "NODE_EXTRA_CA_CERTS": "/var/runtime/ca-cert.pem",
           "NODE_PATH": "/opt/nodejs/node18/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task",
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
@@ -3087,7 +3087,7 @@
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
           "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
-          "NODE_EXTRA_CA_CERTS": "/etc/pki/tls/certs/ca-bundle.crt",
+          "NODE_EXTRA_CA_CERTS": "/var/runtime/ca-cert.pem",
           "NODE_PATH": "/opt/nodejs/node18/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task",
           "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "27-02-2023, 15:51:10",
+    "recorded-date": "30-04-2023, 18:46:08",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3162,13 +3162,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs12.x]": {
-    "recorded-date": "27-02-2023, 15:52:55",
+    "recorded-date": "30-04-2023, 18:46:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "7Kp9bB7d81J5cxZrK9PzbM/luXLmI68YXbXlIbPMMWk=",
+        "CodeSha256": "fKhqWrhw1PbQjGlzohF8mf9D4PldsYo8PNarq/muZw8=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3211,13 +3211,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs14.x]": {
-    "recorded-date": "27-02-2023, 15:52:58",
+    "recorded-date": "30-04-2023, 18:46:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "1CCL+mA9dhOFe98gl0DP/p5jSStv0+OzxHBZjTdLYwI=",
+        "CodeSha256": "dFKshw5sd3qg1dJ9uxfO3DHkJF0NdquoK/fkrldwMv8=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3260,13 +3260,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "27-02-2023, 15:53:01",
+    "recorded-date": "30-04-2023, 18:46:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "S/Qw+/13v5feqoexcZziFhGCCJuLXYdK/APm/4HirOE=",
+        "CodeSha256": "/a1uiOwovs3wwwqvcUXHmvyO/RhuoUNx4+MvU3qu9U4=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3309,13 +3309,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "27-02-2023, 15:53:04",
+    "recorded-date": "30-04-2023, 18:46:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "+XDjR2nTpssauodt+UlbzBP7CNWmfoHCl3WidmvnPHc=",
+        "CodeSha256": "DdS2iqXkBnD+EDms3lVz+UjS0Ywma3PSMGQ8wY0BZs8=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3675,6 +3675,206 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
+    "recorded-date": "30-04-2023, 18:43:27",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
+    "recorded-date": "30-04-2023, 18:45:02",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "/GM9lSawOZzH9EYupX4RNuApW9aAwUt8CTPed/kRFEA=",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.10",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
+    "recorded-date": "30-04-2023, 18:46:00",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "cayht/n0owXb+ceXJMUeCetNIKgyxdowwtl/JO/9mgM=",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.10",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Failed: some_error_msg",
+          "errorType": "Exception",
+          "requestId": "<uuid:2>",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -501,7 +501,7 @@ class TestPythonRuntimes:
         assert "stackTrace" in payload
 
         if (
-            runtime == "python3.9" and not is_old_provider()
+            runtime in ("python3.9", "python3.10") and not is_old_provider()
         ):  # TODO: remove this after the legacy provider is gone
             assert "requestId" in payload
         else:

--- a/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs14.x]": {
-    "recorded-date": "27-02-2023, 17:20:20",
+    "recorded-date": "02-05-2023, 11:58:47",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -62,7 +62,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
-    "recorded-date": "27-02-2023, 17:20:39",
+    "recorded-date": "02-05-2023, 11:58:55",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -124,7 +124,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_runtime_with_lib": {
-    "recorded-date": "27-02-2023, 17:20:55",
+    "recorded-date": "02-05-2023, 11:59:07",
     "recorded-content": {
       "create-result-jar-with-lib": {
         "CreateEventSourceMappingResponse": null,
@@ -291,7 +291,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8]": {
-    "recorded-date": "27-02-2023, 17:20:59",
+    "recorded-date": "02-05-2023, 11:59:10",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -305,7 +305,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "recorded-date": "27-02-2023, 17:21:02",
+    "recorded-date": "02-05-2023, 11:59:13",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -319,7 +319,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "recorded-date": "27-02-2023, 17:21:06",
+    "recorded-date": "02-05-2023, 11:59:15",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -333,7 +333,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8]": {
-    "recorded-date": "27-02-2023, 17:21:17",
+    "recorded-date": "02-05-2023, 11:59:23",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -396,7 +396,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "recorded-date": "27-02-2023, 17:21:28",
+    "recorded-date": "02-05-2023, 11:59:31",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -459,7 +459,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "recorded-date": "27-02-2023, 17:21:37",
+    "recorded-date": "02-05-2023, 11:59:38",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -522,7 +522,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequestCustom-CUSTOM]": {
-    "recorded-date": "27-02-2023, 17:21:44",
+    "recorded-date": "02-05-2023, 11:59:49",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -581,7 +581,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom-INTERFACE]": {
-    "recorded-date": "27-02-2023, 17:21:51",
+    "recorded-date": "02-05-2023, 11:59:58",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -640,7 +640,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequest-INTERFACE]": {
-    "recorded-date": "27-02-2023, 17:22:03",
+    "recorded-date": "02-05-2023, 12:00:06",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -698,306 +698,8 @@
       }
     }
   },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.7]": {
-    "recorded-date": "27-02-2023, 17:22:18",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "27-02-2023, 17:22:28",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "27-02-2023, 17:22:41",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "recorded-date": "26-04-2023, 20:23:41",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.7]": {
-    "recorded-date": "27-02-2023, 17:22:44",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "27-02-2023, 17:22:48",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "27-02-2023, 17:22:51",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "recorded-date": "26-04-2023, 20:24:51",
-    "recorded-content": {}
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.7]": {
-    "recorded-date": "27-02-2023, 17:22:54",
-    "recorded-content": {
-      "creation_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<<code-sha-256>:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.7",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "invocation_response": {
-        "ExecutedVersion": "$LATEST",
-        "FunctionError": "Unhandled",
-        "Payload": {
-          "errorMessage": "some error occurred",
-          "errorType": "CustomException",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
-          ]
-        },
-        "StatusCode": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.8]": {
-    "recorded-date": "27-02-2023, 17:22:58",
-    "recorded-content": {
-      "creation_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<<code-sha-256>:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.8",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "invocation_response": {
-        "ExecutedVersion": "$LATEST",
-        "FunctionError": "Unhandled",
-        "Payload": {
-          "errorMessage": "some error occurred",
-          "errorType": "CustomException",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
-          ]
-        },
-        "StatusCode": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.9]": {
-    "recorded-date": "27-02-2023, 17:23:01",
-    "recorded-content": {
-      "creation_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<<code-sha-256>:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "invocation_response": {
-        "ExecutedVersion": "$LATEST",
-        "FunctionError": "Unhandled",
-        "Payload": {
-          "errorMessage": "some error occurred",
-          "errorType": "CustomException",
-          "requestId": "<uuid:2>",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
-          ]
-        },
-        "StatusCode": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.10]": {
-    "recorded-date": "26-04-2023, 20:23:01",
-    "recorded-content": {
-      "creation_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<<code-sha-256>:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "handler.handler",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "invocation_response": {
-        "ExecutedVersion": "$LATEST",
-        "FunctionError": "Unhandled",
-        "Payload": {
-          "errorMessage": "some error occurred",
-          "errorType": "CustomException",
-          "requestId": "<uuid:2>",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
-          ]
-        },
-        "StatusCode": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_lambda_subscribe_sns_topic": {
-    "recorded-date": "22-03-2023, 17:40:56",
+    "recorded-date": "02-05-2023, 12:00:28",
     "recorded-content": {
       "get-function": {
         "Code": {
@@ -1064,6 +766,304 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.7]": {
+    "recorded-date": "02-05-2023, 12:00:30",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
+    "recorded-date": "02-05-2023, 12:00:32",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
+    "recorded-date": "02-05-2023, 12:00:35",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
+    "recorded-date": "02-05-2023, 12:00:37",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.7]": {
+    "recorded-date": "02-05-2023, 12:00:39",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
+    "recorded-date": "02-05-2023, 12:00:41",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
+    "recorded-date": "02-05-2023, 12:00:44",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
+    "recorded-date": "02-05-2023, 12:00:46",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.7]": {
+    "recorded-date": "02-05-2023, 12:00:48",
+    "recorded-content": {
+      "creation_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.7",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation_response": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "some error occurred",
+          "errorType": "CustomException",
+          "stackTrace": [
+            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
+          ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.8]": {
+    "recorded-date": "02-05-2023, 12:00:50",
+    "recorded-content": {
+      "creation_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation_response": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "some error occurred",
+          "errorType": "CustomException",
+          "stackTrace": [
+            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
+          ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.9]": {
+    "recorded-date": "02-05-2023, 12:00:53",
+    "recorded-content": {
+      "creation_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation_response": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "some error occurred",
+          "errorType": "CustomException",
+          "requestId": "<uuid:2>",
+          "stackTrace": [
+            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
+          ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.10]": {
+    "recorded-date": "02-05-2023, 12:00:55",
+    "recorded-content": {
+      "creation_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.10",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation_response": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "some error occurred",
+          "errorType": "CustomException",
+          "requestId": "<uuid:2>",
+          "stackTrace": [
+            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
+          ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
@@ -710,6 +710,10 @@
     "recorded-date": "27-02-2023, 17:22:41",
     "recorded-content": {}
   },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
+    "recorded-date": "26-04-2023, 20:23:41",
+    "recorded-content": {}
+  },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.7]": {
     "recorded-date": "27-02-2023, 17:22:44",
     "recorded-content": {}
@@ -720,6 +724,10 @@
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
     "recorded-date": "27-02-2023, 17:22:51",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
+    "recorded-date": "26-04-2023, 20:24:51",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.7]": {
@@ -856,6 +864,73 @@
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.9]": {
     "recorded-date": "27-02-2023, 17:23:01",
+    "recorded-content": {
+      "creation_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invocation_response": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "some error occurred",
+          "errorType": "CustomException",
+          "requestId": "<uuid:2>",
+          "stackTrace": [
+            "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
+          ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.10]": {
+    "recorded-date": "26-04-2023, 20:23:01",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,


### PR DESCRIPTION
## Changes
This PR introduces support for the python3.10 runtime recently released by AWS.

https://aws.amazon.com/blogs/compute/python-3-10-runtime-now-available-in-aws-lambda/

Fixes #8185