### PR TITLE
Add AWS::Lambda::Function CFn resource provider

### DIFF
--- a/localstack/services/awslambda/resource_providers/function.py
+++ b/localstack/services/awslambda/resource_providers/function.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from localstack.services.cloudformation.resource_provider import (
+    OperationStatus,
+    ProgressEvent,
+    ResourceProvider,
+    ResourceRequest,
+    register_resource_provider,
+)
+
+
+@dataclass
+class TracingConfig:
+    Mode: Optional[str] = None
+
+
+@dataclass
+class VpcConfig:
+    SecurityGroupIds: Optional[list] = None
+    SubnetIds: Optional[list] = None
+
+
+@dataclass
+class RuntimeManagementConfig:
+    RuntimeVersionArn: Optional[str] = None
+    UpdateRuntimeOn: Optional[str] = None
+
+
+@dataclass
+class SnapStart:
+    ApplyOn: Optional[str] = None
+
+
+@dataclass
+class ImageConfig:
+    Command: Optional[list] = None
+    EntryPoint: Optional[list] = None
+    WorkingDirectory: Optional[str] = None
+
+
+@dataclass
+class DeadLetterConfig:
+    TargetArn: Optional[str] = None
+
+
+@dataclass
+class SnapStartResponse:
+    ApplyOn: Optional[str] = None
+    OptimizationStatus: Optional[str] = None
+
+
+@dataclass
+class Code:
+    ImageUri: Optional[str] = None
+    S3Bucket: Optional[str] = None
+    S3Key: Optional[str] = None
+    S3ObjectVersion: Optional[str] = None
+    ZipFile: Optional[str] = None
+
+
+@dataclass
+class Environment:
+    Variables: Optional[dict] = None
+
+
+@dataclass
+class EphemeralStorage:
+    Size: Optional[int] = None
+
+
+@dataclass
+class LambdaFunctionProperties:
+    Code: Code
+    Role: str
+    Architectures: Optional[list] = None
+    Arn: Optional[str] = None
+    CodeSigningConfigArn: Optional[str] = None
+    DeadLetterConfig: Optional[DeadLetterConfig] = None
+    Description: Optional[str] = None
+    Environment: Optional[Environment] = None
+    EphemeralStorage: Optional[EphemeralStorage] = None
+    FileSystemConfigs: Optional[list] = None
+    FunctionName: Optional[str] = None
+    Handler: Optional[str] = None
+    ImageConfig: Optional[ImageConfig] = None
+    KmsKeyArn: Optional[str] = None
+    Layers: Optional[list] = None
+    MemorySize: Optional[int] = None
+    PackageType: Optional[str] = None
+    ReservedConcurrentExecutions: Optional[int] = None
+    Runtime: Optional[str] = None
+    RuntimeManagementConfig: Optional[RuntimeManagementConfig] = None
+    SnapStart: Optional[SnapStart] = None
+    SnapStartResponse: Optional[SnapStartResponse] = None
+    Tags: Optional[list] = None
+    Timeout: Optional[int] = None
+    TracingConfig: Optional[TracingConfig] = None
+    VpcConfig: Optional[VpcConfig] = None
+
+
+class LambdaFunctionAllProperties(LambdaFunctionProperties):
+    physical_resource_id: Optional[str] = None
+
+
+@register_resource_provider
+class LambdaFunctionProvider(ResourceProvider[LambdaFunctionAllProperties]):
+
+    TYPE = "AWS::Lambda::Function"
+
+    def create(
+        self,
+        request: ResourceRequest[LambdaFunctionAllProperties],
+    ) -> ProgressEvent[LambdaFunctionAllProperties]:
+        """
+        Create a new resource.
+        """
+        raise NotImplementedError
+        model = request.desired_state
+
+        # TODO: validations
+
+        if model.physical_resource_id is None:
+            # this is the first time this callback is invoked
+            # TODO: defaults
+            # TODO: idempotency
+            # TODO: actually create the resource
+            # TODO: set model.physical_resource_id
+            return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
+
+        # TODO: check the status of the resource
+        # - if finished, update the model with all fields and return success event:
+        #   return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
+        # - else
+        #   return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
+
+        raise NotImplementedError
+
+    def delete(
+        self,
+        request: ResourceRequest[LambdaFunctionAllProperties],
+    ) -> ProgressEvent[LambdaFunctionAllProperties]:
+        raise NotImplementedError

