### PR TITLE
CFn: simplify signature of params helper 

### DIFF
--- a/localstack/services/cloudformation/cfn_utils.py
+++ b/localstack/services/cloudformation/cfn_utils.py
@@ -5,8 +5,8 @@ from localstack.utils.objects import recurse_object
 
 
 def rename_params(func, rename_map):
-    def do_rename(params, **kwargs):
-        values = func(params, **kwargs) if func else params
+    def do_rename(params, logical_resource_id, *args, **kwargs):
+        values = func(params, logical_resource_id, *args, **kwargs) if func else params
         for old_param, new_param in rename_map.items():
             values[new_param] = values.pop(old_param, None)
         return values
@@ -66,7 +66,7 @@ def convert_types(obj, types):
 def get_tags_param(resource_type: str) -> Callable:
     """Return a tag parameters creation function for the given resource type"""
 
-    def _param(params, **kwargs):
+    def _param(params, logical_resource_id, *args, **kwargs):
         tags = params.get("Tags")
         if not tags:
             return None

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -20,8 +20,8 @@ LOG = logging.getLogger(__name__)
 
 
 def dump_json_params(param_func=None, *param_names):
-    def replace(params, *args, **kwargs):
-        result = param_func(params, **kwargs) if param_func else params
+    def replace(params, logical_resource_id, *args, **kwargs):
+        result = param_func(params, logical_resource_id, *args, **kwargs) if param_func else params
         for name in param_names:
             if isinstance(result.get(name), (dict, list)):
                 # Fix for https://github.com/localstack/localstack/issues/2022
@@ -35,7 +35,7 @@ def dump_json_params(param_func=None, *param_names):
 
 def param_defaults(param_func, defaults):
     def replace(properties: dict, logical_resource_id: str, *args, **kwargs):
-        result = param_func(properties, **kwargs)
+        result = param_func(properties, logical_resource_id, *args, **kwargs)
         for key, value in defaults.items():
             if result.get(key) in ["", None]:
                 result[key] = value
@@ -62,7 +62,7 @@ def remove_none_values(params):
 
 
 def params_list_to_dict(param_name, key_attr_name="Key", value_attr_name="Value"):
-    def do_replace(params, **kwargs):
+    def do_replace(params, logical_resource_id, *args, **kwargs):
         result = {}
         for entry in params.get(param_name, []):
             key = entry[key_attr_name]
