### PR TITLE
SNS: Implement cross-account access

### DIFF
--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -112,6 +112,7 @@ class SnsSubscription(TypedDict):
 class SnsStore(BaseStore):
     # maps topic ARN to subscriptions ARN
     topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
+
     # maps subscription ARN to SnsSubscription
     subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)
 

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -1,5 +1,6 @@
 import itertools
 import time
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, TypedDict, Union
 
@@ -111,7 +112,7 @@ class SnsSubscription(TypedDict):
 
 class SnsStore(BaseStore):
     # maps topic ARN to subscriptions ARN
-    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
+    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=lambda: defaultdict(list))
 
     # maps subscription ARN to SnsSubscription
     subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -1,6 +1,5 @@
 import itertools
 import time
-from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, TypedDict, Union
 
@@ -112,7 +111,7 @@ class SnsSubscription(TypedDict):
 
 class SnsStore(BaseStore):
     # maps topic ARN to subscriptions ARN
-    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=lambda: defaultdict(list))
+    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
 
     # maps subscription ARN to SnsSubscription
     subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -573,7 +573,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
         # An endpoint may only be subscribed to a topic once. Subsequent
         # subscribe calls do nothing (subscribe is idempotent).
-        for existing_topic_subscription in store.topic_subscriptions[topic_arn]:
+        for existing_topic_subscription in store.topic_subscriptions.get(topic_arn, []):
             sub = store.subscriptions.get(existing_topic_subscription, {})
             if sub.get("Endpoint") == endpoint:
                 return SubscribeResponse(SubscriptionArn=sub["SubscriptionArn"])
@@ -596,6 +596,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 )
 
         store.subscriptions[subscription_arn] = subscription
