### PR TITLE
fix failing test related to shutdown method of hypercorn server

### DIFF
--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -11,6 +11,7 @@ from localstack.aws.handlers.proxy import ProxyHandler
 from localstack.aws.serving.asgi import AsgiGateway
 from localstack.logging.setup import setup_hypercorn_logger
 from localstack.utils.collections import ensure_list
+from localstack.utils.functions import call_safe
 from localstack.utils.serving import Server
 from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 
@@ -62,7 +63,8 @@ class HypercornServer(Server):
         self._closed.wait(timeout=10)
         asyncio.run_coroutine_threadsafe(self.loop.shutdown_asyncgens(), self.loop)
         self.loop.shutdown_default_executor()
-        self.loop.close()
+        self.loop.stop()
+        call_safe(self.loop.close)
 
     async def _set_closed(self):
         self._close.set()


### PR DESCRIPTION
This is a quick band-aid for the failing unit test in main:

```
=================================== FAILURES ===================================
_____________________________ test_gateway_server ______________________________

    def test_gateway_server():
        def echo_request_handler(_: HandlerChain, context: RequestContext, response: Response):
            response.set_response(context.request.data)
            response.status_code = 200
            response.headers = context.request.headers
    
        gateway = Gateway()
        gateway.request_handlers.append(echo_request_handler)
        port = get_free_tcp_port()
        server = GatewayServer(gateway, port, "127.0.0.1", use_ssl=True)
>       with server_context(server):

tests/unit/http_/test_hypercorn.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/circleci/.pyenv/versions/3.10.3/lib/python3.10/contextlib.py:142: in __exit__
    next(self.gen)
tests/unit/http_/test_hypercorn.py:25: in server_context
    server.shutdown()
localstack/utils/serving.py:115: in shutdown
    self.do_shutdown()
localstack/http/hypercorn.py:113: in do_shutdown
    super().do_shutdown()
localstack/http/hypercorn.py:65: in do_shutdown
    self.loop.close()
/opt/circleci/.pyenv/versions/3.10.3/lib/python3.10/asyncio/unix_events.py:68: in close
    super().close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=True closed=False debug=False>

    def close(self):
        if self.is_running():
>           raise RuntimeError("Cannot close a running event loop")
E           RuntimeError: Cannot close a running event loop

/opt/circleci/.pyenv/versions/3.10.3/lib/python3.10/asyncio/selector_events.py:84: RuntimeError
------------------------------ Captured log call -------------------------------
DEBUG    localstack.utils.ssl:ssl.py:35 Using cached SSL certificate (less than 6hrs since last update).
INFO     hypercorn.error:logging.py:102 Running on https://127.0.0.1:41355 (CTRL + C to quit)
DEBUG    charset_normalizer:api.py:437 Encoding detection: ascii is most likely the one.
```

I don't fully understand why this is suddenly happening, and also wasn't able to reproduce it locally. I tried to find out whether any of the dependencies changed, but couldn't reproduce it through that either.

So I this band-aid to stop the event loop and not propagate the runtime exception of `close`.

I'm not happy with the way we are handling event loops at all at the moment. Conceptually we should be re-using the event loop from the application if possible, but we cannot do that currently because we yield to control of the loop's lifecycle to the server/gateway. We need that because we need to clean it up in case we use `new_event_loop`. So in future iterations it would be great to better deal with the event loop.