### PR TITLE
add support for CFN and s3 bucket website configuration

### DIFF
--- a/tests/integration/cloudformation/resources/test_s3.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_s3.snapshot.json
@@ -44,5 +44,33 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_s3.py::test_website_configuration": {
+    "recorded-date": "02-06-2023, 18:24:39",
+    "recorded-content": {
+      "get_bucket_website": {
+        "ErrorDocument": {
+          "Key": "error.html"
+        },
+        "IndexDocument": {
+          "Suffix": "index.html"
+        },
+        "RoutingRules": [
+          {
+            "Condition": {
+              "HttpErrorCodeReturnedEquals": "404",
+              "KeyPrefixEquals": "out1/"
+            },
+            "Redirect": {
+              "ReplaceKeyWith": "redirected.html"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/s3_bucket_website_config.yaml
+++ b/tests/integration/templates/s3_bucket_website_config.yaml
@@ -1,0 +1,33 @@
+Parameters:
+  BucketName:
+    Type: String
+Resources:
+  S3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Ref BucketName
+      # this config is required to run the sample with AWS
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: False
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
+      # website config is what we actually want to test
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
+        RoutingRules:
+          - RoutingRuleCondition:
+              HttpErrorCodeReturnedEquals: '404'
+              KeyPrefixEquals: out1/
+            RedirectRule:
+              ReplaceKeyWith: "redirected.html"
+Outputs:
+  BucketNameOutput:
+    Value:
+      Ref: S3Bucket
+  WebsiteURL:
+    Value: !GetAtt
+      - S3Bucket
+      - WebsiteURL
+    Description: URL for website hosted on S3


### PR DESCRIPTION
This PR adds support for bucket website configuration when creating a S3 bucket using cloudformation.

Missing feature was revealed by an AWS sample.
