### PR TITLE
Fix termination of generators when client connection is closed

### DIFF
--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -82,7 +82,9 @@ class ResponseLogger:
     def _log(self, context: RequestContext, response: Response):
         aws_logger = self.aws_logger
         http_logger = self.http_logger
-        is_internal_call = is_internal_call_context(context.request.headers)
+        is_internal_call = (
+            is_internal_call_context(context.request.headers) or context.is_internal_call
+        )
         if is_internal_call:
             aws_logger = self.internal_aws_logger
             http_logger = self.internal_http_logger

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -143,7 +143,7 @@ class ResponseLogger:
                     "request_headers": dict(context.request.headers),
                     # response
                     "output_type": "Response",
-                    "output": response.data,
+                    "output": "StreamingBody(unknown)" if response.is_streamed else response.data,
                     "response_headers": dict(response.headers),
                 },
             )

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -253,6 +253,8 @@ class WsgiStartResponse:
     async def write(self, data: bytes) -> None:
         if not self.started:
             raise ValueError("not started the response yet")
+        if getattr(self.send.__self__, "closed", None):
+            raise BrokenPipeError("Connection closed")
         await self.send({"type": "http.response.body", "body": data, "more_body": True})
         self.sent += len(data)
         if self.sent >= self.content_length:
@@ -374,6 +376,12 @@ class ASGIAdapter:
                 else:
                     for packet in iterable:
                         await response.write(packet)
+        except ConnectionError as e:
+            client_info = "unknown"
+            if client := scope.get("client"):
+                address, port = client
+                client_info = f"{address}:{port}"
+            LOG.debug("Error while writing responses: %s (client_info: %s)", e, client_info)
         finally:
             await response.close()
 

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -383,6 +383,8 @@ class ASGIAdapter:
                 client_info = f"{address}:{port}"
             LOG.debug("Error while writing responses: %s (client_info: %s)", e, client_info)
         finally:
+            if iterable and hasattr(iterable, "aclose"):
+                await iterable.aclose()
             await response.close()
 
     async def handle_lifespan(

--- a/tests/unit/http_/test_asgi.py
+++ b/tests/unit/http_/test_asgi.py
@@ -130,7 +130,7 @@ def test_chunked_transfer_encoding_client_timeout(serve_asgi_adapter):
 
     # request is now closed, continue the response generator
     continue_request.set()
-    # the generator should have been terminated before setting this value
+    # this flag is only set when generator is exited
     assert generator_exited.wait(timeout=10)
 
 

--- a/tests/unit/http_/test_asgi.py
+++ b/tests/unit/http_/test_asgi.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
@@ -94,6 +95,44 @@ def test_chunked_transfer_encoding_response(serve_asgi_adapter):
 
     assert next(it) == b"foobar"
     assert next(it) == b"baz"
+
+
+def test_chunked_transfer_encoding_client_timeout(serve_asgi_adapter):
+    # this test makes sure that creating a response with a generator automatically creates a
+    # transfer-encoding=chunked response
+
+    ended = False
+    continue_request = threading.Event()
+
+    @Request.application
+    def app(_request: Request) -> Response:
+        def _gen():
+            nonlocal ended
+            yield "foo"
+            yield "bar\n"
+            continue_request.wait()
+            # only three are needed, let's send some more to make sure
+            for _ in range(10):
+                yield "baz\n"
+            ended = True
+
+        return Response(_gen(), 200)
+
+    server = serve_asgi_adapter(app)
+
+    with requests.get(server.url, stream=True) as response:
+        assert response.headers["Transfer-Encoding"] == "chunked"
+
+        it = response.iter_lines()
+
+        assert next(it) == b"foobar"
+
+    # request is now closed, continue the response generator
+    continue_request.set()
+    # we need to wait for a second, to ensure the iterator had a chance to terminate one way or the other
+    time.sleep(1)
+    # the generator should have been terminated before setting this value
+    assert not ended
 
 
 def test_chunked_transfer_encoding_request(serve_asgi_adapter):


### PR DESCRIPTION
## Current Issue
We are currently not closing down our response generators after the client closes the connection. This leads to resource leaks, as the generators keep running in the background, even though no one will ever read the response.

This snipped from hypercorn `http_stream.py` shows us, that all response `send` calls will return immediately once the connection is closed.

```python
    async def app_send(self, message: Optional[ASGISendEvent]) -> None:
        if self.closed:
            # Allow app to finish after close
            return
```

We now need to also stop the generators, once we detect the client connection is closed.

## Changes
* Access internals of `send` call to determine if the connection to the client is closed already and raise a `BrokenPipeError` in that case.
* If any `ConnectionError` is raised during sending data from the iterator, we stop reading from it and close the (async) generator
* Add test for this behavior in the asgi bridge, to avoid future regression
* We do not read all responses in our request logging, to enable chunked responses for requests not parsed by the serializer