### PR TITLE
fix ListBuckets tag order

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2271,8 +2271,8 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
 
 
 class ListBucketsOutput(TypedDict, total=False):
-    Buckets: Optional[Buckets]
     Owner: Optional[Owner]
+    Buckets: Optional[Buckets]
 
 
 class MultipartUpload(TypedDict, total=False):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -773,6 +773,18 @@
         "documentation": "<p>The specified method is not allowed against this resource.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/ListBucketsOutput/members/Buckets"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ListBucketsOutput/members/Buckets",
+      "value": {
+        "shape":"Buckets",
+        "documentation":"<p>The list of buckets owned by the requester.</p>"
+      }
     }
   ]
 }

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3414,6 +3414,12 @@ class TestS3:
 
         resp_dict = xmltodict.parse(resp.content)
         assert "ListAllMyBucketsResult" in resp_dict
+        # validate that the Owner tag is first, before Buckets. This is because the Java SDK is counting on the order
+        # to properly set the Owner value to the buckets.
+        resp_dict["ListAllMyBucketsResult"].pop("@xmlns", None)
+        list_buckets_tags = list(resp_dict["ListAllMyBucketsResult"].keys())
+        assert list_buckets_tags[0] == "Owner"
+        assert list_buckets_tags[1] == "Buckets"
 
         # Lists all objects in a bucket
         bucket_url = _bucket_url(s3_bucket)


### PR DESCRIPTION
This PR fixes #8325 
This bug seemed really weird, as our response was exactly the same as AWS, format was the same.

However, after trying to debug the issue in Java, it seemed the `Owner` field was properly parsed by the SDK. 

After looking at the code of the SDK, it seemed the order of the XML tag was important for the way they populate each bucket with the owner. Basically, if the Owner tag is second, they first populate every bucket with an empty owner, even though the owner was properly parsed at the end. (I'll put the Java code snippet from the SDK at the end of the PR).

We keep the order from the specs when we serialize the response: we use and iterate over the shapes members.
In the specs, `Buckets` is first and `Owner` is second. The trick is to remove `Buckets` from the specs and add it back, to put it as the last member. Dirty, but it works. 

I could test the fix in the `localstack-java-utils` repo, by adding a test case in `S3FeaturesTest`. 

```java
@Test
public void testGetBucketOwner() {
	AmazonS3 s3 = TestUtils.getClientS3();

	String bucketName = UUID.randomUUID().toString();
	Bucket bucket = s3.createBucket(bucketName);

	List<Bucket> buckets = s3.listBuckets();
	System.out.println("buckets " + buckets);

}
```

I've also added an integration test that is AWS validated to keep the order.

SDK snippet:
```java
protected void doStartElement(String uri, String name, String qName, Attributes attrs) {
    if (this.in(new String[]{"ListAllMyBucketsResult"})) {
        if (name.equals("Owner")) {
            this.bucketsOwner = new Owner();
        }
    } else if (this.in(new String[]{"ListAllMyBucketsResult", "Buckets"}) && name.equals("Bucket")) {
        this.currentBucket = new Bucket();
        this.currentBucket.setOwner(this.bucketsOwner);
    }

}

protected void doEndElement(String uri, String name, String qName) {
    if (this.in(new String[]{"ListAllMyBucketsResult", "Owner"})) {
        if (name.equals("ID")) {
            this.bucketsOwner.setId(this.getText());
        } else if (name.equals("DisplayName")) {
            this.bucketsOwner.setDisplayName(this.getText());
        }
    } else if (this.in(new String[]{"ListAllMyBucketsResult", "Buckets"})) {
        if (name.equals("Bucket")) {
            this.buckets.add(this.currentBucket);
            this.currentBucket = null;
        }
    } else if (this.in(new String[]{"ListAllMyBucketsResult", "Buckets", "Bucket"})) {
        if (name.equals("Name")) {
            this.currentBucket.setName(this.getText());
        } else if (name.equals("CreationDate")) {
            Date creationDate = DateUtils.parseISO8601Date(this.getText());
            this.currentBucket.setCreationDate(creationDate);
        }
    }

}
```