### PR TITLE
Add support for Lambda java17 runtime

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -75,13 +75,14 @@ IMAGE_MAPPING = {
     "java8": "java:8",
     "java8.al2": "java:8.al2",
     "java11": "java:11",
+    "java17": "java:17",
     "dotnetcore3.1": "dotnet:core3.1",
     "dotnet6": "dotnet:6",
     "go1.x": "go:1",
     "provided": "provided:alami",
     "provided.al2": "provided:al2",
 }
-SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11]
+SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11, Runtime.java17]
 
 
 # TODO: maybe we should make this more "transient" by always initializing to Pending and *not* persisting it?

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -236,6 +236,14 @@ def s3_create_bucket(s3_resource, aws_client):
         if "Bucket" not in kwargs:
             kwargs["Bucket"] = "test-bucket-%s" % short_uid()
 
+        if (
+            "CreateBucketConfiguration" not in kwargs
+            and aws_client.s3.meta.region_name != "us-east-1"
+        ):
+            kwargs["CreateBucketConfiguration"] = {
+                "LocationConstraint": aws_client.s3.meta.region_name
+            }
+
         aws_client.s3.create_bucket(**kwargs)
         buckets.append(kwargs["Bucket"])
         return kwargs["Bucket"]

--- a/tests/integration/awslambda/conftest.py
+++ b/tests/integration/awslambda/conftest.py
@@ -36,7 +36,7 @@ RUNTIMES_AGGREGATED = {
     "python": [Runtime.python3_7, Runtime.python3_8, Runtime.python3_9, Runtime.python3_10],
     "nodejs": [Runtime.nodejs12_x, Runtime.nodejs14_x, Runtime.nodejs16_x, Runtime.nodejs18_x],
     "ruby": [Runtime.ruby2_7],
-    "java": [Runtime.java8, Runtime.java8_al2, Runtime.java11],
+    "java": [Runtime.java8, Runtime.java8_al2, Runtime.java11, Runtime.java17],
     "dotnet": [
         Runtime.dotnetcore3_1,
         Runtime.dotnet6,

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -99,7 +99,7 @@ PYTHON_TEST_RUNTIMES = (
         Runtime.python3_10,
     ]
     if (not is_old_provider() or use_docker()) and get_arch() != "arm64"
-    else [Runtime.python3_9]
+    else [Runtime.python3_10]
 )
 NODE_TEST_RUNTIMES = (
     [Runtime.nodejs12_x, Runtime.nodejs14_x, Runtime.nodejs16_x]
@@ -107,11 +107,7 @@ NODE_TEST_RUNTIMES = (
     else [Runtime.nodejs16_x]
 )
 JAVA_TEST_RUNTIMES = (
-    [
-        Runtime.java8,
-        Runtime.java8_al2,
-        Runtime.java11,
-    ]
+    [Runtime.java8, Runtime.java8_al2, Runtime.java11, Runtime.java17]
     if (not is_old_provider() or use_docker()) and get_arch() != "arm64"
     else [Runtime.java11]
 )
@@ -183,7 +179,7 @@ class TestLambdaBaseFeatures:
         create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             func_name=function_name,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
         large_value = "test123456" * 100 * 1000 * 5
         snapshot.add_transformer(snapshot.transform.regex(large_value, "<large-value>"))
@@ -213,7 +209,7 @@ class TestLambdaBaseFeatures:
         # create_response is the original create call response, even though the fixture waits until it's not pending
         create_response = create_lambda_function_aws(
             FunctionName=function_name,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Handler="handler.handler",
             Role=lambda_su_role,
             Code={"ZipFile": zip_file},
@@ -238,7 +234,7 @@ class TestLambdaBaseFeatures:
         create_result = create_lambda_function(
             func_name=function_name,
             handler_file=TEST_LAMBDA_SLEEP_ENVIRONMENT,
-            runtime=Runtime.python3_8,
+            runtime=Runtime.python3_10,
             role=lambda_su_role,
         )
         snapshot.match("create-result", create_result)
@@ -335,7 +331,7 @@ class TestLambdaBehavior:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             timeout=9,
             Architectures=[Architecture.x86_64],
         )
@@ -364,7 +360,7 @@ class TestLambdaBehavior:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             timeout=9,
             Architectures=[Architecture.arm64],
         )
@@ -384,14 +380,14 @@ class TestLambdaBehavior:
         monkeypatch.setattr(
             config,
             "LAMBDA_DOCKER_FLAGS",
-            "--ulimit nofile=1024:1024 --ulimit nproc=735:735 --ulimit core=-1:-1 --ulimit stack=8388608:-1",
+            "--ulimit nofile=1024:1024 --ulimit nproc=735:735 --ulimit core=-1:-1 --ulimit stack=8388608:-1 --ulimit memlock=65536:65536",
         )
 
         func_name = f"test_lambda_ulimits_{short_uid()}"
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_ULIMITS,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
 
         invoke_result = aws_client.awslambda.invoke(FunctionName=func_name)
@@ -403,7 +399,7 @@ class TestLambdaBehavior:
         reason="Monkey-patching of Docker flags is not applicable because no new container is spawned",
     )
     @pytest.mark.only_localstack
-    def test_ignore_architecture(self, create_lambda_function, snapshot, monkeypatch, aws_client):
+    def test_ignore_architecture(self, create_lambda_function, monkeypatch, aws_client):
         """Test configuration to ignore lambda architecture by creating a lambda with non-native architecture."""
         monkeypatch.setattr(config, "LAMBDA_IGNORE_ARCHITECTURE", True)
 
@@ -417,7 +413,7 @@ class TestLambdaBehavior:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             Architectures=[non_native_architecture],
         )
 
@@ -437,7 +433,7 @@ class TestLambdaBehavior:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             Architectures=[Architecture.x86_64],
         )
 
@@ -450,7 +446,7 @@ class TestLambdaBehavior:
         create_lambda_function(
             func_name=func_name_arm,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             Architectures=[Architecture.arm64],
         )
 
@@ -494,7 +490,7 @@ class TestLambdaBehavior:
         ["lambda_fn", "lambda_runtime"],
         [
             (TEST_LAMBDA_CACHE_NODEJS, Runtime.nodejs12_x),
-            (TEST_LAMBDA_CACHE_PYTHON, Runtime.python3_8),
+            (TEST_LAMBDA_CACHE_PYTHON, Runtime.python3_10),
         ],
         ids=["nodejs", "python"],
     )
@@ -634,7 +630,7 @@ class TestLambdaBehavior:
         create_result = create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_TIMEOUT_ENV_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
             timeout=1,
         )
@@ -768,7 +764,7 @@ class TestLambdaURL:
         create_lambda_function(
             func_name=function_name,
             handler_file=handler_file,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
 
         url_config = aws_client.awslambda.create_function_url_config(
@@ -858,7 +854,7 @@ class TestLambdaURL:
         create_lambda_function(
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_UNHANDLED_ERROR,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
         get_fn_result = aws_client.awslambda.get_function(FunctionName=function_name)
         snapshot.match("get_fn_result", get_fn_result)
@@ -887,7 +883,7 @@ class TestLambdaURL:
         assert result.status_code == 502
 
 
-@pytest.mark.skip(reason="Not yet implemented")
+@pytest.mark.skipif(not is_aws(), reason="Not yet implemented")
 class TestLambdaPermissions:
     @pytest.mark.aws_validated
     def test_lambda_permission_url_invocation(self, create_lambda_function, snapshot, aws_client):
@@ -1203,7 +1199,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
 
         default_concurrency_result = aws_client.awslambda.get_function_concurrency(
@@ -1242,7 +1238,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
         )
 
         # reserved concurrency
@@ -1443,7 +1439,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INVOCATION_TYPE,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
         )
 
@@ -1482,7 +1478,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
             timeout=20,
         )
@@ -1554,7 +1550,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
             timeout=20,
         )
@@ -1608,7 +1604,7 @@ class TestLambdaConcurrency:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_INVOCATION_TYPE,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
         )
 
@@ -1692,7 +1688,7 @@ class TestLambdaVersions:
             Code={"ZipFile": zip_file_v1},
             PackageType="Zip",
             Role=lambda_su_role,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Description="No version :(",
         )
         snapshot.match("create_response", create_response)
@@ -1773,7 +1769,7 @@ class TestLambdaAliases:
             Code={"ZipFile": zip_file_v1},
             PackageType="Zip",
             Role=lambda_su_role,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Description="No version :(",
         )
         snapshot.match("create_response", create_response)
@@ -1860,7 +1856,7 @@ class TestLambdaAliases:
             Code={"ZipFile": zip_file_v1},
             PackageType="Zip",
             Role=lambda_su_role,
-            Runtime=Runtime.python3_9,
+            Runtime=Runtime.python3_10,
             Description="First version :)",
             Publish=True,
         )
@@ -1915,7 +1911,7 @@ class TestRequestIdHandling:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
         )
 
@@ -1956,7 +1952,7 @@ class TestRequestIdHandling:
         create_lambda_function(
             func_name=fn_name,
             handler_file=handler_file,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
         )
 
@@ -2015,7 +2011,7 @@ class TestRequestIdHandling:
         create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_CONTEXT_REQID,
