### PR TITLE
fix stack set instance creation, add deletion

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1405,6 +1405,9 @@ class TemplateDeployer:
         existing_stack.outputs.update(new_stack.outputs)
         existing_stack.conditions.update(new_stack.conditions)
 
+        # TODO: ideally the entire template has to be replaced, but tricky at this point
+        existing_stack.template["Metadata"] = new_stack.template.get("Metadata")
+
         # start deployment loop
         return self.apply_changes_in_loop(
             changes, existing_stack, action=action, new_stack=new_stack

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -387,6 +387,7 @@ class CloudformationProvider(CloudformationApi):
             {"ResourceType": key, "LogicalResourceIds": values}
             for key, values in id_summaries.items()
         ]
+        result["Metadata"] = stack.template.get("Metadata")
         result["Version"] = stack.template.get("AWSTemplateFormatVersion", "2010-09-09")
         # these do not appear in the output
         result.pop("Capabilities", None)

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -20,6 +20,8 @@ from localstack.aws.api.cloudformation import (
     CreateStackSetInput,
     CreateStackSetOutput,
     DeleteChangeSetOutput,
+    DeleteStackInstancesInput,
+    DeleteStackInstancesOutput,
     DeleteStackSetOutput,
     DescribeChangeSetOutput,
     DescribeStackEventsOutput,
@@ -92,7 +94,7 @@ from localstack.utils.collections import (
     select_from_typed_dict,
 )
 from localstack.utils.json import clone
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import long_uid, short_uid
 
 LOG = logging.getLogger(__name__)
 
@@ -110,6 +112,13 @@ def clone_stack_params(stack_params):
     except Exception as e:
         LOG.info("Unable to clone stack parameters: %s", e)
         return stack_params
+
+
+def find_stack_instance(stack_set: StackSet, account: str, region: str):
+    for instance in stack_set.stack_instances:
+        if instance.metadata["Account"] == account and instance.metadata["Region"] == region:
+            return instance
+    return None
 
 
 def stack_not_found_error(stack_name: str):
@@ -729,7 +738,7 @@ class CloudformationProvider(CloudformationApi):
     ) -> CreateStackSetOutput:
         state = get_cloudformation_store()
         stack_set = StackSet(request)
-        stack_set_id = short_uid()
+        stack_set_id = f"{stack_set.stack_set_name}:{long_uid()}"
         stack_set.metadata["StackSetId"] = stack_set_id
         state.stack_sets[stack_set_id] = stack_set
 
@@ -821,6 +830,8 @@ class CloudformationProvider(CloudformationApi):
         if not stack_set:
             return not_found_error(f'Stack set named "{stack_set_name}" does not exist')
 
+        # TODO: add a check for remaining stack instances
+
         for instance in stack_set[0].stack_instances:
             deployer = template_deployer.TemplateDeployer(instance.stack)
             deployer.delete_stack()
@@ -856,6 +867,11 @@ class CloudformationProvider(CloudformationApi):
                     sset_meta, ["TemplateURL"]
                 )
                 stack_name = f"sset-{set_name}-{account}"
+
+                # skip creation of existing stacks
+                if find_stack(stack_name):
+                    continue
+
                 result = cf_client.create_stack(StackName=stack_name, **kwargs)
                 stacks_to_await.append((stack_name, region))
                 # store stack instance
@@ -902,6 +918,43 @@ class CloudformationProvider(CloudformationApi):
         stack_set = stack_set[0]
         result = [inst.metadata for inst in stack_set.stack_instances]
         return ListStackInstancesOutput(Summaries=result)
