### PR TITLE
fix apigw model resolving when importing and when validating

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -118,7 +118,7 @@ def get_apigateway_store(account_id: str = None, region: str = None) -> ApiGatew
     return apigateway_stores[account_id or get_aws_account_id()][region or aws_stack.get_region()]
 
 
-class Resolver:
+class OpenAPISpecificationResolver:
     def __init__(self, document: dict, rest_api_id: str, allow_recursive=True):
         self.document = document
         self.allow_recursive = allow_recursive
@@ -400,7 +400,9 @@ class RequestParametersResolver:
 
 
 def resolve_references(data: dict, rest_api_id, allow_recursive=True) -> dict:
-    resolver = Resolver(data, allow_recursive=allow_recursive, rest_api_id=rest_api_id)
+    resolver = OpenAPISpecificationResolver(
+        data, allow_recursive=allow_recursive, rest_api_id=rest_api_id
+    )
     return resolver.resolve_references()
 
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -92,6 +92,7 @@ class RequestValidator:
             schema_name = request_models.get(APPLICATION_JSON, EMPTY_MODEL)
 
         try:
+            # TODO: use the store, so we can cache the resolved model
             model = self.apigateway_client.get_model(
                 restApiId=self.context.api_id,
                 modelName=schema_name,
@@ -102,6 +103,10 @@ class RequestValidator:
 
         try:
             # if the body is empty, replace it with an empty JSON body
+            # TODO: we need to resolve the schema, we should cache it also?
+            # could use $defs, fetching every model and replacing it with
+            # https://json-schema.org/understanding-json-schema/structuring.html#defs
+            # definitely a good idea
             validate(
                 instance=json.loads(self.context.data or "{}"), schema=json.loads(model["schema"])
             )

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -2,9 +2,9 @@ import json
 import logging
 from typing import Dict
 
-from botocore.exceptions import ClientError
 from jsonschema import ValidationError, validate
 from requests.models import Response
+from werkzeug.exceptions import NotFound
 
 from localstack.aws.connect import connect_to
 from localstack.constants import APPLICATION_JSON
@@ -12,8 +12,10 @@ from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import (
     EMPTY_MODEL,
+    ModelResolver,
     extract_path_params,
     extract_query_string_params,
+    get_apigateway_store,
     get_cors_response,
     make_error_response,
 )
@@ -29,6 +31,7 @@ from localstack.services.apigateway.integration import (
     SQSIntegration,
     StepFunctionIntegration,
 )
+from localstack.services.apigateway.models import ApiGatewayStore
 from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
@@ -39,11 +42,17 @@ class AuthorizationError(Exception):
 
 
 class RequestValidator:
-    __slots__ = ["context", "apigateway_client"]
+    __slots__ = ["context", "rest_api_container"]
 
-    def __init__(self, context: ApiInvocationContext, apigateway_client):
+    def __init__(self, context: ApiInvocationContext, store: ApiGatewayStore = None):
         self.context = context
-        self.apigateway_client = apigateway_client
+        store = store or get_apigateway_store(
+            account_id=context.account_id, region=context.region_name
+        )
+        if not (container := store.rest_apis.get(context.api_id)):
+            # TODO: find the right exception
+            raise NotFound()
+        self.rest_api_container = container
 
     def is_request_valid(self) -> bool:
         # make all the positive checks first
@@ -60,15 +69,9 @@ class RequestValidator:
             return True
 
         # check if there is a validator for this request
-        try:
-            validator = self.apigateway_client.get_request_validator(
-                restApiId=self.context.api_id, requestValidatorId=resource["requestValidatorId"]
-            )
-        except ClientError as e:
-            if "NotFoundException" in e:
-                return True
-
-            raise
+        validator = self.rest_api_container.validators.get(resource["requestValidatorId"])
+        if not validator:
+            return True
 
         # are we validating the body?
         if self.should_validate_body(validator):
@@ -87,35 +90,35 @@ class RequestValidator:
         # if there's no model to validate the body, use the Empty model
         # https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-apigateway.EmptyModel.html
         if not (request_models := resource.get("requestModels")):
-            schema_name = EMPTY_MODEL
+            model_name = EMPTY_MODEL
         else:
-            schema_name = request_models.get(APPLICATION_JSON, EMPTY_MODEL)
+            model_name = request_models.get(APPLICATION_JSON, EMPTY_MODEL)
 
-        try:
-            # TODO: use the store, so we can cache the resolved model
-            model = self.apigateway_client.get_model(
-                restApiId=self.context.api_id,
-                modelName=schema_name,
+        model_resolver = ModelResolver(
+            rest_api_container=self.rest_api_container,
+            model_name=model_name,
+        )
+
+        # try to get the resolved model first
+        resolved_schema = model_resolver.get_resolved_model()
+        # print(resolved_model)
+        if not resolved_schema:
+            LOG.exception(
+                "An exception occurred while trying to validate the request: could not find the model"
             )
-        except ClientError as e:
-            LOG.exception("An exception occurred while trying to validate the request: %s", e)
             return False
 
         try:
             # if the body is empty, replace it with an empty JSON body
-            # TODO: we need to resolve the schema, we should cache it also?
-            # could use $defs, fetching every model and replacing it with
-            # https://json-schema.org/understanding-json-schema/structuring.html#defs
-            # definitely a good idea
             validate(
-                instance=json.loads(self.context.data or "{}"), schema=json.loads(model["schema"])
+                instance=json.loads(self.context.data or "{}"),
+                schema=resolved_schema,
             )
             return True
         except ValidationError as e:
             LOG.warning("failed to validate request body %s", e)
             return False
         except json.JSONDecodeError as e:
-            # TODO: for now, it could also be the loading of the schema failing but it will be validated at some point
             LOG.warning("failed to validate request body, request data is not valid JSON %s", e)
             return False
 
@@ -252,7 +255,7 @@ def invoke_rest_api(invocation_context: ApiInvocationContext):
         return make_error_response("Unable to find path %s" % invocation_context.path, 404)
 
     # validate request
-    validator = RequestValidator(invocation_context, aws_stack.connect_to_service("apigateway"))
+    validator = RequestValidator(invocation_context)
     if not validator.is_request_valid():
         return make_error_response("Invalid request body", 400)
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -101,7 +101,6 @@ class RequestValidator:
 
         # try to get the resolved model first
         resolved_schema = model_resolver.get_resolved_model()
-        # print(resolved_model)
         if not resolved_schema:
             LOG.exception(
                 "An exception occurred while trying to validate the request: could not find the model"

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -32,6 +32,8 @@ class RestApiContainer:
     gateway_responses: Dict[str, GatewayResponse]
     # maps Model name -> Model
     models: Dict[str, Model]
+    # maps Model name -> resolved dict Model, so we don't need to load the JSON everytime
+    resolved_models: Dict[str, dict]
     # maps ResourceId of a Resource to its children ResourceIds
     resource_children: Dict[str, List[str]]
 
@@ -42,6 +44,7 @@ class RestApiContainer:
         self.documentation_parts = {}
         self.gateway_responses = {}
         self.models = {}
+        self.resolved_models = {}
         self.resource_children = {}
 
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1582,10 +1582,13 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
             key = path[1:]  # remove the leading slash
             value = operation.get("value")
-            if key == "schema" and not value:
-                raise BadRequestException(
-                    "Model schema must have at least 1 property or array items defined"
-                )
+            if key == "schema":
+                if not value:
+                    raise BadRequestException(
+                        "Model schema must have at least 1 property or array items defined"
+                    )
+                # delete the resolved model to invalidate it
+                store.rest_apis[rest_api_id].resolved_models.pop(model_name, None)
             model[key] = value
         remove_empty_attributes_from_model(model)
         return model
@@ -1605,6 +1608,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         validate_model_in_use(moto_rest_api, model_name)
 
         store.rest_apis[rest_api_id].models.pop(model_name, None)
+        store.rest_apis[rest_api_id].resolved_models.pop(model_name, None)
 
 
 # ---------------

--- a/tests/integration/apigateway/apigateway_fixtures.py
+++ b/tests/integration/apigateway/apigateway_fixtures.py
@@ -47,6 +47,7 @@ def import_rest_api(apigateway_client, **kwargs):
     assert_response_is_201(response)
     resources = apigateway_client.get_resources(restApiId=response.get("id"))
     root_id = next(item for item in resources["items"] if item["path"] == "/")["id"]
+
     return response, root_id
 
 

--- a/tests/integration/apigateway/test_apigateway_import.py
+++ b/tests/integration/apigateway/test_apigateway_import.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import time
@@ -39,7 +38,10 @@ TEST_IMPORT_REST_API_FILE = os.path.join(PARENT_DIR, "files", "pets.json")
 TEST_IMPORT_OPEN_API_GLOBAL_API_KEY_AUTHORIZER = os.path.join(
     PARENT_DIR, "files", "openapi.spec.global-auth.json"
 )
-
+OAS_30_CIRCULAR_REF = os.path.join(PARENT_DIR, "files", "openapi.spec.circular-ref.json")
+OAS_30_CIRCULAR_REF_WITH_REQUEST_BODY = os.path.join(
+    PARENT_DIR, "files", "openapi.spec.circular-ref-with-request-body.json"
+)
 
 TEST_LAMBDA_PYTHON_ECHO = os.path.join(PARENT_DIR, "awslambda/functions/lambda_echo.py")
 
@@ -115,8 +117,17 @@ def apigw_snapshot_imported_resources(snapshot, aws_client):
 
 @pytest.fixture(autouse=True)
 def apigw_snapshot_transformer(request, snapshot):
+    if is_aws_cloud():
+        model_base_url = "https://apigateway.amazonaws.com"
+    else:
+        host_definition = localstack_host(use_localhost_cloud=True)
+        model_base_url = f"{config.get_protocol()}://apigateway.{host_definition.host_and_port()}"
+
+    snapshot.add_transformer(snapshot.transform.regex(model_base_url, "<model-base-url>"))
+
     if "no_apigw_snap_transformers" in request.keywords:
         return
+
     snapshot.add_transformer(snapshot.transform.apigateway_api())
 
 
@@ -279,16 +290,6 @@ class TestApiGatewayImportRestApi:
                 snapshot.transform.jsonpath("$.get-models.items..id", value_replacement="model-id"),
             ]
         )
-        if is_aws_cloud():
-            model_base_url = "https://apigateway.amazonaws.com"
-        else:
-            host_definition = localstack_host(use_localhost_cloud=True)
-            model_base_url = (
-                f"{config.get_protocol()}://apigateway.{host_definition.host_and_port()}"
-            )
-
-        snapshot.add_transformer(snapshot.transform.regex(model_base_url, "<model-base-url>"))
-
         spec_file = load_file(PETSTORE_SWAGGER_JSON)
         spec_file = spec_file.replace(
             "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:account-id:function:function-name/invocations",
@@ -309,19 +310,6 @@ class TestApiGatewayImportRestApi:
 
         models = aws_client.apigateway.get_models(restApiId=rest_api_id)
         models["items"] = sorted(models["items"], key=itemgetter("name"))
-        # FIXME: AWS is returning field with $ref which makes JSON path selecting difficult
-        # we're renaming those, but this is very dirty
-        for model in models["items"]:
-            schema = model.get("schema", {})
-            assert isinstance(schema, str)
-            schema = json.loads(schema)
-            if "$ref" in schema.get("items", {}):
-                schema["items"]["ref"] = schema["items"].pop("$ref")
-            elif properties := schema.get("properties", {}):
-                for prop in ("pet", "type"):
-                    if "$ref" in properties.get(prop, {}):
-                        properties[prop]["ref"] = properties[prop].pop("$ref")
-            model["schema"] = schema
 
         snapshot.match("get-models", models)
 
@@ -605,3 +593,129 @@ class TestApiGatewayImportRestApi:
         # this fixture will iterate over every resource and match its method, methodResponse, integration and
         # integrationResponse
         apigw_snapshot_imported_resources(rest_api_id=rest_api_id, resources=response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.no_apigw_snap_transformers  # not using the API Gateway default transformers
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.resources.items..resourceMethods.POST",  # TODO: this is really weird, after importing, AWS returns them empty?
+        ]
+    )
+    def test_import_with_circular_models(
+        self, import_apigw, apigw_snapshot_imported_resources, aws_client, snapshot
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.jsonpath("$.import-api.id", value_replacement="rest-id"),
+                snapshot.transform.jsonpath(
+                    "$.resources.items..id", value_replacement="resource-id"
+                ),
+                snapshot.transform.jsonpath("$.get-models.items..id", value_replacement="model-id"),
+            ]
+        )
+        spec_file = load_file(OAS_30_CIRCULAR_REF)
+
+        response, root_id = import_apigw(body=spec_file, failOnWarnings=True)
+
+        snapshot.match("import-api", response)
+        rest_api_id = response["id"]
+
+        models = aws_client.apigateway.get_models(restApiId=rest_api_id)
+        models["items"] = sorted(models["items"], key=itemgetter("name"))
+
+        snapshot.match("get-models", models)
+
+        response = aws_client.apigateway.get_resources(restApiId=rest_api_id)
+        response["items"] = sorted(response["items"], key=itemgetter("path"))
+        snapshot.match("resources", response)
+
+        # this fixture will iterate over every resource and match its method, methodResponse, integration and
+        # integrationResponse
+        apigw_snapshot_imported_resources(rest_api_id=rest_api_id, resources=response)
+
+    @pytest.mark.no_apigw_snap_transformers  # not using the API Gateway default transformers
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.resources.items..resourceMethods.POST",
+            # TODO: this is really weird, after importing, AWS returns them empty?
+        ]
+    )
+    def test_import_with_circular_models_and_request_validation(
+        self, import_apigw, apigw_snapshot_imported_resources, aws_client, snapshot
+    ):
+        # manually add all transformers, as the default will mess up Model names and such
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.jsonpath("$.import-api.id", value_replacement="rest-id"),
+                snapshot.transform.jsonpath(
+                    "$.resources.items..id", value_replacement="resource-id"
+                ),
+                snapshot.transform.jsonpath("$.get-models.items..id", value_replacement="model-id"),
+                snapshot.transform.jsonpath(
+                    "$.request-validators.items..id", value_replacement="request-validator-id"
+                ),
+            ]
+        )
+        spec_file = load_file(OAS_30_CIRCULAR_REF_WITH_REQUEST_BODY)
+
+        response, root_id = import_apigw(body=spec_file, failOnWarnings=True)
+
+        snapshot.match("import-api", response)
+        rest_api_id = response["id"]
+
+        models = aws_client.apigateway.get_models(restApiId=rest_api_id)
+        models["items"] = sorted(models["items"], key=itemgetter("name"))
+
+        snapshot.match("get-models", models)
+
+        response = aws_client.apigateway.get_request_validators(restApiId=rest_api_id)
+        snapshot.match("request-validators", response)
+
+        response = aws_client.apigateway.get_resources(restApiId=rest_api_id)
+        response["items"] = sorted(response["items"], key=itemgetter("path"))
+        snapshot.match("resources", response)
+
+        # this fixture will iterate over every resource and match its method, methodResponse, integration and
+        # integrationResponse
+        apigw_snapshot_imported_resources(rest_api_id=rest_api_id, resources=response)
+
+        stage_name = "dev"
+        aws_client.apigateway.create_deployment(restApiId=rest_api_id, stageName=stage_name)
+
+        url = api_invoke_url(api_id=rest_api_id, stage=stage_name, path="/person")
+
+        request_data = {
+            "name": "Person1",
+            "b": 2,
+            "house": {
+                "randomProperty": "this is random",
+                "contains": [{"name": "Person2", "b": 3}],
+            },
+        }
+        if is_aws_cloud():
+            time.sleep(5)
+
+        request = requests.post(url, json=request_data)
+        assert request.ok
+        # we cannot make the body passthrough, because MOCK integrations don't allow to pass the body from the
+        # request to the response: https://stackoverflow.com/a/47945574/6998584
+        # the MOCK integration requestTemplate returns {"statusCode": 200}, but AWS does not pass it to $input.json('$')
+        # TODO: get parity with the MOCK integration
+
+        wrong_request = {"random": "blabla"}
+
+        request = requests.post(url, json=wrong_request)
+        assert request.status_code == 400
+        assert request.json() == {"message": "Invalid request body"}
+
+        wrong_request_schema = {
+            "name": "Person1",
+            "b": 2,
+            "house": {
+                "randomProperty": "this is random, but I follow House schema except for contains",
+                "contains": [{"randomObject": "I am not following Person schema"}],
+            },
+        }
+        request = requests.post(url, json=wrong_request_schema)
+        assert request.status_code == 400
+        assert request.json() == {"message": "Invalid request body"}

