### PR TITLE
Refactor handling of CFn stack parameters

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -129,7 +129,9 @@ class Stack:
         outputs = self.resolved_outputs
         if outputs:
             result["Outputs"] = outputs
-        result["Parameters"] = convert_stack_parameters_to_list(self.resolved_parameters)
+        stack_parameters = convert_stack_parameters_to_list(self.resolved_parameters)
+        if stack_parameters:
+            result["Parameters"] = stack_parameters
         if not result.get("DriftInformation"):
             result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
         for attr in ["Tags", "NotificationARNs"]:

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -1,8 +1,12 @@
 import logging
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Optional, TypedDict
 
 from localstack.aws.api.cloudformation import Capability, ChangeSetType, Parameter
-from localstack.utils.aws import arns, aws_stack
+from localstack.services.cloudformation.engine.parameters import (
+    convert_stack_parameters_to_list,
+    map_to_legacy_structure,
+)
+from localstack.utils.aws import arns
 from localstack.utils.collections import select_attributes
 from localstack.utils.json import clone_safe
 from localstack.utils.objects import recurse_object
@@ -64,6 +68,7 @@ class Stack:
             template = {}
 
         self.resolved_outputs = list()  # TODO
+        self.resolved_parameters: dict[str, Parameter] = {}
 
         self.metadata = metadata or {}
         self.template = template or {}
@@ -124,12 +129,10 @@ class Stack:
         outputs = self.resolved_outputs
         if outputs:
             result["Outputs"] = outputs
-        params = self.stack_parameters()
-        if params:
-            result["Parameters"] = params
+        result["Parameters"] = convert_stack_parameters_to_list(self.resolved_parameters)
         if not result.get("DriftInformation"):
             result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
-        for attr in ["Capabilities", "Tags", "NotificationARNs"]:
+        for attr in ["Tags", "NotificationARNs"]:
             result.setdefault(attr, [])
         return result
 
@@ -232,9 +235,9 @@ class Stack:
         """Return dict of resources, parameters, conditions, and other stack metadata."""
         result = dict(self.template_resources)
 
-        # add stack params (without defaults)
-        stack_params = self._resolve_stack_parameters(defaults=False, existing=result)
-        result.update(stack_params)
+        result.update(
+            {k: map_to_legacy_structure(k, v) for k, v in self.resolved_parameters.items()}
+        )
 
         # TODO: conditions and mappings don't really belong here and should be handled separately
         for name, value in self.conditions.items():
@@ -252,41 +255,6 @@ class Stack:
                     "Properties": {"Value": value},
                 }
 
-        stack_params = self._resolve_stack_parameters(defaults=True, existing=result)
-        result.update(stack_params)
-
-        return result
-
-    # TODO: check duplication with stack_parameters(..) property method
-    def _resolve_stack_parameters(
-        self, defaults=True, existing: Dict[str, Dict] = None
-    ) -> Dict[str, Dict]:
-        """Resolve the parameter values of this stack, skipping the params already present in `existing`"""
-        existing = existing or {}
-        result = {}
-        for param in self.stack_parameters(defaults=defaults):
-            param_key = param["ParameterKey"]
-            if param_key not in existing:
-                template_parameter = self.template_parameters.get(param_key, {})
-                param_type = template_parameter.get("Type")
-                resolved_value = param.get("ResolvedValue")
-                # TODO: check if we should fall back to template_parameter.get("Default") in case prop_value is None
-                prop_value = (
-                    resolved_value if resolved_value is not None else param.get("ParameterValue")
-                )
-                # TODO: consider replacing "Value" with "ResolvedValue", to have a clearer distinction
-                properties = {
-                    "Value": prop_value,
-                    "ParameterType": param_type,
-                    "ParameterValue": param.get("ParameterValue"),
-                }
-                if resolved_value is not None:
-                    properties["ResolvedValue"] = resolved_value
-                result[param_key] = {
-                    "Type": "Parameter",
-                    "LogicalResourceId": param_key,
-                    "Properties": properties,
-                }
         return result
 
     @property
@@ -308,43 +276,6 @@ class Stack:
 
         result = set()
         recurse_object(self.resources, _collect)
-        return result
-
-    # TODO: check if metadata already populated/resolved and use it if possible (avoid unnecessary re-resolving)
-    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
-        result = {}
-        # add default template parameter values
-        if defaults:
-            for key, value in self.template_parameters.items():
-                param_value = value.get("Default")
-                result[key] = {
-                    "ParameterKey": key,
-                    "ParameterValue": param_value,
-                }
-                # TODO: extract dynamic parameter resolving
-                # TODO: support different types and refactor logic to use metadata (here not yet populated properly)
-                param_type = value.get("Type", "")
-                if not param_type:
-                    if param_type == "AWS::SSM::Parameter::Value<String>":
-                        result[key]["ResolvedValue"] = resolve_ssm_parameter_value(
-                            param_type, param_value
-                        )
-                    elif param_type.startswith("AWS::"):
-                        LOG.info(
-                            f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
-                        )
-                    else:
-                        # lets assume we support the normal CFn parameters
-                        pass
-
-        # add stack parameters
-        result.update({p["ParameterKey"]: p for p in self.metadata["Parameters"]})
-        # add parameters of change sets
-        for change_set in self.change_sets:
-            for param in change_set.metadata["Parameters"]:
-                if not param.get("UsePreviousValue"):
-                    result.update({param["ParameterKey"]: param})
-        result = list(result.values())
         return result
 
     @property
