### PR TITLE
Verify AssumeRolePolicyDocument is valid json

### DIFF
--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -269,7 +269,7 @@ class IAMRole(GenericBaseModel):
                 client.delete_role(RoleName=_states.get("RoleName"))
                 role = client.create_role(
                     RoleName=props.get("RoleName"),
-                    AssumeRolePolicyDocument=str(props_policy),
+                    AssumeRolePolicyDocument=json.dumps(props_policy),
                 )
                 IAMRole._post_create(resource_id, resources, None, None, None)
                 return role["Role"]

--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -28,6 +28,7 @@ from localstack.aws.api.iam import (
     IamApi,
     ListInstanceProfileTagsResponse,
     ListRolesResponse,
+    MalformedPolicyDocumentException,
     NoSuchEntityException,
     PolicyEvaluationDecisionType,
     ResourceHandlingOptionType,
@@ -101,6 +102,10 @@ class IamProvider(IamApi):
     def create_role(
         self, context: RequestContext, request: CreateRoleRequest
     ) -> CreateRoleResponse:
+        try:
+            json.loads(request["AssumeRolePolicyDocument"])
+        except json.JSONDecodeError:
+            raise MalformedPolicyDocumentException("This policy contains invalid Json")
         result = call_moto(context)
 
         if not request.get("MaxSessionDuration") and result["Role"].get("MaxSessionDuration"):

--- a/tests/integration/test_iam.snapshot.json
+++ b/tests/integration/test_iam.snapshot.json
@@ -38,5 +38,21 @@
         }
       }
     }
+  },
+  "tests/integration/test_iam.py::TestIAMExtensions::test_create_role_with_malformed_assume_role_policy_document": {
+    "recorded-date": "07-06-2023, 15:25:23",
+    "recorded-content": {
+      "invalid-json": {
+        "Error": {
+          "Code": "MalformedPolicyDocument",
+          "Message": "This policy contains invalid Json",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
If the AssumeRolePolicyDocument is not valid json, we have problems later with IAM enforcement, as it breaks the interface contract of the STS IAM plugin.

## Changes
* Verify the AssumeRolePolicyDocument actually being valid json by trying to decode it
* AWS validated test for this behavior