### PR TITLE
Managed docker network

### DIFF
--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -15,6 +15,7 @@ services:
       - PERSISTENCE=${PERSISTENCE-}
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # required for Pro
       - DOCKER_HOST=unix:///var/run/docker.sock
+      # - USE_MANAGED_DOCKER_NETWORK=1  # allow LocalStack to manage networking
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - DEBUG=${DEBUG-}
       - DOCKER_HOST=unix:///var/run/docker.sock
+      # - USE_MANAGED_DOCKER_NETWORK=1  # allow LocalStack to manage networking
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -819,6 +819,13 @@ BUCKET_MARKER_LOCAL = (
     os.environ.get("BUCKET_MARKER_LOCAL", "").strip() or DEFAULT_BUCKET_MARKER_LOCAL
 )
 
+# Create managed docker network
+USE_MANAGED_DOCKER_NETWORK = is_env_true("USE_MANAGED_DOCKER_NETWORK")
+MANAGED_DOCKER_NETWORK_NAME = os.environ.get(
+    "MANAGED_DOCKER_NETWORK_NAME",
+    "lsnet",
+)
+
 # PUBLIC: bridge (Docker default)
 # Docker network driver for the Lambda and ECS containers. https://docs.docker.com/network/
 LAMBDA_DOCKER_NETWORK = os.environ.get("LAMBDA_DOCKER_NETWORK", "").strip()
@@ -1120,6 +1127,7 @@ CONFIG_ENV_VARS = [
     "LS_LOG",
     "MAIN_CONTAINER_NAME",
     "MAIN_DOCKER_NETWORK",
+    "MANAGED_DOCKER_NETWORK_NAME",
     "OPENSEARCH_ENDPOINT_STRATEGY",
     "OUTBOUND_HTTP_PROXY",
     "OUTBOUND_HTTPS_PROXY",
@@ -1147,6 +1155,7 @@ CONFIG_ENV_VARS = [
     "TEST_IAM_USER_ID",
     "TEST_IAM_USER_NAME",
     "TF_COMPAT_MODE",
+    "USE_MANAGED_DOCKER_NETWORK",
     "USE_SINGLE_REGION",
     "USE_SSL",
     "WAIT_FOR_DEBUGGER",
@@ -1312,3 +1321,8 @@ def init_directories() -> Directories:
 # initialize directories
 dirs: Directories
 dirs = init_directories()
+
+# merge docker networks if required
+if USE_MANAGED_DOCKER_NETWORK:
+    LAMBDA_DOCKER_NETWORK = MANAGED_DOCKER_NETWORK_NAME
+    MAIN_DOCKER_NETWORK = MANAGED_DOCKER_NETWORK_NAME

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -395,7 +395,7 @@ class CmdDockerClient(ContainerClient):
         cmd = self._docker_cmd()
         cmd += ["inspect", "--format", "{{json .}}", object_name_or_id]
         try:
-            cmd_result = run(cmd)
+            cmd_result = run(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             # note: case-insensitive comparison, to support Docker and Podman output formats
             if "no such object" in to_str(e.stdout).lower():


### PR DESCRIPTION
This PR allows the user to configure a "managed" docker network.

Putting containers on the same docker network means more straightforward configuration. The containers can make requests to each other using their container names. LocalStack currently adds configuration to allow the user to specify which docker network to add created containers to, for services such as Lambda or ECS. This requires:

1. the user to be aware of docker networking, and
2. for them to have set up a network in advance.

Instead, let's make LocalStack the curator of this docker network. On startup, create a named network (if it doesn't exist) and add all containers to it for the user. This means:

1. the user does not _have_ to know about docker networking, and
2. they don't have to perform any setup.

Users using docker compose will see the example compose file in the repo and replicate the behaviour in their own compose files.

## Implementation

We use the existing configuration variables to control the networks of created containers, and add new configuration to override their behaviour. When the CLI starts up, we create the network if it doesn't exist.

## Questions

* Should we delete the network after the container stops? Probably not, but this is untidy
* Should we make this behaviour the default in the compose files? I.e. uncomment the `USE_MANAGED_DOCKER_NETWORK` lines?
