### PR TITLE
Fix container port detection with the cmd docker client

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -146,8 +146,8 @@ def container_ports_can_be_bound(ports: Union[IntOrPort, List[IntOrPort]]) -> bo
     try:
         result = DOCKER_CLIENT.run_container(
             _get_ports_check_docker_image(),
-            entrypoint="sh -c",
-            command=["echo test123"],
+            entrypoint="sh",
+            command=["-c", "echo test123"],
             ports=port_mappings,
             remove=True,
         )


### PR DESCRIPTION
## Motivation
The command line docker client does not like an entrypoint with an argument. It will interpret this as a single binary, i.e. look for "sh -c" in the path.

Since we cannot have an empty entrypoint, due to podman, and not an entrypoint including a command prefix, due to the docker cmd client.

## Changes
* Change entrypoint to "sh" and the command to "-c", "echo123". This should be compatible with all clients.

## Future considerations
* We might want to change the docker cmd client to properly pass these entrypoints.