@@ -423,24 +354,3 @@ class StackChangeSet(Stack):
     def changes(self):
         result = self.metadata["Changes"] = self.metadata.get("Changes", [])
         return result
-
-    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
-        return self.stack.stack_parameters(defaults=defaults)
-
-
-def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> str:
-    """
-    Resolve the SSM stack parameter with the name specified via the given `parameter_value`.
-
-    Given a stack template with parameter {"param1": {"Type": "AWS::SSM::Parameter::Value<String>"}} and
-    a stack instance with stack parameter {"ParameterKey": "param1", "ParameterValue": "test-param"}, this
-    function will resolve the SSM parameter with name `test-param` and return the SSM parameter's value.
-    """
-    # TODO: support different parameter value types
-    if (
-        parameter_type == "AWS::SSM::Parameter::Value<String>"
-        or parameter_type == "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    ):
-        ssm_client = aws_stack.connect_to_service("ssm")
-        return ssm_client.get_parameter(Name=parameter_value)["Parameter"]["Value"]
-    raise Exception(f"Unsupported parameter value type {parameter_type}")

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -57,6 +57,7 @@ class StackTemplate(TypedDict):
     Resources: dict
 
 
+# TODO: remove metadata (flatten into individual fields)
 class Stack:
     def __init__(
         self,
@@ -103,6 +104,11 @@ class Stack:
         self.events = []
         # list of stack change sets
         self.change_sets = []
+
+    def set_resolved_parameters(self, resolved_parameters: dict[str, Parameter]):
+        self.resolved_parameters = resolved_parameters
+        if resolved_parameters:
+            self.metadata["Parameters"] = list(resolved_parameters.values())
 
     def describe_details(self):
         attrs = [

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -1,0 +1,158 @@
+"""
+AWS docs (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html):
+
+The following requirements apply when using parameters:
+
+    You can have a maximum of 200 parameters in an AWS CloudFormation template.
+    Each parameter must be given a logical name (also called logical ID), which must be alphanumeric and unique among all logical names within the template.
+    Each parameter must be assigned a parameter type that is supported by AWS CloudFormation. For more information, see Type.
+    Each parameter must be assigned a value at runtime for AWS CloudFormation to successfully provision the stack. You can optionally specify a default value for AWS CloudFormation to use unless another value is provided.
+    Parameters must be declared and referenced from within the same template. You can reference parameters from the Resources and Outputs sections of the template.
+
+
+
+    When you create or update stacks and create change sets, AWS CloudFormation uses whatever values exist in Parameter Store at the time the operation is run. If a specified parameter doesn't exist in Parameter Store under the caller's AWS account, AWS CloudFormation returns a validation error.
+
+    For stack updates, the Use existing value option in the console and the UsePreviousValue attribute for update-stack tell AWS CloudFormation to use the existing Systems Manager parameter key—not its value. AWS CloudFormation always fetches the latest values from Parameter Store when it updates stacks.
+
+
+    TODO: ordering & grouping of parameters
+    TODO: design proper structure for parameters to facilitate validation etc.
+    TODO: clearer language around both parameters and "resolving"
+"""
+from typing import Literal, Optional, TypedDict
+
+from localstack.aws.api.cloudformation import Parameter, ParameterDeclaration
+from localstack.aws.connect import connect_to
+
+
+def resolve_parameters(
+    parameter_declarations: dict[str, ParameterDeclaration],
+    new_parameters: dict[str, Parameter],
+    old_parameters: dict[str, Parameter],
+) -> dict[str, Parameter]:
+    """
+    Resolves stack parameters or raises an exception if any parameter can not be resolved.
+
+    Assumptions:
+        - There are no extra undeclared parameters given (validate before calling this method)
+
+    TODO: does "UsePreviousValue" refer to the value or the resolved value? Will an update stack do a new lookup on the same parameter if it has been updated since?
+    TODO: is UsePreviousValue=False equivalent to not specifying it, in all situations?
+
+    :param parameter_declarations: The parameter declaration from the (potentially new) template, i.e. the "Parameters" section
+    :param new_parameters: The parameters to resolve
+    :param old_parameters: The old parameters from the previous stack deployment, if available
+    :return: a copy of new_parameters with resolved values
+    """
+    resolved_parameters = dict()
+
+    # populate values for every parameter declared in the template
+    for pm in parameter_declarations.values():
+        pm_key = pm["ParameterKey"]
+        resolved_param = Parameter(ParameterKey=pm_key)
+        new_parameter = new_parameters.get(pm_key)
+        old_parameter = old_parameters.get(pm_key)
+
+        if new_parameter is None:
+            # since no value has been specified for the deployment, we need to be able to resolve the default or fail
+            default_value = pm["DefaultValue"]
+            if default_value is None:
+                raise Exception("Invalid. Needs to have either param specified or Default. todo")
+
+            resolved_param["ParameterValue"] = default_value
+        else:
+            if (
+                new_parameter.get("UsePreviousValue", False)
+                and new_parameter.get("ParameterValue") is not None
+            ):
+                raise Exception("Can't use both previous value and specifying one. todo")
+
+            if new_parameter.get("UsePreviousValue", False):
+                if old_parameter is None:
+                    raise Exception("no previous value :(")
+
+                resolved_param["ParameterValue"] = old_parameter["ParameterValue"]
+            else:
+                resolved_param["ParameterValue"] = new_parameter["ParameterValue"]
+
+        resolved_parameters[pm_key] = resolved_param
+
+        # Note that SSM parameters always need to be resolved anew here
+        # TODO: support more parameter types
+        if pm["ParameterType"].startswith("AWS::SSM"):
+            if pm["ParameterType"] in [
+                "AWS::SSM::Parameter::Value<String>",
+                "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            ]:
+                # TODO: error handling
+                resolved_param["ResolvedValue"] = resolve_dynamic_parameter(
+                    resolved_param["ParameterValue"]
+                )
+            else:
+                raise Exception(f"Unsupported stack parameter type: {pm['ParameterType']}")
+
+    return resolved_parameters
+
+
+# TODO: inject credentials / client factory for proper account/region lookup
+def resolve_dynamic_parameter(parameter_value: str) -> str:
+    """
+    Resolve the SSM stack parameter with the name specified via the given `parameter_value`.
+
+    Given a stack template with parameter {"param1": {"Type": "AWS::SSM::Parameter::Value<String>"}} and
+    a stack instance with stack parameter {"ParameterKey": "param1", "ParameterValue": "test-param"}, this
+    function will resolve the SSM parameter with name `test-param` and return the SSM parameter's value.
+    """
+    return connect_to().ssm.get_parameter(Name=parameter_value)["Parameter"]["Value"]
+
+
+def convert_stack_parameters_to_list(in_params: dict[str, Parameter]) -> list[Parameter]:
+    return list(in_params.values())
+
+
+def convert_stack_parameters_to_dict(in_params: list[Parameter]) -> dict[str, Parameter]:
+    return {p["ParameterKey"]: p for p in in_params}
+
+
+class LegacyParameterProperties(TypedDict):
+    Value: str
+    ParameterType: str
+    ParameterValue: Optional[str]
+    ResolvedValue: Optional[str]
+
+
+class LegacyParameter(TypedDict):
+    LogicalResourceId: str
+    Type: Literal["Parameter"]
+    Properties: LegacyParameterProperties
+
+
+def map_to_legacy_structure(parameter_type: str, new_parameter: Parameter) -> LegacyParameter:
+    return LegacyParameter(
+        LogicalResourceId=new_parameter["ParameterKey"],
+        Type="Parameter",
+        Properties=LegacyParameterProperties(
+            ParameterType=parameter_type,
+            ParameterValue=new_parameter.get("ParameterValue"),
+            ResolvedValue=new_parameter.get("ResolvedValue"),
+            Value=new_parameter.get("ResolvedValue", new_parameter.get("ParameterValue")),
+        ),
+    )
+
+
+def extract_parameter_declarations_from_template(template: dict) -> dict[str, ParameterDeclaration]:
+    if "Parameters" not in template:
+        return {}
+
+    result = {}
+
+    for param_key, param in template["Parameters"].items():
+        result[param_key] = ParameterDeclaration(
+            ParameterKey=param_key,
+            DefaultValue=param.get("Default"),
+            ParameterType=param.get("Type"),
+            # TODO: rest
+        )
+
+    return result

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -107,11 +107,15 @@ def resolve_dynamic_parameter(parameter_value: str) -> str:
     return connect_to().ssm.get_parameter(Name=parameter_value)["Parameter"]["Value"]
 
 
-def convert_stack_parameters_to_list(in_params: dict[str, Parameter]) -> list[Parameter]:
+def convert_stack_parameters_to_list(in_params: dict[str, Parameter] | None) -> list[Parameter]:
+    if not in_params:
+        return []
     return list(in_params.values())
 
 
-def convert_stack_parameters_to_dict(in_params: list[Parameter]) -> dict[str, Parameter]:
+def convert_stack_parameters_to_dict(in_params: list[Parameter] | None) -> dict[str, Parameter]:
+    if not in_params:
+        return {}
     return {p["ParameterKey"]: p for p in in_params}
 
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -22,11 +22,7 @@ from localstack.services.cloudformation.deployment_utils import (
     log_not_available_message,
     remove_none_values,
 )
-from localstack.services.cloudformation.engine.entities import (
-    Stack,
-    StackChangeSet,
-    resolve_ssm_parameter_value,
-)
+from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet
 from localstack.services.cloudformation.service_models import (
     KEY_RESOURCE_STATE,
     DependencyNotYetSatisfied,
@@ -292,11 +288,6 @@ def extract_resource_attribute(
             "Value",
             resource.get("Value", resource_props.get("Properties", {}).get("Value")),
         )
-        param_value_type = resource_props.get("ParameterType") or ""
-        if param_value_type.startswith("AWS::SSM::Parameter::Value"):
-            param_value = resolve_ssm_parameter_value(
-                param_value_type, resource_props.get("ParameterValue")
-            )
         if is_ref_attr_or_arn:
             result = param_value
         elif isinstance(param_value, dict):
@@ -316,6 +307,7 @@ def extract_resource_attribute(
                 resource_id=resource_id,
             )
     if is_ref_attribute:
+        # TODO: remove
         for attr in ["Id", "PhysicalResourceId", "Ref"]:
             if result is None:
                 for obj in [resource_state, resource]:
@@ -1058,6 +1050,8 @@ class TemplateDeployer:
             else "CREATE"
         )
         change_set.stack.set_stack_status(f"{action}_IN_PROGRESS")
+        # update parameters
+        change_set.stack.resolved_parameters = change_set.resolved_parameters
 
         # update attributes that the stack inherits from the changeset
         change_set.stack.metadata["Capabilities"] = change_set.metadata.get("Capabilities")
@@ -1302,56 +1296,6 @@ class TemplateDeployer:
             "Resources"
         ][resource_id]
 
-    def resolve_param(
-        self, logical_id: str, param_type: str, default_value: Optional[str] = None
-    ) -> Optional[str]:
-        if param_type == "AWS::SSM::Parameter::Value<String>":
-            return resolve_ssm_parameter_value(param_type, default_value)
-        return None
-
-    def apply_parameter_changes(self, old_stack, new_stack) -> None:
-        parameters = {
-            p["ParameterKey"]: p
-            for p in old_stack.metadata["Parameters"]  # go through current parameter values
-        }
-
-        for logical_id, value in new_stack.template["Parameters"].items():
-            default = value.get("Default")
-            provided_param_value = parameters.get(logical_id)
-            param = {
-                "ParameterKey": logical_id,
-                "ParameterValue": provided_param_value if default is None else default,
-            }
-            if default is not None:
-                resolved_value = self.resolve_param(logical_id, value.get("Type"), default)
-                if resolved_value is not None:
-                    param["ResolvedValue"] = resolved_value
-
-            parameters[logical_id] = param
-
-        def _update_params(params_list: list[dict]):
-            for param in params_list:
-                # make sure we preserve parameter values if UsePreviousValue=true
-                if not param.get("UsePreviousValue"):
-                    parameters.update({param["ParameterKey"]: param})
-
-        _update_params(new_stack.metadata["Parameters"])
-        for change_set in new_stack.change_sets:
-            _update_params(change_set.metadata["Parameters"])
-
-        # TODO: unclear/undocumented behavior in implicitly updating old_stack parameter here
-        # Note: Indeed it seems that parameters from Change Sets are applied to a stack
-        #   itself, and are preserved even after a change set has been deleted. However,
-        #   a proper implementation would distinguish between (1) Change Sets and (2) Change
-        #   Set Executions - the former are only a template for the changes to be applied,
-        #   whereas the latter actually perform changes (including parameter updates).
-        #   Also, (1) can be deleted, and (2) can only be rolled back (in case of errors).
-        #   Once we have the distinction between (1) and (2) in place, this logic (updating
-        #   the parameters of the stack itself) will become obsolete, then the parameter
-        #   values can be determined by replaying the values of the sequence of (immutable)
-        #   Change Set Executions.
-        old_stack.metadata["Parameters"] = [v for v in parameters.values() if v]
-
     def construct_changes(
         self,
         existing_stack,
@@ -1402,7 +1346,7 @@ class TemplateDeployer:
         self.init_resource_status(old_resources, action="UPDATE")
 
         # apply parameter changes to existing stack
-        self.apply_parameter_changes(existing_stack, new_stack)
+        # self.apply_parameter_changes(existing_stack, new_stack)
 
         # construct changes
         changes = self.construct_changes(

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1051,7 +1051,7 @@ class TemplateDeployer:
         )
         change_set.stack.set_stack_status(f"{action}_IN_PROGRESS")
         # update parameters
-        change_set.stack.resolved_parameters = change_set.resolved_parameters
+        change_set.stack.set_resolved_parameters(change_set.resolved_parameters)
 
         # update attributes that the stack inherits from the changeset
         change_set.stack.metadata["Capabilities"] = change_set.metadata.get("Capabilities")

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from typing import Dict, List
 
 import boto3
 from samtranslator.translator.transform import transform as transform_sam
@@ -9,7 +8,6 @@ from samtranslator.translator.transform import transform as transform_sam
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException
 from localstack.services.cloudformation.engine import yaml_parser
-from localstack.services.cloudformation.engine.entities import resolve_ssm_parameter_value
 from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.services.cloudformation.engine.transformers import (
     apply_transform_intrinsic_functions,
@@ -42,7 +40,7 @@ def template_to_json(template: str) -> str:
 
 
 # TODO: consider moving to transformers.py as well
-def transform_template(template: dict, parameters: list, stack=None) -> Dict:
+def transform_template(template: dict, parameters: list, stack=None) -> dict:
     result = dict(template)
 
     # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
@@ -82,6 +80,7 @@ def execute_macro(parsed_template: dict, macro: dict, stack_parameters: list) ->
     if not macro_definition:
         raise FailedTransformationException(macro["Name"], "2DO")
 
+    # TODO: needs to consider ResolvedValue for SSM parameters as well
     formatted_stack_parameters = {
         param["ParameterKey"]: param["ParameterValue"] for param in stack_parameters
     }
@@ -174,38 +173,6 @@ def format_transforms(transforms: list | dict | str) -> list[dict]:
                 formatted_transformations.append(transformation)
 
     return formatted_transformations
-
-
-# TODO add support for "previous values"
-def resolve_parameters(template_parameters: dict, request_parameters: List[dict]):
-    """
-    Macros can use the template parameters so this method resolves them so they can be pass to the lambda function.
-    This method was extracted from entities.py with the intent to not depend on the Stack Class.
-    """
-    result = {}
-    # add default template parameter values
-    for key, value in template_parameters.items():
-        param_value = value.get("Default")
-        result[key] = {
-            "ParameterKey": key,
-            "ParameterValue": param_value,
-        }
-        param_type = value.get("Type", "")
-        if not param_type:
-            if param_type == "AWS::SSM::Parameter::Value<String>":
-                result[key]["ResolvedValue"] = resolve_ssm_parameter_value(param_type, param_value)
-            elif param_type.startswith("AWS::"):
-                LOG.info(
-                    f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
-                )
-            else:
-                # lets assume we support the normal CFn parameters
-                pass
-
-    # add stack parameters
-    result.update({p["ParameterKey"]: p for p in request_parameters})
-    result = list(result.values())
-    return result
 
 
 class FailedTransformationException(Exception):

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -40,12 +40,12 @@ def template_to_json(template: str) -> str:
 
 
 # TODO: consider moving to transformers.py as well
-def transform_template(template: dict, parameters: list, stack=None) -> dict:
+def transform_template(template: dict, parameters: list, stack_name: str, resources: dict) -> dict:
     result = dict(template)
 
     # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
     #  transforms below, as some utils - incl samtransformer - expect them to be resolved already)
-    result = apply_transform_intrinsic_functions(result, stack=stack)
+    result = apply_transform_intrinsic_functions(result, stack_name, resources)
 
     # apply global transforms
     transformations = format_transforms(result.get("Transform", []))

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -39,7 +39,7 @@ class AwsIncludeTransformer(Transformer):
 transformers: Dict[str, Type] = {"AWS::Include": AwsIncludeTransformer}
 
 
-def apply_transform_intrinsic_functions(template: dict, stack=None) -> dict:
+def apply_transform_intrinsic_functions(template: dict, stack_name: str, resources: dict) -> dict:
     """Resolve constructs using the 'Fn::Transform' intrinsic function."""
     from localstack.services.cloudformation.engine.template_deployer import resolve_refs_recursively
 
@@ -51,8 +51,7 @@ def apply_transform_intrinsic_functions(template: dict, stack=None) -> dict:
             if transformer_class:
                 transformer = transformer_class()
                 parameters = transform.get("Parameters") or {}
-                if stack:
-                    resolve_refs_recursively(stack.stack_name, stack.resources, parameters)
+                parameters = resolve_refs_recursively(stack_name, resources, parameters)
                 return transformer.transform(parameters)
         return obj
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -190,7 +190,7 @@ class CloudformationProvider(CloudformationApi):
             )
 
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
-            request["Parameters"]
+            request.get("Parameters")
         )
         parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
             template
@@ -274,7 +274,7 @@ class CloudformationProvider(CloudformationApi):
             )
 
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
-            request["Parameters"]
+            request.get("Parameters")
         )
         parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
             template
@@ -508,7 +508,7 @@ class CloudformationProvider(CloudformationApi):
 
         # apply template transformations
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
-            request["Parameters"]
+            request.get("Parameters")
         )
         parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
             template

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -219,7 +219,7 @@ class CloudformationProvider(CloudformationApi):
             return CreateStackOutput(StackId=stack.stack_id)
 
         stack = Stack(request, template)
