### PR TITLE
Try to fix flaky http integration tests

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -559,6 +559,13 @@ class HTTPIntegration(BackendIntegration):
             query_params=query_string_params,
         )
         result = requests.request(method=method, url=uri, data=payload, headers=headers)
+        if not result.ok:
+            LOG.debug(
+                "Upstream response from <%s> %s returned with status code: %s",
+                method,
+                uri,
+                result.status_code,
+            )
         # apply custom response template
         invocation_context.response = result
         response_templates = ResponseTemplates()


### PR DESCRIPTION
## Motivation
Our http integration tests often fail as they return a `504` status code. Since our gateway probably does not return that, it is reasonable to assume the upstream `httpbin.org/robots.txt` request does that.

Log of failed run:
```
tests/integration/apigateway/test_apigateway_integrations.py::test_put_integration_responses 
-------------------------------- live log call ---------------------------------
2023-05-03T11:02:27.604  INFO --- [   asgi_gw_7] localstack.request.aws     : AWS apigateway.CreateRestApi => 201
2023-05-03T11:02:27.612  INFO --- [   asgi_gw_9] localstack.request.aws     : AWS apigateway.GetResources => 200
2023-05-03T11:02:27.621  INFO --- [   asgi_gw_8] localstack.request.aws     : AWS apigateway.PutMethod => 201
2023-05-03T11:02:27.629  INFO --- [   asgi_gw_3] localstack.request.aws     : AWS apigateway.PutMethodResponse => 201
2023-05-03T11:02:27.641  INFO --- [   asgi_gw_2] localstack.request.aws     : AWS apigateway.PutIntegration => 201
2023-05-03T11:02:27.668  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS apigateway.PutIntegrationResponse => 201
2023-05-03T11:02:27.685  INFO --- [   asgi_gw_5] localstack.request.aws     : AWS apigateway.GetIntegrationResponse => 200
2023-05-03T11:02:27.694  INFO --- [   asgi_gw_4] localstack.request.aws     : AWS apigateway.GetMethod => 200
2023-05-03T11:02:27.723  INFO --- [   asgi_gw_1] localstack.services.apigateway.helpers : Failed to get stage local for API id k460vifue5
2023-05-03T11:02:27.724  INFO --- [   asgi_gw_1] localstack.services.apigateway.templates : Method request body before transformations: {"egg": "ham"}
2023-05-03T11:02:37.730  INFO --- [   asgi_gw_1] localstack.request.http    : GET /restapis/k460vifue5/local/_user_request_/ => 504
FAILED
```

This is very annoying, so we need to fix this.

## Changes
* Use local http echo fixture instead of remote server to test http integrations
* Add a log message for http integrations, if the remote returns a not-ok status code. This should allow us to better debug these issues.