### PR TITLE
DynamoDB: Remove extraneous call during region resolution

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1141,8 +1141,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         self, context: RequestContext, table_name: TableName, stream_arn: StreamArn
     ) -> KinesisStreamingDestinationOutput:
         # Check if table exists, to avoid error log output from DynamoDBLocal
-        if not self.table_exists(context.account_id, context.region, table_name):
-            raise ResourceNotFoundException("Cannot do operations on a non-existent table")
+        self.ensure_table_exists(context.account_id, context.region, table_name)
+
         stream = EventForwarder.is_kinesis_stream_exists(stream_arn=stream_arn)
         if not stream:
             raise ValidationException("User does not have a permission to use kinesis stream")
@@ -1183,8 +1183,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         self, context: RequestContext, table_name: TableName, stream_arn: StreamArn
     ) -> KinesisStreamingDestinationOutput:
         # Check if table exists, to avoid error log output from DynamoDBLocal
-        if not self.table_exists(context.account_id, context.region, table_name):
-            raise ResourceNotFoundException("Cannot do operations on a non-existent table")
+        self.ensure_table_exists(context.account_id, context.region, table_name)
+
         stream = EventForwarder.is_kinesis_stream_exists(stream_arn=stream_arn)
         if not stream:
             raise ValidationException(
@@ -1217,8 +1217,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         self, context: RequestContext, table_name: TableName
     ) -> DescribeKinesisStreamingDestinationOutput:
         # Check if table exists, to avoid error log output from DynamoDBLocal
