### PR TITLE
use vpcId to fectch state of EC2::VPC

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -368,9 +368,12 @@ class EC2VPC(GenericBaseModel):
         return "AWS::EC2::VPC"
 
     def fetch_state(self, stack_name, resources):
-        client = aws_stack.connect_to_service("ec2")
-        resp = client.describe_vpcs(Filters=[{"Name": "cidr", "Values": [self.props["CidrBlock"]]}])
-        return (resp["Vpcs"] or [None])[0]
+        if self.physical_resource_id:
+            client = aws_stack.connect_to_service("ec2")
+            resp = client.describe_vpcs(
+                Filters=[{"Name": "vpc-id", "Values": [self.physical_resource_id]}]
+            )
+            return (resp["Vpcs"] or [None])[0]
 
     def get_cfn_attribute(self, attribute_name):
         ec2_client = aws_stack.connect_to_service("ec2")


### PR DESCRIPTION
this PR replaces the usage of the CIDR block to fetch the resource state for  the VPC ID that the EC2 service generates. This allows CFn to deploy multiple VPCs with the same CIDR Block.
