### PR TITLE
add ClientRequestToken validation for SecretsManager

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -133,7 +133,12 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def create_secret(
         self, context: RequestContext, request: CreateSecretRequest
     ) -> CreateSecretResponse:
+        if "ClientRequestToken" not in request:
+            raise InvalidRequestException(
+                "You must provide a ClientRequestToken value. We recommend a UUID-type value."
+            )
         self._raise_if_invalid_secret_id(request["Name"])
+
         return call_moto(context)
 
     @handler("DeleteResourcePolicy", expand=False)
@@ -192,6 +197,10 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def put_secret_value(
         self, context: RequestContext, request: PutSecretValueRequest
     ) -> PutSecretValueResponse:
+        if "ClientRequestToken" not in request:
+            raise InvalidRequestException(
+                "You must provide a ClientRequestToken value. We recommend a UUID-type value."
+            )
         self._raise_if_invalid_secret_id(request["SecretId"])
         return call_moto(context, request)
 
@@ -220,6 +229,10 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def rotate_secret(
         self, context: RequestContext, request: RotateSecretRequest
     ) -> RotateSecretResponse:
+        if "ClientRequestToken" not in request:
+            raise InvalidRequestException(
+                "You must provide a ClientRequestToken value. We recommend a UUID-type value."
+            )
         self._raise_if_invalid_secret_id(request["SecretId"])
         return call_moto(context, request)
 
@@ -244,6 +257,13 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def update_secret(
         self, context: RequestContext, request: UpdateSecretRequest
     ) -> UpdateSecretResponse:
+        # if we're modifying the value of the secret, ClientRequestToken is required
+        if "ClientRequestToken" not in request and any(
+            key for key in request if key in ("SecretBinary", "SecretString")
+        ):
+            raise InvalidRequestException(
+                "You must provide a ClientRequestToken value. We recommend a UUID-type value."
+            )
         self._raise_if_invalid_secret_id(request["SecretId"])
         return call_moto(context, request)
 

--- a/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
@@ -3594,5 +3594,61 @@
         }
       }
     }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
+    "recorded-date": "12-05-2023, 12:09:22",
+    "recorded-content": {
+      "no-client-request-exc": {
+        "Error": {
+          "Message": "You must provide a ClientRequestToken value. We recommend a UUID-type value.",
+          "__type": "InvalidRequestException"
+        },
+        "Metadata": {
+          "StatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[UpdateSecret]": {
+    "recorded-date": "12-05-2023, 12:09:23",
+    "recorded-content": {
+      "no-client-request-exc": {
+        "Error": {
+          "Message": "You must provide a ClientRequestToken value. We recommend a UUID-type value.",
+          "__type": "InvalidRequestException"
+        },
+        "Metadata": {
+          "StatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[RotateSecret]": {
+    "recorded-date": "12-05-2023, 12:09:23",
+    "recorded-content": {
+      "no-client-request-exc": {
+        "Error": {
+          "Message": "You must provide a ClientRequestToken value. We recommend a UUID-type value.",
+          "__type": "InvalidParameterException"
+        },
+        "Metadata": {
+          "StatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[PutSecretValue]": {
+    "recorded-date": "12-05-2023, 12:09:24",
+    "recorded-content": {
+      "no-client-request-exc": {
+        "Error": {
+          "Message": "You must provide a ClientRequestToken value. We recommend a UUID-type value.",
+          "__type": "InvalidRequestException"
+        },
+        "Metadata": {
+          "StatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
For `ClientRequestToken` in the following operations (CreateSecret, UpdateSecret, RotateSecret, PutSecretValue), there's a specific note in the documentation:
https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/create-secret.html#options

> If you use the AWS CLI or one of the AWS SDKs to call this operation, then you can leave this parameter empty. The CLI or SDK generates a random UUID for you and includes it as the value for this parameter in the request. If you don't use the SDK and instead generate a raw HTTP request to the Secrets Manager service endpoint, then you must generate a ClientRequestToken yourself for the new version and include the value in the request.

As we tested with boto, we never tried to run a request without it against AWS (just mocked locally with `request`). It is now done with the use of the `aws_http_client_factory`, and I could validate the behaviour against AWS.

This PR also fixes and rewrites tests that had a bad assumption of having the `ClientRequestToken` being created server side like moto does, but as the AWS validated test shows, AWS actually reject any request not having this field. I wonder if those tests have actual value, as they are not AWS tested and I think most of them were testing the wrong behaviour.
