### PR TITLE
extend conditional if att functionality

### DIFF
--- a/tests/integration/cloudformation/test_template_engine.py
+++ b/tests/integration/cloudformation/test_template_engine.py
@@ -245,6 +245,23 @@ class TestIntrinsicFunctions:
         zone = "us-east-1a"  # TODO parametrize
         assert zone in deployed.outputs["Zones"]
 
+    @pytest.mark.aws_validated
+    @pytest.mark.parametrize("create_parameter", ("true", "false"), ids=("create", "no-create"))
+    def test_conditional_att_to_conditional_resources(self, deploy_cfn_template, create_parameter):
+        template_path = os.path.join(
+            os.path.dirname(__file__), "../templates/cfn_if_attribute_none.yml"
+        )
+
+        deployed = deploy_cfn_template(
+            template_path=template_path,
+            parameters={"CreateParameter": create_parameter},
+        )
+
+        if create_parameter == "false":
+            assert deployed.outputs["Result"] == "Value1"
+        else:
+            assert deployed.outputs["Result"] == "Value2"
+
 
 class TestImports:
     @pytest.mark.skip(reason="flaky due to issues in parameter handling and re-resolving")

--- a/tests/integration/templates/cfn_if_attribute_none.yml
+++ b/tests/integration/templates/cfn_if_attribute_none.yml
@@ -1,0 +1,42 @@
+Parameters:
+  Value1:
+    Type: String
+    Default: "Value1"
+  Value2:
+    Type: String
+    Default: "Value2"
+  CreateParameter:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+Conditions:
+  UseParameter1: !Equals [!Ref CreateParameter, "false"]
+  UseParameter2: !Equals [!Ref CreateParameter, "true"]
+
+Resources:
+  Parameter1:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !Ref Value1
+
+  Parameter2:
+    Condition: UseParameter2
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !Ref Value2
+
+  Parameter3:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !If [UseParameter1, !Ref Value1, !Ref Value2]
+
+Outputs:
+  Result:
+    Value:
+      Fn::GetAtt: [Parameter3, Value]


### PR DESCRIPTION
This PR allows the template deployer ignore a resource dependency in a ref function if such resource has a conditional deployment and it evaluates to false.

Explained in a different way. If a resource is not deployable due to a condition, and it is referenced ( in this case inside an if function) the ref evaluates to AWS::NoValue instead of preventing the resource to not be deployed.

