### PR TITLE
make test_fifo_queue_send_message_with_delay_on_queue_works more robust

### DIFF
--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1586,12 +1586,13 @@ class TestSqsProvider:
 
     @pytest.mark.aws_validated
     def test_fifo_queue_send_message_with_delay_on_queue_works(self, sqs_create_queue, aws_client):
+        delay_seconds = 2
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
             Attributes={
                 "FifoQueue": "true",
                 "ContentBasedDeduplication": "true",
-                "DelaySeconds": "2",
+                "DelaySeconds": str(delay_seconds),
             },
         )
 
@@ -1602,9 +1603,9 @@ class TestSqsProvider:
         response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert response.get("Messages", []) == []
 
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, WaitTimeSeconds=3, MaxNumberOfMessages=3
-        )
+        time.sleep(delay_seconds + 1)
+
+        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=3)
         messages = response["Messages"]
         assert len(messages) == 3
 


### PR DESCRIPTION
This is a minor change for a test that has been flaking. The reason is that potentially not enough time has passed between the delay and receiving the messages. Since we changed the behavior of `receive_message` in combination with `MaxNumberOfMessages` and `WaitTimeSeconds` there's a chance that fewer messages than 3 will be returned, although we are asking for 3.

So now, we do a hard sleep with an extra second to give the messages enough time to arrive in the queue. since this is a FIFO queue, we should receive all three messages in the `receive_message` call if they are in the queue.