### PR TITLE
Add Lambda Docker DNS configuration

### DIFF
--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -273,6 +273,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             network=network,
             entrypoint=RAPID_ENTRYPOINT,
             platform=docker_platform(self.function_version.config.architectures[0]),
+            dns=config.LAMBDA_DOCKER_DNS,
             additional_flags=config.LAMBDA_DOCKER_FLAGS,
         )
         if self.function_version.config.package_type == PackageType.Zip:


### PR DESCRIPTION
Addresses https://github.com/localstack/localstack/issues/7539

This PR re-introduces the `LAMBDA_DOCKER_DNS` configuration previously supported in the [old lambda provider](https://docs.localstack.cloud/references/configuration/#lambda-legacy).
This optional configuration sets a DNS server for the container running your lambda function. `LAMBDA_DOCKER_DNS` takes precedence over [transparent endpoint injection](https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/dns-server/) when using LocalStack Pro. A warning message informs pro users.

Depends on ext companion PR to selectively disable transparent endpoint injection: https://github.com/localstack/localstack-ext/pull/1758

# Testing

The following scenarios are tested:
- [x] community with `LAMBDA_DOCKER_DNS`
- [x] community without `LAMBDA_DOCKER_DNS`
- [x] pro with `LAMBDA_DOCKER_DNS` (disables transparent endpoint injection)
- [x] pro without `LAMBDA_DOCKER_DNS` (transparent endpoint injection still works)
- [x] pro with `LAMBDA_DOCKER_DNS` set to the LocalStack gateway and `DNS_SERVER` set to the host gateway (i.e., what `host.docker.internal` resolves to; e.g., `192.168.65.254`) and a custom local DNS server running. This leads to the following DNS chain: Lambda code => Docker custom DNS `127.0.0.11` => LocalStack DNS => Upstream DNS

Tested against Docker (locally built) with a Python Lambda function that performs a DNS lookup and uses transparent endpoint injection:

```python
import json
import os

import boto3
from nslookup import Nslookup


def handler(event, context):
    localstack_hostname = os.getenv('LOCALSTACK_HOSTNAME')
    print(f"{localstack_hostname=}")

    # Test custom DNS resolution
    # domain = "aws.amazon.com"
    # domain = "amazonaws.com"
    # domain = "s3.aws.amazon.com"
    domain = "lambda.us-east-1.amazonaws.com"
    dns_query = Nslookup()
    ips_record = dns_query.dns_lookup(domain)
    print(f"Lookup {domain=}")
    print(ips_record.response_full, ips_record.answer)

    # Test transparent endpoint injection
    client = boto3.client('lambda')
    account_settings = client.get_account_settings()
    print(account_settings)

    return {
        "statusCode": 200,
        "body": json.dumps({
            "message": f"{localstack_hostname=}",
        }),
    }
```