-            runtime=Runtime.python3_9,
+            runtime=Runtime.python3_10,
             client=aws_client.awslambda,
         )
 

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -152,7 +152,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[nodejs]": {
-    "recorded-date": "30-04-2023, 18:55:41",
+    "recorded-date": "02-05-2023, 16:51:46",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -179,7 +179,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[python]": {
-    "recorded-date": "30-04-2023, 18:55:43",
+    "recorded-date": "02-05-2023, 16:51:48",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -206,7 +206,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_with_timeout": {
-    "recorded-date": "30-04-2023, 18:55:49",
+    "recorded-date": "02-05-2023, 16:51:53",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -268,7 +268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {
-    "recorded-date": "30-04-2023, 18:55:56",
+    "recorded-date": "02-05-2023, 16:52:03",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -327,7 +327,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_function_state": {
-    "recorded-date": "30-04-2023, 18:55:24",
+    "recorded-date": "02-05-2023, 16:51:31",
     "recorded-content": {
       "create-fn-response": {
         "Architectures": [
@@ -347,7 +347,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -392,7 +392,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
+          "Runtime": "python3.10",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
@@ -415,7 +415,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_large_payloads": {
-    "recorded-date": "30-04-2023, 18:55:22",
+    "recorded-date": "02-05-2023, 16:51:29",
     "recorded-content": {
       "invocation_response": {
         "ExecutedVersion": "$LATEST",
@@ -449,7 +449,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.10]": {
-    "recorded-date": "30-04-2023, 18:56:32",
+    "recorded-date": "02-05-2023, 16:52:42",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -467,7 +467,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:56:30",
+    "recorded-date": "02-05-2023, 16:52:40",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -499,7 +499,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[python3.10]": {
-    "recorded-date": "30-04-2023, 18:56:36",
+    "recorded-date": "02-05-2023, 16:52:47",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -513,7 +513,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:56:34",
+    "recorded-date": "02-05-2023, 16:52:44",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -540,7 +540,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[python3.10]": {
-    "recorded-date": "30-04-2023, 18:56:40",
+    "recorded-date": "02-05-2023, 16:52:51",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -553,7 +553,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:56:38",
+    "recorded-date": "02-05-2023, 16:52:49",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -697,7 +697,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_qualifier": {
-    "recorded-date": "30-04-2023, 18:56:51",
+    "recorded-date": "02-05-2023, 16:53:01",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -773,7 +773,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_upload_lambda_from_s3": {
-    "recorded-date": "30-04-2023, 18:56:57",
+    "recorded-date": "02-05-2023, 16:53:08",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -1019,7 +1019,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaVersions::test_lambda_versions_with_code_changes": {
-    "recorded-date": "30-04-2023, 18:57:27",
+    "recorded-date": "02-05-2023, 17:00:57",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1039,7 +1039,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1079,7 +1079,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1119,7 +1119,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1183,7 +1183,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1233,7 +1233,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1309,7 +1309,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_lambda_alias_moving": {
-    "recorded-date": "30-04-2023, 18:57:31",
+    "recorded-date": "02-05-2023, 17:01:03",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1329,7 +1329,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1408,7 +1408,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1459,7 +1459,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -1530,7 +1530,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_alias_routingconfig": {
-    "recorded-date": "30-04-2023, 18:57:41",
+    "recorded-date": "02-05-2023, 17:01:13",
     "recorded-content": {
       "create_alias_response": {
         "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
@@ -1551,7 +1551,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_lambda_different_iam_keys_environment": {
-    "recorded-date": "30-04-2023, 18:55:31",
+    "recorded-date": "02-05-2023, 16:51:37",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -1576,7 +1576,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.8",
+          "Runtime": "python3.10",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
@@ -2088,7 +2088,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_timed_out_environment_reuse": {
-    "recorded-date": "30-04-2023, 18:56:00",
+    "recorded-date": "02-05-2023, 16:52:08",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -2113,7 +2113,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
+          "Runtime": "python3.10",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
@@ -2212,7 +2212,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
-    "recorded-date": "30-04-2023, 18:56:28",
+    "recorded-date": "02-05-2023, 16:52:35",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -2241,7 +2241,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.9",
+          "Runtime": "python3.10",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
@@ -2292,7 +2292,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
-    "recorded-date": "30-04-2023, 18:57:01",
+    "recorded-date": "02-05-2023, 16:53:10",
     "recorded-content": {
       "get_function_concurrency_default": {
         "ResponseMetadata": {
@@ -2323,7 +2323,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaPermissions::test_lambda_permission_url_invocation": {
-    "recorded-date": "10-01-2023, 09:11:18",
+    "recorded-date": "02-05-2023, 16:52:38",
     "recorded-content": {
       "lambda_url_invocation_missing_permission": {
         "Message": "Forbidden"
@@ -2331,7 +2331,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[dict]": {
-    "recorded-date": "30-04-2023, 18:56:04",
+    "recorded-date": "02-05-2023, 16:52:11",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2374,7 +2374,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response]": {
-    "recorded-date": "30-04-2023, 18:56:07",
+    "recorded-date": "02-05-2023, 16:52:13",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2415,7 +2415,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response-json]": {
-    "recorded-date": "30-04-2023, 18:56:09",
+    "recorded-date": "02-05-2023, 16:52:16",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2458,7 +2458,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[list-mixed]": {
-    "recorded-date": "30-04-2023, 18:56:11",
+    "recorded-date": "02-05-2023, 16:52:19",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2499,7 +2499,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[string]": {
-    "recorded-date": "30-04-2023, 18:56:13",
+    "recorded-date": "02-05-2023, 16:52:22",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2540,7 +2540,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[integer]": {
-    "recorded-date": "30-04-2023, 18:56:16",
+    "recorded-date": "02-05-2023, 16:52:24",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2581,7 +2581,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[float]": {
-    "recorded-date": "30-04-2023, 18:56:18",
+    "recorded-date": "02-05-2023, 16:52:27",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2622,7 +2622,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[boolean]": {
-    "recorded-date": "30-04-2023, 18:56:22",
+    "recorded-date": "02-05-2023, 16:52:30",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2663,7 +2663,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_echo_invoke": {
-    "recorded-date": "30-04-2023, 18:56:26",
+    "recorded-date": "02-05-2023, 16:52:33",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2696,7 +2696,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
-    "recorded-date": "30-04-2023, 18:55:37",
+    "recorded-date": "02-05-2023, 16:51:41",
     "recorded-content": {
       "invoke_runtime_arm_introspection": {
         "ExecutedVersion": "$LATEST",
@@ -2735,7 +2735,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_x86": {
-    "recorded-date": "30-04-2023, 18:55:33",
+    "recorded-date": "02-05-2023, 16:51:39",
     "recorded-content": {
       "invoke_runtime_x86_introspection": {
         "ExecutedVersion": "$LATEST",
@@ -2774,7 +2774,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_ulimits": {
-    "recorded-date": "30-04-2023, 18:55:39",
+    "recorded-date": "02-05-2023, 16:51:44",
     "recorded-content": {
       "invoke_runtime_ulimits": {
         "ExecutedVersion": "$LATEST",
@@ -2829,7 +2829,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_reserved_concurrency": {
-    "recorded-date": "30-04-2023, 18:57:10",
+    "recorded-date": "02-05-2023, 16:56:17",
     "recorded-content": {
       "fn": {
         "Architectures": [
@@ -2853,7 +2853,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -2940,7 +2940,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_reserved_concurrency_async_queue": {
-    "recorded-date": "30-04-2023, 19:41:56",
+    "recorded-date": "02-05-2023, 16:55:59",
     "recorded-content": {
       "fn": {
         "Architectures": [
@@ -2964,7 +2964,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -3018,7 +3018,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency": {
-    "recorded-date": "15-03-2023, 15:25:42",
+    "recorded-date": "02-05-2023, 16:55:21",
     "recorded-content": {
       "put_provisioned_5": {
         "AllocatedProvisionedConcurrentExecutions": 0,
@@ -3056,7 +3056,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_reserved_provisioned_overlap": {
-    "recorded-date": "20-03-2023, 14:26:53",
+    "recorded-date": "02-05-2023, 17:00:45",
     "recorded-content": {
       "put_provisioned_5": {
         "AllocatedProvisionedConcurrentExecutions": 0,
@@ -3146,7 +3146,7 @@
         "PackageType": "Zip",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "python3.9",
+        "Runtime": "python3.10",
         "RuntimeVersionConfig": {
           "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
         },
@@ -3192,11 +3192,11 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_format": {
-    "recorded-date": "30-04-2023, 18:57:41",
+    "recorded-date": "02-05-2023, 17:01:14",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_invoke": {
-    "recorded-date": "30-04-2023, 18:57:53",
+    "recorded-date": "02-05-2023, 17:01:20",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -3215,7 +3215,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_async_invoke_with_retry": {
-    "recorded-date": "30-04-2023, 19:00:04",
+    "recorded-date": "02-05-2023, 17:03:31",
     "recorded-content": {
       "invoke_result": {
         "Payload": "",
@@ -3232,7 +3232,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestRequestIdHandling::test_request_id_invoke_url": {
-    "recorded-date": "30-04-2023, 18:58:00",
+    "recorded-date": "02-05-2023, 17:01:28",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -4884,7 +4884,8 @@ class TestLambdaLayer:
 @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
 class TestLambdaSnapStart:
     @pytest.mark.aws_validated
-    def test_snapstart_lifecycle(self, create_lambda_function, snapshot, aws_client):
+    @pytest.mark.parametrize("runtime", [Runtime.java11, Runtime.java17])
+    def test_snapstart_lifecycle(self, create_lambda_function, snapshot, aws_client, runtime):
         """Test the API of the SnapStart feature. The optimization behavior is not supported in LocalStack.
         Slow (~1-2min) against AWS.
         """
@@ -4893,7 +4894,7 @@ class TestLambdaSnapStart:
         create_response = create_lambda_function(
             func_name=function_name,
             zip_file=java_jar_with_lib,
-            runtime=Runtime.java11,
+            runtime=runtime,
             handler="cloud.localstack.sample.LambdaHandlerWithLib",
             SnapStart={"ApplyOn": "PublishedVersions"},
         )
@@ -4917,8 +4918,9 @@ class TestLambdaSnapStart:
         snapshot.match("get_function_response_version_1", get_function_response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.parametrize("runtime", [Runtime.java11, Runtime.java17])
     def test_snapstart_update_function_configuration(
-        self, create_lambda_function, snapshot, aws_client
+        self, create_lambda_function, snapshot, aws_client, runtime
     ):
         """Test enabling SnapStart when updating a function."""
         function_name = f"fn-{short_uid()}"
@@ -4926,7 +4928,7 @@ class TestLambdaSnapStart:
         create_response = create_lambda_function(
             func_name=function_name,
             zip_file=java_jar_with_lib,
-            runtime=Runtime.java11,
+            runtime=runtime,
             handler="cloud.localstack.sample.LambdaHandlerWithLib",
         )
         snapshot.match("create_function_response", create_response)

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "recorded-date": "27-04-2023, 20:34:59",
+    "recorded-date": "02-05-2023, 17:33:02",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -303,7 +303,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "recorded-date": "27-04-2023, 20:35:04",
+    "recorded-date": "02-05-2023, 17:33:07",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -574,7 +574,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "recorded-date": "27-04-2023, 20:35:04",
+    "recorded-date": "02-05-2023, 17:33:07",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -603,7 +603,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "recorded-date": "27-04-2023, 20:35:04",
+    "recorded-date": "02-05-2023, 17:33:07",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -632,7 +632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "recorded-date": "27-04-2023, 20:35:05",
+    "recorded-date": "02-05-2023, 17:33:07",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -661,7 +661,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "recorded-date": "27-04-2023, 20:35:07",
+    "recorded-date": "02-05-2023, 17:33:09",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -678,7 +678,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "recorded-date": "27-04-2023, 20:35:09",
+    "recorded-date": "02-05-2023, 17:33:11",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -695,7 +695,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "recorded-date": "27-04-2023, 20:35:11",
+    "recorded-date": "02-05-2023, 17:33:13",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -712,7 +712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "recorded-date": "27-04-2023, 20:35:13",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "delete_function_response_non_existent": {
         "Error": {
@@ -741,7 +741,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "recorded-date": "27-04-2023, 20:35:13",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -758,7 +758,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -775,7 +775,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -792,7 +792,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -809,7 +809,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -826,7 +826,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:16",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -843,7 +843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "recorded-date": "27-04-2023, 20:35:14",
+    "recorded-date": "02-05-2023, 17:33:17",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -860,7 +860,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "recorded-date": "27-04-2023, 20:35:16",
+    "recorded-date": "02-05-2023, 17:33:18",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -877,7 +877,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "recorded-date": "27-04-2023, 20:35:18",
+    "recorded-date": "02-05-2023, 17:33:20",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -894,7 +894,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "recorded-date": "27-04-2023, 20:35:20",
+    "recorded-date": "02-05-2023, 17:33:22",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -911,7 +911,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "recorded-date": "27-04-2023, 20:35:22",
+    "recorded-date": "02-05-2023, 17:33:24",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -928,7 +928,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "recorded-date": "27-04-2023, 20:35:24",
+    "recorded-date": "02-05-2023, 17:33:26",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -945,7 +945,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "recorded-date": "27-04-2023, 20:35:26",
+    "recorded-date": "02-05-2023, 17:33:28",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -962,7 +962,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "recorded-date": "27-04-2023, 20:35:28",
+    "recorded-date": "02-05-2023, 17:33:29",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -979,7 +979,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "recorded-date": "27-04-2023, 20:35:30",
+    "recorded-date": "02-05-2023, 17:33:31",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -996,7 +996,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "recorded-date": "27-04-2023, 20:35:32",
+    "recorded-date": "02-05-2023, 17:33:34",
     "recorded-content": {
       "create-response-zip-file": {
         "Architectures": [
@@ -1170,7 +1170,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "recorded-date": "27-04-2023, 20:35:37",
+    "recorded-date": "02-05-2023, 17:33:40",
     "recorded-content": {
       "create_response_s3": {
         "Architectures": [
@@ -1344,7 +1344,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_version_on_create": {
-    "recorded-date": "27-02-2023, 21:39:19",
+    "recorded-date": "02-05-2023, 17:35:44",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1690,7 +1690,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "recorded-date": "27-02-2023, 21:39:27",
+    "recorded-date": "02-05-2023, 17:35:49",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2391,7 +2391,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_wrong_sha256": {
-    "recorded-date": "27-02-2023, 21:39:29",
+    "recorded-date": "02-05-2023, 17:35:51",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2529,7 +2529,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_update": {
-    "recorded-date": "27-02-2023, 21:41:30",
+    "recorded-date": "02-05-2023, 17:35:53",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2747,7 +2747,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_alias_lifecycle": {
-    "recorded-date": "21-03-2023, 07:41:08",
+    "recorded-date": "02-05-2023, 17:35:58",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -3319,7 +3319,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
-    "recorded-date": "27-02-2023, 21:42:10",
+    "recorded-date": "02-05-2023, 17:36:09",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -3617,7 +3617,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_create_tag_on_fn_create": {
-    "recorded-date": "17-02-2023, 11:39:18",
+    "recorded-date": "02-05-2023, 17:36:21",
     "recorded-content": {
       "get_function_result": {
         "Code": {
@@ -3681,7 +3681,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle": {
-    "recorded-date": "17-02-2023, 11:39:23",
+    "recorded-date": "02-05-2023, 17:36:23",
     "recorded-content": {
       "tag_single_response": {
         "ResponseMetadata": {
@@ -3796,7 +3796,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_nonexisting_resource": {
-    "recorded-date": "17-02-2023, 11:39:27",
+    "recorded-date": "02-05-2023, 17:36:25",
     "recorded-content": {
       "pre_delete_get_function": {
         "Code": {
@@ -3884,7 +3884,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_exceptions": {
-    "recorded-date": "17-02-2023, 11:39:54",
+    "recorded-date": "02-05-2023, 17:36:39",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -4541,7 +4541,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency_exceptions": {
-    "recorded-date": "17-02-2023, 12:35:56",
+    "recorded-date": "02-05-2023, 17:36:41",
     "recorded-content": {
       "put_concurrency_unknown_fn": {
         "Error": {
@@ -4601,7 +4601,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency": {
-    "recorded-date": "17-02-2023, 12:38:26",
+    "recorded-date": "02-05-2023, 17:36:43",
     "recorded-content": {
       "put_function_concurrency": {
         "ReservedConcurrentExecutions": 1,
@@ -4632,7 +4632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_aws": {
-    "recorded-date": "17-02-2023, 11:40:18",
+    "recorded-date": "02-05-2023, 17:36:54",
     "recorded-content": {
       "create_lambda": {
         "CreateEventSourceMappingResponse": null,
@@ -4729,7 +4729,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_remove_multi_permissions": {
-    "recorded-date": "17-02-2023, 11:40:33",
+    "recorded-date": "02-05-2023, 17:37:02",
     "recorded-content": {
       "add_permission_1": {
         "Statement": {
@@ -4873,7 +4873,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_create_multiple_lambda_permissions": {
-    "recorded-date": "17-02-2023, 11:40:36",
+    "recorded-date": "02-05-2023, 17:37:04",
     "recorded-content": {
       "add_permission_response_1": {
         "Statement": {
@@ -4939,7 +4939,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_lifecycle": {
-    "recorded-date": "17-02-2023, 11:41:05",
+    "recorded-date": "02-05-2023, 17:37:23",
     "recorded-content": {
       "url_creation": {
         "AuthType": "NONE",
@@ -5061,7 +5061,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_variables_fails": {
-    "recorded-date": "17-02-2023, 11:42:51",
+    "recorded-date": "02-05-2023, 17:38:37",
     "recorded-content": {
       "failed_create_fn_result": {
         "Error": {
@@ -5078,7 +5078,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_fails_multiple_keys": {
-    "recorded-date": "17-02-2023, 11:43:08",
+    "recorded-date": "02-05-2023, 17:38:54",
     "recorded-content": {
       "failured_create_fn_result_multi_key": {
         "Error": {
@@ -5095,7 +5095,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_lambda_envvars_near_limit_succeeds": {
-    "recorded-date": "17-02-2023, 11:43:11",
+    "recorded-date": "02-05-2023, 17:38:56",
     "recorded-content": {
       "successful_create_fn_result": {
         "CreateEventSourceMappingResponse": null,
@@ -5147,7 +5147,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestCodeSigningConfig::test_function_code_signing_config": {
-    "recorded-date": "17-02-2023, 11:43:16",
+    "recorded-date": "02-05-2023, 17:38:58",
     "recorded-content": {
       "create_code_signing_config": {
         "CodeSigningConfig": {
@@ -5230,6 +5230,48 @@
           {
             "AllowedPublishers": {
               "SigningProfileVersionArns": [
+                "arn:aws:signer:us-east-1:000000000000:/signing-profiles/test"
+              ]
+            },
+            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:2>",
+            "CodeSigningConfigId": "<resource:2>",
+            "CodeSigningPolicies": {
+              "UntrustedArtifactOnDeployment": "Enforce"
+            },
+            "Description": "Testing CodeSigning Config",
+            "LastModified": "date"
+          },
+          {
+            "AllowedPublishers": {
+              "SigningProfileVersionArns": [
+                "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
+              ]
+            },
+            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:3>",
+            "CodeSigningConfigId": "<resource:3>",
+            "CodeSigningPolicies": {
+              "UntrustedArtifactOnDeployment": "Enforce"
+            },
+            "Description": "Testing CodeSigning Config",
+            "LastModified": "date"
+          },
+          {
+            "AllowedPublishers": {
+              "SigningProfileVersionArns": [
+                "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
+              ]
+            },
+            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:4>",
+            "CodeSigningConfigId": "<resource:4>",
+            "CodeSigningPolicies": {
+              "UntrustedArtifactOnDeployment": "Enforce"
+            },
+            "Description": "Testing CodeSigning Config",
+            "LastModified": "date"
+          },
+          {
+            "AllowedPublishers": {
+              "SigningProfileVersionArns": [
                 "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
               ]
             },
@@ -5237,6 +5279,20 @@
             "CodeSigningConfigId": "<resource:1>",
             "CodeSigningPolicies": {
               "UntrustedArtifactOnDeployment": "Warn"
+            },
+            "Description": "Testing CodeSigning Config",
+            "LastModified": "date"
+          },
+          {
+            "AllowedPublishers": {
+              "SigningProfileVersionArns": [
+                "arn:aws:signer:us-east-1:000000000000:/signing-profiles/test"
+              ]
+            },
+            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:5>",
+            "CodeSigningConfigId": "<resource:5>",
+            "CodeSigningPolicies": {
+              "UntrustedArtifactOnDeployment": "Enforce"
             },
             "Description": "Testing CodeSigning Config",
             "LastModified": "date"
@@ -5271,7 +5327,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestCodeSigningConfig::test_code_signing_not_found_excs": {
-    "recorded-date": "30-09-2022, 15:35:33",
+    "recorded-date": "02-05-2023, 17:39:03",
     "recorded-content": {
       "create_code_signing_config": {
         "CodeSigningConfig": {
@@ -5450,7 +5506,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings": {
-    "recorded-date": "17-02-2023, 11:43:17",
+    "recorded-date": "02-05-2023, 17:39:03",
     "recorded-content": {
       "acc_settings_modded": {
         "AccountLimit": [
@@ -5472,7 +5528,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
-    "recorded-date": "17-02-2023, 11:43:39",
+    "recorded-date": "02-05-2023, 17:39:20",
     "recorded-content": {
       "get_unknown_uuid": {
         "Error": {
@@ -5537,7 +5593,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_lifecycle": {
-    "recorded-date": "23-11-2022, 10:09:53",
+    "recorded-date": "02-05-2023, 17:39:31",
     "recorded-content": {
       "update_table_response": {
         "TableDescription": {
@@ -5552,6 +5608,7 @@
             "LastUpdateToPayPerRequestDateTime": "datetime"
           },
           "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {
@@ -5665,7 +5722,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_exceptions": {
-    "recorded-date": "30-09-2022, 15:36:19",
+    "recorded-date": "02-05-2023, 17:39:46",
     "recorded-content": {
       "tag_lambda_invalidarn": {
         "Error": {
@@ -5739,7 +5796,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "recorded-date": "27-02-2023, 21:42:31",
+    "recorded-date": "02-05-2023, 17:39:48",
     "recorded-content": {
       "tag_lambda_too_many_tags": {
         "Error": {
@@ -5931,7 +5988,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_lifecycle": {
-    "recorded-date": "27-02-2023, 21:42:57",
+    "recorded-date": "02-05-2023, 17:39:53",
     "recorded-content": {
       "list_tags_response_postfncreate": {
         "Tags": {
@@ -6270,7 +6327,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_provisioned_concurrency_exceptions": {
-    "recorded-date": "15-03-2023, 15:21:53",
+    "recorded-date": "02-05-2023, 17:36:46",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
@@ -6519,7 +6576,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_lambda_provisioned_lifecycle": {
-    "recorded-date": "17-02-2023, 12:32:55",
+    "recorded-date": "02-05-2023, 17:36:49",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
@@ -6665,7 +6722,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_request_create_lambda": {
-    "recorded-date": "17-02-2023, 11:41:24",
+    "recorded-date": "02-05-2023, 17:37:36",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -6680,7 +6737,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_versions": {
-    "recorded-date": "03-10-2022, 20:42:55",
+    "recorded-date": "02-05-2023, 17:39:50",
     "recorded-content": {
       "tag_resource_exception": {
         "Error": {
@@ -6709,7 +6766,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_list_paging": {
-    "recorded-date": "17-02-2023, 11:41:01",
+    "recorded-date": "02-05-2023, 17:37:20",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -6827,7 +6884,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_exceptions": {
-    "recorded-date": "17-02-2023, 11:40:55",
+    "recorded-date": "02-05-2023, 17:37:17",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -7261,7 +7318,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_permission_exceptions": {
-    "recorded-date": "28-02-2023, 11:08:16",
+    "recorded-date": "02-05-2023, 17:36:52",
     "recorded-content": {
       "add_permission_invalid_statement_id": {
         "Error": {
@@ -7442,7 +7499,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_unzipped_lambda": {
-    "recorded-date": "17-02-2023, 11:42:33",
+    "recorded-date": "02-05-2023, 17:38:20",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -7459,7 +7516,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "27-04-2023, 20:35:38",
+    "recorded-date": "02-05-2023, 17:33:41",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7531,7 +7588,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "27-04-2023, 20:35:39",
+    "recorded-date": "02-05-2023, 17:33:43",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7570,7 +7627,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "recorded-date": "27-04-2023, 20:35:52",
+    "recorded-date": "02-05-2023, 17:33:54",
     "recorded-content": {
       "create_response_1": {
         "CreateEventSourceMappingResponse": null,
@@ -7843,7 +7900,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "27-04-2023, 20:39:18",
+    "recorded-date": "02-05-2023, 17:40:03",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8041,7 +8098,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_lifecycle": {
-    "recorded-date": "27-04-2023, 20:40:59",
+    "recorded-date": "02-05-2023, 17:41:41",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -8445,7 +8502,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_exceptions": {
-    "recorded-date": "27-04-2023, 20:41:04",
+    "recorded-date": "02-05-2023, 17:41:52",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8628,7 +8685,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_lifecycle": {
-    "recorded-date": "27-04-2023, 20:41:09",
+    "recorded-date": "02-05-2023, 17:41:57",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8756,7 +8813,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_s3_content": {
-    "recorded-date": "27-04-2023, 21:01:08",
+    "recorded-date": "02-05-2023, 17:41:47",
     "recorded-content": {
       "publish_layer_result": {
         "Content": {
@@ -8777,7 +8834,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
-    "recorded-date": "27-04-2023, 20:39:58",
+    "recorded-date": "02-05-2023, 17:40:41",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8971,7 +9028,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_crud": {
-    "recorded-date": "17-02-2023, 11:36:22",
+    "recorded-date": "02-05-2023, 17:34:33",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -9233,7 +9290,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_and_image_config_crud": {
-    "recorded-date": "17-02-2023, 11:38:24",
+    "recorded-date": "02-05-2023, 17:35:08",
     "recorded-content": {
       "create-image-with-config-response": {
         "Architectures": [
@@ -9669,7 +9726,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_zip_file_to_image": {
-    "recorded-date": "17-02-2023, 11:36:41",
+    "recorded-date": "02-05-2023, 17:34:42",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -9889,7 +9946,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size": {
-    "recorded-date": "17-02-2023, 11:43:31",
+    "recorded-date": "02-05-2023, 17:39:15",
     "recorded-content": {
       "total_code_size_diff_create_function": 276,
       "total_code_size_diff_update_function": 276,
@@ -9898,7 +9955,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size_config_update": {
-    "recorded-date": "17-02-2023, 11:43:37",
+    "recorded-date": "02-05-2023, 17:39:18",
     "recorded-content": {
       "is_total_code_size_diff_create_function_more_than_200": true,
       "total_code_size_diff_update_function_configuration": 0,
@@ -9906,7 +9963,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
-    "recorded-date": "22-03-2023, 18:49:13",
+    "recorded-date": "02-05-2023, 17:36:29",
     "recorded-content": {
       "put_invokeconfig_retries_0": {
         "DestinationConfig": {
@@ -10269,126 +10326,57 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_fields": {
-    "recorded-date": "17-02-2023, 11:40:29",
+    "recorded-date": "02-05-2023, 17:37:00",
     "recorded-content": {
       "add_permission_principal_wildcard": {
-        "Statement": {
-          "Sid": "wilcard",
-          "Effect": "Allow",
-          "Principal": "*",
-          "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
-          "Condition": {
-            "StringEquals": {
-              "AWS:SourceAccount": "111111111111"
-            }
-          }
-        },
+        "Statement": "{\"Sid\":\"wilcard\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\",\"Condition\":{\"StringEquals\":{\"AWS:SourceAccount\":\"869636330914\"}}}",
         "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
+          "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "277",
+            "content-type": "application/json",
+            "date": "Tue, 02 May 2023 15:36:58 GMT",
+            "x-amzn-requestid": "a6efaabd-6879-4101-b95a-48a5c7cf7f8f"
+          },
+          "HTTPStatusCode": 201,
+          "RequestId": "a6efaabd-6879-4101-b95a-48a5c7cf7f8f",
+          "RetryAttempts": 0
         }
       },
       "add_permission_principal_service": {
-        "Statement": {
-          "Sid": "lambda",
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "lambda.amazonaws.com"
-          },
-          "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
-          "Condition": {
-            "StringEquals": {
-              "AWS:SourceAccount": "111111111111"
-            }
-          }
-        },
+        "Statement": "{\"Sid\":\"lambda\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\",\"Condition\":{\"StringEquals\":{\"AWS:SourceAccount\":\"869636330914\"}}}",
         "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
+          "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "309",
+            "content-type": "application/json",
+            "date": "Tue, 02 May 2023 15:36:59 GMT",
+            "x-amzn-requestid": "eff7ee5e-d49d-49e9-8e1d-df6c59af2b79"
+          },
+          "HTTPStatusCode": 201,
+          "RequestId": "eff7ee5e-d49d-49e9-8e1d-df6c59af2b79",
+          "RetryAttempts": 0
         }
       },
       "add_permission_principal_account": {
-        "Statement": {
-          "Sid": "account-id",
-          "Effect": "Allow",
-          "Principal": {
-            "AWS": "arn:aws:iam::111111111111:<resource:2>"
+        "Statement": "{\"Sid\":\"account-id\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::869636330914:root\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\"}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "245",
+            "content-type": "application/json",
+            "date": "Tue, 02 May 2023 15:36:59 GMT",
+            "x-amzn-requestid": "45bdbc21-da9e-42c9-8d25-26e510333243"
           },
-          "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "add_permission_principal_arn": {
-        "Statement": {
-          "Sid": "user-arn",
-          "Effect": "Allow",
-          "Principal": {
-            "AWS": "<user_arn>"
-          },
-          "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
-          "Condition": {
-            "StringEquals": {
-              "AWS:SourceAccount": "111111111111"
-            }
-          }
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "add_permission_optional_fields": {
-        "Statement": {
-          "Sid": "urlPermission",
-          "Effect": "Allow",
-          "Principal": "*",
-          "Action": "lambda:InvokeFunctionUrl",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
-          "Condition": {
-            "StringEquals": {
-              "AWS:SourceAccount": "111111111111",
-              "lambda:FunctionUrlAuthType": "NONE",
-              "aws:PrincipalOrgID": "o-1234567890"
-            },
-            "ArnLike": {
-              "AWS:SourceArn": "arn:aws:s3:::<resource:3>"
-            }
-          }
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "add_permission_alexa_skill": {
-        "Statement": {
-          "Sid": "alexaSkill",
-          "Effect": "Allow",
-          "Principal": "*",
-          "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
-          "Condition": {
-            "StringEquals": {
-              "lambda:EventSourceToken": "amzn1.ask.skill.xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-            }
-          }
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
+          "HTTPStatusCode": 201,
+          "RequestId": "45bdbc21-da9e-42c9-8d25-26e510333243",
+          "RetryAttempts": 0
         }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "17-02-2023, 11:40:24",
+    "recorded-date": "02-05-2023, 17:36:57",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -11021,7 +11009,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_basic": {
-    "recorded-date": "17-02-2023, 11:39:05",
+    "recorded-date": "02-05-2023, 17:36:14",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -11322,7 +11310,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
-    "recorded-date": "17-02-2023, 11:39:10",
+    "recorded-date": "02-05-2023, 17:36:16",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -11694,7 +11682,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_permissions": {
-    "recorded-date": "17-02-2023, 11:39:14",
+    "recorded-date": "02-05-2023, 17:36:19",
     "recorded-content": {
       "add_permission_revision_exception": {
         "Error": {
@@ -11766,7 +11754,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_quota_exception": {
-    "recorded-date": "27-04-2023, 20:40:38",
+    "recorded-date": "02-05-2023, 17:41:18",
     "recorded-content": {
       "create_function_with_six_layers": {
         "Error": {
@@ -11783,7 +11771,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
-    "recorded-date": "15-02-2023, 11:03:02",
+    "recorded-date": "02-05-2023, 17:39:44",
     "recorded-content": {
       "error": {
         "Error": {
@@ -11800,7 +11788,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "recorded-date": "17-02-2023, 11:46:20",
+    "recorded-date": "02-05-2023, 17:45:12",
     "recorded-content": {
       "create_function_unsupported_snapstart_runtime": {
         "Error": {
@@ -11826,245 +11814,8 @@
       }
     }
   },
-  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle": {
-    "recorded-date": "17-02-2023, 11:46:16",
-    "recorded-content": {
-      "create_function_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "java11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "get_function_response_latest": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:2>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "java11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Active",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_response_version_1": {
-        "Code": {
-          "Location": "<location>",
-          "RepositoryType": "S3"
-        },
-        "Configuration": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "version1",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
-          "FunctionName": "<function-name:1>",
-          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
-          "LastModified": "date",
-          "LastUpdateStatus": "Successful",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:3>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "java11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "PublishedVersions",
-            "OptimizationStatus": "On"
-          },
-          "State": "Active",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "1"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration": {
-    "recorded-date": "17-02-2023, 11:46:19",
-    "recorded-content": {
-      "create_function_response": {
-        "CreateEventSourceMappingResponse": null,
-        "CreateFunctionResponse": {
-          "Architectures": [
-            "x86_64"
-          ],
-          "CodeSha256": "<code-sha256:1>",
-          "CodeSize": "<code-size>",
-          "Description": "",
-          "Environment": {
-            "Variables": {}
-          },
-          "EphemeralStorage": {
-            "Size": 512
-          },
-          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-          "FunctionName": "<function-name:1>",
-          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
-          "LastModified": "date",
-          "MemorySize": 128,
-          "PackageType": "Zip",
-          "RevisionId": "<uuid:1>",
-          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "java11",
-          "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-          },
-          "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
-          },
-          "State": "Pending",
-          "StateReason": "The function is being created.",
-          "StateReasonCode": "Creating",
-          "Timeout": 30,
-          "TracingConfig": {
-            "Mode": "PassThrough"
-          },
-          "Version": "$LATEST",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 201
-          }
-        }
-      },
-      "update_function_response": {
-        "Architectures": [
-          "x86_64"
-        ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
-        "Description": "",
-        "Environment": {
-          "Variables": {}
-        },
-        "EphemeralStorage": {
-          "Size": 512
-        },
-        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
-        "FunctionName": "<function-name:1>",
-        "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
-        "LastModified": "date",
-        "LastUpdateStatus": "InProgress",
-        "LastUpdateStatusReason": "The function is being created.",
-        "LastUpdateStatusReasonCode": "Creating",
-        "MemorySize": 128,
-        "PackageType": "Zip",
-        "RevisionId": "<uuid:2>",
-        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-        "Runtime": "java11",
-        "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
-        },
-        "SnapStart": {
-          "ApplyOn": "PublishedVersions",
-          "OptimizationStatus": "Off"
-        },
-        "State": "Active",
-        "Timeout": 30,
-        "TracingConfig": {
-          "Mode": "PassThrough"
-        },
-        "Version": "$LATEST",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_versions": {
-    "recorded-date": "21-04-2023, 17:05:08",
+    "recorded-date": "02-05-2023, 17:35:35",
     "recorded-content": {
       "create_image_response": {
         "Architectures": [
@@ -12478,6 +12229,480 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
+    "recorded-date": "02-05-2023, 17:43:31",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "get_function_response_latest": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_version_1": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "version1",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "On"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
+    "recorded-date": "02-05-2023, 17:45:07",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java17",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "get_function_response_latest": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java17",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_version_1": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "version1",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java17",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "On"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
+    "recorded-date": "02-05-2023, 17:45:09",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
+    "recorded-date": "02-05-2023, 17:45:11",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java17",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "java17",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "recorded-date": "02-05-2023, 17:33:02",
+    "recorded-date": "27-04-2023, 20:34:59",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -303,7 +303,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "recorded-date": "02-05-2023, 17:33:07",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -574,7 +574,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "recorded-date": "02-05-2023, 17:33:07",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -603,7 +603,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "recorded-date": "02-05-2023, 17:33:07",
+    "recorded-date": "27-04-2023, 20:35:04",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -632,7 +632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "recorded-date": "02-05-2023, 17:33:07",
+    "recorded-date": "27-04-2023, 20:35:05",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -661,7 +661,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "recorded-date": "02-05-2023, 17:33:09",
+    "recorded-date": "27-04-2023, 20:35:07",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -678,7 +678,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "recorded-date": "02-05-2023, 17:33:11",
+    "recorded-date": "27-04-2023, 20:35:09",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -695,7 +695,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "recorded-date": "02-05-2023, 17:33:13",
+    "recorded-date": "27-04-2023, 20:35:11",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -712,7 +712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:13",
     "recorded-content": {
       "delete_function_response_non_existent": {
         "Error": {
@@ -741,7 +741,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:13",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -758,7 +758,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -775,7 +775,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -792,7 +792,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -809,7 +809,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -826,7 +826,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "recorded-date": "02-05-2023, 17:33:16",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -843,7 +843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "recorded-date": "02-05-2023, 17:33:17",
+    "recorded-date": "27-04-2023, 20:35:14",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -860,7 +860,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "recorded-date": "02-05-2023, 17:33:18",
+    "recorded-date": "27-04-2023, 20:35:16",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -877,7 +877,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "recorded-date": "02-05-2023, 17:33:20",
+    "recorded-date": "27-04-2023, 20:35:18",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -894,7 +894,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "recorded-date": "02-05-2023, 17:33:22",
+    "recorded-date": "27-04-2023, 20:35:20",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -911,7 +911,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "recorded-date": "02-05-2023, 17:33:24",
+    "recorded-date": "27-04-2023, 20:35:22",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -928,7 +928,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "recorded-date": "02-05-2023, 17:33:26",
+    "recorded-date": "27-04-2023, 20:35:24",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -945,7 +945,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "recorded-date": "02-05-2023, 17:33:28",
+    "recorded-date": "27-04-2023, 20:35:26",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -962,7 +962,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "recorded-date": "02-05-2023, 17:33:29",
+    "recorded-date": "27-04-2023, 20:35:28",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -979,7 +979,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "recorded-date": "02-05-2023, 17:33:31",
+    "recorded-date": "27-04-2023, 20:35:30",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -996,7 +996,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "recorded-date": "02-05-2023, 17:33:34",
+    "recorded-date": "27-04-2023, 20:35:32",
     "recorded-content": {
       "create-response-zip-file": {
         "Architectures": [
@@ -1170,7 +1170,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "recorded-date": "02-05-2023, 17:33:40",
+    "recorded-date": "27-04-2023, 20:35:37",
     "recorded-content": {
       "create_response_s3": {
         "Architectures": [
@@ -1344,7 +1344,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_version_on_create": {
-    "recorded-date": "02-05-2023, 17:35:44",
+    "recorded-date": "27-02-2023, 21:39:19",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1690,7 +1690,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "recorded-date": "02-05-2023, 17:35:49",
+    "recorded-date": "27-02-2023, 21:39:27",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2391,7 +2391,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_wrong_sha256": {
-    "recorded-date": "02-05-2023, 17:35:51",
+    "recorded-date": "27-02-2023, 21:39:29",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2529,7 +2529,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_update": {
-    "recorded-date": "02-05-2023, 17:35:53",
+    "recorded-date": "27-02-2023, 21:41:30",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2747,7 +2747,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_alias_lifecycle": {
-    "recorded-date": "02-05-2023, 17:35:58",
+    "recorded-date": "21-03-2023, 07:41:08",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -3319,7 +3319,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
-    "recorded-date": "02-05-2023, 17:36:09",
+    "recorded-date": "27-02-2023, 21:42:10",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -3617,7 +3617,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_create_tag_on_fn_create": {
-    "recorded-date": "02-05-2023, 17:36:21",
+    "recorded-date": "17-02-2023, 11:39:18",
     "recorded-content": {
       "get_function_result": {
         "Code": {
@@ -3681,7 +3681,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle": {
-    "recorded-date": "02-05-2023, 17:36:23",
+    "recorded-date": "17-02-2023, 11:39:23",
     "recorded-content": {
       "tag_single_response": {
         "ResponseMetadata": {
@@ -3796,7 +3796,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_nonexisting_resource": {
-    "recorded-date": "02-05-2023, 17:36:25",
+    "recorded-date": "17-02-2023, 11:39:27",
     "recorded-content": {
       "pre_delete_get_function": {
         "Code": {
@@ -3884,7 +3884,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_exceptions": {
-    "recorded-date": "02-05-2023, 17:36:39",
+    "recorded-date": "17-02-2023, 11:39:54",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -4541,7 +4541,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency_exceptions": {
-    "recorded-date": "02-05-2023, 17:36:41",
+    "recorded-date": "17-02-2023, 12:35:56",
     "recorded-content": {
       "put_concurrency_unknown_fn": {
         "Error": {
@@ -4601,7 +4601,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency": {
-    "recorded-date": "02-05-2023, 17:36:43",
+    "recorded-date": "17-02-2023, 12:38:26",
     "recorded-content": {
       "put_function_concurrency": {
         "ReservedConcurrentExecutions": 1,
@@ -4632,7 +4632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_aws": {
-    "recorded-date": "02-05-2023, 17:36:54",
+    "recorded-date": "17-02-2023, 11:40:18",
     "recorded-content": {
       "create_lambda": {
         "CreateEventSourceMappingResponse": null,
@@ -4729,7 +4729,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_remove_multi_permissions": {
-    "recorded-date": "02-05-2023, 17:37:02",
+    "recorded-date": "17-02-2023, 11:40:33",
     "recorded-content": {
       "add_permission_1": {
         "Statement": {
@@ -4873,7 +4873,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_create_multiple_lambda_permissions": {
-    "recorded-date": "02-05-2023, 17:37:04",
+    "recorded-date": "17-02-2023, 11:40:36",
     "recorded-content": {
       "add_permission_response_1": {
         "Statement": {
@@ -4939,7 +4939,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_lifecycle": {
-    "recorded-date": "02-05-2023, 17:37:23",
+    "recorded-date": "17-02-2023, 11:41:05",
     "recorded-content": {
       "url_creation": {
         "AuthType": "NONE",
@@ -5061,7 +5061,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_variables_fails": {
-    "recorded-date": "02-05-2023, 17:38:37",
+    "recorded-date": "17-02-2023, 11:42:51",
     "recorded-content": {
       "failed_create_fn_result": {
         "Error": {
@@ -5078,7 +5078,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_fails_multiple_keys": {
-    "recorded-date": "02-05-2023, 17:38:54",
+    "recorded-date": "17-02-2023, 11:43:08",
     "recorded-content": {
       "failured_create_fn_result_multi_key": {
         "Error": {
@@ -5095,7 +5095,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_lambda_envvars_near_limit_succeeds": {
-    "recorded-date": "02-05-2023, 17:38:56",
+    "recorded-date": "17-02-2023, 11:43:11",
     "recorded-content": {
       "successful_create_fn_result": {
         "CreateEventSourceMappingResponse": null,
@@ -5147,7 +5147,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestCodeSigningConfig::test_function_code_signing_config": {
-    "recorded-date": "02-05-2023, 17:38:58",
+    "recorded-date": "17-02-2023, 11:43:16",
     "recorded-content": {
       "create_code_signing_config": {
         "CodeSigningConfig": {
@@ -5230,48 +5230,6 @@
           {
             "AllowedPublishers": {
               "SigningProfileVersionArns": [
-                "arn:aws:signer:us-east-1:000000000000:/signing-profiles/test"
-              ]
-            },
-            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:2>",
-            "CodeSigningConfigId": "<resource:2>",
-            "CodeSigningPolicies": {
-              "UntrustedArtifactOnDeployment": "Enforce"
-            },
-            "Description": "Testing CodeSigning Config",
-            "LastModified": "date"
-          },
-          {
-            "AllowedPublishers": {
-              "SigningProfileVersionArns": [
-                "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
-              ]
-            },
-            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:3>",
-            "CodeSigningConfigId": "<resource:3>",
-            "CodeSigningPolicies": {
-              "UntrustedArtifactOnDeployment": "Enforce"
-            },
-            "Description": "Testing CodeSigning Config",
-            "LastModified": "date"
-          },
-          {
-            "AllowedPublishers": {
-              "SigningProfileVersionArns": [
-                "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
-              ]
-            },
-            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:4>",
-            "CodeSigningConfigId": "<resource:4>",
-            "CodeSigningPolicies": {
-              "UntrustedArtifactOnDeployment": "Enforce"
-            },
-            "Description": "Testing CodeSigning Config",
-            "LastModified": "date"
-          },
-          {
-            "AllowedPublishers": {
-              "SigningProfileVersionArns": [
                 "arn:aws:signer:<region>:111111111111:/signing-profiles/test"
               ]
             },
@@ -5279,20 +5237,6 @@
             "CodeSigningConfigId": "<resource:1>",
             "CodeSigningPolicies": {
               "UntrustedArtifactOnDeployment": "Warn"
-            },
-            "Description": "Testing CodeSigning Config",
-            "LastModified": "date"
-          },
-          {
-            "AllowedPublishers": {
-              "SigningProfileVersionArns": [
-                "arn:aws:signer:us-east-1:000000000000:/signing-profiles/test"
-              ]
-            },
-            "CodeSigningConfigArn": "arn:aws:lambda:<region>:111111111111:code-signing-config:<resource:5>",
-            "CodeSigningConfigId": "<resource:5>",
-            "CodeSigningPolicies": {
-              "UntrustedArtifactOnDeployment": "Enforce"
             },
             "Description": "Testing CodeSigning Config",
             "LastModified": "date"
@@ -5327,7 +5271,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestCodeSigningConfig::test_code_signing_not_found_excs": {
-    "recorded-date": "02-05-2023, 17:39:03",
+    "recorded-date": "30-09-2022, 15:35:33",
     "recorded-content": {
       "create_code_signing_config": {
         "CodeSigningConfig": {
@@ -5506,7 +5450,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings": {
-    "recorded-date": "02-05-2023, 17:39:03",
+    "recorded-date": "17-02-2023, 11:43:17",
     "recorded-content": {
       "acc_settings_modded": {
         "AccountLimit": [
@@ -5528,7 +5472,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
-    "recorded-date": "02-05-2023, 17:39:20",
+    "recorded-date": "17-02-2023, 11:43:39",
     "recorded-content": {
       "get_unknown_uuid": {
         "Error": {
@@ -5593,7 +5537,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_lifecycle": {
-    "recorded-date": "02-05-2023, 17:39:31",
+    "recorded-date": "23-11-2022, 10:09:53",
     "recorded-content": {
       "update_table_response": {
         "TableDescription": {
@@ -5608,7 +5552,6 @@
             "LastUpdateToPayPerRequestDateTime": "datetime"
           },
           "CreationDateTime": "datetime",
-          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {
@@ -5722,7 +5665,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_exceptions": {
-    "recorded-date": "02-05-2023, 17:39:46",
+    "recorded-date": "30-09-2022, 15:36:19",
     "recorded-content": {
       "tag_lambda_invalidarn": {
         "Error": {
@@ -5796,7 +5739,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "recorded-date": "02-05-2023, 17:39:48",
+    "recorded-date": "27-02-2023, 21:42:31",
     "recorded-content": {
       "tag_lambda_too_many_tags": {
         "Error": {
@@ -5988,7 +5931,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_lifecycle": {
-    "recorded-date": "02-05-2023, 17:39:53",
+    "recorded-date": "27-02-2023, 21:42:57",
     "recorded-content": {
       "list_tags_response_postfncreate": {
         "Tags": {
@@ -6327,7 +6270,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_provisioned_concurrency_exceptions": {
-    "recorded-date": "02-05-2023, 17:36:46",
+    "recorded-date": "15-03-2023, 15:21:53",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
@@ -6576,7 +6519,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_lambda_provisioned_lifecycle": {
-    "recorded-date": "02-05-2023, 17:36:49",
+    "recorded-date": "17-02-2023, 12:32:55",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
@@ -6722,7 +6665,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_request_create_lambda": {
-    "recorded-date": "02-05-2023, 17:37:36",
+    "recorded-date": "17-02-2023, 11:41:24",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -6737,7 +6680,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_versions": {
-    "recorded-date": "02-05-2023, 17:39:50",
+    "recorded-date": "03-10-2022, 20:42:55",
     "recorded-content": {
       "tag_resource_exception": {
         "Error": {
@@ -6766,7 +6709,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_list_paging": {
-    "recorded-date": "02-05-2023, 17:37:20",
+    "recorded-date": "17-02-2023, 11:41:01",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -6884,7 +6827,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_exceptions": {
-    "recorded-date": "02-05-2023, 17:37:17",
+    "recorded-date": "17-02-2023, 11:40:55",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -7318,7 +7261,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_permission_exceptions": {
-    "recorded-date": "02-05-2023, 17:36:52",
+    "recorded-date": "28-02-2023, 11:08:16",
     "recorded-content": {
       "add_permission_invalid_statement_id": {
         "Error": {
@@ -7499,7 +7442,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_unzipped_lambda": {
-    "recorded-date": "02-05-2023, 17:38:20",
+    "recorded-date": "17-02-2023, 11:42:33",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -7516,7 +7459,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "02-05-2023, 17:33:41",
+    "recorded-date": "27-04-2023, 20:35:38",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7588,7 +7531,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "02-05-2023, 17:33:43",
+    "recorded-date": "27-04-2023, 20:35:39",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7627,7 +7570,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "recorded-date": "02-05-2023, 17:33:54",
+    "recorded-date": "27-04-2023, 20:35:52",
     "recorded-content": {
       "create_response_1": {
         "CreateEventSourceMappingResponse": null,
@@ -7900,7 +7843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "02-05-2023, 17:40:03",
+    "recorded-date": "27-04-2023, 20:39:18",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8098,7 +8041,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_lifecycle": {
-    "recorded-date": "02-05-2023, 17:41:41",
+    "recorded-date": "27-04-2023, 20:40:59",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -8502,7 +8445,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_exceptions": {
-    "recorded-date": "02-05-2023, 17:41:52",
+    "recorded-date": "27-04-2023, 20:41:04",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8685,7 +8628,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_lifecycle": {
-    "recorded-date": "02-05-2023, 17:41:57",
+    "recorded-date": "27-04-2023, 20:41:09",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8813,7 +8756,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_s3_content": {
-    "recorded-date": "02-05-2023, 17:41:47",
+    "recorded-date": "27-04-2023, 21:01:08",
     "recorded-content": {
       "publish_layer_result": {
         "Content": {
@@ -8834,7 +8777,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
-    "recorded-date": "02-05-2023, 17:40:41",
+    "recorded-date": "27-04-2023, 20:39:58",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -9028,7 +8971,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_crud": {
-    "recorded-date": "02-05-2023, 17:34:33",
+    "recorded-date": "17-02-2023, 11:36:22",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -9290,7 +9233,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_and_image_config_crud": {
-    "recorded-date": "02-05-2023, 17:35:08",
+    "recorded-date": "17-02-2023, 11:38:24",
     "recorded-content": {
       "create-image-with-config-response": {
         "Architectures": [
@@ -9726,7 +9669,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_zip_file_to_image": {
-    "recorded-date": "02-05-2023, 17:34:42",
+    "recorded-date": "17-02-2023, 11:36:41",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -9946,7 +9889,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size": {
-    "recorded-date": "02-05-2023, 17:39:15",
+    "recorded-date": "17-02-2023, 11:43:31",
     "recorded-content": {
       "total_code_size_diff_create_function": 276,
       "total_code_size_diff_update_function": 276,
@@ -9955,7 +9898,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size_config_update": {
-    "recorded-date": "02-05-2023, 17:39:18",
+    "recorded-date": "17-02-2023, 11:43:37",
     "recorded-content": {
       "is_total_code_size_diff_create_function_more_than_200": true,
       "total_code_size_diff_update_function_configuration": 0,
@@ -9963,7 +9906,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
-    "recorded-date": "02-05-2023, 17:36:29",
+    "recorded-date": "22-03-2023, 18:49:13",
     "recorded-content": {
       "put_invokeconfig_retries_0": {
         "DestinationConfig": {
@@ -10326,57 +10269,126 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_fields": {
-    "recorded-date": "02-05-2023, 17:37:00",
+    "recorded-date": "17-02-2023, 11:40:29",
     "recorded-content": {
       "add_permission_principal_wildcard": {
-        "Statement": "{\"Sid\":\"wilcard\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\",\"Condition\":{\"StringEquals\":{\"AWS:SourceAccount\":\"869636330914\"}}}",
+        "Statement": {
+          "Sid": "wilcard",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Condition": {
+            "StringEquals": {
+              "AWS:SourceAccount": "111111111111"
+            }
+          }
+        },
         "ResponseMetadata": {
-          "HTTPHeaders": {
-            "connection": "keep-alive",
-            "content-length": "277",
-            "content-type": "application/json",
-            "date": "Tue, 02 May 2023 15:36:58 GMT",
-            "x-amzn-requestid": "a6efaabd-6879-4101-b95a-48a5c7cf7f8f"
-          },
-          "HTTPStatusCode": 201,
-          "RequestId": "a6efaabd-6879-4101-b95a-48a5c7cf7f8f",
-          "RetryAttempts": 0
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       },
       "add_permission_principal_service": {
-        "Statement": "{\"Sid\":\"lambda\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\",\"Condition\":{\"StringEquals\":{\"AWS:SourceAccount\":\"869636330914\"}}}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {
-            "connection": "keep-alive",
-            "content-length": "309",
-            "content-type": "application/json",
-            "date": "Tue, 02 May 2023 15:36:59 GMT",
-            "x-amzn-requestid": "eff7ee5e-d49d-49e9-8e1d-df6c59af2b79"
+        "Statement": {
+          "Sid": "lambda",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
           },
-          "HTTPStatusCode": 201,
-          "RequestId": "eff7ee5e-d49d-49e9-8e1d-df6c59af2b79",
-          "RetryAttempts": 0
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Condition": {
+            "StringEquals": {
+              "AWS:SourceAccount": "111111111111"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       },
       "add_permission_principal_account": {
-        "Statement": "{\"Sid\":\"account-id\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::869636330914:root\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:eu-central-1:869636330914:function:lambda_func-e460529e\"}",
-        "ResponseMetadata": {
-          "HTTPHeaders": {
-            "connection": "keep-alive",
-            "content-length": "245",
-            "content-type": "application/json",
-            "date": "Tue, 02 May 2023 15:36:59 GMT",
-            "x-amzn-requestid": "45bdbc21-da9e-42c9-8d25-26e510333243"
+        "Statement": {
+          "Sid": "account-id",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:<resource:2>"
           },
-          "HTTPStatusCode": 201,
-          "RequestId": "45bdbc21-da9e-42c9-8d25-26e510333243",
-          "RetryAttempts": 0
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "add_permission_principal_arn": {
+        "Statement": {
+          "Sid": "user-arn",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "<user_arn>"
+          },
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Condition": {
+            "StringEquals": {
+              "AWS:SourceAccount": "111111111111"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "add_permission_optional_fields": {
+        "Statement": {
+          "Sid": "urlPermission",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "lambda:InvokeFunctionUrl",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Condition": {
+            "StringEquals": {
+              "AWS:SourceAccount": "111111111111",
+              "lambda:FunctionUrlAuthType": "NONE",
+              "aws:PrincipalOrgID": "o-1234567890"
+            },
+            "ArnLike": {
+              "AWS:SourceArn": "arn:aws:s3:::<resource:3>"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "add_permission_alexa_skill": {
+        "Statement": {
+          "Sid": "alexaSkill",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Condition": {
+            "StringEquals": {
+              "lambda:EventSourceToken": "amzn1.ask.skill.xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "02-05-2023, 17:36:57",
+    "recorded-date": "17-02-2023, 11:40:24",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -11009,7 +11021,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_basic": {
-    "recorded-date": "02-05-2023, 17:36:14",
+    "recorded-date": "17-02-2023, 11:39:05",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -11310,7 +11322,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
-    "recorded-date": "02-05-2023, 17:36:16",
+    "recorded-date": "17-02-2023, 11:39:10",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -11682,7 +11694,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_permissions": {
-    "recorded-date": "02-05-2023, 17:36:19",
+    "recorded-date": "17-02-2023, 11:39:14",
     "recorded-content": {
       "add_permission_revision_exception": {
         "Error": {
@@ -11754,7 +11766,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_quota_exception": {
-    "recorded-date": "02-05-2023, 17:41:18",
+    "recorded-date": "27-04-2023, 20:40:38",
     "recorded-content": {
       "create_function_with_six_layers": {
         "Error": {
@@ -11771,7 +11783,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
-    "recorded-date": "02-05-2023, 17:39:44",
+    "recorded-date": "15-02-2023, 11:03:02",
     "recorded-content": {
       "error": {
         "Error": {
@@ -11788,7 +11800,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "recorded-date": "02-05-2023, 17:45:12",
+    "recorded-date": "02-05-2023, 18:15:16",
     "recorded-content": {
       "create_function_unsupported_snapstart_runtime": {
         "Error": {
@@ -11815,7 +11827,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_versions": {
-    "recorded-date": "02-05-2023, 17:35:35",
+    "recorded-date": "21-04-2023, 17:05:08",
     "recorded-content": {
       "create_image_response": {
         "Architectures": [
@@ -12234,7 +12246,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
-    "recorded-date": "02-05-2023, 17:43:31",
+    "recorded-date": "02-05-2023, 18:13:35",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -12378,7 +12390,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
-    "recorded-date": "02-05-2023, 17:45:07",
+    "recorded-date": "02-05-2023, 18:15:11",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -12522,7 +12534,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
-    "recorded-date": "02-05-2023, 17:45:09",
+    "recorded-date": "02-05-2023, 18:15:13",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -12615,7 +12627,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
-    "recorded-date": "02-05-2023, 17:45:11",
+    "recorded-date": "02-05-2023, 18:15:16",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs12.x]": {
-    "recorded-date": "30-04-2023, 18:45:04",
+    "recorded-date": "02-05-2023, 17:49:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -137,7 +137,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs14.x]": {
-    "recorded-date": "30-04-2023, 18:45:07",
+    "recorded-date": "02-05-2023, 17:49:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -274,7 +274,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:45:10",
+    "recorded-date": "02-05-2023, 17:50:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -411,7 +411,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.7]": {
-    "recorded-date": "30-04-2023, 18:44:57",
+    "recorded-date": "02-05-2023, 17:49:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -542,7 +542,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "30-04-2023, 18:44:58",
+    "recorded-date": "02-05-2023, 17:49:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -679,7 +679,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "30-04-2023, 18:45:00",
+    "recorded-date": "02-05-2023, 17:49:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -816,7 +816,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby2.7]": {
-    "recorded-date": "30-04-2023, 18:45:14",
+    "recorded-date": "02-05-2023, 17:50:05",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -957,13 +957,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8]": {
-    "recorded-date": "30-04-2023, 18:45:22",
+    "recorded-date": "02-05-2023, 17:50:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
+        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1094,13 +1094,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "30-04-2023, 18:45:30",
+    "recorded-date": "02-05-2023, 17:50:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
+        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1229,13 +1229,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "30-04-2023, 18:45:38",
+    "recorded-date": "02-05-2023, 17:50:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EIHcJLLHxO2t+7bCSyhzSs7ZoowNOLZ/OXtT8vw5Kr0=",
+        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1364,13 +1364,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[go1.x]": {
-    "recorded-date": "30-04-2023, 18:45:47",
+    "recorded-date": "02-05-2023, 17:50:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EVxqKUhMTC8LAXQ90Vo5gXZ4gcQO/orXJIYTgwAkMow=",
+        "CodeSha256": "ElaqZ3vc40BIziwnNowuXMWrN3+4NPjLwMCCv1zfykg=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1503,13 +1503,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "30-04-2023, 18:45:42",
+    "recorded-date": "02-05-2023, 17:50:37",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "auaig2ijl0r9T1HOo69YonJ2lGt47J3InDMMtIEywKI=",
+        "CodeSha256": "EN2qdeZgTKkfpE37f/UE/xEjmT67XROIiGLW4Ubaxbs=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1644,13 +1644,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnetcore3.1]": {
-    "recorded-date": "30-04-2023, 18:45:40",
+    "recorded-date": "02-05-2023, 17:50:34",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "grKQ2jWhrYPgzcO8fDu2mhmQXUeHHWzOIy81E+/sdzg=",
+        "CodeSha256": "dk2zuRfKIAOV3aZPdSvxUKi0pn+l99PNfPZmqHQKgks=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1777,13 +1777,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided]": {
-    "recorded-date": "30-04-2023, 18:45:50",
+    "recorded-date": "02-05-2023, 17:50:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "N1Uy0eAVXHKaOp+CHxsuXmEsXD//FFGMBZhwppNdTTs=",
+        "CodeSha256": "KxpLsmctzB9dzIfADnkBS5USHNKCcpW6Dd8CcU1IxHc=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1906,13 +1906,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "30-04-2023, 18:45:52",
+    "recorded-date": "02-05-2023, 17:50:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "N1Uy0eAVXHKaOp+CHxsuXmEsXD//FFGMBZhwppNdTTs=",
+        "CodeSha256": "KxpLsmctzB9dzIfADnkBS5USHNKCcpW6Dd8CcU1IxHc=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -2035,7 +2035,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.7]": {
-    "recorded-date": "30-04-2023, 18:45:55",
+    "recorded-date": "02-05-2023, 17:50:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2093,7 +2093,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "30-04-2023, 18:45:57",
+    "recorded-date": "02-05-2023, 17:50:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2151,7 +2151,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "30-04-2023, 18:45:59",
+    "recorded-date": "02-05-2023, 17:50:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2210,7 +2210,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs12.x]": {
-    "recorded-date": "30-04-2023, 18:46:02",
+    "recorded-date": "02-05-2023, 17:50:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2268,7 +2268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs14.x]": {
-    "recorded-date": "30-04-2023, 18:46:04",
+    "recorded-date": "02-05-2023, 17:50:58",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2326,7 +2326,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:46:06",
+    "recorded-date": "02-05-2023, 17:51:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2384,13 +2384,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8]": {
-    "recorded-date": "30-04-2023, 18:46:18",
+    "recorded-date": "02-05-2023, 17:51:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
+        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2442,13 +2442,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "30-04-2023, 18:46:25",
+    "recorded-date": "02-05-2023, 17:51:18",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
+        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2500,13 +2500,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "30-04-2023, 18:46:33",
+    "recorded-date": "02-05-2023, 17:51:25",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "TiaZtDKtXsqwETehw6YY3TRUw+/uB8Asspb1u1AABXA=",
+        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2558,7 +2558,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby2.7]": {
-    "recorded-date": "30-04-2023, 18:46:10",
+    "recorded-date": "02-05-2023, 17:51:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2616,13 +2616,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[go1.x]": {
-    "recorded-date": "30-04-2023, 18:46:42",
+    "recorded-date": "02-05-2023, 17:51:40",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "/HENxf/w1A4pmZiS4KE4hBXNPfJ/oBi/5boLUW40gbM=",
+        "CodeSha256": "SCDyyKP0IKATEQD0LxqsAgguOGEwDlDUReehN6Q04jo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2673,13 +2673,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided]": {
-    "recorded-date": "30-04-2023, 18:46:46",
+    "recorded-date": "02-05-2023, 17:51:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "HZO/38cx+0gOKUr19lI2upfd7j2O54SmOzIgneWYqQo=",
+        "CodeSha256": "Tu0Jt/5Ih3J4d9mIEzBFyS8iN5nf0DjO8yL+ZWqL72s=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2718,7 +2718,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
+          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2730,13 +2730,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "30-04-2023, 18:46:49",
+    "recorded-date": "02-05-2023, 17:51:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "HZO/38cx+0gOKUr19lI2upfd7j2O54SmOzIgneWYqQo=",
+        "CodeSha256": "Tu0Jt/5Ih3J4d9mIEzBFyS8iN5nf0DjO8yL+ZWqL72s=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2775,7 +2775,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
+          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2787,13 +2787,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "30-04-2023, 18:46:37",
+    "recorded-date": "02-05-2023, 17:51:35",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EHUV3FF9Y50HzjCFzJ2KlPXQPvPCcC0YoeqGOftrMLM=",
+        "CodeSha256": "SRo/CNHtnjkN6EflAqg029GSsLIRRmtwsjCskIu9Ncs=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2845,13 +2845,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnetcore3.1]": {
-    "recorded-date": "30-04-2023, 18:46:35",
+    "recorded-date": "02-05-2023, 17:51:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "ZuL/R1kGyXQ4eVGJq+w9teGyyK/5UOgchVjG6o8OK5M=",
+        "CodeSha256": "o9MV1/KnGpxyzwAx8gRhiXsChrGsEni72ZZJKJhP6lw=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2903,71 +2903,71 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.7]": {
-    "recorded-date": "30-04-2023, 18:43:14",
+    "recorded-date": "02-05-2023, 17:48:12",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "30-04-2023, 18:43:18",
+    "recorded-date": "02-05-2023, 17:48:17",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "30-04-2023, 18:43:22",
+    "recorded-date": "02-05-2023, 17:48:21",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs12.x]": {
-    "recorded-date": "30-04-2023, 18:43:32",
+    "recorded-date": "02-05-2023, 17:48:30",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs14.x]": {
-    "recorded-date": "30-04-2023, 18:43:37",
+    "recorded-date": "02-05-2023, 17:48:33",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:43:42",
+    "recorded-date": "02-05-2023, 17:48:37",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby2.7]": {
-    "recorded-date": "30-04-2023, 18:43:52",
+    "recorded-date": "02-05-2023, 17:48:45",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8]": {
-    "recorded-date": "30-04-2023, 18:44:02",
+    "recorded-date": "02-05-2023, 17:48:52",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "30-04-2023, 18:44:12",
+    "recorded-date": "02-05-2023, 17:49:01",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "30-04-2023, 18:44:21",
+    "recorded-date": "02-05-2023, 17:49:09",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnetcore3.1]": {
-    "recorded-date": "30-04-2023, 18:44:26",
+    "recorded-date": "02-05-2023, 17:49:20",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "30-04-2023, 18:44:31",
+    "recorded-date": "02-05-2023, 17:49:24",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[go1.x]": {
-    "recorded-date": "30-04-2023, 18:44:39",
+    "recorded-date": "02-05-2023, 17:49:31",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided]": {
-    "recorded-date": "30-04-2023, 18:44:47",
+    "recorded-date": "02-05-2023, 17:49:38",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "30-04-2023, 18:44:55",
+    "recorded-date": "02-05-2023, 17:49:45",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "30-04-2023, 18:43:47",
+    "recorded-date": "02-05-2023, 17:48:41",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "30-04-2023, 18:45:13",
+    "recorded-date": "02-05-2023, 17:50:03",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "30-04-2023, 18:46:08",
+    "recorded-date": "02-05-2023, 17:51:02",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3162,13 +3162,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs12.x]": {
-    "recorded-date": "30-04-2023, 18:46:51",
+    "recorded-date": "02-05-2023, 17:51:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "fKhqWrhw1PbQjGlzohF8mf9D4PldsYo8PNarq/muZw8=",
+        "CodeSha256": "z9BMINzwVBqS8Ii5JL8ovi2Z9nQhN3bZcZA9MBQlYO0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3211,13 +3211,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs14.x]": {
-    "recorded-date": "30-04-2023, 18:46:53",
+    "recorded-date": "02-05-2023, 17:51:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "dFKshw5sd3qg1dJ9uxfO3DHkJF0NdquoK/fkrldwMv8=",
+        "CodeSha256": "dtrXPh+kj68uMmCbuK33HVF2CfCwc6UJMEwWOtFyHcM=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3260,13 +3260,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "30-04-2023, 18:46:55",
+    "recorded-date": "02-05-2023, 17:51:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "/a1uiOwovs3wwwqvcUXHmvyO/RhuoUNx4+MvU3qu9U4=",
+        "CodeSha256": "1xq7YLMDN8eCt3SXIiy5QGVLyBh2EOV2rWfgE4w2w64=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3309,13 +3309,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "30-04-2023, 18:46:57",
+    "recorded-date": "02-05-2023, 17:51:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "DdS2iqXkBnD+EDms3lVz+UjS0Ywma3PSMGQ8wY0BZs8=",
+        "CodeSha256": "aWq/IusSU1QitvG1FWp7con8tAUpWL4tUOeqUPY5hDg=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3680,11 +3680,11 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "recorded-date": "30-04-2023, 18:43:27",
+    "recorded-date": "02-05-2023, 17:48:26",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "recorded-date": "30-04-2023, 18:45:02",
+    "recorded-date": "02-05-2023, 17:49:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3821,7 +3821,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "30-04-2023, 18:46:00",
+    "recorded-date": "02-05-2023, 17:50:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3869,6 +3869,199 @@
           "errorMessage": "Failed: some_error_msg",
           "errorType": "Exception",
           "requestId": "<uuid:2>",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
+    "recorded-date": "02-05-2023, 17:49:16",
+    "recorded-content": {}
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
+    "recorded-date": "02-05-2023, 17:50:32",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "eVn60S7b09aYSVdmCtubfLRgSaVdfZRpoVMWPWnbwCo=",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "java17",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_java17",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "echo.Handler",
+          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_java17",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "echo.Handler",
+          "_LAMBDA_TELEMETRY_LOG_FD": "3"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
+    "recorded-date": "02-05-2023, 17:51:31",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "9G7gTXxil7XroabIU5ZOQMKPpVDTJlKEVCsEhjGK8X0=",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "java17",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Error: some_error_msg",
+          "errorType": "java.lang.RuntimeException",
           "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -2035,7 +2035,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.7]": {
-    "recorded-date": "02-05-2023, 17:50:49",
+    "recorded-date": "02-05-2023, 19:48:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2093,7 +2093,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "02-05-2023, 17:50:51",
+    "recorded-date": "02-05-2023, 19:48:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2151,7 +2151,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "02-05-2023, 17:50:53",
+    "recorded-date": "02-05-2023, 19:48:44",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2210,7 +2210,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs12.x]": {
-    "recorded-date": "02-05-2023, 17:50:57",
+    "recorded-date": "02-05-2023, 19:48:48",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2268,7 +2268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs14.x]": {
-    "recorded-date": "02-05-2023, 17:50:58",
+    "recorded-date": "02-05-2023, 19:48:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2326,7 +2326,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "02-05-2023, 17:51:00",
+    "recorded-date": "02-05-2023, 19:48:52",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2384,7 +2384,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8]": {
-    "recorded-date": "02-05-2023, 17:51:11",
+    "recorded-date": "02-05-2023, 19:49:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2442,7 +2442,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "02-05-2023, 17:51:18",
+    "recorded-date": "02-05-2023, 19:49:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2500,7 +2500,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "02-05-2023, 17:51:25",
+    "recorded-date": "02-05-2023, 19:49:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2558,7 +2558,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby2.7]": {
-    "recorded-date": "02-05-2023, 17:51:04",
+    "recorded-date": "02-05-2023, 19:48:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2616,7 +2616,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[go1.x]": {
-    "recorded-date": "02-05-2023, 17:51:40",
+    "recorded-date": "02-05-2023, 19:49:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2673,13 +2673,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided]": {
-    "recorded-date": "02-05-2023, 17:51:43",
+    "recorded-date": "02-05-2023, 19:49:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "Tu0Jt/5Ih3J4d9mIEzBFyS8iN5nf0DjO8yL+ZWqL72s=",
+        "CodeSha256": "TT3fsFOET/+vAaze3gX3ixqYizuF/AQV3q1NR0UTh34=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2718,7 +2718,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
+          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2730,13 +2730,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "02-05-2023, 17:51:45",
+    "recorded-date": "02-05-2023, 19:49:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "Tu0Jt/5Ih3J4d9mIEzBFyS8iN5nf0DjO8yL+ZWqL72s=",
+        "CodeSha256": "TT3fsFOET/+vAaze3gX3ixqYizuF/AQV3q1NR0UTh34=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2775,7 +2775,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
+          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2787,7 +2787,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "02-05-2023, 17:51:35",
+    "recorded-date": "02-05-2023, 19:49:28",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2845,7 +2845,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnetcore3.1]": {
-    "recorded-date": "02-05-2023, 17:51:33",
+    "recorded-date": "02-05-2023, 19:49:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "02-05-2023, 17:51:02",
+    "recorded-date": "02-05-2023, 19:48:54",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3821,7 +3821,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "02-05-2023, 17:50:54",
+    "recorded-date": "02-05-2023, 19:48:46",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4015,7 +4015,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "recorded-date": "02-05-2023, 17:51:31",
+    "recorded-date": "02-05-2023, 19:49:24",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [

--- a/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs14.x]": {
-    "recorded-date": "02-05-2023, 11:58:47",
+    "recorded-date": "02-05-2023, 17:56:02",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -62,7 +62,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
-    "recorded-date": "02-05-2023, 11:58:55",
+    "recorded-date": "02-05-2023, 17:56:12",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -124,7 +124,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_runtime_with_lib": {
-    "recorded-date": "02-05-2023, 11:59:07",
+    "recorded-date": "02-05-2023, 17:56:26",
     "recorded-content": {
       "create-result-jar-with-lib": {
         "CreateEventSourceMappingResponse": null,
@@ -291,7 +291,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8]": {
-    "recorded-date": "02-05-2023, 11:59:10",
+    "recorded-date": "02-05-2023, 17:56:29",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -305,7 +305,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "recorded-date": "02-05-2023, 11:59:13",
+    "recorded-date": "02-05-2023, 17:56:32",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -319,7 +319,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "recorded-date": "02-05-2023, 11:59:15",
+    "recorded-date": "02-05-2023, 17:56:34",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -333,7 +333,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8]": {
-    "recorded-date": "02-05-2023, 11:59:23",
+    "recorded-date": "02-05-2023, 17:56:44",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -396,7 +396,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "recorded-date": "02-05-2023, 11:59:31",
+    "recorded-date": "02-05-2023, 17:56:52",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -459,7 +459,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "recorded-date": "02-05-2023, 11:59:38",
+    "recorded-date": "02-05-2023, 17:57:00",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -522,7 +522,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequestCustom-CUSTOM]": {
-    "recorded-date": "02-05-2023, 11:59:49",
+    "recorded-date": "02-05-2023, 17:57:12",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -581,7 +581,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom-INTERFACE]": {
-    "recorded-date": "02-05-2023, 11:59:58",
+    "recorded-date": "02-05-2023, 17:57:22",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -640,7 +640,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequest-INTERFACE]": {
-    "recorded-date": "02-05-2023, 12:00:06",
+    "recorded-date": "02-05-2023, 17:57:34",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -699,7 +699,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_lambda_subscribe_sns_topic": {
-    "recorded-date": "02-05-2023, 12:00:28",
+    "recorded-date": "02-05-2023, 17:57:56",
     "recorded-content": {
       "get-function": {
         "Code": {
@@ -771,39 +771,39 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.7]": {
-    "recorded-date": "02-05-2023, 12:00:30",
+    "recorded-date": "02-05-2023, 17:57:58",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "02-05-2023, 12:00:32",
+    "recorded-date": "02-05-2023, 17:58:00",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "02-05-2023, 12:00:35",
+    "recorded-date": "02-05-2023, 17:58:02",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "recorded-date": "02-05-2023, 12:00:37",
+    "recorded-date": "02-05-2023, 17:58:05",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.7]": {
-    "recorded-date": "02-05-2023, 12:00:39",
+    "recorded-date": "02-05-2023, 17:58:07",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "02-05-2023, 12:00:41",
+    "recorded-date": "02-05-2023, 17:58:11",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "02-05-2023, 12:00:44",
+    "recorded-date": "02-05-2023, 17:58:14",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "recorded-date": "02-05-2023, 12:00:46",
+    "recorded-date": "02-05-2023, 17:58:16",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.7]": {
-    "recorded-date": "02-05-2023, 12:00:48",
+    "recorded-date": "02-05-2023, 17:58:18",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -869,7 +869,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.8]": {
-    "recorded-date": "02-05-2023, 12:00:50",
+    "recorded-date": "02-05-2023, 17:58:20",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -935,7 +935,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.9]": {
-    "recorded-date": "02-05-2023, 12:00:53",
+    "recorded-date": "02-05-2023, 17:58:22",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -1002,7 +1002,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.10]": {
-    "recorded-date": "02-05-2023, 12:00:55",
+    "recorded-date": "02-05-2023, 17:58:25",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -1059,6 +1059,83 @@
           "stackTrace": [
             "  File \"/var/task/handler.py\", line 6, in handler\n    raise CustomException(\"some error occurred\")\n"
           ]
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java17]": {
+    "recorded-date": "02-05-2023, 17:56:37",
+    "recorded-content": {
+      "invoke_result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {},
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java17]": {
+    "recorded-date": "02-05-2023, 17:57:07",
+    "recorded-content": {
+      "create-result": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.awssdkv1.sample.SerializedInputLambdaHandler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java17",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invoke-result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "bucket": "test_bucket",
+          "key": "test_key",
+          "validated": true
         },
         "StatusCode": 200,
         "ResponseMetadata": {


### PR DESCRIPTION
## Motivation

AWS Lambda recently released the java17 managed runtime.

https://aws.amazon.com/blogs/compute/java-17-runtime-now-available-on-aws-lambda/

We also aim to support it.

## Changes
* Add java17 to supported runtimes
* Add java17 to snapshot supported runtimes https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-runtimes
* Add java17 to snapshot tests
* Add java17 to common runtime tests
* Add java17 to java specific runtime tests
* Use python3.10 as default runtime for test_lambda.py tests

I also regenerated a lot of snapshots.

Fixes #8219