### PR TITLE
CFn: remove physical resource id from some services

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -8,7 +8,7 @@ from localstack.services.cloudformation.deployment_utils import (
     params_list_to_dict,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack, queries
+from localstack.utils.aws import queries
 from localstack.utils.common import keys_to_lower, select_attributes, to_bytes
 from localstack.utils.strings import first_char_to_lower
 
@@ -23,7 +23,7 @@ class GatewayResponse(GenericBaseModel):
         api_id = props.get("RestApiId")
         if not api_id:
             return
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         result = client.get_gateway_response(restApiId=api_id, responseType=props["ResponseType"])
         return result if "responseType" in result else None
 
@@ -48,11 +48,8 @@ class GatewayRequestValidator(GenericBaseModel):
     def cloudformation_type():
         return "AWS::ApiGateway::RequestValidator"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
-
     def fetch_state(self, stack_name, resources):
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         props = self.props
         api_id = props["RestApiId"]
         name = props["Name"]
@@ -70,6 +67,9 @@ class GatewayRequestValidator(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_request_validator",
@@ -79,6 +79,7 @@ class GatewayRequestValidator(GenericBaseModel):
                     "validateRequestBody": "ValidateRequestBody",
                     "validateRequestParameters": "ValidateRequestParameters",
                 },
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_request_validator",
@@ -95,24 +96,17 @@ class GatewayRestAPI(GenericBaseModel):
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "RootResourceId":
             api_id = self.props.get("id")
-            resources = aws_stack.connect_to_service("apigateway").get_resources(restApiId=api_id)[
-                "items"
-            ]
+            resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
             for res in resources:
                 if res["path"] == "/" and not res.get("parentId"):
                     return res["id"]
         return super(GatewayRestAPI, self).get_cfn_attribute(attribute_name)
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
-
     def fetch_state(self, stack_name, resources):
         if not self.props.get("id"):
             return None
 
-        return aws_stack.connect_to_service("apigateway").get_rest_api(
-            restApiId=self.props.get("id")
-        )
+        return connect_to().apigateway.get_rest_api(restApiId=self.props.get("id"))
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
@@ -127,10 +121,10 @@ class GatewayRestAPI(GenericBaseModel):
     def get_deploy_templates(cls):
         def _api_id(params, resources, resource_id, **kwargs):
             resource = cls(resources[resource_id])
-            return resource.physical_resource_id or resource.get_physical_resource_id()
+            return resource.physical_resource_id
 
         def _create(resource_id, resources, resource_type, func, stack_name):
-            client = aws_stack.connect_to_service("apigateway")
+            client = connect_to().apigateway
             resource = resources[resource_id]
             props = resource["Properties"]
 
@@ -153,7 +147,7 @@ class GatewayRestAPI(GenericBaseModel):
             kwargs = keys_to_lower(kwargs, skip_children_of=["policy"])
             kwargs["tags"] = {tag["key"]: tag["value"] for tag in kwargs.get("tags", [])}
 
-            cfn_client = aws_stack.connect_to_service("cloudformation")
+            cfn_client = connect_to().apigateway
             stack_id = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]["StackId"]
             kwargs["tags"].update(
                 {
@@ -212,8 +206,11 @@ class GatewayRestAPI(GenericBaseModel):
             props["id"] = result["id"]
             return result
 
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
-            "create": {"function": _create},
+            "create": {"function": _create, "result_handler": _handle_result},
             "delete": {
                 "function": "delete_rest_api",
                 "parameters": {
@@ -234,17 +231,17 @@ class GatewayDeployment(GenericBaseModel):
         if not api_id:
             return None
 
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         result = client.get_deployments(restApiId=api_id)["items"]
         # TODO possibly filter results by stage name or other criteria
 
         return result[0] if result else None
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
-
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_deployment",
@@ -254,6 +251,7 @@ class GatewayDeployment(GenericBaseModel):
                     "stageDescription": "StageDescription",
                     "description": "Description",
                 },
+                "result_handler": _handle_result,
             }
         }
 
@@ -263,9 +261,6 @@ class GatewayResource(GenericBaseModel):
     def cloudformation_type():
         return "AWS::ApiGateway::Resource"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
-
     def fetch_state(self, stack_name, resources):
         props = self.props
         api_id = props.get("RestApiId") or self.logical_resource_id
@@ -274,9 +269,7 @@ class GatewayResource(GenericBaseModel):
         if not api_id or not parent_id:
             return None
 
-        api_resources = aws_stack.connect_to_service("apigateway").get_resources(restApiId=api_id)[
-            "items"
-        ]
+        api_resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
         target_resource = list(
             filter(
                 lambda res: res.get("parentId") == parent_id
@@ -304,7 +297,7 @@ class GatewayResource(GenericBaseModel):
             }
             if not result.get("parentId"):
                 # get root resource id
-                apigw = aws_stack.connect_to_service("apigateway")
+                apigw = connect_to().apigateway
                 resources = apigw.get_resources(restApiId=result["restApiId"])["items"]
                 root_resource = ([r for r in resources if r["path"] == "/"] or [None])[0]
                 if not root_resource:
@@ -314,10 +307,14 @@ class GatewayResource(GenericBaseModel):
                 result["parentId"] = root_resource["id"]
             return result
 
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_resource",
                 "parameters": get_apigw_resource_params,
+                "result_handler": _handle_result,
             }
         }
 
@@ -335,9 +332,7 @@ class GatewayMethod(GenericBaseModel):
         if not api_id or not res_id:
             return None
 
