### PR TITLE
fix PutEvents non-existent custom EventBus

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -511,11 +511,13 @@ def events_handler_put_events(self):
     for event_envelope in events:
         event = event_envelope["event"]
         event_bus_name = event.get("EventBusName") or DEFAULT_EVENT_BUS_NAME
-        event_rules = self.events_backend.event_buses[event_bus_name].rules
+        event_bus = self.events_backend.event_buses.get(event_bus_name)
+        if not event_bus:
+            continue
 
         matching_rules = [
             r
-            for r in event_rules.values()
+            for r in event_bus.rules.values()
             if r.event_bus_name == event_bus_name and not r.scheduled_expression
         ]
         if not matching_rules:

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -367,7 +367,6 @@ class TestEvents:
         sqs_client.set_queue_attributes(
             QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)}
         )
-        # ALLOWHERE
 
         events_client.create_event_bus(Name=bus_name)
         events_client.put_rule(

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -367,6 +367,7 @@ class TestEvents:
         sqs_client.set_queue_attributes(
             QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)}
         )
+        # ALLOWHERE
 
         events_client.create_event_bus(Name=bus_name)
         events_client.put_rule(
@@ -1737,3 +1738,78 @@ class TestEvents:
             )
 
         retry(check_invocation, sleep=5, retries=15)
+
+    @pytest.mark.aws_validated
+    def test_put_events_nonexistent_event_bus(
+        self,
+        aws_client,
+        sqs_create_queue,
+        sqs_queue_arn,
+        events_put_rule,
+        events_allow_event_rule_to_sqs_queue,
+        snapshot,
+    ):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("MD5OfBody"),  # the event contains a timestamp
+                snapshot.transform.key_value("ReceiptHandle"),
+            ]
+        )
+        default_bus_rule_name = f"rule-{short_uid()}"
+        default_bus_target_id = f"test-target-default-b-{short_uid()}"
+        nonexistent_event_bus = f"event-bus-{short_uid()}"
+
+        # create SQS queue + add rules & targets so that we can check the default event bus received the message
+        # even if one entry was wrong
+
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_queue_arn(queue_url)
+
+        rule_on_default_bus = events_put_rule(
+            Name=default_bus_rule_name,
+            EventPattern=json.dumps({"detail-type": ["CustomType"], "source": ["MySource"]}),
+            State="ENABLED",
+        )
+
+        events_allow_event_rule_to_sqs_queue(
+            event_rule_arn=rule_on_default_bus["RuleArn"],
+            sqs_queue_arn=queue_arn,
+            sqs_queue_url=queue_url,
+        )
+
+        aws_client.events.put_targets(
+            Rule=default_bus_rule_name,
+            Targets=[{"Id": default_bus_target_id, "Arn": queue_arn}],
+        )
+
+        # create two entries, one with no EventBus specified (so it will target the default one)
+        # and one with a nonexistent EventBusName, which should be ignored
+        entries = [
+            {
+                "Source": "MySource",
+                "DetailType": "CustomType",
+                "Detail": json.dumps({"message": "for the default event bus"}),
+            },
+            {
+                "EventBusName": nonexistent_event_bus,
+                "Source": "MySource",
+                "DetailType": "CustomType",
+                "Detail": json.dumps({"message": "for the custom event bus"}),
+            },
+        ]
+        response = aws_client.events.put_events(Entries=entries)
+        snapshot.match("put-events", response)
+
+        def _get_sqs_messages():
+            resp = aws_client.sqs.receive_message(
+                QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
+            )
+            msgs = resp.get("Messages")
+            assert len(msgs) == 1
+            aws_client.sqs.delete_message(
+                QueueUrl=queue_url, ReceiptHandle=msgs[0]["ReceiptHandle"]
+            )
+            return msgs
+
+        messages = retry(_get_sqs_messages, retries=5, sleep=0.1)
+        snapshot.match("get-events", messages)

--- a/tests/integration/test_events.snapshot.json
+++ b/tests/integration/test_events.snapshot.json
@@ -102,5 +102,45 @@
         }
       }
     }
+  },
+  "tests/integration/test_events.py::TestEvents::test_put_events_nonexistent_event_bus": {
+    "recorded-date": "05-05-2023, 11:51:33",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          },
+          {
+            "EventId": "<uuid:2>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "for the default event bus"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/integration/test_events.snapshot.json
+++ b/tests/integration/test_events.snapshot.json
@@ -104,7 +104,7 @@
     }
   },
   "tests/integration/test_events.py::TestEvents::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "05-05-2023, 11:51:33",
+    "recorded-date": "05-05-2023, 12:00:22",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -140,7 +140,17 @@
             }
           }
         }
-      ]
+      ],
+      "non-existent-bus": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <custom-event-bus> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR would fix #8261
AWS allows publishing an Event to a nonexistent custom EventBus, it will just accept it and not do anything with it, as the test demonstrates (we even try to describe the nonexistent custom EventBus and it raises an error)