### PR TITLE
CFn: Stub WaitCondition resource

### DIFF
--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.deployment_utils import generate_default_name
@@ -153,6 +154,38 @@ class CloudFormationWaitConditionHandle(GenericBaseModel):
                 stack_name=result["stack_name"],
             )
             resources[resource_id]["PhysicalResourceId"] = waitcondition_url
+
+        return {
+            "create": {
+                "function": _create,
+                "result_handler": _set_physical_resource_id,
+            },
+            "delete": {
+                "function": lambda *args, **kwargs: {},
+            },
+        }
+
+
+class CloudFormationWaitCondition(GenericBaseModel):
+    @classmethod
+    def cloudformation_type(cls):
+        return "AWS::CloudFormation::WaitCondition"
+
+    def fetch_state(self, stack_name, resources):
+        if self.physical_resource_id is not None:
+            return {"deployed": True}
+
+    @staticmethod
+    def get_deploy_templates():
+        def _create(resource_id, resources, resource_type, func, stack_name) -> dict:
+            # no resources to create, but the physical resource id requires the stack name
+            return {"stack_name": stack_name}
+
+        def _set_physical_resource_id(result, resource_id, resources, resource_type):
+            stack_arn = arns.cloudformation_stack_arn(result["stack_name"])
+            resources[resource_id][
+                "PhysicalResourceId"
+            ] = f"{stack_arn}/{uuid.uuid4()}/{resource_id}"
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -134,9 +134,13 @@ def generate_waitcondition_url(stack_name: str) -> str:
 
 
 class CloudFormationWaitConditionHandle(GenericBaseModel):
-    @staticmethod
-    def cloudformation_type():
+    @classmethod
+    def cloudformation_type(cls):
         return "AWS::CloudFormation::WaitConditionHandle"
+
+    def fetch_state(self, stack_name, resources):
+        if self.physical_resource_id is not None:
+            return {"deployed": True}
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -590,6 +590,8 @@ class EC2Instance(GenericBaseModel):
                     "SecurityGroups": "SecurityGroups",
                     "KeyName": "KeyName",
                     "ImageId": "ImageId",
+                    "MaxCount": "MaxCount",
+                    "MinCount": "MinCount",
                 },
                 "result_handler": _store_instance_id,
             },

--- a/tests/integration/cloudformation/resources/test_cloudformation.py
+++ b/tests/integration/cloudformation/resources/test_cloudformation.py
@@ -1,15 +1,89 @@
+import logging
 import os
+import time
+import uuid
+from threading import Thread
+from typing import TYPE_CHECKING
+
+import pytest
+import requests
+
+if TYPE_CHECKING:
+    try:
+        from mypy_boto3_ssm import SSMClient
+    except ImportError:
+        pass
+
+LOG = logging.getLogger(__name__)
+
+PARAMETER_NAME = "wait-handle-url"
 
 
-# @pytest.mark.skip_snapshot_verify(paths=["$.."])
-def test_waitconditionhandle(deploy_cfn_template, snapshot, aws_client):
-    stack = deploy_cfn_template(
-        template_path=os.path.join(
-            os.path.dirname(__file__), "../../templates/cfn_waitconditionhandle.yaml"
+class SignalSuccess(Thread):
+    def __init__(self, client: "SSMClient"):
+        Thread.__init__(self)
+        self.client = client
+        self.session = requests.Session()
+        self.should_break = False
+
+    def run(self):
+        while not self.should_break:
+            try:
+                LOG.debug("fetching parameter")
+                res = self.client.get_parameter(Name=PARAMETER_NAME)
+                url = res["Parameter"]["Value"]
+                LOG.info(f"signalling url {url}")
+
+                payload = {
+                    "Status": "SUCCESS",
+                    "Reason": "Wait condition reached",
+                    "UniqueId": str(uuid.uuid4()),
+                    "Data": "Application has completed configuration.",
+                }
+                r = self.session.put(url, json=payload)
+                LOG.debug(f"status from signalling: {r.status_code}")
+                r.raise_for_status()
+                LOG.debug("status signalled")
+                break
+            except self.client.exceptions.ParameterNotFound:
+                LOG.warning("parameter not available, trying again")
+                time.sleep(5)
+            except Exception:
+                LOG.exception("got python exception")
+                raise
+
+    def stop(self):
+        self.should_break = True
+
+
+@pytest.mark.skip_snapshot_verify(paths=["$..WaitConditionName"])
+def test_waitcondition(deploy_cfn_template, snapshot, aws_client):
+    """
+    Complicated test, since we have a wait condition that must signal
+    a successful value to before the stack finishes. We use the
+    fact that CFn will deploy the SSM parameter before moving on
+    to the wait condition itself, so in a background thread we
+    try to set the value to success so that the stack will
+    deploy correctly.
+    """
+    signal_thread = SignalSuccess(aws_client.ssm)
+    signal_thread.daemon = True
+    signal_thread.start()
+
+    try:
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/cfn_waitcondition.yaml"
+            ),
+            parameters={"ParameterName": PARAMETER_NAME},
         )