--- a/localstack/services/awslambda/resource_providers/function.py
+++ b/localstack/services/awslambda/resource_providers/function.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass
 from typing import Optional
 
+from localstack.aws.api.lambda_ import Runtime, State
 from localstack.services.cloudformation.resource_provider import (
     OperationStatus,
     ProgressEvent,
@@ -10,6 +13,7 @@ from localstack.services.cloudformation.resource_provider import (
     ResourceRequest,
     register_resource_provider,
 )
+from localstack.utils.testutil import create_lambda_archive
 
 
 @dataclass
@@ -53,6 +57,7 @@ class SnapStartResponse:
 
 
 @dataclass
+# TODO: how to instantiate this type? Should this be a (TypedDict, total=False)
 class Code:
     ImageUri: Optional[str] = None
     S3Bucket: Optional[str] = None
@@ -105,6 +110,13 @@ class LambdaFunctionAllProperties(LambdaFunctionProperties):
     physical_resource_id: Optional[str] = None
 
 
+LOG = logging.getLogger(__name__)
+
+PYTHON_RUNTIMES = [Runtime.python3_7, Runtime.python3_8, Runtime.python3_9, Runtime.python3_10]
+NODEJS_RUNTIMES = [Runtime.nodejs12_x, Runtime.nodejs14_x, Runtime.nodejs16_x, Runtime.nodejs18_x]
+INLINE_CODE_RUNTIMES = [*PYTHON_RUNTIMES, *NODEJS_RUNTIMES]
+
+
 @register_resource_provider
 class LambdaFunctionProvider(ResourceProvider[LambdaFunctionAllProperties]):
 
@@ -114,14 +126,12 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionAllProperties]):
         self,
         request: ResourceRequest[LambdaFunctionAllProperties],
     ) -> ProgressEvent[LambdaFunctionAllProperties]:
-        """
-        Create a new resource.
-        """
         model = request.desired_state
 
         # Validation
         assert model.FunctionName is not None
-        # TODO: more input parameter validations
+        assert model.Role is not None
+        # TODO: more input parameter validations. Re-use from Lambda provider or boto-spec based validation possible?
 
         if model.physical_resource_id is None:
             # this is the first time this callback is invoked
@@ -129,32 +139,75 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionAllProperties]):
             # TODO: What are these defaults?
 
             # Idempotency
-            # TODO: idempotency
-            # try:
-            # request.aws_client_factory.awslambda.get_function(...)
-            # except request.aws_client_factory.awslambda.exceptions.ResourceNotFoundException:
-            #     pass
-            # else:
-            # the resource already exists, raise exception
-            # raise RuntimeError(f"lambda function {model.FunctionName} already exists")
+            try:
+                request.aws_client_factory.awslambda.get_function(FunctionName=model.FunctionName)
+            except request.aws_client_factory.awslambda.exceptions.ResourceNotFoundException:
+                pass
+            else:
+                # the resource already exists
+                # for now raise an exception
+                raise RuntimeError(f"Lambda function {model.FunctionName} already exists")
 
-            # TODO: actually create the resource
-            # res = request.aws_client_factory.awslambda.create_function(...)
+            zip_file = model.Code.get("ZipFile")
+            zip_file_exists = os.path.isfile(zip_file)
+            # Handle inline ZipFile supported for Node.js and Python
+            if not zip_file_exists and model.Runtime in INLINE_CODE_RUNTIMES:
+                # TODO: extract functionality, do not misuse testutils !!!
+                inline_zip_file = create_lambda_archive(
+                    zip_file,
+                    get_content=True,
+                    runtime=model.Runtime,
+                )
+                model.Code = {"ZipFile": inline_zip_file}
+            # TODO: add cfn-response dependency for Node.js and Python for interaction with custom CF resource:
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html
 