+        store.topic_subscriptions[topic_arn] = store.topic_subscriptions.get(topic_arn) or []
         store.topic_subscriptions[topic_arn].append(subscription_arn)
 
         # store the token and subscription arn

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -11,50 +11,25 @@ from moto.sns.utils import is_e164
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api.sns import (
-    ActionsList,
     AmazonResourceName,
     BatchEntryIdsNotDistinctException,
-    CheckIfPhoneNumberIsOptedOutResponse,
     ConfirmSubscriptionResponse,
     CreateEndpointResponse,
     CreatePlatformApplicationResponse,
-    CreateSMSSandboxPhoneNumberResult,
     CreateTopicResponse,
-    DelegatesList,
-    DeleteSMSSandboxPhoneNumberResult,
-    GetEndpointAttributesResponse,
-    GetPlatformApplicationAttributesResponse,
-    GetSMSAttributesResponse,
-    GetSMSSandboxAccountStatusResult,
     GetSubscriptionAttributesResponse,
     GetTopicAttributesResponse,
     InvalidParameterException,
     InvalidParameterValueException,
-    LanguageCodeString,
-    ListEndpointsByPlatformApplicationResponse,
-    ListOriginationNumbersResult,
-    ListPhoneNumbersOptedOutResponse,
-    ListPlatformApplicationsResponse,
-    ListSMSSandboxPhoneNumbersResult,
-    ListString,
-    ListSubscriptionsByTopicResponse,
     ListSubscriptionsResponse,
     ListTagsForResourceResponse,
-    ListTopicsResponse,
     MapStringToString,
-    MaxItems,
-    MaxItemsListOriginationNumbers,
     MessageAttributeMap,
     NotFoundException,
-    OptInPhoneNumberResponse,
-    OTPCode,
-    PhoneNumber,
-    PhoneNumberString,
     PublishBatchRequestEntryList,
     PublishBatchResponse,
     PublishBatchResultEntry,
     PublishResponse,
-    SetSMSAttributesResponse,
     SnsApi,
     String,
     SubscribeResponse,
@@ -65,7 +40,6 @@ from localstack.aws.api.sns import (
     TooManyEntriesInBatchRequestException,
     TopicAttributesMap,
     UntagResourceResponse,
-    VerifySMSSandboxPhoneNumberResult,
     attributeName,
     attributeValue,
     authenticateOnUnsubscribe,
@@ -88,7 +62,6 @@ from localstack.services.sns.publisher import (
     SnsPublishContext,
 )
 from localstack.utils.aws.arns import parse_arn
-from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid
 
 # set up logger
@@ -120,151 +93,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         arn_data = parse_arn(arn)
         backend = SnsProvider.get_moto_backend(arn_data["account"], arn_data["region"])
         return backend.get_topic(arn)
-
-    def add_permission(
-        self,
-        context: RequestContext,
-        topic_arn: topicARN,
-        label: String,
-        aws_account_id: DelegatesList,
-        action_name: ActionsList,
-    ) -> None:
-        call_moto(context)
-
-    def check_if_phone_number_is_opted_out(
-        self, context: RequestContext, phone_number: PhoneNumber
-    ) -> CheckIfPhoneNumberIsOptedOutResponse:
-        moto_response: CheckIfPhoneNumberIsOptedOutResponse = call_moto(context)
-        return moto_response
-
-    def create_sms_sandbox_phone_number(
-        self,
-        context: RequestContext,
-        phone_number: PhoneNumberString,
-        language_code: LanguageCodeString = None,
-    ) -> CreateSMSSandboxPhoneNumberResult:
-        call_moto(context)
-        return CreateSMSSandboxPhoneNumberResult()
-
-    def delete_sms_sandbox_phone_number(
-        self, context: RequestContext, phone_number: PhoneNumberString
-    ) -> DeleteSMSSandboxPhoneNumberResult:
-        call_moto(context)
-        return DeleteSMSSandboxPhoneNumberResult()
-
-    def get_endpoint_attributes(
-        self, context: RequestContext, endpoint_arn: String
-    ) -> GetEndpointAttributesResponse:
-        moto_response: GetEndpointAttributesResponse = call_moto(context)
-        return moto_response
-
-    def get_platform_application_attributes(
-        self, context: RequestContext, platform_application_arn: String
-    ) -> GetPlatformApplicationAttributesResponse:
-        moto_response = call_moto(context)
-        return select_from_typed_dict(GetPlatformApplicationAttributesResponse, moto_response)
-
-    def get_sms_attributes(
-        self, context: RequestContext, attributes: ListString = None
-    ) -> GetSMSAttributesResponse:
-        moto_response: GetSMSAttributesResponse = call_moto(context)
-        return moto_response
-
-    def get_sms_sandbox_account_status(
-        self, context: RequestContext
-    ) -> GetSMSSandboxAccountStatusResult:
-        moto_response: GetSMSSandboxAccountStatusResult = call_moto(context)
-        return moto_response
-
-    def list_endpoints_by_platform_application(
-        self, context: RequestContext, platform_application_arn: String, next_token: String = None
-    ) -> ListEndpointsByPlatformApplicationResponse:
-        moto_response: ListEndpointsByPlatformApplicationResponse = call_moto(context)
-        return moto_response
-
-    def list_origination_numbers(
-        self,
-        context: RequestContext,
-        next_token: nextToken = None,
-        max_results: MaxItemsListOriginationNumbers = None,
-    ) -> ListOriginationNumbersResult:
-        moto_response: ListOriginationNumbersResult = call_moto(context)
-        return moto_response
-
-    def list_phone_numbers_opted_out(
-        self, context: RequestContext, next_token: String = None
-    ) -> ListPhoneNumbersOptedOutResponse:
-        moto_response: ListPhoneNumbersOptedOutResponse = call_moto(context)
-        return moto_response
-
-    def list_platform_applications(
-        self, context: RequestContext, next_token: String = None
-    ) -> ListPlatformApplicationsResponse:
-        moto_response: ListPlatformApplicationsResponse = call_moto(context)
-        return moto_response
-
-    def list_sms_sandbox_phone_numbers(
-        self, context: RequestContext, next_token: nextToken = None, max_results: MaxItems = None
-    ) -> ListSMSSandboxPhoneNumbersResult:
-        moto_response: ListSMSSandboxPhoneNumbersResult = call_moto(context)
-        return moto_response
-
-    def list_subscriptions_by_topic(
-        self, context: RequestContext, topic_arn: topicARN, next_token: nextToken = None
-    ) -> ListSubscriptionsByTopicResponse:
-        moto_response: ListSubscriptionsByTopicResponse = call_moto(context)
-        return moto_response
-
-    def list_topics(
-        self, context: RequestContext, next_token: nextToken = None
-    ) -> ListTopicsResponse:
-        moto_response: ListTopicsResponse = call_moto(context)
-        return moto_response
-
-    def opt_in_phone_number(
-        self, context: RequestContext, phone_number: PhoneNumber
-    ) -> OptInPhoneNumberResponse:
-        call_moto(context)
-        return OptInPhoneNumberResponse()
-
-    def remove_permission(
-        self, context: RequestContext, topic_arn: topicARN, label: String
-    ) -> None:
-        call_moto(context)
-
-    def set_endpoint_attributes(
-        self, context: RequestContext, endpoint_arn: String, attributes: MapStringToString
-    ) -> None:
-        call_moto(context)
-
-    def set_platform_application_attributes(
-        self,
-        context: RequestContext,
-        platform_application_arn: String,
-        attributes: MapStringToString,
-    ) -> None:
-        call_moto(context)
-
-    def set_sms_attributes(
-        self, context: RequestContext, attributes: MapStringToString
-    ) -> SetSMSAttributesResponse:
-        call_moto(context)
-        return SetSMSAttributesResponse()
-
-    def set_topic_attributes(
-        self,
-        context: RequestContext,
-        topic_arn: topicARN,
-        attribute_name: attributeName,
-        attribute_value: attributeValue = None,
-    ) -> None:
-        call_moto(context)
-
-    def verify_sms_sandbox_phone_number(
-        self, context: RequestContext, phone_number: PhoneNumberString, one_time_password: OTPCode
-    ) -> VerifySMSSandboxPhoneNumberResult:
-        call_moto(context)
-        return VerifySMSSandboxPhoneNumberResult()
 
     def get_topic_attributes(
         self, context: RequestContext, topic_arn: topicARN

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -596,8 +596,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 )
 
         store.subscriptions[subscription_arn] = subscription
-        store.topic_subscriptions[topic_arn] = store.topic_subscriptions.get(topic_arn) or []
-        store.topic_subscriptions[topic_arn].append(subscription_arn)
+
+        topic_subscription = store.topic_subscriptions.setdefault(topic_arn, [])
+        topic_subscription.append(subscription_arn)
 
         # store the token and subscription arn
         # TODO: the token is a 288 hex char string

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -70,6 +70,20 @@ LOG = logging.getLogger(__name__)
 
 
 class SnsProvider(SnsApi, ServiceLifecycleHook):
+    """
+    Provider class for AWS Simple Notification Service.
+
+    AWS supports following operations in a cross-account setup:
+    - GetTopicAttributes
+    - SetTopicAttributes
+    - AddPermission
+    - RemovePermission
+    - Publish
+    - Subscribe
+    - ListSubscriptionByTopic
+    - DeleteTopic
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self._publisher = PublishDispatcher()

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -590,7 +590,7 @@ class TestSNSProvider:
         )
         subscription_arn = subscription["SubscriptionArn"]
         parsed_arn = parse_arn(subscription_arn)
-        store = SnsProvider.get_store(account_id=parsed_arn["account"], region=parsed_arn["region"])
+        store = SnsProvider.get_store(parsed_arn["account"], parsed_arn["region"])
 
         sub_attr = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
         assert sub_attr["Attributes"]["PendingConfirmation"] == "true"

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -18,6 +18,7 @@ from werkzeug import Response
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
+from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.sns.constants import PLATFORM_ENDPOINT_MSGS_ENDPOINT
 from localstack.services.sns.provider import SnsProvider
 from localstack.testing.aws.util import is_aws_cloud
@@ -464,7 +465,7 @@ class TestSNSProvider:
         self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
     ):
 
-        sns_backend = SnsProvider.get_store()
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
         topic_arn = sns_create_topic()["TopicArn"]
 
         app_arn = sns_create_platform_application(Name="app1", Platform="p1", Attributes={})[
@@ -1145,7 +1146,7 @@ class TestSNSProvider:
 
         aws_client.sns.publish(Message=message, TopicArn=topic_arn)
 
-        sns_backend = SnsProvider.get_store()
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
 
         def check_messages():
             sms_messages = sns_backend.sms_messages
@@ -2728,7 +2729,7 @@ class TestSNSProvider:
     def test_publish_to_platform_endpoint_can_retrospect(
         self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
     ):
-        sns_backend = SnsProvider.get_store()
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
         # clean up the saved messages
         sns_backend_endpoint_arns = list(sns_backend.platform_endpoint_messages.keys())
         for saved_endpoint_arn in sns_backend_endpoint_arns:
@@ -2885,7 +2886,7 @@ class TestSNSProvider:
             MessageStructure="json",
         )
 
-        sns_backend = SnsProvider.get_store()
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
         platform_endpoint_msgs = sns_backend.platform_endpoint_messages
 
         # assert that message has been received


### PR DESCRIPTION
This PR adds cross-account access support for SNS topics.

This is allowed for following operations:

- GetTopicAttributes
- SetTopicAttributes
- AddPermission
- RemovePermission
- Publish
- Subscribe
- ListSubscriptionsByTopic
- DeleteTopic

Depends on [getmoto/moto#6330](https://github.com/getmoto/moto/pull/6330)