### PR TITLE
KMS: Remove the reserved key value pair from aad

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -132,8 +132,10 @@ def _serialize_encryption_context(encryption_context: Optional[EncryptionContext
     if encryption_context:
         aad = io.BytesIO()
         for key, value in sorted(encryption_context.items(), key=lambda x: x[0]):
-            aad.write(key.encode("utf-8"))
-            aad.write(value.encode("utf-8"))
+            # remove the reserved key-value pair from additional authentication data
+            if key != "`aws-crypto-public-key`":
+                aad.write(key.encode("utf-8"))
+                aad.write(value.encode("utf-8"))
         return aad.getvalue()
     else:
         return b""

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -110,6 +110,9 @@ RESERVED_ALIASES = [
     "alias/aws/xray",
 ]
 
+# list of key names that should be skipped when serializing the encryption context
+IGNORED_CONTEXT_KEYS = ["aws-crypto-public-key"]
+
 
 def _serialize_ciphertext_blob(ciphertext: Ciphertext) -> bytes:
     header = struct.pack(
@@ -133,7 +136,7 @@ def _serialize_encryption_context(encryption_context: Optional[EncryptionContext
         aad = io.BytesIO()
         for key, value in sorted(encryption_context.items(), key=lambda x: x[0]):
             # remove the reserved key-value pair from additional authentication data
-            if key != "`aws-crypto-public-key`":
+            if key not in IGNORED_CONTEXT_KEYS:
                 aad.write(key.encode("utf-8"))
                 aad.write(value.encode("utf-8"))
         return aad.getvalue()


### PR DESCRIPTION
Issue: `test_encrypt_via_aws_encryption_sdk` in localstack-ext repo invokes `aws_encryption_sdk` which internally updates encryption context param value by the method `_generate_signing_key_and_update_encryption_context` which is done after the actual encryption. Now, when we decrypt this cipher text, we have an additional reserved key-value pair of `encryption_context` by the name `aws-crypto-public-key` which was missing during encryption.

The PR removes the check of any such reserved key-value pair during decryption as no such value is passed for authentication in encryption.