### PR TITLE
fix GetBucketCORS if CORS does not exist in store

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import os
-from typing import IO, Dict, List
+from typing import IO, Dict, List, Optional
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 import moto.s3.responses as moto_s3_responses
@@ -65,6 +65,7 @@ from localstack.aws.api.s3 import (
     MissingSecurityHeader,
     MultipartUpload,
     NoSuchBucket,
+    NoSuchCORSConfiguration,
     NoSuchKey,
     NoSuchLifecycleConfiguration,
     NoSuchWebsiteConfiguration,
@@ -179,8 +180,11 @@ def get_full_default_bucket_location(bucket_name):
 
 class S3Provider(S3Api, ServiceLifecycleHook):
     @staticmethod
-    def get_store() -> S3Store:
-        return s3_stores[get_aws_account_id()][aws_stack.get_region()]
+    def get_store(context: Optional[RequestContext] = None) -> S3Store:
+        if not context:
+            return s3_stores[get_aws_account_id()][aws_stack.get_region()]
+
+        return s3_stores[context.account_id][context.region]
 
     def _clear_bucket_from_store(self, bucket: BucketName):
         store = self.get_store()
@@ -807,7 +811,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         response = call_moto(context)
-        self.get_store().bucket_cors[bucket] = cors_configuration
+        self.get_store(context).bucket_cors[bucket] = cors_configuration
         self._cors_handler.invalidate_cache()
         return response
 
@@ -815,14 +819,19 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketCorsOutput:
         call_moto(context)
-        cors_rules = self.get_store().bucket_cors.get(bucket)
+        cors_rules = self.get_store(context).bucket_cors.get(bucket)
+        if not cors_rules:
+            raise NoSuchCORSConfiguration(
+                "The CORS configuration does not exist",
+                BucketName=bucket,
+            )
         return GetBucketCorsOutput(CORSRules=cors_rules["CORSRules"])
 
     def delete_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
         response = call_moto(context)
-        if self.get_store().bucket_cors.pop(bucket, None):
+        if self.get_store(context).bucket_cors.pop(bucket, None):
             self._cors_handler.invalidate_cache()
         return response
 


### PR DESCRIPTION
This PR would fix the case when the usr restore the state created with the legacy S3 provider (everything would be stored in moto). The assumption was that moto would raise an exception if the CORS configuration didn't exist. However, while restoring an older state, the data would exist in moto but not in our store, thus creating a value error when trying to access the `CORSRules` (`NoneType` etc etc).

This will properly raise the 404 exception if the state is not properly restored.  