### PR TITLE
Fix KeyId return value as ARN for "generate_data_key*" methods

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -536,7 +536,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self._validate_key_for_encryption_decryption(context, key)
         crypto_key = KmsCryptoKey(key_pair_spec)
         return {
-            "KeyId": key_id,
+            "KeyId": key.metadata["Arn"],
             "KeyPairSpec": key_pair_spec,
             "PrivateKeyCiphertextBlob": key.encrypt(crypto_key.private_key),
             "PrivateKeyPlaintext": crypto_key.private_key,
@@ -598,7 +598,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self._validate_key_for_encryption_decryption(context, key)
         crypto_key = KmsCryptoKey("SYMMETRIC_DEFAULT")
         return {
-            "KeyId": key_id,
+            "KeyId": key.metadata["Arn"],
             "Plaintext": crypto_key.key_material,
             "CiphertextBlob": key.encrypt(crypto_key.key_material),
         }

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1409,5 +1409,63 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair_without_plaintext": {
+    "recorded-date": "11-05-2023, 14:40:23",
+    "recorded-content": {
+      "generate-data-key-pair-without-plaintext": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/<resource:1>",
+        "KeyPairSpec": "RSA_2048",
+        "PrivateKeyCiphertextBlob": "private-key-ciphertext-blob",
+        "PublicKey": "public-key",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_pair": {
+    "recorded-date": "11-05-2023, 14:40:23",
+    "recorded-content": {
+      "generate-data-key-pair": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/<resource:1>",
+        "KeyPairSpec": "RSA_2048",
+        "PrivateKeyCiphertextBlob": "private-key-ciphertext-blob",
+        "PrivateKeyPlaintext": "private-key-plaintext",
+        "PublicKey": "public-key",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_generate_data_key": {
+    "recorded-date": "11-05-2023, 14:40:24",
+    "recorded-content": {
+      "generate-data-key-result": {
+        "CiphertextBlob": "ciphertext-blob",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/<resource:1>",
+        "Plaintext": "plaintext",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_generate_data_key_without_plaintext": {
+    "recorded-date": "11-05-2023, 14:40:24",
+    "recorded-content": {
+      "generate-data-key-without-plaintext": {
+        "CiphertextBlob": "ciphertext-blob",
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
#8253 introduced a regression for some methods the key arn in the `KeyId` field instead of the ID.

The API documentation for (at least one) of the operation clearly states it will return the ARN in that field: https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKey.html#API_GenerateDataKey_ResponseSyntax

## Changes
* Add snapshot validated tests for the generate_data_key* methods
* Fix the return value

This is mainly done because the `aws_encryption_sdk` depends on the format being an ARN, which breaks our -ext pipeline.

## Future work
* Check more return values of `KeyId` to be the correct ones @viren-nadkarni 