### PR TITLE
re-install DynamoDB in Dockerfile, use cache for archive download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,15 @@ ADD localstack/ localstack/
 # Generate the plugin entrypoints
 RUN make entrypoints
 
+# Install packages which should be shipped by default
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/var/lib/localstack/cache \
+    source .venv/bin/activate && \
+    python -m localstack.cli.lpm install \
+      dynamodb-local && \
+    chown -R localstack:localstack /usr/lib/localstack && \
+    chmod -R 777 /usr/lib/localstack
+
 # link the extensions virtual environment into the localstack venv
 RUN echo /var/lib/localstack/lib/extensions/python_venv/lib/python3.10/site-packages > localstack-extensions-venv.pth && \
     mv localstack-extensions-venv.pth .venv/lib/python*/site-packages/

--- a/localstack/services/dynamodb/packages.py
+++ b/localstack/services/dynamodb/packages.py
@@ -1,7 +1,7 @@
 import os
-import tempfile
 from typing import List
 
+from localstack import config
 from localstack.constants import ARTIFACTS_REPO, MAVEN_REPO_URL
 from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.utils.archives import (
@@ -43,7 +43,7 @@ class DynamoDBLocalPackageInstaller(PackageInstaller):
 
     def _install(self, target: InstallTarget):
         # download and extract archive
-        tmp_archive = os.path.join(tempfile.gettempdir(), "localstack.ddb.zip")
+        tmp_archive = os.path.join(config.dirs.cache, "localstack.ddb.zip")
         install_dir = self._get_install_dir(target)
         download_and_extract_with_retry(DYNAMODB_JAR_URL, tmp_archive, install_dir)
 


### PR DESCRIPTION
## Issue
With the release of 2.0, specifically with #7927, we completely refactored the way LocalStack is built.
Together with this change, the pre-installation of LPM packages has been removed in order to further decrease the Docker image size (and lazy-loading them on-demand when the respective service needs a specific package).

Unfortunately, some users are facing issues with DynamoDB, one of the most used services of LocalStack:
- #8192
- #8100
- #8058
- #8054

This only affects the Community Docker image, `localstack/localstack-pro` always contained DynamoDB (as well as other packages).

## Solution
After some internal discussions, we came to the conclusion that it might be the best approach to:
- Pre-ship the LocalStack Community Docker image with all packages necessary to run the most used (top 15) services out-of-the-box (i.e. without the necessity to download any packages on demand).
- If there is a high request for a minimum Docker image, we might introduce a `slim` variant of the image in the future (which then does not contain any preinstalled packages).

## Implications
Analysis of the Docker image size increase due to this change:
```
$ make docker-build
...
$ docker tag localstack/localstack:latest localstack/localstack:ddb
$ docker pull localstack/localstack
...
$ docker inspect localstack/localstack | jq ".[0].Size"                                                                                                                                                                               1075345104
$ docker inspect localstack/localstack:ddb | jq ".[0].Size"                                                                                                                                                                          
1132873716
```
The uncompressed image size will increase by `1132873716 - 1075345104 = 57528612 bytes = ~55MB`.

```
$ docker save localstack/localstack:latest | gzip > image-wo-ddb.tar.gz
$ docker save localstack/localstack:ddb | gzip > image-w-ddb.tar.gz
$ ls -lh | grep image | awk -v OFS='\t' '{print $9, $5}'                                                                                                                                                                     
image-w-ddb.tar.gz	371M
image-wo-ddb.tar.gz	324M
```
The compressed image size increases by **~47MB**.
The lack of compression is not too surprising, considering the fact that the JAR files are already compressed ZIP files.