### PR TITLE
CFn: simplify "result_handler" function signature

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -833,8 +833,8 @@ class GatewayModel(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["id"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["id"]
 
         return {
             "create": {
@@ -846,7 +846,7 @@ class GatewayModel(GenericBaseModel):
                     "contentType": "ContentType",
                 },
                 "types": {"schema": str},
-                "result_handler": _store_id,
+                "result_handler": _handle_result,
             }
         }
 

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -99,9 +99,9 @@ class DynamoDBTable(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _set_attributes(result: dict, resource_id: str, resources: dict, resource_type: str):
-            resources[resource_id]["PhysicalResourceId"] = result["TableDescription"]["TableName"]
-            resources[resource_id]["Properties"]["Table"] = result["TableDescription"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["TableDescription"]["TableName"]
+            resource["Properties"]["Table"] = result["TableDescription"]
 
         return {
             "create": [
@@ -123,7 +123,7 @@ class DynamoDBTable(GenericBaseModel):
                             )
                         ),
                     },
-                    "result_handler": _set_attributes,
+                    "result_handler": _handle_result,
                 },
                 {
                     "function": "enable_kinesis_streaming_destination",

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -24,8 +24,8 @@ class EC2RouteTable(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["RouteTable"]["RouteTableId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["RouteTable"]["RouteTableId"]
 
         return {
             "create": {
@@ -34,7 +34,7 @@ class EC2RouteTable(GenericBaseModel):
                     "VpcId": "VpcId",
                     "TagSpecifications": get_tags_param("route-table"),
                 },
-                "result_handler": _store_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_route_table",
@@ -68,10 +68,10 @@ class EC2Route(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _id(result, resource_id, resources, resource_type):
-            resource_props = resources[resource_id]["Properties"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource_props = resource["Properties"]
 
-            resources[resource_id]["PhysicalResourceId"] = generate_route_id(
+            resource["PhysicalResourceId"] = generate_route_id(
                 resource_props["RouteTableId"],
                 resource_props.get("DestinationCidrBlock", ""),
                 resource_props.get("DestinationIpv6CidrBlock"),
@@ -81,7 +81,7 @@ class EC2Route(GenericBaseModel):
             "create": {
                 "function": "create_route",
                 "parameters": ["DestinationCidrBlock", "DestinationIpv6CidrBlock", "RouteTableId"],
-                "result_handler": _id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_route",
@@ -111,19 +111,17 @@ class EC2InternetGateway(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["Properties"]["InternetGatewayId"] = result["InternetGateway"][
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["InternetGatewayId"] = result["InternetGateway"][
                 "InternetGatewayId"
             ]
-            resources[resource_id]["PhysicalResourceId"] = result["InternetGateway"][
-                "InternetGatewayId"
-            ]
+            resource["PhysicalResourceId"] = result["InternetGateway"]["InternetGatewayId"]
 
         return {
             "create": {
                 "function": "create_internet_gateway",
                 "parameters": {"TagSpecifications": get_tags_param("internet-gateway")},
-                "result_handler": _store_id,
+                "result_handler": _handle_result,
             }
         }
 
@@ -150,10 +148,8 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["AssociationId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["AssociationId"]
 
         return {
             "create": {
@@ -163,7 +159,7 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
                     "RouteTableId": "RouteTableId",
                     "SubnetId": "SubnetId",
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "disassociate_route_table",
@@ -209,17 +205,12 @@ class EC2VPCGatewayAttachment(GenericBaseModel):
             elif vpngw_id:
                 return client.attach_vpn_gateway(VpcId=vpc_id, VpnGatewayId=vpngw_id)
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             props = resource["Properties"]
             gw_id = props.get("VpnGatewayId") or props.get("InternetGatewayId")
             resource["PhysicalResourceId"] = f"{gw_id}-{props['VpcId']}"
 
-        return {
-            "create": {"function": _attach_gateway, "result_handler": _set_physical_resource_id}
-        }
+        return {"create": {"function": _attach_gateway, "result_handler": _handle_result}}
 
 
 class SecurityGroup(GenericBaseModel):
@@ -255,9 +246,9 @@ class SecurityGroup(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_group_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["Properties"]["GroupId"] = result["GroupId"]
-            resources[resource_id]["PhysicalResourceId"] = result["GroupId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["GroupId"] = result["GroupId"]
+            resource["PhysicalResourceId"] = result["GroupId"]
 
         return {
             "create": {
@@ -267,7 +258,7 @@ class SecurityGroup(GenericBaseModel):
                     "VpcId": "VpcId",
                     "Description": "GroupDescription",
                 },
-                "result_handler": _store_group_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_security_group",
@@ -333,9 +324,9 @@ class EC2Subnet(GenericBaseModel):
                         PrivateDnsHostnameTypeOnLaunch=dns_options.get("HostnameType"),
                     )
 
-        def _store_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["Subnet"]["SubnetId"]
-            resources[resource_id]["Properties"]["SubnetId"] = result["Subnet"]["SubnetId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Subnet"]["SubnetId"]
+            resource["Properties"]["SubnetId"] = result["Subnet"]["SubnetId"]
 
         return {
             "create": [
@@ -351,7 +342,7 @@ class EC2Subnet(GenericBaseModel):
                         {"TagSpecifications": get_tags_param("subnet")},
                         "VpcId",
                     ],
-                    "result_handler": _store_id,
+                    "result_handler": _handle_result,
                 },
                 {"function": _post_create},
             ],
@@ -424,9 +415,9 @@ class EC2VPC(GenericBaseModel):
                         )
                     ec2_client.delete_route_table(RouteTableId=rt["RouteTableId"])
 
-        def _store_vpc_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["Vpc"]["VpcId"]
-            resources[resource_id]["Properties"]["VpcId"] = result["Vpc"]["VpcId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Vpc"]["VpcId"]
+            resource["Properties"]["VpcId"] = result["Vpc"]["VpcId"]
 
         return {
             "create": {
@@ -436,7 +427,7 @@ class EC2VPC(GenericBaseModel):
                     "InstanceTenancy": "InstanceTenancy",
                     "TagSpecifications": get_tags_param("vpc"),
                 },
-                "result_handler": _store_vpc_id,
+                "result_handler": _handle_result,
             },
             "delete": [
                 {"function": _pre_delete},
@@ -471,10 +462,8 @@ class EC2NatGateway(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["NatGateway"]["NatGatewayId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["NatGateway"]["NatGatewayId"]
 
         return {
             "create": {
@@ -484,7 +473,7 @@ class EC2NatGateway(GenericBaseModel):
                     "AllocationId": "AllocationId",
                     "TagSpecifications": get_tags_param("natgateway"),
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_nat_gateway",
@@ -555,8 +544,8 @@ class EC2Instance(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         # TODO: validate again
-        def _store_instance_id(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["Instances"][0]["InstanceId"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Instances"][0]["InstanceId"]
 
         return {
             "create": {
@@ -569,7 +558,7 @@ class EC2Instance(GenericBaseModel):
                     "MaxCount": "MaxCount",
                     "MinCount": "MinCount",
                 },
-                "result_handler": _store_instance_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "terminate_instances",

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -55,8 +55,7 @@ class ECRRepository(GenericBaseModel):
             if default_repos_per_stack.get(stack_name):
                 del default_repos_per_stack[stack_name]
 
-        def _set_physical_resource_id(result, resource_id, resources, resource_type):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             repo_name = resource["Properties"]["RepositoryName"]
             resource["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
 
@@ -67,7 +66,7 @@ class ECRRepository(GenericBaseModel):
         return {
             "create": {
                 "function": _create_repo,
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": _delete_repo,

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -59,17 +59,15 @@ class EventBus(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def result_handler(result, resource_id, resources, resource_type):
-            resources[resource_id]["Properties"]["Arn"] = result["EventBusArn"]
-            resources[resource_id]["PhysicalResourceId"] = resources[resource_id]["Properties"][
-                "Name"
-            ]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["Arn"] = result["EventBusArn"]
+            resource["PhysicalResourceId"] = resource["Properties"]["Name"]
 
         return {
             "create": {
                 "function": "create_event_bus",
                 "parameters": ["Name"],
-                "result_handler": result_handler,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_event_bus", "parameters": ["Name"]},
         }

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -59,10 +59,10 @@ class IAMManagedPolicy(GenericBaseModel):
                 iam.attach_group_policy(GroupName=group, PolicyArn=policy_arn)
             return policy
 
-        def _set_physical_resource_id(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = result["Policy"]["Arn"]
 
-        return {"create": {"function": _create, "result_handler": _set_physical_resource_id}}
+        return {"create": {"function": _create, "result_handler": _handle_result}}
 
 
 class IAMUser(GenericBaseModel):
@@ -132,17 +132,15 @@ class IAMUser(GenericBaseModel):
             for inline_policy_name in remaining_policies:
                 client.delete_user_policy(UserName=user_name, PolicyName=inline_policy_name)
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["User"]["UserName"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["User"]["UserName"]
 
         return {
             "create": [
                 {
                     "function": "create_user",
                     "parameters": ["Path", "UserName", "PermissionsBoundary", "Tags"],
-                    "result_handler": _set_physical_resource_id,
+                    "result_handler": _handle_result,
                 },
                 {"function": _post_create},
             ],
@@ -198,15 +196,13 @@ class IAMAccessKey(GenericBaseModel):
                 if "NotSuchEntity" not in err.response["Error"]["Code"]:
                     raise
 
-        def _store_key_id(result, resource_id, resources, resource_type):
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             access_key_id = result["AccessKey"]["AccessKeyId"]
-            resources[resource_id]["PhysicalResourceId"] = access_key_id
-            resources[resource_id]["Properties"]["SecretAccessKey"] = result["AccessKey"][
-                "SecretAccessKey"
-            ]
-            status = resources[resource_id]["Properties"].get("Status", "Active")
+            resource["PhysicalResourceId"] = access_key_id
+            resource["Properties"]["SecretAccessKey"] = result["AccessKey"]["SecretAccessKey"]
+            status = resource["Properties"].get("Status", "Active")
             if status == "Inactive":
-                user_name = resources[resource_id]["Properties"]["UserName"]
+                user_name = resource["Properties"]["UserName"]
                 client = aws_stack.connect_to_service("iam")
                 client.update_access_key(
                     UserName=user_name, AccessKeyId=access_key_id, Status="Inactive"
@@ -216,7 +212,7 @@ class IAMAccessKey(GenericBaseModel):
             "create": {
                 "function": "create_access_key",
                 "parameters": ["UserName"],
-                "result_handler": _store_key_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": _delete},
         }
@@ -361,7 +357,7 @@ class IAMRole(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _set_physical_resource_id(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = result["Role"]["RoleName"]
 
         return {
@@ -383,7 +379,7 @@ class IAMRole(GenericBaseModel):
                         ),
                         {"RoleName": "RoleName"},
                     ),
-                    "result_handler": _set_physical_resource_id,
+                    "result_handler": _handle_result,
                 },
                 {"function": IAMRole._post_create},
             ],
@@ -413,15 +409,13 @@ class IAMServiceLinkedRole(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["Role"]["RoleName"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Role"]["RoleName"]
 
         return {
             "create": {
                 "function": "create_service_linked_role",
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_service_linked_role", "parameters": ["RoleName"]},
         }
@@ -457,8 +451,7 @@ class IAMPolicy(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _store_physical_id(result, resource_id, resources, resource_type):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             # the physical resource ID here has a bit of a weird format
             # e.g. 'stack-fnSe-1OKWZIBB89193' where fnSe are the first 4 characters of the LogicalResourceId (or name?)
             suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=13))
@@ -490,7 +483,7 @@ class IAMPolicy(GenericBaseModel):
         return {
             "create": {
                 "function": _create,
-                "result_handler": _store_physical_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_policy", "parameters": _delete_params},
         }
@@ -584,10 +577,8 @@ class InstanceProfile(GenericBaseModel):
                 if "NoSuchEntity" not in str(e):
                     raise
 
-        def _store_profile_name(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["InstanceProfile"][
-                "InstanceProfileName"
-            ]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["InstanceProfile"]["InstanceProfileName"]
 
         return {
             "create": [
@@ -597,7 +588,7 @@ class InstanceProfile(GenericBaseModel):
                         "InstanceProfileName": "InstanceProfileName",
                         "Path": "Path",
                     },
-                    "result_handler": _store_profile_name,
+                    "result_handler": _handle_result,
                 },
                 {"function": _add_roles},
             ],
@@ -664,17 +655,15 @@ class IAMGroup(GenericBaseModel):
             for inline_policy_name in remaining_policies:
                 client.delete_group_policy(GroupName=group_name, PolicyName=inline_policy_name)
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["Group"]["GroupName"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Group"]["GroupName"]
 
         return {
             "create": [
                 {
                     "function": "create_group",
                     "parameters": ["GroupName", "Path"],
-                    "result_handler": _set_physical_resource_id,
+                    "result_handler": _handle_result,
                 },
                 {"function": _post_create},
             ],

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -59,10 +59,8 @@ class IAMManagedPolicy(GenericBaseModel):
                 iam.attach_group_policy(GroupName=group, PolicyArn=policy_arn)
             return policy
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["Policy"]["Arn"]
+        def _set_physical_resource_id(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Policy"]["Arn"]
 
         return {"create": {"function": _create, "result_handler": _set_physical_resource_id}}
 
@@ -363,10 +361,8 @@ class IAMRole(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["Role"]["RoleName"]
+        def _set_physical_resource_id(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Role"]["RoleName"]
 
         return {
             "create": [

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -105,17 +105,14 @@ class KMSAlias(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = resource["Properties"]["AliasName"]
 
         return {
             "create": {
                 "function": "create_alias",
                 "parameters": {"AliasName": "AliasName", "TargetKeyId": "TargetKeyId"},
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_alias",

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -30,17 +30,14 @@ class LogsLogGroup(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]
 
         return {
             "create": {
                 "function": "create_log_group",
                 "parameters": {"logGroupName": "LogGroupName"},
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_log_group",
@@ -76,17 +73,14 @@ class LogsLogStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = resource["Properties"]["LogStreamName"]
 
         return {
             "create": {
                 "function": "create_log_stream",
                 "parameters": {"logGroupName": "LogGroupName", "logStreamName": "LogStreamName"},
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_log_stream",
@@ -111,10 +105,7 @@ class LogsSubscriptionFilter(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]
 
         return {
@@ -126,7 +117,7 @@ class LogsSubscriptionFilter(GenericBaseModel):
                     "filterPattern": "FilterPattern",
                     "destinationArn": "DestinationArn",
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_subscription_filter",

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -50,17 +50,15 @@ class OpenSearchDomain(GenericBaseModel):
                 )
             return result
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["DomainStatus"]["DomainName"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["DomainStatus"]["DomainName"]
 
         return {
             "create": [
                 {
                     "function": "create_domain",
                     "parameters": _create_params,
-                    "result_handler": _set_physical_resource_id,
+                    "result_handler": _handle_result,
                 },
                 {"function": "add_tags", "parameters": opensearch_add_tags_params},
             ],

--- a/localstack/services/cloudformation/models/resourcegroups.py
+++ b/localstack/services/cloudformation/models/resourcegroups.py
@@ -20,10 +20,8 @@ class ResourceGroupsGroup(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["Group"]["Name"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["Group"]["Name"]
 
         return {
             "create": {
@@ -35,7 +33,7 @@ class ResourceGroupsGroup(GenericBaseModel):
                     "Configuration": "Configuration",
                     "Tags": params_list_to_dict("Tags"),
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_group", "parameters": {"Group": "Name"}},
         }

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -27,10 +27,7 @@ class S3BucketPolicy(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = md5(
                 canonical_json(resource["Properties"]["PolicyDocument"])
             )
@@ -42,7 +39,7 @@ class S3BucketPolicy(GenericBaseModel):
                     dump_json_params(None, "PolicyDocument"),
                     {"PolicyDocument": "Policy", "Bucket": "Bucket"},
                 ),
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_bucket_policy", "parameters": {"Bucket": "Bucket"}},
         }
@@ -168,10 +165,7 @@ class S3Bucket(GenericBaseModel):
             }
             return result
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = resource["Properties"]["BucketName"]
 
         def _pre_delete(logical_resource_id: str, resource: dict, stack_name: str):
@@ -260,7 +254,7 @@ class S3Bucket(GenericBaseModel):
             "create": [
                 {
                     "function": _create_bucket,
-                    "result_handler": _set_physical_resource_id,
+                    "result_handler": _handle_result,
                 },
                 {
                     "function": "put_bucket_notification_configuration",

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -111,16 +111,14 @@ class SecretsManagerSecret(GenericBaseModel):
                 result["SecretString"] = secret_value
             return result
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["ARN"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["ARN"]
 
         return {
             "create": {
                 "function": "create_secret",
                 "parameters": _create_params,
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {"function": "delete_secret", "parameters": {"SecretId": "Name"}},
         }
@@ -169,10 +167,7 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
                 "BlockPublicPolicy": properties.get("BlockPublicPolicy"),
             }
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resource = resources[resource_id]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = arns.secretsmanager_secret_arn(
                 resource["Properties"]["Name"]
             )
@@ -181,7 +176,7 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
             "create": {
                 "function": "put_resource_policy",
                 "parameters": create_params,
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_resource_policy",

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -94,16 +94,16 @@ class SNSTopic(GenericBaseModel):
                     TopicArn=topic_arn, Protocol=subscription["Protocol"], Endpoint=endpoint
                 )
 
-        def result_handler(result, resource_id, resources, resource_type):
-            resources[resource_id]["PhysicalResourceId"] = result["TopicArn"]
-            resources[resource_id]["Properties"]["TopicArn"] = result["TopicArn"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["TopicArn"]
+            resource["Properties"]["TopicArn"] = result["TopicArn"]
 
         return {
             "create": [
                 {
                     "function": "create_topic",
                     "parameters": _create_params,
-                    "result_handler": result_handler,
+                    "result_handler": _handle_result,
                 },
                 {"function": _add_topics},
             ],
@@ -155,10 +155,8 @@ class SNSSubscription(GenericBaseModel):
             result = {a: attr_val(properties[a]) for a in attrs if a in properties}
             return result
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["SubscriptionArn"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["SubscriptionArn"]
 
         return {
             "create": {
@@ -169,7 +167,7 @@ class SNSSubscription(GenericBaseModel):
                     "Endpoint": "Endpoint",
                     "Attributes": sns_subscription_params,
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "unsubscribe",

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -111,10 +111,8 @@ class SQSQueue(GenericBaseModel):
                 return queue_url
             return arns.sqs_queue_url_for_arn(properties["QueueArn"])
 
-        def _set_physical_resource_id(
-            result: dict, resource_id: str, resources: dict, resource_type: str
-        ):
-            resources[resource_id]["PhysicalResourceId"] = result["QueueUrl"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = result["QueueUrl"]
 
         return {
             "create": {
@@ -133,7 +131,7 @@ class SQSQueue(GenericBaseModel):
                     ),
                     "tags": params_list_to_dict("Tags"),
                 },
-                "result_handler": _set_physical_resource_id,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_queue",

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -25,15 +25,15 @@ class SFNActivity(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_arn(result, resource_id, resources, resource_type):
-            resources[resource_id]["Properties"]["Arn"] = result["activityArn"]
-            resources[resource_id]["PhysicalResourceId"] = result["activityArn"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["Arn"] = result["activityArn"]
+            resource["PhysicalResourceId"] = result["activityArn"]
 
         return {
             "create": {
                 "function": "create_activity",
                 "parameters": {"name": "Name", "tags": "Tags"},
-                "result_handler": _store_arn,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_activity",
@@ -87,9 +87,9 @@ class SFNStateMachine(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def result_handler(result, resource_id, resources, resource_type):
-            resources[resource_id]["Properties"]["Arn"] = result["stateMachineArn"]
-            resources[resource_id]["PhysicalResourceId"] = result["stateMachineArn"]
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["Arn"] = result["stateMachineArn"]
+            resource["PhysicalResourceId"] = result["stateMachineArn"]
 
         def _create_params(
             properties: dict, logical_resource_id: str, resource: dict, stack_name: str
@@ -122,7 +122,7 @@ class SFNStateMachine(GenericBaseModel):
             "create": {
                 "function": "create_state_machine",
                 "parameters": _create_params,
-                "result_handler": result_handler,
+                "result_handler": _handle_result,
             },
             "delete": {
                 "function": "delete_state_machine",


### PR DESCRIPTION
Update signature of the "result_handler" functions to remove unused parameters, and parameters that the provider should not have access to, particularly the full list of resource definitions.

This work is in preparation of integrating the new resource providers into the template deployer.
