### PR TITLE
Add support for list-type stack parameters 

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -3,8 +3,10 @@ from typing import Optional, TypedDict
 
 from localstack.aws.api.cloudformation import Capability, ChangeSetType, Parameter
 from localstack.services.cloudformation.engine.parameters import (
+    StackParameter,
     convert_stack_parameters_to_list,
     map_to_legacy_structure,
+    strip_parameter_type,
 )
 from localstack.utils.aws import arns
 from localstack.utils.collections import select_attributes
@@ -69,7 +71,7 @@ class Stack:
             template = {}
 
         self.resolved_outputs = list()  # TODO
-        self.resolved_parameters: dict[str, Parameter] = {}
+        self.resolved_parameters: dict[str, StackParameter] = {}
 
         self.metadata = metadata or {}
         self.template = template or {}
@@ -106,7 +108,7 @@ class Stack:
         self.change_sets = []
         # self.evaluated_conditions = {}
 
-    def set_resolved_parameters(self, resolved_parameters: dict[str, Parameter]):
+    def set_resolved_parameters(self, resolved_parameters: dict[str, StackParameter]):
         self.resolved_parameters = resolved_parameters
         if resolved_parameters:
             self.metadata["Parameters"] = list(resolved_parameters.values())
@@ -138,7 +140,7 @@ class Stack:
             result["Outputs"] = outputs
         stack_parameters = convert_stack_parameters_to_list(self.resolved_parameters)
         if stack_parameters:
-            result["Parameters"] = stack_parameters
+            result["Parameters"] = [strip_parameter_type(sp) for sp in stack_parameters]
         if not result.get("DriftInformation"):
             result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
         for attr in ["Tags", "NotificationARNs"]:

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -151,6 +151,7 @@ class LegacyParameter(TypedDict):
     Properties: LegacyParameterProperties
 
 
+# TODO: not actually parameter_type but the logical "ID"
 def map_to_legacy_structure(parameter_type: str, new_parameter: Parameter) -> LegacyParameter:
     """
     Helper util to convert a normal (resolved) stack parameter to a legacy parameter structure that can then be merged with stack resources.

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -44,11 +44,17 @@ def extract_stack_parameter_declarations(template: dict) -> dict[str, ParameterD
     return result
 
 
+class StackParameter(Parameter):
+    # we need the type information downstream when actually using the resolved value
+    # e.g. in case of lists so that we know that we should interpret the string as a comma-separated list.
+    ParameterType: str
+
+
 def resolve_parameters(
     parameter_declarations: dict[str, ParameterDeclaration],
     new_parameters: dict[str, Parameter],
     old_parameters: dict[str, Parameter],
-) -> dict[str, Parameter]:
+) -> dict[str, StackParameter]:
     """
     Resolves stack parameters or raises an exception if any parameter can not be resolved.
 
