### PR TITLE
added support for intelligent tier in s3

### DIFF
--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -11,6 +11,8 @@ from localstack.aws.api.s3 import (
     BucketLifecycleConfiguration,
     BucketName,
     CORSConfiguration,
+    IntelligentTieringConfiguration,
+    IntelligentTieringId,
     NotificationConfiguration,
     ReplicationConfiguration,
     WebsiteConfiguration,
@@ -55,7 +57,7 @@ class S3Store(BaseStore):
     ] = CrossRegionAttribute(default=dict)
 
     bucket_intelligent_tiering_configuration: Dict[
-        BucketName, Dict[BucketName, AnalyticsConfiguration]
+        BucketName, Dict[IntelligentTieringId, IntelligentTieringConfiguration]
     ] = CrossRegionAttribute(default=dict)
 
 

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -54,6 +54,10 @@ class S3Store(BaseStore):
         BucketName, Dict[AnalyticsId, AnalyticsConfiguration]
     ] = CrossRegionAttribute(default=dict)
 
+    bucket_intelligent_tiering_configuration: Dict[
+        BucketName, Dict[BucketName, AnalyticsConfiguration]
+    ] = CrossRegionAttribute(default=dict)
+
 
 class BucketCorsIndex:
     def __init__(self):

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -40,6 +40,7 @@ from localstack.aws.api.s3 import (
     GetBucketAclOutput,
     GetBucketAnalyticsConfigurationOutput,
     GetBucketCorsOutput,
+    GetBucketIntelligentTieringConfigurationOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLifecycleOutput,
     GetBucketLocationOutput,
@@ -57,10 +58,14 @@ from localstack.aws.api.s3 import (
     GetObjectTaggingRequest,
     HeadObjectOutput,
     HeadObjectRequest,
+    IntelligentTieringConfiguration,
+    IntelligentTieringConfigurationList,
+    IntelligentTieringId,
     InvalidBucketName,
     InvalidPartOrder,
     InvalidStorageClass,
     ListBucketAnalyticsConfigurationsOutput,
+    ListBucketIntelligentTieringConfigurationsOutput,
     ListMultipartUploadsOutput,
     ListMultipartUploadsRequest,
     ListObjectsOutput,
@@ -1236,11 +1241,86 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not analytics_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
 
+    def put_bucket_intelligent_tiering_configuration(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        id: IntelligentTieringId,
+        intelligent_tiering_configuration: IntelligentTieringConfiguration,
+    ) -> None:
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket)
+
+        validate_bucket_intelligent_tiering_configuration(id, intelligent_tiering_configuration)
+
+        store = self.get_store()
+        bucket_intelligent_tiering_configuration = (
+            store.bucket_intelligent_tiering_configuration.setdefault(bucket, {})
+        )
+        bucket_intelligent_tiering_configuration[id] = intelligent_tiering_configuration
+
+    def get_bucket_intelligent_tiering_configuration(
+        self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
+    ) -> GetBucketIntelligentTieringConfigurationOutput:
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket)
+
+        store = self.get_store()
+        intelligent_tiering_configuration: IntelligentTieringConfiguration = (
+            store.bucket_intelligent_tiering_configuration.get(bucket, {}).get(id)
+        )
+        if not intelligent_tiering_configuration:
+            raise NoSuchConfiguration("The specified configuration does not exist.")
+        return GetBucketIntelligentTieringConfigurationOutput(
+            IntelligentTieringConfiguration=intelligent_tiering_configuration
+        )
+
+    def delete_bucket_intelligent_tiering_configuration(
+        self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
+    ) -> None:
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket)
+
+        store = self.get_store()
+        bucket_intelligent_tiering_configuration = (
+            store.bucket_intelligent_tiering_configuration.get(bucket, {})
+        )
+        if not bucket_intelligent_tiering_configuration.pop(id, None):
+            raise NoSuchConfiguration("The specified configuration does not exist.")
+
+    def list_bucket_intelligent_tiering_configurations(
+        self, context: RequestContext, bucket: BucketName, continuation_token: Token = None
+    ) -> ListBucketIntelligentTieringConfigurationsOutput:
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket)
+
+        store = self.get_store()
+        bucket_intelligent_tiering_configuration: Dict[
+            IntelligentTieringId, IntelligentTieringConfiguration
+        ] = store.bucket_intelligent_tiering_configuration.get(bucket, {})
+
+        bucket_intelligent_tiering_configuration: IntelligentTieringConfigurationList = sorted(
+            bucket_intelligent_tiering_configuration.values(), key=lambda x: x["Id"]
+        )
+        return ListBucketIntelligentTieringConfigurationsOutput(
+            IsTruncated=False,
+            IntelligentTieringConfigurationList=bucket_intelligent_tiering_configuration,
+        )
+
 
 def validate_bucket_analytics_configuration(
     id: AnalyticsId, analytics_configuration: AnalyticsConfiguration
 ) -> None:
     if id != analytics_configuration.get("Id"):
+        raise MalformedXML(
+            "The XML you provided was not well-formed or did not validate against our published schema"
+        )
+
+
+def validate_bucket_intelligent_tiering_configuration(
+    id: IntelligentTieringId, intelligent_tiering_configuration: IntelligentTieringConfiguration
+) -> None:
+    if id != intelligent_tiering_configuration.get("Id"):
         raise MalformedXML(
             "The XML you provided was not well-formed or did not validate against our published schema"
         )

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1183,8 +1183,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             id=id, analytics_configuration=analytics_configuration
         )
 
