### PR TITLE
fix: s3 parsing key with trailing backslash and reserved chars

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -70,6 +70,7 @@ from abc import ABC
 from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 from typing.io import IO
+from urllib.parse import quote
 from xml.etree import ElementTree as ETree
 
 import cbor2
@@ -1066,14 +1067,15 @@ class S3RequestParser(RestXMLRequestParser):
         """
         Special handling of parsing the shape for s3 object-names (=key):
         trailing '/' are valid and need to be preserved, however, the url-matcher removes it from the key
-        we check the request.url to verify the name
+        we check the request.url to verify the name.
+        We might want to encode the key to take into account the ones with special characters.
         """
         if (
             shape is not None
             and uri_params is not None
             and shape.serialization.get("location") == "uri"
             and shape.serialization.get("name") == "Key"
-            and request.base_url.endswith(f"{uri_params['Key']}/")
+            and request.base_url.endswith(f"{quote(uri_params['Key'])}/")
         ):
             uri_params = dict(uri_params)
             uri_params["Key"] = uri_params["Key"] + "/"

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1083,7 +1083,7 @@ def test_s3_get_object_keys_with_slashes():
     )
 
 
-def test_s3_put_object_keys_with_slashes_and_special_characters():
+def test_s3_put_object_keys_with_trailing_slash_and_special_characters():
     _botocore_parser_integration_test(
         service="s3",
         action="PutObject",

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1083,6 +1083,17 @@ def test_s3_get_object_keys_with_slashes():
     )
 
 
+def test_s3_put_object_keys_with_slashes_and_special_characters():
+    _botocore_parser_integration_test(
+        service="s3",
+        action="PutObject",
+        Bucket="test-bucket",
+        Key="test@key/",
+        ContentLength=0,
+        Metadata={},
+    )
+
+
 def test_restxml_headers_parsing():
     """Test the parsing of a map with the location trait 'headers'."""
     _botocore_parser_integration_test(


### PR DESCRIPTION
Addresses #8174.

In a nutshell, the issue was caused by not re-adding a trailing backslash for keys with special quoted characters.