### PR TITLE
Migrate s3 notifications to new clients, send test events

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -274,6 +274,8 @@ class LambdaService:
             payload = b"{}"
         if invocation_type is None:
             invocation_type = "RequestResponse"
+        if invocation_type == InvocationType.DryRun:
+            return None
         # TODO payload verification  An error occurred (InvalidRequestContentException) when calling the Invoke operation: Could not parse request body into json: Could not parse payload into json: Unexpected character (''' (code 39)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
         #  at [Source: (byte[])"'test'"; line: 1, column: 2]
 

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1229,9 +1229,12 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             request_id=context.request_id,
             payload=payload.read() if payload else None,
         )
-        if invocation_type == "Event":
+        if invocation_type == InvocationType.Event:
             # This happens when invocation type is event
             return InvocationResponse(StatusCode=202)
+        if invocation_type == InvocationType.DryRun:
+            # This happens when invocation type is dryrun
+            return InvocationResponse(StatusCode=204)
         try:
             invocation_result = result.result()
         except Exception as e:

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -28,6 +28,7 @@ from localstack.aws.api.s3 import (
     TopicArn,
     TopicConfiguration,
 )
+from localstack.aws.connect import connect_to
 from localstack.config import DEFAULT_REGION
 from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.utils import (
@@ -36,7 +37,8 @@ from localstack.services.s3.utils import (
     get_key_from_moto_bucket,
 )
 from localstack.utils.aws import arns, aws_stack
-from localstack.utils.aws.arns import ArnData, parse_arn
+from localstack.utils.aws.arns import ArnData, parse_arn, s3_bucket_arn
+from localstack.utils.aws.client_types import ServicePrincipal
 from localstack.utils.strings import short_uid
 from localstack.utils.time import timestamp_millis
 
@@ -149,6 +151,14 @@ class S3EventNotificationContext:
         )
 
 
+@dataclass
+class BucketVerificationContext:
+    request_id: str
+    bucket_name: str
+    configuration: Dict
+    skip_destination_validation: bool
+
+
 def _matching_event(events: EventList, event_name: str) -> bool:
     """
     See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
@@ -213,15 +223,26 @@ class BaseNotifier:
         raise NotImplementedError
 
     def validate_configuration_for_notifier(
-        self, configurations: List[Dict], skip_destination_validation=False
+        self,
+        configurations: List[Dict],
+        skip_destination_validation: bool,
+        context: RequestContext,
+        bucket_name: str,
     ):
         for configuration in configurations:
-            self._validate_notification(configuration, skip_destination_validation)
+            self._validate_notification(
+                BucketVerificationContext(
+                    configuration=configuration,
+                    bucket_name=bucket_name,
+                    request_id=context.request_id,
+                    skip_destination_validation=skip_destination_validation,
+                )
+            )
 
-    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+    def _verify_target(self, target_arn: str, verification_ctx: BucketVerificationContext) -> None:
         raise NotImplementedError
 
-    def _validate_notification(self, configuration: Dict, skip_destination_validation=False):
+    def _validate_notification(self, verification_ctx: BucketVerificationContext):
         """
         Validates the notification configuration
         - setting default ID if not provided
