### PR TITLE
show error on frozen attempt to update localstack-cli

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -370,6 +370,16 @@ def cmd_update_all(ctx):
 @localstack_update.command(name="localstack-cli", help="Update LocalStack CLI tools")
 @publish_invocation
 def cmd_update_localstack_cli():
+    # if is_frozen_bundle():
+    if True:
+        # "update" can only be performed if running from source / in a non-frozen interpreter
+        console.print(
+            ":heavy_multiplication_x: The LocalStack CLI can only update itself if installed via PIP. "
+            "Please follow the instructions on https://docs.localstack.cloud/ to update your CLI.",
+            style="bold red",
+        )
+        sys.exit(1)
+
     import subprocess
     from subprocess import CalledProcessError
 
@@ -580,3 +590,12 @@ def print_error(format, error):
 
 def print_banner():
     print(BANNER)
+
+
+def is_frozen_bundle() -> bool:
+    """
+    :return: true if we are currently running in a frozen bundle / a pyinstaller binary.
+    """
+    # check if we are in a PyInstaller binary
+    # https://pyinstaller.org/en/stable/runtime-information.html
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -370,8 +370,7 @@ def cmd_update_all(ctx):
 @localstack_update.command(name="localstack-cli", help="Update LocalStack CLI tools")
 @publish_invocation
 def cmd_update_localstack_cli():
-    # if is_frozen_bundle():
-    if True:
+    if is_frozen_bundle():
         # "update" can only be performed if running from source / in a non-frozen interpreter
         console.print(
             ":heavy_multiplication_x: The LocalStack CLI can only update itself if installed via PIP. "

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -158,8 +158,9 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
             if config.DEBUG:
                 console.print_exception()
             raise click.ClickException(
-                "It appears you have a light install of localstack which only supports running in docker\n"
-                "If you would like to use --host, please reinstall localstack using `pip install localstack[runtime]`"
+                "It appears you have a light install of localstack which only supports running in docker.\n"
+                "If you would like to use --host, please install localstack with Python using "
+                "`pip install localstack[runtime]` instead."
             )
     else:
         # make sure to initialize the bootstrap environment and directories for the host (even if we're executing
@@ -464,10 +465,7 @@ def update_images(image_list: List[str]):
 
 
 # legacy support
-@localstack.group(
-    name="infra",
-    help="Manipulate LocalStack infrastructure (legacy)",
-)
+@localstack.group(name="infra", help="Manipulate LocalStack infrastructure", deprecated=True)
 def infra():
     pass
 


### PR DESCRIPTION
This PR fixes a confusing error message when using the `localstack update` command to update the CLI (either with `all` or `localstack-cli`) when using our LocalStack CLI frozen binaries built with PyInstaller ([localstack/localstack-cli](https://github.com/localstack/localstack-cli)):
```
$ localstack update localstack-cli
─────────── Updating LocalStack CLI ───────────
⠦ Updating LocalStack CLI...Usage: localstack [OPTIONS] COMMAND [ARGS]...
Try 'localstack --help' for help.

Error: No such option: -m
✖ LocalStack CLI update failed
```
With this PR we explicitly detect that we are running in a frozen environment, print a warning and exit with a non-zero exit code:
```
$ localstack update all
✖ The LocalStack CLI can only update itself if installed via PIP. Please follow the instructions on https://docs.localstack.cloud/ to update your CLI.
``` 