### PR TITLE
fix SNS cross account SQS publish + SQS get_queue_url

### DIFF
--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -9,12 +9,7 @@ from localstack.aws.api.sns import (
     subscriptionARN,
     topicARN,
 )
-from localstack.services.stores import (
-    AccountRegionBundle,
-    BaseStore,
-    CrossAccountAttribute,
-    LocalAttribute,
-)
+from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid
 
@@ -116,10 +111,10 @@ class SnsSubscription(TypedDict):
 
 class SnsStore(BaseStore):
     # maps topic ARN to subscriptions ARN
-    topic_subscriptions: Dict[str, List[str]] = CrossAccountAttribute(default=dict)
+    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
 
     # maps subscription ARN to SnsSubscription
-    subscriptions: Dict[str, SnsSubscription] = CrossAccountAttribute(default=dict)
+    subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)
 
     # maps confirmation token to subscription ARN
     subscription_tokens: Dict[str, str] = LocalAttribute(default=dict)
@@ -134,7 +129,7 @@ class SnsStore(BaseStore):
     sms_messages: List[Dict] = LocalAttribute(default=list)
 
     # filter policy are stored as JSON string in subscriptions, store the decoded result Dict
-    subscription_filter_policy: Dict[subscriptionARN, Dict] = CrossAccountAttribute(default=dict)
+    subscription_filter_policy: Dict[subscriptionARN, Dict] = LocalAttribute(default=dict)
 
     def get_topic_subscriptions(self, topic_arn: str) -> List[SnsSubscription]:
         topic_subscriptions = self.topic_subscriptions.get(topic_arn, [])

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -9,7 +9,12 @@ from localstack.aws.api.sns import (
     subscriptionARN,
     topicARN,
 )
-from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.services.stores import (
+    AccountRegionBundle,
+    BaseStore,
+    CrossAccountAttribute,
+    LocalAttribute,
+)
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid
 
@@ -111,10 +116,10 @@ class SnsSubscription(TypedDict):
 
 class SnsStore(BaseStore):
     # maps topic ARN to subscriptions ARN
-    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
+    topic_subscriptions: Dict[str, List[str]] = CrossAccountAttribute(default=dict)
 
     # maps subscription ARN to SnsSubscription
-    subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)
+    subscriptions: Dict[str, SnsSubscription] = CrossAccountAttribute(default=dict)
 
     # maps confirmation token to subscription ARN
     subscription_tokens: Dict[str, str] = LocalAttribute(default=dict)
@@ -129,7 +134,7 @@ class SnsStore(BaseStore):
     sms_messages: List[Dict] = LocalAttribute(default=list)
 
     # filter policy are stored as JSON string in subscriptions, store the decoded result Dict
-    subscription_filter_policy: Dict[subscriptionARN, Dict] = LocalAttribute(default=dict)
+    subscription_filter_policy: Dict[subscriptionARN, Dict] = CrossAccountAttribute(default=dict)
 
     def get_topic_subscriptions(self, topic_arn: str) -> List[SnsSubscription]:
         topic_subscriptions = self.topic_subscriptions.get(topic_arn, [])

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -5,7 +5,6 @@ from typing import Dict, List
 from botocore.utils import InvalidArnException
 from moto.core.utils import camelcase_to_pascal, underscores_to_camelcase
 from moto.sns import sns_backends
-from moto.sns.exceptions import SNSNotFoundError
 from moto.sns.models import MAXIMUM_MESSAGE_LENGTH, SNSBackend, Topic
 from moto.sns.utils import is_e164
 
@@ -485,10 +484,10 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                         "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified"
                     )
             else:
