### PR TITLE
use checksum stored in moto key, implement checksum for CopyObject

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -127,6 +127,7 @@ from localstack.services.s3.presigned_url import (
 from localstack.services.s3.utils import (
     _create_invalid_argument_exc,
     capitalize_header_name_from_snake_case,
+    extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
     get_header_name,
     get_key_from_moto_bucket,
@@ -407,13 +408,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["ContentEncoding"] = ""
 
         if request.get("ChecksumMode") == "ENABLED" and checksum_algorithm:
-            # TODO: moto does not store the checksum of object, there is a TODO there as well
-            # in the meantime, just compute the hash everytime it's requested
-            checksum = get_object_checksum_for_algorithm(
-                checksum_algorithm=checksum_algorithm,
-                data=key_object.value,
-            )
-            response[f"Checksum{checksum_algorithm.upper()}"] = checksum  # noqa
+            response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
 
         response["AcceptRanges"] = "bytes"
         return response
@@ -466,6 +461,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             )
             response["SSEKMSKeyId"] = key_object.kms_key_id
 
+        if key_object.checksum_algorithm == ChecksumAlgorithm.CRC32C:
+            # moto does not support CRC32C yet, it uses CRC32 instead
+            # recalculate the proper checksum to store in the key
+            key_object.checksum_value = get_object_checksum_for_algorithm(
+                ChecksumAlgorithm.CRC32C,
+                key_object.value,
+            )
+
         self._notify(context)
 
         return response
@@ -476,12 +479,41 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
+        moto_backend = get_moto_s3_backend(context)
+        dest_moto_bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
-            moto_backend = get_moto_s3_backend(context)
-            bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
-            validate_kms_key_id(sse_kms_key_id, bucket)
+            validate_kms_key_id(sse_kms_key_id, dest_moto_bucket)
 
         response: CopyObjectOutput = call_moto(context)
+
+        src_bucket, src_key, src_version_id = extract_bucket_key_version_id_from_copy_source(
+            request["CopySource"]
+        )
+        src_moto_bucket = get_bucket_from_moto(moto_backend, bucket=src_bucket)
+        source_key_object = get_key_from_moto_bucket(
+            src_moto_bucket, key=src_key, version_id=src_version_id
+        )
+
+        # we properly calculate the Checksum for the destination Key
+        checksum_algorithm = (
+            request.get("ChecksumAlgorithm") or source_key_object.checksum_algorithm
+        )
+        if checksum_algorithm:
+            dest_key_object = get_key_from_moto_bucket(dest_moto_bucket, key=request["Key"])
+            dest_key_object.checksum_algorithm = checksum_algorithm
+
+            if not source_key_object.checksum_value:
+                dest_key_object.checksum_value = get_object_checksum_for_algorithm(
+                    checksum_algorithm, source_key_object.value
+                )
+            else:
+                dest_key_object.checksum_value = source_key_object.checksum_value
+            dest_key_object.checksum_algorithm = checksum_algorithm
+
+            response["CopyObjectResult"][
+                f"Checksum{checksum_algorithm.upper()}"
+            ] = dest_key_object.checksum_value  # noqa
+
         self._notify(context)
         return response
 
@@ -1168,13 +1200,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "ObjectSize" in object_attrs:
             response["ObjectSize"] = key.size
         if "Checksum" in object_attrs and (checksum_algorithm := key.checksum_algorithm):
-            # TODO: moto does not store the checksum of object, there is a TODO there as well
-            # in the meantime, just compute the hash everytime it's requested
-            checksum = get_object_checksum_for_algorithm(
-                checksum_algorithm=checksum_algorithm,
-                data=key.value,
-            )
-            response["Checksum"] = {f"Checksum{checksum_algorithm.upper()}": checksum}  # noqa
+            response["Checksum"] = {
+                f"Checksum{checksum_algorithm.upper()}": key.checksum_value
+            }  # noqa
 
         response["LastModified"] = key.last_modified
 

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -508,6 +508,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 )
             else:
                 dest_key_object.checksum_value = source_key_object.checksum_value