@@ -234,7 +255,7 @@ class BaseNotifier:
         :raises InvalidArgument if the rule is not valid, infos in ArgumentName and ArgumentValue members
         :return:
         """
-
+        configuration = verification_ctx.configuration
         # id's can be set the request, but need to be auto-generated if they are not provided
         if not configuration.get("Id"):
             configuration["Id"] = short_uid()
@@ -243,11 +264,10 @@ class BaseNotifier:
 
         if not arn.startswith(f"arn:aws:{self.service_name}:"):
             raise _create_invalid_argument_exc(
-                "The ARN is not well formed", name=argument_name, value=arn
+                "The ARN could not be parsed", name=argument_name, value=arn
             )
-        if not skip_destination_validation:
-            arn_data = parse_arn(arn)
-            self._verify_target_exists(arn, arn_data)
+        if not verification_ctx.skip_destination_validation:
+            self._verify_target(arn, verification_ctx)
 
         if filter_rules := configuration.get("Filter", {}).get("Key", {}).get("FilterRules"):
             for rule in filter_rules:
@@ -262,6 +282,17 @@ class BaseNotifier:
                     raise _create_invalid_argument_exc(
                         "filter value cannot be empty", rule["Name"], rule["Value"]
                     )
+
+    @staticmethod
+    def _get_test_payload(verification_ctx: BucketVerificationContext):
+        return {
+            "Service": "Amazon S3",
+            "Event": "s3:TestEvent",
+            "Time": timestamp_millis(),
+            "Bucket": verification_ctx.bucket_name,
+            "RequestId": verification_ctx.request_id,
+            "HostId": "eftixk72aD6Ap51TnqcoF8eFidJG9Z/2",
+        }
 
     @staticmethod
     def _get_event_payload(
@@ -321,18 +352,39 @@ class SqsNotifier(BaseNotifier):
     def _get_arn_value_and_name(queue_configuration: QueueConfiguration) -> Tuple[QueueArn, str]:
         return queue_configuration.get("QueueArn", ""), "QueueArn"
 
-    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
-        client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
+    def _verify_target(self, target_arn: str, verification_ctx: BucketVerificationContext) -> None:
+        arn_data = parse_arn(target_arn)
+        sqs_client = connect_to(region_name=arn_data["region"]).sqs
         try:
-            client.get_queue_url(
+            queue_url = sqs_client.get_queue_url(
                 QueueName=arn_data["resource"], QueueOwnerAWSAccountId=arn_data["account"]
-            )
+            )["QueueUrl"]
         except ClientError:
-            LOG.exception("Could not validate the notification destination %s", arn)
+            LOG.exception("Could not validate the notification destination %s", target_arn)
             raise _create_invalid_argument_exc(
                 "Unable to validate the following destination configurations",
-                name=arn,
+                name=target_arn,
                 value="The destination queue does not exist",
+            )
+        # send test event
+        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types
+        sqs_client = sqs_client.request_metadata(
+            source_arn=s3_bucket_arn(verification_ctx.bucket_name),
+            service_principal=ServicePrincipal.s3,
+        )
+        test_payload = self._get_test_payload(verification_ctx)
+        try:
+            sqs_client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(test_payload))
+        except Exception:
+            LOG.error(
+                'Unable to send test notification for S3 bucket "%s" to SQS queue "%s"',
+                verification_ctx.bucket_name,
+                target_arn,
+            )
+            raise _create_invalid_argument_exc(
+                "Unable to validate the following destination configurations",
+                name=target_arn,
+                value="Permissions on the destination queue do not allow S3 to publish notifications from this bucket",
             )
 
     def notify(self, ctx: S3EventNotificationContext, config: QueueConfiguration):
@@ -341,7 +393,10 @@ class SqsNotifier(BaseNotifier):
         queue_arn = config["QueueArn"]
 
         parsed_arn = parse_arn(queue_arn)
-        sqs_client = aws_stack.connect_to_service("sqs", region_name=parsed_arn["region"])
+        region = parsed_arn["region"]
+        sqs_client = connect_to(region_name=region).sqs.request_metadata(
+            source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
+        )
         try:
             queue_url = arns.sqs_queue_url_for_arn(queue_arn)
             system_attributes = {}
@@ -370,15 +425,39 @@ class SnsNotifier(BaseNotifier):
     def _get_arn_value_and_name(topic_configuration: TopicConfiguration) -> [TopicArn, str]:
         return topic_configuration.get("TopicArn", ""), "TopicArn"
 
-    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
-        client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
+    def _verify_target(self, target_arn: str, verification_ctx: BucketVerificationContext) -> None:
+        arn_data = parse_arn(target_arn)
+        sns_client = connect_to(region_name=arn_data["region"]).sns
         try:
-            client.get_topic_attributes(TopicArn=arn)
+            sns_client.get_topic_attributes(TopicArn=target_arn)
         except ClientError:
             raise _create_invalid_argument_exc(
                 "Unable to validate the following destination configurations",
-                name=arn,
+                name=target_arn,
                 value="The destination topic does not exist",
+            )
+
+        sns_client = sns_client.request_metadata(
+            source_arn=s3_bucket_arn(verification_ctx.bucket_name),
+            service_principal=ServicePrincipal.s3,
+        )
+        test_payload = self._get_test_payload(verification_ctx)
+        try:
+            sns_client.publish(
+                TopicArn=target_arn,
+                Message=json.dumps(test_payload),
+                Subject="Amazon S3 Notification",
+            )
+        except Exception:
+            LOG.error(
+                'Unable to send test notification for S3 bucket "%s" to SNS topic "%s"',
+                verification_ctx.bucket_name,
+                target_arn,
+            )
+            raise _create_invalid_argument_exc(
+                "Unable to validate the following destination configurations",
+                name=target_arn,
+                value="Permissions on the destination topic do not allow S3 to publish notifications from this bucket",
             )
 
     def notify(self, ctx: S3EventNotificationContext, config: TopicConfiguration):
@@ -394,7 +473,9 @@ class SnsNotifier(BaseNotifier):
         topic_arn = config["TopicArn"]
 
         region_name = arns.extract_region_from_arn(topic_arn)
-        sns_client = aws_stack.connect_to_service("sns", region_name=region_name)
+        sns_client = connect_to(region_name=region_name).sns.request_metadata(
+            source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
+        )
         try:
             sns_client.publish(
                 TopicArn=topic_arn,
@@ -418,14 +499,14 @@ class LambdaNotifier(BaseNotifier):
     ) -> Tuple[LambdaFunctionArn, str]:
         return lambda_configuration.get("LambdaFunctionArn", ""), "LambdaFunctionArn"
 
-    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+    def _verify_target(self, target_arn: str, arn_data: ArnData) -> None:
         client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
         try:
             client.get_function(FunctionName=arn_data["resource"])
         except ClientError:
             raise _create_invalid_argument_exc(
                 "Unable to validate the following destination configurations",
-                name=arn,
+                name=target_arn,
                 value="The destination Lambda does not exist",
             )
 
@@ -519,12 +600,16 @@ class EventBridgeNotifier(BaseNotifier):
         return True
 
     def validate_configuration_for_notifier(
-        self, configurations: List[Dict], skip_destination_validation=False
+        self,
+        configurations: List[Dict],
+        skip_destination_validation: bool,
+        context: RequestContext,
+        bucket_name: str,
     ):
         # There are no configuration for EventBridge, simply passing an empty dict will enable notifications
         return
 
-    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+    def _verify_target(self, target_arn: str, arn_data: ArnData) -> None:
         # There are no target for EventBridge
         return
 
@@ -571,9 +656,11 @@ class NotificationDispatcher:
     def verify_configuration(
         self,
         notification_configurations: NotificationConfiguration,
-        skip_destination_validation=False,
+        skip_destination_validation,
+        context: RequestContext,
+        bucket_name: str,
     ):
         for notifier_type, notification_configuration in notification_configurations.items():
             self.notifiers[notifier_type].validate_configuration_for_notifier(
-                notification_configuration, skip_destination_validation
+                notification_configuration, skip_destination_validation, context, bucket_name
             )

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -228,9 +228,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self,
         notification_configuration: NotificationConfiguration,
         skip_destination_validation: SkipValidation,
+        context: RequestContext,
+        bucket_name: str,
     ):
         self._notification_dispatcher.verify_configuration(
-            notification_configuration, skip_destination_validation
+            notification_configuration, skip_destination_validation, context, bucket_name
         )
 
     @handler("CreateBucket", expand=False)
@@ -971,7 +973,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # check if the bucket exists
         get_bucket_from_moto(get_moto_s3_backend(context), bucket=bucket)
         self._verify_notification_configuration(
-            notification_configuration, skip_destination_validation
+            notification_configuration, skip_destination_validation, context, bucket
         )
         self.get_store().bucket_notification_configs[bucket] = notification_configuration
 

--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -290,7 +290,7 @@ def ssm_parameter_arn(param_name: str, account_id: str = None, region_name: str 
 
 def s3_bucket_arn(bucket_name_or_arn: str, account_id=None):
     bucket_name = s3_bucket_name(bucket_name_or_arn)
-    return "arn:aws:s3:::%s" % bucket_name
+    return f"arn:aws:s3:::{bucket_name}"
 
 
 def s3_bucket_name(bucket_name_or_arn: str) -> str:

--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -327,9 +327,10 @@ def sqs_queue_name(queue_arn):
         return queue_arn
 
 
-def sns_topic_arn(topic_name, account_id=None):
+def sns_topic_arn(topic_name, account_id=None, region_name=None):
     account_id = account_id or get_aws_account_id()
-    return "arn:aws:sns:%s:%s:%s" % (get_region(), account_id, topic_name)
+    region_name = region_name or get_region()
+    return f"arn:aws:sns:{region_name}:{account_id}:{topic_name}"
 
 
 def firehose_name(firehose_arn):

--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -230,9 +230,10 @@ class ServicePrincipal(str):
     To save some space in our DTOs, we only add the `<service-name>` part of the service principal here.
     """
 
