### PR TITLE
Fix KeyError when looking up handlers on legacy models

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -446,7 +446,14 @@ class LegacyResourceProvider(ResourceProvider):
             request.logical_resource_id,
         )
 
-        func_details = func_details[LEGACY_ACTION_MAP[request.action]]
+        func_details = func_details.get(LEGACY_ACTION_MAP[request.action])
+        if not func_details:
+            LOG.debug(
+                "No resource handler for %s action on resource type %s available. Skipping.",
+                request.action,
+                self.resource_type,
+            )
+            return ProgressEvent(status=OperationStatus.SUCCESS, resource_model={})
         func_details = func_details if isinstance(func_details, list) else [func_details]
         results = []
         # TODO: other top level keys


### PR DESCRIPTION
Currently the logs get spammed with `KeyError`s caused by the stack cleanup and its `delete` action lookups on the GenericBaseModels. 

Example:
```
2023-06-28T09:20:35.957 ERROR --- [  asgi_gw_10] localstack.services.cloudformation.engine.template_deployer : Last cycle failed to delete resource with id Version. Final exception: 'delete'
Traceback (most recent call last):
  File "/tmp/workspace/repo/localstack/services/cloudformation/engine/template_deployer.py", line 881, in delete_stack
    executor.deploy_loop(resource_provider_payload)  # noqa
  File "/tmp/workspace/repo/localstack/services/cloudformation/resource_provider.py", line 558, in deploy_loop
    event = self.execute_action(payload)
  File "/tmp/workspace/repo/localstack/services/cloudformation/resource_provider.py", line 602, in execute_action
    return resource_provider.delete(request)
  File "/tmp/workspace/repo/localstack/services/cloudformation/resource_provider.py", line 421, in delete
    return self.create_or_delete(request)
  File "/tmp/workspace/repo/localstack/services/cloudformation/resource_provider.py", line 449, in create_or_delete
    func_details = func_details[LEGACY_ACTION_MAP[request.action]]
KeyError: 'delete'
```

This now behaves as previously before the introduction of the LegacyResourceProvider by simply ignoring the resource action and assuming a `SUCCESS` state immediately if `get_deploy_templates` doesn't contain the requested handler.