### PR TITLE
Use non-default formatted access key ID for tests

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -145,16 +145,20 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = (
+    os.getenv("TEST_AWS_ACCESS_KEY_ID") or "LSIAQAAAAAAAQAATEST1"
+)  # translates to account ID: 000000000001
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION_NAME") or "us-west-2"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"
-SECONDARY_TEST_AWS_ACCESS_KEY_ID = os.getenv("SECONDARY_TEST_AWS_ACCESS_KEY_ID") or "000000000002"
+SECONDARY_TEST_AWS_ACCESS_KEY_ID = (
+    os.getenv("SECONDARY_TEST_AWS_ACCESS_KEY_ID") or "LSIAQAAAAAABAAATEST2"
+)  # translates to account ID: 000000000002
 SECONDARY_TEST_AWS_SECRET_ACCESS_KEY = os.getenv("SECONDARY_TEST_AWS_SECRET_ACCESS_KEY") or "test2"
-SECONDARY_TEST_AWS_REGION_NAME = os.getenv("SECONDARY_TEST_AWS_REGION") or "ap-southeast-1"
+SECONDARY_TEST_AWS_REGION_NAME = os.getenv("SECONDARY_TEST_AWS_REGION_NAME") or "ap-southeast-1"
 
 # Credentials used for internal calls
 INTERNAL_AWS_ACCESS_KEY_ID = "__internal_call__"

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -16,7 +16,11 @@ from localstack.aws.connect import (
 from localstack.aws.gateway import Gateway
 from localstack.aws.handlers import add_internal_request_params, add_region_from_header
 from localstack.config import HostAndPort
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
+from localstack.constants import (
+    TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_REGION_NAME,
+    TEST_AWS_SECRET_ACCESS_KEY,
+)
 from localstack.http import Response
 from localstack.http.duplex_socket import enable_duplex_socket
 from localstack.http.hypercorn import GatewayServer
@@ -92,7 +96,7 @@ class TestClientFactory:
         )
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=TEST_AWS_REGION_NAME,
             use_ssl=True,
             verify=False,
             endpoint_url="http://localhost:4566",
@@ -107,7 +111,7 @@ class TestClientFactory:
         connect_to.get_client("def", region_name=None, aws_access_key_id=TEST_AWS_ACCESS_KEY_ID)
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=TEST_AWS_REGION_NAME,
             use_ssl=True,
             verify=False,
             endpoint_url="http://localhost:4566",
@@ -147,7 +151,7 @@ class TestClientFactory:
         )
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=TEST_AWS_REGION_NAME,
             use_ssl=True,
             verify=True,
             endpoint_url=None,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,17 @@
 import pytest
 
+from localstack.constants import (
+    TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_REGION_NAME,
+    TEST_AWS_SECRET_ACCESS_KEY,
+)
+
 
 @pytest.fixture(autouse=True)
 def set_boto_test_credentials_and_region(monkeypatch):
     """
     Automatically sets the default credentials and region for all unit tests.
     """
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", TEST_AWS_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", TEST_AWS_SECRET_ACCESS_KEY)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", TEST_AWS_REGION_NAME)


### PR DESCRIPTION
## Summary

This PR makes use of formatted access key IDs for tests that resolve to `000000000001` (for primary account) and `000000000002` (for secondary account). The primary account is used for all tests (via the `aws_client` fixture) whereas the latter is used for cross-account testing (via `secondary_aws_client`). This PR also changes to a non-default test region to make sure multi-region works correctly.

In effect, this assures that all services in LocalStack now can work with any arbitrary account ID, and furthermore that service integrations also use the correct account ID. Prior to this PR the fallback account ID `000000000000` and default region `us-east-1` was used across LocalStack. For example, when using a service integration with a non-fallback account ID, the called service would still use the fallback account ID.

## Related
<!--
Depends on:
- https://github.com/localstack/localstack/pull/8223
- https://github.com/localstack/localstack/pull/8235
- https://github.com/localstack/localstack/pull/8541
- https://github.com/localstack/localstack/pull/8636
- https://github.com/localstack/localstack/pull/8674
- https://github.com/localstack/localstack/pull/8748

  - https://github.com/localstack/localstack/pull/8749
  - https://github.com/localstack/localstack/pull/8747
  - https://github.com/localstack/localstack/pull/8765
  - https://github.com/localstack/localstack/pull/8764
  - https://github.com/localstack/localstack/pull/8795

- https://github.com/localstack/localstack/pull/8822
- https://github.com/localstack/localstack/pull/8858
- https://github.com/localstack/localstack/pull/8879
- https://github.com/localstack/localstack/pull/8892
- https://github.com/localstack/localstack/pull/8912
- https://github.com/localstack/localstack/pull/8967
- https://github.com/localstack/localstack/pull/8968
- https://github.com/localstack/localstack/pull/9017
- https://github.com/localstack/localstack/pull/9023
- https://github.com/localstack/localstack/pull/9031
- https://github.com/localstack/localstack/pull/9119
- https://github.com/localstack/localstack/pull/9149
- https://github.com/localstack/localstack/pull/9201
- https://github.com/localstack/localstack/pull/9343
-->

Supersedes: https://github.com/localstack/localstack/pull/7040

Closes: #7041