### PR TITLE
Use awslocal in LocalStack hint logs

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -263,7 +263,8 @@ class LambdaService:
                 HINT_LOG.warning(
                     "Lambda functions are created and updated asynchronously in the new lambda provider like in AWS. "
                     f"Before invoking {function_name}, please wait until the function transitioned from the state "
-                    f'Pending to Active using: "aws lambda wait function-active-v2 --function-name {function_name}" '
+                    "Pending to Active using: "
+                    f'"awslocal lambda wait function-active-v2 --function-name {function_name}" '
                     "Check out https://docs.localstack.cloud/user-guide/aws/lambda/#function-in-pending-state"
                 )
             raise ResourceConflictException(


### PR DESCRIPTION
Be consistent with linked documentation and use `awslocal` instead of `aws` CLI for LocalStack hint logging.