### PR TITLE
Support to import documentation parts

### DIFF
--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -2538,5 +2538,70 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts": {
+    "recorded-date": "26-06-2023, 12:01:38",
+    "recorded-content": {
+      "create-import-documentations_parts": [
+        {
+          "id": "<id:1>",
+          "location": {
+            "type": "API"
+          },
+          "properties": {
+            "description": "API description",
+            "info": {
+              "description": "API info description 4",
+              "version": "API info version 3"
+            }
+          }
+        },
+        {
+          "id": "<id:2>",
+          "location": {
+            "type": "METHOD",
+            "path": "/",
+            "method": "GET"
+          },
+          "properties": {
+            "description": "Method description."
+          }
+        },
+        {
+          "id": "<id:3>",
+          "location": {
+            "type": "MODEL",
+            "name": "<name:1>"
+          },
+          "properties": {
+            "title": "<name:1> Schema"
+          }
+        },
+        {
+          "id": "<id:4>",
+          "location": {
+            "type": "RESPONSE",
+            "path": "/",
+            "method": "GET",
+            "statusCode": "200"
+          },
+          "properties": {
+            "description": "200 response"
+          }
+        }
+      ],
+      "import-documentation-parts": {
+        "ids": [
+          "<id:5>",
+          "<id:6>",
+          "<id:7>",
+          "<id:8>"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/files/oas30_documentation_parts.json
+++ b/tests/integration/files/oas30_documentation_parts.json
@@ -1,0 +1,85 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "description",
+    "version": "1",
+    "title": "doc"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Method description.",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-amazon-apigateway-documentation": {
+    "version": "1.0.3",
+    "documentationParts": [
+      {
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "description": "API description",
+          "info": {
+            "description": "API info description 4",
+            "version": "API info version 3"
+          }
+        }
+      },
+      {
+        "location": {
+          "type": "METHOD",
+          "method": "GET"
+        },
+        "properties": {
+          "description": "Method description."
+        }
+      },
+      {
+        "location": {
+          "type": "MODEL",
+          "name": "Empty"
+        },
+        "properties": {
+          "title": "Empty Schema"
+        }
+      },
+      {
+        "location": {
+          "type": "RESPONSE",
+          "method": "GET",
+          "statusCode": "200"
+        },
+        "properties": {
+          "description": "200 response"
+        }
+      }
+    ]
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Empty": {
+        "type": "object",
+        "title": "Empty Schema"
+      }
+    }
+  }
+}


### PR DESCRIPTION
REST API supports adding documentation to an API, using the "import documentation parts" API.

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api-quick-start-import-export.html

This PR adds support to "import documentation parts" for REST API but only the "override" mode.

# Changes

- implements `import_documentation_parts` for "overwrite" mode.
- adds snapshot testing.
