### PR TITLE
fix release helper script for requirements.txt files

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -159,8 +159,8 @@ function cmd-set-dep-ver() {
     dep=$1
     ver=$2
 
-    egrep -h "^(\s+)${dep}(\[[a-zA-Z0-9]+\])?(>|=|<)(.*)" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
-    sed -i -r "s/^(\s+)(${dep})(\[[a-zA-Z0-9,]+\])?(>|=|<)(.*)/\1\2\3${ver}/g" ${DEPENDENCY_FILE}
+    egrep -h "^(\s*)${dep}(\[[a-zA-Z0-9]+\])?(>|=|<)(.*)" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
+    sed -i -r "s/^(\s*)(${dep})(\[[a-zA-Z0-9,]+\])?(>|=|<)(.*)/\1\2\3${ver}/g" ${DEPENDENCY_FILE}
 }
 
 function cmd-github-outputs() {


### PR DESCRIPTION
This PR contains a very small fix which allows using `set-dep-ver` in `bin/release-helper.sh` with `requirements.txt` files (instead of just `setup.cfg`). It just changes the regex such that the spaces at the beginning of the file are optional (`\s*`) instead of "at least once" (`\s+`).