### PR TITLE
Use new clients in lambda event source mappings

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/dynamodb_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/dynamodb_event_source_listener.py
@@ -25,8 +25,10 @@ class DynamoDBEventSourceListener(StreamEventSourceListener):
         event_sources = self._invoke_adapter.get_event_sources(source_arn=r".*:dynamodb:.*")
         return [source for source in event_sources if source["State"] == "Enabled"]
 
-    def _get_stream_client(self, region_name):
-        return aws_stack.connect_to_service("dynamodbstreams", region_name=region_name)
+    def _get_stream_client(self, function_arn: str, region_name: str):
+        return self._invoke_adapter.get_client_factory(
+            function_arn=function_arn, region_name=region_name
+        ).dynamodbstreams.request_metadata(source_arn=function_arn)
 
     def _get_stream_description(self, stream_client, stream_arn):
         return stream_client.describe_stream(StreamArn=stream_arn)["StreamDescription"]

--- a/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
@@ -268,7 +268,6 @@ class StreamEventSourceListener(EventSourceListener):
                         num_invocation_failures = 0
                 time.sleep(self._POLL_INTERVAL_SEC)
         except Exception as e:
-            #
             LOG.error(
                 "Error while listening to shard / executing lambda with params %s: %s",
                 params,

--- a/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
@@ -59,7 +59,7 @@ class StreamEventSourceListener(EventSourceListener):
         """
         raise NotImplementedError
 
-    def _get_stream_client(self, region_name: str):
+    def _get_stream_client(self, function_arn: str, region_name: str):
         """
         to be implemented by subclasses
         :returns: An AWS service client instance for communicating with the appropriate API
@@ -332,7 +332,7 @@ class StreamEventSourceListener(EventSourceListener):
                     mapping_uuid = source["UUID"]
                     stream_arn = source["EventSourceArn"]
                     region_name = extract_region_from_arn(stream_arn)
-                    stream_client = self._get_stream_client(region_name)
+                    stream_client = self._get_stream_client(source["FunctionArn"], region_name)
                     batch_size = source.get("BatchSize", 10)
                     failure_destination = (
                         source.get("DestinationConfig", {})

--- a/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
@@ -3,6 +3,8 @@ import math
 import time
 from typing import Dict, List, Optional, Tuple
 
+from botocore.exceptions import ClientError
+
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.services.awslambda.event_source_listeners.adapters import (
     EventSourceAdapter,
@@ -198,63 +200,75 @@ class StreamEventSourceListener(EventSourceListener):
             num_invocation_failures = 0
 
             while lock_discriminator in self._STREAM_LISTENER_THREADS:
-                records_response = stream_client.get_records(
-                    ShardIterator=shard_iterator, Limit=batch_size
-                )
-                records = records_response.get("Records")
-                event_filter_criterias = self._get_lambda_event_filters_for_arn(
-                    function_arn, stream_arn
-                )
-                if len(event_filter_criterias) > 0:
-                    records = filter_stream_records(records, event_filter_criterias)
-
-                should_get_next_batch = True
-                if records:
-                    payload = self._create_lambda_event_payload(
-                        stream_arn, records, shard_id=shard_id
+                try:
+                    records_response = stream_client.get_records(
+                        ShardIterator=shard_iterator, Limit=batch_size
                     )
-                    is_invocation_successful, status_code = self._invoke_lambda(
-                        function_arn, payload, lock_discriminator, parallelization_factor
-                    )
-                    if is_invocation_successful:
-                        should_get_next_batch = True
+                except ClientError as e:
+                    if "AccessDeniedException" in str(e):
+                        LOG.warning(
+                            "Insufficient permissions to get records from stream %s: %s",
+                            stream_arn,
+                            e,
+                        )
                     else:
-                        num_invocation_failures += 1
-                        if num_invocation_failures >= max_num_retries:
+                        raise
+                else:
+                    records = records_response.get("Records")
+                    event_filter_criterias = self._get_lambda_event_filters_for_arn(
+                        function_arn, stream_arn
+                    )
+                    if len(event_filter_criterias) > 0:
+                        records = filter_stream_records(records, event_filter_criterias)
+
+                    should_get_next_batch = True
+                    if records:
+                        payload = self._create_lambda_event_payload(
+                            stream_arn, records, shard_id=shard_id
+                        )
+                        is_invocation_successful, status_code = self._invoke_lambda(
+                            function_arn, payload, lock_discriminator, parallelization_factor
+                        )
+                        if is_invocation_successful:
                             should_get_next_batch = True
-                            if failure_destination:
-                                first_rec = records[0]
-                                last_rec = records[-1]
-                                (
-                                    first_seq_num,
-                                    last_seq_num,
-                                ) = self._get_starting_and_ending_sequence_numbers(
-                                    first_rec, last_rec
-                                )
-                                (
-                                    first_arrival_time,
-                                    last_arrival_time,
-                                ) = self._get_first_and_last_arrival_time(first_rec, last_rec)
-                                self._send_to_failure_destination(
-                                    shard_id,
-                                    first_seq_num,
-                                    last_seq_num,
-                                    stream_arn,
-                                    function_arn,
-                                    num_invocation_failures,
-                                    status_code,
-                                    batch_size,
-                                    first_arrival_time,
-                                    last_arrival_time,
-                                    failure_destination,
-                                )
                         else:
-                            should_get_next_batch = False
-                if should_get_next_batch:
-                    shard_iterator = records_response["NextShardIterator"]
-                    num_invocation_failures = 0
+                            num_invocation_failures += 1
+                            if num_invocation_failures >= max_num_retries:
+                                should_get_next_batch = True
+                                if failure_destination:
+                                    first_rec = records[0]
+                                    last_rec = records[-1]
+                                    (
+                                        first_seq_num,
+                                        last_seq_num,
+                                    ) = self._get_starting_and_ending_sequence_numbers(
+                                        first_rec, last_rec
+                                    )
+                                    (
+                                        first_arrival_time,
+                                        last_arrival_time,
+                                    ) = self._get_first_and_last_arrival_time(first_rec, last_rec)
+                                    self._send_to_failure_destination(
+                                        shard_id,
+                                        first_seq_num,
+                                        last_seq_num,
+                                        stream_arn,
+                                        function_arn,
+                                        num_invocation_failures,
+                                        status_code,
+                                        batch_size,
+                                        first_arrival_time,
+                                        last_arrival_time,
+                                        failure_destination,
+                                    )
+                            else:
+                                should_get_next_batch = False
+                    if should_get_next_batch:
+                        shard_iterator = records_response["NextShardIterator"]
+                        num_invocation_failures = 0
                 time.sleep(self._POLL_INTERVAL_SEC)
         except Exception as e:
+            #
             LOG.error(
                 "Error while listening to shard / executing lambda with params %s: %s",
                 params,

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -656,7 +656,7 @@ def wait_for_stream_ready(aws_client):
                 "UPDATING",
             ]
 
-        poll_condition(is_stream_ready)
+        return poll_condition(is_stream_ready)
 
     return _wait_for_stream_ready
 


### PR DESCRIPTION
## Motivation
To provide IAM enforcement, we have to use the new clients, with the execution role assumed, for the event source mapping operations.

## Changes
* Use Adapters to get the right clients for the operation
* Migrate to new client factory
* Consolidate `wait_for_dynamodb_stream_ready` fixtures
* Handle failure for get_records operation in the streams event source listener separately, to avoid crashing the whole thread