### PR TITLE
[minor] Fix extraction of Arn in KMS Key CloudFormation resource

### DIFF
--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -13,7 +13,7 @@ class KMSKey(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "Arn":
-            return self.props.get("KeyMetadata", {}).get("Arn")
+            return arns.kms_key_arn(self.physical_resource_id)
         return super(KMSKey, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -870,7 +870,7 @@ class CloudformationProvider(CloudformationApi):
                 stack_name = f"sset-{set_name}-{account}"
 
                 # skip creation of existing stacks
-                if find_stack(stack_name):
+                if find_stack(stack_name, region=region):
                     continue
 
                 result = cf_client.create_stack(StackName=stack_name, **kwargs)

--- a/localstack/services/cloudformation/stores.py
+++ b/localstack/services/cloudformation/stores.py
@@ -59,8 +59,8 @@ def get_cloudformation_store(
     return cloudformation_stores[account_id][region]
 
 
-def find_stack(stack_name: str) -> Stack | None:
-    state = get_cloudformation_store()
+def find_stack(stack_name: str, region: Optional[str] = None) -> Stack | None:
+    state = get_cloudformation_store(region=region)
     return (
         [s for s in state.stacks.values() if stack_name in [s.stack_name, s.stack_id]] or [None]
     )[0]

--- a/tests/integration/cloudformation/resources/test_kms.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_kms.snapshot.json
@@ -1,0 +1,11 @@
+{
+  "tests/integration/cloudformation/resources/test_kms.py::test_cfn_with_kms_resources": {
+    "recorded-date": "29-05-2023, 15:45:17",
+    "recorded-content": {
+      "stack-outputs": {
+        "KeyAlias": "<key-alias:1>",
+        "KeyArn": "arn:aws:kms:<region>:111111111111:key/<resource:1>"
+      }
+    }
+  }
+}

--- a/tests/integration/templates/template34.yaml
+++ b/tests/integration/templates/template34.yaml
@@ -1,8 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Test stack
 
+Parameters:
+  AliasName:
+    Type: String
+
 Resources:
-  KMSKeyDefinition:
+  KMSKey:
     Type: AWS::KMS::Key
     Properties:
       Description: Sample KMS
@@ -19,11 +23,13 @@ Resources:
 
   KMSKeyAlias:
     Type: AWS::KMS::Alias
-    DependsOn: KMSKeyDefinition
+    DependsOn: KMSKey
     Properties:
-      AliasName: alias/sample-5302
-      TargetKeyId: !Ref KMSKeyDefinition
+      AliasName: !Ref AliasName
+      TargetKeyId: !Ref KMSKey
 
 Outputs:
   KeyAlias:
     Value: !Ref KMSKeyAlias
+  KeyArn:
+    Value: !GetAtt KMSKey.Arn


### PR DESCRIPTION
Small change to fix extraction of `Arn` attribute in KMS Key CloudFormation resources.

The starting point for this change was an issue with the [`copilotlocal`](https://github.com/localstack/copilot-cli-local) CLI, which was raising seg faults:
```
$ copilotlocal app init
...
$ copilotlocal env init
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102ebd0ec]

goroutine 1 [running]:
github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack.ToAppRegionalResources(0x14000139438)
	github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack/app.go:237 +0xdc
...
```

The root cause for this that the stack outputs of the stack created by Copilot contains an output without `OutputValue` attribute (the value should be included in the output below):
```
$ awslocal cloudformation describe-stacks --stack-name ... 
...
            "Outputs": [
                {
                    "OutputKey": "KMSKeyARN",
                    "Description": "KMS Key used by CodePipeline for encrypting artifacts.",
                    "ExportName": "hosted-ArtifactKey"
                },
...
```

The PR extends one of the existing tests to include a `!GetAtt KMSKey.Arn` stack output, and also adds a snapshot test to verify we have the same behavior as AWS.

---

The PR also contains a small fix in `create_stack_instances(..)`, passing the region name to `find_stack(..)`. Turns out this is required - otherwise the `copilotlocal` deployment raises the following error, when deploying the stack against a non-default region:
```
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the CreateStack operation: Stack named "sset-hosted-infrastructure-000000000000" already exists with status "CREATE_COMPLETE"
```