### PR TITLE
remove install dependency on localstack_client

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1179,14 +1179,18 @@ def collect_config_items() -> List[Tuple[str, Any]]:
 def populate_config_env_var_names():
     global CONFIG_ENV_VARS
 
-    CONFIG_ENV_VARS = [
+    CONFIG_ENV_VARS += [
         key
         for key in [key.upper() for key in os.environ]
-        if key.startswith("LOCALSTACK_")
-        if key.endswith("_BACKEND")
-        or key.endswith("_PORT_EXTERNAL")
-        or key.startswith("PROVIDER_OVERRIDE_")
+        if key.startswith("LOCALSTACK_") or key.startswith("PROVIDER_OVERRIDE_")
     ]
+
+    # create variable aliases prefixed with LOCALSTACK_ (except LOCALSTACK_HOSTNAME)
+    CONFIG_ENV_VARS += [
+        "LOCALSTACK_" + v for v in CONFIG_ENV_VARS if not v.startswith("LOCALSTACK_")
+    ]
+
+    CONFIG_ENV_VARS = list(set(CONFIG_ENV_VARS))
 
 
 # populate env var names to be passed to the container

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1014,44 +1014,6 @@ MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER
 # Whether to return and parse access key ids starting with an "A", like on AWS
 PARITY_AWS_ACCESS_KEY_ID = is_env_true("PARITY_AWS_ACCESS_KEY_ID")
 
-# List of services supported by LocalStack
-SUPPORTED_SERVICES = [
-    "acm",
-    "apigateway",
-    "cloudformation",
-    "cloudwatch",
-    "config",
-    "dynamodb",
-    "dynamodbstreams",
-    "ec2",
-    "es",
-    "events",
-    "firehose",
-    "iam",
-    "kinesis",
-    "kms",
-    "lambda",
-    "logs",
-    "opensearch",
-    "redshift",
-    "resource-groups",
-    "resourcegroupstaggingapi",
-    "route53",
-    "route53resolver",
-    "s3",
-    "s3control",
-    "secretsmanager",
-    "ses",
-    "sns",
-    "sqs",
-    "ssm",
-    "stepfunctions",
-    "sts",
-    "support",
-    "swf",
-    "transcribe",
-]
-
 # HINT: Please add deprecated environment variables to deprecations.py
 
 # list of environment variable names used for configuration.
@@ -1217,19 +1179,14 @@ def collect_config_items() -> List[Tuple[str, Any]]:
 def populate_config_env_var_names():
     global CONFIG_ENV_VARS
 
-    for service in SUPPORTED_SERVICES:
-        clean_key = service.upper().replace("-", "_")
-        CONFIG_ENV_VARS += [
-            clean_key + "_BACKEND",
-            clean_key + "_PORT_EXTERNAL",
-            "PROVIDER_OVERRIDE_" + clean_key,
-        ]
-
-    # create variable aliases prefixed with LOCALSTACK_ (except LOCALSTACK_HOSTNAME)
-    CONFIG_ENV_VARS += [
-        "LOCALSTACK_" + v for v in CONFIG_ENV_VARS if not v.startswith("LOCALSTACK_")
+    CONFIG_ENV_VARS = [
+        key
+        for key in [key.upper() for key in os.environ]
+        if key.startswith("LOCALSTACK_")
+        if key.endswith("_BACKEND")
+        or key.endswith("_PORT_EXTERNAL")
+        or key.startswith("PROVIDER_OVERRIDE_")
     ]
-    CONFIG_ENV_VARS = list(set(CONFIG_ENV_VARS))
 
 
 # populate env var names to be passed to the container

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -1,7 +1,5 @@
 import os
 
-import localstack_client.config
-
 import localstack
 
 # LocalStack version
@@ -39,9 +37,6 @@ ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 # Download URLs
 SSL_CERT_URL = f"{ARTIFACTS_REPO}/raw/master/local-certs/server.key"
 SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key"
-
-# map of default service APIs and ports to be spun up (fetch map from localstack_client)
-DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 
 # host to bind to when starting the services
 BIND_HOST = "0.0.0.0"
@@ -194,8 +189,7 @@ TRACE_LOG_LEVELS = [LS_LOG_TRACE, LS_LOG_TRACE_INTERNAL]
 # list of official docker images
 OFFICIAL_IMAGES = [
     "localstack/localstack",
-    "localstack/localstack-light",
-    "localstack/localstack-full",
+    "localstack/localstack-pro",
 ]
 
 # s3 virtual host name

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -10,7 +10,7 @@ from functools import wraps
 from typing import Dict, Iterable, List, Optional, Set
 
 from localstack import config, constants
-from localstack.config import SUPPORTED_SERVICES, get_edge_port_http, is_env_true
+from localstack.config import get_edge_port_http, is_env_true
 from localstack.constants import DEFAULT_VOLUME_DIR
 from localstack.runtime import hooks
 from localstack.utils.container_networking import get_main_container_name
@@ -219,7 +219,9 @@ def get_enabled_apis() -> Set[str]:
         LOG.warning("SERVICES variable is ignored if EAGER_SERVICE_LOADING=0.")
         services = None
     if not services:
-        services = SUPPORTED_SERVICES
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        services = SERVICE_PLUGINS.list_available()
     return resolve_apis(services)
 
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -10,6 +10,7 @@ from functools import wraps
 from typing import Dict, Iterable, List, Optional, Set
 
 from localstack import config, constants
+from localstack.config import SUPPORTED_SERVICES, get_edge_port_http, is_env_true
 from localstack.constants import DEFAULT_VOLUME_DIR
 from localstack.runtime import hooks
 from localstack.utils.container_networking import get_main_container_name
@@ -213,7 +214,13 @@ def get_enabled_apis() -> Set[str]:
 
     The result is cached, so it's safe to call. Clear the cache with get_enabled_apis.cache_clear().
     """
-    return resolve_apis(config.parse_service_ports().keys())
+    services = os.environ.get("SERVICES", "").strip()
+    if services and not is_env_true("EAGER_SERVICE_LOADING"):
+        LOG.warning("SERVICES variable is ignored if EAGER_SERVICE_LOADING=0.")
+        services = None
+    if not services:
+        services = SUPPORTED_SERVICES
+    return resolve_apis(services)
 
 
 # DEPRECATED, lazy loading should be assumed
@@ -510,12 +517,7 @@ def configure_container(container: LocalstackContainer):
     hooks.configure_localstack_container.run(container)
 
     # construct default port mappings
-    service_ports = config.SERVICE_PORTS
-    if service_ports.get("edge") == 0:
-        service_ports.pop("edge")
-    for port in service_ports.values():
-        if port:
-            container.ports.add(port)
+    container.ports.add(get_edge_port_http())
     for port in range(config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END):
         container.ports.add(port)
 

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -46,7 +46,6 @@ DIAGNOSE_IMAGES = [
 
 EXCLUDE_CONFIG_KEYS = {
     "CONFIG_ENV_VARS",
-    "DEFAULT_SERVICE_PORTS",
     "copyright",
     "__builtins__",
     "__cached__",

--- a/localstack/utils/strings.py
+++ b/localstack/utils/strings.py
@@ -9,8 +9,6 @@ import uuid
 import zlib
 from typing import Dict, List, Union
 
-from botocore.httpchecksum import CrtCrc32cChecksum
-
 from localstack.config import DEFAULT_ENCODING
 
 _unprintables = (
@@ -153,6 +151,9 @@ def checksum_crc32(string: Union[str, bytes]) -> str:
 
 
 def checksum_crc32c(string: Union[str, bytes]):
+    # import botocore locally here to avoid a dependency of the CLI to botocore
+    from botocore.httpchecksum import CrtCrc32cChecksum
+
     checksum = CrtCrc32cChecksum()
     checksum.update(to_bytes(string))
     return base64.b64encode(checksum.digest()).decode()

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,13 +24,11 @@ packages=find:
 
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
-    boto3>=1.26.121
     click>=7.0
     cachetools~=5.0.0
     cryptography
     dill==0.3.2
     dnspython>=1.16.0
-    localstack-client>=2.0
     plux>=1.3.1
     psutil>=5.4.8,<6.0.0
     python-dotenv>=0.19.1
@@ -44,7 +42,6 @@ install_requires =
     # needed for python3.7 compat (TypedDict, Literal, type hints)
     typing-extensions; python_version < '3.8'
     tailer>=0.4.1
-    apispec>=5.1.1
 
 [options.packages.find]
 exclude =
@@ -64,13 +61,14 @@ localstack =
 # required to actually run localstack on the host
 runtime =
     airspeed-ext==0.5.19
-    # TODO: check amazon_kclpy pin once build failure in 2.1.0 has been fixed
-    amazon_kclpy>=2.0.6,<2.1.0
+    amazon_kclpy>=2.0.6,!=2.1.0
     antlr4-python3-runtime==4.11.1
+    apispec>=5.1.1
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     awscrt>=0.13.14
     boto>=2.49.0
+    boto3>=1.26.121
     botocore>=1.29.121,<=1.29.121
     cbor2>=5.2.0
     crontab>=0.22.6
@@ -85,6 +83,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-ng>=1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
+    localstack-client>=2.0
     moto-ext[all]==4.1.8.post1
     opensearch-py==2.1.1
     pproxy>=2.7.0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,65 +73,6 @@ class TestProviderConfig:
         assert provider_config.get_provider("kinesis") == default_value
 
 
-class TestParseServicePorts:
-    def test_returns_default_service_ports(self):
-        result = config.parse_service_ports()
-        assert result == config.DEFAULT_SERVICE_PORTS
-
-    def test_with_service_subset(self):
-        with temporary_env({"SERVICES": "s3,sqs", "EAGER_SERVICE_LOADING": "1"}):
-            result = config.parse_service_ports()
-
-        assert len(result) == 2
-        assert "s3" in result
-        assert "sqs" in result
-        assert result["s3"] == 4566
-        assert result["sqs"] == 4566
-
-    def test_custom_service_default_port(self):
-        with temporary_env({"SERVICES": "foobar", "EAGER_SERVICE_LOADING": "1"}):
-            result = config.parse_service_ports()
-
-        assert len(result) == 1
-        assert "foobar" not in config.DEFAULT_SERVICE_PORTS
-        assert "foobar" in result
-        # foobar is not a default service so it is assigned 0
-        assert result["foobar"] == 0
-
-    def test_custom_port_mapping(self):
-        with temporary_env(
-            {"SERVICES": "foobar", "FOOBAR_PORT": "1234", "EAGER_SERVICE_LOADING": "1"}
-        ):
-            result = config.parse_service_ports()
-
-        assert len(result) == 1
-        assert "foobar" not in config.DEFAULT_SERVICE_PORTS
-        assert "foobar" in result
-        assert result["foobar"] == 1234
-
-    def test_custom_illegal_port_mapping(self):
-        with temporary_env(
-            {"SERVICES": "foobar", "FOOBAR_PORT": "asdf", "EAGER_SERVICE_LOADING": "1"}
-        ):
-            result = config.parse_service_ports()
-
-        assert len(result) == 1
-        assert "foobar" not in config.DEFAULT_SERVICE_PORTS
-        assert "foobar" in result
-        # FOOBAR_PORT cannot be parsed
-        assert result["foobar"] == 0
-
-    def test_custom_port_mapping_in_services_env(self):
-        with temporary_env({"SERVICES": "foobar:1235", "EAGER_SERVICE_LOADING": "1"}):
-            result = config.parse_service_ports()
-
-        assert len(result) == 1
-        assert "foobar" not in config.DEFAULT_SERVICE_PORTS
-        assert "foobar" in result
-        # FOOBAR_PORT cannot be parsed
-        assert result["foobar"] == 1235
-
-
 class TestEdgeVariablesDerivedCorrectly:
     """
     Post-v2 we are deriving

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,21 +1,6 @@
-import os
-from contextlib import contextmanager
-from typing import Any, Dict
-
 import pytest
 
 from localstack import config
-
-
-@contextmanager
-def temporary_env(env: Dict[str, Any]):
-    old = os.environ.copy()
-    try:
-        os.environ.update(env)
-        yield os.environ
-    finally:
-        os.environ.clear()
-        os.environ.update(old)
 
 
 class TestProviderConfig:

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -1,0 +1,73 @@
+import os
+from contextlib import contextmanager
+from typing import Any, Dict
+
+import pytest
+
+from localstack.utils.bootstrap import get_enabled_apis
+
+
+@contextmanager
+def temporary_env(env: Dict[str, Any]):
+    old = os.environ.copy()
+    try:
+        os.environ.update(env)
+        yield os.environ
+    finally:
+        os.environ.clear()
+        os.environ.update(old)
+
+
+class TestGetEnabledServices:
+    @pytest.fixture(autouse=True)
+    def reset_get_enabled_apis(self):
+        """
+        Ensures that the cache is reset on get_enabled_apis.
+        :return: get_enabled_apis method with reset fixture
+        """
+        get_enabled_apis.cache_clear()
+        yield
+        get_enabled_apis.cache_clear()
+
+    def test_returns_default_service_ports(self):
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        result = get_enabled_apis()
+        assert result == set(SERVICE_PLUGINS.list_available())
+
+    def test_with_service_subset(self):
+        with temporary_env({"SERVICES": "s3,sqs", "EAGER_SERVICE_LOADING": "1"}):
+            result = get_enabled_apis()
+
+        assert len(result) == 2
+        assert "s3" in result
+        assert "sqs" in result
+
+    def test_custom_service_without_port(self):
+        with temporary_env({"SERVICES": "foobar", "EAGER_SERVICE_LOADING": "1"}):
+            result = get_enabled_apis()
+
+        assert len(result) == 1
+        assert "foobar" in result
+
+    def test_custom_port_mapping_in_services_env(self):
+        with temporary_env({"SERVICES": "foobar:1235", "EAGER_SERVICE_LOADING": "1"}):
+            result = get_enabled_apis()
+
+        assert len(result) == 1
+        assert "foobar" in result
+
+    def test_resolve_meta(self):
+        with temporary_env({"SERVICES": "es,cognito:1337", "EAGER_SERVICE_LOADING": "1"}):
+            result = get_enabled_apis()
+
+        assert len(result) == 4
+        assert result == {
+            # directly given
+            "es",
+            # a dependency of es
+            "opensearch",
+            # "cognito" is a composite for "cognito-idp" and "cognito-identity"
+            "cognito-idp",
+            "cognito-identity",
+        }


### PR DESCRIPTION
This PR contains the following changes:
- It moves the dependency on `localstack_client` (and its transitive dependency `boto3` from `install` to the `runtime` extra).
  - It also cleans up the dependencies a bit (moving `apispec` to `runtime`, removes an unnecessary version pin on `amazon_kclpy`).
  - This effectively reduces the CLI dependencies (because the install dependencies currently are the CLI dependencies).
- It replaces the legacy `service:port` mapping from the `localstack-client` with an dynamically detected list of services based on the loaded plugins.
  - This means that the `localstack-client` does not have to be changed and released when introducing a new service emulator in LocalStack.
  - The ports from the `localstack-client` would only be used with the environment variable `USE_LEGACY_PORTS`, but these wouldn't work with the new "one endpoint for everything" anyways.
  - In the long run, we should try to deprecate the rest of `localstack-client` as well (or maybe completely strip it down to the part patching `boto3`), however, this is out of scope for this PR. It's rather a first step towards that direction.
- Updates the list of "official localstack images" to the new images defined in v2 (this is used by the validation command in the CLI).

I am happy for any feedback!