@@ -74,7 +74,7 @@ def params_list_to_dict(param_name, key_attr_name="Key", value_attr_name="Value"
 
 
 def lambda_keys_to_lower(key=None, skip_children_of: List[str] = None):
-    return lambda params, **kwargs: common.keys_to_lower(
+    return lambda params, logical_resource_id, *args, **kwargs: common.keys_to_lower(
         obj=(params.get(key) if key else params), skip_children_of=skip_children_of
     )
 
@@ -90,7 +90,7 @@ def str_or_none(o):
 
 
 def params_dict_to_list(param_name, key_attr_name="Key", value_attr_name="Value", wrapper=None):
-    def do_replace(params, **kwargs):
+    def do_replace(params, logical_resource_id, *args, **kwargs):
         result = []
         for key, value in params.get(param_name, {}).items():
             result.append({key_attr_name: key, value_attr_name: value})
@@ -102,7 +102,7 @@ def params_dict_to_list(param_name, key_attr_name="Key", value_attr_name="Value"
 
 
 def params_select_attributes(*attrs):
-    def do_select(params, **kwargs):
+    def do_select(params, logical_resource_id, *args, **kwargs):
         result = {}
         for attr in attrs:
             if params.get(attr) is not None:
@@ -113,7 +113,7 @@ def params_select_attributes(*attrs):
 
 
 def param_json_to_str(name):
-    def _convert(params, **kwargs):
+    def _convert(params, logical_resource_id, *args, **kwargs):
         result = params.get(name)
         if result:
             result = json.dumps(result)
@@ -128,7 +128,9 @@ def lambda_select_params(*selected):
 
 
 def select_parameters(*param_names):
-    return lambda params, *args, **kwargs: select_attributes(params, param_names)
+    return lambda properties, logical_resource_id, *args, **kwargs: select_attributes(
+        properties, param_names
+    )
 
 
 def is_none_or_empty_value(value):

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 
 
 def dump_json_params(param_func=None, *param_names):
-    def replace(params, **kwargs):
+    def replace(params, *args, **kwargs):
         result = param_func(params, **kwargs) if param_func else params
         for name in param_names:
             if isinstance(result.get(name), (dict, list)):
@@ -34,8 +34,8 @@ def dump_json_params(param_func=None, *param_names):
 
 
 def param_defaults(param_func, defaults):
-    def replace(params, **kwargs):
-        result = param_func(params, **kwargs)
+    def replace(properties: dict, logical_resource_id: str, *args, **kwargs):
+        result = param_func(properties, **kwargs)
         for key, value in defaults.items():
             if result.get(key) in ["", None]:
                 result[key] = value
@@ -80,8 +80,8 @@ def lambda_keys_to_lower(key=None, skip_children_of: List[str] = None):
 
 
 def merge_parameters(func1, func2):
-    return lambda params, **kwargs: common.merge_dicts(
-        func1(params, **kwargs), func2(params, **kwargs)
+    return lambda properties, logical_resource_id, *args, **kwargs: common.merge_dicts(
+        func1(properties, **kwargs), func2(properties, **kwargs)
     )
 
 
@@ -128,7 +128,7 @@ def lambda_select_params(*selected):
 
 
 def select_parameters(*param_names):
-    return lambda params, **kwargs: select_attributes(params, param_names)
+    return lambda params, *args, **kwargs: select_attributes(params, param_names)
 
 
 def is_none_or_empty_value(value):

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -81,7 +81,8 @@ def lambda_keys_to_lower(key=None, skip_children_of: List[str] = None):
 
 def merge_parameters(func1, func2):
     return lambda properties, logical_resource_id, *args, **kwargs: common.merge_dicts(
-        func1(properties, **kwargs), func2(properties, **kwargs)
+        func1(properties, logical_resource_id, *args, **kwargs),
+        func2(properties, logical_resource_id, *args, **kwargs),
     )
 
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -72,11 +72,19 @@ ResourceDefinition = dict[str, ResourceProp]
 
 
 class FuncDetailsValue(TypedDict):
-    # Callable here takes the arguments:
+    # First callable here takes the arguments:
     # - logical_resource_id
     # - resource
     # - stack_name
-    function: str | Callable[[str, dict, str], Any]
+    # Second callable here takes the arguments:
+    # - resource_id
+    # - resources
+    # - resource_type
+    # - func
+    # - stack_name
+    function: str | Callable[[str, dict, str], Any] | Callable[
+        [str, dict[str, dict], str, Any, str], Any
+    ]
     """Either an api method to call directly with `parameters` or a callable to directly invoke"""
     # Callable here takes the arguments:
     # - resource_props
@@ -808,7 +816,6 @@ def execute_resource_action(
     for func in func_details:
         result = None
         executed = False
-        # TODO(srw) 3 - callable function
         if callable(func.get("function")):
             sig = inspect.signature(func["function"])
             if "logical_resource_id" in sig.parameters:

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -910,7 +910,9 @@ def resolve_resource_parameters(
     resource_id: str,
     func_details: FuncDetailsValue,
 ) -> dict | None:
-    params = func_details.get("parameters") or (lambda params, **kwargs: params)
+    params = func_details.get("parameters") or (
+        lambda properties, logical_resource_id, *args, **kwargs: properties
+    )
     resource_props = resource_definition["Properties"] = resource_definition.get("Properties", {})
     resource_props = dict(resource_props)
     resource_state = resource_definition.get(KEY_RESOURCE_STATE, {})
@@ -921,6 +923,7 @@ def resolve_resource_parameters(
         if "logical_resource_id" in sig.parameters:
             params = params(resource_props, resource_id, resource_definition, stack_name)
         else:
+            raise NotImplementedError(func_details)
             params = params(
                 resource_props,
                 stack_name=stack_name,
@@ -955,6 +958,7 @@ def resolve_resource_parameters(
                             stack_name,
                         )
                     else:
+                        raise NotImplementedError
                         prop_value = prop_key(
                             resource_props,
                             stack_name=stack_name,

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -92,11 +92,16 @@ ParamsFuncSignature = Callable[[dict, str, dict, str], dict]
 # - resource_id
 ParamsFuncSignatureLegacy = Callable[[dict, str, dict[str, dict], str], dict]
 
+# either a dictionary of strings to
+# - strings, or
+# - instances of the parameter function (current or legacy)
+ParamsDefinition = dict[str, str | ParamsFuncSignature | ParamsFuncSignatureLegacy]
+
 
 class FuncDetailsValue(TypedDict):
     function: str | FunctionFuncSignature | FunctionFuncSignatureLegacy
     """Either an api method to call directly with `parameters` or a callable to directly invoke"""
-    parameters: Optional[ResourceDefinition | ParamsFuncSignature | ParamsFuncSignatureLegacy]
+    parameters: Optional[ParamsDefinition | ParamsFuncSignature | ParamsFuncSignatureLegacy]
     """arguments to the function, or a function that generates the arguments to the function"""
     # Callable here takes the arguments
     # - result

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -502,7 +502,6 @@ class GatewayStage(GenericBaseModel):
     def get_deploy_templates():
         def get_params(resource_props, stack_name, resources, resource_id):
             stage_name = resource_props.get("StageName", "default")
-            resources[resource_id]["Properties"]["StageName"] = stage_name
             result = keys_to_lower(resource_props)
             param_names = [
                 "restApiId",
@@ -523,6 +522,7 @@ class GatewayStage(GenericBaseModel):
 
         def _handle_result(result, resource_id, resources, resource_type):
             resources[resource_id]["PhysicalResourceId"] = result["stageName"]
+            resources[resource_id]["Properties"]["StageName"] = result["stageName"]
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -119,9 +119,8 @@ class GatewayRestAPI(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _api_id(params, resources, resource_id, **kwargs):
-            resource = cls(resources[resource_id])
-            return resource.physical_resource_id
+        def _api_id(properties: dict, logical_resource_id: str, resource: dict, stack_name: str):
+            return resource["PhysicalResourceId"]
 
         def _create(logical_resource_id: str, resource: dict, stack_name: str):
             client = connect_to().apigateway
@@ -289,9 +288,8 @@ class GatewayResource(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def get_apigw_resource_params(
-            logical_resource_id: str, resource: dict, stack_name: str
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
         ) -> dict:
-            properties = resource["Properties"]
             result = {
                 "restApiId": properties.get("RestApiId"),
                 "pathPart": properties.get("PathPart"),
@@ -385,8 +383,9 @@ class GatewayMethod(GenericBaseModel):
         https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html
         """
 
-        def get_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def get_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             result = keys_to_lower(properties)
             param_names = [
                 "restApiId",
@@ -504,8 +503,9 @@ class GatewayStage(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def get_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             stage_name = properties.get("StageName", "default")
             result = keys_to_lower(properties)
             param_names = [

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -288,11 +288,14 @@ class GatewayResource(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_apigw_resource_params(params, **kwargs):
+        def get_apigw_resource_params(
+            logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
+            properties = resource["Properties"]
             result = {
-                "restApiId": params.get("RestApiId"),
-                "pathPart": params.get("PathPart"),
-                "parentId": params.get("ParentId"),
+                "restApiId": properties.get("RestApiId"),
+                "pathPart": properties.get("PathPart"),
+                "parentId": properties.get("ParentId"),
             }
             if not result.get("parentId"):
                 # get root resource id
@@ -382,8 +385,9 @@ class GatewayMethod(GenericBaseModel):
         https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html
         """
 
-        def get_params(resource_props, stack_name, resources, resource_id):
-            result = keys_to_lower(resource_props)
+        def get_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+            result = keys_to_lower(properties)
             param_names = [
                 "restApiId",
                 "resourceId",
@@ -500,9 +504,10 @@ class GatewayStage(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_params(resource_props, stack_name, resources, resource_id):
-            stage_name = resource_props.get("StageName", "default")
-            result = keys_to_lower(resource_props)
+        def get_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+            stage_name = properties.get("StageName", "default")
+            result = keys_to_lower(properties)
             param_names = [
                 "restApiId",
                 "deploymentId",

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -86,7 +86,13 @@ class LambdaFunction(GenericBaseModel):
             )
 
     @staticmethod
-    def get_lambda_code_param(properties, _include_arch=False, **kwargs):
+    def get_lambda_code_param(
+        properties: dict,
+        logical_resource_id: str,
+        resource: dict,
+        stack_name: str,
+        _include_arch=False,
+    ):
         code = properties.get("Code", {}).copy()
         zip_file = code.get("ZipFile")
         if zip_file and not is_base64(zip_file) and not is_zip_file(to_bytes(zip_file)):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -63,7 +63,13 @@ class LambdaFunction(GenericBaseModel):
                 LOG.debug(
                     'Updating code for Lambda "%s" from location: %s', props["FunctionName"], code
                 )
-            code = LambdaFunction.get_lambda_code_param(props, _include_arch=True)
+            code = LambdaFunction.get_lambda_code_param(
+                props,
+                new_resource["LogicalResourceId"],
+                new_resource,
+                stack_name,
+                _include_arch=True,
+            )
             client.update_function_code(FunctionName=props["FunctionName"], **code)
         if "Environment" in update_config_props:
             environment_variables = update_config_props["Environment"].get("Variables", {})

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -302,7 +302,7 @@ class LambdaPermission(GenericBaseModel):
             properties: dict, logical_resource_id: str, resource: dict, stack_name: str
         ) -> dict:
             result = select_parameters("FunctionName", "Action", "Principal", "SourceArn")(
-                properties
+                properties, logical_resource_id, resource, stack_name
             )
             # generate SID
             # e.g. stack-78d0ac66-fnAllowInvokeLambdaPermissionsStacktopicF723B1A748672DB5-1D7VMEAZ2UQIN

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -17,8 +17,9 @@ class CertificateManagerCertificate(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             result = select_attributes(
                 properties,
                 [

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -17,9 +17,10 @@ class CertificateManagerCertificate(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(params, *args, **kwargs):
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
             result = select_attributes(
-                params,
+                properties,
                 [
                     "CertificateAuthorityArn",
                     "DomainName",

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -52,20 +52,21 @@ class CloudFormationStack(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def get_nested_stack_params(params, **kwargs):
-            nested_stack_name = params["StackName"]
-            stack_params = params.get("Parameters", {})
-            stack_params = [
+        def get_nested_stack_params(logical_resource_id: str, resource: dict, stack_name: str):
+            properties = resource["Properties"]
+            nested_stack_name = properties["StackName"]
+            stack_parameters = properties.get("Parameters", {})
+            stack_parameters = [
                 {
                     "ParameterKey": k,
                     "ParameterValue": str(v).lower() if isinstance(v, bool) else str(v),
                 }
-                for k, v in stack_params.items()
+                for k, v in stack_parameters.items()
             ]
             result = {
                 "StackName": nested_stack_name,
-                "TemplateURL": params.get("TemplateURL"),
-                "Parameters": stack_params,
+                "TemplateURL": properties.get("TemplateURL"),
+                "Parameters": stack_parameters,
             }
             return result
 

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -52,8 +52,9 @@ class CloudFormationStack(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def get_nested_stack_params(logical_resource_id: str, resource: dict, stack_name: str):
-            properties = resource["Properties"]
+        def get_nested_stack_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ):
             nested_stack_name = properties["StackName"]
             stack_parameters = properties.get("Parameters", {})
             stack_parameters = [

--- a/localstack/services/cloudformation/models/cloudwatch.py
+++ b/localstack/services/cloudformation/models/cloudwatch.py
@@ -40,8 +40,9 @@ class CloudWatchAlarm(GenericBaseModel):
             resource = resources[resource_id]
             resources[resource_id]["PhysicalResourceId"] = resource["Properties"]["AlarmName"]
 
-        def get_delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def get_delete_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             return {"AlarmNames": [properties["AlarmName"]]}
 
         return {

--- a/localstack/services/cloudformation/models/cloudwatch.py
+++ b/localstack/services/cloudformation/models/cloudwatch.py
@@ -40,8 +40,9 @@ class CloudWatchAlarm(GenericBaseModel):
             resource = resources[resource_id]
             resources[resource_id]["PhysicalResourceId"] = resource["Properties"]["AlarmName"]
 
-        def get_delete_params(params, **kwargs):
-            return {"AlarmNames": [params["AlarmName"]]}
+        def get_delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+            return {"AlarmNames": [properties["AlarmName"]]}
 
         return {
             "create": {"function": cls._create_function_name(), "result_handler": _handle_result},

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -7,12 +7,14 @@ from localstack.utils import common
 from localstack.utils.aws import aws_stack
 
 
-def get_ddb_provisioned_throughput(params, **kwargs):
+def get_ddb_provisioned_throughput(
+    properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+) -> dict | None:
     # see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-provisionedthroughput
-    args = params.get("ProvisionedThroughput")
+    args = properties.get("ProvisionedThroughput")
     if args == PLACEHOLDER_AWS_NO_VALUE:
         return None
-    is_ondemand = params.get("BillingMode") == "PAY_PER_REQUEST"
+    is_ondemand = properties.get("BillingMode") == "PAY_PER_REQUEST"
     # if the BillingMode is set to PAY_PER_REQUEST, you cannot specify ProvisionedThroughput
     # if the BillingMode is set to PROVISIONED (default), you have to specify ProvisionedThroughput
 
@@ -35,9 +37,11 @@ def get_ddb_provisioned_throughput(params, **kwargs):
     return args
 
 
-def get_ddb_global_sec_indexes(params: dict, **kwargs) -> list | None:
-    args: list = params.get("GlobalSecondaryIndexes")
-    is_ondemand = params.get("BillingMode") == "PAY_PER_REQUEST"
+def get_ddb_global_sec_indexes(
+    properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+) -> list | None:
+    args: list = properties.get("GlobalSecondaryIndexes")
+    is_ondemand = properties.get("BillingMode") == "PAY_PER_REQUEST"
     if not args:
         return
 
@@ -111,9 +115,9 @@ class DynamoDBTable(GenericBaseModel):
                         "ProvisionedThroughput": get_ddb_provisioned_throughput,
                         "LocalSecondaryIndexes": "LocalSecondaryIndexes",
                         "GlobalSecondaryIndexes": get_ddb_global_sec_indexes,
-                        "StreamSpecification": lambda params, **kwargs: (
+                        "StreamSpecification": lambda properties, logical_resource_id, *args, **kwargs: (
                             common.merge_dicts(
-                                params.get("StreamSpecification"),
+                                properties.get("StreamSpecification"),
                                 {"StreamEnabled": True},
                                 default=None,
                             )

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -59,9 +59,8 @@ def get_ddb_global_sec_indexes(params: dict, **kwargs) -> list | None:
 
 
 def get_ddb_kinesis_stream_specification(
-    logical_resource_id: str, resource: dict, stack_name: str
+    properties: dict, logical_resource_id: str, resource: dict, stack_name: str
 ) -> dict:
-    properties = resource["Properties"]
     args = properties.get("KinesisStreamSpecification")
     if args:
         args["TableName"] = properties["TableName"]

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -58,10 +58,13 @@ def get_ddb_global_sec_indexes(params: dict, **kwargs) -> list | None:
     return args
 
 
-def get_ddb_kinesis_stream_specification(params, **kwargs):
-    args = params.get("KinesisStreamSpecification")
+def get_ddb_kinesis_stream_specification(
+    logical_resource_id: str, resource: dict, stack_name: str
+) -> dict:
+    properties = resource["Properties"]
+    args = properties.get("KinesisStreamSpecification")
     if args:
-        args["TableName"] = params["TableName"]
+        args["TableName"] = properties["TableName"]
     return args
 
 

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -6,9 +6,10 @@ from localstack.utils.aws import arns, aws_stack
 from localstack.utils.collections import convert_to_typed_dict
 
 
-def es_add_tags_params(params, **kwargs):
-    es_arn = arns.es_domain_arn(params.get("DomainName"))
-    tags = params.get("Tags", [])
+def es_add_tags_params(logical_resource_id: str, resource: dict, stack_name: str):
+    properties = resource["Properties"]
+    es_arn = arns.es_domain_arn(properties.get("DomainName"))
+    tags = properties.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
 
@@ -39,8 +40,9 @@ class ElasticsearchDomain(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_params(params, **kwargs):
-            result = convert_to_typed_dict(CreateElasticsearchDomainRequest, params)
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str):
+            properties = resource["Properties"]
+            result = convert_to_typed_dict(CreateElasticsearchDomainRequest, properties)
             result = remove_none_values(result)
             cluster_config = result.get("ElasticsearchClusterConfig")
             if isinstance(cluster_config, dict):

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -6,8 +6,7 @@ from localstack.utils.aws import arns, aws_stack
 from localstack.utils.collections import convert_to_typed_dict
 
 
-def es_add_tags_params(logical_resource_id: str, resource: dict, stack_name: str):
-    properties = resource["Properties"]
+def es_add_tags_params(properties: dict, logical_resource_id: str, resource: dict, stack_name: str):
     es_arn = arns.es_domain_arn(properties.get("DomainName"))
     tags = properties.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
@@ -40,8 +39,9 @@ class ElasticsearchDomain(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str):
-            properties = resource["Properties"]
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ):
             result = convert_to_typed_dict(CreateElasticsearchDomainRequest, properties)
             result = remove_none_values(result)
             cluster_config = result.get("ElasticsearchClusterConfig")

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -116,7 +116,9 @@ class EventsRule(GenericBaseModel):
                 "Name",
                 "EventBusName",
             ]
-            result = select_parameters(*attrs)(properties)
+            result = select_parameters(*attrs)(
+                properties, logical_resource_id, resource, stack_name
+            )
 
             # TODO: remove this when refactoring events (prefix etc. was excluded here already to avoid most of the wrong behavior)
             def wrap_in_lists(o, **kwargs):

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -114,7 +114,7 @@ class EventsRule(GenericBaseModel):
                 "Name",
                 "EventBusName",
             ]
-            result = select_parameters(*attrs)(params, **kwargs)
+            result = select_parameters(*attrs)(params)
 
             # TODO: remove this when refactoring events (prefix etc. was excluded here already to avoid most of the wrong behavior)
             def wrap_in_lists(o, **kwargs):

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -105,7 +105,10 @@ class EventsRule(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def events_put_rule_params(params, **kwargs):
+        def events_put_rule_params(
+            logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
+            properties = resource["Properties"]
             attrs = [
                 "ScheduleExpression",
                 "EventPattern",
@@ -114,7 +117,7 @@ class EventsRule(GenericBaseModel):
                 "Name",
                 "EventBusName",
             ]
-            result = select_parameters(*attrs)(params)
+            result = select_parameters(*attrs)(properties)
 
             # TODO: remove this when refactoring events (prefix etc. was excluded here already to avoid most of the wrong behavior)
             def wrap_in_lists(o, **kwargs):

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -106,9 +106,8 @@ class EventsRule(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def events_put_rule_params(
-            logical_resource_id: str, resource: dict, stack_name: str
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
         ) -> dict:
-            properties = resource["Properties"]
             attrs = [
                 "ScheduleExpression",
                 "EventPattern",

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -484,8 +484,9 @@ class IAMPolicy(GenericBaseModel):
                     GroupName=group, PolicyName=policy_name, PolicyDocument=policy_doc
                 )
 
-        def _delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def _delete_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             return {"PolicyArn": arns.policy_arn(properties["PolicyName"])}
 
         return {

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -484,8 +484,9 @@ class IAMPolicy(GenericBaseModel):
                     GroupName=group, PolicyName=policy_name, PolicyDocument=policy_doc
                 )
 
-        def _delete_params(params, *args, **kwargs):
-            return {"PolicyArn": arns.policy_arn(params["PolicyName"])}
+        def _delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+            return {"PolicyArn": arns.policy_arn(properties["PolicyName"])}
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -278,17 +278,17 @@ class IAMRole(GenericBaseModel):
     def _post_create(cls, logical_resource_id: str, resource: dict, stack_name: str):
         """attaches managed policies from the template to the role"""
 
+        properties = resource["Properties"]
         iam = aws_stack.connect_to_service("iam")
-        props = resource["Properties"]
-        role_name = props["RoleName"]
+        role_name = properties["RoleName"]
 
         # attach managed policies
-        policy_arns = props.get("ManagedPolicyArns", [])
+        policy_arns = properties.get("ManagedPolicyArns", [])
         for arn in policy_arns:
             iam.attach_role_policy(RoleName=role_name, PolicyArn=arn)
 
         # add inline policies
-        inline_policies = props.get("Policies", [])
+        inline_policies = properties.get("Policies", [])
         for policy in inline_policies:
             assert not isinstance(
                 policy, list
@@ -297,7 +297,9 @@ class IAMRole(GenericBaseModel):
                 continue
             if not isinstance(policy, dict):
                 LOG.info(
-                    'Invalid format of policy for IAM role "%s": %s', props.get("RoleName"), policy
+                    'Invalid format of policy for IAM role "%s": %s',
+                    properties.get("RoleName"),
+                    policy,
                 )
                 continue
             pol_name = policy.get("PolicyName")
@@ -314,7 +316,7 @@ class IAMRole(GenericBaseModel):
                     statement["Resource"] = [r for r in statement["Resource"] if r]
             doc = json.dumps(doc)
             iam.put_role_policy(
-                RoleName=props["RoleName"],
+                RoleName=properties["RoleName"],
                 PolicyName=pol_name,
                 PolicyDocument=doc,
             )

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -55,8 +55,9 @@ class KinesisStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_delete_params(params, **kwargs):
-            return {"StreamName": params["Name"], "EnforceConsumerDeletion": True}
+        def get_delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+            return {"StreamName": properties["Name"], "EnforceConsumerDeletion": True}
 
         def _store_arn(result, resource_id, resources, resource_type):
             client = aws_stack.connect_to_service("kinesis")

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -55,8 +55,9 @@ class KinesisStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_delete_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def get_delete_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             return {"StreamName": properties["Name"], "EnforceConsumerDeletion": True}
 
         def _store_arn(result, resource_id, resources, resource_type):

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -12,8 +12,9 @@ from localstack.utils.collections import convert_to_typed_dict
 # OpenSearch still uses "es" ARNs
 # See examples in:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
-def opensearch_add_tags_params(logical_resource_id: str, resource: dict, stack_name: str):
-    properties = resource["Properties"]
+def opensearch_add_tags_params(
+    properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+):
     es_arn = arns.es_domain_arn(properties.get("DomainName"))
     tags = properties.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
@@ -33,9 +34,10 @@ class OpenSearchDomain(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str):
-            raw_properties = resource["Properties"]
-            properties = remove_none_values(raw_properties)
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ):
+            properties = remove_none_values(properties)
             result = convert_to_typed_dict(CreateDomainRequest, properties)
             cluster_config = result.get("ClusterConfig")
             if isinstance(cluster_config, dict):

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -12,9 +12,10 @@ from localstack.utils.collections import convert_to_typed_dict
 # OpenSearch still uses "es" ARNs
 # See examples in:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
-def opensearch_add_tags_params(params, **kwargs):
-    es_arn = arns.es_domain_arn(params.get("DomainName"))
-    tags = params.get("Tags", [])
+def opensearch_add_tags_params(logical_resource_id: str, resource: dict, stack_name: str):
+    properties = resource["Properties"]
+    es_arn = arns.es_domain_arn(properties.get("DomainName"))
+    tags = properties.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
 
@@ -32,9 +33,10 @@ class OpenSearchDomain(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_params(params, **kwargs):
-            params = remove_none_values(params)
-            result = convert_to_typed_dict(CreateDomainRequest, params)
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str):
+            raw_properties = resource["Properties"]
+            properties = remove_none_values(raw_properties)
+            result = convert_to_typed_dict(CreateDomainRequest, properties)
             cluster_config = result.get("ClusterConfig")
             if isinstance(cluster_config, dict):
                 # set defaults required for boto3 calls

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -123,8 +123,11 @@ class S3Bucket(GenericBaseModel):
 
             return {"CORSRules": cors_rules}
 
-        def s3_bucket_notification_config(params, **kwargs):
-            notif_config = params.get("NotificationConfiguration")
+        def s3_bucket_notification_config(
+            logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
+            properties = resource["Properties"]
+            notif_config = properties.get("NotificationConfiguration")
             if not notif_config:
                 return None
 
@@ -157,7 +160,7 @@ class S3Bucket(GenericBaseModel):
 
             # construct final result
             result = {
-                "Bucket": params.get("BucketName"),
+                "Bucket": properties.get("BucketName"),
                 "NotificationConfiguration": {
                     "LambdaFunctionConfigurations": lambda_configs,
                     "QueueConfigurations": queue_configs,

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -124,9 +124,8 @@ class S3Bucket(GenericBaseModel):
             return {"CORSRules": cors_rules}
 
         def s3_bucket_notification_config(
-            logical_resource_id: str, resource: dict, stack_name: str
-        ) -> dict:
-            properties = resource["Properties"]
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict | None:
             notif_config = properties.get("NotificationConfiguration")
             if not notif_config:
                 return None

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -77,10 +77,11 @@ class SecretsManagerSecret(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(params, **kwargs):
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
             attributes = ["Name", "Description", "KmsKeyId", "SecretString", "Tags"]
-            result = select_attributes(params, attributes)
-            gen_secret = params.get("GenerateSecretString")
+            result = select_attributes(properties, attributes)
+            gen_secret = properties.get("GenerateSecretString")
             if gen_secret:
                 excl_lower = gen_secret.get("ExcludeLowercase")
                 excl_upper = gen_secret.get("ExcludeUppercase")
@@ -158,11 +159,12 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def create_params(params, **kwargs):
+        def create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
             return {
-                "SecretId": params["SecretId"].split(":")[-1],
-                "ResourcePolicy": json.dumps(params["ResourcePolicy"]),
-                "BlockPublicPolicy": params.get("BlockPublicPolicy"),
+                "SecretId": properties["SecretId"].split(":")[-1],
+                "ResourcePolicy": json.dumps(properties["ResourcePolicy"]),
+                "BlockPublicPolicy": properties.get("BlockPublicPolicy"),
             }
 
         def _set_physical_resource_id(

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -77,8 +77,9 @@ class SecretsManagerSecret(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             attributes = ["Name", "Description", "KmsKeyId", "SecretString", "Tags"]
             result = select_attributes(properties, attributes)
             gen_secret = properties.get("GenerateSecretString")
@@ -159,8 +160,9 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             return {
                 "SecretId": properties["SecretId"].split(":")[-1],
                 "ResourcePolicy": json.dumps(properties["ResourcePolicy"]),

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -37,14 +37,15 @@ class SNSTopic(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(params, *args, **kwargs):
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
             attributes = {}
-            dedup = params.get("ContentBasedDeduplication")
-            display_name = params.get("DisplayName")
-            fifo_topic = params.get("FifoTopic")
-            kms_master_key = params.get("KmsMasterKeyId")
-            tags = params.get("Tags") or []
-            topic_name = params.get("TopicName")
+            dedup = properties.get("ContentBasedDeduplication")
+            display_name = properties.get("DisplayName")
+            fifo_topic = properties.get("FifoTopic")
+            kms_master_key = properties.get("KmsMasterKeyId")
+            tags = properties.get("Tags") or []
+            topic_name = properties.get("TopicName")
             if dedup is not None:
                 attributes["ContentBasedDeduplication"] = canonicalize_bool_to_str(dedup)
             if display_name:

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -37,8 +37,9 @@ class SNSTopic(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             attributes = {}
             dedup = properties.get("ContentBasedDeduplication")
             display_name = properties.get("DisplayName")
@@ -57,9 +58,11 @@ class SNSTopic(GenericBaseModel):
             result = {"Name": topic_name, "Attributes": attributes, "Tags": tags}
             return result
 
-        def _topic_arn(params, resources, resource_id, **kwargs):
-            resource = cls(resources[resource_id])
-            return resource.physical_resource_id
+        def _topic_arn(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
+            provider = cls(resource)
+            return provider.physical_resource_id
 
         def _list_all_topics(sns_client):
             rs = sns_client.list_topics()
@@ -132,11 +135,14 @@ class SNSSubscription(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def sns_subscription_arn(params, resources, resource_id, **kwargs):
-            resource = resources[resource_id]
+        def sns_subscription_arn(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             return resource["PhysicalResourceId"]
 
-        def sns_subscription_params(params, **kwargs):
+        def sns_subscription_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             def attr_val(val):
                 return json.dumps(val) if isinstance(val, (dict, list)) else str(val)
 
@@ -146,7 +152,7 @@ class SNSSubscription(GenericBaseModel):
                 "RawMessageDelivery",
                 "RedrivePolicy",
             ]
-            result = {a: attr_val(params[a]) for a in attrs if a in params}
+            result = {a: attr_val(properties[a]) for a in attrs if a in properties}
             return result
 
         def _set_physical_resource_id(

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -104,13 +104,12 @@ class SQSQueue(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _queue_url(params, resources, resource_id, **kwargs):
-            resource = cls(resources[resource_id])
-            props = resource.props
-            queue_url = resource.physical_resource_id or props.get("QueueUrl")
+        def _queue_url(properties: dict, logical_resource_id: str, resource: dict, stack_name: str):
+            provider = cls(resource)
+            queue_url = provider.physical_resource_id or properties.get("QueueUrl")
             if queue_url:
                 return queue_url
-            return arns.sqs_queue_url_for_arn(props["QueueArn"])
+            return arns.sqs_queue_url_for_arn(properties["QueueArn"])
 
         def _set_physical_resource_id(
             result: dict, resource_id: str, resources: dict, resource_type: str

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -91,11 +91,13 @@ class SFNStateMachine(GenericBaseModel):
             resources[resource_id]["Properties"]["Arn"] = result["stateMachineArn"]
             resources[resource_id]["PhysicalResourceId"] = result["stateMachineArn"]
 
-        def _create_params(params, **kwargs):
-            def _get_definition(params):
+        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
+            properties = resource["Properties"]
+
+            def _get_definition(properties):
                 # TODO: support "Definition" parameter
-                definition_str = params.get("DefinitionString")
-                s3_location = params.get("DefinitionS3Location")
+                definition_str = properties.get("DefinitionString")
+                s3_location = properties.get("DefinitionS3Location")
                 if not definition_str and s3_location:
                     # TODO: currently not covered by tests - add a test to mimick the behavior of "sam deploy ..."
                     s3_client = aws_stack.connect_to_service("s3")
@@ -104,16 +106,16 @@ class SFNStateMachine(GenericBaseModel):
                         Bucket=s3_location["Bucket"], Key=s3_location["Key"]
                     )
                     definition_str = to_str(result["Body"].read())
-                substitutions = params.get("DefinitionSubstitutions")
+                substitutions = properties.get("DefinitionSubstitutions")
                 if substitutions is not None:
                     definition_str = _apply_substitutions(definition_str, substitutions)
                 return definition_str
 
             return {
-                "name": params.get("StateMachineName"),
-                "definition": _get_definition(params),
-                "roleArn": params.get("RoleArn"),
-                "type": params.get("StateMachineType", None),
+                "name": properties.get("StateMachineName"),
+                "definition": _get_definition(properties),
+                "roleArn": properties.get("RoleArn"),
+                "type": properties.get("StateMachineType", None),
             }
 
         return {

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -91,9 +91,9 @@ class SFNStateMachine(GenericBaseModel):
             resources[resource_id]["Properties"]["Arn"] = result["stateMachineArn"]
             resources[resource_id]["PhysicalResourceId"] = result["stateMachineArn"]
 
-        def _create_params(logical_resource_id: str, resource: dict, stack_name: str) -> dict:
-            properties = resource["Properties"]
-
+        def _create_params(
+            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+        ) -> dict:
             def _get_definition(properties):
                 # TODO: support "Definition" parameter
                 definition_str = properties.get("DefinitionString")

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -309,14 +309,7 @@ def test_lambda_vpc(deploy_cfn_template, aws_client):
 
 
 @pytest.mark.xfail(condition=is_new_provider(), reason="fails/times out with new provider")
-@pytest.mark.skip_snapshot_verify(
-    paths=[
-        "$..Policy.PolicyArn",
-        "$..Policy.PolicyName",
-        "$..Policy.Statement..Resource",
-        "$..Policy.Statement..Sid",
-    ]
-)
+@pytest.mark.aws_validated
 def test_update_lambda_permissions(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(


### PR DESCRIPTION
Update call sites to the `params` helper function to not use `resources` since this is not available with the new provider structure.

*Note*: unfortunately there is still duplication: the `properties` argument is the same as `resource["Properties"]` however we have an extensive list of helper functions in `deployment_utils.py` that it's not worth re-writing at this stage. The main output is that we no longer depend on the `resources` dictionary.
