### PR TITLE
replace the method wait_until with boto3 waiters in cfn fixture

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -949,13 +949,16 @@ def deploy_cfn_template(
         template_mapping: Optional[Dict[str, any]] = None,
         parameters: Optional[Dict[str, str]] = None,
         role_arn: Optional[str] = None,
-        max_wait: Optional[int] = 60,
+        max_wait: Optional[int] = None,
         delay_between_polls: Optional[int] = 2,
     ) -> DeployResult:
         if is_update:
             assert stack_name
         stack_name = stack_name or f"stack-{short_uid()}"
         change_set_name = change_set_name or f"change-set-{short_uid()}"
+
+        if max_wait is None:
+            max_wait = 1800 if is_aws_cloud() else 60
 
         if template_path is not None:
             template = load_template_file(template_path)

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -65,6 +65,7 @@ def test_nested_stack_output_refs(deploy_cfn_template, s3_create_bucket, aws_cli
             "s3_bucket_url": f"/{bucket_name}/{key}",
             "nested_bucket_name": nested_bucket_name,
         },
+        max_wait=120,  # test is flaky, so we need to wait a bit longer
     )
 
     nested_stack_id = result.outputs["CustomNestedStackId"]


### PR DESCRIPTION
This PR replace the usage of the wait_until method for boto3 waiters due to  the better behavior on stacks that take too much time to deploy.

