### PR TITLE
CDK fixture for defining a stack

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,8 @@ full =
 # for running tests and coverage analysis
 test =
     # coverage version should be synced with bin/Dockerfile.base
+    aws-cdk-lib==2.78.0
+    constructs>=10.0.0,<11.0.0
     coverage[toml]>=5.5
     deepdiff>=5.5.0
     jsonpath-ng>=1.5.3


### PR DESCRIPTION
Add fixture to allow the definition of a CFn stack via CDK.

*Previous work (that I had forgotten existed): #6333* :facepalm: 

## Motivation

We as LocalStack developers have effectively re-built CloudFormation and CDK with our own fixtures. Instead, let's define our test setup with resources that are designed exactly for this purpose.

## Example

```python
from localstack.aws.connect import ServiceLevelClientFactory
from aws_cdk import aws_sns as sns
from aws_cdk import aws_sqs as sqs
from aws_cdk import aws_sns_subscriptions as subscriptions


def test_plugin(define_infrastructure, aws_client: ServiceLevelClientFactory):
    with define_infrastructure() as cdk:
        topic = sns.Topic(cdk, "MyTopic")
        queue = sqs.Queue(cdk, "MyQueue")
        topic.add_subscription(subscriptions.SqsSubscription(queue))

    assert len(aws_client.cloudformation.list_stacks()["StackSummaries"]) == 1
    assert len(aws_client.sns.list_topics()["Topics"]) == 1
    assert len(aws_client.sqs.list_queues()["QueueUrls"]) == 1
```