-        bucket_analytics_configuration = store.bucket_analytics_configuration.setdefault(bucket, {})
-        bucket_analytics_configuration[id] = analytics_configuration
+        bucket_analytics_configurations = store.bucket_analytics_configuration.setdefault(
+            bucket, {}
+        )
+        bucket_analytics_configurations[id] = analytics_configuration
 
     def get_bucket_analytics_configuration(
         self,
@@ -1254,10 +1256,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         validate_bucket_intelligent_tiering_configuration(id, intelligent_tiering_configuration)
 
         store = self.get_store()
-        bucket_intelligent_tiering_configuration = (
+        bucket_intelligent_tiering_configurations = (
             store.bucket_intelligent_tiering_configuration.setdefault(bucket, {})
         )
-        bucket_intelligent_tiering_configuration[id] = intelligent_tiering_configuration
+        bucket_intelligent_tiering_configurations[id] = intelligent_tiering_configuration
 
     def get_bucket_intelligent_tiering_configuration(
         self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
@@ -1282,10 +1284,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         get_bucket_from_moto(moto_backend, bucket)
 
         store = self.get_store()
-        bucket_intelligent_tiering_configuration = (
+        bucket_intelligent_tiering_configurations = (
             store.bucket_intelligent_tiering_configuration.get(bucket, {})
         )
-        if not bucket_intelligent_tiering_configuration.pop(id, None):
+        if not bucket_intelligent_tiering_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
 
     def list_bucket_intelligent_tiering_configurations(
@@ -1295,16 +1297,16 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         get_bucket_from_moto(moto_backend, bucket)
 
         store = self.get_store()
-        bucket_intelligent_tiering_configuration: Dict[
+        bucket_intelligent_tiering_configurations: Dict[
             IntelligentTieringId, IntelligentTieringConfiguration
         ] = store.bucket_intelligent_tiering_configuration.get(bucket, {})
 
-        bucket_intelligent_tiering_configuration: IntelligentTieringConfigurationList = sorted(
-            bucket_intelligent_tiering_configuration.values(), key=lambda x: x["Id"]
+        bucket_intelligent_tiering_configurations: IntelligentTieringConfigurationList = sorted(
+            bucket_intelligent_tiering_configurations.values(), key=lambda x: x["Id"]
         )
         return ListBucketIntelligentTieringConfigurationsOutput(
             IsTruncated=False,
-            IntelligentTieringConfigurationList=bucket_intelligent_tiering_configuration,
+            IntelligentTieringConfigurationList=bucket_intelligent_tiering_configurations,
         )
 
 

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7057,5 +7057,152 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_intelligent_tier_config": {
+    "recorded-date": "26-05-2023, 19:17:48",
+    "recorded-content": {
+      "put_bucket_intelligent_tiering_configuration_err_1`": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get_bucket_intelligent_tiering_configuration_1": {
+        "IntelligentTieringConfiguration": {
+          "Filter": {
+            "Prefix": "test1"
+          },
+          "Id": "test1",
+          "Status": "Enabled",
+          "Tierings": [
+            {
+              "AccessTier": "ARCHIVE_ACCESS",
+              "Days": 90
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_bucket_intelligent_tiering_configurations_1": {
+        "IntelligentTieringConfigurationList": [
+          {
+            "Filter": {
+              "Prefix": "test1"
+            },
+            "Id": "test1",
+            "Status": "Enabled",
+            "Tierings": [
+              {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 90
+              }
+            ]
+          },
+          {
+            "Filter": {
+              "Prefix": "test2"
+            },
+            "Id": "test2",
+            "Status": "Enabled",
+            "Tierings": [
+              {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 90
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_bucket_intelligent_tiering_configurations_2": {
+        "IntelligentTieringConfigurationList": [
+          {
+            "Filter": {
+              "Prefix": "testupdate"
+            },
+            "Id": "test1",
+            "Status": "Enabled",
+            "Tierings": [
+              {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 90
+              }
+            ]
+          },
+          {
+            "Filter": {
+              "Prefix": "test2"
+            },
+            "Id": "test2",
+            "Status": "Enabled",
+            "Tierings": [
+              {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 90
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_bucket_intelligent_tiering_configuration_err_1": {
+        "Error": {
+          "BucketName": "non-existing-bucket",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete_bucket_intelligent_tiering_configuration_err_2": {
+        "Error": {
+          "Code": "NoSuchConfiguration",
+          "Message": "The specified configuration does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list_bucket_intelligent_tiering_configurations_3": {
+        "IntelligentTieringConfigurationList": [
+          {
+            "Filter": {
+              "Prefix": "test2"
+            },
+            "Id": "test2",
+            "Status": "Enabled",
+            "Tierings": [
+              {
+                "AccessTier": "ARCHIVE_ACCESS",
+                "Days": 90
+              }
+            ]
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds support for S3 intelligent tier configuration mocking.

### Implemented APIs
- get-bucket-intelligent-tiering-configuration
- put-bucket-intelligent-tiering-configuration
- delete-bucket-intelligent-tiering-configuration
- list-bucket-intelligent-tiering-configurations

### Parity Improvements with TF
- TestAccS3BucketIntelligentTieringConfiguration_basic
- TestAccS3BucketIntelligentTieringConfiguration_disappears
- TestAccS3BucketIntelligentTieringConfiguration_Filter