-        if not self.table_exists(context.account_id, context.region, table_name):
-            raise ResourceNotFoundException("Cannot do operations on a non-existent table")
+        self.ensure_table_exists(context.account_id, context.region, table_name)
 
         table_def = (
             get_store(context.account_id, context.region).table_definitions.get(table_name) or {}
@@ -1317,30 +1316,40 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         return dynamodb_table_exists(table_name, client)
 
     @staticmethod
+    def ensure_table_exists(account_id: str, region_name: str, table_name: str):
+        """
+        Raise ResourceNotFoundException if the given table does not exist.
+
+        :param account_id: account id
+        :param region_name: region name
+        :param table_name: table name
+        :raise: ResourceNotFoundException if table does not exist in DynamoDB Local
+        """
+        if not DynamoDBProvider.table_exists(account_id, region_name, table_name):
+            raise ResourceNotFoundException("Cannot do operations on a non-existent table")
+
+    @staticmethod
     def get_global_table_region(context: RequestContext, table_name: str) -> str:
         """
-        Return the table region considering that it might be a replicated table and that it exists within DDBLocal.
+        Return the table region considering that it might be a replicated table.
+
+        Replication in LocalStack works by keeping a single copy of a table and forwarding
+        requests to the region where this table exists.
+
+        This method does not check whether the table actually exists in DDBLocal.
+
         :param context: request context
         :param table_name: table name
         :return: region
-        :raise: ResourceNotFoundException if table does not exist in DynamoDB Local
         """
         replicas = get_store(context.account_id, context.region).REPLICA_UPDATES.get(table_name)
         if replicas:
             global_table_region = list(replicas.keys())[0]
             replicated_at = replicas[global_table_region]
             # Ensure that a replica exists in the current context region, and that the table exists in DDB Local
-            if (
-                context.region == global_table_region or context.region in replicated_at
-            ) and DynamoDBProvider.table_exists(
-                context.account_id, global_table_region, table_name
-            ):
+            if context.region == global_table_region or context.region in replicated_at:
                 return global_table_region
-        else:
-            if DynamoDBProvider.table_exists(context.account_id, context.region, table_name):
-                return context.region
-
-        raise ResourceNotFoundException("Cannot do operations on a non-existent table")
+        return context.region
 
     @staticmethod
     def prepare_request_headers(headers: Dict, account_id: str, region_name: str):

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -74,6 +74,7 @@ from localstack.aws.api.dynamodb import (
     ReplicaStatus,
     ReplicaUpdateList,
     ResourceArnString,
+    ResourceInUseException,
     ResourceNotFoundException,
     ReturnConsumedCapacity,
     ScanInput,
@@ -461,6 +462,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         create_table_input: CreateTableInput,
     ) -> CreateTableOutput:
         table_name = create_table_input["TableName"]
+
+        # Return this specific error message to keep parity with AWS
+        if self.table_exists(context.account_id, context.region, table_name):
+            raise ResourceInUseException(f"Table already exists: {table_name}")
+
         billing_mode = create_table_input.get("BillingMode")
         provisioned_throughput = create_table_input.get("ProvisionedThroughput")
         if billing_mode == BillingMode.PAY_PER_REQUEST and provisioned_throughput is not None:

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -74,7 +74,6 @@ from localstack.aws.api.dynamodb import (
     ReplicaStatus,
     ReplicaUpdateList,
     ResourceArnString,
-    ResourceInUseException,
     ResourceNotFoundException,
     ReturnConsumedCapacity,
     ScanInput,
@@ -461,10 +460,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         context: RequestContext,
         create_table_input: CreateTableInput,
     ) -> CreateTableOutput:
-        # Check if table exists, to avoid error log output from DynamoDBLocal
         table_name = create_table_input["TableName"]
-        if self.table_exists(context.account_id, context.region, table_name):
-            raise ResourceInUseException(f"Table already exists: {table_name}")
         billing_mode = create_table_input.get("BillingMode")
         provisioned_throughput = create_table_input.get("ProvisionedThroughput")
         if billing_mode == BillingMode.PAY_PER_REQUEST and provisioned_throughput is not None:
@@ -1140,7 +1136,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def enable_kinesis_streaming_destination(
         self, context: RequestContext, table_name: TableName, stream_arn: StreamArn
     ) -> KinesisStreamingDestinationOutput:
-        # Check if table exists, to avoid error log output from DynamoDBLocal
         self.ensure_table_exists(context.account_id, context.region, table_name)
 
         stream = EventForwarder.is_kinesis_stream_exists(stream_arn=stream_arn)
@@ -1182,7 +1177,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def disable_kinesis_streaming_destination(
         self, context: RequestContext, table_name: TableName, stream_arn: StreamArn
     ) -> KinesisStreamingDestinationOutput:
-        # Check if table exists, to avoid error log output from DynamoDBLocal
         self.ensure_table_exists(context.account_id, context.region, table_name)
 
         stream = EventForwarder.is_kinesis_stream_exists(stream_arn=stream_arn)
@@ -1216,7 +1210,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def describe_kinesis_streaming_destination(
         self, context: RequestContext, table_name: TableName
     ) -> DescribeKinesisStreamingDestinationOutput:
-        # Check if table exists, to avoid error log output from DynamoDBLocal
         self.ensure_table_exists(context.account_id, context.region, table_name)
 
         table_def = (

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -18,7 +18,7 @@ RESTART_LOCK = threading.RLock()
 
 
 def _log_listener(line, **_kwargs):
-    LOG.info(line.rstrip())
+    LOG.debug(line.rstrip())
 
 
 class DynamodbServer(Server):
@@ -148,13 +148,13 @@ class DynamodbServer(Server):
         dynamodblocal_package.install()
 
         cmd = self._create_shell_command()
-        LOG.debug("starting dynamodb process %s", cmd)
+        LOG.debug("Starting DynamoDB Local: %s", cmd)
         t = ShellCommandThread(
             cmd,
             strip_color=True,
             log_listener=_log_listener,
             auto_restart=True,
-            name="dynamodb-server",
+            name="dynamodb-local",
         )
         TMP_THREADS.append(t)
         t.start()


### PR DESCRIPTION
This PR improves the performance of commonly used operations by eliminating a `ListTables` call to DDB Local.

Earlier, LocalStack would use this call to look up whether the table existed in DDB Local during the replication region resolution. It was originally added to suppress error messages produced by DDB Local.

This PR also changes to log level of all DDB Local logs to DEBUG.

Error message printed by DDB Local when operating on non-existent table:
```
2023-05-11T17:07:05.987 DEBUG --- [-functhread9] l.services.dynamodb.server : 17:07:05.974 [qtp1511574902-17] WARN  com.amazonaws.services.dynamodbv2.local.server.LocalDynamoDBServerHandler - DynamoDBLocalServiceException exception occured
2023-05-11T17:07:05.987 DEBUG --- [-functhread9] l.services.dynamodb.server : com.amazonaws.services.dynamodbv2.exceptions.DynamoDBLocalServiceException: Cannot do operations on a non-existent table
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.exceptions.AWSExceptionFactory.buildLocalServiceException(AWSExceptionFactory.java:93) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.exceptions.AWSExceptionFactory.buildAWSException(AWSExceptionFactory.java:58) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.shared.access.api.DynamoDbApiFunction.validateTableExists(DynamoDbApiFunction.java:67) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.shared.access.api.dp.PutItemFunction.apply(PutItemFunction.java:41) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.shared.access.awssdkv1.client.LocalAmazonDynamoDB.putItem(LocalAmazonDynamoDB.java:289) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.server.LocalDynamoDBRequestHandler.putItem(LocalDynamoDBRequestHandler.java:359) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.dispatchers.PutItemDispatcher.enact(PutItemDispatcher.java:18) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.dispatchers.PutItemDispatcher.enact(PutItemDispatcher.java:12) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.server.LocalDynamoDBServerHandler.packageDynamoDBResponse(LocalDynamoDBServerHandler.java:406) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at com.amazonaws.services.dynamodbv2.local.server.LocalDynamoDBServerHandler.handle(LocalDynamoDBServerHandler.java:495) ~[DynamoDBLocal.jar:?]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:190) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:191) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.988 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) ~[jetty-server-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[jetty-io-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[jetty-io-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[jetty-io-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
2023-05-11T17:07:05.989 DEBUG --- [-functhread9] l.services.dynamodb.server : at java.lang.Thread.run(Thread.java:833) ~[?:?]
2023-05-11T17:07:05.995  INFO --- [   asgi_gw_1] localstack.request.aws     : AWS dynamodb.PutItem => 400 (ResourceNotFoundException)
```


Performance before:
```
In [12]: %timeit dynamodb.put_item(TableName="tab",Item={"id": {"S": "Fred"},})
51.4 ms ± 2.52 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [13]: %timeit dynamodb.put_item(TableName="tab",Item={"id": {"S": "Fred"},})
47 ms ± 4.2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Performance after:
```
In [8]: %timeit dynamodb.put_item(TableName="tab",Item={"id": {"S": "Fred"},})
28.8 ms ± 3.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [9]: %timeit dynamodb.put_item(TableName="tab",Item={"id": {"S": "Fred"},})
26.9 ms ± 3.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

cc: @thrau 