### PR TITLE
Avoid loading the request stream to retrieve context

### DIFF
--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -84,10 +84,11 @@ def extract_region_from_headers(headers):
 
 
 def get_request_context():
-    candidates = [get_proxy_request_for_thread(), get_flask_request_for_thread()]
+    candidates = [get_proxy_request_for_thread, get_flask_request_for_thread]
     for req in candidates:
-        if req is not None:
-            return req
+        context = req()
+        if context is not None:
+            return context
 
 
 class RequestContextManager:


### PR DESCRIPTION
## Issue
We are currently loading the flask request for a thread every time we call get_request_context(), even though we might find it in the thread local variable anyway.

This leads to the request streams being read, if you access methods like "get_region_from_request_context`, and the streams not being available anymore.

## Solution
Instead of loading both, and then iterating, we will now load while iterating. This means, if the threadlocal request context is set, we will not call `get_flask_request_for_thread`, and therefore not load the request.

While this is still implicit, and it is still possibly loading the request into a flask request, it provides a reasonable improvement until we can get rid of the flask context one and for all.