### PR TITLE
Move CFn utils and remove redundant code

### DIFF
--- a/localstack/services/cloudformation/cfn_utils.py
+++ b/localstack/services/cloudformation/cfn_utils.py
@@ -1,4 +1,5 @@
 import json
+from typing import Callable
 
 from localstack.utils.objects import recurse_object
 
@@ -60,3 +61,16 @@ def convert_types(obj, types):
     for key, type_class in types.items():
         fix_types(key, type_class)
     return obj
+
+
+def get_tags_param(resource_type: str) -> Callable:
+    """Return a tag parameters creation function for the given resource type"""
+
+    def _param(params, **kwargs):
+        tags = params.get("Tags")
+        if not tags:
+            return None
+
+        return [{"ResourceType": resource_type, "Tags": tags}]
+
+    return _param

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -4,8 +4,14 @@ import re
 from copy import deepcopy
 from typing import Callable, List
 
+from localstack.services.cloudformation.engine.template_deployer import LOG
 from localstack.utils import common
+from localstack.utils.aws import aws_stack
 from localstack.utils.common import select_attributes, short_uid
+from localstack.utils.functions import run_safe
+from localstack.utils.json import json_safe
+from localstack.utils.objects import recurse_object
+from localstack.utils.strings import is_string
 
 # placeholders
 PLACEHOLDER_AWS_NO_VALUE = "__aws_no_value__"
@@ -197,3 +203,60 @@ def fix_boto_parameters_based_on_report(original_params: dict, report: str) -> d
             new_value = cast_class(old_value)
         set_nested(params, param_name, new_value)
     return params
+
+
+def fix_account_id_in_arns(params: dict) -> dict:
+    def fix_ids(o, **kwargs):
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if is_string(v, exclude_binary=True):
+                    o[k] = aws_stack.fix_account_id_in_arns(v)
+        elif is_string(o, exclude_binary=True):
+            o = aws_stack.fix_account_id_in_arns(o)
+        return o
+
+    result = recurse_object(params, fix_ids)
+    return result
+
+
+def convert_data_types(func_details, params):
+    """Convert data types in the "params" object, with the type defs
+    specified in the 'types' attribute of "func_details"."""
+    types = func_details.get("types") or {}
+    attr_names = types.keys() or []
+
+    def cast(_obj, _type):
+        if _type == bool:
+            return _obj in ["True", "true", True]
+        if _type == str:
+            if isinstance(_obj, bool):
+                return str(_obj).lower()
+            return str(_obj)
+        if _type in (int, float):
+            return _type(_obj)
+        return _obj
+
+    def fix_types(o, **kwargs):
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k in attr_names:
+                    o[k] = cast(v, types[k])
+        return o
+
+    result = recurse_object(params, fix_types)
+    return result
+
+
+def log_not_available_message(resource_type: str, message: str):
+    LOG.warning(
+        f"{message}. To find out if {resource_type} is supported in LocalStack Pro, "
+        "please check out our docs at https://docs.localstack.cloud/user-guide/aws/cloudformation/#resources-pro--enterprise-edition"
+    )
+
+
+def dump_resource_as_json(resource: dict) -> str:
+    return str(run_safe(lambda: json.dumps(json_safe(resource))) or resource)
+
+
+def get_action_name_for_resource_change(res_change: str) -> str:
+    return {"Add": "CREATE", "Remove": "DELETE", "Modify": "UPDATE"}.get(res_change)

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -1,10 +1,10 @@
 import builtins
 import json
+import logging
 import re
 from copy import deepcopy
 from typing import Callable, List
 
-from localstack.services.cloudformation.engine.template_deployer import LOG
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import select_attributes, short_uid
@@ -15,6 +15,8 @@ from localstack.utils.strings import is_string
 
 # placeholders
 PLACEHOLDER_AWS_NO_VALUE = "__aws_no_value__"
+
+LOG = logging.getLogger(__name__)
 
 
 def dump_json_params(param_func=None, *param_names):

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -966,7 +966,7 @@ class TemplateDeployer:
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = resource.get["Type"]  # why?
+            resource["ResourceType"] = resource["Type"]
 
         def _safe_lookup_is_deleted(r_id):
             """handles the case where self.stack.resource_status(..) fails for whatever reason"""

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -79,11 +79,11 @@ def get_deployment_config(res_type):
 
 
 def get_resource_type(resource):
-    return resource.get("Type")
+    return resource["Type"]
 
 
 def get_service_name(resource):
-    res_type = resource.get("Type", resource.get("ResourceType", ""))
+    res_type = resource["Type"]
     parts = res_type.split("::")
     if len(parts) == 1:
         return None
@@ -960,11 +960,13 @@ class TemplateDeployer:
         self.stack.set_stack_status("DELETE_IN_PROGRESS")
         stack_resources = list(self.stack.resources.values())
         resources = {r["LogicalResourceId"]: clone_safe(r) for r in stack_resources}
