### PR TITLE
Fix container port check and host detection on podman

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -720,7 +720,10 @@ try:
             DOCKER_HOST_FROM_CONTAINER = "host.docker.internal"
     # update LOCALSTACK_HOSTNAME if host.docker.internal is available
     if is_in_docker:
-        DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.docker.internal")
+        try:
+            DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.docker.internal")
+        except socket.error:
+            DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.containers.internal")
         if LOCALSTACK_HOSTNAME == DOCKER_BRIDGE_IP:
             LOCALSTACK_HOSTNAME = DOCKER_HOST_FROM_CONTAINER
 except socket.error:

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -146,8 +146,8 @@ def container_ports_can_be_bound(ports: Union[IntOrPort, List[IntOrPort]]) -> bo
     try:
         result = DOCKER_CLIENT.run_container(
             _get_ports_check_docker_image(),
-            entrypoint="",
-            command=["echo", "test123"],
+            entrypoint="sh -c",
+            command=["echo test123"],
             ports=port_mappings,
             remove=True,
         )


### PR DESCRIPTION
## Motivation
* Podman has issues with empty entrypoints. While they seem to be fixed in some cases, using the docker sdk seems to still trigger this behavior.
* Podman cannot resolve `host.docker.internal`, which is necessary for services like EKS. The default fallback to the bridge network gateway is invalid as well. It can however use `host.containers.internal`.

## Changes
* Start port detection container with `sh -c` instead of an empty entrypoint to circumvent the issue. We might seek a more fundamental fix at some point, but this will do for now.
* Add a fallback to `host.containers.internal` if `host.docker.internal` does not resolve. If this as well fails, the fallback behaves like it currently does.