### PR TITLE
Enhance bootstrap logic to allow CLI startup from within Docker

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -162,6 +162,12 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
                 "If you would like to use --host, please reinstall localstack using `pip install localstack[runtime]`"
             )
     else:
+        # make sure to initialize the bootstrap environment and directories for the host (even if we're executing
+        # in Docker), to allow starting the container from within other containers (e.g., Github Codespaces).
+        config.OVERRIDE_IN_DOCKER = False
+        config.is_in_docker = False
+        config.dirs = config.init_directories()
+
         if detached:
             bootstrap.start_infra_in_docker_detached(console)
         else:

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -423,7 +423,7 @@ class LocalstackContainer:
         if isinstance(DOCKER_CLIENT, CmdDockerClient):
             DOCKER_CLIENT.default_run_outfile = self.logfile
 
-        try:
+        def _run_container(_volume_mounts: List[SimpleVolumeBind]):
             return DOCKER_CLIENT.run_container(
                 image_name=self.image_name,
                 stdin=self.stdin,
@@ -434,7 +434,7 @@ class LocalstackContainer:
                 tty=self.tty,
                 detach=self.detach,
                 command=self.command or None,
-                mount_volumes=self._get_mount_volumes(),
+                mount_volumes=_volume_mounts,
                 ports=self.ports,
                 env_vars=self.env_vars,
                 user=self.user,
@@ -445,6 +445,23 @@ class LocalstackContainer:
                 workdir=self.workdir,
                 privileged=self.privileged,
             )
+
+        try:
+            volume_mounts = self._get_mount_volumes()
+            try:
+                return _run_container(volume_mounts)
+            except ContainerException as e:
+                err_str = str(e) + str(e.__cause__)
+                if "Mounts denied" in err_str:
+                    # This can happen if Docker doesn't have access to the LocalStack volume directory.
+                    # We remove the volume dir mount from the list, and then attempt to run the container again.
+                    LOG.warning(
+                        "Error mounting volumes in Docker - attempting again without LocalStack volume mount"
+                    )
+                    volume_mounts = [vol for vol in volume_mounts if vol[1] != DEFAULT_VOLUME_DIR]
+                    DOCKER_CLIENT.remove_container(self.name, force=True)
+                    return _run_container(volume_mounts)
+                raise
         except ContainerException as e:
             if LOG.isEnabledFor(logging.DEBUG):
                 LOG.exception("Error while starting LocalStack container")

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -149,7 +149,9 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-fu", user])
         assert "localstack-supervisor" in to_str(output[0])
 
-    def test_start_cli_within_container(self, runner, container_client):
+    @pytest.mark.parametrize("custom_volume_dir", [True, False])
+    def test_start_cli_within_container(self, runner, container_client, custom_volume_dir):
+        env_vars = {"LOCALSTACK_VOLUME_DIR": "/tmp/ls-volume"} if custom_volume_dir else {}
         output = container_client.run_container(
             # CAVEAT: Updates to the Docker image are not immediately reflected when using the latest image from
             # DockerHub in the CI. Re-build the Docker image locally through `make docker-build` for local testing.
@@ -161,7 +163,7 @@ class TestCliContainerLifecycle:
                 ("/var/run/docker.sock", "/var/run/docker.sock"),
                 (MODULE_MAIN_PATH, "/opt/code/localstack/localstack"),
             ],
-            env_vars={"LOCALSTACK_VOLUME_DIR": "/tmp/ls-volume"},
+            env_vars=env_vars,
         )
         stdout = to_str(output[0])
         assert "starting LocalStack" in stdout

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -149,9 +149,7 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-fu", user])
         assert "localstack-supervisor" in to_str(output[0])
 
-    @pytest.mark.parametrize("custom_volume_dir", [True, False])
-    def test_start_cli_within_container(self, runner, container_client, custom_volume_dir):
-        env_vars = {"LOCALSTACK_VOLUME_DIR": "/tmp/ls-volume"} if custom_volume_dir else {}
+    def test_start_cli_within_container(self, runner, container_client, tmp_path):
         output = container_client.run_container(
             # CAVEAT: Updates to the Docker image are not immediately reflected when using the latest image from
             # DockerHub in the CI. Re-build the Docker image locally through `make docker-build` for local testing.
@@ -163,7 +161,7 @@ class TestCliContainerLifecycle:
                 ("/var/run/docker.sock", "/var/run/docker.sock"),
                 (MODULE_MAIN_PATH, "/opt/code/localstack/localstack"),
             ],
