### PR TITLE
fix SdkDockerClient recovery if docker socket not available initially

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -613,6 +613,9 @@ DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
 # Default timeout for Docker API calls sent by the Docker SDK client, in seconds.
 DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS") or 60)
 
+# Default number of retries to connect to the Docker API by the Docker SDK client.
+DOCKER_SDK_DEFAULT_RETRIES = int(os.environ.get("DOCKER_SDK_DEFAULT_RETRIES") or 0)
+
 # whether to enable API-based updates of configuration variables at runtime
 ENABLE_CONFIG_UPDATES = is_env_true("ENABLE_CONFIG_UPDATES")
 

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1394,7 +1394,7 @@ class TestDockerNetworking:
         init_thread = FuncThread(func=on_demand_init)
         init_thread.start()
         # reset / fix the DOCKER_HOST config
-        # monkeypatch.delenv("DOCKER_HOST")
+        monkeypatch.delenv("DOCKER_HOST")
         # wait for the init thread to finish
         init_thread.join()
         # verify that the client is available

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -35,6 +35,7 @@ from localstack.utils.docker_utils import (
     reserve_container_port,
 )
 from localstack.utils.net import Port, PortNotAvailableException, get_free_tcp_port
+from localstack.utils.threads import FuncThread
 
 ContainerInfo = NamedTuple(
     "ContainerInfo",
@@ -1369,6 +1370,58 @@ class TestDockerNetworking:
         monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_TIMEOUT_SECONDS", 987)
         sdk_client = SdkDockerClient()
         assert sdk_client.docker_client.api.timeout == 987
+
+    def test_docker_sdk_no_retries(self, monkeypatch):
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_RETRIES", 0)
+        # change the env for the docker socket (such that it cannot be initialized)
+        monkeypatch.setenv("DOCKER_HOST", "tcp://non_existing_docker_client:2375/")
+        sdk_client = SdkDockerClient()
+        assert sdk_client.docker_client is None
+
+    def test_docker_sdk_retries_on_init(self, monkeypatch):
+        # increase the number of retries
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_RETRIES", 10)
+        # change the env for the docker socket (such that it cannot be initialized)
+        monkeypatch.setenv("DOCKER_HOST", "tcp://non_existing_docker_client:2375/")
+        global sdk_client
+
+        def on_demand_init(*args):
+            global sdk_client
+            sdk_client = SdkDockerClient()
+            assert sdk_client.docker_client is not None
+
+        # start initializing the client in another thread (with 10 retries)
+        init_thread = FuncThread(func=on_demand_init)
+        init_thread.start()
+        # reset / fix the DOCKER_HOST config
+        # monkeypatch.delenv("DOCKER_HOST")
+        # wait for the init thread to finish
+        init_thread.join()
+        # verify that the client is available
+        assert sdk_client.docker_client is not None
+
+    def test_docker_sdk_retries_after_init(self, monkeypatch):
+        # increase the number of retries
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_RETRIES", 0)
+        # change the env for the docker socket (such that it cannot be initialized)
+        monkeypatch.setenv("DOCKER_HOST", "tcp://non_existing_docker_client:2375/")
+        sdk_client = SdkDockerClient()
+        assert sdk_client.docker_client is None
+        monkeypatch.setattr(config, "DOCKER_SDK_DEFAULT_RETRIES", 10)
+
+        def on_demand_init(*args):
+            internal_sdk_client = sdk_client.client()
+            assert internal_sdk_client is not None
+
+        # start initializing the client in another thread (with 10 retries)
+        init_thread = FuncThread(func=on_demand_init)
+        init_thread.start()
+        # reset / fix the DOCKER_HOST config
+        monkeypatch.delenv("DOCKER_HOST")
+        # wait for the init thread to finish
+        init_thread.join()
+        # verify that the client is available
+        assert sdk_client.docker_client is not None
 
 
 class TestDockerPermissions:


### PR DESCRIPTION
Currently, if the Docker socket is not available at the start of LocalStack, the initialization of the `SdkDockerClient` fails and the client will not recover during the runtime of LocalStack.
This PR changes this behavior such that:
- The initialization is tried again if the client is accessed at runtime, but not already available (lazy init of the SDK client if it was unsuccessful before).
- Introduces a retry config `DOCKER_SDK_DEFAULT_RETRIES` which allows configuring the amount of retries when initializing the client.

This addresses https://github.com/localstack/helm-charts/issues/21.