--- a/tests/integration/apigateway/test_apigateway_import.py
+++ b/tests/integration/apigateway/test_apigateway_import.py
@@ -11,6 +11,7 @@ from localstack import config
 from localstack.aws.api.apigateway import Resources
 from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.aws import arns
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -611,6 +612,7 @@ class TestApiGatewayImportRestApi:
                     "$.resources.items..id", value_replacement="resource-id"
                 ),
                 snapshot.transform.jsonpath("$.get-models.items..id", value_replacement="model-id"),
+                SortingTransformer("required"),
             ]
         )
         spec_file = load_file(OAS_30_CIRCULAR_REF)
@@ -654,6 +656,7 @@ class TestApiGatewayImportRestApi:
                 snapshot.transform.jsonpath(
                     "$.request-validators.items..id", value_replacement="request-validator-id"
                 ),
+                SortingTransformer("required"),
             ]
         )
         spec_file = load_file(OAS_30_CIRCULAR_REF_WITH_REQUEST_BODY)
@@ -706,7 +709,7 @@ class TestApiGatewayImportRestApi:
 
         request = requests.post(url, json=wrong_request)
         assert request.status_code == 400
-        assert request.json() == {"message": "Invalid request body"}
+        assert request.json().get("message") == "Invalid request body"
 
         wrong_request_schema = {
             "name": "Person1",
@@ -718,4 +721,4 @@ class TestApiGatewayImportRestApi:
         }
         request = requests.post(url, json=wrong_request_schema)
         assert request.status_code == 400
