### PR TITLE
update ListObjects(V2) tag order for Java SDK

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2373,7 +2373,6 @@ class ListObjectsOutput(TypedDict, total=False):
     IsTruncated: Optional[IsTruncated]
     Marker: Optional[Marker]
     NextMarker: Optional[NextMarker]
-    Contents: Optional[ObjectList]
     Name: Optional[BucketName]
     Prefix: Optional[Prefix]
     Delimiter: Optional[Delimiter]
@@ -2381,6 +2380,7 @@ class ListObjectsOutput(TypedDict, total=False):
     CommonPrefixes: Optional[CommonPrefixList]
     EncodingType: Optional[EncodingType]
     BucketRegion: Optional[BucketRegion]
+    Contents: Optional[ObjectList]
 
 
 class ListObjectsRequest(ServiceRequest):
@@ -2396,7 +2396,6 @@ class ListObjectsRequest(ServiceRequest):
 
 class ListObjectsV2Output(TypedDict, total=False):
     IsTruncated: Optional[IsTruncated]
-    Contents: Optional[ObjectList]
     Name: Optional[BucketName]
     Prefix: Optional[Prefix]
     Delimiter: Optional[Delimiter]
@@ -2408,6 +2407,7 @@ class ListObjectsV2Output(TypedDict, total=False):
     NextContinuationToken: Optional[NextToken]
     StartAfter: Optional[StartAfter]
     BucketRegion: Optional[BucketRegion]
+    Contents: Optional[ObjectList]
 
 
 class ListObjectsV2Request(ServiceRequest):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -785,6 +785,30 @@
         "shape":"Buckets",
         "documentation":"<p>The list of buckets owned by the requester.</p>"
       }
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/ListObjectsOutput/members/Contents"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ListObjectsOutput/members/Contents",
+      "value": {
+        "shape":"ObjectList",
+        "documentation":"<p>Metadata about each object returned.</p>"
+      }
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/ListObjectsV2Output/members/Contents"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ListObjectsV2Output/members/Contents",
+      "value": {
+        "shape":"ObjectList",
+        "documentation":"<p>Metadata about each object returned.</p>"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR fixes the order of XML tags for `ListObjects` and `ListObjectsV2`.

This issue surfaced with #8359, where the Java SDK `TransferManager` would fail with a bucket name equal to `null`. After investigating, this utils is making use of the `ListObjects` API, and indeed, every object in `ObjectListing` `ObjectSummary` would have a bucket name equal to `null`, even though the response would properly return the `Name` field with the bucket name.
And once again, the tag order was important, I think this time from the reflection class `ObjectListing`, the way they cast an XML response into a class makes the order important, as they must first parse the bucket name to properly set it to each object in `Contents`. 

If these issues are getting more common, we might need to implement something in the serializer, while making use of the S3 documentation (like #8037) which has the proper expected order of XML tags, to _sigh_ sort the keys before serialising the XML. 

This is the proper order of tags, from the documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html#API_ListObjects_Example_2

This also have been validating with a small Java test making use of `TransferManager`, and also checked with both `ListBuckets`.

```java
// need to create the S3 client, and set the `bucketName`, `key_prefix` and `dir_path`
TransferManager xfer_mgr = TransferManagerBuilder.standard().withS3Client(s3).build();

try {
	MultipleFileDownload xfer = xfer_mgr.downloadDirectory(
			bucketName, key_prefix, new File(dir_path));
	// loop with Transfer.isDone()
	// XferMgrProgress.showTransferProgress(xfer);
	// or block with Transfer.waitForCompletion()
	xfer.waitForCompletion();
} catch (AmazonServiceException | InterruptedException e) {
	System.err.println(e.toString());
	System.exit(1);
}
xfer_mgr.shutdownNow();
``` 