+
+        # TODO: what is this doing?
         for key, resource in resources.items():
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = resource.get("ResourceType") or resource.get("Type")
+            resource["ResourceType"] = resource.get["Type"]  # why?
 
         def _safe_lookup_is_deleted(r_id):
             """handles the case where self.stack.resource_status(..) fails for whatever reason"""
@@ -1116,7 +1118,7 @@ class TemplateDeployer:
                 "Action": action,
                 "LogicalResourceId": resource.get("LogicalResourceId"),
                 "PhysicalResourceId": resource.get("PhysicalResourceId"),
-                "ResourceType": resource.get("Type"),
+                "ResourceType": resource["Type"],
                 # TODO ChangeSetId is only set for *nested* change sets
                 # "ChangeSetId": change_set_id,
                 "Scope": [],  # TODO

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -73,8 +73,7 @@ class NoStackUpdates(Exception):
 
 
 def get_deployment_config(res_type):
-    canonical_type = canonical_resource_type(res_type)
-    resource_class = RESOURCE_MODELS.get(canonical_type)
+    resource_class = RESOURCE_MODELS.get(res_type)
     if resource_class:
         return resource_class.get_deploy_templates()
 
@@ -260,14 +259,7 @@ def extract_resource_attribute(
     return result
 
 
-def canonical_resource_type(resource_type):
-    if "::" in resource_type and not resource_type.startswith("AWS::"):
-        resource_type = "AWS::%s" % resource_type
-    return resource_type
-
-
 def get_attr_from_model_instance(resource, attribute, resource_type, resource_id=None):
-    resource_type = canonical_resource_type(resource_type)
     model_class = RESOURCE_MODELS.get(resource_type)
     if not model_class:
         if resource_type not in ["AWS::Parameter", "Parameter"]:
@@ -652,8 +644,7 @@ def get_resource_model_instance(resource_id: str, resources) -> Optional[Generic
     """Obtain a typed resource entity instance representing the given stack resource."""
     resource = resources[resource_id]
     resource_type = get_resource_type(resource)
-    canonical_type = canonical_resource_type(resource_type)
-    resource_class = RESOURCE_MODELS.get(canonical_type)
+    resource_class = RESOURCE_MODELS.get(resource_type)
     if not resource_class:
         return None
     instance = resource_class(resource)
@@ -850,8 +841,7 @@ def determine_resource_physical_id(
     resource_type = get_resource_type(resource)
 
     # determine result from resource class
-    canonical_type = canonical_resource_type(resource_type)  # FIXME: remove
-    resource_class = RESOURCE_MODELS.get(canonical_type)
+    resource_class = RESOURCE_MODELS.get(resource_type)
     if resource_class:
         resource_inst = resource_class(resource)
         resource_inst.fetch_state_if_missing(stack_name=stack_name, resources=resources)
@@ -893,8 +883,7 @@ def add_default_resource_props(
     """Apply some fixes to resource props which otherwise cause deployments to fail"""
 
     res_type = resource["Type"]
-    canonical_type = canonical_resource_type(res_type)
-    resource_class = RESOURCE_MODELS.get(canonical_type)
+    resource_class = RESOURCE_MODELS.get(res_type)
     if resource_class is not None:
         resource_class.add_defaults(resource, stack_name)
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -78,9 +78,8 @@ def get_deployment_config(res_type):
         return resource_class.get_deploy_templates()
 
 
-# FIXME: still too many cases
 def get_resource_type(resource):
-    return resource.get("ResourceType") or resource.get("Type") or ""
+    return resource.get("Type")
 
 
 def get_service_name(resource):
@@ -962,7 +961,9 @@ class TemplateDeployer:
         stack_resources = list(self.stack.resources.values())
         resources = {r["LogicalResourceId"]: clone_safe(r) for r in stack_resources}
         for key, resource in resources.items():
-            resource["Properties"] = resource.get("Properties", clone_safe(resource))
+            resource["Properties"] = resource.get(
+                "Properties", clone_safe(resource)
+            )  # TODO: why is there a fallback?
             resource["ResourceType"] = resource.get("ResourceType") or resource.get("Type")
 
         def _safe_lookup_is_deleted(r_id):

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -1,8 +1,8 @@
 import json
-from typing import Callable
 
 from moto.ec2.utils import generate_route_id
 
+from localstack.services.cloudformation.cfn_utils import get_tags_param
 from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
@@ -582,16 +582,3 @@ class EC2Instance(GenericBaseModel):
                 },
             },
         }
-
-
-def get_tags_param(resource_type: str) -> Callable:
-    """Return a tag parameters creation function for the given resource type"""
-
-    def _param(params, **kwargs):
-        tags = params.get("Tags")
-        if not tags:
-            return None
-
-        return [{"ResourceType": resource_type, "Tags": tags}]
-
-    return _param


### PR DESCRIPTION
Changes

* Move CFn utils from template_deployer to util files
* Remove fallback to "ResourceType" when "Type" was not available (didn't see where this would occur anyway)
* Remove reference to canonical resource type since all now already in their canonical form 