### PR TITLE
fix S3 exception when using KMS key state PendingDeletion

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -235,6 +235,11 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket) -> None:
     try:
         key = kms_client.describe_key(KeyId=kms_key)
         if not key["KeyMetadata"]["Enabled"]:
+            if key["KeyMetadata"]["KeyState"] == "PendingDeletion":
+                raise CommonServiceException(
+                    code="KMS.KMSInvalidStateException",
+                    message=f'{key["KeyMetadata"]["Arn"]} is pending deletion.',
+                )
             raise CommonServiceException(
                 code="KMS.DisabledException", message=f'{key["KeyMetadata"]["Arn"]} is disabled.'
             )

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3794,6 +3794,15 @@ class TestS3:
             )
         snapshot.match("put-obj-disabled-key", e.value.response)
 
+        # schedule the deletion of the key
+        aws_client.kms.schedule_key_deletion(KeyId=kms_key["KeyId"], PendingWindowInDays=7)
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object(
+                Bucket=s3_bucket,
+                Key=key_name,
+            )
+        snapshot.match("get-obj-pending-deletion-key", e.value.response)
+
     @pytest.mark.aws_validated
     @pytest.mark.xfail(
         condition=LEGACY_S3_PROVIDER, reason="Validation not implemented in legacy provider"

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5037,7 +5037,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key_state": {
-    "recorded-date": "02-03-2023, 20:16:36",
+    "recorded-date": "01-06-2023, 23:39:32",
     "recorded-content": {
       "create-kms-key": {
         "AWSAccountId": "111111111111",
@@ -5058,7 +5058,7 @@
         "Origin": "AWS_KMS"
       },
       "success-put-object-sse": {
-        "ETag": "\"e68bbef73b652d1dc50bf77e0d79db33\"",
+        "ETag": "\"8fcef97dd418deded0d80da0c9bb9e35\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5071,7 +5071,7 @@
         "Body": "test-sse",
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"e68bbef73b652d1dc50bf77e0d79db33\"",
+        "ETag": "\"8fcef97dd418deded0d80da0c9bb9e35\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
@@ -5095,6 +5095,16 @@
         "Error": {
           "Code": "KMS.DisabledException",
           "Message": "arn:aws:kms:<region>:111111111111:key/<uuid:1> is disabled."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-obj-pending-deletion-key": {
+        "Error": {
+          "Code": "KMS.KMSInvalidStateException",
+          "Message": "arn:aws:kms:<region>:111111111111:key/<uuid:1> is pending deletion."
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},


### PR DESCRIPTION
This PR will fix one case of #8422, the first case is already fixed. 

We would raise an exception when the `key["KeyMetadata"]["Enabled"]` was `False`, but there is a specific exception when the `key["KeyMetadata"]["KeyState"]` is `PendingDeletion`. We're now raising the proper exception, and it's AWS validated. 

This fix needs `S3_SKIP_KMS_KEY_VALIDATION=0` to be effective.

_fixes #8422_