### PR TITLE
CFn: add error reasons and tidy error message on stack deploy failure

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1480,6 +1480,25 @@ class TemplateDeployer:
                         e,
                     )
                     j += 1
+                except Exception as e:
+                    status_action = {
+                        "Add": "CREATE",
+                        "Modify": "UPDATE",
+                        "Dynamic": "UPDATE",
+                        "Remove": "DELETE",
+                    }[action]
+                    stack.add_stack_event(
+                        resource_id=resource_id,
+                        # TODO
+                        physical_res_id=new_resources[resource_id].get("PhysicalResourceId"),
+                        status=f"{status_action}_FAILED",
+                        status_reason=str(e),
+                    )
+                    if config.CFN_VERBOSE_ERRORS:
+                        LOG.exception(
+                            f"Failed to deploy resource {resource_id}, stack deploy failed"
+                        )
+                    raise
             if not changes:
                 break
             if not updated:

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -41,7 +41,7 @@ from localstack.utils.aws.resources import create_dynamodb_table
 from localstack.utils.collections import ensure_list
 from localstack.utils.functions import run_safe
 from localstack.utils.http import safe_requests as requests
-from localstack.utils.json import json_safe
+from localstack.utils.json import CustomEncoder, json_safe
 from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import ShortCircuitWaitException, poll_condition, retry, wait_until
@@ -935,8 +935,26 @@ class StackDeployError(Exception):
         self.describe_result = describe_res
         self.events = events
         super().__init__(
-            f"Stack deploy failed - describe output: {self.describe_result} events: {self.events}"
+            f"Describe output:\n{json.dumps(self.describe_result, cls=CustomEncoder)}\nEvents:\n{self.format_events(events)}"
         )
+
+    def format_events(self, events: list[dict]) -> str:
+        event_details = (
+            json.dumps(
+                {
+                    key: event.get(key)
+                    for key in [
+                        "LogicalResourceId",
+                        "ResourceType",
+                        "ResourceStatus",
+                        "ResourceStatusReason",
+                    ]
+                },
+                cls=CustomEncoder,
+            )
+            for event in events
+        )
+        return "\n".join(event_details)
 
 
 @pytest.fixture

--- a/tests/integration/cloudformation/test_template_engine.snapshot.json
+++ b/tests/integration/cloudformation/test_template_engine.snapshot.json
@@ -580,5 +580,24 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/test_template_engine.py::TestStackEvents::test_invalid_stack_deploy": {
+    "recorded-date": "12-06-2023, 17:08:47",
+    "recorded-content": {
+      "failed_event": {
+        "EventId": "MyParameter-CREATE_FAILED-date",
+        "LogicalResourceId": "MyParameter",
+        "PhysicalResourceId": "",
+        "ResourceProperties": {
+          "Value": "abc123"
+        },
+        "ResourceStatus": "CREATE_FAILED",
+        "ResourceStatusReason": "Property validation failure: [The property {/Type} is required]",
+        "ResourceType": "AWS::SSM::Parameter",
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+        "StackName": "<stack-name:1>",
+        "Timestamp": "timestamp"
+      }
+    }
   }
 }


### PR DESCRIPTION
When a cloudformation stack fails to deploy, it's hard to know why. In a [previous PR](https://github.com/localstack/localstack/pull/8336) we added printing the events to the traceback, but we don't capture the reason why the stack failed. Also the output format was hard to read.

Now the output is nicer, and the resource deploy events are nicer.

*PICTURE TBD*

Note: we don't assert parity right now, just that the failure reason is _present_. It's too much API surface to try to ensure parity on failure events.