-            # TODO: set model.physical_resource_id
-            model.physical_resource_id = "my-lambda-function"  # model.FunctionName
+            # create the function
+            # TODO: handle many more parameters and configuration combinations
+            response = request.aws_client_factory.awslambda.create_function(
+                FunctionName=model.FunctionName,
+                Code=model.Code,
+                Role=model.Role,
+                Runtime=model.Runtime,
+            )
+
+            model.physical_resource_id = model.FunctionName
             return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
 
-        # TODO: check the status of the resource
-        # aws lambda get-function --function-name my-function --query 'Configuration.[State, LastUpdateStatus]'
-        # - if finished, update the model with all fields and return success event:
-        return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
-        # - else
-        #   return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
+        # MAYBE: optimize query to only return the state like --query 'Configuration.[State, LastUpdateStatus]'
+        response = request.aws_client_factory.awslambda.get_function(
+            FunctionName=model.FunctionName
+        )
+        function_state = response["Configuration"]["State"]
+        if function_state == State.Pending:
+            return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
+        elif function_state == State.Active:
+            return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
+        elif function_state == State.Inactive:
+            # This might happen when setting LAMBDA_KEEPALIVE_MS=0
+            LOG.warning(
+                f"Lambda function {model.FunctionName} is in Inactive state during deployment"
+            )
+            return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
+        elif function_state == State.Failed:
+            return ProgressEvent(status=OperationStatus.FAILED, resource_model=model)
+        else:
+            LOG.warning(
+                f"Lambda function {model.FunctionName} is in invalid function state {function_state}"
+            )
 
     def delete(
         self,
         request: ResourceRequest[LambdaFunctionAllProperties],
     ) -> ProgressEvent[LambdaFunctionAllProperties]:
-        # TODO: impl
+        function_name = request.desired_state.FunctionName
+        try:
+            request.aws_client_factory.awslambda.get_function(FunctionName=function_name)
+            request.aws_client_factory.awslambda.delete_function(FunctionName=function_name)
+            # We assume that function deletion happens instantly at API level. The background task to stop any running
+            # function containers might take longer.
+        except request.aws_client_factory.awslambda.exceptions.ResourceNotFoundException:
+            # Function already deleted
+            pass
+
         return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=request.desired_state)

--- a/localstack/services/awslambda/resource_providers/function.py
+++ b/localstack/services/awslambda/resource_providers/function.py
@@ -117,29 +117,44 @@ class LambdaFunctionProvider(ResourceProvider[LambdaFunctionAllProperties]):
         """
         Create a new resource.
         """
-        raise NotImplementedError
         model = request.desired_state
 
-        # TODO: validations
+        # Validation
+        assert model.FunctionName is not None
+        # TODO: more input parameter validations
 
         if model.physical_resource_id is None:
             # this is the first time this callback is invoked
             # TODO: defaults
+            # TODO: What are these defaults?
+
+            # Idempotency
             # TODO: idempotency
+            # try:
+            # request.aws_client_factory.awslambda.get_function(...)
+            # except request.aws_client_factory.awslambda.exceptions.ResourceNotFoundException:
+            #     pass
+            # else:
+            # the resource already exists, raise exception
+            # raise RuntimeError(f"lambda function {model.FunctionName} already exists")
+
             # TODO: actually create the resource
+            # res = request.aws_client_factory.awslambda.create_function(...)
+
             # TODO: set model.physical_resource_id
+            model.physical_resource_id = "my-lambda-function"  # model.FunctionName
             return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
 
         # TODO: check the status of the resource
+        # aws lambda get-function --function-name my-function --query 'Configuration.[State, LastUpdateStatus]'
         # - if finished, update the model with all fields and return success event:
-        #   return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
+        return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=model)
         # - else
         #   return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model=model)
-
-        raise NotImplementedError
 
     def delete(
         self,
         request: ResourceRequest[LambdaFunctionAllProperties],
     ) -> ProgressEvent[LambdaFunctionAllProperties]:
-        raise NotImplementedError
+        # TODO: impl
+        return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=request.desired_state)

--- a/tests/integration/cloudformation/nextgen/test_deploy.py
+++ b/tests/integration/cloudformation/nextgen/test_deploy.py
@@ -2,6 +2,7 @@ from typing import TypeVar
 
 import pytest
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.services.awslambda.resource_providers.function import LambdaFunctionAllProperties
 from localstack.services.opensearch.resource_providers.domain import OpenSearchDomainAllProperties
 from localstack.services.ssm.resource_providers.parameter import SSMParameterAllProperties
@@ -27,6 +28,7 @@ Properties = TypeVar("Properties")
             LambdaFunctionAllProperties(
                 FunctionName=f"cfn-lambda-function-{short_uid()}",
                 # TODO: How to set up a ZIP file dependency in these parameters here?
+                # TODO: typing, would be nice if this works like in ASF
                 Code={
                     "ZipFile": "exports.handler = function(event, context){\nconsole.log('SUCCESS');"
                 },
@@ -34,6 +36,7 @@ Properties = TypeVar("Properties")
                 # TODO: How to setup a dependency resource here?
                 Role="arn:aws:iam::000000000000:role/lambda-role",
                 # Role=LambdaRole.Arn,
+                Runtime=Runtime.nodejs18_x,
             ),
         )
         # TODO: Add your resource definitions here!

--- a/tests/integration/cloudformation/resource_providers/awslambda/test_function.py
+++ b/tests/integration/cloudformation/resource_providers/awslambda/test_function.py
@@ -7,14 +7,14 @@ from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest.fixtures import StackDeployError
 
 RESOURCE_GETATT_TARGETS = [
-    "Description",
-    "FunctionName",
-    "Runtime",
-    "KmsKeyArn",
-    "PackageType",
-    "CodeSigningConfigArn",
-    "Handler",
-    "Role",
+    # "Description",
+    # "FunctionName",
+    # "Runtime",
+    # "KmsKeyArn",
+    # "PackageType",
+    # "CodeSigningConfigArn",
+    # "Handler",
+    # "Role",
     "Arn",
 ]
 
@@ -31,8 +31,9 @@ class TestAttributeAccess:
         aws_client: ServiceLevelClientFactory,
         deploy_cfn_template,
         attribute,
-        template_root,
+        # template_root,
         snapshot,
