### PR TITLE
Remove implementations of get_physical_resource_id from models

### DIFF
--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -26,6 +26,7 @@ class SFNActivity(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _store_arn(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["Arn"] = result["activityArn"]
             resources[resource_id]["PhysicalResourceId"] = result["activityArn"]
 
         return {
@@ -82,6 +83,10 @@ class SFNStateMachine(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
+        def result_handler(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["Arn"] = result["stateMachineArn"]
+            resources[resource_id]["PhysicalResourceId"] = result["stateMachineArn"]
+
         def _create_params(params, **kwargs):
             def _get_definition(params):
                 # TODO: support "Definition" parameter
@@ -111,6 +116,7 @@ class SFNStateMachine(GenericBaseModel):
             "create": {
                 "function": "create_state_machine",
                 "parameters": _create_params,
+                "result_handler": result_handler,
             },
             "delete": {
                 "function": "delete_state_machine",

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -58,7 +58,7 @@ class GenericBaseModel:
     # TODO: this shouldn't have an attribute parameter
     def get_physical_resource_id(self, attribute=None, **kwargs):
         """Determine the physical resource ID (Ref) of this resource (to be overwritten by subclasses)"""
-        return None
+        return self.physical_resource_id
 
     # TODO: change the signature to pass in a Stack instance (instead of stack_name and resources)
     def fetch_state(self, stack_name, resources):


### PR DESCRIPTION
In this first iteration we'll remove any dynamic physical resource ID lookup and replace it with a static lookup based on the state set in the result_handler, i.e. from the create call.