### PR TITLE
fix cli profile handling, add profile indicator to banner

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -131,6 +131,7 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
     if not no_banner:
         print_banner()
         print_version()
+        print_profile()
         console.line()
 
     from localstack.utils import bootstrap
@@ -563,7 +564,14 @@ def print_service_table(services: Dict[str, str]):
 
 
 def print_version():
-    console.print(" :laptop_computer: [bold]LocalStack CLI[/bold] [blue]%s[/blue]" % __version__)
+    console.print(f" :laptop_computer: [bold]LocalStack CLI[/bold] [blue]{__version__}[/blue]")
+
+
+def print_profile():
+    if config.LOADED_PROFILE:
+        console.print(
+            f" :bust_in_silhouette: [bold]Profile:[/bold] [blue]{config.LOADED_PROFILE}[/blue]"
+        )
 
 
 def print_error(format, error):

--- a/localstack/cli/profiles.py
+++ b/localstack/cli/profiles.py
@@ -23,12 +23,14 @@ def parse_profile_argument(args) -> Optional[str]:
     :param args: list of CLI arguments
     :returns: the value of ``--profile``.
     """
-    for i, arg in enumerate(args):
-        if arg.startswith("--profile="):
-            return arg[10:]
-        if arg == "--profile":
+    for i, current_arg in enumerate(args):
+        if current_arg.startswith("--profile="):
+            # if using the "<arg>=<value>" notation, we remove the "--profile=" prefix to get the value
+            return current_arg[10:]
+        if current_arg == "--profile":
+            # otherwise use the next arg in the args list as value
             try:
-                return arg[i + 1]
+                return args[i + 1]
             except KeyError:
                 return None
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -223,20 +223,22 @@ def is_env_not_false(env_var_name: str) -> bool:
     return os.environ.get(env_var_name, "").lower().strip() not in FALSE_STRINGS
 
 
-def load_environment(profile: str = None):
+def load_environment(profile: str = None) -> Optional[str]:
     """Loads the environment variables from ~/.localstack/{profile}.env
     :param profile: the profile to load (defaults to "default")
+    :returns str: the name of the actually loaded profile (might be the fallback)
     """
     if not profile:
         profile = "default"
 
     path = os.path.join(CONFIG_DIR, f"{profile}.env")
     if not os.path.exists(path):
-        return
+        return None
 
     import dotenv
 
     dotenv.load_dotenv(path, override=False)
+    return profile
 
 
 def is_persistence_enabled() -> bool:
@@ -360,10 +362,11 @@ CONFIG_DIR = os.environ.get("CONFIG_DIR", os.path.expanduser("~/.localstack"))
 
 # keep this on top to populate environment
 try:
-    load_environment(CONFIG_PROFILE)
+    # CLI specific: the actually loaded configuration profile
+    LOADED_PROFILE = load_environment(CONFIG_PROFILE)
 except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
-    pass
+    LOADED_PROFILE = None
 
 # default AWS region
 DEFAULT_REGION = (

--- a/tests/unit/cli/test_profiles.py
+++ b/tests/unit/cli/test_profiles.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+from localstack.cli.profiles import set_profile_from_sys_argv
+
+
+def test_profiles_equals_notation(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["--profile=non-existing-test-profile"])
+    monkeypatch.setenv("CONFIG_PROFILE", "")
+    set_profile_from_sys_argv()
+    assert os.environ["CONFIG_PROFILE"] == "non-existing-test-profile"
+
+
+def test_profiles_separate_args_notation(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["--profile", "non-existing-test-profile"])
+    monkeypatch.setenv("CONFIG_PROFILE", "")
+    set_profile_from_sys_argv()
+    assert os.environ["CONFIG_PROFILE"] == "non-existing-test-profile"


### PR DESCRIPTION
This PR fixes a small issue in the CLI which we overlooked in #7329.
This linked PR fixes the CLI profile detection (by manually parsing the `profile` argument and setting the `CONFIG_PROFILE` environment variable). This works perfectly fine when using the `--profile=<profile-name>` notation, but there was a small issue when using the `--profile <profile-name>` notation.
It also adds another line to the banner which indicates the loaded profile (if a profile was loaded, otherwise the line is not shown):
```
$ .venv/bin/python -m localstack.cli.main --profile pro start 

     __                     _______ __             __
    / /   ____  _________ _/ / ___// /_____ ______/ /__
   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
 /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|

 💻 LocalStack CLI 2.1.1.dev
 👤 Profile: pro
```

I am happy for any feedback!