### PR TITLE
Fix CFn model class & attribute lookup

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -685,7 +685,10 @@ def resolve_placeholders_in_string(result, stack_name: str, resources: dict):
             # Resource attributes specified => Use GetAtt to resolve
             resource_name, _, attr_name = ref_expression.partition(".")
             resolved = get_attr_from_model_instance(
-                resources[resource_name], attr_name, resources[resource_name]["Type"], resource_name
+                resources[resource_name],
+                attr_name,
+                get_resource_type(resources[resource_name]),
+                resource_name,
             )
             if resolved is None:
                 raise DependencyNotYetSatisfied(
@@ -979,7 +982,7 @@ def add_default_resource_props(
 ):
     """Apply some fixes to resource props which otherwise cause deployments to fail"""
 
-    res_type = resource["Type"]
+    res_type = get_resource_type(resource)
     resource_class = RESOURCE_MODELS.get(res_type)
     if resource_class is not None:
         resource_class.add_defaults(resource, stack_name)
@@ -1064,7 +1067,7 @@ class TemplateDeployer:
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = resource["Type"]
+            resource["ResourceType"] = get_resource_type(resource)
 
         def _safe_lookup_is_deleted(r_id):
             """handles the case where self.stack.resource_status(..) fails for whatever reason"""

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -695,6 +695,8 @@ def resolve_placeholders_in_string(result, stack_name: str, resources: dict):
                     resource_ids=resource_name,
                     message=f"Unable to resolve attribute ref {ref_expression}",
                 )
+            if not isinstance(resolved, str):
+                resolved = str(resolved)
             return resolved
         if len(parts) == 1 and parts[0] in resources:
             # Logical resource ID or parameter name specified => Use Ref for lookup

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -535,7 +535,7 @@ def _resolve_refs_recursively(stack_name, resources, value: dict | list | str | 
             resource = resources.get(resource_logical_id)
 
             resolved_getatt = get_attr_from_model_instance(
-                resource, attribute_name, resource["Type"]
+                resource, attribute_name, get_resource_type(resource)
             )
             # TODO: we should check the deployment state and not try to GetAtt from a resource that is still IN_PROGRESS or hasn't started yet.
             if resolved_getatt is None:

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -127,7 +127,8 @@ def get_deployment_config(res_type: str) -> DeployTemplates | None:
         usage.missing_resource_types.record(res_type)
 
 
-def get_resource_type(resource):
+def get_resource_type(resource: dict) -> str:
+    """this is currently overwritten in PRO to add support for custom resources"""
     return resource["Type"]
 
 
@@ -330,8 +331,7 @@ def get_attr_from_model_instance(
 
 def get_ref_from_model(resources: dict, logical_resource_id: str) -> Optional[str]:
     resource = resources[logical_resource_id]
-    resource_type: str = resource["Type"]
-
+    resource_type = get_resource_type(resource)
     model_class = RESOURCE_MODELS.get(resource_type)
     if model_class:
         return model_class(resource_name=logical_resource_id, resource_json=resource).get_ref()

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -41,7 +41,7 @@ class EC2RouteTable(GenericBaseModel):
             },
             "delete": {
                 "function": "delete_route_table",
-                "parameters": {"RouteTableId": "PhysicalResourceId"},
+                "parameters": {"RouteTableId": "RouteTableId"},
             },
         }
 
@@ -288,7 +288,7 @@ class SecurityGroup(GenericBaseModel):
             },
             "delete": {
                 "function": "delete_security_group",
-                "parameters": {"GroupId": "PhysicalResourceId"},
+                "parameters": {"GroupId": "GroupId"},
             },
         }
 
@@ -378,7 +378,7 @@ class EC2Subnet(GenericBaseModel):
             ],
             "delete": {
                 "function": "delete_subnet",
-                "parameters": {"SubnetId": "PhysicalResourceId"},
+                "parameters": ["SubnetId"],
             },
         }
 
@@ -463,7 +463,7 @@ class EC2VPC(GenericBaseModel):
                 {"function": _pre_delete},
                 {
                     "function": "delete_vpc",
-                    "parameters": {"VpcId": "PhysicalResourceId"},
+                    "parameters": ["VpcId"],
                 },
             ],
         }
@@ -506,7 +506,7 @@ class EC2NatGateway(GenericBaseModel):
             },
             "delete": {
                 "function": "delete_nat_gateway",
-                "parameters": {"NatGatewayId": "PhysicalResourceId"},
+                "parameters": ["NatGatewayId"],
             },
         }
 
@@ -595,10 +595,6 @@ class EC2Instance(GenericBaseModel):
             },
             "delete": {
                 "function": "terminate_instances",
-                "parameters": {
-                    "InstanceIds": lambda params, **kw: [
-                        kw["resources"][kw["resource_id"]]["PhysicalResourceId"]
-                    ]
-                },
+                "parameters": {"InstanceIds": ["InstanceId"]},
             },
         }

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -387,7 +387,7 @@ class EC2VPC(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         ec2_client = aws_stack.connect_to_service("ec2")
-        vpc_id = self.state["VpcId"]
+        vpc_id = self.props["VpcId"]
 
         if attribute_name == "DefaultSecurityGroup":
             sgs = ec2_client.describe_security_groups(
@@ -439,6 +439,7 @@ class EC2VPC(GenericBaseModel):
 
         def _store_vpc_id(result, resource_id, resources, resource_type):
             resources[resource_id]["PhysicalResourceId"] = result["Vpc"]["VpcId"]
+            resources[resource_id]["Properties"]["VpcId"] = result["Vpc"]["VpcId"]
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -299,6 +299,8 @@ class EC2Subnet(GenericBaseModel):
         return "AWS::EC2::Subnet"
 
     def fetch_state(self, stack_name, resources):
+        if not self.physical_resource_id:
+            return None
         client = aws_stack.connect_to_service("ec2")
         props = self.props
         filters = [
@@ -310,6 +312,11 @@ class EC2Subnet(GenericBaseModel):
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         return self.props.get("SubnetId")
+
+    def get_cfn_attribute(self, attribute_name):
+        if attribute_name == "SubnetId":
+            return self.props.get("SubnetId")
+        return super(EC2Subnet, self).get_cfn_attribute(attribute_name)
 
     @classmethod
     def get_deploy_templates(cls):
@@ -349,6 +356,7 @@ class EC2Subnet(GenericBaseModel):
 
         def _store_id(result, resource_id, resources, resource_type):
             resources[resource_id]["PhysicalResourceId"] = result["Subnet"]["SubnetId"]
+            resources[resource_id]["Properties"]["SubnetId"] = result["Subnet"]["SubnetId"]
 
         return {
             "create": [


### PR DESCRIPTION
Fixes a regression introduced in recent CFn refactorings. 

PRO overwrites get_resource_type to add support for custom resources, but we didn't use this in get_ref and other call sites, causing this to fail -ext tests.