-        stack.resolved_parameters = resolved_parameters
+        stack.set_resolved_parameters(resolved_parameters)
         stack.template_body = json.dumps(template)
         state.stacks[stack.stack_id] = stack
         LOG.debug(
@@ -302,8 +302,8 @@ class CloudformationProvider(CloudformationApi):
         deployer = template_deployer.TemplateDeployer(stack)
         # TODO: there shouldn't be a "new" stack on update
         new_stack = Stack(request, template)
-        new_stack.resolved_parameters = resolved_parameters
-        stack.resolved_parameters = resolved_parameters
+        new_stack.set_resolved_parameters(resolved_parameters)
+        stack.set_resolved_parameters(resolved_parameters)
         try:
             deployer.update_stack(new_stack)
         except Exception as e:
@@ -525,7 +525,7 @@ class CloudformationProvider(CloudformationApi):
         # create change set for the stack and apply changes
         change_set = StackChangeSet(stack, req_params, template)
         # only set parameters for the changeset, then switch to stack on execute_change_set
-        change_set.resolved_parameters = resolved_parameters
+        change_set.set_resolved_parameters(resolved_parameters)
 
         deployer = template_deployer.TemplateDeployer(change_set)
         changes = deployer.construct_changes(
@@ -585,6 +585,7 @@ class CloudformationProvider(CloudformationApi):
             "Transform",
         ]
         result = remove_attributes(deepcopy(change_set.metadata), attrs)
+        # result["Parameters"] = list(change_set.resolved_parameters.values())
         return result
 
     @handler("DeleteChangeSet")

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -192,9 +192,7 @@ class CloudformationProvider(CloudformationApi):
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
             request.get("Parameters")
         )