-                try:
-                    moto_sns_backend.get_topic(topic_or_target_arn)
-                except SNSNotFoundError:
-                    raise NotFoundException("Topic does not exist")
+                if topic_or_target_arn not in store.topic_subscriptions:
+                    raise NotFoundException(
+                        "Topic does not exist",
+                    )
 
         message_ctx = SnsMessage(
             type="Notification",

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -256,7 +256,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         # `authenticate_on_unsubscribe` to force a signing client to do this request.
         # so, the region and account_id might not be in the request. Use the ones from the topic_arn
         try:
-            parsed_arn = parse_topic_arn(topic_arn)
+            parsed_arn = parse_arn(topic_arn)
         except InvalidArnException:
             raise InvalidParameterException("Invalid parameter: Topic")
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -675,7 +675,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     def get_queue_url(
         self, context: RequestContext, queue_name: String, queue_owner_aws_account_id: String = None
     ) -> GetQueueUrlResult:
-        store = self.get_store(context.account_id, context.region)
+        store = self.get_store(queue_owner_aws_account_id or context.account_id, context.region)
         if queue_name not in store.queues.keys():
             raise QueueDoesNotExist("The specified queue does not exist for this wsdl version.")
 

--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -4,7 +4,7 @@ from typing import Optional, TypedDict
 
 from botocore.utils import ArnParser, InvalidArnException
 
-from localstack.aws.accounts import get_aws_account_id
+from localstack.aws.accounts import DEFAULT_AWS_ACCOUNT_ID, get_aws_account_id
 from localstack.utils.aws.aws_stack import connect_to_service, get_region, get_valid_regions
 
 # set up logger
@@ -28,12 +28,16 @@ def sqs_queue_url_for_arn(queue_arn):
         arn = parse_arn(queue_arn)
         region_name = arn["region"]
         queue_name = arn["resource"]
+        account_id = arn["account"]
     except InvalidArnException:
         region_name = None
         queue_name = queue_arn
+        account_id = DEFAULT_AWS_ACCOUNT_ID
 
     sqs_client = connect_to_service("sqs", region_name=region_name)
-    result = sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+    result = sqs_client.get_queue_url(QueueName=queue_name, QueueOwnerAWSAccountId=account_id)[
+        "QueueUrl"
+    ]
     SQS_ARN_TO_URL_CACHE[queue_arn] = result
     return result
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3595,7 +3595,25 @@ class TestSNSProvider:
 
         snapshot.match("token-not-exists", e.value.response)
 
-    def test_cross_account_access(self, aws_client, aws_client_factory):
+
+@pytest.mark.only_localstack
+class TestS3MultiAccounts:
+    @pytest.fixture
+    def sns_primary_client(self, aws_client):
+        return aws_client.sns
+
+    @pytest.fixture
+    def sns_secondary_client(self, aws_client_factory):
+        """
+        Create a boto client with secondary test credentials and region.
+        """
+        return aws_client_factory.get_client(
+            "sns",
+            aws_access_key_id=SECONDARY_TEST_AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
+        )
+
+    def test_cross_account_access(self, sns_primary_client, sns_secondary_client):
         # Cross-account access is supported for below operations.
         # This list is taken from ActionName param of the AddPermissions operation
         #
@@ -3609,41 +3627,118 @@ class TestSNSProvider:
         # - DeleteTopic
 
         topic_name = f"topic-{short_uid()}"
-        topic_arn = aws_client.sns.create_topic(Name=topic_name)["TopicArn"]
+        topic_arn = sns_primary_client.create_topic(Name=topic_name)["TopicArn"]
 
-        # Client for secondary account
-        client = aws_client_factory.get_client(
-            "sns",
-            aws_access_key_id=SECONDARY_TEST_AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
-        )
-
-        assert client.set_topic_attributes(
+        assert sns_secondary_client.set_topic_attributes(
             TopicArn=topic_arn, AttributeName="DisplayName", AttributeValue="xenon"
         )
 
-        response = client.get_topic_attributes(TopicArn=topic_arn)
+        response = sns_secondary_client.get_topic_attributes(TopicArn=topic_arn)
         assert response["Attributes"]["DisplayName"] == "xenon"
 
-        assert client.add_permission(
+        assert sns_secondary_client.add_permission(
             TopicArn=topic_arn,
             Label="foo",
             AWSAccountId=["666666666666"],
             ActionName=["AddPermission"],
         )
-        assert client.remove_permission(TopicArn=topic_arn, Label="foo")
+        assert sns_secondary_client.remove_permission(TopicArn=topic_arn, Label="foo")
 
-        assert client.publish(TopicArn=topic_arn, Message="hello world")
+        assert sns_secondary_client.publish(TopicArn=topic_arn, Message="hello world")
 
-        subscription_arn = client.subscribe(
+        subscription_arn = sns_secondary_client.subscribe(
             TopicArn=topic_arn, Protocol="email", Endpoint="devil@hell.com"
         )["SubscriptionArn"]
 
-        response = client.list_subscriptions_by_topic(TopicArn=topic_arn)
+        response = sns_secondary_client.list_subscriptions_by_topic(TopicArn=topic_arn)
         subscriptions = [s["SubscriptionArn"] for s in response["Subscriptions"]]
         assert subscription_arn in subscriptions
 
-        assert client.delete_topic(TopicArn=topic_arn)
+        assert sns_secondary_client.delete_topic(TopicArn=topic_arn)
+
+    def test_cross_account_publish_to_sqs(
+        self,
+        sns_primary_client,
+        sns_secondary_client,
+        aws_client,
+        aws_client_factory,
+        sqs_queue_arn,
+    ):
+        """
+        This test validates that we can publish to SQS queues that are not in the default account, and that another
+        account can publish to the topic as well
+
+        Note: we are not setting Queue policies here as it's only in localstack and IAM is not enforced, for the sake
+        of simplicity
+        """
+
+        # create the 2 SQS clients needed for testing
+        sqs_primary_client = aws_client.sqs
+        sqs_secondary_client = aws_client_factory.get_client(
+            "sqs",
+            aws_access_key_id=SECONDARY_TEST_AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
+        )
+
+        topic_name = "sample_topic"
+        topic_1 = sns_primary_client.create_topic(Name=topic_name)
+        topic_1_arn = topic_1["TopicArn"]
+
+        # create a queue with the primary AccountId
+        queue_name = "sample_queue"
+        queue_1 = sqs_primary_client.create_queue(QueueName=queue_name)
+        queue_1_url = queue_1["QueueUrl"]
+        queue_1_arn = sqs_queue_arn(queue_1_url)
+
+        # create a queue with the secondary AccountId
+        queue_2 = sqs_secondary_client.create_queue(QueueName=queue_name)
+        queue_2_url = queue_2["QueueUrl"]
+        # test that we get the right queue URL at the same time, even if we use the primary client
+        queue_2_arn = sqs_queue_arn(queue_2_url)
+
+        # test that we can subscribe with the primary client to a queue from the same account
+        sns_primary_client.subscribe(
+            TopicArn=topic_1_arn,
+            Protocol="sqs",
+            Endpoint=queue_1_arn,
+        )
+
+        # test that we can subscribe with the primary client to a queue from the secondary account
+        sns_primary_client.subscribe(
+            TopicArn=topic_1_arn,
+            Protocol="sqs",
+            Endpoint=queue_2_arn,
+        )
+
+        # now, we have 2 subscriptions in topic_1, one to the queue_1 located in the same account, and to queue_2
+        # located in the secondary account
+
+        sns_primary_client.publish(TopicArn=topic_1_arn, Message="TestMessageOwner")
+
+        def get_messages_from_queues(message_content: str):
+            for client, queue_url in (
+                (sqs_primary_client, queue_1_url),
+                (sqs_secondary_client, queue_2_url),
+            ):
+                response = client.receive_message(
+                    QueueUrl=queue_url,
+                    VisibilityTimeout=0,
+                    WaitTimeSeconds=5,
+                )
+                messages = response["Messages"]
+                assert len(messages) == 1
+                assert topic_1_arn in messages[0]["Body"]
+                assert message_content in messages[0]["Body"]
+                client.delete_message(
+                    QueueUrl=queue_url, ReceiptHandle=messages[0]["ReceiptHandle"]
+                )
+
+        get_messages_from_queues("TestMessageOwner")
+
+        # assert that we can also publish to the topic 1 from the secondary account
+        sns_secondary_client.publish(TopicArn=topic_1_arn, Message="TestMessageSecondary")
+
+        get_messages_from_queues("TestMessageSecondary")
 
 
 class TestSNSPublishDelivery:

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1187,6 +1187,19 @@ class TestSNSProvider:
         snapshot.match("wrong-endpoint", e.value.response)
 
     @pytest.mark.aws_validated
+    def test_publish_wrong_arn_format(self, snapshot, aws_client):
+        message = "Good news everyone!"
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, TopicArn="randomstring")
+
+        snapshot.match("invalid-topic-arn", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, TopicArn="randomstring:1")
+
+        snapshot.match("invalid-topic-arn-1", e.value.response)
+
+    @pytest.mark.aws_validated
     def test_publish_sqs_from_sns(
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
     ):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3610,7 +3610,7 @@ class TestSNSProvider:
 
 
 @pytest.mark.only_localstack
-class TestS3MultiAccounts:
+class TestSNSMultiAccounts:
     @pytest.fixture
     def sns_primary_client(self, aws_client):
         return aws_client.sns

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3978,5 +3978,32 @@
         "Type": "UnsubscribeConfirmation"
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_publish_wrong_arn_format": {
+    "recorded-date": "01-06-2023, 20:18:02",
+    "recorded-content": {
+      "invalid-topic-arn": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 1",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-topic-arn-1": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 2",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
We've had a report that cross account publishing didn't work as expected, especially with queues from another account.

This PR does not add any enforcement of cross account access, but now allow SNS to publish to a queue in another account.
The fix consists of properly passing `QueueOwnerAWSAccountId` using the account id present in the queue URL to the `get_queue_url` call. Also, `GetQueueUrl` now properly uses this account id to retrieve the proper store.
~Also modified the SNS store attributes to be cross-account, as those are needed in the publisher, and an account can publish to another account's topic.~
Now removed that part, and properly parsed the ARN of the topic in the necessary operation to properly use the account id from the arn to then pass the store to the publisher, and the tests are still passing 🎉 

I've added 2 cross account tests to validate the behaviour.

\cc @dfangl, thanks for your help with the client! 

~note: back to the draft, it's more complicated than cross account attributes~