### PR TITLE
add config variable to explicitly ignore AWS credentials

### DIFF
--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -117,7 +117,7 @@ def get_account_id_from_access_key_id(access_key_id: str) -> str:
         if not config.PARITY_AWS_ACCESS_KEY_ID:
             # If AWS_ACCESS_KEY_ID has production AWS credentials, ignore them
             if access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA"):
-                LOG.warning(
+                LOG.debug(
                     "Ignoring production AWS credentials provided to LocalStack. Falling back to default account ID."
                 )
 

--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -117,10 +117,9 @@ def get_account_id_from_access_key_id(access_key_id: str) -> str:
         if not config.PARITY_AWS_ACCESS_KEY_ID:
             # If AWS_ACCESS_KEY_ID has production AWS credentials, ignore them
             if access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA"):
-                if not config.IGNORE_PRODUCTION_AWS_CREDENTIALS:
-                    LOG.warning(
-                        "Ignoring production AWS credentials provided to LocalStack. Falling back to default account ID."
-                    )
+                LOG.warning(
+                    "Ignoring production AWS credentials provided to LocalStack. Falling back to default account ID."
+                )
 
             elif access_key_id.startswith("LSIA") or access_key_id.startswith("LKIA"):
                 return extract_account_id_from_access_key_id(access_key_id)

--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -117,9 +117,10 @@ def get_account_id_from_access_key_id(access_key_id: str) -> str:
         if not config.PARITY_AWS_ACCESS_KEY_ID:
             # If AWS_ACCESS_KEY_ID has production AWS credentials, ignore them
             if access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA"):
-                LOG.warning(
-                    "Ignoring production AWS credentials provided to LocalStack. Falling back to default account ID."
-                )
+                if not config.IGNORE_PRODUCTION_AWS_CREDENTIALS:
+                    LOG.warning(
+                        "Ignoring production AWS credentials provided to LocalStack. Falling back to default account ID."
+                    )
 
             elif access_key_id.startswith("LSIA") or access_key_id.startswith("LKIA"):
                 return extract_account_id_from_access_key_id(access_key_id)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1034,6 +1034,9 @@ MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER
 # Whether to return and parse access key ids starting with an "A", like on AWS
 PARITY_AWS_ACCESS_KEY_ID = is_env_true("PARITY_AWS_ACCESS_KEY_ID")
 
+# Whether to ignore AWS credentials that are configured in the environment
+IGNORE_PRODUCTION_AWS_CREDENTIALS = is_env_true("IGNORE_PRODUCTION_AWS_CREDENTIALS")
+
 # Show exceptions for CloudFormation deploy errors
 CFN_VERBOSE_ERRORS = is_env_true("CFN_VERBOSE_ERRORS")
 
@@ -1087,6 +1090,7 @@ CONFIG_ENV_VARS = [
     "HOSTNAME",
     "HOSTNAME_EXTERNAL",
     "HOSTNAME_FROM_LAMBDA",
+    "IGNORE_PRODUCTION_AWS_CREDENTIALS",
     "KINESIS_ERROR_PROBABILITY",
     "KINESIS_INITIALIZE_STREAMS",
     "KINESIS_MOCK_PERSIST_INTERVAL",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1034,9 +1034,6 @@ MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER
 # Whether to return and parse access key ids starting with an "A", like on AWS
 PARITY_AWS_ACCESS_KEY_ID = is_env_true("PARITY_AWS_ACCESS_KEY_ID")
 
-# Whether to ignore AWS credentials that are configured in the environment
-IGNORE_PRODUCTION_AWS_CREDENTIALS = is_env_true("IGNORE_PRODUCTION_AWS_CREDENTIALS")
-
 # Show exceptions for CloudFormation deploy errors
 CFN_VERBOSE_ERRORS = is_env_true("CFN_VERBOSE_ERRORS")
 
@@ -1090,7 +1087,6 @@ CONFIG_ENV_VARS = [
     "HOSTNAME",
     "HOSTNAME_EXTERNAL",
     "HOSTNAME_FROM_LAMBDA",
-    "IGNORE_PRODUCTION_AWS_CREDENTIALS",
     "KINESIS_ERROR_PROBABILITY",
     "KINESIS_INITIALIZE_STREAMS",
     "KINESIS_MOCK_PERSIST_INTERVAL",


### PR DESCRIPTION
quick fix for #8225 and #8380

i'd like to get some input from @dfangl and @viren-nadkarni whether this makes sense and is something we can expand on.