### PR TITLE
CloudFormation: add types and restructure

### DIFF
--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -221,11 +221,10 @@ def fix_account_id_in_arns(params: dict) -> dict:
     return result
 
 
-def convert_data_types(func_details, params):
+def convert_data_types(type_conversions: dict[str, Callable], params: dict) -> dict:
     """Convert data types in the "params" object, with the type defs
     specified in the 'types' attribute of "func_details"."""
-    types = func_details.get("types") or {}
-    attr_names = types.keys() or []
+    attr_names = type_conversions.keys() or []
 
     def cast(_obj, _type):
         if _type == bool:
@@ -242,7 +241,7 @@ def convert_data_types(func_details, params):
         if isinstance(o, dict):
             for k, v in o.items():
                 if k in attr_names:
-                    o[k] = cast(v, types[k])
+                    o[k] = cast(v, type_conversions[k])
         return o
 
     result = recurse_object(params, fix_types)

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -696,7 +696,10 @@ def get_resource_model_instance(resource_id: str, resources) -> Optional[Generic
     return instance
 
 
-def execute_resource_action(resource_id: str, stack_name, resources, action_name: str):
+# yeah `Any | None` is a bit pointless, but I want to ensure that None values are represented
+def execute_resource_action(
+    resource_id: str, stack_name: str, resources: dict, action_name: str
+) -> List[Any | None]:
     resource = resources[resource_id]
     resource_type = get_resource_type(resource)
     if action_name == ACTION_CREATE and resource_type:
@@ -763,7 +766,7 @@ def invoke_function(
     func_details: FuncDetails,
     action_name: str,
     resource: Any,
-):
+) -> Any:
     try:
         LOG.debug(
             'Request for resource type "%s" in region %s: %s %s',

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -101,8 +101,11 @@ class FuncDetailsValue(TypedDict):
     """Possible type conversions"""
 
 
-# Type definition for func_details supplied to invoke_function and configure_resource_via_sdk
-FuncDetails = list[FuncDetailsValue] | FuncDetailsValue | Any
+# Type definition for func_details supplied to invoke_function
+FuncDetails = list[FuncDetailsValue] | FuncDetailsValue
+
+# Type definition returned by GenericBaseModel.get_deploy_templates
+DeployTemplates = dict[str, FuncDetails | Callable]
 
 
 class NoStackUpdates(Exception):
@@ -116,7 +119,7 @@ class NoStackUpdates(Exception):
 # ---------------------
 
 
-def get_deployment_config(res_type: str) -> FuncDetailsValue | None:
+def get_deployment_config(res_type: str) -> DeployTemplates | None:
     resource_class = RESOURCE_MODELS.get(res_type)
     if resource_class:
         return resource_class.get_deploy_templates()

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -107,7 +107,7 @@ def get_service_name(resource):
     return parts[1].lower()
 
 
-def get_client(resource: dict, func_config: dict):
+def get_client(resource: dict):
     resource_type = get_resource_type(resource)
     service = get_service_name(resource)
     resource_config = get_deployment_config(resource_type)
@@ -693,7 +693,7 @@ def execute_resource_action(resource_id: str, stack_name, resources, action_name
             results.append(result)
             executed = True
 
-        if not executed and get_client(resource, func):
+        if not executed and get_client(resource):
             result = configure_resource_via_sdk(
                 stack_name,
                 resources,
@@ -797,7 +797,7 @@ def configure_resource_via_sdk(
 ):
     resource = resources[resource_id]
 
-    client = get_client(resource, func_details)
+    client = get_client(resource)
 
     function = getattr(client, func_details["function"])
     params = func_details.get("parameters") or (lambda params, **kwargs: params)


### PR DESCRIPTION
Gain understanding by refactoring internals and add static types.

In particular, the `func_details` type was difficult to nail down. 

Remove `configure_resource_via_sdk` since it had two purposes. Instead, inline the two behaviours into
* a  function that resolves the function properties, and
* code that deploys the resource via the SDK.
