### PR TITLE
add docker client commands to get docker system info

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -456,6 +456,14 @@ class ContainerClient(metaclass=ABCMeta):
     STOP_TIMEOUT = 0
 
     @abstractmethod
+    def get_system_info(self) -> dict:
+        """Returns the docker system-wide information as dictionary (``docker info``)."""
+
+    def get_system_id(self) -> str:
+        """Returns the unique and stable ID of the docker daemon."""
+        return self.get_system_info()["ID"]
+
+    @abstractmethod
     def get_container_status(self, container_name: str) -> DockerContainerStatus:
         """Returns the status of the container with the given name"""
         pass

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -68,6 +68,17 @@ class CmdDockerClient(ContainerClient):
         """Return the string to be used for running Docker commands."""
         return config.DOCKER_CMD.split()
 
+    def get_system_info(self) -> dict:
+        cmd = [
+            *self._docker_cmd(),
+            "info",
+            "--format",
+            "{{json .}}",
+        ]
+        cmd_result = run(cmd)
+
+        return json.loads(cmd_result)
+
     def get_container_status(self, container_name: str) -> DockerContainerStatus:
         cmd = self._docker_cmd()
         cmd += [

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -125,6 +125,9 @@ class SdkDockerClient(ContainerClient):
         target_is_dir = target_exists and bool(stats["mode"] & SDK_ISDIR)
         return target_exists, target_is_dir
 
+    def get_system_info(self) -> dict:
+        return self.client().info()
+
     def get_container_status(self, container_name: str) -> DockerContainerStatus:
         # LOG.debug("Getting container status for container: %s", container_name) #  too verbose
         try:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import time
-import uuid
 from typing import NamedTuple
 
 import pytest

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import time
+import uuid
 from typing import NamedTuple
 
 import pytest
@@ -118,6 +119,16 @@ def create_network(docker_client: ContainerClient):
 
 
 class TestDockerClient:
+    def test_get_system_info(self, docker_client: ContainerClient):
+        info = docker_client.get_system_info()
+        assert "ID" in info
+        assert "OperatingSystem" in info
+        assert "Architecture" in info
+
+    def test_get_system_id(self, docker_client: ContainerClient):
+        assert uuid.UUID(docker_client.get_system_id())
+        assert docker_client.get_system_id() == docker_client.get_system_id()
+
     def test_container_lifecycle_commands(self, docker_client: ContainerClient):
         container_name = _random_container_name()
         output = docker_client.create_container(

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -126,7 +126,7 @@ class TestDockerClient:
         assert "Architecture" in info
 
     def test_get_system_id(self, docker_client: ContainerClient):
-        assert uuid.UUID(docker_client.get_system_id())
+        assert len(docker_client.get_system_id()) > 1
         assert docker_client.get_system_id() == docker_client.get_system_id()
 
     def test_container_lifecycle_commands(self, docker_client: ContainerClient):


### PR DESCRIPTION
Adds two methods `get_system_info` and `get_system_id` to the container client interface. On docker, this is populated using `docker info`, and can provide a stable machine ID even from within the container.

Future work: check whether this works on podman (ad: daniel checked, it works), and how that would work on k8s.