### PR TITLE
Fix mapping of denied access in docker hub

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -289,6 +289,8 @@ class CmdDockerClient(ContainerClient):
         except subprocess.CalledProcessError as e:
             if "is denied" in to_str(e.stdout):
                 raise AccessDenied(docker_image)
+            if "requesting higher privileges than access token allows" in to_str(e.stdout):
+                raise AccessDenied(docker_image)
             if "does not exist" in to_str(e.stdout):
                 raise NoSuchImage(docker_image)
             if "connection refused" in to_str(e.stdout):

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -249,6 +249,8 @@ class SdkDockerClient(ContainerClient):
                     raise NoSuchImage(docker_image)
                 if "is denied" in to_str(result):
                     raise AccessDenied(docker_image)
+                if "requesting higher privileges than access token allows" in to_str(result):
+                    raise AccessDenied(docker_image)
                 if "connection refused" in to_str(result):
                     raise RegistryConnectionError(result)
                 raise ContainerException(result)


### PR DESCRIPTION
## Motivation
We are currently seeing error messages in the community test pipeline in -ext which indicate an error when verifying the access denied error of a docker push.

```
-------------------------------- live log call ---------------------------------
2023-04-27T11:45:30.758 DEBUG --- [  MainThread] localstack.utils.container_utils.docker_cmd_client : Pushing image with cmd: ['docker', 'push', 'alpine']
2023-04-27T11:45:30.758 DEBUG --- [  MainThread] localstack.utils.run       : Executing command: ['docker', 'push', 'alpine']
ERROR: '['docker', 'push', 'alpine']': exit code 1; output: b'Using default tag: latest\nThe push refers to repository [docker.io/library/alpine]\nf1417ff83b31: Preparing\nf1417ff83b31: Retrying in 5 seconds\nf1417ff83b31: Retrying in 4 seconds\nf1417ff83b31: Retrying in 3 seconds\nf1417ff83b31: Retrying in 2 seconds\nf1417ff83b31: Retrying in 1 second\nf1417ff83b31: Retrying in 10 seconds\nf1417ff83b31: Retrying in 9 seconds\nf1417ff83b31: Retrying in 8 seconds\nf1417ff83b31: Retrying in 7 seconds\nf1417ff83b31: Retrying in 6 seconds\nf1417ff83b31: Retrying in 5 seconds\nf1417ff83b31: Retrying in 4 seconds\nf1417ff83b31: Retrying in 3 seconds\nf1417ff83b31: Retrying in 2 seconds\nf1417ff83b31: Retrying in 1 second\nf1417ff83b31: Retrying in 15 seconds\nf1417ff83b31: Retrying in 14 seconds\nf1417ff83b31: Retrying in 13 seconds\nf1417ff83b31: Retrying in 12 seconds\nf1417ff83b31: Retrying in 11 seconds\nf1417ff83b31: Retrying in 10 seconds\nf1417ff83b31: Retrying in 9 seconds\nf1417ff83b31: Retrying in 8 seconds\nf1417ff83b31: Retrying in 7 seconds\nf1417ff83b31: Retrying in 6 seconds\nf1417ff83b31: Retrying in 5 seconds\nf1417ff83b31: Retrying in 4 seconds\nf1417ff83b31: Retrying in 3 seconds\nf1417ff83b31: Retrying in 2 seconds\nf1417ff83b31: Retrying in 1 second\nf1417ff83b31: Retrying in 20 seconds\nf1417ff83b31: Retrying in 19 seconds\nf1417ff83b31: Retrying in 18 seconds\nf1417ff83b31: Retrying in 17 seconds\nf1417ff83b31: Retrying in 16 seconds\nf1417ff83b31: Retrying in 15 seconds\nf1417ff83b31: Retrying in 14 seconds\nf1417ff83b31: Retrying in 13 seconds\nf1417ff83b31: Retrying in 12 seconds\nf1417ff83b31: Retrying in 11 seconds\nf1417ff83b31: Retrying in 10 seconds\nf1417ff83b31: Retrying in 9 seconds\nf1417ff83b31: Retrying in 8 seconds\nf1417ff83b31: Retrying in 7 seconds\nf1417ff83b31: Retrying in 6 seconds\nf1417ff83b31: Retrying in 5 seconds\nf1417ff83b31: Retrying in 4 seconds\nf1417ff83b31: Retrying in 3 seconds\nf1417ff83b31: Retrying in 2 seconds\nf1417ff83b31: Retrying in 1 second\nunknown: requesting higher privileges than access token allows\n'
RERUN
```

While it is not clear why there are different error messages returned here, we still have to map this return to AccessDenied (as it effectively is).

## Changes
* Add case of `requesting higher privileges than access token allows` to be mapped to a AccessDenied exception