+                if checksum_algorithm == ChecksumAlgorithm.CRC32C:
+                    # TODO: the logic for rendering the template in moto is the following:
+                    # if `CRC32` in `key.checksum_algorithm` which is valid for both CRC32 and CRC32C
+                    # remove the key if it's CRC32C.
+                    response["CopyObjectResult"].pop("ChecksumCRC32", None)
             dest_key_object.checksum_algorithm = checksum_algorithm
 
             response["CopyObjectResult"][

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 from typing import Dict, Literal, Optional, Tuple, Union
+from urllib import parse as urlparser
 
 import moto.s3.models as moto_s3_models
 from botocore.exceptions import ClientError
@@ -54,6 +55,15 @@ class InvalidRequest(ServiceException):
     code: str = "InvalidRequest"
     sender_fault: bool = False
     status_code: int = 400
+
+
+def extract_bucket_key_version_id_from_copy_source(
+    copy_source: str,
+) -> tuple[BucketName, ObjectKey, Optional[str]]:
+    copy_source_parsed = urlparser.urlparse(copy_source)
+    src_bucket, src_key = urlparser.unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
+    src_version_id = urlparser.parse_qs(copy_source_parsed.query).get("versionId", [None])[0]
+    return src_bucket, src_key, src_version_id
 
 
 def get_object_checksum_for_algorithm(checksum_algorithm: str, data: bytes):

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1750,10 +1750,10 @@ class TestS3:
             )
         snapshot.match("exc-invalid-request-storage-class", e.value.response)
 
-    # TODO: maybe different checksums?
     @pytest.mark.aws_validated
+    @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "SHA1", "SHA256"])
     @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
-    def test_s3_copy_object_with_checksum(self, s3_create_bucket, snapshot, aws_client):
+    def test_s3_copy_object_with_checksum(self, s3_create_bucket, snapshot, aws_client, algorithm):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
         bucket_name = s3_create_bucket()
@@ -1779,7 +1779,7 @@ class TestS3:
             Bucket=bucket_name,
             CopySource=f"{bucket_name}/{object_key}",
             Key=object_key,
-            ChecksumAlgorithm="SHA256",
+            ChecksumAlgorithm=algorithm,
             Metadata={"key1": "value1"},
             MetadataDirective="REPLACE",
         )

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5967,60 +5967,6 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum": {
-    "recorded-date": "10-05-2023, 12:35:27",
-    "recorded-content": {
-      "put-object-no-checksum": {
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "object-attrs": {
-        "LastModified": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "copy-object-in-place-with-checksum": {
-        "CopyObjectResult": {
-          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
-          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-          "LastModified": "datetime"
-        },
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "object-attrs-after-copy": {
-        "Checksum": {
-          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U="
-        },
-        "LastModified": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "copy-object-to-dest-keep-checksum": {
-        "CopyObjectResult": {
-          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
-          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-          "LastModified": "datetime"
-        },
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_metadata_directive": {
     "recorded-date": "26-04-2023, 19:52:10",
     "recorded-content": {
@@ -7249,6 +7195,222 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[CRC32]": {
+    "recorded-date": "21-06-2023, 21:32:59",
+    "recorded-content": {
+      "put-object-no-checksum": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-checksum": {
+        "CopyObjectResult": {
+          "ChecksumCRC32": "MzVIGw==",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "Checksum": {
+          "ChecksumCRC32": "MzVIGw=="
+        },
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-to-dest-keep-checksum": {
+        "CopyObjectResult": {
+          "ChecksumCRC32": "MzVIGw==",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[CRC32C]": {
+    "recorded-date": "21-06-2023, 21:33:03",
+    "recorded-content": {
+      "put-object-no-checksum": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-checksum": {
+        "CopyObjectResult": {
+          "ChecksumCRC32C": "078Ilw==",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "Checksum": {
+          "ChecksumCRC32C": "078Ilw=="
+        },
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-to-dest-keep-checksum": {
+        "CopyObjectResult": {
+          "ChecksumCRC32C": "078Ilw==",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[SHA1]": {
+    "recorded-date": "21-06-2023, 21:33:07",
+    "recorded-content": {
+      "put-object-no-checksum": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA1": "5zXdjmjYk4EJ8Cw4PMnQVslCpRQ=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "Checksum": {
+          "ChecksumSHA1": "5zXdjmjYk4EJ8Cw4PMnQVslCpRQ="
+        },
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-to-dest-keep-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA1": "5zXdjmjYk4EJ8Cw4PMnQVslCpRQ=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[SHA256]": {
+    "recorded-date": "21-06-2023, 21:33:11",
+    "recorded-content": {
+      "put-object-no-checksum": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-with-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-after-copy": {
+        "Checksum": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U="
+        },
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-to-dest-keep-checksum": {
+        "CopyObjectResult": {
+          "ChecksumSHA256": "lyTB4g5uPk1/V+0l+dTvsAblCFkNUoyQ2ll/andcE+U=",
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }


### PR DESCRIPTION
This PR supersedes #8182

This is needed for https://github.com/localstack/moto/pull/67, so that we can isolate the changes in this PR (adding the behaviour that has been removed in moto) and already release a new moto version without merging the big S3 stream handling PR. 

Also, moto does not handle the checksum for CRC32C as it depends on `awscrt`. We are recalculating it for this specific algorithm. 

It also has benefits on its own, as it allows us to properly cache the checksum value in the S3 Object instead of calculating it every time it's requested. 