-        parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
-            template
-        )
+        parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
         resolved_parameters = param_resolver.resolve_parameters(
             parameter_declarations=parameter_declarations,
             new_parameters=new_parameters,
@@ -276,9 +274,7 @@ class CloudformationProvider(CloudformationApi):
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
             request.get("Parameters")
         )
-        parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
-            template
-        )
+        parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
         resolved_parameters = param_resolver.resolve_parameters(
             parameter_declarations=parameter_declarations,
             new_parameters=new_parameters,
@@ -370,8 +366,6 @@ class CloudformationProvider(CloudformationApi):
         change_set_name: ChangeSetNameOrId = None,
         template_stage: TemplateStage = None,
     ) -> GetTemplateOutput:
-
-        stack = None
         if change_set_name:
             stack = find_change_set(stack_name=stack_name, cs_name=change_set_name)
         else:
@@ -407,7 +401,7 @@ class CloudformationProvider(CloudformationApi):
 
         # build parameter declarations
         result["Parameters"] = list(
-            param_resolver.extract_parameter_declarations_from_template(template).values()
+            param_resolver.extract_stack_parameter_declarations(template).values()
         )
 
         id_summaries = defaultdict(list)
@@ -516,9 +510,7 @@ class CloudformationProvider(CloudformationApi):
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
             request.get("Parameters")
         )
