### PR TITLE
add new CLI command to simplify shell completion

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -499,11 +499,11 @@ def cmd_infra_start(ctx, *args, **kwargs):
            source '$HOME/.localstack/completion.bash.inc'
            " >> $HOME/.bash_profile
            source $HOME/.bash_profile
-
+        \b
            # zsh
            ## Set the LocalStack completion code for zsh to autoload on startup:
            localstack completion zsh > "${fpath[1]}/_localstack"
-
+        \b
            # fish
            ## Set the LocalStack completion code for fish to autoload on startup:
            localstack completion fish > ~/.config/fish/completions/localstack.fish

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -480,6 +480,70 @@ def cmd_infra_start(ctx, *args, **kwargs):
     ctx.invoke(cmd_start, *args, **kwargs)
 
 
+@localstack.command(
+    name="completion",
+    short_help="CLI shell completion",
+    help="""
+         Print shell completion code for the specified shell (bash, zsh, or fish).
+         The shell code must be evaluated to enable the interactive shell completion of LocalStack CLI commands.
+         This is usually done by sourcing it from the .bash_profile.
+
+         \b
+         Examples:
+           # Bash
+           ## Bash completion on Linux depends on the 'bash-completion' package.
+           ## Write the LocalStack CLI completion code for bash to a file and source it from .bash_profile
+           localstack completion bash > ~/.localstack/completion.bash.inc
+           printf "
+           # LocalStack CLI bash completion
+           source '$HOME/.localstack/completion.bash.inc'
+           " >> $HOME/.bash_profile
+           source $HOME/.bash_profile
+
+           # zsh
+           ## Set the LocalStack completion code for zsh to autoload on startup:
+           localstack completion zsh > "${fpath[1]}/_localstack"
+
+           # fish
+           ## Set the LocalStack completion code for fish to autoload on startup:
+           localstack completion fish > ~/.config/fish/completions/localstack.fish
+         """,
+)
+@click.pass_context
+@click.argument(
+    "shell", required=True, type=click.Choice(["bash", "zsh", "fish"], case_sensitive=False)
+)
+@publish_invocation
+def localstack_completion(ctx: click.Context, shell: str):
+    """
+    Click's autocompletion is not perfectly user-friendly.
+    This command prints the autocompletion script of Click for this program.
+    It can then be simply piped to a completion file.
+    Example:
+        localstack complete fish > ~/.config/fish/completions/localstack.fish
+    :param ctx: Click context
+    :param shell: Shell to show the autocompletion script for
+    """
+    # lookup the completion, raise an error if the given completion is not found
+    import click.shell_completion
+
+    comp_cls = click.shell_completion.get_completion_class(shell)
+    if comp_cls is None:
+        raise click.ClickException("Completion for given shell could not be found.")
+
+    # Click's program name is the base path of sys.argv[0]
+    path = sys.argv[0]
+    prog_name = os.path.basename(path)
+
+    # create the completion variable according to the docs
+    # https://click.palletsprojects.com/en/8.1.x/shell-completion/#enabling-completion
+    complete_var = f"_{prog_name}_COMPLETE".replace("-", "_").upper()
+
+    # instantiate the completion class and print the completion source
+    comp = comp_cls(ctx.command, {}, prog_name, complete_var)
+    click.echo(comp.source())
+
+
 class DockerStatus(TypedDict, total=False):
     running: bool
     runtime_version: str

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -271,3 +271,19 @@ def test_not_is_frozen(monkeypatch):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.delattr(sys, "_MEIPASS", raising=False)
     assert not is_frozen_bundle()
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+def test_completion(monkeypatch, runner, shell: str):
+    test_binary_name = "testbinaryname"
+    monkeypatch.setattr(localstack.config, "DISABLE_EVENTS", True)
+    monkeypatch.setattr(sys, "argv", [test_binary_name])
+    result = runner.invoke(cli, ["completion", shell])
+    assert result.exit_code == 0
+    assert f"_{test_binary_name.upper()}_COMPLETE={shell}_complete" in result.output
+
+
+def test_completion_unknown_shell(monkeypatch, runner):
+    monkeypatch.setattr(localstack.config, "DISABLE_EVENTS", True)
+    result = runner.invoke(cli, ["completion", "unknown_shell"])
+    assert result.exit_code != 0


### PR DESCRIPTION
This PR adds a new shell command to support the configuration of auto-completion for the LocalStack CLI.
It uses the Click-feature for Shell completion: https://click.palletsprojects.com/en/8.1.x/shell-completion/

Unfortunately, the configuration is a bit cumbersome:
> In order for completion to be used, the user needs to register a special function with their shell. The script is different for every shell, and Click will output it when called with _{PROG_NAME}_COMPLETE set to {shell}_source. {PROG_NAME} is the executable name in uppercase with dashes replaced by underscores. The built-in shells are bash, zsh, and fish.

This is where the new `completion` command comes in. It basically just simplifies printing the shell completion code for a given shell. This completion code can then - depending on the shell - be used to configure the shell completion.
By implementing a specific command, it's also easy to ship an extensive documentation explaining the feature (as you can see in the code).

When starting to work on this, I used [click-contrib/click-completion](https://github.com/click-contrib/click-completion) for a first PoC. It would even have an install command and powershell support, but I decided against it because:
- It would have added `Jinja2` as an install dependency.
- It is not too well maintained, there hasn't been a proper release for quite some time (Click >= 8 is not supported in the latest release on PyPi).
- It seem like the powershell support might be broken right now, and click allows to easily add new completions.