### PR TITLE
xfail flaky sns java lambda subscribe integration test

### DIFF
--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -317,6 +317,7 @@ class TestJavaRuntimes:
             "$..Statement.Condition.ArnLike",
         ],
     )
+    @pytest.mark.xfail(is_old_provider(), reason="Test flaky with local executor.")
     # TODO maybe snapshot payload as well
     def test_java_lambda_subscribe_sns_topic(
         self,


### PR DESCRIPTION
## Motivation
The test is flaky for the old executor, in particular the local executor. As we do not aim to fix / modify the deprecated provider, the easiest option is to xfail that test.

Most recent example: https://app.circleci.com/pipelines/github/localstack/localstack/15418/workflows/6dba1f5e-feea-4e98-9df6-20bc710cb578/jobs/115278/tests#failed-test-0

## Changes

* Xfail flaky `tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_lambda_subscribe_sns_topic` test 