### PR TITLE
fix apigw import default authorizer, apiKeySource and ANY method

### DIFF
--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -177,7 +177,9 @@ def validate_api_key(api_key: str, invocation_context: ApiInvocationContext):
 
 def is_api_key_valid(invocation_context: ApiInvocationContext) -> bool:
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html
-    client = aws_stack.connect_to_service("apigateway")
+    client = connect_to(
+        aws_access_key_id=invocation_context.account_id, region_name=invocation_context.region_name
+    ).apigateway
     rest_api = client.get_rest_api(restApiId=invocation_context.api_id)
 
     if rest_api.get("apiKeySource") != "HEADER":

--- a/tests/integration/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_import.snapshot.json
@@ -3937,5 +3937,237 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
+    "recorded-date": "06-06-2023, 00:26:37",
+    "recorded-content": {
+      "import-swagger": {
+        "apiKeySource": "AUTHORIZER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "version": "2020-02-10",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-authorizers": {
+        "items": [
+          {
+            "authType": "custom",
+            "authorizerResultTtlInSeconds": 300,
+            "authorizerUri": "<authorizer-uri:1>",
+            "id": "<id:2>",
+            "identitySource": "method.request.header.Custom-Authorization",
+            "name": "<name:2>",
+            "type": "REQUEST"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "resources": {
+        "items": [
+          {
+            "id": "<id:3>",
+            "path": "/"
+          },
+          {
+            "id": "<id:4>",
+            "parentId": "<id:3>",
+            "path": "/echo",
+            "pathPart": "echo"
+          },
+          {
+            "id": "<id:5>",
+            "parentId": "<id:4>",
+            "path": "/echo/{data}",
+            "pathPart": "{data}",
+            "resourceMethods": {
+              "ANY": {}
+            }
+          },
+          {
+            "id": "<id:6>",
+            "parentId": "<id:3>",
+            "path": "/pets",
+            "pathPart": "pets",
+            "resourceMethods": {
+              "GET": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-echo/{data}-any": {
+        "apiKeyRequired": false,
+        "authorizationType": "CUSTOM",
+        "authorizerId": "<id:2>",
+        "httpMethod": "ANY",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:5>",
+          "integrationResponses": {
+            "200": {
+              "responseTemplates": {
+                "application/json": {
+                  "echo": "$input.params('data')",
+                  "response": "mocked"
+                }
+              },
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_TEMPLATES",
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "statusCode": "200"
+          }
+        },
+        "requestParameters": {
+          "method.request.path.data": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-echo/{data}-any": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-echo/{data}-any": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<id:5>",
+        "integrationResponses": {
+          "200": {
+            "responseTemplates": {
+              "application/json": {
+                "echo": "$input.params('data')",
+                "response": "mocked"
+              }
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_TEMPLATES",
+        "requestTemplates": {
+          "application/json": {
+            "statusCode": 200
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-echo/{data}-any": {
+        "responseTemplates": {
+          "application/json": {
+            "echo": "$input.params('data')",
+            "response": "mocked"
+          }
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-pets-get": {
+        "apiKeyRequired": false,
+        "authorizationType": "CUSTOM",
+        "authorizerId": "<id:2>",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:6>",
+          "connectionType": "INTERNET",
+          "httpMethod": "GET",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "HTTP",
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-pets-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-pets-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<id:6>",
+        "connectionType": "INTERNET",
+        "httpMethod": "GET",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP",
+        "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-pets-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/files/openapi.spec.global-auth.json
+++ b/tests/integration/files/openapi.spec.global-auth.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Fulfillment OS Gateway",
+    "version": "2020-02-10"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "http"
+        }
+      }
+    },
+    "/echo/{data}": {
+      "x-amazon-apigateway-any-method": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseTemplates": {
+                "application/json": "{\"echo\": \"$input.params('data')\", \"response\": \"mocked\"}"
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_templates"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Empty": {
+        "title": "Empty Schema",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "GatewayAuthorizer": {
+        "type": "apiKey",
+        "description": "API key authentication via the 'X-Api-Key' header",
+        "name": "X-Api-Key",
+        "in": "header",
+        "x-amazon-apigateway-authorizer": {
+          "type": "request",
+          "authorizerUri": "${authorizer_lambda_invocation_arn}",
+          "identitySource": "method.request.header.Custom-Authorization",
+          "authorizerResultTtlInSeconds": 300
+        },
+        "x-amazon-apigateway-authtype": "custom"
+      }
+    }
+  },
+  "security": [
+    {
+      "GatewayAuthorizer": []
+    }
+  ],
+  "x-amazon-apigateway-api-key-source": "AUTHORIZER"
+}


### PR DESCRIPTION
This PR is building on #8437, we were not properly setting the `apiKeySource` of the REST API when importing the file.

Also, we were not making use of default authorizer defined as a top level property. 

I also fixed passing `x-amazon-apigateway-any-method` as an HTTP method, but properly replaced it by  "ANY" like AWS does. I think we could remove any `x-amazon-apigateway-any-method` in the invocation code now, as it has been properly replaced. 