@@ -67,7 +73,7 @@ def resolve_parameters(
     # populate values for every parameter declared in the template
     for pm in parameter_declarations.values():
         pm_key = pm["ParameterKey"]
-        resolved_param = Parameter(ParameterKey=pm_key)
+        resolved_param = StackParameter(ParameterKey=pm_key, ParameterType=pm["ParameterType"])
         new_parameter = new_parameters.get(pm_key)
         old_parameter = old_parameters.get(pm_key)
 
@@ -126,7 +132,15 @@ def resolve_ssm_parameter(stack_parameter_value: str) -> str:
     return connect_to().ssm.get_parameter(Name=stack_parameter_value)["Parameter"]["Value"]
 
 
-def convert_stack_parameters_to_list(in_params: dict[str, Parameter] | None) -> list[Parameter]:
+def strip_parameter_type(in_param: StackParameter) -> Parameter:
+    result = in_param.copy()
+    result.pop("ParameterType", None)
+    return result
+
+
+def convert_stack_parameters_to_list(
+    in_params: dict[str, StackParameter] | None
+) -> list[StackParameter]:
     if not in_params:
         return []
     return list(in_params.values())
@@ -152,11 +166,10 @@ class LegacyParameter(TypedDict):
 
 
 # TODO: not actually parameter_type but the logical "ID"
-def map_to_legacy_structure(parameter_type: str, new_parameter: Parameter) -> LegacyParameter:
+def map_to_legacy_structure(parameter_name: str, new_parameter: StackParameter) -> LegacyParameter:
     """
     Helper util to convert a normal (resolved) stack parameter to a legacy parameter structure that can then be merged with stack resources.
 
-    :param parameter_type: the stack parameter type (e.g. "String", "AWS::SSM::Parameter::Value<String>", ...)
     :param new_parameter: a resolved stack parameter
     :return: legacy parameter that can be merged with stack resources for uniform lookup based on logical ID
     """
@@ -164,7 +177,7 @@ def map_to_legacy_structure(parameter_type: str, new_parameter: Parameter) -> Le
         LogicalResourceId=new_parameter["ParameterKey"],
         Type="Parameter",
         Properties=LegacyParameterProperties(
-            ParameterType=parameter_type,
+            ParameterType=new_parameter.get("ParameterType"),
             ParameterValue=new_parameter.get("ParameterValue"),
             ResolvedValue=new_parameter.get("ResolvedValue"),
             Value=new_parameter.get("ResolvedValue", new_parameter.get("ParameterValue")),

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -262,7 +262,13 @@ def resolve_ref(stack_name: str, resources: dict, mappings: dict, ref: str, attr
 
         # TODO: remove after refactoring parameter resolution
         if resource["Type"] == "Parameter":
-            return resource["Properties"]["Value"]
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+            # TODO: extract this into a util function and extend type support
+            parameter_type: str = resource["Properties"]["ParameterType"]
+            if parameter_type in ["CommaDelimitedList"] or parameter_type.startswith("List<"):
+                return [p.strip() for p in resource["Properties"]["Value"].split(",")]
+            else:
+                return resource["Properties"]["Value"]
         else:
             # TODO: this shouldn't be needed when dependency graph and deployment status is honored
             resolve_refs_recursively(stack_name, resources, mappings, resources.get(ref))

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -80,6 +80,7 @@ from localstack.services.cloudformation.engine.entities import (
     StackInstance,
     StackSet,
 )
+from localstack.services.cloudformation.engine.parameters import strip_parameter_type
 from localstack.services.cloudformation.engine.template_deployer import NoStackUpdates
 from localstack.services.cloudformation.engine.template_preparer import (
     FailedTransformationException,
@@ -190,9 +191,7 @@ class CloudformationProvider(CloudformationApi):
             )
 
         # resolve stack parameters
-        new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
-            request.get("Parameters")
-        )
+        new_parameters = param_resolver.convert_stack_parameters_to_dict(request.get("Parameters"))
         parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
         resolved_parameters = param_resolver.resolve_parameters(
             parameter_declarations=parameter_declarations,
@@ -490,7 +489,7 @@ class CloudformationProvider(CloudformationApi):
                 raise ValidationError(
                     f"Stack '{stack_name}' does not exist."
                 )  # stack should exist already
-            old_parameters = stack.resolved_parameters
+            old_parameters = {k: strip_parameter_type(v) for k, v in stack.resolved_parameters}
         elif change_set_type == "CREATE":
             # create new (empty) stack
             if stack is not None:
@@ -612,7 +611,8 @@ class CloudformationProvider(CloudformationApi):
             "Transform",
         ]
         result = remove_attributes(deepcopy(change_set.metadata), attrs)
-        # result["Parameters"] = list(change_set.resolved_parameters.values())
+        # TODO: replace this patch with a better solution
+        result["Parameters"] = [strip_parameter_type(p) for p in result.get("Parameters", [])]
         return result
 
     @handler("DeleteChangeSet")

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -591,36 +591,25 @@ def test_events_resource_types(deploy_cfn_template, snapshot, aws_client):
     snapshot.match("resource_types", resource_types)
 
 
-
-# TODO: move to parameters tests when the parameter test PR is merged
-def test_list_parameter_type(aws_client, cleanups, lambda_su_role):
+# TODO: rewrite this for proper compatibility with AWS by using a different resource (that doesn't need a deployed VPC)
+# technically this is validated, but you'll need to replace the two parameters SubnetParam and SecurityGroupId with valid values
+# @pytest.mark.aws_validated
+@pytest.mark.only_localstack
+def test_list_parameter_type(aws_client, deploy_cfn_template, cleanups, lambda_su_role):
     stack_name = f"test-stack-{short_uid()}"
     cleanups.append(lambda: aws_client.cloudformation.delete_stack(StackName=stack_name))
-    changeset_name = "init"
-    try:
-        template_body = load_file(os.path.join(os.path.dirname(__file__), "../../templates/cfn_parameter_list_type.yaml"))
-        create_cs = aws_client.cloudformation.create_change_set(
-            StackName=stack_name,
-            ChangeSetType="CREATE",
-            ChangeSetName=changeset_name,
-            TemplateBody=template_body,
-            Capabilities=["CAPABILITY_IAM"],
-            Parameters=[
-                {"ParameterKey": "SubnetParam", "ParameterValue": "subnet-0f09422873fa875d0,subnet-08974bcce674becf3"},
-                {"ParameterKey": "SecurityGroupId", "ParameterValue": "sg-0f7230557f9e0abe7"},
-                {"ParameterKey": "FunctionRole", "ParameterValue": lambda_su_role}
-            ]
-        )
-        describe_cs = aws_client.cloudformation.describe_change_set(ChangeSetName=changeset_name, StackName=stack_name)
-        aws_client.cloudformation.get_waiter("change_set_create_complete").wait(ChangeSetName=changeset_name, StackName=stack_name)
-        describe_cs_2 = aws_client.cloudformation.describe_change_set(ChangeSetName=changeset_name, StackName=stack_name)
+    deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/cfn_parameter_list_type.yaml"
+        ),
+        parameters={
+            "SubnetParam": "subnet-1,subnet-2",
+            "SecurityGroupId": "sg-1",
+            "FunctionRole": lambda_su_role,
+        },
+    )
 