-    awslambda = "lambda"
     apigateway = "apigateway"
-    firehose = "firehose"
-    sqs = "sqs"
-    sns = "sns"
+    awslambda = "lambda"
     events = "events"
+    firehose = "firehose"
+    s3 = "s3"
+    sns = "sns"
+    sqs = "sqs"

--- a/tests/integration/s3/test_s3_notifications_lambda.py
+++ b/tests/integration/s3/test_s3_notifications_lambda.py
@@ -251,7 +251,7 @@ class TestS3NotificationsToLambda:
         # set valid but not-existing lambda
         config["LambdaFunctionConfigurations"][0][
             "LambdaFunctionArn"
-        ] = f"{arns.lambda_function_arn('my-lambda', account_id=account_id)}"
+        ] = f"{arns.lambda_function_arn('my-lambda', account_id=account_id, region_name=aws_client.s3.meta.region_name)}"
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
@@ -120,14 +120,14 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_lambda.py::TestS3NotificationsToLambda::test_invalid_lambda_arn": {
-    "recorded-date": "22-09-2022, 19:47:46",
+    "recorded-date": "05-05-2023, 16:10:00",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {
           "ArgumentName": "CloudFunction",
           "ArgumentValue": "invalid-queue",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -139,7 +139,7 @@
           "ArgumentName": "CloudFunction",
           "ArgumentValue": "invalid-queue",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3_notifications_sns.py
+++ b/tests/integration/s3/test_s3_notifications_sns.py
@@ -292,7 +292,7 @@ class TestS3NotificationsToSns:
         # set valid but not-existing topic
         config["TopicConfigurations"][0][
             "TopicArn"
-        ] = f"{arns.sns_topic_arn('my-topic', account_id=account_id)}"
+        ] = f"{arns.sns_topic_arn('my-topic', account_id=account_id, region_name=aws_client.s3.meta.region_name)}"
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_sns.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sns.snapshot.json
@@ -161,14 +161,14 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_invalid_topic_arn": {
-    "recorded-date": "22-09-2022, 19:29:33",
+    "recorded-date": "05-05-2023, 16:14:02",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {
           "ArgumentName": "Topic",
           "ArgumentValue": "invalid-topic",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -180,7 +180,7 @@
           "ArgumentName": "Topic",
           "ArgumentValue": "invalid-topic",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -615,6 +615,9 @@ class TestS3NotificationsToSQS:
             )
             for m in resp["Messages"]:
                 if "s3:TestEvent" in m["Body"]:
