### PR TITLE
CFn: simplify deploy function handling

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -73,12 +73,10 @@ ResourceDefinition = dict[str, ResourceProp]
 
 class FuncDetailsValue(TypedDict):
     # Callable here takes the arguments:
-    # - resource_id
-    # - resources
-    # - resource_type
-    # - func
+    # - logical_resource_id
+    # - resource
     # - stack_name
-    function: str | Callable[[str, list[dict], str, Any, str], Any]
+    function: str | Callable[[str, dict, str], Any]
     """Either an api method to call directly with `parameters` or a callable to directly invoke"""
     # Callable here takes the arguments:
     # - resource_props

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1,4 +1,5 @@
 import base64
+import inspect
 import json
 import logging
 import re
@@ -172,7 +173,6 @@ def get_client(resource: dict):
 def retrieve_resource_details(
     resource_id, resource_status, resources: dict[str, Type[GenericBaseModel]], stack_name
 ):
-
     resource = resources.get(resource_id)
     resource_id = resource_status.get("PhysicalResourceId") or resource_id
     if not resource:
@@ -812,7 +812,11 @@ def execute_resource_action(
         executed = False
         # TODO(srw) 3 - callable function
         if callable(func.get("function")):
-            result = func["function"](resource_id, resources, resource_type, func, stack_name)
+            sig = inspect.signature(func["function"])
+            if "logical_resource_id" in sig.parameters:
+                result = func["function"](resource_id, resources[resource_id], stack_name)
+            else:
+                result = func["function"](resource_id, resources, resource_type, func, stack_name)
             results.append(result)
             executed = True
 

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -101,14 +101,12 @@ class CloudFormationMacro(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _store_macro(resource_id, resources, resource_type, func, stack_name):
-            resource = resources[resource_id]
+        def _store_macro(logical_resource_id: str, resource: dict, stack_name: str):
             properties = resource["Properties"]
             name = properties["Name"]
             get_cloudformation_store().macros[name] = properties
 
-        def _delete_macro(resource_id, resources, resource_type, func, stack_name):
-            resource = resources[resource_id]
+        def _delete_macro(logical_resource_id: str, resource: dict, stack_name: str):
             properties = resource["Properties"]
             name = properties["Name"]
             get_cloudformation_store().macros.pop(name)
@@ -153,7 +151,7 @@ class CloudFormationWaitConditionHandle(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create(resource_id, resources, resource_type, func, stack_name) -> dict:
+        def _create(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
             # no resources to create as such, but the physical resource id needs the stack name
             return {"stack_name": stack_name}
 
@@ -185,7 +183,7 @@ class CloudFormationWaitCondition(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create(resource_id, resources, resource_type, func, stack_name) -> dict:
+        def _create(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
             # no resources to create, but the physical resource id requires the stack name
             return {"stack_name": stack_name}
 

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -403,8 +403,8 @@ class EC2VPC(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _pre_delete(resource_id, resources, *args, **kwargs):
-            res = cls(resources[resource_id])
+        def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
+            res = cls(resource)
             vpc_id = res.state.get("VpcId")
             if vpc_id:
                 ec2_client = aws_stack.connect_to_service("ec2")

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -197,10 +197,10 @@ class EC2VPCGatewayAttachment(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _attach_gateway(resource_id, resources, *args, **kwargs):
+        def _attach_gateway(logical_resource_id: str, resource: dict, stack_name: str):
             client = aws_stack.connect_to_service("ec2")
-            resource = cls(resources[resource_id])
-            props = resource.props
+            resource_provider = cls(resource)
+            props = resource_provider.props
             igw_id = props.get("InternetGatewayId")
             vpngw_id = props.get("VpnGatewayId")
             vpc_id = props.get("VpcId")
@@ -281,7 +281,7 @@ class EC2Subnet(GenericBaseModel):
     def cloudformation_type():
         return "AWS::EC2::Subnet"
 
-    def fetch_state(self, stack_name, resources):
+    def fetch_state(self, stack_name, resources) -> dict:
         if not self.physical_resource_id:
             return None
         client = aws_stack.connect_to_service("ec2")
@@ -300,10 +300,10 @@ class EC2Subnet(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _post_create(resource_id, resources, resource_type, func, stack_name):
+        def _post_create(logical_resource_id: str, resource: dict, stack_name: str):
             client = aws_stack.connect_to_service("ec2")
-            resource = cls(resources[resource_id])
-            props = resource.props
+            resource_provider = cls(resource)
+            props = resource_provider.props
 
             bool_attrs = [
                 "AssignIpv6AddressOnCreation",
@@ -314,8 +314,7 @@ class EC2Subnet(GenericBaseModel):
             if not any(attr in props for attr in custom_attrs):
                 return
 
-            state = resource.fetch_state(stack_name, resources)
-            subnet_id = state.get("SubnetId")
+            subnet_id = props.get("SubnetId")
 
             # update boolean attributes
             for attr in bool_attrs:

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -45,14 +45,13 @@ class ECRRepository(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_repo(resource_id, resources, resource_type, func, stack_name):
-            resource = resources[resource_id]
+        def _create_repo(logical_resource_id: str, resource: dict, stack_name: str):
             default_repos_per_stack[stack_name] = resource["Properties"]["RepositoryName"]
             LOG.warning(
                 "Creating a Mock ECR Repository for CloudFormation. This is only intended to be used for allowing a successful CDK bootstrap and does not provision any underlying ECR repository."
             )
 
-        def _delete_repo(resource_id, resources, resource_type, func, stack_name):
+        def _delete_repo(logical_resource_id: str, resource: dict, stack_name: str):
             if default_repos_per_stack.get(stack_name):
                 del default_repos_per_stack[stack_name]
 

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -1,5 +1,7 @@
 import json
 
+from botocore.exceptions import ClientError
+
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     select_parameters,
@@ -132,9 +134,8 @@ class EventsRule(GenericBaseModel):
                 result["EventPattern"] = json.dumps(wrapped)
             return result
 
-        def _delete_rule(resource_id, resources, *args, **kwargs):
+        def _delete_rule(logical_resource_id: str, resource: dict, stack_name: str):
             events = aws_stack.connect_to_service("events")
-            resource = resources[resource_id]
             props = resource["Properties"]
             rule_name = props["Name"]
             targets = events.list_targets_by_rule(Rule=rule_name)["Targets"]
@@ -143,9 +144,8 @@ class EventsRule(GenericBaseModel):
                 events.remove_targets(Rule=rule_name, Ids=target_ids, Force=True)
             events.delete_rule(Name=rule_name)
 
-        def _put_targets(resource_id, resources, *args, **kwargs):
+        def _put_targets(logical_resource_id: str, resource: dict, stack_name: str):
             events = aws_stack.connect_to_service("events")
-            resource = resources[resource_id]
             props = resource["Properties"]
             rule_name = props["Name"]
             event_bus_name = props.get("EventBusName")
@@ -180,9 +180,8 @@ class EventBusPolicy(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create(resource_id, resources, resource_type, func, stack_name):
+        def _create(logical_resource_id: str, resource: dict, stack_name: str):
             events = aws_stack.connect_to_service("events")
-            resource = resources[resource_id]
             props = resource["Properties"]
 
             resource["PhysicalResourceId"] = f"EventBusPolicy-{short_uid()}"
@@ -217,9 +216,8 @@ class EventBusPolicy(GenericBaseModel):
                     **optional_condition,
                 )
 
-        def _delete(resource_id, resources, resource_type, func, stack_name):
+        def _delete(logical_resource_id: str, resource: dict, stack_name: str):
             events = aws_stack.connect_to_service("events")
-            resource = resources[resource_id]
             props = resource["Properties"]
             statement_id = props["StatementId"]
             event_bus_name = props.get("EventBusName")
@@ -229,7 +227,10 @@ class EventBusPolicy(GenericBaseModel):
                     StatementId=statement_id, RemoveAllPermissions=False, **optional_event_bus_name
                 )
             except Exception as err:
-                if err.response["Error"]["Code"] == "ResourceNotFoundException":
+                if (
+                    isinstance(err, ClientError)
+                    and err.response["Error"]["Code"] == "ResourceNotFoundException"
+                ):
                     pass  # expected behavior ("parent" resource event bus already deleted)
                 else:
                     raise err

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -110,9 +110,8 @@ class IAMUser(GenericBaseModel):
                     PasswordResetRequired=login_profile.get("PasswordResetRequired"),
                 )
 
-        def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+        def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
             client = aws_stack.connect_to_service("iam")
-            resource = resources[resource_id]
             props = resource["Properties"]
             user_name = props["UserName"]
 
@@ -189,9 +188,8 @@ class IAMAccessKey(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _delete(resource_id, resources, resource_type, func, stack_name):
+        def _delete(logical_resource_id: str, resource: dict, stack_name: str):
             iam_client = aws_stack.connect_to_service("iam")
-            resource = resources[resource_id]
             props = resource["Properties"]
             user_name = props["UserName"]
             access_key_id = resource["PhysicalResourceId"]
@@ -254,10 +252,8 @@ class IAMRole(GenericBaseModel):
             )
             if name_changed or policy_changed:
                 resource_id = new_resource.get("LogicalResourceId")
-                dummy_resources = {
-                    resource_id: {"Properties": {"RoleName": _states.get("RoleName")}}
-                }
-                IAMRole._pre_delete(resource_id, dummy_resources, None, None, None)
+                dummy_resource = {"Properties": {"RoleName": _states.get("RoleName")}}
+                IAMRole._pre_delete(resource_id, dummy_resource, stack_name)
                 client.delete_role(RoleName=_states.get("RoleName"))
                 role = client.create_role(
                     RoleName=props.get("RoleName"),
@@ -324,10 +320,9 @@ class IAMRole(GenericBaseModel):
             )
 
     @staticmethod
-    def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+    def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
         """detach managed policies from role before deleting"""
         iam_client = aws_stack.connect_to_service("iam")
-        resource = resources[resource_id]
         props = resource["Properties"]
         role_name = props["RoleName"]
 
@@ -575,9 +570,8 @@ class InstanceProfile(GenericBaseModel):
                     RoleName=roles[0],
                 )
 
-        def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+        def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
             iam_client = aws_stack.connect_to_service("iam")
-            resource = resources[resource_id]
             props = resource["Properties"]
             roles = props.get("Roles")
             assert len(roles) == 1
@@ -652,9 +646,8 @@ class IAMGroup(GenericBaseModel):
                     PolicyDocument=doc,
                 )
 
-        def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+        def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
             client = aws_stack.connect_to_service("iam")
-            resource = resources[resource_id]
             props = resource["Properties"]
             group_name = props["GroupName"]
 

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -42,10 +42,10 @@ class KMSKey(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create(resource_id, resources, resource_type, func, stack_name):
+        def _create(logical_resource_id: str, resource: dict, stack_name: str):
             kms_client = aws_stack.connect_to_service("kms")
-            resource = cls(resources[resource_id])
-            props = resource.props
+            resource_provider = cls(resource)
+            props = resource_provider.props
             params = {}
             if props.get("KeyPolicy"):
                 params["Policy"] = json.dumps(props["KeyPolicy"])

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -189,18 +189,16 @@ class S3Bucket(GenericBaseModel):
                 if "NoSuchBucket" not in str(e):
                     raise
 
-        def _add_bucket_tags(resource_id, resources, resource_type, func, stack_name):
+        def _add_bucket_tags(logical_resource_id: str, resource: dict, stack_name: str):
             s3 = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             tags = props.get("Tags", [])
             if len(tags) > 0:
                 s3.put_bucket_tagging(Bucket=bucket_name, Tagging={"TagSet": tags})
 
-        def _put_bucket_versioning(resource_id, resources, resource_type, func, stack_name):
+        def _put_bucket_versioning(logical_resource_id: str, resource: dict, stack_name: str):
             s3_client = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             versioning_config = props.get("VersioningConfiguration")
@@ -212,9 +210,10 @@ class S3Bucket(GenericBaseModel):
                     },
                 )
 
-        def _put_bucket_cors_configuration(resource_id, resources, resource_type, func, stack_name):
+        def _put_bucket_cors_configuration(
+            logical_resource_id: str, resource: dict, stack_name: str
+        ):
             s3_client = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             cors_configuration = transform_cfn_cors(props.get("CorsConfiguration"))
@@ -225,10 +224,9 @@ class S3Bucket(GenericBaseModel):
                 )
 
         def _put_bucket_website_configuration(
-            resource_id, resources, resource_type, func, stack_name
+            logical_resource_id: str, resource: dict, stack_name: str
         ):
             s3_client = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             website_config = transform_website_configuration(props.get("WebsiteConfiguration"))
@@ -238,9 +236,8 @@ class S3Bucket(GenericBaseModel):
                     WebsiteConfiguration=website_config,
                 )
 
-        def _create_bucket(resource_id, resources, resource_type, func, stack_name):
+        def _create_bucket(logical_resource_id: str, resource: dict, stack_name: str):
             s3_client = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             try:

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -172,9 +172,8 @@ class S3Bucket(GenericBaseModel):
             resource = resources[resource_id]
             resource["PhysicalResourceId"] = resource["Properties"]["BucketName"]
 
-        def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+        def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
             s3 = aws_stack.connect_to_service("s3")
-            resource = resources[resource_id]
             props = resource["Properties"]
             bucket_name = props.get("BucketName")
             try:

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -26,14 +26,14 @@ class QueuePolicy(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create(resource_id, resources, resource_type, func, stack_name):
+        def _create(logical_resource_id: str, resource: dict, stack_name: str):
             sqs_client = aws_stack.connect_to_service("sqs")
-            resource = cls(resources[resource_id])
-            props = resource.props
+            resource_provider = cls(resource)
+            props = resource_provider.props
 
-            resources[resource_id]["PhysicalResourceId"] = "%s-%s-%s" % (
+            resource["PhysicalResourceId"] = "%s-%s-%s" % (
                 stack_name,
-                resource_id,
+                logical_resource_id,
                 short_uid(),
             )
 

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -41,10 +41,10 @@ class QueuePolicy(GenericBaseModel):
             for queue in props["Queues"]:
                 sqs_client.set_queue_attributes(QueueUrl=queue, Attributes={"Policy": policy})
 
-        def _delete(resource_id, resources, *args, **kwargs):
+        def _delete(logical_resource_id: str, resource: dict, stack_name: str):
             sqs_client = aws_stack.connect_to_service("sqs")
-            resource = cls(resources[resource_id])
-            props = resource.props
+            resource_provider = cls(resource)
+            props = resource_provider.props
 
             for queue in props["Queues"]:
                 try:


### PR DESCRIPTION
The CloudFormation `GenericBaseModel` classes allowed use of an arbitrary function to deploy the resource. The function signature was:

```
def create(resource_id, resources, resource_type, func, stack_name):
    ...
```

When deploying a single resource:
* the list of resources is redundant
* the resource type is already known
* the `func` argument is not relevant

This PR changes the function signature to `def create(logical_resource_id: str, resource: dict, stack_name: str)` to only supply the relevant information.

To prevent `-ext` breakage, if attempting to call this function raises a type error (because the signature is still the old signature) then we fall back to using the old function signature.

## Motivation

A PR integrating the new style resource providers depends on this change, since I need to call `execute_resource_action` but don't have access to the complete list of resources in a new style provider. Updating `execute_resource_action` will happen once we've removed the fallback old behaviour from all code.