### PR TITLE
avoid Werkzeug and Flask upgrade to 2.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ runtime =
     dnslib>=0.9.10
     dnspython>=1.16.0
     docker==6.0.1
-    flask>=2.2.3
+    flask>=2.2.3,<2.3.0
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
     hypercorn==0.14.2
@@ -93,7 +93,7 @@ runtime =
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
     vosk==0.3.43
-    Werkzeug>=2.2.3
+    Werkzeug>=2.2.3,<2.3.0
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
Right after upgrading to Werkzeug==2.2.3 with https://github.com/localstack/localstack/pull/8104, version 2.3 has been released: https://github.com/pallets/werkzeug/releases/tag/2.3.0
Unfortunately, the upgrade again causes some issues. These issues are addressed in https://github.com/localstack/localstack/pull/8200.

In the meantime, this PR avoids the upgrade to Werkzeug and Flask 2.3.0 by adding an upper version boundary in the `setup.cfg`.