### PR TITLE
fix SNS SignatureVersion for Topic and validate Subscription attributes when set a creation

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -387,7 +387,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store = self.get_store(account_id=context.account_id, region_name=context.region)
         sub = store.subscriptions.get(subscription_arn)
         if not sub:
-            raise NotFoundException(f"Subscription with arn {subscription_arn} not found")
+            raise NotFoundException("Subscription does not exist")
         removed_attrs = ["sqs_queue_url"]
         if "FilterPolicyScope" in sub and "FilterPolicy" not in sub:
             removed_attrs.append("FilterPolicyScope")

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -120,13 +120,19 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 raise NotFoundException("Topic does not exist")
             raise
         # TODO: fix some attributes by moto, see snapshot
+        # DeliveryPolicy
+        # EffectiveDeliveryPolicy
+        # Policy.Statement..Action -> SNS:Receive is added by moto but not returned in AWS
         # TODO: very hacky way to get the attributes we need instead of a moto patch
+        # see the attributes we need: https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html
         # would need more work to have the proper format out of moto, maybe extract the model to our store
         moto_topic_model = self._get_topic(topic_arn, context)
         for attr in vars(moto_topic_model):
             if "success_feedback" in attr:
                 key = camelcase_to_pascal(underscores_to_camelcase(attr))
                 moto_response["Attributes"][key] = getattr(moto_topic_model, attr)
+            elif attr == "signature_version":
+                moto_response["Attributes"]["SignatureVersion"] = moto_topic_model.signature_version
         return moto_response
 
     def publish_batch(
@@ -696,7 +702,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             )
         if tags:
             self.tag_resource(context=context, resource_arn=topic_arn, tags=tags)
-        store.topic_subscriptions[topic_arn] = store.topic_subscriptions.get(topic_arn) or []
+        store.topic_subscriptions.setdefault(topic_arn, [])
         return CreateTopicResponse(TopicArn=topic_arn)
 
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -273,14 +273,10 @@ class TestSNSProvider:
         )
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="RawMessageDelivery",
-            AttributeValue="true",
+        subscription = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_url, Attributes={"RawMessageDelivery": "true"}
         )
+        subscription_arn = subscription["SubscriptionArn"]
 
         response_attributes = aws_client.sns.get_subscription_attributes(
             SubscriptionArn=subscription_arn

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -197,7 +197,6 @@ class TestSNSProvider:
         snapshot.match("empty-unsubscribe", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$.get-topic-attrs.Attributes.DeliveryPolicy",

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -4045,5 +4045,84 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_create_topic_with_attributes": {
+    "recorded-date": "07-06-2023, 18:34:51",
+    "recorded-content": {
+      "get-topic-attrs": {
+        "Attributes": {
+          "ContentBasedDeduplication": "false",
+          "DisplayName": "TestTopic",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "FifoTopic": "true",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SignatureVersion": "2",
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs-nonexistent-topic": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Topic does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -4005,5 +4005,45 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_create_subscriptions_with_attributes": {
+    "recorded-date": "07-06-2023, 18:27:05",
+    "recorded-content": {
+      "subscribe": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs-nonexistent-sub": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Subscription does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR will fix #8415, and validate that #8441 has been fixed since 1.4. 

We needed to retrieve the attribute from moto, because moto is hardcoding what attributes it returns, and is not dynamic. 
Added bit of parity, but this is a small fix.