### PR TITLE
fix SQS SetQueueAttributes when seting ContentBasedDeduplication

### DIFF
--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -26,7 +26,6 @@ INTERNAL_QUEUE_ATTRIBUTES = [
     QueueAttributeName.ApproximateNumberOfMessages,
     QueueAttributeName.ApproximateNumberOfMessagesDelayed,
     QueueAttributeName.ApproximateNumberOfMessagesNotVisible,
-    QueueAttributeName.ContentBasedDeduplication,
     QueueAttributeName.CreatedTimestamp,
     QueueAttributeName.LastModifiedTimestamp,
     QueueAttributeName.QueueArn,

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -802,5 +802,58 @@
   "tests/integration/test_sqs.py::TestSqsProvider::test_list_queues": {
     "recorded-date": "06-05-2023, 04:43:47",
     "recorded-content": {}
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_set_content_based_deduplication_strategy": {
+    "recorded-date": "30-05-2023, 20:20:59",
+    "recorded-content": {
+      "before-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "true",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "after-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #8397. Looks like we mistakenly considered `ContentBasedDeduplication` to be an intrinsic property, but I added a couple of tests that show it can be updated and checked correctly when calling `CreateQueue` with different values of it.