-        aws_client.cloudformation.execute_change_set(ChangeSetName=changeset_name, StackName=stack_name)
-        aws_client.cloudformation.get_waiter("stack_create_complete").wait(StackName=stack_name)
-        describe_stacks = aws_client.cloudformation.describe_stacks(StackName=stack_name)
-
-        print('done')
-    except Exception as e:
-        events = aws_client.cloudformation.describe_stack_events(StackName=stack_name)
-        print('error done')
-
+    # TODO: the lambda provider doesn't currently support the vpc config (even as CRUD-only)
+    # vpc_config = aws_client.awslambda.get_function_configuration(FunctionName=stack.outputs["LambdaName"])['VpcConfig']
+    # assert vpc_config['SecurityGroupIds'] == ["sg-1"]
+    # assert vpc_config['SubnetIds'] == ["subnet-1", "subnet-2"]

--- a/tests/integration/templates/cfn_parameter_list_type.yaml
+++ b/tests/integration/templates/cfn_parameter_list_type.yaml
@@ -1,5 +1,7 @@
 Parameters:
   SubnetParam:
+    # fun fact: this works but is not documented in the docs
+    # see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
     Type: List<String>
   SecurityGroupId:
     Type: String

--- a/tests/integration/templates/cfn_parameter_list_type.yaml
+++ b/tests/integration/templates/cfn_parameter_list_type.yaml
@@ -1,0 +1,27 @@
+Parameters:
+  SubnetParam:
+    Type: List<String>
+  SecurityGroupId:
+    Type: String
+  FunctionRole:
+    Type: String
+Resources:
+  Function76856677:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          def handler(event, context):
+              return {"hello": "world"}
+      Role: !Ref FunctionRole
+      Handler: index.handler
+      Runtime: python3.9
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds:
+          Ref: SubnetParam
+Outputs:
+  LambdaName:
+    Value:
+      Ref: Function76856677


### PR DESCRIPTION
Adds very basic support for CloudFormation stack parameters that aren't just a single value but actually a comma-delimited list, e.g. `List<AWS::EC2::Subnet::Id>`

The tests needs to be replaced at some point, just churned this out as a quick fix for now. The behavior has been verified against AWS and can be verified using the test by setting the subnet and security group IDs manually.

/cc @sannya-singal 