+                    aws_client.sqs.delete_message(
+                        QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"]
+                    )
                     continue
                 recv_messages.append(m)
 

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -839,6 +839,10 @@ class TestS3NotificationsToSQS:
 
     @pytest.mark.aws_validated
     @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="no validation implemented")
+    # AWS seems to return "ArgumentName" (without the number) if the request fails a basic verification
+    # -  basically everything it can check isolated of the structure of the request
+    # and then the "ArgumentNameX" (with the number) for each verification against the target services
+    # e.g. queues not existing, no permissions etc.
     @pytest.mark.skip_snapshot_verify(
         condition=lambda: not LEGACY_S3_PROVIDER,
         paths=[
@@ -877,9 +881,9 @@ class TestS3NotificationsToSQS:
         snapshot.match("invalid_skip", e.value.response)
 
         # set valid but not-existing queue
-        config["QueueConfigurations"][0][
-            "QueueArn"
-        ] = f"{arns.sqs_queue_arn('my-queue', account_id=account_id)}"
+        config["QueueConfigurations"][0]["QueueArn"] = arns.sqs_queue_arn(
+            "my-queue", account_id=account_id, region_name=aws_client.s3.meta.region_name
+        )
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_notification_configuration(
                 Bucket=bucket_name,
@@ -892,6 +896,63 @@ class TestS3NotificationsToSQS:
         )
         config = aws_client.s3.get_bucket_notification_configuration(Bucket=bucket_name)
         snapshot.match("skip_destination_validation", config)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="no validation implemented")
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: not LEGACY_S3_PROVIDER,
+        paths=[
+            "$..Error.ArgumentName",
+            "$..Error.ArgumentValue",
+            "$..Error.ArgumentName1",
+            "$..Error.ArgumentValue1",
+            "$..Error.ArgumentName2",
+            "$..Error.ArgumentValue2",
+            # AWS seems to validate all "form" verifications beforehand, so one error message is wrong
+            "$..Error.Message",
+        ],
+    )
+    def test_multiple_invalid_sqs_arns(self, s3_create_bucket, account_id, snapshot, aws_client):
+        bucket_name = s3_create_bucket()
+        config = {
+            "QueueConfigurations": [
+                {"Id": "id1", "Events": ["s3:ObjectCreated:*"], "QueueArn": "invalid_arn"},
+                {
+                    "Id": "id2",
+                    "Events": ["s3:ObjectRemoved:*"],
+                    "QueueArn": "invalid_arn_2",
+                },
+            ]
+        }
+        # multiple invalid arns
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+            )
+        snapshot.match("two-queue-arns-invalid", e.value.response)
+
+        # one invalid arn, one not existing
+        config["QueueConfigurations"][0]["QueueArn"] = arns.sqs_queue_arn(
+            "my-queue", account_id=account_id, region_name=aws_client.s3.meta.region_name
+        )
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+            )
+        snapshot.match("one-queue-invalid-one-not-existent", e.value.response)
+
+        # multiple not existing queues
+        config["QueueConfigurations"][1]["QueueArn"] = arns.sqs_queue_arn(
+            "my-queue-2", account_id=account_id, region_name=aws_client.s3.meta.region_name
+        )
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+            )
+        snapshot.match("multiple-queues-do-not-exist", e.value.response)
 
     @pytest.mark.aws_validated
     @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="not implemented")

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -684,14 +684,14 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_invalid_sqs_arn": {
-    "recorded-date": "22-09-2022, 19:40:45",
+    "recorded-date": "04-05-2023, 18:28:16",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {
           "ArgumentName": "Queue",
           "ArgumentValue": "invalid-queue",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -703,7 +703,7 @@
           "ArgumentName": "Queue",
           "ArgumentValue": "invalid-queue",
           "Code": "InvalidArgument",
-          "Message": "The ARN is not well formed"
+          "Message": "The ARN could not be parsed"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -946,6 +946,49 @@
             }
           }
         ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_multiple_invalid_sqs_arns": {