-            env_vars=env_vars,
+            env_vars={"LOCALSTACK_VOLUME_DIR": f"{tmp_path}/ls-volume"},
         )
         stdout = to_str(output[0])
         assert "starting LocalStack" in stdout


### PR DESCRIPTION
This PR adds small enhancements to the bootstrap logic, to enable CLI startup (`localstack start`) from within Docker containers in different environments.

The starting point for this change is a Github Codespaces workspace that we're currently preparing for the AWS Builders Day workshop: https://github.com/localstack/localstack-workshop/blob/main/.devcontainer/devcontainer.json . The Codespaces environment is itself running in a Docker container (devcontainer), and with the current version of the CLI we're receiving this error:
```
$ localstack start
 ...
  File "/tmp/venv/lib/python3.10/site-packages/localstack/cli/localstack.py", line 168, in cmd_start
    bootstrap.start_infra_in_docker()
  File "/tmp/venv/lib/python3.10/site-packages/localstack/utils/bootstrap.py", line 591, in start_infra_in_docker
    container.truncate_log()
  File "/tmp/venv/lib/python3.10/site-packages/localstack/utils/bootstrap.py", line 458, in truncate_log
    with open(self.logfile, "wb") as fd:
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/localstack/tmp/localstack_main_container.log'
```

Note that the bootstrap code is attempting to access `/var/lib/localstack`, which is the default directory for the LocalStack volume inside the container.

One of the key ingredients of the approach is to allow an override config `OVERRIDE_IN_DOCKER=0`, in addition to the already supported `OVERRIDE_IN_DOCKER=1`. It seems reasonable to not only allow overriding the Docker detection for false negatives, but also for false positives.  As far as I can see in the code (and our docs), this change should be backward-compatible (there is one reference in our [docs](https://docs.localstack.cloud/references/configuration/#miscellaneous) which needs to be updated).

(As a general note: currently the host/container switch is coupled to the "is in Docker" checks (which makes sense, as it covers 99% of use cases!) - but at some point we could consider splitting up the two, and make the distinction a bit more explicit.)

The second change in the PR is around mounting of the LocalStack volume dir. When executing in Docker, it can happen that the volume directory inside the container cannot be mounted into a new container, as it may not be available to the Docker engine. The following example is when executing our `test_start_cli_within_container(..)` test using Docker Desktop on macOS without passing the custom volume dir override:
```
...
docker.errors.APIError: 500 Server Error for http+docker://localhost/v1.42/containers/90af042d297b9254ad5cdf957937e434ef65c884030ba07e3bc9c5e0c64a133c/start: Internal Server Error ("b'Mounts denied: \nThe path /root/.cache/localstack/volume is not shared from the host and is not known to Docker.\nYou can configure shared paths from Docker -> Preferences... -> Resources -> File Sharing.\nSee https://docs.docker.com/desktop/mac for more info.'")
```

The change proposed in the PR adds a fallback logic which looks for this error message, and then. This is covered by an integration test - parametrizing the existing `test_start_cli_within_container(..)` test to start up with and without the custom volume dir configuration (it should ideally work out of the box without having to specify `LOCALSTACK_VOLUME_DIR` manually).

---
Summary of changes:
* add new `parse_boolean_env(..)` helper function to parse the value of boolean env variables (if specified)
* update the logic around `OVERRIDE_IN_DOCKER` to allow both, overriding with falsy and truthy values
* adjust the logic in `cli/localstack.py` to ensure `config.OVERRIDE_IN_DOCKER` and `config.is_in_docker` are both set to False, and then re-initialize the directories (somewhat similar to the `if host` logic switch further above in the same function)
* add a fallback logic for `Mounts denied` errors, to gracefully handle situations where the local volume directory (could be either on the host, or inside a countainer) cannot be mounted by Docker into the LocalStack container

With these changes, the container properly starts up in a Codespaces environment, after installing the CLI and doing a `localstack start` out of the box. 

/cc @giograno 