-        parameter_declarations = param_resolver.extract_parameter_declarations_from_template(
-            template
-        )
+        parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
         resolved_parameters = param_resolver.resolve_parameters(
             parameter_declarations=parameter_declarations,
             new_parameters=new_parameters,

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -518,13 +518,7 @@ class CloudformationProvider(CloudformationApi):
             new_parameters=new_parameters,
             old_parameters=old_parameters,
         )
-        # stack.resolved_parameters = resolved_parameters
 
-        # parameters = template_preparer.resolve_parameters(
-        #     template.get("Parameters", {}), request.get("Parameters", [])
-        # )
-        # TODO: if this is a create, we already have a stack with parameters
-        # TODO: enable again with new parameters
         parameters = list(resolved_parameters.values())
         template = template_preparer.transform_template(template, parameters, stack=stack)
 

--- a/tests/integration/cloudformation/api/test_changesets.py
+++ b/tests/integration/cloudformation/api/test_changesets.py
@@ -236,6 +236,7 @@ def test_create_change_set_missing_stackname(aws_client):
         )
 
 
+@pytest.mark.aws_validated
 def test_create_change_set_with_ssm_parameter(
     cleanup_changesets,
     cleanup_stacks,

--- a/tests/integration/cloudformation/resources/test_kinesis.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_kinesis.snapshot.json
@@ -62,5 +62,160 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_kinesis.py::test_describe_template": {
+    "recorded-date": "22-05-2023, 09:25:32",
+    "recorded-content": {
+      "get_template_summary_by_url": {
+        "Capabilities": [
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "CapabilitiesReason": "The following resource(s) require capabilities: [AWS::IAM::Role]",
+        "Parameters": [
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "KinesisRoleName",
+            "ParameterType": "String"
+          },
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "DeliveryStreamName",
+            "ParameterType": "String"
+          },
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "KinesisStreamName",
+            "ParameterType": "String"
+          }
+        ],
+        "ResourceIdentifierSummaries": [
+          {
+            "LogicalResourceIds": [
+              "MyBucket"
+            ],
+            "ResourceIdentifiers": [
+              "BucketName"
+            ],
+            "ResourceType": "AWS::S3::Bucket"
+          },
+          {
+            "LogicalResourceIds": [
+              "MyRole"
+            ],
+            "ResourceIdentifiers": [
+              "RoleName"
+            ],
+            "ResourceType": "AWS::IAM::Role"
+          },
+          {
+            "LogicalResourceIds": [
+              "KinesisStream"
+            ],
+            "ResourceIdentifiers": [
+              "Name"
+            ],
+            "ResourceType": "AWS::Kinesis::Stream"
+          },
+          {
+            "LogicalResourceIds": [
+              "DeliveryStream"
+            ],
+            "ResourceIdentifiers": [
+              "DeliveryStreamName"
+            ],
+            "ResourceType": "AWS::KinesisFirehose::DeliveryStream"
+          }
+        ],
+        "ResourceTypes": [
+          "AWS::Kinesis::Stream",
+          "AWS::IAM::Role",
+          "AWS::S3::Bucket",
+          "AWS::KinesisFirehose::DeliveryStream"
+        ],
+        "Version": "2010-09-09",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_template_summary_by_body": {
+        "Capabilities": [
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "CapabilitiesReason": "The following resource(s) require capabilities: [AWS::IAM::Role]",
+        "Parameters": [
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "KinesisRoleName",
+            "ParameterType": "String"
+          },
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "DeliveryStreamName",
+            "ParameterType": "String"
+          },
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {},
+            "ParameterKey": "KinesisStreamName",
+            "ParameterType": "String"
+          }
+        ],
+        "ResourceIdentifierSummaries": [
+          {
+            "LogicalResourceIds": [
+              "MyBucket"
+            ],
+            "ResourceIdentifiers": [
+              "BucketName"
+            ],
+            "ResourceType": "AWS::S3::Bucket"
+          },
+          {
+            "LogicalResourceIds": [
+              "MyRole"
+            ],
+            "ResourceIdentifiers": [
+              "RoleName"
+            ],
+            "ResourceType": "AWS::IAM::Role"
+          },
+          {
+            "LogicalResourceIds": [
+              "KinesisStream"
+            ],
+            "ResourceIdentifiers": [
+              "Name"
+            ],
+            "ResourceType": "AWS::Kinesis::Stream"
+          },
+          {
+            "LogicalResourceIds": [
+              "DeliveryStream"
+            ],
+            "ResourceIdentifiers": [
+              "DeliveryStreamName"
+            ],
+            "ResourceType": "AWS::KinesisFirehose::DeliveryStream"
+          }
+        ],
+        "ResourceTypes": [
+          "AWS::Kinesis::Stream",
+          "AWS::IAM::Role",
+          "AWS::S3::Bucket",
+          "AWS::KinesisFirehose::DeliveryStream"
+        ],
+        "Version": "2010-09-09",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/resources/test_s3.py
+++ b/tests/integration/cloudformation/resources/test_s3.py
@@ -32,6 +32,7 @@ def test_bucketpolicy(deploy_cfn_template, aws_client):
     assert err.value.response["Error"]["Code"] == "NoSuchBucketPolicy"
 
 
