### PR TITLE
Fix defaulting to privileged=true if additional flags are provided

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -1094,11 +1094,11 @@ class Util:
             )
             platform = args.platform
 
-        if args.privileged is not None:
+        if args.privileged:
             LOG.warning(
                 f"Overwriting Docker container privileged flag {privileged} with new value {args.privileged}"
             )
-            privileged = True
+            privileged = args.privileged
 
         if args.publish_ports:
             for port_mapping in args.publish_ports:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -186,6 +186,9 @@ class TestArgumentParsing:
         argument_string = r"--privileged"
         flags = Util.parse_additional_flags(argument_string)
         assert flags.privileged
+        argument_string = ""
+        flags = Util.parse_additional_flags(argument_string)
+        assert not flags.privileged
 
     def test_ulimits(self):
         argument_string = r"--ulimit nofile=1024"


### PR DESCRIPTION
## Motivation
Currently, if additional flags like `LAMBDA_DOCKER_FLAGS` are provided at all, privileged is set to true for docker containers. This is not only dangerous, but also problematic in restricted docker environments, e.g. bitbucket.

Fixes #8460.

## Changes
* Fixes argparser always adding privileged=True. The cause of this was the argparser setting the privileged flag to true or false, never None, even if not provided. This is expected behavior for the "store_true" action.
* Add test to check if privileged flags are indeed false for an empty string as argument string. This test extension would have caught the issue.