+
+    @handler("DeleteStackInstances", expand=False)
+    def delete_stack_instances(
+        self,
+        context: RequestContext,
+        request: DeleteStackInstancesInput,
+    ) -> DeleteStackInstancesOutput:
+        op_id = request.get("OperationId") or short_uid()
+
+        accounts = request["Accounts"]
+        regions = request["Regions"]
+
+        state = get_cloudformation_store()
+        stack_sets = state.stack_sets.values()
+
+        set_name = request.get("StackSetName")
+        stack_set = next((sset for sset in stack_sets if sset.stack_set_name == set_name), None)
+
+        if not stack_set:
+            return not_found_error(f'Stack set named "{set_name}" does not exist')
+
+        for account in accounts:
+            for region in regions:
+                instance = find_stack_instance(stack_set, account, region)
+                if instance:
+                    stack_set.stack_instances.remove(instance)
+
+        # record operation
+        operation = {
+            "OperationId": op_id,
+            "StackSetId": stack_set.metadata["StackSetId"],
+            "Action": "DELETE",
+            "Status": "SUCCEEDED",
+        }
+        stack_set.operations[op_id] = operation
+
+        return DeleteStackInstancesOutput(OperationId=op_id)
 
     @handler("RegisterType", expand=False)
     def register_type(

--- a/tests/integration/cloudformation/api/test_get_template_summary.snapshot.json
+++ b/tests/integration/cloudformation/api/test_get_template_summary.snapshot.json
@@ -1,16 +1,14 @@
 {
   "tests/integration/cloudformation/api/test_get_template_summary.py::test_get_template_summary": {
-    "recorded-date": "30-11-2022, 14:27:17",
+    "recorded-date": "24-05-2023, 15:05:00",
     "recorded-content": {
       "template-summary": {
+        "Metadata": "{'TopicName': 'sns-topic-simple'}",
         "Parameters": [],
         "ResourceIdentifierSummaries": [
           {
             "LogicalResourceIds": [
               "topic123"
-            ],
-            "ResourceIdentifiers": [
-              "TopicArn"
             ],
             "ResourceType": "AWS::SNS::Topic"
           }

--- a/tests/integration/cloudformation/resources/test_stack_sets.py
+++ b/tests/integration/cloudformation/resources/test_stack_sets.py
@@ -1,0 +1,78 @@
+import os
+
+import pytest
+
+from localstack.utils.files import load_file
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import wait_until
+
+
+@pytest.fixture
+def wait_stack_set_operation(aws_client):
+    def waiter(stack_set_name: str, operation_id: str):
+        def _operation_is_ready():
+            operation = aws_client.cloudformation.describe_stack_set_operation(
+                StackSetName=stack_set_name,
+                OperationId=operation_id,
+            )
+            return operation["StackSetOperation"]["Status"] not in ["RUNNING", "STOPPING"]
+
+        wait_until(_operation_is_ready)
+
+    return waiter
+
+
+@pytest.mark.aws_validated
+def test_create_stack_set_with_stack_instances(
+    account_id,
+    region,
+    aws_client,
+    snapshot,
+    wait_stack_set_operation,
+):
+    snapshot.add_transformer(snapshot.transform.key_value("StackSetId", "stack-set-id"))
+
+    stack_set_name = f"StackSet-{short_uid()}"
+
+    template_body = load_file(
+        os.path.join(os.path.dirname(__file__), "../../templates/s3_cors_bucket.yaml")
+    )
+
+    result = aws_client.cloudformation.create_stack_set(
+        StackSetName=stack_set_name,
+        TemplateBody=template_body,
+    )
+
+    snapshot.match("create_stack_set", result)
+
+    create_instances_result = aws_client.cloudformation.create_stack_instances(
+        StackSetName=stack_set_name,
+        Accounts=[account_id],
+        Regions=[region],
+    )
+
+    snapshot.match("create_stack_instances", create_instances_result)
+
+    wait_stack_set_operation(stack_set_name, create_instances_result["OperationId"])
+
+    # make sure additional calls do not result in errors
+    # even the stack already exists, but returns operation id instead
+    create_instances_result = aws_client.cloudformation.create_stack_instances(
+        StackSetName=stack_set_name,
+        Accounts=[account_id],
+        Regions=[region],
+    )
+
+    assert "OperationId" in create_instances_result
+
+    wait_stack_set_operation(stack_set_name, create_instances_result["OperationId"])
+
+    delete_instances_result = aws_client.cloudformation.delete_stack_instances(
+        StackSetName=stack_set_name,
+        Accounts=[account_id],
+        Regions=[region],
+        RetainStacks=False,
+    )
+    wait_stack_set_operation(stack_set_name, delete_instances_result["OperationId"])
+
+    aws_client.cloudformation.delete_stack_set(StackSetName=stack_set_name)

--- a/tests/integration/cloudformation/resources/test_stack_sets.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_stack_sets.snapshot.json
@@ -1,0 +1,21 @@
+{
+  "tests/integration/cloudformation/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
+    "recorded-date": "24-05-2023, 15:32:47",
+    "recorded-content": {
+      "create_stack_set": {
+        "StackSetId": "<stack-set-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_stack_instances": {
+        "OperationId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/templates/sns_topic_simple.yaml
+++ b/tests/integration/templates/sns_topic_simple.yaml
@@ -1,4 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Metadata:
+  TopicName: sns-topic-simple
 Resources:
   topic123:
     Type: AWS::SNS::Topic


### PR DESCRIPTION
## Summary

* fix "CreateStackInstances" operation where repetitive calls were resulting in 500 errors. Few runs against AWS have shown that AWS returns an OperationId in any case. This can be also reproduced with `aws copilot`
* update `StackSet` id format to match the one in AWS
* implement `DeleteStackInstances` operation to complete the parity test
* update template metadata on changeset execution
* Include template metadata into `GetTemplateSummary` response

## Linked Issues

https://github.com/localstack/localstack/issues/8255
