### PR TITLE
fix: Lambda integration with DDB binary items

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/adapters.py
+++ b/localstack/services/awslambda/event_source_listeners/adapters.py
@@ -16,6 +16,7 @@ from localstack.services.awslambda.lambda_executors import (
     InvocationResult as LegacyInvocationResult,  # TODO: extract
 )
 from localstack.services.awslambda.lambda_utils import event_source_arn_matches
+from localstack.utils.json import BytesEncoder
 from localstack.utils.strings import to_bytes, to_str
 
 LOG = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ class EventSourceAsfAdapter(EventSourceAdapter):
             account_id=fn_parts["account_id"],
             invocation_type=invocation_type,
             client_context=json.dumps(context or {}),
-            payload=to_bytes(json.dumps(payload or {})),
+            payload=to_bytes(json.dumps(payload or {}, cls=BytesEncoder)),
             request_id=gen_amzn_requestid(),
         )
 
@@ -189,7 +190,7 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                 account_id=fn_parts["account_id"],
                 invocation_type=invocation_type,
                 client_context=json.dumps(context or {}),
-                payload=to_bytes(json.dumps(payload or {})),
+                payload=to_bytes(json.dumps(payload or {}, cls=BytesEncoder)),
                 request_id=gen_amzn_requestid(),
             )
 

--- a/localstack/services/awslambda/event_source_listeners/adapters.py
+++ b/localstack/services/awslambda/event_source_listeners/adapters.py
@@ -64,6 +64,11 @@ class EventSourceLegacyAdapter(EventSourceAdapter):
     def invoke(self, function_arn, context, payload, invocation_type, callback=None):
         from localstack.services.awslambda.lambda_api import run_lambda
 
+        try:
+            json.dumps(payload)
+        except TypeError:
+            payload = json.loads(json.dumps(payload or {}, cls=BytesEncoder))
+
         run_lambda(
             func_arn=function_arn,
             event=payload,
@@ -92,6 +97,11 @@ class EventSourceLegacyAdapter(EventSourceAdapter):
             )
         else:
             lock_discriminator = None
+
+        try:
+            json.dumps(payload)
+        except TypeError:
+            payload = json.loads(json.dumps(payload or {}, cls=BytesEncoder))
 
         result = run_lambda(
             func_arn=function_arn,

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
@@ -117,7 +117,7 @@ class TestDynamoDBEventSourceMapping:
         policy_name = f"test-lambda-policy-{short_uid()}"
         table_name = f"test-table-{short_uid()}"
         partition_key = "my_partition_key"
-        db_item = {partition_key: {"S": "hello world"}}
+        db_item = {partition_key: {"S": "hello world"}, "binary_key": {"B": b"foobar"}}
         role_arn = create_iam_role_with_policy(
             RoleName=role,
             PolicyName=policy_name,

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
@@ -90,6 +90,7 @@ def get_lambda_logs_event(aws_client):
     paths=[
         # dynamodb issues, not related to lambda
         "$..TableDescription.BillingModeSummary.LastUpdateToPayPerRequestDateTime",
+        "$..TableDescription.DeletionProtectionEnabled",
         "$..TableDescription.ProvisionedThroughput.LastDecreaseDateTime",
         "$..TableDescription.ProvisionedThroughput.LastIncreaseDateTime",
         "$..TableDescription.StreamSpecification",

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
@@ -94,6 +94,7 @@ def get_lambda_logs_event(aws_client):
         "$..TableDescription.ProvisionedThroughput.LastIncreaseDateTime",
         "$..TableDescription.StreamSpecification",
         "$..TableDescription.TableStatus",
+        "$..Records..dynamodb.NewImage.binary_key.B",
         "$..Records..dynamodb.SizeBytes",
         "$..Records..eventVersion",
     ],

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "recorded-date": "27-02-2023, 18:33:49",
+    "recorded-date": "26-04-2023, 10:48:20",
     "recorded-content": {
       "create-table-result": {
         "TableDescription": {
@@ -14,6 +14,7 @@
             "BillingMode": "PAY_PER_REQUEST"
           },
           "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {
@@ -79,12 +80,15 @@
                   }
                 },
                 "NewImage": {
+                  "binary_key": {
+                    "B": "Zm9vYmFy"
+                  },
                   "my_partition_key": {
                     "S": "hello world"
                   }
                 },
                 "SequenceNumber": "<sequence-number:1>",
-                "SizeBytes": 54,
+                "SizeBytes": 70,
                 "StreamViewType": "NEW_IMAGE"
               },
               "eventSourceARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>"


### PR DESCRIPTION
Should address #8199.
We reuse the same encoder from the DDB provider. 

Nit: we don't do base 64 encoding in DynamoDB. Therefore, I temporarily skipped the validation for `"$..Records..dynamodb.NewImage.binary_key.B"`.