### PR TITLE
Enhance support for Podman API in Docker client

### DIFF
--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/tests-podman.yml"
       - "localstack/utils/container_utils"
+      - "tests/integration/docker_utils"
     branches:
       - master
       - release/*
@@ -13,6 +14,7 @@ on:
     paths:
       - ".github/workflows/tests-podman.yml"
       - "localstack/utils/container_utils"
+      - "tests/integration/docker_utils"
     branches:
       - master
       - release/*
@@ -54,7 +56,6 @@ jobs:
         run: |
           # determine path of podman socket
           podmanSocket=$(podman system info --format json | jq -r '.host.remoteSocket.path')
-          echo $podmanSocket
-          ls -la $podmanSocket || true
+          echo "Running tests against local podman socket $podmanSocket"
 
           DOCKER_CMD=podman DOCKER_HOST=$podmanSocket TEST_PATH=tests/integration/docker_utils DEBUG=1 make test

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -5,16 +5,18 @@ on:
   pull_request:
     paths:
       - ".github/workflows/tests-podman.yml"
-      - "localstack/utils/container_utils"
-      - "tests/integration/docker_utils"
+      - "localstack/utils/container_utils/"
+      - "localstack/utils/docker_utils.py"
+      - "tests/integration/docker_utils/"
     branches:
       - master
       - release/*
   push:
     paths:
       - ".github/workflows/tests-podman.yml"
-      - "localstack/utils/container_utils"
-      - "tests/integration/docker_utils"
+      - "localstack/utils/container_utils/"
+      - "localstack/utils/docker_utils.py"
+      - "tests/integration/docker_utils/"
     branches:
       - master
       - release/*

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -1,0 +1,44 @@
+name: Podman Docker Client Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/tests-podman.yml"
+      - "localstack/utils/container_utils"
+    branches:
+      - master
+      - release/*
+  push:
+    paths:
+      - ".github/workflows/tests-podman.yml"
+      - "localstack/utils/container_utils"
+    branches:
+      - master
+      - release/*
+
+jobs:
+  podman-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install podman
+        run:
+          apt install -y podman
+
+      - name: Install test dependencies
+        run: |
+          make install-test
+
+      - name: Run Podman Docker client tests
+        run: |
+          # TODO: check value of $DOCKER_SOCK for podman
+          DOCKER_CMD=podman DOCKER_SOCK=/var/run/docker.sock python -m pytest tests/integration/docker_utils

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -57,4 +57,4 @@ jobs:
           echo $podmanSocket
           ls -la $podmanSocket || true
 
-          DOCKER_CMD=podman DOCKER_SOCK=$podmanSocket TEST_PATH=tests/integration/docker_utils DEBUG=1 make test
+          DOCKER_CMD=podman DOCKER_HOST=$podmanSocket TEST_PATH=tests/integration/docker_utils DEBUG=1 make test

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   podman-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,15 +30,31 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install podman
-        run:
-          apt install -y podman
-
-      - name: Install test dependencies
+      - name: Install podman and test dependencies
         run: |
-          make install-test
+          make install-test &
+
+          # install podman
+          sudo apt update
+          sudo apt install -y podman
+          podman ps
+          podman system info
+
+          # disable Docker, to ensure the tests are running against Podman only
+          docker ps
+          sudo mv /var/run/docker.sock /var/run/docker.sock.bk
+          docker ps && exit 1
+          dockerCmd=$(which docker)
+          sudo mv $dockerCmd $dockerCmd".bk"
+
+          # wait for async installation process to finish
+          wait
 
       - name: Run Podman Docker client tests
         run: |
-          # TODO: check value of $DOCKER_SOCK for podman
-          DOCKER_CMD=podman DOCKER_SOCK=/var/run/docker.sock python -m pytest tests/integration/docker_utils
+          # determine path of podman socket
+          podmanSocket=$(podman system info --format json | jq -r '.host.remoteSocket.path')
+          echo $podmanSocket
+          ls -la $podmanSocket || true
+
+          DOCKER_CMD=podman DOCKER_SOCK=$podmanSocket TEST_PATH=tests/integration/docker_utils DEBUG=1 make test

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -425,6 +425,8 @@ class DockerRunFlags:
     user: Optional[str]
 
 
+# TODO: remove Docker/Podman compatibility switches (in particular strip_wellknown_repo_prefixes=...)
+#  from the container client base interface and introduce derived Podman client implementations instead!
 class ContainerClient(metaclass=ABCMeta):
     STOP_TIMEOUT = 0
 
@@ -477,7 +479,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param timeout: Timeout after which SIGKILL is sent to the container.
                         If not specified, defaults to `STOP_TIMEOUT`
         """
-        pass
 
     @abstractmethod
     def restart_container(self, container_name: str, timeout: int = 10):
@@ -497,7 +498,6 @@ class ContainerClient(metaclass=ABCMeta):
     @abstractmethod
     def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
         """Removes container with given name"""
-        pass
 
     @abstractmethod
     def remove_image(self, image: str, force: bool = True) -> None:
@@ -506,7 +506,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param image: Image name and tag
         :param force: Force removal
         """
-        pass
 
     @abstractmethod
     def list_containers(self, filter: Union[List[str], str, None] = None, all=True) -> List[dict]:
@@ -514,7 +513,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: A list of dicts with keys id, image, name, labels, status
         """
-        pass
 
     def get_running_container_names(self) -> List[str]:
         """Returns a list of the names of all running containers"""
@@ -531,24 +529,20 @@ class ContainerClient(metaclass=ABCMeta):
         self, container_name: str, local_path: str, container_path: str
     ) -> None:
         """Copy contents of the given local path into the container"""
-        pass
 
     @abstractmethod
     def copy_from_container(
         self, container_name: str, local_path: str, container_path: str
     ) -> None:
         """Copy contents of the given container to the host"""
-        pass
 
     @abstractmethod
     def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         """Pulls an image with a given name from a Docker registry"""
-        pass
 
     @abstractmethod
     def push_image(self, docker_image: str) -> None:
         """Pushes an image with a given name to a Docker registry"""
-        pass
 
     @abstractmethod
     def build_image(
@@ -565,7 +559,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param context_path: Path for build context (defaults to dirname of Dockerfile)
         :param platform: Target platform for build (defaults to platform of Docker host)
         """
-        pass
 
     @abstractmethod
     def tag_image(self, source_ref: str, target_name: str) -> None:
@@ -574,7 +567,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param source_ref: Name or ID of the image to be tagged
         :param target_name: New name (tag) of the tagged image
         """
-        pass
 
     @abstractmethod
     def get_docker_image_names(
@@ -591,17 +583,14 @@ class ContainerClient(metaclass=ABCMeta):
                "localhost/" or "docker.io/library/" which are added by the Podman API, but not by Docker
         :return: List of image names
         """
-        pass
 
     @abstractmethod
     def get_container_logs(self, container_name_or_id: str, safe: bool = False) -> str:
         """Get all logs of a given container"""
-        pass
 
     @abstractmethod
     def stream_container_logs(self, container_name_or_id: str) -> CancellableStream:
         """Returns a blocking generator you can iterate over to retrieve log output as it happens."""
-        pass
 
     @abstractmethod
     def inspect_container(self, container_name_or_id: str) -> Dict[str, Union[Dict, str]]:
@@ -609,7 +598,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: Dict containing docker attributes as returned by the daemon
         """
-        pass
 
     def inspect_container_volumes(self, container_name_or_id) -> List[VolumeInfo]:
         """Return information about the volumes mounted into the given container.
@@ -635,7 +623,6 @@ class ContainerClient(metaclass=ABCMeta):
                "localhost/" or "docker.io/library/" which are added by the Podman API, but not by Docker
         :return: Dict containing docker attributes as returned by the daemon
         """
-        pass
 
     @abstractmethod
     def create_network(self, network_name: str) -> str:
@@ -644,7 +631,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param network_name: Name of the network
         :return Network ID
         """
-        pass
 
     @abstractmethod
     def delete_network(self, network_name: str) -> None:
@@ -652,7 +638,6 @@ class ContainerClient(metaclass=ABCMeta):
         Delete a network with the given name
         :param network_name: Name of the network
         """
-        pass
 
     @abstractmethod
     def inspect_network(self, network_name: str) -> Dict[str, Union[Dict, str]]:
@@ -660,7 +645,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: Dict containing docker attributes as returned by the daemon
         """
-        pass
 
     @abstractmethod
     def connect_container_to_network(
@@ -672,7 +656,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param container_name_or_id: Container to connect to the network
         :param aliases: List of dns names the container should be available under in the network
         """
-        pass
 
     @abstractmethod
     def disconnect_container_from_network(
@@ -683,7 +666,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param network_name: Network to disconnect the container from
         :param container_name_or_id: Container to disconnect from the network
         """
-        pass
 
     def get_container_name(self, container_id: str) -> str:
         """Get the name of a container by a given identifier"""
@@ -699,7 +681,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         If container has multiple networks, it will return the IP of the first
         """
-        pass
 
     def get_image_cmd(self, docker_image: str, pull: bool = True) -> List[str]:
         """Get the command for the given image
@@ -723,7 +704,6 @@ class ContainerClient(metaclass=ABCMeta):
     @abstractmethod
     def has_docker(self) -> bool:
         """Check if system has docker available"""
-        pass
 
     @abstractmethod
     def commit(
@@ -738,7 +718,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param image_name: Destination image name
         :param image_tag: Destination image tag
         """
-        pass
 
     def create_container_from_config(self, container_config: ContainerConfiguration) -> str:
         """
@@ -801,7 +780,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: Container ID
         """
-        pass
 
     @abstractmethod
     def run_container(
@@ -835,7 +813,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: A tuple (stdout, stderr)
         """
-        pass
 
     @abstractmethod
     def exec_in_container(
@@ -853,7 +830,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: A tuple (stdout, stderr)
         """
-        pass
 
     @abstractmethod
     def start_container(
@@ -868,7 +844,6 @@ class ContainerClient(metaclass=ABCMeta):
 
         :return: A tuple (stdout, stderr) if attach or interactive is set, otherwise a tuple (b"container_name_or_id", b"")
         """
-        pass
 
     @abstractmethod
     def login(self, username: str, password: str, registry: Optional[str] = None) -> None:
@@ -879,7 +854,6 @@ class ContainerClient(metaclass=ABCMeta):
         :param password: Password / token for the registry
         :param registry: Registry url
         """
-        pass
 
 
 class Util:

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -715,7 +715,7 @@ class ContainerClient(metaclass=ABCMeta):
         :return: Image entrypoint
         """
         LOG.debug("Getting the entrypoint for image: %s", docker_image)
-        entrypoint_list = self.inspect_image(docker_image, pull)["Config"]["Entrypoint"] or []
+        entrypoint_list = self.inspect_image(docker_image, pull)["Config"].get("Entrypoint") or []
         return shlex.join(entrypoint_list)
 
     @abstractmethod
@@ -949,7 +949,7 @@ class Util:
                     # strip only one of the matching prefixes (avoid multi-stripping)
                     break
             result.append(image)
-        return image_names
+        return result
 
     @staticmethod
     def tar_path(path: str, target_path: str, is_dir: bool):

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -436,8 +436,7 @@ class ContainerClient(metaclass=ABCMeta):
     def get_networks(self, container_name: str) -> List[str]:
         LOG.debug("Getting networks for container: %s", container_name)
         container_attrs = self.inspect_container(container_name_or_id=container_name)
-        print("!!!container_attrs get_networks", container_attrs)
-        return list(container_attrs["NetworkSettings"]["Networks"].keys())
+        return list(container_attrs["NetworkSettings"].get("Networks", {}).keys())
 
     def get_container_ipv4_for_network(
         self, container_name_or_id: str, container_network: str
@@ -626,11 +625,15 @@ class ContainerClient(metaclass=ABCMeta):
         return volumes
 
     @abstractmethod
-    def inspect_image(self, image_name: str, pull: bool = True) -> Dict[str, Union[Dict, str]]:
+    def inspect_image(
+        self, image_name: str, pull: bool = True, strip_wellknown_repo_prefixes: bool = True
+    ) -> Dict[str, Union[dict, list, str]]:
         """Get detailed attributes of an image.
 
         :param image_name: Image name to inspect
         :param pull: Whether to pull image if not existent
+        :param strip_wellknown_repo_prefixes: whether to strip off well-known repo prefixes like
+               "localhost/" or "docker.io/library/" which are added by the Podman API, but not by Docker
         :return: Dict containing docker attributes as returned by the daemon
         """
         pass

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -455,8 +455,7 @@ class ContainerClient(metaclass=ABCMeta):
         # we always need the ID for this
         container_id = self.get_container_id(container_name=container_name_or_id)
         network_attrs = self.inspect_network(container_network)
-        print("!!!network_attrs", network_attrs)
-        containers = network_attrs["Containers"]
+        containers = network_attrs.get("Containers") or {}
         if container_id not in containers:
             raise ContainerException(
                 "Container %s is not connected to target network %s",
@@ -931,14 +930,14 @@ class Util:
         return f
 
     @staticmethod
-    def append_without_latest(image_names: list[str]):
+    def append_without_latest(image_names: List[str]):
         suffix = ":latest"
         for image in list(image_names):
             if image.endswith(suffix):
                 image_names.append(image[: -len(suffix)])
 
     @staticmethod
-    def strip_wellknown_repo_prefixes(image_names: list[str]) -> list[str]:
+    def strip_wellknown_repo_prefixes(image_names: List[str]) -> List[str]:
         """
         Remove well-known repo prefixes like `localhost/` or `docker.io/library/` from the list of given
         image names. This is mostly to ensure compatibility of our Docker client with Podman API responses.

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -54,7 +54,13 @@ class CancellableProcessStream(CancellableStream):
 
 
 class CmdDockerClient(ContainerClient):
-    """Class for managing docker containers using the command line executable"""
+    """
+    Class for managing Docker (or Podman) containers using the command line executable.
+
+    The client also supports targeting Podman engines, as Podman is almost a drop-in replacement
+    for Docker these days. The majority of compatibility switches in this class is to handle slightly
+    different response payloads or error messages returned by the `docker` vs `podman` commands.
+    """
 
     default_run_outfile: Optional[str] = None
 
@@ -649,7 +655,6 @@ class CmdDockerClient(ContainerClient):
         try:
             process = run(cmd, **kwargs)
             stdout, stderr = process.communicate(input=stdin)
-            print("!!!cmd", cmd, kwargs, process.returncode)
             if process.returncode != 0:
                 raise subprocess.CalledProcessError(
                     process.returncode,

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -153,12 +153,12 @@ class CmdDockerClient(ContainerClient):
         try:
             run(cmd)
         except subprocess.CalledProcessError as e:
-            if "No such image" in to_str(e.stdout):
+            # raise slightly different error messages for Docker and podman
+            if "No such image" in to_str(e.stdout) or "image not known" in to_str(e.stdout):
                 raise NoSuchImage(image, stdout=e.stdout, stderr=e.stderr)
-            else:
-                raise ContainerException(
-                    "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                ) from e
+            raise ContainerException(
+                "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
+            ) from e
 
     def commit(
         self,

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import Dict, List, Optional, Tuple, Union
 
 from localstack import config
+from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
     CancellableStream,
@@ -226,9 +227,11 @@ class CmdDockerClient(ContainerClient):
         for container in container_list:
             result.append(
                 {
-                    "id": container["ID"],
+                    # support both, Docker and podman API response formats (`ID` vs `Id`)
+                    "id": container.get("ID") or container["Id"],
                     "image": container["Image"],
-                    "name": container["Names"],
+                    # Docker returns a single string for `Names`, whereas podman returns a list of names
+                    "name": ensure_list(container["Names"])[0],
                     "status": container["State"],
                     "labels": container["Labels"],
                 }

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -61,10 +61,9 @@ class SdkDockerClient(ContainerClient):
     def client(self):
         if self.docker_client:
             return self.docker_client
-        else:
-            # if the initialization failed before, try to initialize on-demand
-            self.docker_client = self._create_client()
-            return self.docker_client
+        # if the initialization failed before, try to initialize on-demand
+        self.docker_client = self._create_client()
+        return self.docker_client
 
     @staticmethod
     def _create_client():

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -278,6 +278,9 @@ class SdkDockerClient(ContainerClient):
         except ImageNotFound:
             raise NoSuchImage(docker_image)
         except APIError as e:
+            # note: error message 'image not known' raised by Podman API
+            if "image not known" in str(e):
+                raise NoSuchImage(docker_image)
             raise ContainerException() from e
 
     def build_image(
@@ -461,6 +464,8 @@ class SdkDockerClient(ContainerClient):
             if not force:
                 raise NoSuchImage(image)
         except APIError as e:
+            if "image not known" in str(e):
+                raise NoSuchImage(image)
             raise ContainerException() from e
 
     def commit(

--- a/tests/integration/apigateway/conftest.py
+++ b/tests/integration/apigateway/conftest.py
@@ -10,6 +10,8 @@ from tests.integration.apigateway.apigateway_fixtures import (
     create_rest_api_stage,
     create_rest_resource,
     create_rest_resource_method,
+    delete_rest_api,
+    import_rest_api,
 )
 
 # default name used for created REST API stages
@@ -151,3 +153,18 @@ def apigw_redeploy_api(aws_client):
         )
 
     return _factory
+
+
+@pytest.fixture
+def import_apigw(aws_client):
+    rest_api_ids = []
+
+    def _import_apigateway_function(*args, **kwargs):
+        response, root_id = import_rest_api(aws_client.apigateway, **kwargs)
+        rest_api_ids.append(response.get("id"))
+        return response, root_id
+
+    yield _import_apigateway_function
+
+    for rest_api_id in rest_api_ids:
+        delete_rest_api(aws_client.apigateway, restApiId=rest_api_id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,6 @@ from localstack.runtime import events
 from localstack.services import infra
 from localstack.testing.aws.util import base_aws_client, base_aws_client_factory, base_aws_session
 from localstack.utils.common import safe_requests
-from tests.integration.apigateway.apigateway_fixtures import delete_rest_api, import_rest_api
 from tests.integration.test_es import install_async as es_install_async
 from tests.integration.test_opensearch import install_async as opensearch_install_async
 from tests.integration.test_terraform import TestTerraform
@@ -178,21 +177,6 @@ def localstack_runtime():
     localstack_started.wait()
     yield
     return
-
-
-@pytest.fixture
-def import_apigw(aws_client):
-    rest_api_ids = []
-
-    def _import_apigateway_function(*args, **kwargs):
-        response, root_id = import_rest_api(aws_client.apigateway, **kwargs)
-        rest_api_ids.append(response.get("id"))
-        return response, root_id
-
-    yield _import_apigateway_function
-
-    for rest_api_id in rest_api_ids:
-        delete_rest_api(aws_client.apigateway, restApiId=rest_api_id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/docker_utils/conftest.py
+++ b/tests/integration/docker_utils/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from localstack.config import is_env_not_false
@@ -23,3 +25,14 @@ def docker_client(request):
         client
     )  # this is a hack to get a global skip for all tests that require the docker client
     yield client
+
+
+def is_podman_test():
+    return os.environ.get("DOCKER_CMD") == "podman"
+
+
+# marker to indicate tests that don't work against Podman (i.e., should only be run against Docker)
+skip_for_podman = pytest.mark.skipif(
+    is_podman_test(),
+    reason="Test not applicable when run against Podman (only Docker)",
+)


### PR DESCRIPTION
Enhance support for targeting Podman API with our Docker client. Running on Podman has been increasingly requested by some customers recently, and during testing we've identified some gaps and discrepancies between the Docker API and Podman API responses (see also previous PR #8333). 

## Design Notes

This PR aims to be a starting point to address Podman support more systematically, and also have it covered by tests (we can reuse our excellent Docker client test suite for that purpose). Some/most of the existing Docker client tests are already working against Podman, and a new test marker `@skip_for_podman` has been introduced to temporarily skip failing tests for now. The goal would be to make all test pass over time, and then remove the `@skip_for_podman` marker.

The initial idea was to create a derived `PodmanClient` and inherit the functionality from the Docker client, but it turns out that the two platforms are sufficiently similar to handle both targets in a single client implementation. The majority of compatibility switches (especially in the `CmdDockerClient` class) is to handle slightly different response payloads or error messages returned by the `docker` vs `podman` commands.

The PR introduces a new CI build workflow to run the Podman Docker client tests in a separate build, whenever any of the relevant files are changing.

## Patch vs minor release

Currently the changes are targeting a simple patch release and are not behind a feature flag (arguably shouldn't be breaking, as so far we didn't officially support Podman, and our Docker test coverage is pretty decent). I'm open to discussion, though, whether we want to add the compatibility mode behind a feature flag for now. 👍 

## Summary of changes

* adjust the logic in the Docker CLI and SDK clients to support both, Docker and Podman API responses
* add `strip_wellknown_repo_prefixes` utility to strip off well-known image repo names like `localhost/` or `docker.io/library/` which are added by the Podman API, but not by Docker
* introduce a new CI build workflow to run the Podman Docker client tests in a separate build
* ... more details following soon ...