### PR TITLE
Prefix dynamodb streams shard iterator with stream arn

### DIFF
--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -102,7 +102,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             raise ExpiredIteratorException("Shard iterator has expired")
         result = {
             "Records": [],
-            "NextShardIterator": f"{prefix}{kinesis_records.get('ShardIterator')}",
+            "NextShardIterator": f"{prefix}|{kinesis_records.get('NextShardIterator')}",
         }
         for record in kinesis_records["Records"]:
             record_data = loads(record["Data"])

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -23,6 +23,7 @@ from localstack.aws.api.dynamodbstreams import (
     StreamStatus,
     TableName,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.dynamodbstreams.dynamodbstreams_api import (
     get_dynamodbstreams_store,
     get_kinesis_stream_name,
@@ -92,7 +93,8 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
 
     @handler("GetRecords", expand=False)
     def get_records(self, context: RequestContext, payload: GetRecordsInput) -> GetRecordsOutput:
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = connect_to().kinesis
+        prefix, _, payload["ShardIterator"] = payload["ShardIterator"].rpartition("|")
         try:
             kinesis_records = kinesis.get_records(**payload)
         except kinesis.exceptions.ExpiredIteratorException:
@@ -100,7 +102,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             raise ExpiredIteratorException("Shard iterator has expired")
         result = {
             "Records": [],
-            "NextShardIterator": kinesis_records.get("NextShardIterator"),
+            "NextShardIterator": f"{prefix}{kinesis_records.get('ShardIterator')}",
         }
         for record in kinesis_records["Records"]:
             record_data = loads(record["Data"])
@@ -118,7 +120,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
     ) -> GetShardIteratorOutput:
         stream_name = stream_name_from_stream_arn(stream_arn)
         stream_shard_id = kinesis_shard_id(shard_id)
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = connect_to().kinesis
 
         kwargs = {"StartingSequenceNumber": sequence_number} if sequence_number else {}
         result = kinesis.get_shard_iterator(
@@ -128,6 +130,8 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             **kwargs,
         )
         del result["ResponseMetadata"]
+        # TODO not quite clear what the |1| exactly denotes, because at AWS it's sometimes other numbers
+        result["ShardIterator"] = f"{stream_arn}|1|{result['ShardIterator']}"
         return GetShardIteratorOutput(**result)
 
     def list_streams(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -687,7 +687,7 @@ def wait_for_dynamodb_stream_ready(aws_client):
             )
             return describe_stream_response["StreamDescription"]["StreamStatus"] == "ENABLED"
 
-        poll_condition(is_stream_ready)
+        return poll_condition(is_stream_ready)
 
     return _wait_for_stream_ready
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -14,6 +14,7 @@ from localstack.aws.api.dynamodb import (
 )
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
+from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
 from localstack.utils.aws import arns, aws_stack, queries, resources
@@ -1441,6 +1442,40 @@ class TestDynamoDB:
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         assert len(response["StreamDescription"]["Shards"]) == 0
+
+    @pytest.mark.aws_validated
+    def test_dynamodb_streams_arn_format(
+        self,
+        dynamodb_create_table,
+        wait_for_dynamodb_stream_ready,
+        aws_client,
+    ):
+        table_name = f"test-table-{short_uid()}"
+        partition_key = "my_partition_key"
+
+        dynamodb_create_table(table_name=table_name, partition_key=partition_key)
+
+        _await_dynamodb_table_active(aws_client.dynamodb, table_name)
+        stream_arn = aws_client.dynamodb.update_table(
+            TableName=table_name,
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_IMAGE"},
+        )["TableDescription"]["LatestStreamArn"]
+        assert wait_for_dynamodb_stream_ready(stream_arn)
+
+        shard_id = aws_client.dynamodbstreams.describe_stream(StreamArn=stream_arn)[
+            "StreamDescription"
+        ]["Shards"][0]["ShardId"]
+
+        shard_iterator = aws_client.dynamodbstreams.get_shard_iterator(
+            StreamArn=stream_arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
+        )["ShardIterator"]
+
+        assert shard_iterator.startswith(f"{stream_arn}|")
+
+        get_records_result = aws_client.dynamodbstreams.get_records(ShardIterator=shard_iterator)
+        shard_iterator = get_records_result["NextShardIterator"]
+        assert shard_iterator.startswith(f"{stream_arn}|")
+        assert not get_records_result["Records"]
 
     @pytest.mark.aws_validated
     def test_dynamodb_idempotent_writing(

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -409,5 +409,9 @@
         }
       }
     }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_arn_format": {
+    "recorded-date": "05-06-2023, 13:54:14",
+    "recorded-content": {}
   }
 }

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -413,5 +413,9 @@
   "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_arn_format": {
     "recorded-date": "05-06-2023, 13:54:14",
     "recorded-content": {}
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_shard_iterator_format": {
+    "recorded-date": "05-06-2023, 17:04:25",
+    "recorded-content": {}
   }
 }


### PR DESCRIPTION
## Motivation
As seen here: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html, the shard iterator for dynamodbstreams differs from the kinesis one in one important aspect, namely the prefix of the stream arn followed by `|<int>|` and then an iterator in a similar format like kinesis data streams.

## Changes
* Add tests specifically asserting on the sharditerator format
* Fix shard iterator format

## Future challenges
It is quite unclear to me, and I did not find any information on that, what the integer between the pipes `|<int>|` is supposed to represent. I got the values 1 and 2 back from AWS, not sure what they are exactly denoting. As long as this is unclear, and since it does not seem to make a difference for now, I hardcoded it to 1 with a comment for it.