### PR TITLE
Add a fetch state call after CFn resource deployment

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1233,6 +1233,18 @@ class TemplateDeployer:
             if physical_id:
                 resource["PhysicalResourceId"] = physical_id
 
+        # Fetch state for compatibility purposes
+        # Since we now have the PhysicalResourceId available without a fetch_state, other attributes that still depend on fetch-state state might not work otherwise
+        if not resource:
+            return
+        resource_type = get_resource_type(resource)
+        resource_class = RESOURCE_MODELS.get(resource_type)
+        if resource_class:
+            resource_inst = resource_class(resource)
+            resource_inst.fetch_state_if_missing(
+                stack_name=stack.stack_name, resources=stack.resources
+            )
+
         # set resource status
         stack.set_resource_status(resource_id, f"{action}_COMPLETE", physical_res_id=physical_id)
 


### PR DESCRIPTION
Previously when deploying a resource in `determine_physical_resource_id` a fetch_state was executed and the result was then available in the resource props for later deletion.

With our rework of the physical resource ID, this will now not necessarily be the case anymore since the `PhysicalResourceId` is available immediately after the handler/boto call and therefore `determine_physical_resource_id` won't be called and the state missing from the props.

This sometimes now leads to issues when trying to delete resources because the attributes they depend on might not have been saved to the resource state if they haven't been added manually in the result handler to the resource properties.