-        assert request.json() == {"message": "Invalid request body"}
+        assert request.json().get("message") == "Invalid request body"

--- a/tests/integration/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_import.snapshot.json
@@ -25,7 +25,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "recorded-date": "06-06-2023, 03:53:07",
+    "recorded-date": "07-06-2023, 03:24:26",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -79,15 +79,15 @@
             "id": "<model-id:2>",
             "name": "NewPet",
             "schema": {
+              "type": "object",
               "properties": {
-                "price": {
-                  "type": "number"
-                },
                 "type": {
                   "$ref": "<model-base-url>/restapis/<rest-id:1>/models/PetType"
+                },
+                "price": {
+                  "type": "number"
                 }
-              },
-              "type": "object"
+              }
             }
           },
           {
@@ -95,15 +95,15 @@
             "id": "<model-id:3>",
             "name": "NewPetResponse",
             "schema": {
+              "type": "object",
               "properties": {
-                "message": {
-                  "type": "string"
-                },
                 "pet": {
                   "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
+                },
+                "message": {
+                  "type": "string"
                 }
-              },
-              "type": "object"
+              }
             }
           },
           {
@@ -111,18 +111,18 @@
             "id": "<model-id:4>",
             "name": "Pet",
             "schema": {
+              "type": "object",
               "properties": {
                 "petid": {
                   "type": "integer"
                 },
-                "price": {
-                  "type": "number"
-                },
                 "type": {
                   "type": "string"
+                },
+                "price": {
+                  "type": "number"
                 }
-              },
-              "type": "object"
+              }
             }
           },
           {
@@ -130,14 +130,14 @@
             "id": "<model-id:5>",
             "name": "PetType",
             "schema": {
+              "type": "string",
               "enum": [
                 "dog",
                 "cat",
                 "fish",
                 "bird",
                 "gecko"
-              ],
-              "type": "string"
+              ]
             }
           },
           {
@@ -145,10 +145,10 @@
             "id": "<model-id:6>",
             "name": "Pets",
             "schema": {
+              "type": "array",
               "items": {
                 "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
-              },
-              "type": "array"
+              }
             }
           }
         ],