+@pytest.mark.aws_validated
 def test_bucket_autoname(deploy_cfn_template, aws_client):
     result = deploy_cfn_template(
         template_path=os.path.join(

--- a/tests/integration/cloudformation/test_template_engine.py
+++ b/tests/integration/cloudformation/test_template_engine.py
@@ -514,6 +514,7 @@ class TestMacros:
         paths=[
             "$..TemplateBody.Resources.Parameter.LogicalResourceId",
             "$..TemplateBody.Conditions",
+            "$..TemplateBody.Mappings",
             "$..TemplateBody.StackId",
             "$..TemplateBody.StackName",
             "$..TemplateBody.Transform",
@@ -672,6 +673,7 @@ class TestMacros:
         paths=[
             "$..TemplateBody.Resources.Parameter.LogicalResourceId",
             "$..TemplateBody.Conditions",
+            "$..TemplateBody.Mappings",
             "$..TemplateBody.Parameters",
             "$..TemplateBody.StackId",
             "$..TemplateBody.StackName",
@@ -739,6 +741,7 @@ class TestMacros:
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Event.fragment.Conditions",
+            "$..Event.fragment.Mappings",
             "$..Event.fragment.Outputs",
             "$..Event.fragment.Resources.Parameter.LogicalResourceId",
             "$..Event.fragment.StackId",

--- a/tests/integration/templates/cfn_intrinsic_functions.yaml
+++ b/tests/integration/templates/cfn_intrinsic_functions.yaml
@@ -3,7 +3,7 @@ Parameters:
     Type: String
   Param2:
     Type: String
-  BuckeName:
+  BucketName:
     Type: String
 Conditions:
   condition1:

--- a/tests/integration/templates/cfn_kinesis_stream.yaml
+++ b/tests/integration/templates/cfn_kinesis_stream.yaml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  KinesisStreamName:
+    Type: String
+  DeliveryStreamName:
+    Type: String
+  KinesisRoleName:
+    Type: String
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref KinesisRoleName
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref "DeliveryStreamName"
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name : !Ref "KinesisStreamName"
+      ShardCount : 5
+  DeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: !Ref "DeliveryStreamName"
+      DeliveryStreamType: DirectPut
+      S3DestinationConfiguration:
+        BucketARN: !Ref MyBucket
+        BufferingHints:
+          IntervalInSeconds: 600
+          SizeInMBs: 50
+        CompressionFormat: UNCOMPRESSED
+        Prefix: raw/
+        RoleARN: !GetAtt "MyRole.Arn"
+Outputs:
+  MyStreamArn:
+    Value: !GetAtt "DeliveryStream.Arn"

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -1,40 +1,8 @@
-import re
-from typing import Dict
-
 from localstack.services.cloudformation.api_utils import is_local_service_url
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     remove_none_values,
 )
-from localstack.services.cloudformation.engine import template_deployer
-from localstack.services.cloudformation.engine.entities import Stack
-from localstack.services.cloudformation.models.stepfunctions import _apply_substitutions
-
-
-def test_resolve_references():
-    ref = {
-        "Fn::Join": [
-            "",
-            [
-                "arn:",
-                {"Ref": "AWS::Partition"},
-                ":apigateway:",
-                {"Ref": "AWS::Region"},
-                ":lambda:path/2015-03-31/functions/",
-                "test:lambda:arn",
-                "/invocations",
-            ],
-        ]
-    }
-    result = _resolve_refs_in_template(ref)
-    pattern = r"arn:aws:apigateway:.*:lambda:path/2015-03-31/functions/test:lambda:arn/invocations"
-    assert re.match(pattern, result)
-
-
-def test_sub_numeric_value():
-    template = {"test": {"Sub": "${TestNumValue}"}}
-    result = _resolve_refs_in_template(template, stack_params={"TestNumValue": 1234})
-    assert result == {"test": "1234"}
 
 
 def test_is_local_service_url():
@@ -58,13 +26,6 @@ def test_is_local_service_url():
         assert not is_local_service_url(url)
 
 
-def test_apply_substitutions():
-    blubstr = "something ${foo} and ${test} + ${foo}"
-    subs = {"foo": "bar", "test": "resolved"}
-
-    assert _apply_substitutions(blubstr, subs) == "something bar and resolved + bar"
-
-
 def test_remove_none_values():
     template = {
         "Properties": {
@@ -75,12 +36,3 @@ def test_remove_none_values():
     }
     result = remove_none_values(template)
     assert result == {"Properties": {"prop1": 123, "nested": {}, "list": [1, 2, 3]}}
-
-
-def _resolve_refs_in_template(template, stack_params: Dict = None):
-    stack = Stack({"StackName": "test"})
-    stack.stack_parameters()
-    stack_params = stack_params or {}
-    stack_params = [{"ParameterKey": k, "ParameterValue": v} for k, v in stack_params.items()]
-    stack.metadata["Parameters"].extend(stack_params)
-    return template_deployer.resolve_refs_recursively(stack.stack_name, stack.resources, template)


### PR DESCRIPTION
# Changes
- Parameters are resolved only once when executing CREATE/UPDATE tasks. While the corresponding logic lives in `parameters.py` now, the responsibility is moved further up to the API provider to make this as transparent as possible.
- Unifies parameter resolving (previously this was done in multiple places such as in Stack methods, template_processing, transformations, template deployer)
- Update handling is now more robust and simpler.

# What hasn't changed

- Does not affect how parameters are used when resolving values/refs in the TemplateDeployer/Stack, i.e. they are still merged with resources and mappings/conditions in `Stack.resources` for now. This will be split up in a future PR.
- No new parameter types have been added


Also note I didn't add further tests yet since I didn't want to bloat this too much. I've started on more parity focused tests but I want to give them a bit more polish and build a proper parameter test suite out of it first.