### PR TITLE
Add encryption context to encrypt and decrypt operations in KMS

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -255,7 +255,7 @@ class KmsKey:
 
     # Encrypt is a method of KmsKey and not of KmsCryptoKey only because it requires KeyId, and KmsCryptoKeys do not
     # hold KeyIds. Maybe it would be possible to remodel this better.
-    def encrypt(self, plaintext: bytes, encryption_context: EncryptionContextType) -> bytes:
+    def encrypt(self, plaintext: bytes, encryption_context: EncryptionContextType = None) -> bytes:
         iv = os.urandom(IV_LEN)
         aad = _serialize_encryption_context(encryption_context=encryption_context)
         ciphertext, tag = encrypt(self.crypto_key.key_material, plaintext, iv, aad)

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -266,7 +266,7 @@ class KmsKey:
         )
 
     # The ciphertext has to be deserialized before this call.
-    def decrypt(self, ciphertext: Ciphertext, encryption_context: EncryptionContextType) -> bytes:
+    def decrypt(self, ciphertext: Ciphertext, encryption_context: EncryptionContextType = None) -> bytes:
         aad = _serialize_encryption_context(encryption_context=encryption_context)
         return decrypt(
             self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -268,7 +268,9 @@ class KmsKey:
     # The ciphertext has to be deserialized before this call.
     def decrypt(self, ciphertext: Ciphertext, encryption_context: EncryptionContextType) -> bytes:
         aad = _serialize_encryption_context(encryption_context=encryption_context)
-        return decrypt(self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad)
+        return decrypt(
+            self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad
+        )
 
     def sign(
         self, data: bytes, message_type: MessageType, signing_algorithm: SigningAlgorithmSpec

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -266,7 +266,9 @@ class KmsKey:
         )
 
     # The ciphertext has to be deserialized before this call.
-    def decrypt(self, ciphertext: Ciphertext, encryption_context: EncryptionContextType = None) -> bytes:
+    def decrypt(
+        self, ciphertext: Ciphertext, encryption_context: EncryptionContextType = None
+    ) -> bytes:
         aad = _serialize_encryption_context(encryption_context=encryption_context)
         return decrypt(
             self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv, ciphertext.tag, aad

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -10,7 +10,7 @@ import struct
 import uuid
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, hmac
@@ -128,7 +128,7 @@ def deserialize_ciphertext_blob(ciphertext_blob: bytes) -> Ciphertext:
     return Ciphertext(key_id=key_id.decode("utf-8"), iv=iv, ciphertext=ciphertext, tag=tag)
 
 
-def _serialize_encryption_context(encryption_context: EncryptionContextType) -> bytes:
+def _serialize_encryption_context(encryption_context: Optional[EncryptionContextType]) -> bytes:
     if encryption_context:
         aad = io.BytesIO()
         for key, value in sorted(encryption_context.items(), key=lambda x: x[0]):

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -736,11 +736,11 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 
-        ciphertext_blob = key.encrypt(plaintext)
+        ciphertext_blob = key.encrypt(plaintext, encryption_context)
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
         # encrypts with symmetric encryption no matter the key settings.
         return EncryptResponse(
-            CiphertextBlob=ciphertext_blob, KeyId=key_id, EncryptionAlgorithm=encryption_algorithm
+            CiphertextBlob=ciphertext_blob, KeyId=key.metadata.get("Arn"), EncryptionAlgorithm=encryption_algorithm
         )
 
     # TODO We currently do not even check encryption_context, while moto does. Should add the corresponding logic later.
@@ -776,7 +776,10 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self._validate_key_for_encryption_decryption(context, key)
         self._validate_key_state_not_pending_import(key)
 
-        plaintext = key.decrypt(ciphertext)
+        try:
+            plaintext = key.decrypt(ciphertext, encryption_context)
+        except Exception:
+            raise InvalidCiphertextException()
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
         # encrypts with symmetric encryption no matter the key settings.
         #

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -5,6 +5,7 @@ import logging
 import os
 from typing import Dict, Tuple
 
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -780,7 +781,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
         try:
             plaintext = key.decrypt(ciphertext, encryption_context)
-        except Exception:
+        except InvalidTag:
             raise InvalidCiphertextException()
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
         # encrypts with symmetric encryption no matter the key settings.

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -740,7 +740,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         # For compatibility, we return EncryptionAlgorithm values expected from AWS. But LocalStack currently always
         # encrypts with symmetric encryption no matter the key settings.
         return EncryptResponse(
-            CiphertextBlob=ciphertext_blob, KeyId=key.metadata.get("Arn"), EncryptionAlgorithm=encryption_algorithm
+            CiphertextBlob=ciphertext_blob,
+            KeyId=key.metadata.get("Arn"),
+            EncryptionAlgorithm=encryption_algorithm,
         )
 
     # TODO We currently do not even check encryption_context, while moto does. Should add the corresponding logic later.

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -400,6 +400,8 @@ class TransformerUtility:
             TransformerUtility.jsonpath(
                 jsonpath="$..Mac", value_replacement="<mac>", reference_replacement=False
             ),
+            TransformerUtility.key_value("CiphertextBlob", reference_replacement=False),
+            TransformerUtility.key_value("Plaintext", reference_replacement=False),
             RegexTransformer(PATTERN_KEY_ARN, replacement="<key-arn>"),
         ]
 

--- a/localstack/utils/crypto.py
+++ b/localstack/utils/crypto.py
@@ -170,7 +170,9 @@ def encrypt(key: bytes, message: bytes, iv: bytes = None, aad: bytes = None) -> 
     return encrypted, encryptor.tag
 
 
-def decrypt(key: bytes, encrypted: bytes, iv: bytes = None, tag: bytes = None, aad: bytes = None) -> bytes:
+def decrypt(
+    key: bytes, encrypted: bytes, iv: bytes = None, tag: bytes = None, aad: bytes = None
+) -> bytes:
     iv = iv or b"0" * BLOCK_SIZE
     cipher = Cipher(algorithms.AES(key), modes.GCM(iv, tag), backend=default_backend())
     decryptor = cipher.decryptor()

--- a/localstack/utils/crypto.py
+++ b/localstack/utils/crypto.py
@@ -4,6 +4,7 @@ import os
 import re
 import threading
 
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from .files import TMP_FILES, file_exists_not_empty, load_file, new_tmp_file, save_file
@@ -160,18 +161,20 @@ def unpad(s: bytes) -> bytes:
     return s[0 : -s[-1]]
 
 
-def encrypt(key: bytes, message: bytes, iv: bytes = None) -> bytes:
+def encrypt(key: bytes, message: bytes, iv: bytes = None, aad: bytes = None) -> bytes:
     iv = iv or b"0" * BLOCK_SIZE
-    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    cipher = Cipher(algorithms.AES(key), modes.GCM(iv), backend=default_backend())
     encryptor = cipher.encryptor()
+    encryptor.authenticate_additional_data(aad)
     encrypted = encryptor.update(pad(message)) + encryptor.finalize()
-    return encrypted
+    return encrypted, encryptor.tag
 
 
-def decrypt(key: bytes, encrypted: bytes, iv: bytes = None) -> bytes:
+def decrypt(key: bytes, encrypted: bytes, iv: bytes = None, tag: bytes = None, aad: bytes = None) -> bytes:
     iv = iv or b"0" * BLOCK_SIZE
-    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    cipher = Cipher(algorithms.AES(key), modes.GCM(iv, tag), backend=default_backend())
     decryptor = cipher.decryptor()
+    decryptor.authenticate_additional_data(aad)
     decrypted = decryptor.update(encrypted) + decryptor.finalize()
     decrypted = unpad(decrypted)
     return decrypted

--- a/localstack/utils/crypto.py
+++ b/localstack/utils/crypto.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import threading
+from typing import Tuple
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -161,7 +162,7 @@ def unpad(s: bytes) -> bytes:
     return s[0 : -s[-1]]
 
 
-def encrypt(key: bytes, message: bytes, iv: bytes = None, aad: bytes = None) -> bytes:
+def encrypt(key: bytes, message: bytes, iv: bytes = None, aad: bytes = None) -> Tuple[bytes, bytes]:
     iv = iv or b"0" * BLOCK_SIZE
     cipher = Cipher(algorithms.AES(key), modes.GCM(iv), backend=default_backend())
     encryptor = cipher.encryptor()

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1182,19 +1182,21 @@ class TestKMS:
         key_id = kms_create_key()["KeyId"]
         message = b"test message 123 !%$@ 1234567890"
         encryption_context = {"context-key": "context-value"}
+        algo = "SYMMETRIC_DEFAULT"
 
         encrypt_response = aws_client.kms.encrypt(
             KeyId=key_id,
             Plaintext=base64.b64encode(message),
-            EncryptionAlgorithm="SYMMETRIC_DEFAULT",
+            EncryptionAlgorithm=algo,
             EncryptionContext=encryption_context,
         )
         snapshot.match("encrypt_response", encrypt_response)
+        ciphertext = encrypt_response["CiphertextBlob"]
 
         decrypt_response = aws_client.kms.decrypt(
             KeyId=key_id,
-            CiphertextBlob=encrypt_response["CiphertextBlob"],
-            EncryptionAlgorithm="SYMMETRIC_DEFAULT",
+            CiphertextBlob=ciphertext,
+            EncryptionAlgorithm=algo,
             EncryptionContext=encryption_context,
         )
         snapshot.match("decrypt_response_with_encryption_context", decrypt_response)
@@ -1202,8 +1204,8 @@ class TestKMS:
         with pytest.raises(ClientError) as e:
             aws_client.kms.decrypt(
                 KeyId=key_id,
-                CiphertextBlob=encrypt_response["CiphertextBlob"],
-                EncryptionAlgorithm="SYMMETRIC_DEFAULT",
+                CiphertextBlob=ciphertext,
+                EncryptionAlgorithm=algo,
             )
         snapshot.match("decrypt_response_without_encryption_context", e.value.response)
 

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1184,25 +1184,26 @@ class TestKMS:
         encryption_context = {"context-key": "context-value"}
 
         encrypt_response = aws_client.kms.encrypt(
-            KeyId = key_id,
-            Plaintext = base64.b64encode(message),
-            EncryptionAlgorithm = "SYMMETRIC_DEFAULT",
-            EncryptionContext = encryption_context
+            KeyId=key_id,
+            Plaintext=base64.b64encode(message),
+            EncryptionAlgorithm="SYMMETRIC_DEFAULT",
+            EncryptionContext=encryption_context,
         )
         snapshot.match("encrypt_response", encrypt_response)
 
         decrypt_response = aws_client.kms.decrypt(
-            KeyId = key_id,
-            CiphertextBlob = encrypt_response["CiphertextBlob"],
-            EncryptionAlgorithm = "SYMMETRIC_DEFAULT",
-            EncryptionContext = encryption_context)
+            KeyId=key_id,
+            CiphertextBlob=encrypt_response["CiphertextBlob"],
+            EncryptionAlgorithm="SYMMETRIC_DEFAULT",
+            EncryptionContext=encryption_context,
+        )
         snapshot.match("decrypt_response_with_encryption_context", decrypt_response)
 
         with pytest.raises(ClientError) as e:
             aws_client.kms.decrypt(
-                KeyId = key_id,
-                CiphertextBlob = encrypt_response["CiphertextBlob"],
-                EncryptionAlgorithm = "SYMMETRIC_DEFAULT"
+                KeyId=key_id,
+                CiphertextBlob=encrypt_response["CiphertextBlob"],
+                EncryptionAlgorithm="SYMMETRIC_DEFAULT",
             )
         snapshot.match("decrypt_response_without_encryption_context", e.value.response)
 
