### PR TITLE
Fix extraction of container Image when using podman

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -138,12 +138,6 @@ OPENSEARCH_PLUGIN_LIST = [
     "ingest-attachment",
 ]
 
-ELASTICMQ_JAR_URL = (
-    "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar"
-)
-STEPFUNCTIONS_ZIP_URL = "https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip"
-KMS_URL_PATTERN = "https://s3-eu-west-2.amazonaws.com/local-kms/3/local-kms_<arch>.bin"
-
 # API endpoint for analytics events
 API_ENDPOINT = os.environ.get("API_ENDPOINT") or "https://api.localstack.cloud/v1"
 # new analytics API endpoint

--- a/localstack/services/kms/packages.py
+++ b/localstack/services/kms/packages.py
@@ -1,10 +1,11 @@
 import platform
 from typing import List
 
-from localstack.constants import KMS_URL_PATTERN
 from localstack.packages import Package, PackageInstaller
 from localstack.packages.core import PermissionDownloadInstaller
 from localstack.utils.platform import get_arch
+
+KMS_URL_PATTERN = "https://s3-eu-west-2.amazonaws.com/local-kms/3/local-kms_<arch>.bin"
 
 
 class KMSLocalPackage(Package):

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -7,6 +7,7 @@ import time
 from typing import NamedTuple
 
 import pytest
+from docker.models.containers import Container
 
 from localstack import config
 from localstack.config import in_docker
@@ -709,6 +710,40 @@ class TestDockerClient:
         )
         assert 1 == len(container_list)
         assert c1.container_name == container_list[0]["name"]
+
+    def test_list_containers_with_podman_image_ref_format(
+        self, docker_client: ContainerClient, create_container, cleanups, monkeypatch
+    ):
+        # create custom image tag
+        image_name = f"alpine:tag-{short_uid()}"
+        docker_client.tag_image("alpine", image_name)
+        cleanups.append(lambda: docker_client.remove_image(image_name))
+
+        def container_init(self, attrs=None, *args, **kwargs):
+            # Simulate podman API response, Docker returns "sha:..." for Image, podman returns "<image-name>:<tag>".
+            #  See https://github.com/containers/podman/issues/8329
+            attrs["Image"] = image_name
+            container_init_orig(self, attrs=attrs, *args, **kwargs)
+
+        # apply patch to simulate podman behavior
+        container_init_orig = Container.__init__
+        monkeypatch.setattr(Container, "__init__", container_init)
+
+        # start a container from the custom image tag
+        c1 = create_container(image_name, command=["sleep", "3"])
+        docker_client.start_container(c1.container_id, attach=False)
+
+        # list containers, assert that container is contained in the list
+        container_list = docker_client.list_containers()
+        running_containers = [cnt for cnt in container_list if cnt["status"] == "running"]
+        assert running_containers
+        container_names = [info["name"] for info in container_list]
+        assert c1.container_name in container_names
+
+        # assert that get_running_container_names(..) call is successful as well
+        container_names = docker_client.get_running_container_names()
+        assert len(running_containers) == len(container_names)
+        assert c1.container_name in container_names
 
     def test_get_container_entrypoint(self, docker_client: ContainerClient):
         entrypoint = docker_client.get_image_entrypoint("alpine")


### PR DESCRIPTION
Fix extraction of container Image when using podman. We have some customers who are using podman (with Docker not being available), and one of the issues that has surfaced is that the `list_containers(..)` Docker SDK call fails when using podman.

<img width="1397" alt="image" src="https://github.com/localstack/localstack/assets/2807888/e8d10ba9-2f94-471a-a1ec-ff719b74f0e1">

The root cause is that certain versions of podman use a slightly different API response format for listing containers: https://github.com/containers/podman/issues/8329 . In particular, the `Image` attribute of containers is `"sha256:..."` for Docker, but it contains the actual image name/tag like `"myimage:mytag-123"` for podman.

A simple integration test is added which simulates the podman API response via a monkey patch. Without the fix in the PR, this test would fail, and the patch in `docker_sdk_client.py` makes the test pass (and should fix the customer issue, too).

We can consider contributing this fix to the upstream repo, too - but for now the goal is to get a fix out quickly to our users.

The PR also removes a few unused strings in `constants.py`. 🧹 