### PR TITLE
kms: Add encryption context to generate data key with and without plaintext 

### DIFF
--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1500,5 +1500,35 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_encryption_context_generate_data_key": {
+    "recorded-date": "16-06-2023, 12:47:28",
+    "recorded-content": {
+      "decrypt-without-encryption-context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_encryption_context_generate_data_key_without_plaintext": {
+    "recorded-date": "16-06-2023, 12:47:45",
+    "recorded-content": {
+      "decrypt-without-encryption-context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Add `EncryptionContext` parameter to `GenerateDataKeyWithoutPlaintext` and `GenerateDataKey'. 
- Write snapshot tests to check the expected behaviour against AWS. 

Related issues: https://github.com/localstack/localstack/issues/8505 and https://github.com/localstack/localstack/issues/8503