@@ -3939,7 +3939,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
-    "recorded-date": "06-06-2023, 00:26:37",
+    "recorded-date": "07-06-2023, 03:16:37",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "AUTHORIZER",
@@ -3952,7 +3952,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
-        "version": "2020-02-10",
+        "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -4171,7 +4171,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models": {
-    "recorded-date": "06-06-2023, 18:31:09",
+    "recorded-date": "07-06-2023, 02:26:07",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -4289,10 +4289,7 @@
           "integrationResponses": {
             "200": {
               "responseTemplates": {
-                "application/json": {
-                  "echo": "$input.body",
-                  "response": "mocked"
-                }
+                "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
               },
               "statusCode": "200"
             }
@@ -4339,10 +4336,7 @@
         "integrationResponses": {
           "200": {
             "responseTemplates": {
-              "application/json": {
-                "echo": "$input.body",
-                "response": "mocked"
-              }
+              "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
             },
             "statusCode": "200"
           }
@@ -4362,10 +4356,7 @@
       },
       "integration-response-person-post": {
         "responseTemplates": {
-          "application/json": {
-            "echo": "$input.body",
-            "response": "mocked"
-          }
+          "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
         },
         "statusCode": "200",
         "ResponseMetadata": {
@@ -4376,7 +4367,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models_and_request_validation": {
-    "recorded-date": "06-06-2023, 19:19:48",
+    "recorded-date": "07-06-2023, 02:25:28",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",

--- a/tests/integration/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_import.snapshot.json
@@ -84,7 +84,7 @@
                   "type": "number"
                 },
                 "type": {
-                  "ref": "<model-base-url>/restapis/<rest-id:1>/models/PetType"
+                  "$ref": "<model-base-url>/restapis/<rest-id:1>/models/PetType"
                 }
               },
               "type": "object"
@@ -100,7 +100,7 @@
                   "type": "string"
                 },
                 "pet": {
-                  "ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
+                  "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
                 }
               },
               "type": "object"
