### PR TITLE
Fix docker copy_to_container performance, especially on mac

### DIFF
--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -6,6 +6,7 @@ import queue
 import socket
 import threading
 from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 import docker
 from docker import DockerClient
@@ -91,7 +92,8 @@ class SdkDockerClient(ContainerClient):
                 api_client.base_url + url, **api_client._set_request_timeout(kwargs)
             )
 
-        result = _head(f"/containers/{container.id}/archive", params={"path": container_path})
+        escaped_id = quote(container.id, safe="/:")
+        result = _head(f"/containers/{escaped_id}/archive", params={"path": container_path})
         stats = result.headers.get("X-Docker-Container-Path-Stat")
         target_exists = result.ok
 

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -87,9 +87,9 @@ class SdkDockerClient(ContainerClient):
         # https://golang.org/src/os/types.go?s=2650:2683
         api_client = self.client().api
 
-        def _head(url, **kwargs):
+        def _head(path_suffix, **kwargs):
             return api_client.head(
-                api_client.base_url + url, **api_client._set_request_timeout(kwargs)
+                api_client.base_url + path_suffix, **api_client._set_request_timeout(kwargs)
             )
 
         escaped_id = quote(container.id, safe="/:")


### PR DESCRIPTION
## Motivation
This fixes the _significant_ performance issues of lambda on MacOS / Docker Desktop systems.
The main issue behind it was the check if a directory in the container exists and whether it is a directory, which was naively implemented as `get_archive`, which downloads the complete target directory.

This was caused mainly (by me :D) due to the missing API operation in the upstream docker sdk client for python, which is missing the abstraction for the head operation described here: https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerArchiveInfo

## Changes
* Uses the head operation https://docs.docker.com/engine/api/v1.42/#tag/Container/operation/ContainerArchiveInfo to get the container archive info without downloading it. This needs some internal operations of the docker client, but seems like the most compatible option for now.

Co-debugged by @joe4dev 