### PR TITLE
fix TypeError for get_ddb_provisioned_throughput

### DIFF
--- a/tests/integration/cloudformation/resources/test_dynamodb.py
+++ b/tests/integration/cloudformation/resources/test_dynamodb.py
@@ -55,6 +55,7 @@ def test_globalindex_read_write_provisioned_throughput_dynamodb_table(
         assert isinstance(test_write_capacity, int)
 
 
+@pytest.mark.aws_validated
 @pytest.mark.skip_snapshot_verify(
     paths=[
         "$..Table.ProvisionedThroughput.LastDecreaseDateTime",


### PR DESCRIPTION
Follow up from #8160 to not raise a TypeError if the wrong parameters are passed to a DynamoDB Table in a cloudformation template. 
I am not sure how to add negative testing for CloudFormation, but I tried against AWS with `test_default_name_for_table` and not specifying a `ProvisionedThroughput` and it fails. 

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-provisionedthroughput