### PR TITLE
fix mapping of insufficient scopes return value to access denied exception

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -291,6 +291,8 @@ class CmdDockerClient(ContainerClient):
                 raise AccessDenied(docker_image)
             if "requesting higher privileges than access token allows" in to_str(e.stdout):
                 raise AccessDenied(docker_image)
+            if "access token has insufficient scopes" in to_str(e.stdout):
+                raise AccessDenied(docker_image)
             if "does not exist" in to_str(e.stdout):
                 raise NoSuchImage(docker_image)
             if "connection refused" in to_str(e.stdout):

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -251,6 +251,8 @@ class SdkDockerClient(ContainerClient):
                     raise AccessDenied(docker_image)
                 if "requesting higher privileges than access token allows" in to_str(result):
                     raise AccessDenied(docker_image)
+                if "access token has insufficient scopes" in to_str(result):
+                    raise AccessDenied(docker_image)
                 if "connection refused" in to_str(result):
                     raise RegistryConnectionError(result)
                 raise ContainerException(result)


### PR DESCRIPTION
This PR relates to / extends https://github.com/localstack/localstack/pull/8215.

## Motivation
We are currently seeing a new error message in the community test pipeline in -ext which indicate an error when verifying the access denied error of a docker push.

```
2023-05-04T08:32:39.397 DEBUG --- [  MainThread] localstack.utils.container_utils.docker_cmd_client : Pushing image with cmd: ['docker', 'push', 'alpine']
2023-05-04T08:32:39.397 DEBUG --- [  MainThread] localstack.utils.run       : Executing command: ['docker', 'push', 'alpine']
ERROR: '['docker', 'push', 'alpine']': exit code 1; output: b'Using default tag: latest\nThe push refers to repository [docker.io/library/alpine]\nf1417ff83b31: Preparing\nunauthorized: access token has insufficient scopes\n'
RERUN
../localstack/tests/integration/docker_utils/test_docker.py::TestDockerClient::test_push_access_denied[CmdDockerClient] 
```
While it is not clear why there are different error messages returned here, we still have to map this return to `AccessDenied` (as it effectively is).

## Changes
* Add case of `access token has insufficient scopes` to be mapped to a `AccessDenied` exception