### PR TITLE
fix ASF parsing for optional list header fields

### DIFF
--- a/localstack/aws/api/iam/__init__.py
+++ b/localstack/aws/api/iam/__init__.py
@@ -10,6 +10,8 @@ else:
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
 ActionNameType = str
+CertificationKeyType = str
+CertificationValueType = str
 ColumnNumber = int
 ConcurrentModificationMessage = str
 ContextKeyNameType = str
@@ -507,6 +509,7 @@ class AttachedPolicy(TypedDict, total=False):
 
 
 BootstrapDatum = bytes
+CertificationMapType = Dict[CertificationKeyType, CertificationValueType]
 
 
 class ChangePasswordRequest(ServiceRequest):
@@ -1207,6 +1210,18 @@ class GetLoginProfileRequest(ServiceRequest):
 
 class GetLoginProfileResponse(TypedDict, total=False):
     LoginProfile: LoginProfile
+
+
+class GetMFADeviceRequest(ServiceRequest):
+    SerialNumber: serialNumberType
+    UserName: Optional[userNameType]
+
+
+class GetMFADeviceResponse(TypedDict, total=False):
+    UserName: Optional[userNameType]
+    SerialNumber: serialNumberType
+    EnableDate: Optional[dateType]
+    Certifications: Optional[CertificationMapType]
 
 
 class GetOpenIDConnectProviderRequest(ServiceRequest):
@@ -2731,6 +2746,15 @@ class IamApi:
     def get_login_profile(
         self, context: RequestContext, user_name: userNameType
     ) -> GetLoginProfileResponse:
+        raise NotImplementedError
+
+    @handler("GetMFADevice")
+    def get_mfa_device(
+        self,
+        context: RequestContext,
+        serial_number: serialNumberType,
+        user_name: userNameType = None,
+    ) -> GetMFADeviceResponse:
         raise NotImplementedError
 
     @handler("GetOpenIDConnectProvider")

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -82,6 +82,7 @@ InventoryId = str
 IsEnabled = bool
 IsLatest = bool
 IsPublic = bool
+IsRestoreInProgress = bool
 IsTruncated = bool
 KMSContext = str
 KeyCount = int
@@ -453,6 +454,10 @@ class ObjectStorageClass(str):
 
 class ObjectVersionStorageClass(str):
     STANDARD = "STANDARD"
+
+
+class OptionalObjectAttributes(str):
+    RestoreStatus = "RestoreStatus"
 
 
 class OwnerOverride(str):
@@ -2319,6 +2324,14 @@ class ListMultipartUploadsRequest(ServiceRequest):
     RequestPayer: Optional[RequestPayer]
 
 
+RestoreExpiryDate = datetime
+
+
+class RestoreStatus(TypedDict, total=False):
+    IsRestoreInProgress: Optional[IsRestoreInProgress]
+    RestoreExpiryDate: Optional[RestoreExpiryDate]
+
+
 class ObjectVersion(TypedDict, total=False):
     ETag: Optional[ETag]
     ChecksumAlgorithm: Optional[ChecksumAlgorithmList]
@@ -2329,6 +2342,7 @@ class ObjectVersion(TypedDict, total=False):
     IsLatest: Optional[IsLatest]
     LastModified: Optional[LastModified]
     Owner: Optional[Owner]
+    RestoreStatus: Optional[RestoreStatus]
 
 
 ObjectVersionList = List[ObjectVersion]
@@ -2351,6 +2365,9 @@ class ListObjectVersionsOutput(TypedDict, total=False):
     RequestCharged: Optional[RequestCharged]
 
 
+OptionalObjectAttributesList = List[OptionalObjectAttributes]
+
+
 class ListObjectVersionsRequest(ServiceRequest):
     Bucket: BucketName
     Delimiter: Optional[Delimiter]
@@ -2361,6 +2378,7 @@ class ListObjectVersionsRequest(ServiceRequest):
     VersionIdMarker: Optional[VersionIdMarker]
     ExpectedBucketOwner: Optional[AccountId]
     RequestPayer: Optional[RequestPayer]
+    OptionalObjectAttributes: Optional[OptionalObjectAttributesList]
 
 
 class Object(TypedDict, total=False):
@@ -2371,6 +2389,7 @@ class Object(TypedDict, total=False):
     Size: Optional[Size]
     StorageClass: Optional[ObjectStorageClass]
     Owner: Optional[Owner]
+    RestoreStatus: Optional[RestoreStatus]
 
 
 ObjectList = List[Object]
@@ -2400,6 +2419,7 @@ class ListObjectsRequest(ServiceRequest):
     Prefix: Optional[Prefix]
     RequestPayer: Optional[RequestPayer]
     ExpectedBucketOwner: Optional[AccountId]
+    OptionalObjectAttributes: Optional[OptionalObjectAttributesList]
 
 
 class ListObjectsV2Output(TypedDict, total=False):
@@ -2430,6 +2450,7 @@ class ListObjectsV2Request(ServiceRequest):
     StartAfter: Optional[StartAfter]
     RequestPayer: Optional[RequestPayer]
     ExpectedBucketOwner: Optional[AccountId]
+    OptionalObjectAttributes: Optional[OptionalObjectAttributesList]
 
 
 class Part(TypedDict, total=False):
@@ -3756,6 +3777,7 @@ class S3Api:
         version_id_marker: VersionIdMarker = None,
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
+        optional_object_attributes: OptionalObjectAttributesList = None,
     ) -> ListObjectVersionsOutput:
         raise NotImplementedError
 
@@ -3771,6 +3793,7 @@ class S3Api:
         prefix: Prefix = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
+        optional_object_attributes: OptionalObjectAttributesList = None,
     ) -> ListObjectsOutput:
         raise NotImplementedError
 
@@ -3788,6 +3811,7 @@ class S3Api:
         start_after: StartAfter = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
+        optional_object_attributes: OptionalObjectAttributesList = None,
     ) -> ListObjectsV2Output:
         raise NotImplementedError
 

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -233,7 +233,7 @@ class RequestParser(abc.ABC):
             if location == "header":
                 header_name = shape.serialization.get("name")
                 payload = request.headers.get(header_name)
-                if shape.type_name == "list":
+                if payload and shape.type_name == "list":
                     # headers may contain a comma separated list of values (e.g., the ObjectAttributes member in
                     # s3.GetObjectAttributes), so we prepare it here for the handler, which will be `_parse_list`.
                     payload = payload.split(",")

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1118,6 +1118,12 @@ def test_restxml_header_list_parsing():
     )
 
 
+def test_restxml_header_optional_list_parsing():
+    """Tests that non-existing header list attributes are working correctly."""
+    # OptionalObjectAttributes (the "x-amz-optional-object-attributes") in ListObjectsV2Request is optional
+    _botocore_parser_integration_test(service="s3", action="ListObjectsV2", Bucket="test-bucket")
+
+
 def test_restxml_header_date_parsing():
     """Test the parsing of a map with the location trait 'headers'."""
     _botocore_parser_integration_test(


### PR DESCRIPTION
This PR fixes a small issue in the ASF parser which was caused by the latest change of `botocore`: https://github.com/boto/botocore/commit/5c337d96e3ff0833fe639be6007ff94bd330bd55
It introduces a new, optional, list-shaped header field `OptionalObjectAttributes` in `ListObjectsV2Request` (header field name `x-amz-optional-object-attributes` in the HTTP request).

Thanks a lot to @dominikschubert for the info on the issue (currently blocking the pipeline on master), a perfect writeup, and a suggestion for the fix!