### PR TITLE
fix account resolution in SQS QueryAPI operations

### DIFF
--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -20,6 +20,7 @@ from localstack.http import Request, Response, Router, route
 from localstack.http.dispatcher import Handler
 from localstack.services.sqs.exceptions import MissingParameter
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
 from localstack.utils.aws.request_context import extract_region_from_headers
 from localstack.utils.strings import long_uid
 
@@ -169,7 +170,13 @@ def try_call_sqs(request: Request, region: str) -> Tuple[Dict, OperationModel]:
 
     # TODO: permissions encoded in URL as AUTHPARAMS cannot be accounted for in this method, which is not a big
     #  problem yet since we generally don't enforce permissions.
-    client = aws_stack.connect_to_service("sqs", region_name=region)
+    account_id = extract_access_key_id_from_auth_header(headers)
+    client = aws_stack.connect_to_service(
+        "sqs",
+        region_name=region,
+        aws_access_key_id=account_id,
+        aws_secret_access_key=account_id,
+    )
     try:
         # using the layer below boto3.client("sqs").<operation>(...) to make the call
         boto_response = client._make_api_call(operation.name, service_request)

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -16,6 +16,7 @@ from localstack.aws.protocol.parser import OperationNotFoundParserError, create_
 from localstack.aws.protocol.serializer import create_serializer
 from localstack.aws.protocol.validate import MissingRequiredField, validate_request
 from localstack.aws.spec import load_service
+from localstack.constants import INTERNAL_AWS_ACCESS_KEY_ID, INTERNAL_AWS_SECRET_ACCESS_KEY
 from localstack.http import Request, Response, Router, route
 from localstack.http.dispatcher import Handler
 from localstack.services.sqs.exceptions import MissingParameter
@@ -174,8 +175,8 @@ def try_call_sqs(request: Request, region: str) -> Tuple[Dict, OperationModel]:
     client = aws_stack.connect_to_service(
         "sqs",
         region_name=region,
-        aws_access_key_id=account_id,
-        aws_secret_access_key=account_id,
+        aws_access_key_id=account_id or INTERNAL_AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=INTERNAL_AWS_SECRET_ACCESS_KEY,
     )
     try:
         # using the layer below boto3.client("sqs").<operation>(...) to make the call

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -117,11 +117,19 @@ def aws_http_client_factory(boto3_session):
             [botocore.credentials.Credentials, str, str], botocore.auth.BaseSigner
         ] = botocore.auth.SigV4QueryAuth,
         endpoint_url: str = None,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
     ):
         region = region or boto3_session.region_name
         region = region or config.DEFAULT_REGION
 
-        credentials = boto3_session.get_credentials()
+        if aws_access_key_id or aws_secret_access_key:
+            credentials = botocore.credentials.Credentials(
+                access_key=aws_access_key_id, secret_key=aws_secret_access_key
+            )
+        else:
+            credentials = boto3_session.get_credentials()
+
         creds = credentials.get_frozen_credentials()
 
         if not endpoint_url:

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -15,6 +15,7 @@ from localstack.aws.api.lambda_ import Runtime
 from localstack.constants import (
     SECONDARY_TEST_AWS_ACCESS_KEY_ID,
     SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
+    TEST_AWS_SECRET_ACCESS_KEY,
 )
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE
 from localstack.services.sqs.models import sqs_stores
@@ -3538,13 +3539,13 @@ class TestSqsQueryApi:
             service_name="sqs",
             region_name="us-east-1",
             aws_access_key_id="000000000001",