+    "recorded-date": "04-05-2023, 18:13:38",
+    "recorded-content": {
+      "two-queue-arns-invalid": {
+        "Error": {
+          "ArgumentName": "Queue",
+          "ArgumentValue": "invalid_arn",
+          "Code": "InvalidArgument",
+          "Message": "The ARN could not be parsed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "one-queue-invalid-one-not-existent": {
+        "Error": {
+          "ArgumentName": "Queue",
+          "ArgumentValue": "invalid_arn_2",
+          "Code": "InvalidArgument",
+          "Message": "The ARN could not be parsed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "multiple-queues-do-not-exist": {
+        "Error": {
+          "ArgumentName1": "arn:aws:sqs:<region>:111111111111:my-queue-2",
+          "ArgumentName2": "arn:aws:sqs:<region>:111111111111:my-queue",
+          "ArgumentValue1": "The destination queue does not exist",
+          "ArgumentValue2": "The destination queue does not exist",
+          "Code": "InvalidArgument",
+          "Message": "Unable to validate the following destination configurations"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
       }
     }
   }


### PR DESCRIPTION
## Motivation

To allow the IAM enforcement of s3 notifications, we need to use the new clients for its requests, and properly send the `s3:TestEvent` for sns and sqs targets (https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-enable-disable-notification-intro.html). For lambda, it seems like no such event is sent, so it uses a dryrun invoke there (which needed to be fixed) to check if the invocation passes through.

## Changes
* Fix lambda dryrun invocations
* Introduce a BucketVerificationContext to contain all data necessary for validation (in essence everything sent in the `s3:TestEvent` payload.
* Send `s3:TestEvent` payload (sns, sqs) / dry run invoke (lambda)
* Migrate to the new clients
* Some changes due to changed AWS error messages caused by snapshot update