### PR TITLE
add BodyS3Location property to AWS::ApiGateway::RestApi

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -545,8 +545,8 @@ def import_api_from_openapi_spec(
     rest_api.description = resolved_schema.get("info", {}).get("description")
 
     # Remove default root, then add paths from API spec
+    # TODO: the default mode is now `merge`, not `overwrite` if using `PutRestApi`
     rest_api.resources = {}
-    rest_api.tags = {}
     # authorizers map to avoid duplication
     authorizers = {}
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -241,6 +241,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("PutRestApi", expand=False)
     def put_rest_api(self, context: RequestContext, request: PutRestApiRequest) -> RestApi:
+        # TODO: take into account the mode: overwrite or merge
+        # the default is now `merge`, but we are removing everything
         body_data = request["body"].read()
         rest_api = get_moto_rest_api(context, request["restApiId"])
 

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -1,6 +1,7 @@
 import json
 from urllib.parse import urlparse
 
+from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     lambda_keys_to_lower,
@@ -181,7 +182,7 @@ class GatewayRestAPI(GenericBaseModel):
                         get_obj_kwargs["VersionId"] = version_id
 
                     # what is the approach when client call fail? Do we bubble it up?
-                    s3_client = aws_stack.connect_to_service("s3")
+                    s3_client = connect_to().s3
                     get_obj_req = s3_client.get_object(
                         Bucket=s3_body_location.get("Bucket"),
                         Key=s3_body_location.get("Key"),
@@ -189,7 +190,7 @@ class GatewayRestAPI(GenericBaseModel):
                     )
                     if etag := s3_body_location.get("ETag"):
                         if etag != get_obj_req["ETag"]:
-                            # TODO: validate the exception message (how?)
+                            # TODO: validate the exception message
                             raise Exception(
                                 "The ETag provided for the S3BodyLocation does not match the S3 Object"
                             )

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -168,7 +168,7 @@ class GatewayRestAPI(GenericBaseModel):
             result = client.create_rest_api(**kwargs)
 
             body = props.get("Body")
-            s3_body_location = props.get("BodyS3Location", {})
+            s3_body_location = props.get("BodyS3Location")
             if body or s3_body_location:
                 # the default behavior for imports via CFn is basepath=ignore (validated against AWS)
                 import_parameters = props.get("Parameters", {})

--- a/tests/integration/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_apigateway.snapshot.json
@@ -109,5 +109,62 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
+    "recorded-date": "02-06-2023, 18:26:01",
+    "recorded-content": {
+      "rest-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "REGIONAL"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {
+          "aws:cloudformation:logical-id": "ApiGatewayRestApi",
+          "aws:cloudformation:stack-id": "arn:aws:cloudformation:<region>:111111111111:stack/stack-name/<resource:1>",
+          "aws:cloudformation:stack-name": "stack-name"
+        },
+        "version": "1.0.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "resources": {
+        "items": [
+          {
+            "id": "<id:2>",
+            "path": "/"
+          },
+          {
+            "id": "<id:3>",
+            "parentId": "<id:2>",
+            "path": "/pets",
+            "pathPart": "pets",
+            "resourceMethods": {
+              "GET": {}
+            }
+          },
+          {
+            "id": "<id:4>",
+            "parentId": "<id:3>",
+            "path": "/pets/{petId}",
+            "pathPart": "{petId}",
+            "resourceMethods": {
+              "GET": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/apigateway_integration_from_s3.yml
+++ b/tests/integration/templates/apigateway_integration_from_s3.yml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: The AWS CloudFormation template for this Serverless application
+Parameters:
+  S3BodyBucket:
+    Type: String
+  S3BodyKey:
+    Type: String
+  S3BodyETag:
+    Type: String
+
+Resources:
+  ApiGatewayRestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      BodyS3Location:
+        Bucket:
+          Ref: S3BodyBucket
+        Key:
+          Ref: S3BodyKey
+        ETag:
+          Ref: S3BodyETag
+
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+
+  ApiGWDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      Description: foobar
+      RestApiId:
+        Ref: ApiGatewayRestApi
+      StageName: local
+
+  ApiGWStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      Description: Test Stage 123
+      DeploymentId:
+        Ref: ApiGWDeployment
+      RestApiId:
+        Ref: ApiGatewayRestApi
+Outputs:
+  RestApiId:
+    Value:
+      Ref: ApiGatewayRestApi


### PR DESCRIPTION
Depends on #8371 

Implementing the `BodyS3Location` property to `AWS::ApiGateway::RestApi` as requested by a customer.

This property allows Cloudformation to directly fetch the "Body" property from an S3 bucket.

However, I am not sure how to do negative testing with Cloudformation, so for now any S3 exception is going to bubble up? 

Small note: I've also removed a line from the API Gateway importer because it was erasing tags after updating a RestAPI, which is not the default mode anymore. 

Resource:
https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-s3location.html