### PR TITLE
Fix issue publishing messages with String.Array attibutes

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -1,5 +1,4 @@
 import abc
-import ast
 import base64
 import copy
 import datetime
@@ -962,7 +961,10 @@ class SubscriptionFilter:
         tpe = attribute.get("DataType") or attribute.get("Type") if attribute else None
         val = attribute.get("StringValue") or attribute.get("Value") if attribute else None
         if attribute is not None and tpe == "String.Array":
-            values = ast.literal_eval(val)
+            try:
+                values = json.loads(val)
+            except ValueError:
+                return False
             for value in values:
                 for condition in conditions:
                     if self._evaluate_condition(value, condition, field_exists):

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -196,7 +196,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['soccer', 'rugby', 'hockey']",
+                        "Value": '["soccer", "rugby", "hockey"]',
                     }
                 },
                 True,
@@ -226,7 +226,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['soccer', 'rugby', 'hockey']",
+                        "Value": '["soccer", "rugby", "hockey"]',
                     }
                 },
                 True,
@@ -249,7 +249,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['soccer', 'rugby', 'hockey']",
+                        "Value": '["soccer", "rugby", "hockey"]',
                     }
                 },
                 False,
@@ -278,7 +278,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['soccer', 'rugby', 'hockey']",
+                        "Value": '["soccer", "rugby", "hockey"]',
                     }
                 },
                 True,
@@ -370,7 +370,7 @@ class TestSns:
             (
                 "logical OR with match on an array",
                 {"filter": ["test1", "test2", {"prefix": "typ"}]},
-                {"filter": {"Type": "String.Array", "Value": "['test1', 'other']"}},
+                {"filter": {"Type": "String.Array", "Value": '["test1", "other"]'}},
                 True,
             ),
             (
@@ -385,7 +385,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['anything', 'something']",
+                        "Value": '["anything", "something"]',
                     }
                 },
                 False,
@@ -474,7 +474,7 @@ class TestSns:
                 {
                     "filter": {
                         "Type": "String.Array",
-                        "Value": "['anything', 'something']",
+                        "Value": '["anything", "something"]',
                     }
                 },
                 True,
@@ -501,6 +501,18 @@ class TestSns:
                 "does not exists with existing attribute",
                 {"field": [{"exists": False}]},
                 {"field": {"Type": "String", "Value": "anything"}},
+                False,
+            ),
+            (
+                "can match on String.Array containing boolean",
+                {"field": [True]},
+                {"field": {"Type": "String.Array", "Value": "[true]"}},
+                True,
+            ),
+            (
+                "can not match on values that are not valid JSON strings",
+                {"field": ["anything"]},
+                {"field": {"Type": "String.Array", "Value": "['anything']"}},
                 False,
             ),
         ]


### PR DESCRIPTION
localstack currently fails to publish messages if there is a filter policy against a message attribute that contains 'true', 'false' or 'null',

As documented, a String.Array attribute [can contain](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html#SNSMessageAttributes.DataTypes) strings, numbers, or the keywords 'true', 'false' or 'null'. Message attributes are also required to be [valid JSON strings](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html) for use in filtering.

Parse String.Array values with `json.loads` instead of `ast.literal_eval` to solve these issues.

Resolves #8304
