### PR TITLE
kms: add encryption context to generate data key pair apis in kms

### DIFF
--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1307,3 +1307,31 @@ class TestKMSGenerateKeys:
         with pytest.raises(ClientError) as e:
             aws_client.kms.decrypt(CiphertextBlob=result["CiphertextBlob"], KeyId=key_id)
         snapshot.match("decrypt-without-encryption-context", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..message"])
+    def test_encryption_context_generate_data_key_pair(self, kms_key, aws_client, snapshot):
+        encryption_context = {"context-key": "context-value"}
+        key_id = kms_key["KeyId"]
+        result = aws_client.kms.generate_data_key_pair(
+            KeyId=key_id, KeyPairSpec="RSA_2048", EncryptionContext=encryption_context
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.decrypt(CiphertextBlob=result["PrivateKeyCiphertextBlob"], KeyId=key_id)
+        snapshot.match("decrypt-without-encryption-context", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..message"])
+    def test_encryption_context_generate_data_key_pair_without_plaintext(
+        self, kms_key, aws_client, snapshot
+    ):
+        encryption_context = {"context-key": "context-value"}
+        key_id = kms_key["KeyId"]
+        result = aws_client.kms.generate_data_key_pair_without_plaintext(
+            KeyId=key_id, KeyPairSpec="RSA_2048", EncryptionContext=encryption_context
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.kms.decrypt(CiphertextBlob=result["PrivateKeyCiphertextBlob"], KeyId=key_id)
+        snapshot.match("decrypt-without-encryption-context", e.value.response)

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1530,5 +1530,35 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_encryption_context_generate_data_key_pair": {
+    "recorded-date": "16-06-2023, 17:51:27",
+    "recorded-content": {
+      "decrypt-without-encryption-context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMSGenerateKeys::test_encryption_context_generate_data_key_pair_without_plaintext": {
+    "recorded-date": "16-06-2023, 17:51:43",
+    "recorded-content": {
+      "decrypt-without-encryption-context": {
+        "Error": {
+          "Code": "InvalidCiphertextException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Add `EncryptionContext` parameter to `GenerateDataKeyPairWithoutPlaintext` and `GenerateDataKeyPair`.
- Write snapshot tests to check the expected behaviour against AWS.