-    )
+    finally:
+        signal_thread.stop()
+
     wait_handle_id = stack.outputs["WaitHandleId"]
+    wait_condition_name = stack.outputs["WaitConditionRef"]
 
     # TODO: more stringent tests
     assert wait_handle_id is not None
     # snapshot.match("waithandle_ref", wait_handle_id)
+    snapshot.match("waitcondition_ref", {"WaitConditionName": wait_condition_name})

--- a/tests/integration/cloudformation/resources/test_cloudformation.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_cloudformation.snapshot.json
@@ -4,5 +4,13 @@
     "recorded-content": {
       "waithandle_ref": "https://cloudformation-waitcondition-<region>.s3.<region>.amazonaws.com/arn%3Aaws%3Acloudformation%3A<region>%3A111111111111%3Astack/stack-03ad7786/c7b3de40-f4c2-11ed-b84b-0a57ddc705d2/WaitHandle?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230517T145504Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86399&X-Amz-Credential=AKIAYYGVRKE7CKDBHLUS%2F20230517%2F<region>%2Fs3%2Faws4_request&X-Amz-Signature=3c79384f6647bd2c655ac78e6811ea0fff9b3a52a9bd751005d35f2a04f6533c"
     }
+  },
+  "tests/integration/cloudformation/resources/test_cloudformation.py::test_waitcondition": {
+    "recorded-date": "18-05-2023, 11:09:21",
+    "recorded-content": {
+      "waitcondition_ref": {
+        "WaitConditionName": "arn:aws:cloudformation:<region>:111111111111:stack/stack-6cc1b50e/f9764ac0-f563-11ed-82f7-061d4a7b8a1e/WaitHandle"
+      }
+    }
   }
 }

--- a/tests/integration/templates/cfn_waitcondition.yaml
+++ b/tests/integration/templates/cfn_waitcondition.yaml
@@ -1,0 +1,33 @@
+Parameters:
+  ParameterName:
+    Type: String
+
+Resources:
+  WaitHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+
+  WaitHandleParameter:
+    Type: AWS::SSM::Parameter
+    DependsOn: WaitHandle
+    Properties:
+      Name:
+        Ref: ParameterName
+      Value:
+        Ref: WaitHandle
+      Type: String
+
+  WaitCondition:
+    Type: AWS::CloudFormation::WaitCondition
+    Properties:
+      Handle:
+        Ref: WaitHandle
+      Timeout: 300
+
+Outputs:
+  WaitHandleId:
+    Value:
+      Ref: WaitHandle
+
+  WaitConditionRef:
+    Value:
+      Ref: WaitCondition

--- a/tests/integration/templates/cfn_waitconditionhandle.yaml
+++ b/tests/integration/templates/cfn_waitconditionhandle.yaml
@@ -1,8 +1,0 @@
-Resources:
-  WaitHandle:
-    Type: AWS::CloudFormation::WaitConditionHandle
-
-Outputs:
-  WaitHandleId:
-    Value:
-      Ref: WaitHandle


### PR DESCRIPTION
Add a fix for the state fetching of `WaitConditionHandle`, and add a _stub_ implementation for `WaitCondition`s.

This stub means that anything referencing the wait condition will resolve correctly, but the template deployer won't actually wait until the condition is met. Since we are doing a re-write of CFn anyway, we should factor it into that project.

This PR also includes a bigfix for EC2 instances: the boto3 `run_instances` method requires `MaxCount` and `MinCount` to be passed, but these are not valid CloudFormation properties.
