### PR TITLE
Let SQS AddPermission call actually influence policy attribute

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -7,7 +7,7 @@ import re
 import threading
 import time
 from queue import Empty, PriorityQueue, Queue
-from typing import Dict, NamedTuple, Optional, Set
+from typing import Dict, Optional, Set
 
 from localstack import config
 from localstack.aws.api import RequestContext
@@ -163,13 +163,6 @@ class SqsMessage:
         return f"SqsMessage(id={self.message_id},group={self.message_group_id})"
 
 
-class Permission(NamedTuple):
-    # TODO: just a placeholder for real policies
-    label: str
-    account_id: str
-    action: str
-
-
 class ReceiveMessageResult:
     """
     Object to communicate the result of a "receive messages" operation between the SqsProvider and
@@ -199,7 +192,6 @@ class SqsQueue:
 
     attributes: QueueAttributeMap
     tags: TagMap
-    permissions: Set[Permission]
 
     purge_in_progress: bool
     purge_timestamp: Optional[float]
@@ -495,6 +487,74 @@ class SqsQueue:
         for k in attributes.keys():
             if k not in valid:
                 raise InvalidAttributeName(f"Unknown Attribute {k}.")
+
+    def add_permission(self, actions: list[str], account_ids: list[str], label: str) -> None:
+        """
+        Create / append to a policy for usage with the add_permission api call
+
+        :param actions: List of actions to be included in the policy, without the SQS: prefix
+        :param account_ids: List of account ids to be included in the policy
+        :param label: Permission label
+        """
+        statement = {
+            "Sid": label,
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [f"arn:aws:iam::{account_id}:root" for account_id in account_ids]
+                if len(account_ids) > 1
+                else f"arn:aws:iam::{account_ids[0]}:root"
+            },
+            "Action": [f"SQS:{action}" for action in actions]
+            if len(actions) > 1
+            else f"SQS:{actions[0]}",
+            "Resource": self.arn,
+        }
+        if policy := self.attributes.get(QueueAttributeName.Policy):
+            policy = json.loads(policy)
+            policy.setdefault("Statement", [])
+        else:
+            policy = {
+                "Version": "2008-10-17",
+                "Id": f"{self.arn}/SQSDefaultPolicy",
+                "Statement": [],
+            }
+        policy.setdefault("Statement", [])
+        existing_statement_ids = [statement.get("Sid") for statement in policy["Statement"]]
+        if label in existing_statement_ids:
+            raise InvalidParameterValue(
+                f"Value {label} for parameter Label is invalid. Reason: Already exists."
+            )
+        policy["Statement"].append(statement)
+        self.attributes[QueueAttributeName.Policy] = json.dumps(policy)
+
+    def remove_permission(self, label: str) -> None:
+        """
+        Delete a policy statement for usage of the remove_permission call
+
+        :param label: Permission label
+        """
+        if policy := self.attributes.get(QueueAttributeName.Policy):
+            policy = json.loads(policy)
+            # this should not be necessary, but we can upload custom policies, so it's better to be safe
+            policy.setdefault("Statement", [])
+        else:
+            policy = {
+                "Version": "2008-10-17",
+                "Id": f"{self.arn}/SQSDefaultPolicy",
+                "Statement": [],
+            }
+        existing_statement_ids = [statement.get("Sid") for statement in policy["Statement"]]
+        if label not in existing_statement_ids:
+            raise InvalidParameterValue(
+                f"Value {label} for parameter Label is invalid. Reason: can't find label."
+            )
+        policy["Statement"] = [
+            statement for statement in policy["Statement"] if statement.get("Sid") != label
+        ]
+        if policy["Statement"]:
+            self.attributes[QueueAttributeName.Policy] = json.dumps(policy)
+        else:
+            del self.attributes[QueueAttributeName.Policy]
 
 
 class StandardQueue(SqsQueue):

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -488,7 +488,7 @@ class SqsQueue:
             if k not in valid:
                 raise InvalidAttributeName(f"Unknown Attribute {k}.")
 
-    def add_permission(self, actions: list[str], account_ids: list[str], label: str) -> None:
+    def add_permission(self, label: str, actions: list[str], account_ids: list[str]) -> None:
         """
         Create / append to a policy for usage with the add_permission api call
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -71,7 +71,6 @@ from localstack.services.sqs import constants as sqs_constants
 from localstack.services.sqs.exceptions import InvalidParameterValue
 from localstack.services.sqs.models import (
     FifoQueue,
-    Permission,
     SqsMessage,
     SqsQueue,
     SqsStore,
@@ -1155,16 +1154,12 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         self._validate_actions(actions)
 
-        for account_id in aws_account_ids:
-            for action in actions:
-                queue.permissions.add(Permission(label, account_id, action))
+        queue.add_permission(actions=actions, account_ids=aws_account_ids, label=label)
 
     def remove_permission(self, context: RequestContext, queue_url: String, label: String) -> None:
         queue = self._resolve_queue(context, queue_url=queue_url)
 
-        candidates = [p for p in queue.permissions if p.label == label]
-        if candidates:
-            queue.permissions.remove(candidates[0])
+        queue.remove_permission(label=label)
 
     def _create_message_attributes(
         self,

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1154,7 +1154,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         self._validate_actions(actions)
 
-        queue.add_permission(actions=actions, account_ids=aws_account_ids, label=label)
+        queue.add_permission(label=label, actions=actions, account_ids=aws_account_ids)
 
     def remove_permission(self, context: RequestContext, queue_url: String, label: String) -> None:
         queue = self._resolve_queue(context, queue_url=queue_url)

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -855,5 +855,162 @@
         }
       }
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_sqs_permission_lifecycle": {
+    "recorded-date": "22-06-2023, 17:01:51",
+    "recorded-content": {
+      "add-permission-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": [
+                    "arn:aws:iam::111111111111:<resource:3>",
+                    "arn:aws:iam::668614515564:<resource:3>"
+                  ]
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-after-removal": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-first-account-same-label": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-second-account-same-label": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value crossaccountpermission for parameter Label is invalid. Reason: Already exists.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-queue-policy-attribute-second-account-different-label": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              },
+              {
+                "Sid": "crossaccountpermission2",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-first-permission": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission2",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-second-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-non-existent-label": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value crossaccountpermission2 for parameter Label is invalid. Reason: can't find label.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
Currently, SQS AddPermission and RemovePermission calls do only save the permissions in some internal datastructure - they are never returned with sqs.GetQueueAttributes. This is problematic, since this is a necessity for cross account evaluation.

You could just use SetQueueAttributes on the `Policy` attribute but we should match AWS behavior.

## Changes
* Rework SQS permission management, by adapting the stored policy
* Add AWS validated test for permission lifecycles.