### PR TITLE
fix validating APIGW API key when apiKeySource is AUTHORIZER

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -14,6 +14,7 @@ from localstack.aws.api import CommonServiceException, RequestContext, ServiceRe
 from localstack.aws.api.apigateway import (
     Account,
     ApigatewayApi,
+    ApiKey,
     ApiKeys,
     Authorizer,
     Authorizers,
@@ -1467,6 +1468,21 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         return ApiKeys(
             items=paginated_list, warnings=moto_response.get("warnings"), position=next_token
         )
+
+    def update_api_key(
+        self,
+        context: RequestContext,
+        api_key: String,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> ApiKey:
+        response: ApiKey = call_moto(context)
+        if "value" in response:
+            response.pop("value", None)
+
+        if "tags" not in response:
+            response["tags"] = {}
+
+        return response
 
     def create_model(
         self,

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -4,8 +4,10 @@ import pytest
 import requests
 
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
 from tests.integration.apigateway.apigateway_fixtures import api_invoke_url
 from tests.integration.awslambda.test_lambda import TEST_LAMBDA_AWS_PROXY
 
@@ -28,6 +30,7 @@ class TestApiGatewayCommon:
         # TODO: create fixture which will provide basic integrations where we can test behaviour
         # see once we have more cases how we can regroup functionality into one or several fixtures
         # example: create a basic echo lambda + integrations + deploy stage
+        # We could also leverage the MOCK integration
         snapshot.add_transformers_list(
             [
                 snapshot.transform.key_value("requestValidatorId"),
@@ -246,3 +249,120 @@ class TestApiGatewayCommon:
         # GET request with an empty body
         response_get = requests.get(url)
         assert response_get.ok
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.create-usage-plan.throttle.rateLimit",  # TODO: wrong type, should be `float` but is `int`
+        ]
+    )
+    def test_api_key_required_for_methods(
+        self,
+        aws_client,
+        snapshot,
+        create_rest_apigw,
+        apigw_redeploy_api,
+    ):
+        snapshot.add_transformer(snapshot.transform.apigateway_api())
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("apiId"),
+                snapshot.transform.key_value("value"),
+            ]
+        )
+
+        # Create a REST API with the apiKeySource set to "HEADER"
+        api_id, _, root_id = create_rest_apigw(name="test API key", apiKeySource="HEADER")
+
+        resource = aws_client.apigateway.create_resource(
+            restApiId=api_id, parentId=root_id, pathPart="test"
+        )
+
+        resource_id = resource["id"]
+
+        aws_client.apigateway.put_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            authorizationType="NONE",
+            apiKeyRequired=True,
+        )
+
+        aws_client.apigateway.put_method_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            statusCode="200",
+        )
+
+        aws_client.apigateway.put_integration(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            integrationHttpMethod="GET",
+            type="MOCK",
+            requestTemplates={"application/json": '{"statusCode": 200}'},
+        )
+
+        aws_client.apigateway.put_integration_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            statusCode="200",
+            selectionPattern="",
+        )
+
+        stage_name = "dev"
+        aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+        usage_plan_response = aws_client.apigateway.create_usage_plan(
+            name=f"test-plan-{short_uid()}",
+            description="Test Usage Plan for API key",
+            quota={"limit": 10, "period": "DAY", "offset": 0},
+            throttle={"rateLimit": 2, "burstLimit": 1},
+            apiStages=[{"apiId": api_id, "stage": stage_name}],
+            tags={"tag_key": "tag_value"},
+        )
+        snapshot.match("create-usage-plan", usage_plan_response)
+
+        usage_plan_id = usage_plan_response["id"]
+
+        key_name = f"testApiKey-{short_uid()}"
+        api_key_response = aws_client.apigateway.create_api_key(
+            name=key_name,
+            enabled=True,
+        )
+        snapshot.match("create-api-key", api_key_response)
+        api_key_id = api_key_response["id"]
+
+        create_usage_plan_key_resp = aws_client.apigateway.create_usage_plan_key(
+            usagePlanId=usage_plan_id,
+            keyId=api_key_id,
+            keyType="API_KEY",
+        )
+        snapshot.match("create-usage-plan-key", create_usage_plan_key_resp)
+
+        url = api_invoke_url(api_id=api_id, stage=stage_name, path="/test")
+        response = requests.get(url)
+        # when the api key is not passed as part of the header
+        assert response.status_code == 403
+
+        def _assert_with_key(expected_status_code: int):
+            _response = requests.get(url, headers={"x-api-key": api_key_response["value"]})
+            assert _response.status_code == expected_status_code
+
+        # AWS takes a very, very long time to make the key enabled
+        retries = 10 if is_aws_cloud() else 3
+        sleep = 12 if is_aws_cloud() else 1
+        retry(_assert_with_key, retries=retries, sleep=sleep, expected_status_code=200)
+
+        # now disable the key to verify that we should not be able to access the api
+        patch_operations = [
+            {"op": "replace", "path": "/enabled", "value": "false"},
+        ]
+        response = aws_client.apigateway.update_api_key(
+            apiKey=api_key_id, patchOperations=patch_operations
+        )
+        snapshot.match("update-api-key-disabled", response)
+
+        retry(_assert_with_key, retries=retries, sleep=sleep, expected_status_code=403)

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -226,5 +226,73 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_key_required_for_methods": {
+    "recorded-date": "05-06-2023, 20:32:45",
+    "recorded-content": {
+      "create-usage-plan": {
+        "apiStages": [
+          {
+            "apiId": "<api-id:1>",
+            "stage": "dev"
+          }
+        ],
+        "description": "Test Usage Plan for API key",
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "quota": {
+          "limit": 10,
+          "offset": 0,
+          "period": "DAY"
+        },
+        "tags": {
+          "tag_key": "tag_value"
+        },
+        "throttle": {
+          "burstLimit": 1,
+          "rateLimit": 2.0
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-api-key": {
+        "createdDate": "datetime",
+        "enabled": true,
+        "id": "<id:2>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:2>",
+        "stageKeys": [],
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-usage-plan-key": {
+        "id": "<id:2>",
+        "name": "<name:2>",
+        "type": "API_KEY",
+        "value": "<value:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-api-key-disabled": {
+        "createdDate": "datetime",
+        "enabled": false,
+        "id": "<id:2>",
+        "lastUpdatedDate": "datetime",
+        "name": "<name:2>",
+        "stageKeys": [],
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
When looking at an OpenAPI file, I've spotted an issue where we didn't validate what the `apiKeySource` was before validating the key (if the source is set to `AUTHORIZER`, as authorizers are only mocked in community, it would always fail before). 

I've migrated one integration test to be AWS validated, there still one left but it'll be migrated when we pushed the migration further for `UsagePlan` and `ApiKey`. 

Also fixed a parity issue where we wouldn't validate if the key was enabled. 