### PR TITLE
Add small fix and test to assert prepare_host hook is called with correct dirs

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -375,12 +375,13 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool) -> None
         else:
             console.log("starting LocalStack in Docker mode :whale:")
 
-    bootstrap.prepare_host(console)
-
     if not no_banner and not detached:
         console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")
 
     if host:
+        # call hooks to prepare host
+        bootstrap.prepare_host(console)
+
         # from here we abandon the regular CLI control path and start treating the process like a localstack
         # runtime process
         os.environ["LOCALSTACK_CLI"] = "0"
@@ -402,6 +403,9 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool) -> None
         config.OVERRIDE_IN_DOCKER = False
         config.is_in_docker = False
         config.dirs = config.init_directories()
+
+        # call hooks to prepare host (note that this call should stay below the config overrides above)
+        bootstrap.prepare_host(console)
 
         if detached:
             bootstrap.start_infra_in_docker_detached(console)

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -324,7 +324,7 @@ def check_valid_numeric_content_base_rule(list_of_operators):
     return True
 
 
-def filter_event_with_content_base_parameter(pattern_value, event_value):
+def filter_event_with_content_base_parameter(pattern_value: list, event_value: str | int):
     for element in pattern_value:
         if (isinstance(element, (str, int))) and (event_value == element or element in event_value):
             return True
@@ -448,7 +448,7 @@ def filter_event_based_on_event_format(
                         if not handle_prefix_filtering(value.get(key_a), value_a):
                             return False
 
-            # 2. check if the pattern is a list and event values are not contained in itEventsApi
+            # 2. check if the pattern is a list and event values are not contained in it
             if isinstance(value, list):
                 if identify_content_base_parameter_in_pattern(value):
                     if not filter_event_with_content_base_parameter(value, event_value):

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -153,7 +153,7 @@ def run_for_max_seconds(max_secs, _function, *args, **kwargs):
 
 def is_command_available(cmd: str) -> bool:
     try:
-        run("which %s" % cmd, print_error=False)
+        run(["which", cmd], print_error=False)
         return True
     except Exception:
         return False

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -8,8 +8,9 @@ from click.testing import CliRunner
 import localstack.utils.container_utils.docker_cmd_client
 from localstack import config, constants
 from localstack.cli.localstack import localstack as cli
-from localstack.config import get_edge_url, in_docker
-from localstack.constants import MODULE_MAIN_PATH
+from localstack.config import Directories, get_edge_url, in_docker
+from localstack.constants import MODULE_MAIN_PATH, TRUE_STRINGS
+from localstack.utils import bootstrap
 from localstack.utils.bootstrap import in_ci
 from localstack.utils.common import poll_condition
 from localstack.utils.files import mkdir
@@ -169,3 +170,45 @@ class TestCliContainerLifecycle:
 
         # assert that container is running
         runner.invoke(cli, ["wait", "-t", "60"])
+
+
+class TestHooks:
+    def test_prepare_host_hook_called_with_correct_dirs(self, runner, monkeypatch):
+        """
+        Assert that the prepare_host(..) hook is called with the appropriate dirs layout (e.g., cache
+        dir writeable). Required, for example, for API key activation and local key caching.
+        """
+
+        # simulate that we're running in Docker
+        monkeypatch.setattr(config, "is_in_docker", True)
+
+        result_configs = []
+
+        def _prepare_host(*args, **kwargs):
+            # store the configs that will be passed to prepare_host hooks (Docker status, infra process, dirs layout)
+            result_configs.append(
+                (config.is_in_docker, os.getenv(constants.LOCALSTACK_INFRA_PROCESS), config.dirs)
+            )
+
+        # patch the prepare_host function which calls the hooks
+        monkeypatch.setattr(bootstrap, "prepare_host", _prepare_host)
+
+        def noop(*args, **kwargs):
+            pass
+
+        # patch start_infra_in_docker to be a no-op (we don't actually want to start the container for this test)
+        assert bootstrap.start_infra_in_docker
+        monkeypatch.setattr(bootstrap, "start_infra_in_docker", noop)
+
+        # run the 'start' command, which should call the prepare_host hooks
+        runner.invoke(cli, ["start"])
+
+        # assert that result configs are as expected
+        assert len(result_configs) == 1
+        dirs: Directories
+        in_docker, is_infra_process, dirs = result_configs[0]
+        assert in_docker is False
+        assert is_infra_process not in TRUE_STRINGS
+        # cache dir should exist and be writeable
+        assert os.path.exists(dirs.cache)
+        assert os.access(dirs.cache, os.W_OK)


### PR DESCRIPTION
Add small fix and test to assert that `prepare_host` hooks are called with appropriate LocalStack directories layout. This is a follow-up from https://github.com/localstack/localstack/pull/8384 . 

The previous PR #8384 adjusted the logic to start up LocalStack using the CLI when running inside a Docker container, for example to run `localstack start` in a [Github Codespaces](https://github.com/codespaces/) environment. This works well for the Community version, but unfortunately there was an oversight for the Pro version, where we're performing operations on the host via `prepare_host` hooks. In particular, the hook used to cache the key locally was failing with a `PermissionError`, as it was trying to access the wrong directory (using the container dirs layout, not the host dirs layout).
```
Traceback (most recent call last):
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/localstack_ext/bootstrap/licensing.py", line 64, in fetch_key
    C=json.loads(to_str(B.content))[_C];cache_key_locally(A,C)
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/localstack_ext/bootstrap/licensing.py", line 75, in cache_key_locally
    A=to_str(base64.b64encode(to_bytes(C)));E=get_key_cache();E.update({_E:int(B),_G:md5(api_key),_C:A});E.save()
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/localstack/utils/json.py", line 84, in save
    os.makedirs(os.path.dirname(self.path), exist_ok=True)
  File "/usr/local/python/3.10.4/lib/python3.10/os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/local/python/3.10.4/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/var/lib/localstack'
```

This PR contains a small follow-up change in `cmd_start(..)` to ensure `bootstrap.prepare_host(..)` is called _after_ we're performing the `config.*` adjustments introduced in #8384 . The change has been tested in Github Codespaces, which now allows to spin up a Pro container via the CLI if the API key is configured. A unit test is added to cover the functionality, with assertions about the "is in Docker" status and the accessibility of the `dirs.cache` directory.

Note: The PR also contains a few minor cleanups/refactorings (add type hints, f-strings, etc) along the way.