### PR TITLE
Add more detail in cloudformation stack deploy failure

### DIFF
--- a/tests/integration/cloudformation/resources/test_sns.py
+++ b/tests/integration/cloudformation/resources/test_sns.py
@@ -31,7 +31,7 @@ def test_sns_topic_fifo_without_suffix_fails(deploy_cfn_template, aws_client):
         deploy_cfn_template(
             stack_name=stack_name, template_path=path, parameters={"TopicName": topic_name}
         )
-    assert ex.typename == "AssertionError"
+    assert ex.typename == "StackDeployError"
 
     stack = aws_client.cloudformation.describe_stacks(StackName=stack_name)["Stacks"][0]
     if is_aws_cloud():


### PR DESCRIPTION
## Motivation

If a stack fails to deploy, it currently shows a helpful "assertion failed: False" error message. This does not explain _why_ the stack failed to deploy.

## Changes

This PR adds the following information to an exception thrown by the fixture:
* the output of `describe_stacks` on the stack, and
* the stack events as this often shows the actual source of the error.


### Before

```
E       AssertionError: assert False
E        +  where False = wait_until(<function is_change_set_finished.<locals>._is_change_set_finished.<locals>._inner at 0x7f789e8d1750>, _max_wait=(None or 60))
E        +    where <function is_change_set_finished.<locals>._is_change_set_finished.<locals>._inner at 0x7f789e8d1750> = <function is_change_set_finished.<locals>._is_change_set_finished at 0x7f78b2ed1000>('arn:aws:cloudformation:us-east-1:000000000000:changeSet/change-set-06b2e514/47987e23')
```

### After

```
>           raise StackDeployError(describe_stack_res, events)
E           localstack.testing.pytest.fixtures.StackDeployError: Stack deploy failed - describe output: {'StackId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'StackName': 'stack-0022f874', 'ChangeSetId': 'arn:aws:cloudformation:us-east-1:000000000000:changeSet/change-set-5c97fde1/a6d1a8c8', 'Description': 'Test stack', 'CreationTime': datetime.datetime(2023, 5, 10, 9, 13, 15, 915000, tzinfo=tzutc()), 'LastUpdatedTime': datetime.datetime(2023, 5, 10, 9, 13, 15, 915000, tzinfo=tzutc()), 'RollbackConfiguration': {}, 'StackStatus': 'CREATE_FAILED', 'StackStatusReason': 'Deployment failed', 'DisableRollback': False, 'NotificationARNs': [], 'Capabilities': ['CAPABILITY_AUTO_EXPAND', 'CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'], 'Tags': [], 'EnableTerminationProtection': False, 'DriftInformation': {'StackDriftStatus': 'NOT_CHECKED'}} events: [{'StackId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'EventId': '48d339c2-0caa-4705-9c83-1c22642adec1', 'StackName': 'stack-0022f874', 'LogicalResourceId': 'stack-0022f874', 'PhysicalResourceId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'ResourceType': 'AWS::CloudFormation::Stack', 'Timestamp': datetime.datetime(2023, 5, 10, 9, 13, 16, 367000, tzinfo=tzutc()), 'ResourceStatus': 'CREATE_FAILED'}, {'StackId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'EventId': 'f7eb4d27-9c59-4f1b-987e-e19a2396d032', 'StackName': 'stack-0022f874', 'LogicalResourceId': 'stack-0022f874', 'PhysicalResourceId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'ResourceType': 'AWS::CloudFormation::Stack', 'Timestamp': datetime.datetime(2023, 5, 10, 9, 13, 15, 934000, tzinfo=tzutc()), 'ResourceStatus': 'CREATE_IN_PROGRESS'}, {'StackId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'EventId': '55083b4c-60e9-4189-9d55-50ccc06c5ce6', 'StackName': 'stack-0022f874', 'LogicalResourceId': 'stack-0022f874', 'PhysicalResourceId': 'arn:aws:cloudformation:us-east-1:000000000000:stack/stack-0022f874/2a2b5e0b', 'ResourceType': 'AWS::CloudFormation::Stack', 'Timestamp': datetime.datetime(2023, 5, 10, 9, 13, 15, 915000, tzinfo=tzutc()), 'ResourceStatus': 'REVIEW_IN_PROGRESS'}]
```
