### PR TITLE
upgrade Werkzeug to 2.3.4

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -70,7 +70,6 @@ from abc import ABC
 from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 from typing.io import IO
-from urllib.parse import quote
 from xml.etree import ElementTree as ETree
 
 import cbor2
@@ -1075,7 +1074,7 @@ class S3RequestParser(RestXMLRequestParser):
             and uri_params is not None
             and shape.serialization.get("location") == "uri"
             and shape.serialization.get("name") == "Key"
-            and request.base_url.endswith(f"{quote(uri_params['Key'])}/")
+            and request.base_url.endswith(f"{uri_params['Key']}/")
         ):
             uri_params = dict(uri_params)
             uri_params["Key"] = uri_params["Key"] + "/"

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -135,15 +135,16 @@ def call_endpoint(
 
 def _clone_map_without_rules(old: Map) -> Map:
     return Map(
-        default_subdomain=old.default_subdomain,
+        # TODO charset and encoding_errors are deprecated, remove with upgrade to Werkzeug 2.4.0
         charset=old.charset,
+        encoding_errors=old.encoding_errors,
+        default_subdomain=old.default_subdomain,
         strict_slashes=old.strict_slashes,
         merge_slashes=old.merge_slashes,
         redirect_defaults=old.redirect_defaults,
         converters=old.converters,
         sort_parameters=old.sort_parameters,
         sort_key=old.sort_key,
-        encoding_errors=old.encoding_errors,
         host_matching=old.host_matching,
     )
 

--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -38,7 +38,7 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> Optional[Test
     use_legacy_report = os.environ.get("SNAPSHOT_LEGACY_REPORT", "0") == "1"
 
     result: _Result = yield
-    report: TestReport = result.result
+    report: TestReport = result.get_result()
 
     if call.excinfo is not None and isinstance(call.excinfo.value, SnapshotAssertionError):
         err: SnapshotAssertionError = call.excinfo.value

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -429,7 +429,7 @@ class TransformerUtility:
             # this will be able to use a KeyValue based once we provide a certificate for message signing in SNS
             # a match must be made case-insensitive because the key casing is different from lambda notifications
             RegexTransformer(
-                r"(?<=(?i)UnsubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=Unsubscribe)",
+                r"(?i)(?<=UnsubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=Unsubscribe)",
                 replacement="<unsubscribe-domain>",
             ),
             KeyValueBasedTransformer(_resource_name_transformer, "resource"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ runtime =
     dnslib>=0.9.10
     dnspython>=1.16.0
     docker==6.0.1
-    flask>=2.2.3,<2.3.0
+    flask>=2.3.2
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
     hypercorn==0.14.2
@@ -93,7 +93,7 @@ runtime =
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
     vosk==0.3.43
-    Werkzeug>=2.2.3,<2.3.0
+    Werkzeug>=2.3.4
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -794,12 +794,12 @@ class TestEvents:
                     ],
                     "HeaderParameters": [
                         {
-                            "Key": "connection_header_param",
+                            "Key": "connection-header-param",
                             "Value": "value",
                             "IsValueSecret": False,
                         },
                         {
-                            "Key": "overwritten_header",
+                            "Key": "overwritten-header",
                             "Value": "original",
                             "IsValueSecret": False,
                         },
@@ -844,7 +844,7 @@ class TestEvents:
                     "HttpParameters": {
                         "PathParameterValues": ["target_path"],
                         "HeaderParameters": {
-                            "target_header": "target_header_value",
+                            "target-header": "target_header_value",
                             "overwritten_header": "changed",
                         },
                         "QueryStringParameters": {
@@ -880,17 +880,17 @@ class TestEvents:
 
         # Connection data validation
         assert event["connection_body_param"] == "value"
-        assert headers["Connection_Header_Param"] == "value"
+        assert headers["Connection-Header-Param"] == "value"
         assert query_args["connection_query_param"] == "value"
 
         # Target parameters validation
         assert "/target_path" in event_request.path
         assert event["target_value"] == "value"
-        assert headers["Target_Header"] == "target_header_value"
+        assert headers["Target-Header"] == "target_header_value"
         assert query_args["target_query"] == "t_query"
 
         # connection/target overwrite test
-        assert headers["Overwritten_Header"] == "original"
+        assert headers["Overwritten-Header"] == "original"
         assert query_args["overwritten_query"] == "original"
 
         # Auth validation

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2189,7 +2189,7 @@ class TestSNSProvider:
                 snapshot.transform.key_value("RequestId"),
                 snapshot.transform.key_value("Token"),
                 snapshot.transform.regex(
-                    r"(?<=(?i)SubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=ConfirmSubscription)",
+                    r"(?i)(?<=SubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=ConfirmSubscription)",
                     replacement="<subscribe-domain>",
                 ),
             ]


### PR DESCRIPTION
Right after upgrading to `Werkzeug==2.2.3` with https://github.com/localstack/localstack/pull/8104, version `2.3` has been released: https://github.com/pallets/werkzeug/releases/tag/2.3.0
In the meantime, the current release is 2.3.4: https://github.com/pallets/werkzeug/releases/tag/2.3.4
This upgrade breaks a few tests, which will be fixed within this PR.

Steps:
- [x] Explicitly upgrade Werkzeug to version 2.3.4.
- [x] Analyze test results
- [x] Fix all failing tests
  - [x] `tests.unit.test_motoserver.test_moto_server`
    - This seems to be an issue with our MotoServer bridge (which is only used in legacy code).
    - This might be related to recent changes in dropping certain decoding steps in Werkzeug 2.3.0 (mentioned in the changeset https://werkzeug.palletsprojects.com/en/2.3.x/changes/).
    - This seems to be fixed with https://github.com/getmoto/moto/pull/6266.
    - The change will end up in localstack with https://github.com/localstack/localstack/pull/8270
  - [x] `tests.integration.test_events.TestEvents.test_api_destinations`
     - https://app.circleci.com/pipelines/github/localstack/localstack/14407/workflows/db9cd6c8-d3e1-4b76-bc66-0f2ee7eb8b24/jobs/107287
     - Caused by https://github.com/pallets/werkzeug/commit/5ee439a692dc4474e0311de2496b567eed2d02cf#diff-abeaeb33abe8954dc4551a4631392ac46ad65e8b9f8404cec0e276a0d345af3b
     - This is actually a bug / implication of a change in werkzeug, its implications in http_server, and the test implementation.
     - Header params with underscores are just removed and cannot be retrieved when using the development server of Werkzeug 2.3+.
     - Changed the test for now. Needs to be clarified with @dominikschubert and @dfangl if this is okay.
     - I created an issue in Werkzeug for this: https://github.com/pallets/werkzeug/issues/2693
     - However, it's effectively a limitation for `pytest-httpserver` (which uses the Werkzeug development server, we don't).
  - [x] `tests.unit.aws.protocol.test_parser.py::test_s3_put_object_keys_with_trailing_slash_and_special_characters`
    - Started failing after rebasing, such that it contains #8198.
    - This has been fixed by removing the encoding handling in the parser (since the path param encoding changed with Werkzeug 2.3).
  - [x] `tests.unit.http_.test_asgi.test_multipart_post_large_payload`
    - This is still to be investigated. This could either be an incompatibility in our ASGI/WSGI bridge, or in Werkzeug 2.3.0.
    - The multipart file streams suddenly have a leading `\r\n` when reading the file stream of the request. The test fails because this adds additional 2 characters, which causes the lengths to diverge.
    - Fixed with https://github.com/pallets/werkzeug/pull/2678
  - [x] `tests.unit.utils.test_http_utils.test_download_with_headers`
    - Issue in `pytest-httpserver`: https://github.com/csernazs/pytest-httpserver/issues/241
    - This test will be fixed in 2.3.1: https://github.com/pallets/werkzeug/issues/2665
- [x] Ensure compatibility with downstream deps
  - [x] `tests.integration.docker_utils.test_docker.TestDockerClient.test_push_access_denied`
    - https://github.com/localstack/localstack/runs/13030344607
    - These tests seem unrelated, because they also failed with Werkzeug 2.2.3 in #8202.
  - [x] Run external integration tests against this branch to catch integration issues early.
    - [External tests are 💚 ](https://github.com/localstack/localstack-ext/actions/runs/4923405174)
- [x] Prepare for 2.4 (fix some deprecation warnings)
   - [x] `localstack/http/router.py:137: DeprecationWarning: The 'charset' parameter is deprecated and will be removed in Werkzeug 2.4.`
     - Added a comment in the code to remove with 2.4 (we are copying the request, for now this is still necessary)
   - [x] `localstack/http/router.py:137: DeprecationWarning: The 'encoding_errors' parameter is deprecated and will be removed in Werkzeug 2.4.`
     - Added a comment in the code to remove with 2.4 (we are copying the request, for now this is still necessary)
   - [x] `localstack/testing/pytest/snapshot.py:41: DeprecationWarning: Use get_result() which forces correct exception handling`
   - [x] `localstack/testing/snapshots/transformer.py:145: DeprecationWarning: Flags not at the start of the expression '(?<=(?i)UnsubscribeU' (truncated) but at position 4`
   - [x] `localstack/testing/snapshots/transformer.py:145: DeprecationWarning: Flags not at the start of the expression '(?<=(?i)SubscribeURL' (truncated) but at position 4`