### PR TITLE
clear deduplication cache in SQS fifo queues

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -980,6 +980,7 @@ class FifoQueue(SqsQueue):
     def clear(self):
         with self.mutex:
             super().clear()
+            self.deduplication.clear()
             self.message_groups.clear()
             self.inflight_groups.clear()
             self.message_group_queue.queue.clear()


### PR DESCRIPTION
Small fix for https://github.com/localstack/localstack/issues/8211

We didn't clear the deduplication cache when purging a FIFO queue.