@@ -146,7 +146,7 @@
             "name": "Pets",
             "schema": {
               "items": {
-                "ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
+                "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
               },
               "type": "array"
             }
@@ -4162,6 +4162,422 @@
         }
       },
       "integration-response-pets-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models": {
+    "recorded-date": "06-06-2023, 18:31:09",
+    "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<rest-id:1>",
+        "name": "Circular model reference",
+        "version": "1.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-models": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "id": "<model-id:1>",
+            "name": "Empty",
+            "schema": {
+              "title": "Empty Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "Where a Person can live",
+            "id": "<model-id:2>",
+            "name": "House",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "randomProperty": {
+                  "type": "string",
+                  "description": "Random property",
+                  "format": "byte"
+                },
+                "contains": {
+                  "minItems": 1,
+                  "type": "array",
+                  "description": "The information of who is living in the house",
+                  "items": {
+                    "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Person"
+                  }
+                }
+              },
+              "description": "Where a Person can live"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "Random person schema.",
+            "id": "<model-id:3>",
+            "name": "Person",
+            "schema": {
+              "required": [
+                "b",
+                "name"
+              ],
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Random property"
+                },
+                "b": {
+                  "type": "number"
+                },
+                "house": {
+                  "$ref": "<model-base-url>/restapis/<rest-id:1>/models/House"
+                }
+              },
+              "description": "Random person schema."
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "resources": {
+        "items": [
+          {
+            "id": "<resource-id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<resource-id:2>",
+            "parentId": "<resource-id:1>",
+            "path": "/person",
+            "pathPart": "person",
+            "resourceMethods": {
+              "POST": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-person-post": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:2>",
+          "integrationResponses": {
+            "200": {
+              "responseTemplates": {
+                "application/json": {
+                  "echo": "$input.body",
+                  "response": "mocked"
+                }
+              },
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_TEMPLATES",
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "statusCode": "200"
+          }
+        },
+        "operationName": "CreatePerson",
+        "requestModels": {
+          "application/json": "Person"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-person-post": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-person-post": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:2>",
+        "integrationResponses": {
+          "200": {
+            "responseTemplates": {
+              "application/json": {
+                "echo": "$input.body",
+                "response": "mocked"
+              }
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_TEMPLATES",
+        "requestTemplates": {
+          "application/json": {
+            "statusCode": 200
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-person-post": {
+        "responseTemplates": {
+          "application/json": {
+            "echo": "$input.body",
+            "response": "mocked"
+          }
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models_and_request_validation": {
+    "recorded-date": "06-06-2023, 19:19:48",
+    "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<rest-id:1>",
+        "name": "Circular model reference",
+        "version": "1.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-models": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "id": "<model-id:1>",
+            "name": "Empty",
+            "schema": {
+              "title": "Empty Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "Where a Person can live",
+            "id": "<model-id:2>",
+            "name": "House",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "randomProperty": {
+                  "type": "string",
+                  "description": "Random property",
+                  "format": "byte"
+                },
+                "contains": {
+                  "minItems": 1,
+                  "type": "array",
+                  "description": "The information of who is living in the house",
+                  "items": {
+                    "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Person"
+                  }
+                }
+              },
+              "description": "Where a Person can live"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "Random person schema.",
+            "id": "<model-id:3>",
+            "name": "Person",
+            "schema": {
+              "required": [
+                "b",
+                "name"
+              ],
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Random property"
+                },
+                "b": {
+                  "type": "number"
+                },
+                "house": {
+                  "$ref": "<model-base-url>/restapis/<rest-id:1>/models/House"
+                }
+              },
+              "description": "Random person schema."
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "request-validators": {
+        "items": [
+          {
+            "id": "<request-validator-id:1>",
+            "name": "basic",
+            "validateRequestBody": true,
+            "validateRequestParameters": true
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "resources": {
+        "items": [
+          {
+            "id": "<resource-id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<resource-id:2>",
+            "parentId": "<resource-id:1>",
+            "path": "/person",
+            "pathPart": "person",
+            "resourceMethods": {
+              "POST": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-person-post": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<resource-id:2>",
+          "integrationResponses": {
+            "200": {
+              "responseTemplates": {
+                "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
+              },
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_TEMPLATES",
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "statusCode": "200"
+          }
+        },
+        "operationName": "CreatePerson",
+        "requestModels": {
+          "application/json": "Person"
+        },
+        "requestValidatorId": "<request-validator-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-person-post": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-person-post": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<resource-id:2>",
+        "integrationResponses": {
+          "200": {
+            "responseTemplates": {
+              "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_TEMPLATES",
+        "requestTemplates": {
+          "application/json": {
+            "statusCode": 200
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-person-post": {
+        "responseTemplates": {
+          "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
+        },
         "statusCode": "200",
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_import.snapshot.json
@@ -25,7 +25,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "recorded-date": "03-06-2023, 13:22:31",
+    "recorded-date": "06-06-2023, 03:53:07",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -84,7 +84,7 @@
                   "type": "number"
                 },
                 "type": {
-                  "ref": "https://apigateway.amazonaws.com/restapis/<rest-id:1>/models/PetType"
+                  "ref": "<model-base-url>/restapis/<rest-id:1>/models/PetType"
                 }
               },
               "type": "object"
@@ -100,7 +100,7 @@
                   "type": "string"
                 },
                 "pet": {
-                  "ref": "https://apigateway.amazonaws.com/restapis/<rest-id:1>/models/Pet"
+                  "ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
                 }
               },
               "type": "object"
@@ -146,7 +146,7 @@
             "name": "Pets",
             "schema": {
               "items": {
-                "ref": "https://apigateway.amazonaws.com/restapis/<rest-id:1>/models/Pet"
+                "ref": "<model-base-url>/restapis/<rest-id:1>/models/Pet"
               },
               "type": "array"
             }

--- a/tests/integration/files/openapi.spec.circular-ref-with-request-body.json
+++ b/tests/integration/files/openapi.spec.circular-ref-with-request-body.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Circular model reference",
+    "version": "1.0"
+  },
+  "x-amazon-apigateway-request-validators" : {
+    "basic": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true
+    }
+  },
+  "x-amazon-apigateway-request-validator" : "basic",
+  "paths": {
+    "/person": {
+      "post": {
+        "description": "Create a Person",
+        "operationId": "CreatePerson",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseTemplates": {
+                "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_templates"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "type": "object",
+        "description": "Random person schema.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Random property"
+          },
+          "b": {
+            "type": "number"
+          },
+          "house": {
+            "$ref": "#/components/schemas/House"
+          }
+        },
+        "required": ["name", "b"]
+      },
+      "House": {
+        "type": "object",
+        "description": "Where a Person can live",
+        "properties": {
+          "randomProperty": {
+            "type": "string",
+            "description": "Random property",
+            "format": "byte"
+          },
+          "contains": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "minItems": 1,
+            "description": "The information of who is living in the house"
+          }
+        }
+      },
+      "Empty": {
+        "title": "Empty Schema",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/tests/integration/files/openapi.spec.circular-ref.json
+++ b/tests/integration/files/openapi.spec.circular-ref.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Circular model reference",
+    "version": "1.0"
+  },
+  "paths": {
+    "/person": {
+      "post": {
+        "description": "Create a Person",
+        "operationId": "CreatePerson",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseTemplates": {
+                "application/json": "{\"echo\": $input.json('$'), \"response\": \"mocked\"}"
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_templates"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "type": "object",
+        "description": "Random person schema.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Random property"
+          },
+          "b": {
+            "type": "number"
+          },
+          "house": {
+            "$ref": "#/components/schemas/House"
+          }
+        },
+        "required": ["name", "b"]
+      },
+      "House": {
+        "type": "object",
+        "description": "Where a Person can live",
+        "properties": {
+          "randomProperty": {
+            "type": "string",
+            "description": "Random property",
+            "format": "byte"
+          },
+          "contains": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "minItems": 1,
+            "description": "The information of who is living in the house"
+          }
+        }
+      },
+      "Empty": {
+        "title": "Empty Schema",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/tests/integration/files/openapi.spec.global-auth.json
+++ b/tests/integration/files/openapi.spec.global-auth.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "title": "Fulfillment OS Gateway",
-    "version": "2020-02-10"
+    "title": "Test Global Authorizer",
+    "version": "1.0"
   },
   "paths": {
     "/pets": {

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -9,8 +9,8 @@ import pytest
 from localstack import config
 from localstack.constants import APPLICATION_JSON, DEFAULT_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.apigateway.helpers import (
+    OpenAPISpecificationResolver,
     RequestParametersResolver,
-    Resolver,
     apply_json_patch_safe,
     create_invocation_headers,
     extract_path_params,
@@ -451,14 +451,14 @@ def test_openapi_resolver_given_unresolvable_references():
         "schema": {"$ref": "#/definitions/NotFound"},
         "definitions": {"Found": {"type": "string"}},
     }
-    resolver = Resolver(document, allow_recursive=True, rest_api_id="123")
+    resolver = OpenAPISpecificationResolver(document, allow_recursive=True, rest_api_id="123")
     result = resolver.resolve_references()
     assert result == {"schema": None, "definitions": {"Found": {"type": "string"}}}
 
 
 def test_openapi_resolver_given_invalid_references():
     document = {"schema": {"$ref": ""}, "definitions": {"Found": {"type": "string"}}}
-    resolver = Resolver(document, allow_recursive=True, rest_api_id="123")
+    resolver = OpenAPISpecificationResolver(document, allow_recursive=True, rest_api_id="123")
     result = resolver.resolve_references()
     assert result == {"schema": None, "definitions": {"Found": {"type": "string"}}}
 
@@ -469,7 +469,7 @@ def test_openapi_resolver_given_schema_list_references():
         "schema": {"$ref": "#/definitions/Found"},
         "definitions": {"Found": {"value": ["v1", "v2"]}},
     }
-    resolver = Resolver(document, allow_recursive=True, rest_api_id="123")
+    resolver = OpenAPISpecificationResolver(document, allow_recursive=True, rest_api_id="123")
     result = resolver.resolve_references()
     assert result == document
 
@@ -479,7 +479,7 @@ def test_openapi_resolver_given_list_references():
         "responses": {"$ref": "#/definitions/ResponsePost"},
         "definitions": {"ResponsePost": {"value": ["v1", "v2"]}},
     }
-    resolver = Resolver(document, allow_recursive=True, rest_api_id="123")
+    resolver = OpenAPISpecificationResolver(document, allow_recursive=True, rest_api_id="123")
     result = resolver.resolve_references()
     assert result == {
         "responses": {"value": ["v1", "v2"]},

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -129,7 +129,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
         )
         ctx.account_id = DEFAULT_AWS_ACCOUNT_ID
         ctx.region_name = TEST_AWS_REGION_NAME
-        validator = RequestValidator(ctx, self._mock_store())
+        validator = RequestValidator(ctx, Mock())
         self.assertTrue(validator.is_request_valid())
 
     def test_if_request_is_valid_with_no_matching_method(self):
@@ -142,7 +142,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
         ctx.resource = {"resourceMethods": {"GET": {}}}
         ctx.account_id = DEFAULT_AWS_ACCOUNT_ID
         ctx.region_name = TEST_AWS_REGION_NAME
-        validator = RequestValidator(ctx, self._mock_store())
+        validator = RequestValidator(ctx, Mock())
         self.assertTrue(validator.is_request_valid())
 
     def test_if_request_is_valid_with_no_validator(self):
@@ -157,7 +157,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
         ctx.region_name = TEST_AWS_REGION_NAME
         ctx.api_id = "deadbeef"
         ctx.resource = {"resourceMethods": {"POST": {"requestValidatorId": " "}}}
-        validator = RequestValidator(ctx, self._mock_store())
+        validator = RequestValidator(ctx, Mock())
         self.assertTrue(validator.is_request_valid())
 
     def test_if_request_has_body_validator(self):


### PR DESCRIPTION
Changes made to avoid circular references in `Model` containing references to itself, which can happen easily.

Example: A Person contains a `children` property, which is a collection of `Person`. After resolving the models, it will fail to be serialised to JSON because it contains circular references. Or a container which contains an object with a reference to its container. 

AWS solves this issue by storing the template with its absolute reference[[1]](https://json-schema.org/understanding-json-schema/structuring.html#retrieval-uri)[[2]](https://stackoverflow.com/questions/37823112/how-do-i-reference-one-model-from-another-model-using-aws-api-gateway). It might be stored fully resolved server-side, or might be resolved when actually validating the template. ~Still WIP, so I'll see how I do this, this is only the importer phase now, next step is to properly read those schema when validating.~

This PR also implements `RequestValidator` when importing ([see here](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html)), and support for `requestBody` property in `Method` for OpenAPI 3.0 ([see here](https://swagger.io/specification/v3/#request-body-object))


### Example:
```json
{
  "Person": {
    "type": "object",
    "description": "Random person schema.",
    "properties": {
      "randomProperty": {
        "type": "string",
        "description": "Random property",
        "format": "byte"
      },
      "container": {
        "$ref": "#/components/schemas/House"
      }
    }
  },
  "House": {
    "type": "object",
    "description": "Where Person can live",
    "properties": {
      "randomProperty": {
        "type": "string",
        "description": "Random property",
        "format": "byte"
      },
      "contains": {
        "type": "array",
        "items": {
          "$ref": "#/components/schemas/Person"
        },
        "minItems": 1,
        "description": "The information of who is living in the house"
      }
    }
  }
}
```
Once resolved before, it would have lead to `House` having a reference to `Person` and `Person` having a reference to `House`. These 2 models could be part of a bigger model, thus being in the same dictionary and make it non-serializable.

From this example, we want our Model to be able to be used to validate incoming requests. First, it will be resolved like AWS, with absolute paths. We will replace the relative `$ref` part with an absolute link to it, `$ref: "http://apigateway.{localstackhost}/restapis/{apiId}/models/{ModelName}`. This allows us to safely JSON dump them, avoiding circular references.

Now, the real issue comes when using those Model. We need to be able to resolve them.
The key is to use some tricks from JSON Schema, namely recursive[[3]](https://json-schema.org/understanding-json-schema/structuring.html#recursion) and `$defs` [[4]](https://json-schema.org/understanding-json-schema/structuring.html#defs). 
This will allow use to get our Model schema, and all `$ref` inside will be resolved and put into a `$defs` field.
We will recursively resolve all models and put them into `$defs`, even transitive ones. If we spot a `$ref` to our Model, to avoid infinite looping, we will replace its `$ref` with `#`, signifying to JSON schema that it references its own model. 

That's basically the gist of it. The PR validates that, changes a bit our schema Resolver, and adds a new `ModelResolver` before validating a request, and that resolved model would be cached in our store (also with the benefit of not `json.loads` every time). 

### What it gives:
Starting with those 2 schemas:
```json
"schemas": {
  "Person": {
    "type": "object",
    "description": "Random person schema.",
    "properties": {
      "name": {
        "type": "string",
        "description": "Random property"
      },
      "b": {
        "type": "number"
      },
      "house": {
        "$ref": "#/components/schemas/House"
      }
    },
    "required": ["name", "b"]
  },
  "House": {
    "type": "object",
    "description": "Where a Person can live",
    "properties": {
      "randomProperty": {
        "type": "string",
        "description": "Random property",
        "format": "byte"
      },
      "contains": {
        "type": "array",
        "items": {
          "$ref": "#/components/schemas/Person"
        },
        "minItems": 1,
        "description": "The information of who is living in the house"
      }
    }
  }
}
```
We then resolve them and store them as `Model` with absolute paths (from the snapshot):
```json
[
  {
    "contentType": "application/json",
    "description": "Where a Person can live",
    "id": "<model-id:2>",
    "name": "House",
    "schema": {
      "type": "object",
      "properties": {
        "randomProperty": {
          "type": "string",
          "description": "Random property",
          "format": "byte"
        },
        "contains": {
          "minItems": 1,
          "type": "array",
          "description": "The information of who is living in the house",
          "items": {
            "$ref": "<model-base-url>/restapis/<rest-id:1>/models/Person"
          }
        }
      },
      "description": "Where a Person can live"
    }
  },
  {
    "contentType": "application/json",
    "description": "Random person schema.",
    "id": "<model-id:3>",
    "name": "Person",
    "schema": {
      "required": [
        "b",
        "name"
      ],
      "type": "object",
      "properties": {
        "name": {
          "type": "string",
          "description": "Random property"
        },
        "b": {
          "type": "number"
        },
        "house": {
          "$ref": "<model-base-url>/restapis/<rest-id:1>/models/House"
        }
      },
      "description": "Random person schema."
    }
  }
]
```

And once we want to use them to validate our request, this is the `Person` schema, using `House` for one of its field:
It's a valid schema, as we can attest [here](https://www.jsonschemavalidator.net/s/xCgryAyF)
```json
{
  "type": "object",
  "description": "Random person schema.",
  "properties": {
    "name": {
      "type": "string",
      "description": "Random property"
    },
    "b": {
      "type": "number"
    },
    "house": {
      "$ref": "#/$defs/House"
    }
  },
  "required": [
    "name",
    "b"
  ],
  "$defs": {
    "House": {
      "type": "object",
      "description": "Where a Person can live",
      "properties": {
        "randomProperty": {
          "type": "string",
          "description": "Random property",
          "format": "byte"
        },
        "contains": {
          "type": "array",
          "items": {
            "$ref": "#"
          },
          "minItems": 1,
          "description": "The information of who is living in the house"
        }
      }
    }
  }
}
```

### Notes
- [[1] https://json-schema.org/understanding-json-schema/structuring.html#retrieval-uri)](https://json-schema.org/understanding-json-schema/structuring.html#retrieval-uri) 
- [[2] https://stackoverflow.com/questions/37823112/how-do-i-reference-one-model-from-another-model-using-aws-api-gateway](https://stackoverflow.com/questions/37823112/how-do-i-reference-one-model-from-another-model-using-aws-api-gateway)
- [[3] https://json-schema.org/understanding-json-schema/structuring.html#recursion](https://json-schema.org/understanding-json-schema/structuring.html#recursion)
- [[4] https://json-schema.org/understanding-json-schema/structuring.html#defs](https://json-schema.org/understanding-json-schema/structuring.html#defs)
