### PR TITLE
fix flaky unit tests using server_context fixture

### DIFF
--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -1,5 +1,6 @@
 import re
 from contextlib import contextmanager
+from typing import Optional
 
 import requests
 from werkzeug.datastructures import Headers
@@ -15,8 +16,9 @@ from localstack.utils.serving import Server
 
 
 @contextmanager
-def server_context(server: Server):
+def server_context(server: Server, timeout: Optional[float] = 10):
     server.start()
+    server.wait_is_up(timeout)
     try:
         yield server
     finally:


### PR DESCRIPTION
This commit slightly adjusts the `server_context` fixture used in the unit tests to wait for the server to be actually up before yielding it. This should fix the - currently more frequently occurring - flaky unit tests, where tests are failing since the servers are not (yet) reachable (f.e. [`test_proxy_server_with_streamed_response` in this test run](https://app.circleci.com/pipelines/github/localstack/localstack/14451/workflows/64d763f8-7d92-4dd6-b354-c14c3bdbafdf/jobs/107646)).

The patch actually came from @simonrw (thanks!) who implemented the fix in a feature branch, I just want to get this on the master asap.