@@ -1276,4 +1277,3 @@ class TestKMSGenerateKeys:
         # LocalStack currently doesn't act on KeySpec or on NumberOfBytes params, but one of them has to be set.
         result = aws_client.kms.generate_data_key_without_plaintext(KeyId=key_id, KeySpec="AES_256")
         snapshot.match("generate-data-key-without-plaintext", result)
-

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1176,6 +1176,36 @@ class TestKMS:
             KeyId=key_arn_3, Message=message, MacAlgorithm="HMAC_SHA_512", Mac=mac
         )["MacValid"]
 
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..message"])
+    def test_encrypt_decrypt_encryption_context(self, kms_create_key, snapshot, aws_client):
+        key_id = kms_create_key()["KeyId"]
+        message = b"test message 123 !%$@ 1234567890"
+        encryption_context = {"context-key": "context-value"}
+
+        encrypt_response = aws_client.kms.encrypt(
+            KeyId = key_id,
+            Plaintext = base64.b64encode(message),
+            EncryptionAlgorithm = "SYMMETRIC_DEFAULT",
+            EncryptionContext = encryption_context
+        )
+        snapshot.match("encrypt_response", encrypt_response)
+
+        decrypt_response = aws_client.kms.decrypt(
+            KeyId = key_id,
+            CiphertextBlob = encrypt_response["CiphertextBlob"],
+            EncryptionAlgorithm = "SYMMETRIC_DEFAULT",
+            EncryptionContext = encryption_context)
+        snapshot.match("decrypt_response_with_encryption_context", decrypt_response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.decrypt(
+                KeyId = key_id,
+                CiphertextBlob = encrypt_response["CiphertextBlob"],
+                EncryptionAlgorithm = "SYMMETRIC_DEFAULT"
+            )
+        snapshot.match("decrypt_response_without_encryption_context", e.value.response)
+
 
 class TestKMSGenerateKeys:
     @pytest.fixture(autouse=True)
@@ -1246,3 +1276,4 @@ class TestKMSGenerateKeys:
         # LocalStack currently doesn't act on KeySpec or on NumberOfBytes params, but one of them has to be set.
         result = aws_client.kms.generate_data_key_without_plaintext(KeyId=key_id, KeySpec="AES_256")
         snapshot.match("generate-data-key-without-plaintext", result)
+

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1467,5 +1467,38 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_encrypt_decrypt_encryption_context": {
+    "recorded-date": "11-05-2023, 22:46:49",
+    "recorded-content": {
+      "encrypt_response": {
+        "CiphertextBlob": "ciphertext-blob",
+        "EncryptionAlgorithm": "SYMMETRIC_DEFAULT",
+        "KeyId": "<key-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "decrypt_response_with_encryption_context": {
+        "EncryptionAlgorithm": "SYMMETRIC_DEFAULT",
+        "KeyId": "<key-id:1>",
+        "Plaintext": "plaintext",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "decrypt_response_without_encryption_context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Fix the return value of `Encrypt` operation 
- Add `EncryptionContext` as an additional authentication data during encryption and decryption 
- Add encryption tags 
- Change mode of encryption from `CBC` to `GCM`, since the previous encryption method lacked built-in authentication and tags. 
- Add snapshot tests for encrypt and decrypt operations 