### PR TITLE
bump moto to 4.1.9.post1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ runtime =
     jsonpath-ng>=1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-client>=2.0
-    moto-ext[all]==4.1.8.post1
+    moto-ext[all]==4.1.9.post1
     opensearch-py==2.1.1
     pproxy>=2.7.0
     pymongo>=4.2.0


### PR DESCRIPTION
Lot of work has been done on S3 `CopyObject` upstream, which is validated by 2 PRs adding tests:
- #8291
- #8216
(Those PR are already targeting this branch, and the CI is green, so confident the fixes are good 👍)

Another S3 PR will build on work that has been on checksum calculation to remove some parts from our provider.

-ext run: https://github.com/localstack/localstack-ext/actions/runs/5022174661
