### PR TITLE
reintroduce vhost use in s3 cors tests

### DIFF
--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -109,9 +109,7 @@ class TestS3Cors:
         response = aws_client.s3.put_object(Bucket=s3_bucket, Key=key, Body=body, ACL="public-read")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        # key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
-        # TODO: replace with vhost again: investigate
-        key_url = f"{config.get_edge_url()}/{s3_bucket}/{key}"
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
 
         response = requests.get(key_url)
         assert response.status_code == 200
@@ -208,8 +206,7 @@ class TestS3Cors:
             "$..Headers.Transfer-Encoding",  # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
         ]
     )
-    def test_cors_match_origins(self, s3_bucket, match_headers, monkeypatch, aws_client):
-        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+    def test_cors_match_origins(self, s3_bucket, match_headers, aws_client):
         bucket_cors_config = {
             "CORSRules": [
                 {
@@ -229,9 +226,7 @@ class TestS3Cors:
 
         aws_client.s3.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
 
-        # key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{object_key}"
-        # TODO: replace with vhost again: investigate
-        key_url = f"{config.get_edge_url()}/{s3_bucket}/{object_key}"
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{object_key}"
 
         # no origin, akin to no CORS
         opt_req = requests.options(key_url)
@@ -290,8 +285,7 @@ class TestS3Cors:
             "$.put-op.Headers.Content-Type",  # issue with default Response values
         ]
     )
-    def test_cors_match_methods(self, s3_create_bucket, match_headers, monkeypatch, aws_client):
-        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+    def test_cors_match_methods(self, s3_create_bucket, match_headers, aws_client):
         origin = "https://localhost:4200"
         bucket_cors_config = {
             "CORSRules": [
@@ -313,9 +307,7 @@ class TestS3Cors:
 
         aws_client.s3.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
 
-        # key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
-        # TODO: replace with vhost again: investigate
-        key_url = f"{config.get_edge_url()}/{bucket_name}/{object_key}"
+        key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
 
         # test with allowed method: GET
         opt_req = requests.options(
@@ -333,9 +325,7 @@ class TestS3Cors:
 
         # test with method: PUT
 
-        # new_key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}new"
-        # TODO: replace with vhost again: investigate
-        new_key_url = f"{config.get_edge_url()}/{bucket_name}/{object_key}new"
+        new_key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}new"
 
         opt_req = requests.options(
             new_key_url, headers={"Origin": origin, "Access-Control-Request-Method": "PUT"}
@@ -357,8 +347,7 @@ class TestS3Cors:
             "$.put-op.Headers.Content-Type",  # issue with default Response values
         ]
     )
-    def test_cors_match_headers(self, s3_create_bucket, match_headers, monkeypatch, aws_client):
-        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+    def test_cors_match_headers(self, s3_create_bucket, match_headers, aws_client):
         origin = "https://localhost:4200"
         bucket_cors_config = {
             "CORSRules": [


### PR DESCRIPTION
Remove comments and reintroduce the usage of virtual host addressing in S3 CORS tests. These were in place because at some point, it seemed like it reduced test failures that were finally fixed with #8134

Also remove some commented out code.