### PR TITLE
add config to disable cloudwatch metrics for SQS

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -783,6 +783,14 @@ SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "off"
 # Disable the check for MaxNumberOfMessage in SQS ReceiveMessage
 SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT = is_env_true("SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT")
 
+# Disable cloudwatch metrics for SQS
+SQS_DISABLE_CLOUDWATCH_METRICS = is_env_true("SQS_DISABLE_CLOUDWATCH_METRICS")
+
+# Interval for reporting "approximate" metrics to cloudwatch, default is 60 seconds
+SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL = int(
+    os.environ.get("SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL") or 60
+)
+
 # DEPRECATED: only applies to old lambda provider
 # Endpoint host under which LocalStack APIs are accessible from Lambda Docker containers.
 HOSTNAME_FROM_LAMBDA = os.environ.get("HOSTNAME_FROM_LAMBDA", "").strip()
@@ -1115,6 +1123,8 @@ CONFIG_ENV_VARS = [
     "SQS_DELAY_RECENTLY_DELETED",
     "SQS_ENDPOINT_STRATEGY",
     "SQS_PORT_EXTERNAL",
+    "SQS_DISABLE_CLOUDWATCH_METRICS",
+    "SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL",
     "STEPFUNCTIONS_LAMBDA_ENDPOINT",
     "SYNCHRONOUS_KINESIS_EVENTS",
     "SYNCHRONOUS_SNS_EVENTS",


### PR DESCRIPTION
Following up on issue #8142 where memory leaks have been reported when LocalStack runs for a longer period (hours/days).

The issue seems to be related to a PR #7182, resulting from a feature request. 
With the PR we also added reporting of `Approximate*` messages to provide AWS parity. On LocalStack those approximate messages are reported periodically, e.g. every minute.
This leads to more metrics being added to CloudWatch, even without any interaction.

We now added two config flags to prevent related issues:
* `SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL` which allows to configure the interval of reporting of the `Approximate*` messages
* `SQS_DISABLE_CLOUDWATCH_METRICS` to disable metrics reporting completely for SQS