-        res_obj = aws_stack.connect_to_service("apigateway").get_resource(
-            restApiId=api_id, resourceId=res_id
-        )
+        res_obj = connect_to().apigateway.get_resource(restApiId=api_id, resourceId=res_id)
         match = [
             v
             for (k, v) in res_obj.get("resourceMethods", {}).items()
@@ -358,7 +353,7 @@ class GatewayMethod(GenericBaseModel):
 
     def update_resource(self, new_resource, stack_name, resources):
         props = new_resource["Properties"]
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         integration = props.get("Integration")
         kwargs = {
             "restApiId": props["RestApiId"],
@@ -378,15 +373,6 @@ class GatewayMethod(GenericBaseModel):
         kwargs["authorizationType"] = props.get("AuthorizationType")
 
         return client.put_method(**kwargs)
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        props = self.props
-        result = "%s-%s-%s" % (
-            props.get("RestApiId"),
-            props.get("ResourceId"),
-            props.get("HttpMethod"),
-        )
-        return result
 
     @classmethod
     def get_deploy_templates(cls):
@@ -416,7 +402,7 @@ class GatewayMethod(GenericBaseModel):
             return result
 
         def _subresources(resource_id, resources, resource_type, func, stack_name):
-            apigateway = aws_stack.connect_to_service("apigateway")
+            apigateway = connect_to().apigateway
             resource = cls(resources[resource_id])
             props = resource.props
 
@@ -477,11 +463,21 @@ class GatewayMethod(GenericBaseModel):
                     responseModels=response.get("responseModels") or {},
                 )
 
+        def _handle_result(result, resource_id, resources, resource_type):
+            resource = resources[resource_id]
+            rest_api_id = resource["Properties"]["RestApiId"]
+            apigw_resource_id = resource["Properties"]["ResourceId"]
+            http_method = resource["Properties"]["HttpMethod"]
+            resources[resource_id][
+                "PhysicalResource"
+            ] = f"{rest_api_id}-{apigw_resource_id}-{http_method}"
+
         return {
             "create": [
                 {
                     "function": "put_method",
                     "parameters": get_params,
+                    "result_handler": _handle_result,
                 },
                 {
                     "function": _subresources  # dynamic mapping for additional sdk calls for this CFn resource
@@ -499,13 +495,10 @@ class GatewayStage(GenericBaseModel):
         api_id = self.props.get("RestApiId") or self.logical_resource_id
         if not api_id:
             return None
-        result = aws_stack.connect_to_service("apigateway").get_stage(
+        result = connect_to().apigateway.get_stage(
             restApiId=api_id, stageName=self.props["StageName"]
         )
         return result
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("StageName")
 
     @staticmethod
     def get_deploy_templates():
@@ -530,10 +523,14 @@ class GatewayStage(GenericBaseModel):
             result["stageName"] = stage_name
             return result
 
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["stageName"]
+
         return {
             "create": {
                 "function": "create_stage",
                 "parameters": get_params,
+                "result_handler": _handle_result,
             }
         }
 
@@ -545,7 +542,7 @@ class GatewayUsagePlan(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         plan_name = self.props.get("UsagePlanName")
-        result = aws_stack.connect_to_service("apigateway").get_usage_plans().get("items", [])
+        result = connect_to().apigateway.get_usage_plans().get("items", [])
         result = [r for r in result if r["name"] == plan_name]
         return (result or [None])[0]
 
@@ -559,6 +556,9 @@ class GatewayUsagePlan(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_usage_plan",
@@ -575,11 +575,9 @@ class GatewayUsagePlan(GenericBaseModel):
                     "burstLimit": int,
                     "rateLimit": float,
                 },
+                "result_handler": _handle_result,
             }
         }
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
 
     def update_resource(self, new_resource, stack_name, resources):
         props = new_resource["Properties"]
@@ -640,7 +638,7 @@ class GatewayUsagePlan(GenericBaseModel):
                 patch_operations.append(
                     {"op": "replace", "path": f"/{first_char_to_lower(parameter)}", "value": value}
                 )
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         client.update_usage_plan(usagePlanId=usage_plan_id, patchOperations=patch_operations)
 
 
@@ -653,7 +651,7 @@ class GatewayApiKey(GenericBaseModel):
         props = self.props
         key_name = props.get("Name")
         cust_id = props.get("CustomerId")
-        result = aws_stack.connect_to_service("apigateway").get_api_keys().get("items", [])
+        result = connect_to().apigateway.get_api_keys().get("items", [])
         result = [
             r
             for r in result
@@ -671,6 +669,9 @@ class GatewayApiKey(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_api_key",
@@ -684,11 +685,9 @@ class GatewayApiKey(GenericBaseModel):
                     "tags": params_list_to_dict("Tags"),
                 },
                 "types": {"enabled": bool},
+                "result_handler": _handle_result,
             }
         }
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
 
 
 class GatewayUsagePlanKey(GenericBaseModel):
@@ -697,7 +696,7 @@ class GatewayUsagePlanKey(GenericBaseModel):
         return "AWS::ApiGateway::UsagePlanKey"
 
     def fetch_state(self, stack_name, resources):
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         key_id = self.props.get("KeyId")
         key_type = self.props.get("KeyType")
         plan_id = self.props.get("UsagePlanId")
@@ -707,15 +706,16 @@ class GatewayUsagePlanKey(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["id"]
+
         return {
             "create": {
                 "function": "create_usage_plan_key",
                 "parameters": lambda_keys_to_lower(),
+                "result_handler": _handle_result,
             }
         }
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
 
 
 # TODO: add tests for this resource type
@@ -725,12 +725,13 @@ class GatewayDomain(GenericBaseModel):
         return "AWS::ApiGateway::DomainName"
 
     def fetch_state(self, stack_name, resources):
-        return aws_stack.connect_to_service("apigateway").get_domain_name(
-            domainName=self.props["DomainName"]
-        )
+        return connect_to().apigateway.get_domain_name(domainName=self.props["DomainName"])
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["domainName"]
+
         return {
             "create": {
                 "function": "create_domain_name",
@@ -746,11 +747,9 @@ class GatewayDomain(GenericBaseModel):
                     "securityPolicy": lambda_keys_to_lower("SecurityPolicy"),
                     "tags": params_list_to_dict("Tags"),
                 },
+                "result_handler": _handle_result,
             }
         }
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("domainName")
 
 
 # TODO: add tests for this resource type
@@ -761,8 +760,8 @@ class GatewayBasePathMapping(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         resources = (
-            aws_stack.connect_to_service("apigateway")
-            .get_base_path_mappings(domainName=self.props.get("DomainName"))
+            connect_to()
+            .apigateway.get_base_path_mappings(domainName=self.props.get("DomainName"))
             .get("items", [])
         )
 
@@ -785,12 +784,17 @@ class GatewayBasePathMapping(GenericBaseModel):
                 **({"stage": props.get("Stage")} if props.get("Stage") else {}),
             }
 
-            aws_stack.connect_to_service("apigateway").create_base_path_mapping(**kwargs)
+            return connect_to().apigateway.create_base_path_mapping(**kwargs)
 
-        return {"create": {"function": _create_base_path_mapping}}
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["restApiId"]
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("restApiId")
+        return {
+            "create": {
+                "function": _create_base_path_mapping,
+                "result_handler": _handle_result,
+            }
+        }
 
 
 class GatewayModel(GenericBaseModel):
@@ -798,11 +802,8 @@ class GatewayModel(GenericBaseModel):
     def cloudformation_type():
         return "AWS::ApiGateway::Model"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("Name")
-
     def fetch_state(self, stack_name, resources):
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         api_id = self.props["RestApiId"]
 
         items = client.get_models(restApiId=api_id)["items"]
@@ -855,11 +856,8 @@ class GatewayAccount(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         if not self.physical_resource_id:
             return None
-        client = aws_stack.connect_to_service("apigateway")
+        client = connect_to().apigateway
         return client.get_account()
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id
 
     @classmethod
     def get_deploy_templates(cls):
@@ -869,7 +867,7 @@ class GatewayAccount(GenericBaseModel):
 
             role_arn = props["CloudWatchRoleArn"]
 
-            aws_stack.connect_to_service("apigateway").update_account(
+            connect_to().apigateway.update_account(
                 patchOperations=[{"op": "replace", "path": "/cloudwatchRoleArn", "value": role_arn}]
             )
 

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -147,7 +147,7 @@ class GatewayRestAPI(GenericBaseModel):
             kwargs = keys_to_lower(kwargs, skip_children_of=["policy"])
             kwargs["tags"] = {tag["key"]: tag["value"] for tag in kwargs.get("tags", [])}
 
-            cfn_client = connect_to().apigateway
+            cfn_client = connect_to().cloudformation
             stack_id = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]["StackId"]
             kwargs["tags"].update(
                 {
@@ -469,7 +469,7 @@ class GatewayMethod(GenericBaseModel):
             apigw_resource_id = resource["Properties"]["ResourceId"]
             http_method = resource["Properties"]["HttpMethod"]
             resources[resource_id][
-                "PhysicalResource"
+                "PhysicalResourceId"
             ] = f"{rest_api_id}-{apigw_resource_id}-{http_method}"
 
         return {

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -483,9 +483,6 @@ class LambdaLayerVersion(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Lambda::LayerVersion"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.state.get("LayerVersionArn")
-
     def fetch_state(self, stack_name, resources):
         layer_name = self.props.get("LayerName")
         # TODO extract region name if layer_name is an ARN
@@ -501,7 +498,10 @@ class LambdaLayerVersion(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        return {"create": {"function": "publish_layer_version"}}
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["LayerVersionArn"]
+
+        return {"create": {"function": "publish_layer_version", "result_handler": _handle_result}}
 
 
 # TODO: test

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import string
+import uuid
 
 from localstack.aws.connect import connect_to
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
@@ -35,12 +36,6 @@ class LambdaFunction(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         func_name = self.props["FunctionName"]
         return connect_to().awslambda.get_function(FunctionName=func_name)
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        func_name = self.props.get("FunctionName")
-        if attribute == "Arn":
-            return arns.lambda_function_arn(func_name)
-        return func_name
 
     def update_resource(self, new_resource, stack_name, resources):
         props = new_resource["Properties"]
@@ -138,6 +133,7 @@ class LambdaFunction(GenericBaseModel):
             resources[resource_id]["Properties"]["Arn"] = result["FunctionArn"]
             lambda_client = aws_stack.connect_to_service("lambda")
             lambda_client.get_waiter("function_active_v2").wait(FunctionName=result["FunctionArn"])
+            resources[resource_id]["PhysicalResourceId"] = result["FunctionName"]
 
         return {
             "create": {
@@ -236,13 +232,14 @@ class LambdaEventSourceMapping(GenericBaseModel):
         if attribute_name == "Id":
             return self.props.get("UUID")
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("UUID")
-
     @staticmethod
     def get_deploy_templates():
+        def result_handler(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["UUID"] = result["UUID"]
+            resources[resource_id]["PhysicalResourceId"] = result["UUID"]
+
         return {
-            "create": {"function": "create_event_source_mapping"},
+            "create": {"function": "create_event_source_mapping", "result_handler": result_handler},
             "delete": {"function": "delete_event_source_mapping", "parameters": ["UUID"]},
         }
 
@@ -333,17 +330,18 @@ class LambdaEventInvokeConfig(GenericBaseModel):
         )
         return result
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        props = self.props
-        return "lambdaconfig-%s-%s" % (
-            props.get("FunctionName"),
-            props.get("Qualifier"),
-        )
-
     @staticmethod
     def get_deploy_templates():
+        def result_handler(result, resource_id, resources, resource_type):
+            generated_id = str(uuid.uuid4())
+            resources[resource_id]["Properties"]["Id"] = generated_id
+            resources[resource_id]["PhysicalResourceId"] = generated_id
+
         return {
-            "create": {"function": "put_function_event_invoke_config"},
+            "create": {
+                "function": "put_function_event_invoke_config",
+                "result_handler": result_handler,
+            },
             "delete": {
                 "function": "delete_function_event_invoke_config",
                 "parameters": {
@@ -358,11 +356,6 @@ class LambdaUrl(GenericBaseModel):
     @classmethod
     def cloudformation_type(cls):
         return "AWS::Lambda::Url"
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get(
-            "TargetFunctionArn"
-        )  # TODO: if this isn't an ARN we need to resolve the full ARN here
 
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("lambda")
@@ -386,6 +379,11 @@ class LambdaUrl(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def result_handler(result, resource_id, resources, resource_type):
+            function_arn = result["FunctionArn"]
+            resources[resource_id]["Properties"]["FunctionArn"] = function_arn
+            resources[resource_id]["PhysicalResourceId"] = function_arn
+
         return {
             "create": {
                 "function": "create_function_url_config",
@@ -395,6 +393,7 @@ class LambdaUrl(GenericBaseModel):
                     "FunctionName": "TargetFunctionArn",
                     "AuthType": "AuthType",
                 },
+                "result_handler": result_handler,
             },
             "delete": {
                 "function": "delete_function_url_config",
@@ -417,6 +416,7 @@ class LambdaAlias(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _store_arn(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["Id"] = result["AliasArn"]
             resources[resource_id]["PhysicalResourceId"] = result["AliasArn"]
 
         return {
@@ -446,9 +446,6 @@ class LambdaCodeSigningConfig(GenericBaseModel):
         ]
         return result
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id
-
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "CodeSigningConfigId":
             return self.props["CodeSigningConfigId"]
@@ -458,21 +455,15 @@ class LambdaCodeSigningConfig(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _store_arn(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["CodeSigningConfig"][
-                "CodeSigningConfigArn"
-            ]
-
-        def _arn(params, resources, resource_id, **kwargs):
-            resource = cls(resources[resource_id])
-            return resource.physical_resource_id or resource.get_physical_resource_id()
+            arn = result["CodeSigningConfig"]["CodeSigningConfigArn"]
+            resources[resource_id]["PhysicalResourceId"] = arn
+            resources[resource_id]["Properties"]["CodeSigningConfigArn"] = arn
 
         return {
             "create": {"function": "create_code_signing_config", "result_handler": _store_arn},
             "delete": {
                 "function": "delete_code_signing_config",
-                "parameters": {
-                    "CodeSigningConfigArn": _arn,
-                },
+                "parameters": ["CodeSigningConfigArn"],
             },
         }
 
@@ -482,9 +473,6 @@ class LambdaLayerVersion(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::Lambda::LayerVersion"
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.state.get("LayerVersionArn")
 
     def fetch_state(self, stack_name, resources):
         layer_name = self.props.get("LayerName")
@@ -501,7 +489,12 @@ class LambdaLayerVersion(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        return {"create": {"function": "publish_layer_version"}}
+        def result_handler(result, resource_id, resources, resource_type):
+            phys_id = result["LayerVersionArn"]
+            resources[resource_id]["Properties"]["Id"] = phys_id
+            resources[resource_id]["PhysicalResourceId"] = phys_id
+
+        return {"create": {"function": "publish_layer_version", "result_handler": result_handler}}
 
 
 # TODO: test

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import string
+import uuid
 
 from localstack.aws.connect import connect_to
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
@@ -35,12 +36,6 @@ class LambdaFunction(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         func_name = self.props["FunctionName"]
         return connect_to().awslambda.get_function(FunctionName=func_name)
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        func_name = self.props.get("FunctionName")
-        if attribute == "Arn":
-            return arns.lambda_function_arn(func_name)
-        return func_name
 
     def update_resource(self, new_resource, stack_name, resources):
         props = new_resource["Properties"]
@@ -136,8 +131,12 @@ class LambdaFunction(GenericBaseModel):
         def result_handler(result, resource_id, resources, resource_type):
             """waits for the lambda to be in a "terminal" state, i.e. not pending"""
             resources[resource_id]["Properties"]["Arn"] = result["FunctionArn"]
-            lambda_client = aws_stack.connect_to_service("lambda")
-            lambda_client.get_waiter("function_active_v2").wait(FunctionName=result["FunctionArn"])
+            resources[resource_id]["PhysicalResourceId"] = resources[resource_id]["Properties"][
+                "FunctionName"
+            ]
+            connect_to().awslambda.get_waiter("function_active_v2").wait(
+                FunctionName=result["FunctionArn"]
+            )
 
         return {
             "create": {
@@ -333,17 +332,19 @@ class LambdaEventInvokeConfig(GenericBaseModel):
         )
         return result
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        props = self.props
-        return "lambdaconfig-%s-%s" % (
-            props.get("FunctionName"),
-            props.get("Qualifier"),
-        )
-
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = str(
+                uuid.uuid4()
+            )  # TODO: not actually a UUIDv4
+            # example format: 6403f864-a20b-4373-ac8f-f8d888f6bc0f
+
         return {
-            "create": {"function": "put_function_event_invoke_config"},
+            "create": {
+                "function": "put_function_event_invoke_config",
+                "result_handler": _handle_result,
+            },
             "delete": {
                 "function": "delete_function_event_invoke_config",
                 "parameters": {
@@ -358,11 +359,6 @@ class LambdaUrl(GenericBaseModel):
     @classmethod
     def cloudformation_type(cls):
         return "AWS::Lambda::Url"
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get(
-            "TargetFunctionArn"
-        )  # TODO: if this isn't an ARN we need to resolve the full ARN here
 
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("lambda")
@@ -386,6 +382,11 @@ class LambdaUrl(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["FunctionArn"]
+            resources[resource_id]["Properties"]["FunctionArn"] = result["FunctionArn"]
+            resources[resource_id]["Properties"]["FunctionUrl"] = result["FunctionUrl"]
+
         return {
             "create": {
                 "function": "create_function_url_config",
@@ -395,6 +396,7 @@ class LambdaUrl(GenericBaseModel):
                     "FunctionName": "TargetFunctionArn",
                     "AuthType": "AuthType",
                 },
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_function_url_config",
@@ -446,32 +448,22 @@ class LambdaCodeSigningConfig(GenericBaseModel):
         ]
         return result
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id
-
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "CodeSigningConfigId":
-            return self.props["CodeSigningConfigId"]
-
-        return self.physical_resource_id
-
     @classmethod
     def get_deploy_templates(cls):
         def _store_arn(result, resource_id, resources, resource_type):
             resources[resource_id]["PhysicalResourceId"] = result["CodeSigningConfig"][
                 "CodeSigningConfigArn"
             ]
-
-        def _arn(params, resources, resource_id, **kwargs):
-            resource = cls(resources[resource_id])
-            return resource.physical_resource_id or resource.get_physical_resource_id()
+            resources[resource_id]["Properties"]["CodeSigningConfigArn"] = result[
+                "CodeSigningConfig"
+            ]["CodeSigningConfigArn"]
 
         return {
             "create": {"function": "create_code_signing_config", "result_handler": _store_arn},
             "delete": {
                 "function": "delete_code_signing_config",
                 "parameters": {
-                    "CodeSigningConfigArn": _arn,
+                    "CodeSigningConfigArn": "CodeSigningConfigArn",
                 },
             },
         }

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -236,13 +236,13 @@ class LambdaEventSourceMapping(GenericBaseModel):
         if attribute_name == "Id":
             return self.props.get("UUID")
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("UUID")
-
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["UUID"]
+
         return {
-            "create": {"function": "create_event_source_mapping"},
+            "create": {"function": "create_event_source_mapping", "result_handler": _handle_result},
             "delete": {"function": "delete_event_source_mapping", "parameters": ["UUID"]},
         }
 

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -15,9 +15,6 @@ class CertificateManagerCertificate(GenericBaseModel):
         result = [c for c in result if c["DomainName"] == domain_name]
         return (result or [None])[0]
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("CertificateArn")
-
     @classmethod
     def get_deploy_templates(cls):
         def _create_params(params, *args, **kwargs):
@@ -51,8 +48,15 @@ class CertificateManagerCertificate(GenericBaseModel):
 
             return result
 
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["CertificateArn"]
+
         return {
-            "create": {"function": "request_certificate", "parameters": _create_params},
+            "create": {
+                "function": "request_certificate",
+                "parameters": _create_params,
+                "result_handler": _handle_result,
+            },
             "delete": {
                 "function": "delete_certificate",
                 "parameters": ["CertificateArn"],

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -49,7 +49,10 @@ class CertificateManagerCertificate(GenericBaseModel):
             return result
 
         def _handle_result(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["CertificateArn"]
+            resource = resources[resource_id]
+            resource["Properties"]["CertificateArn"] = resource["PhysicalResourceId"] = result[
+                "CertificateArn"
+            ]
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -22,9 +22,6 @@ class EC2RouteTable(GenericBaseModel):
         result = client.describe_route_tables(RouteTableIds=[self.physical_resource_id])
         return (result["RouteTables"] or [None])[0]
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id or self.props.get("RouteTableId")
-
     @staticmethod
     def get_deploy_templates():
         def _store_id(result, resource_id, resources, resource_type):
@@ -68,14 +65,6 @@ class EC2Route(GenericBaseModel):
                 or r.get("DestinationIpv6CidrBlock") == (dst_cidr6 or "_not_set_")
             ]
             return (route or [None])[0]
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        props = self.props
-        return generate_route_id(
-            props.get("RouteTableId"),
-            props.get("DestinationCidrBlock"),
-            props.get("DestinationIpv6CidrBlock"),
-        )
 
     @staticmethod
     def get_deploy_templates():
@@ -159,11 +148,13 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
                 association = [a for a in associations if a.get("SubnetId") == subnet_id]
             return (association or [None])[0]
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("RouteTableAssociationId")
-
     @staticmethod
     def get_deploy_templates():
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["AssociationId"]
+
         return {
             "create": {
                 "function": "associate_route_table",
@@ -172,6 +163,7 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
                     "RouteTableId": "RouteTableId",
                     "SubnetId": "SubnetId",
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "disassociate_route_table",
@@ -203,14 +195,6 @@ class EC2VPCGatewayAttachment(GenericBaseModel):
         if result:
             return gateway
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        props = self.props
-        gw_id = props.get("VpnGatewayId") or props.get("InternetGatewayId")
-        attachment = (props.get("Attachments") or props.get("VpcAttachments") or [{}])[0]
-        if attachment:
-            result = "%s-%s" % (gw_id, attachment.get("VpcId"))
-            return result
-
     @classmethod
     def get_deploy_templates(cls):
         def _attach_gateway(resource_id, resources, *args, **kwargs):
@@ -221,11 +205,21 @@ class EC2VPCGatewayAttachment(GenericBaseModel):
             vpngw_id = props.get("VpnGatewayId")
             vpc_id = props.get("VpcId")
             if igw_id:
-                client.attach_internet_gateway(VpcId=vpc_id, InternetGatewayId=igw_id)
+                return client.attach_internet_gateway(VpcId=vpc_id, InternetGatewayId=igw_id)
             elif vpngw_id:
-                client.attach_vpn_gateway(VpcId=vpc_id, VpnGatewayId=vpngw_id)
+                return client.attach_vpn_gateway(VpcId=vpc_id, VpnGatewayId=vpngw_id)
 
-        return {"create": {"function": _attach_gateway}}
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resource = resources[resource_id]
+            props = resource["Properties"]
+            gw_id = props.get("VpnGatewayId") or props.get("InternetGatewayId")
+            resource["PhysicalResourceId"] = f"{gw_id}-{props['VpcId']}"
+
+        return {
+            "create": {"function": _attach_gateway, "result_handler": _set_physical_resource_id}
+        }
 
 
 class SecurityGroup(GenericBaseModel):
@@ -250,17 +244,6 @@ class SecurityGroup(GenericBaseModel):
         if attribute_name == "GroupId":
             return self.props.get("GroupId")
         return super(SecurityGroup, self).get_cfn_attribute(attribute_name)
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        if self.physical_resource_id:
-            return self.physical_resource_id
-        # see docs: "[...] Ref returns the resource ID. For SGs without a VPC, Ref returns the resource name."
-        props = self.props
-        if not props.get("GroupId"):
-            return
-        if not props.get("VpcId"):
-            return props.get("GroupName")
-        return props.get("GroupId")
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
@@ -309,9 +292,6 @@ class EC2Subnet(GenericBaseModel):
         ]
         subnets = client.describe_subnets(Filters=filters)["Subnets"]
         return (subnets or [None])[0]
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("SubnetId")
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "SubnetId":
@@ -468,9 +448,6 @@ class EC2VPC(GenericBaseModel):
             ],
         }
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id or self.props.get("VpcId")
-
 
 class EC2NatGateway(GenericBaseModel):
     @staticmethod
@@ -495,6 +472,11 @@ class EC2NatGateway(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["NatGateway"]["NatGatewayId"]
+
         return {
             "create": {
                 "function": "create_nat_gateway",
@@ -503,15 +485,13 @@ class EC2NatGateway(GenericBaseModel):
                     "AllocationId": "AllocationId",
                     "TagSpecifications": get_tags_param("natgateway"),
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "delete_nat_gateway",
                 "parameters": ["NatGatewayId"],
             },
         }
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id or self.props.get("NatGatewayId")
 
 
 class EC2Instance(GenericBaseModel):
@@ -548,9 +528,6 @@ class EC2Instance(GenericBaseModel):
         reservation = (resp.get("Reservations") or [{}])[0]
         result = (reservation.get("Instances") or [None])[0]
         return result
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.physical_resource_id or self.props.get("InstanceId")
 
     @staticmethod
     def add_defaults(resource, stack_name: str):

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -60,9 +60,14 @@ class ECRRepository(GenericBaseModel):
             if default_repos_per_stack.get(stack_name):
                 del default_repos_per_stack[stack_name]
 
+        def _set_physical_resource_id(result, resource_id, resources, resource_type):
+            repo_name = resources[resource_id]["Properties"]["RepositoryName"]
+            resources[resource_id]["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
+
         return {
             "create": {
                 "function": _create_repo,
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": _delete_repo,

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -28,10 +28,6 @@ class ECRRepository(GenericBaseModel):
             return self.props.get("repositoryUri")
         return super(ECRRepository, self).get_cfn_attribute(attribute_name)
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        repo_name = self.props.get("RepositoryName")
-        return arns.get_ecr_repository_arn(repo_name)
-
     def fetch_state(self, stack_name, resources):
         repo_name = default_repos_per_stack.get(stack_name)
         if repo_name:
@@ -61,8 +57,13 @@ class ECRRepository(GenericBaseModel):
                 del default_repos_per_stack[stack_name]
 
         def _set_physical_resource_id(result, resource_id, resources, resource_type):
-            repo_name = resources[resource_id]["Properties"]["RepositoryName"]
-            resources[resource_id]["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
+            resource = resources[resource_id]
+            repo_name = resource["Properties"]["RepositoryName"]
+            resource["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
+
+            # add in some properties required for GetAtt and Ref
+            resource["Properties"]["repositoryArn"] = arns.get_ecr_repository_arn(repo_name)
+            resource["Properties"]["repositoryUri"] = "http://localhost:4566"
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -8,9 +8,6 @@ class KinesisStreamConsumer(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Kinesis::StreamConsumer"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("ConsumerARN")
-
     def fetch_state(self, stack_name, resources):
         props = self.props
         stream_arn = props["StreamARN"]
@@ -20,8 +17,17 @@ class KinesisStreamConsumer(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result, resource_id, resources, resource_type):
+            resource = resources[resource_id]
+            resource["PhysicalResourceId"] = result["Consumer"]["ConsumerARN"]
+            resource["Properties"]["ConsumerARN"] = result["Consumer"]["ConsumerARN"]
+            resource["Properties"]["ConsumerCreationTimestamp"] = result["Consumer"][
+                "ConsumerCreationTimestamp"
+            ]
+            resource["Properties"]["ConsumerStatus"] = result["Consumer"]["ConsumerStatus"]
+
         return {
-            "create": {"function": "register_stream_consumer"},
+            "create": {"function": "register_stream_consumer", "result_handler": _handle_result},
             "delete": {"function": "deregister_stream_consumer"},
         }
 

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -37,11 +37,6 @@ class KinesisStream(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Kinesis::Stream"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        if attribute == "Arn":
-            return self.props.get("Arn")
-        return self.physical_resource_id
-
     def fetch_state(self, stack_name, resources):
         stream_name = self.props["Name"]
         result = aws_stack.connect_to_service("kinesis").describe_stream(StreamName=stream_name)

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -57,9 +57,6 @@ class LogsLogStream(GenericBaseModel):
     def get_cfn_attribute(self, attribute_name):
         return super(LogsLogStream, self).get_cfn_attribute(attribute_name)
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("LogStreamName")
-
     def fetch_state(self, stack_name, resources):
         group_name = self.props.get("LogGroupName")
         stream_name = self.props.get("LogStreamName")
@@ -79,10 +76,17 @@ class LogsLogStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, stack_name: str
+        ):
+            resource = resources[resource_id]
+            resource["PhysicalResourceId"] = resource["Properties"]["LogStreamName"]
+
         return {
             "create": {
                 "function": "create_log_stream",
                 "parameters": {"logGroupName": "LogGroupName", "logStreamName": "LogStreamName"},
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "delete_log_stream",

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -31,7 +31,7 @@ class LogsLogGroup(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, stack_name: str
+            result: dict, resource_id: str, resources: dict, resource_type: str
         ):
             resource = resources[resource_id]
             resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]
@@ -77,7 +77,7 @@ class LogsLogStream(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, stack_name: str
+            result: dict, resource_id: str, resources: dict, resource_type: str
         ):
             resource = resources[resource_id]
             resource["PhysicalResourceId"] = resource["Properties"]["LogStreamName"]
@@ -112,7 +112,7 @@ class LogsSubscriptionFilter(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, stack_name: str
+            result: dict, resource_id: str, resources: dict, resource_type: str
         ):
             resource = resources[resource_id]
             resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -100,9 +100,6 @@ class LogsSubscriptionFilter(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Logs::SubscriptionFilter"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("LogGroupName")
-
     def fetch_state(self, stack_name, resources):
         props = self.props
         group_name = props.get("LogGroupName")
@@ -114,6 +111,12 @@ class LogsSubscriptionFilter(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, stack_name: str
+        ):
+            resource = resources[resource_id]
+            resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]
+
         return {
             "create": {
                 "function": "put_subscription_filter",
@@ -123,6 +126,7 @@ class LogsSubscriptionFilter(GenericBaseModel):
                     "filterPattern": "FilterPattern",
                     "destinationArn": "DestinationArn",
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "delete_subscription_filter",

--- a/localstack/services/cloudformation/models/redshift.py
+++ b/localstack/services/cloudformation/models/redshift.py
@@ -8,9 +8,6 @@ class RedshiftCluster(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Redshift::Cluster"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("ClusterIdentifier")
-
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("redshift")
         cluster_id = self.props.get("ClusterIdentifier")
@@ -27,4 +24,7 @@ class RedshiftCluster(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        return {"create": {"function": "create_cluster"}}
+        def _handle_result(result, resource_id, resources, resource_type):
+            resources[resource_id]["PhysicalResourceId"] = result["Cluster"]["ClusterIdentifier"]
+
+        return {"create": {"function": "create_cluster", "result_handler": _handle_result}}

--- a/localstack/services/cloudformation/models/resourcegroups.py
+++ b/localstack/services/cloudformation/models/resourcegroups.py
@@ -18,11 +18,13 @@ class ResourceGroupsGroup(GenericBaseModel):
         if attribute_name == "Arn":
             return self.props.get("GroupArn")
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("Name")
-
     @classmethod
     def get_deploy_templates(cls):
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["Group"]["Name"]
+
         return {
             "create": {
                 "function": "create_group",
@@ -33,6 +35,7 @@ class ResourceGroupsGroup(GenericBaseModel):
                     "Configuration": "Configuration",
                     "Tags": params_list_to_dict("Tags"),
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {"function": "delete_group", "parameters": {"Group": "Name"}},
         }

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 from botocore.exceptions import ClientError
@@ -22,16 +21,20 @@ class S3BucketPolicy(GenericBaseModel):
     def cloudformation_type():
         return "AWS::S3::BucketPolicy"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        policy = self.props.get("Policy")
-        return policy and md5(canonical_json(json.loads(policy)))
-
     def fetch_state(self, stack_name, resources):
         bucket_name = self.props.get("Bucket") or self.logical_resource_id
         return aws_stack.connect_to_service("s3").get_bucket_policy(Bucket=bucket_name)
 
     @staticmethod
     def get_deploy_templates():
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resource = resources[resource_id]
+            resource["PhysicalResourceId"] = md5(
+                canonical_json(resource["Properties"]["PolicyDocument"])
+            )
+
         return {
             "create": {
                 "function": "put_bucket_policy",
@@ -39,6 +42,7 @@ class S3BucketPolicy(GenericBaseModel):
                     dump_json_params(None, "PolicyDocument"),
                     {"PolicyDocument": "Policy", "Bucket": "Bucket"},
                 ),
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {"function": "delete_bucket_policy", "parameters": {"Bucket": "Bucket"}},
         }

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -16,7 +16,11 @@ class SecretsManagerSecret(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SecretsManager::Secret"
 
-    def get_cfn_attribute(self, attribute_name):
+    def get_cfn_attribute(self, attribute_name: str):
+        match attribute_name:
+            case "Id":
+                return self.properties["Name"]
+
         return super(SecretsManagerSecret, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
@@ -125,9 +129,6 @@ class SecretsManagerSecretTargetAttachment(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SecretsManager::SecretTargetAttachment"
 
-    def get_physical_resource_id(self, attribute, **kwargs):
-        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
-
     def fetch_state(self, stack_name, resources):
         # TODO implement?
         return {"state": "dummy"}
@@ -138,9 +139,6 @@ class SecretsManagerRotationSchedule(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SecretsManager::RotationSchedule"
 
-    def get_physical_resource_id(self, attribute, **kwargs):
-        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
-
     def fetch_state(self, stack_name, resources):
         # TODO implement?
         return {"state": "dummy"}
@@ -150,9 +148,6 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::SecretsManager::ResourcePolicy"
-
-    def get_physical_resource_id(self, attribute, **kwargs):
-        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         secret_id = self.props.get("SecretId")
@@ -170,8 +165,20 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
                 "BlockPublicPolicy": params.get("BlockPublicPolicy"),
             }
 
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resource = resources[resource_id]
+            resource["PhysicalResourceId"] = arns.secretsmanager_secret_arn(
+                resource["Properties"]["Name"]
+            )
+
         return {
-            "create": {"function": "put_resource_policy", "parameters": create_params},
+            "create": {
+                "function": "put_resource_policy",
+                "parameters": create_params,
+                "result_handler": _set_physical_resource_id,
+            },
             "delete": {
                 "function": "delete_resource_policy",
                 "parameters": {"SecretId": "SecretId"},

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -16,9 +16,6 @@ class SecretsManagerSecret(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SecretsManager::Secret"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("ARN")
-
     def get_cfn_attribute(self, attribute_name):
         return super(SecretsManagerSecret, self).get_cfn_attribute(attribute_name)
 
@@ -108,10 +105,16 @@ class SecretsManagerSecret(GenericBaseModel):
                 result["SecretString"] = secret_value
             return result
 
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["ARN"]
+
         return {
             "create": {
                 "function": "create_secret",
                 "parameters": _create_params,
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {"function": "delete_secret", "parameters": {"SecretId": "Name"}},
         }

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -7,7 +7,7 @@ from localstack.services.cloudformation.deployment_utils import (
     is_none_or_empty_value,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import aws_stack
 from localstack.utils.common import canonicalize_bool_to_str
 
 
@@ -15,9 +15,6 @@ class SNSTopic(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::SNS::Topic"
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return arns.sns_topic_arn(self.props["TopicName"])
 
     def fetch_state(self, stack_name, resources):
         topic_name = self.props["TopicName"]
@@ -61,7 +58,7 @@ class SNSTopic(GenericBaseModel):
 
         def _topic_arn(params, resources, resource_id, **kwargs):
             resource = cls(resources[resource_id])
-            return resource.physical_resource_id or resource.get_physical_resource_id()
+            return resource.physical_resource_id
 
         def _list_all_topics(sns_client):
             rs = sns_client.list_topics()
@@ -118,9 +115,6 @@ class SNSSubscription(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SNS::Subscription"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("SubscriptionArn")
-
     def fetch_state(self, stack_name, resources):
         props = self.props
         topic_arn = props.get("TopicArn")
@@ -154,6 +148,11 @@ class SNSSubscription(GenericBaseModel):
             result = {a: attr_val(params[a]) for a in attrs if a in params}
             return result
 
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["SubscriptionArn"]
+
         return {
             "create": {
                 "function": "subscribe",
@@ -163,6 +162,7 @@ class SNSSubscription(GenericBaseModel):
                     "Endpoint": "Endpoint",
                     "Attributes": sns_subscription_params,
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "unsubscribe",

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -8,10 +8,7 @@ from localstack.services.cloudformation.deployment_utils import (
     params_list_to_dict,
     params_select_attributes,
 )
-from localstack.services.cloudformation.service_models import (
-    DependencyNotYetSatisfied,
-    GenericBaseModel,
-)
+from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import short_uid
 
@@ -70,19 +67,10 @@ class SQSQueue(GenericBaseModel):
     def cloudformation_type(cls):
         return "AWS::SQS::Queue"
 
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        queue_url = None
-        props = self.props
-        try:
-            queue_url = arns.get_sqs_queue_url(props.get("QueueName"))
-        except Exception as e:
-            if "NonExistentQueue" in str(e):
-                raise DependencyNotYetSatisfied(
-                    resource_ids=self.logical_resource_id, message="Unable to get queue: %s" % e
-                )
-        if attribute == "Arn":
-            return arns.sqs_queue_arn(props.get("QueueName"))
-        return queue_url
+    def get_cfn_attribute(self, attribute_name):
+        if attribute_name == "Arn":
+            return arns.sqs_queue_arn(self.properties["QueueName"])
+        return super().get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
         queue_name = self.props["QueueName"]
@@ -125,6 +113,11 @@ class SQSQueue(GenericBaseModel):
                 return queue_url
             return arns.sqs_queue_url_for_arn(props["QueueArn"])
 
+        def _set_physical_resource_id(
+            result: dict, resource_id: str, resources: dict, resource_type: str
+        ):
+            resources[resource_id]["PhysicalResourceId"] = result["QueueUrl"]
+
         return {
             "create": {
                 "function": "create_queue",
@@ -142,6 +135,7 @@ class SQSQueue(GenericBaseModel):
                     ),
                     "tags": params_list_to_dict("Tags"),
                 },
+                "result_handler": _set_physical_resource_id,
             },
             "delete": {
                 "function": "delete_queue",

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -31,7 +31,6 @@ class QueuePolicy(GenericBaseModel):
             resource = cls(resources[resource_id])
             props = resource.props
 
-            # TODO: generalize/support in get_physical_resource_id
             resources[resource_id]["PhysicalResourceId"] = "%s-%s-%s" % (
                 stack_name,
                 resource_id,

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -26,6 +26,7 @@ class SFNActivity(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _store_arn(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["Arn"] = result["activityArn"]
             resources[resource_id]["PhysicalResourceId"] = result["activityArn"]
 
         return {
@@ -89,6 +90,10 @@ class SFNStateMachine(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
+        def result_handler(result, resource_id, resources, resource_type):
+            resources[resource_id]["Properties"]["Arn"] = result["stateMachineArn"]
+            resources[resource_id]["PhysicalResourceId"] = result["stateMachineArn"]
+
         def _create_params(params, **kwargs):
             def _get_definition(params):
                 # TODO: support "Definition" parameter
@@ -118,6 +123,7 @@ class SFNStateMachine(GenericBaseModel):
             "create": {
                 "function": "create_state_machine",
                 "parameters": _create_params,
+                "result_handler": result_handler,
             },
             "delete": {
                 "function": "delete_state_machine",

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -47,15 +47,12 @@ class SFNStateMachine(GenericBaseModel):
     def cloudformation_type():
         return "AWS::StepFunctions::StateMachine"
 
-    def get_cfn_attribute(self, attribute_name):
+    def get_cfn_attribute(self, attribute_name: str):
         if attribute_name == "Arn":
-            return self.props.get("stateMachineArn")
+            return self.props.get("Arn")
         if attribute_name == "Name":
             return self.props.get("StateMachineName")
         return super(SFNStateMachine, self).get_cfn_attribute(attribute_name)
-
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("stateMachineArn")
 
     def fetch_state(self, stack_name, resources):
         sm_name = self.props.get("StateMachineName") or self.logical_resource_id

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -52,7 +52,7 @@ class GenericBaseModel:
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         """Determine the physical resource ID (Ref) of this resource (to be overwritten by subclasses)"""
-        return None
+        return self.physical_resource_id
 
     def fetch_state(self, stack_name, resources):
         """Fetch the latest deployment state of this resource, or return None if not currently deployed (NOTE: THIS IS NOT ALWAYS TRUE)."""

--- a/tests/integration/cloudformation/resources/test_acm.py
+++ b/tests/integration/cloudformation/resources/test_acm.py
@@ -12,6 +12,9 @@ Resources:
         - DomainName: "{{domain}}"
           HostedZoneId: zone123  # using dummy ID for now
       ValidationMethod: DNS
+Outputs:
+  Cert:
+    Value: !Ref cert1
 """
 
 

--- a/tests/integration/cloudformation/resources/test_cloudformation.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_cloudformation.snapshot.json
@@ -12,5 +12,13 @@
         "WaitConditionName": "arn:aws:cloudformation:<region>:111111111111:stack/stack-6cc1b50e/f9764ac0-f563-11ed-82f7-061d4a7b8a1e/WaitHandle"
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_cloudformation.py::test_create_macro": {
+    "recorded-date": "09-06-2023, 14:30:11",
+    "recorded-content": {
+      "stack-outputs": {
+        "MacroRef": "<macro-name>"
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/resources/test_legacy.py
+++ b/tests/integration/cloudformation/resources/test_legacy.py
@@ -608,6 +608,9 @@ class TestCloudFormation:
         topic_arns = [t["TopicArn"] for t in aws_client.sns.list_topics()["Topics"]]
         assert topic_arn not in topic_arns
 
+        certs = aws_client.acm.list_certificates()["CertificateSummaryList"]
+        assert len([c for c in certs if c.get("DomainName") == "example.com"]) == 0
+
     # TODO: refactor
     @pytest.mark.xfail(reason="fails due to / depending on other tests")
     def test_deploy_stack_with_sub_select_and_sub_getaz(

--- a/tests/integration/cloudformation/resources/test_redshift.py
+++ b/tests/integration/cloudformation/resources/test_redshift.py
@@ -1,0 +1,10 @@
+import os
+
+
+def test_redshift_cluster(deploy_cfn_template, aws_client):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(os.path.dirname(__file__), "../../templates/cfn_redshift.yaml")
+    )
+
+    # very basic test to check the cluster deploys
+    assert stack.outputs["ClusterRef"] is not None

--- a/tests/integration/cloudformation/resources/test_secretsmanager.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_secretsmanager.snapshot.json
@@ -1,0 +1,11 @@
+{
+  "tests/integration/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy": {
+    "recorded-date": "09-06-2023, 14:06:25",
+    "recorded-content": {
+      "outputs": {
+        "SecretId": "arn:aws:secretsmanager:<region>:111111111111:secret:MySecret-2SBOcB3zjIU5-wS422S",
+        "SecretPolicyArn": "arn:aws:secretsmanager:<region>:111111111111:secret:MySecret-2SBOcB3zjIU5-wS422S"
+      }
+    }
+  }
+}

--- a/tests/integration/templates/cfn_redshift.yaml
+++ b/tests/integration/templates/cfn_redshift.yaml
@@ -1,0 +1,20 @@
+# awslocal redshift create-cluster
+# --cluster-identifier mysamplecluster
+# --master-username masteruser
+# --master-user-password secret1
+# --node-type ds2.xlarge
+# --cluster-type single-node
+Resources:
+  Cluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterIdentifier: mysamplecluster
+      ClusterType: single-node
+      DBName: db
+      MasterUserPassword: masterpassword
+      MasterUsername: masteruser
+      NodeType: dx2.xlarge
+
+Outputs:
+  ClusterRef:
+    Value: !Ref Cluster


### PR DESCRIPTION
Start to remove the physical resource id from `GenericBaseModel` instances.

## Motivation

This _property_ should not need to be a function - it's known after creation. It's also a discrepancy with the CFn extension API, and as part of the migration towards this framework, we should remove this property.

We allow graceful fallback of the base model function so the template deployer does not need updating at this stage.

This PR starts the process, by selecting some of the "easy" services, i.e. the services where `get_physical_resource_id` is not supplied any arguments.

* [x] certificate manager (easy)
* [x] ecr (easy)
* [x] events (easy)
* [x] redshift (easy)
* [x] sns (easy)
* [x] stepfunctions (easy)
* [x] api gateway (easy)
* [x] cdk (easy)
* [x] cloudformation (easy)
* [x] cloudwatch (@dominikschubert)
* [x] dynamodb
* [x] ec2 (easy)
* [x] iam
* [x] kinesis (@dominikschubert)
* [x] kinesisfirehose (@dominikschubert)
* [x] elasticsearch (@dominikschubert)
* [x] lambda (@dominikschubert)
* [x] logs (@simonrw)
* [x] opensearch (@simonrw)
* [x] resourcegroups (@simonrw)
* [x] route53 (@simonrw)
* [x] s3 (@simonrw)
* [x] secretsmanager (easy)
* [x] sqs (@simonrw)
* [x] ssm (easy)

