### PR TITLE
unify CLI error messages, add global error message handler

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -618,6 +618,10 @@ def start_infra_in_docker():
     try:
         server.start()
         server.join()
+        error = server.get_error()
+        if error:
+            # if the server failed, raise the error
+            raise error
     except KeyboardInterrupt:
         print("ok, bye!")
         shutdown_handler()

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -69,6 +69,15 @@ class TestCliContainerLifecycle:
         with pytest.raises(requests.ConnectionError):
             requests.get(get_edge_url() + "/_localstack/health")
 
+    def test_start_already_running(self, runner, container_client):
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "180"])
+        result = runner.invoke(cli, ["start"])
+        assert container_exists(container_client, config.MAIN_CONTAINER_NAME)
+        assert result.exit_code == 1
+        assert "Error" in result.output
+        assert "is already running" in result.output
+
     def test_wait_timeout_raises_exception(self, runner, container_client):
         # assume a wait without start fails
         result = runner.invoke(cli, ["wait", "-t", "0.5"])

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -15,6 +15,7 @@ from localstack.cli.localstack import create_with_plugins, is_frozen_bundle
 from localstack.cli.localstack import localstack as cli
 from localstack.utils import testutil
 from localstack.utils.common import is_command_available
+from localstack.utils.container_utils.container_client import ContainerException, DockerNotAvailable
 
 cli: click.Group
 
@@ -22,6 +23,37 @@ cli: click.Group
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.mark.parametrize(
+    "exception,expected_message",
+    [
+        (KeyboardInterrupt(), "Aborted!"),
+        (DockerNotAvailable(), "Docker could not be found on the system"),
+        (ContainerException("example message"), "example message"),
+        (click.ClickException("example message"), "example message"),
+        (click.exceptions.Exit(code=1), ""),
+    ],
+)
+def test_error_handling(runner: CliRunner, monkeypatch, exception, expected_message):
+    """Test different globally handled exceptions, their status code, and error message."""
+
+    def mock_call():
+        raise exception
+
+    from localstack.utils import bootstrap
+
+    monkeypatch.setattr(bootstrap, "start_infra_locally", mock_call)
+    result = runner.invoke(cli, ["start", "--host"])
+    assert result.exit_code == 1
+    assert expected_message in result.output
+
+
+def test_error_handling_help(runner):
+    """Make sure the help command is not interpreted as an error (Exit exception is raised)."""
+    result = runner.invoke(cli, ["-h"])
+    assert result.exit_code == 0
+    assert "Usage: localstack" in result.output
 
 
 def test_create_with_plugins(runner):
@@ -41,6 +73,14 @@ def test_status_services_error(runner):
     result = runner.invoke(cli, ["status", "services"])
     assert result.exit_code == 1
     assert "Error" in result.output
+
+
+@pytest.mark.parametrize("command", ["ssh", "stop"])
+def test_container_not_runnin_error(runner, command):
+    result = runner.invoke(cli, [command])
+    assert result.exit_code == 1
+    assert "Error" in result.output
+    assert "Expected a running LocalStack container" in result.output
 
 
 def test_start_docker_is_default(runner, monkeypatch):

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -40,7 +40,7 @@ def test_version(runner):
 def test_status_services_error(runner):
     result = runner.invoke(cli, ["status", "services"])
     assert result.exit_code == 1
-    assert "ERROR" in result.output
+    assert "Error" in result.output
 
 
 def test_start_docker_is_default(runner, monkeypatch):
@@ -147,7 +147,7 @@ def test_validate_config_syntax_error(runner, monkeypatch, tmp_path):
     result = runner.invoke(cli, ["config", "validate", "--file", str(file)])
 
     assert result.exit_code == 1
-    assert "error" in result.output
+    assert "Error" in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR aims at unifying the CLI error- and exitcode-handling.
- It explicitly catches some common exceptions and prints proper error messages (f.e. Docker is not installed, localstack_main is not running for status command,...). /cc @SimonWallner 
- It uses the `ClickException` for all error cases to use a unified error message as well as a non-zero exit code: https://click.palletsprojects.com/en/8.1.x/exceptions/#exception-handling

Changes postponed to later iterations:
- Introduce more fine grained Docker exceptions, clearly indicating that a container cannot be started due to port- or naming conflicts. (This was initially the plan for this PR, but this needs some changes in the Docker clients, which would bloat up this PR quite a lot.) /cc @dfangl 