-            aws_secret_access_key="__test_key__",
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
         client2 = aws_client_factory.get_client(
             service_name="sqs",
             region_name="us-east-1",
             aws_access_key_id="000000000002",
-            aws_secret_access_key="__test_key__",
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
 
         # set up the queues in the two accounts
@@ -3564,14 +3565,14 @@ class TestSqsQueryApi:
             service="sqs",
             region="us-east-1",
             aws_access_key_id="000000000001",
-            aws_secret_access_key="__test_key__",
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
 
         client2_http = aws_http_client_factory(
             service="sqs",
             region="us-east-1",
             aws_access_key_id="000000000002",
-            aws_secret_access_key="__test_key__",
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
 
         # try and delete the queue from one account using the query API and make sure a) it works, and b) it's not deleting the queue from the other account

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -19,6 +19,7 @@ from localstack.constants import (
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE
 from localstack.services.sqs.models import sqs_stores
 from localstack.services.sqs.provider import MAX_NUMBER_OF_MESSAGES
+from localstack.services.sqs.utils import parse_queue_url
 from localstack.testing.snapshots.transformer import GenericTransformer
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import poll_condition, retry, short_uid, to_str
@@ -3527,6 +3528,64 @@ class TestSqsQueryApi:
         assert "<DeleteQueueResponse " in response.text
 
         assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
+
+    @pytest.mark.only_localstack
+    def test_delete_queue_multi_account(
+        self, aws_client_factory, aws_http_client_factory, cleanups
+    ):
+        # set up regular boto clients for creating the queues
+        client1 = aws_client_factory.get_client(
+            service_name="sqs",
+            region_name="us-east-1",
+            aws_access_key_id="000000000001",
+            aws_secret_access_key="__test_key__",
+        )
+        client2 = aws_client_factory.get_client(
+            service_name="sqs",
+            region_name="us-east-1",
+            aws_access_key_id="000000000002",
+            aws_secret_access_key="__test_key__",
+        )
+
+        # set up the queues in the two accounts
+        prefix = f"test-{short_uid()}-"
+        queue1_name = f"{prefix}-queue-{short_uid()}"
+        queue2_name = f"{prefix}-queue-{short_uid()}"
+        response = client1.create_queue(QueueName=queue1_name)
+        queue1_url = response["QueueUrl"]
+        assert parse_queue_url(queue1_url)[0] == "000000000001"
+
+        response = client2.create_queue(QueueName=queue2_name)
+        queue2_url = response["QueueUrl"]
+        assert parse_queue_url(queue2_url)[0] == "000000000002"
+
+        # now prepare the query api clients
+        client1_http = aws_http_client_factory(
+            service="sqs",
+            region="us-east-1",
+            aws_access_key_id="000000000001",
+            aws_secret_access_key="__test_key__",
+        )
+
+        client2_http = aws_http_client_factory(
+            service="sqs",
+            region="us-east-1",
+            aws_access_key_id="000000000002",
+            aws_secret_access_key="__test_key__",
+        )
+
+        # try and delete the queue from one account using the query API and make sure a) it works, and b) it's not deleting the queue from the other account
+        assert len(client1.list_queues(QueueNamePrefix=prefix).get("QueueUrls", [])) == 1
+        assert len(client2.list_queues(QueueNamePrefix=prefix).get("QueueUrls", [])) == 1
+        response = client1_http.post(queue1_url, params={"Action": "DeleteQueue"})
+        assert response.ok
+        assert len(client1.list_queues(QueueNamePrefix=prefix).get("QueueUrls", [])) == 0
+        assert queue2_url in client2.list_queues(QueueNamePrefix=prefix).get("QueueUrls", [])
+
+        # now delete the second one
+        client2_http.post(queue2_url, params={"Action": "DeleteQueue"})
+        assert response.ok
+        assert len(client2.list_queues(QueueNamePrefix=prefix).get("QueueUrls", [])) == 0
 
     @pytest.mark.aws_validated
     def test_get_send_and_receive_messages(self, sqs_create_queue, sqs_http_client):


### PR DESCRIPTION
## Motivation

This PR fixes the account resolution for operations to the SQS QueryAPI. Previously, we were not parsing authorization headers to allow account access outside the default `000000000000` account. This meant that, if you tried to perform an operation on, say, `http://localhost:4566/123456789012/my-queue`, then after proxying the call to the SQS Provider, `context.account_id` would return `000000000000` instead.

Moreover, in the `delete_queue` implementation in the backend, we were not using the account/region from the parsed queue URL, but instead using that of the context. Technically cross-account delete is not allowed, so it would be fine, but it made sense to fix that and add a defensive piece of code to warn the user that they're potentially doing something that's not allowed.

The issue originally surfaced when a user tried to perform a `DeleteQueue` call using a queue in a different account than the default one.

## Changes

* Extract the credentials from the auth headers and set it as `aws_access_key_id` before proxying the call to the localstack backend
* Fix the `delete_queue` method to use region and account from the queue URL, and log a warning if the users it trying cross-account access
* Add the ability to add credentials to the HTTP client factory
* Add a localstack-only test for multi-account queue delete