### PR TITLE
remove pproxy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,6 @@ runtime =
     localstack-client>=2.0
     moto-ext[all]==4.1.11.post1
     opensearch-py==2.1.1
-    pproxy>=2.7.0
     pymongo>=4.2.0
     pyopenssl>=23.0.0
     Quart>=0.18


### PR DESCRIPTION
This PR removes the `proxy_server.start_ssl_proxy` function, as well as the dependency `pproxy`.
Once `pproxy` is removed, we should be able to move towards Python 3.11 for the runtime: https://github.com/localstack/localstack/pull/8087