### PR TITLE
Update lambda init to v0.1.18-pre

### DIFF
--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.17-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.18-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime


### PR DESCRIPTION
Update lambda init version to https://github.com/localstack/lambda-runtime-init/releases/tag/v0.1.18-pre

This will remove some confusing exception logging where raised exceptions during a function invocation were also logged in the same way that an init error was logged.