+        # cfn_store_events_role_arn,
     ):
         """
         Capture the behaviour of getting all available attributes of the model
@@ -44,6 +45,7 @@ class TestAttributeAccess:
                 "../../../templates/resource_providers/lambda/function.yaml",
             ),
             parameters={"AttributeName": attribute},
+            # role_arn=cfn_store_events_role_arn,
         )
         snapshot.match("stack_outputs", stack.outputs)
 

--- a/tests/integration/cloudformation/resource_providers/awslambda/test_function.snapshot.json
+++ b/tests/integration/cloudformation/resource_providers/awslambda/test_function.snapshot.json
@@ -1,0 +1,44 @@
+{
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[Description]": {
+    "recorded-date": "26-05-2023, 15:48:05",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[FunctionName]": {
+    "recorded-date": "26-05-2023, 15:48:14",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[Runtime]": {
+    "recorded-date": "26-05-2023, 15:48:53",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[KmsKeyArn]": {
+    "recorded-date": "26-05-2023, 15:49:32",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[Arn]": {
+    "recorded-date": "26-05-2023, 17:14:01",
+    "recorded-content": {
+      "stack_outputs": {
+        "MyOutput": "arn:aws:lambda:<region>:111111111111:function:test-lambda-function",
+        "MyRef": "test-lambda-function"
+      },
+      "physical_resource_id": "test-lambda-function"
+    }
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[Role]": {
+    "recorded-date": "26-05-2023, 15:45:47",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[PackageType]": {
+    "recorded-date": "26-05-2023, 15:50:12",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[CodeSigningConfigArn]": {
+    "recorded-date": "26-05-2023, 15:50:55",
+    "recorded-content": {}
+  },
+  "tests/integration/cloudformation/resource_providers/awslambda/test_function.py::TestAttributeAccess::test_getattr[Handler]": {
+    "recorded-date": "26-05-2023, 15:51:34",
+    "recorded-content": {}
+  }
+}

--- a/tests/integration/cloudformation/resource_providers/lambda/test_function.py
+++ b/tests/integration/cloudformation/resource_providers/lambda/test_function.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+
+from localstack.aws.connect import ServiceLevelClientFactory
+from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.pytest.fixtures import StackDeployError
+
+RESOURCE_GETATT_TARGETS = [
+    "Description",
+    "FunctionName",
+    "Runtime",
+    "KmsKeyArn",
+    "PackageType",
+    "CodeSigningConfigArn",
+    "Handler",
+    "Role",
+    "Arn",
+]
+
+
+class TestAttributeAccess:
+    @pytest.mark.parametrize("attribute", RESOURCE_GETATT_TARGETS)
+    @pytest.mark.xfail(
+        reason="Some tests are expected to fail, since they try to access invalid CFn attributes",
+        raises=StackDeployError,
+    )
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Exploratory test only")
+    def test_getattr(
+        self,
+        aws_client: ServiceLevelClientFactory,
+        deploy_cfn_template,
+        attribute,
+        template_root,
+        snapshot,
+    ):
+        """
+        Capture the behaviour of getting all available attributes of the model
+        """
+
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__),
+                "../../../templates/resource_providers/lambda/function.yaml",
+            ),
+            parameters={"AttributeName": attribute},
+        )
+        snapshot.match("stack_outputs", stack.outputs)
+
+        # check physical resource id
+        res = aws_client.cloudformation.describe_stack_resource(
+            StackName=stack.stack_name, LogicalResourceId="MyResource"
+        )["StackResourceDetail"]
+        snapshot.match("physical_resource_id", res.get("PhysicalResourceId"))

--- a/tests/integration/templates/resource_providers/lambda/function.yaml
+++ b/tests/integration/templates/resource_providers/lambda/function.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Template to exercise AWS::Lambda::Function
+Parameters:
+  AttributeName:
+    Type: String
+    Description: Name of the attribute to fetch from the resource
+Resources:
+  MyResource:
+    Type: AWS::Lambda::Function
+    Properties: {}
+Outputs:
+  MyRef:
+    Value:
+      Ref: MyResource
+  MyOutput:
+    Value:
+      Fn::GetAtt:
+      - MyResource
+      - Ref: AttributeName

--- a/tests/integration/templates/resource_providers/lambda/function.yaml
+++ b/tests/integration/templates/resource_providers/lambda/function.yaml
@@ -1,3 +1,5 @@
+# Based on awslabs LambdaSample.yml
+# https://github.com/awslabs/aws-cloudformation-templates/blob/master/community/services/Lambda/LambdaSample.yaml
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Template to exercise AWS::Lambda::Function
 Parameters:
@@ -5,9 +7,40 @@ Parameters:
     Type: String
     Description: Name of the attribute to fetch from the resource
 Resources:
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: test-lambda-role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSLambdaExecute
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      Path: /
   MyResource:
     Type: AWS::Lambda::Function
-    Properties: {}
+    Properties:
+      FunctionName: test-lambda-function
+      Description: Sample description of LambdaFunction
+      Runtime: nodejs18.x
+      Code:
+        ZipFile:
+          "exports.handler = function(event, context){\n
+            console.log('SUCCESS');"
+      Handler: index.handler
+      MemorySize: 128
+      Timeout: 10
+      Role: !GetAtt LambdaRole.Arn
+      Environment:
+        Variables:
+          ENV: "dev"
 Outputs:
   MyRef:
     Value:


### PR DESCRIPTION
A first minimal implementation of a CF resource provider for a Lambda function.

The initial example demonstrates a simple inline Python Lambda function.

## Open

- [ ] Extract code for `create_lambda_archive` misused from testutils
- [ ] Implement all parameters and validations
- [ ] see TODOs in code