### PR TITLE
Capture additional coverage context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,8 @@ jobs:
       - store_artifacts:
           path: scripts/implementation_coverage_full.csv
           destination: community/implementation_coverage_full.csv
+      - store_artifacts:
+          path: .coverage
 
   push:
     executor: ubuntu-machine-amd64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ omit = [
     "localstack/extensions/api/*",
     "localstack/services/stepfunctions/asl/antlr/runtime/*"
 ]
+dynamic_context = "test_function"
+
 [tool.coverage.report]
 exclude_lines = [
     "if __name__ == .__main__.:",


### PR DESCRIPTION
Capture additional contexts using pytest and coverage, allowing us to answer the question:

**Which tests execute this line of code?**

## Implementation

`coverage.py` can record "dynamic contexts", which annotate coverage "spans" with metadata. One supported type of context is "test context", meaning that each coverage "span" gets annotated by the test name that ran it.

Using this, `python -m coverage html --show-contexts` adds annotations to the output HTML page indicating which tests executed which lines of code.

![image](https://github.com/localstack/localstack/assets/59756/f5d8919a-193b-49f3-89fb-6a6f79997eb2)

This is unbelievably useful when trying to execute a specific function. If there's test coverage, then simply executing relevant tests runs the code of interest. I'm finding this powerful for investigating our CloudFormation implementation, since I can quickly go from the code block to test and corresponding CFn template, and set debug breakpoints.

## Included changes

All that's required to enable this feature is update the `coverage.run` configuration block, and save the resulting `.coverage` SQLite database as a run artifact. Those who wish to view coverage information for themselves can go to a relevant pipeline run, view the "report" job and find `.coverage` in the list of artifacts [e.g.](https://app.circleci.com/pipelines/github/localstack/localstack/15109/workflows/d3435b1d-73ec-4282-9f9f-f8829573bd4c/jobs/112870/artifacts):

![image](https://github.com/localstack/localstack/assets/59756/b381d9fe-6528-4121-90e0-44e0380b3bc5)

After you've downloaded this file, run `python -m coverage html --data-file <coverage file> --show-contexts` and open `htmlcov/index.html`.


## Performance 

When comparing the execution time of this PR and `master`, the [test step](https://app.circleci.com/pipelines/github/localstack/localstack/15109/workflows/d3435b1d-73ec-4282-9f9f-f8829573bd4c/jobs/112869) takes around 23 minutes compared to the [test step on master](https://app.circleci.com/pipelines/github/localstack/localstack/15106/workflows/795c0b03-b56a-4ab2-8955-c11d7ab0dd7e/jobs/112835) which takes 22 minutes and 49 seconds, meaning this execution adds no additional time overhead on the test duration.

The final artifact captured is 20 MiB which is worth the negligible space to store. 