### PR TITLE
fix package incompatibilities in pipeline

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14=14.8* postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14 postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14 postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14=14.8-0ubuntu0* postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true


### PR DESCRIPTION
It seems like we have issue with the integration tests against our pro extensions due to a conflict with packages being installed on the CI system before running the tests.
This seems to be related to the package repos on the GitHub runners (it does not happen on other, private runners).
Unfortunately, apt is not automatically resolving the conflict by downgrading postgres to a matching version without explicitly stating it.
I cancelled the circle pipeline runs, because this only touches the GitHub workflow.
I'm happy for any feedback, this apt call caused quite a lot of issues in the past.