### PR TITLE
Fix resource type resolution and missing logical resource ID in update

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -168,7 +168,10 @@ class ResourceProvider(Generic[Properties]):
 # legacy helpers
 def get_resource_type(resource: dict) -> str:
     """this is currently overwritten in PRO to add support for custom resources"""
-    return resource["Type"]
+    resource_type: str = resource["Type"]
+    if resource_type.startswith("Custom::"):
+        return "AWS::CloudFormation::CustomResource"
+    return resource_type
 
 
 def check_not_found_exception(e, resource_type, resource, resource_status=None):
@@ -383,6 +386,7 @@ class LegacyResourceProvider(ResourceProvider):
                 "Type": self.resource_type,
                 "Properties": request.desired_state,
                 "PhysicalResourceId": physical_resource_id,
+                "LogicalResourceId": request.logical_resource_id,
             },
             region_name=request.region_name,
         )
@@ -437,6 +441,9 @@ class LegacyResourceProvider(ResourceProvider):
         )
 
         func_details = func_details[LEGACY_ACTION_MAP[request.action]]
+        if not func_details:
+            print(":(")
+        #     return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=resource["Properties"])
         func_details = func_details if isinstance(func_details, list) else [func_details]
         results = []
         # TODO: other top level keys

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -441,9 +441,6 @@ class LegacyResourceProvider(ResourceProvider):
         )
 
         func_details = func_details[LEGACY_ACTION_MAP[request.action]]
-        if not func_details:
-            print(":(")
-        #     return ProgressEvent(status=OperationStatus.SUCCESS, resource_model=resource["Properties"])
         func_details = func_details if isinstance(func_details, list) else [func_details]
         results = []
         # TODO: other top level keys


### PR DESCRIPTION
Changes

- Adds logical resource ID to "meta"-resource data passed when instantiating a GenericBaseModel for updates. This missing lead to KeyErrors on LogicalResourceId
- Adds a patch from -ext here to avoid having to patch this in -ext.