### PR TITLE
Additional debugging for network connection failure

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -7,7 +7,7 @@ import threading
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Dict, Optional, TypedDict
+from typing import IO, Dict, Optional, TypedDict
 
 from botocore.exceptions import ClientError
 
@@ -31,13 +31,10 @@ from localstack.aws.api.lambda_ import (
     StateReasonCode,
     TracingMode,
 )
+from localstack.aws.connect import connect_to
 from localstack.services.awslambda.api_utils import qualified_lambda_arn, unqualified_lambda_arn
 from localstack.utils.archives import unzip
-from localstack.utils.aws import aws_stack
 from localstack.utils.strings import long_uid
-
-if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3Client
 
 LOG = logging.getLogger(__name__)
 
@@ -168,7 +165,7 @@ class S3Code(ArchiveCode):
 
         :param target_file: File the code archive should be downloaded into (IO object)
         """
-        s3_client: "S3Client" = aws_stack.connect_to_service("s3", region_name="us-east-1")
+        s3_client = connect_to(region_name="us-east-1").s3
         extra_args = {"VersionId": self.s3_object_version} if self.s3_object_version else {}
         s3_client.download_fileobj(
             Bucket=self.s3_bucket, Key=self.s3_key, Fileobj=target_file, ExtraArgs=extra_args
@@ -179,9 +176,7 @@ class S3Code(ArchiveCode):
         """
         Generates a presigned url pointing to the code archive
         """
-        s3_client: "S3Client" = aws_stack.connect_to_service(
-            "s3", region_name="us-east-1", endpoint_url=endpoint_url
-        )
+        s3_client = connect_to(region_name="us-east-1", endpoint_url=endpoint_url)
         params = {"Bucket": self.s3_bucket, "Key": self.s3_key}
         if self.s3_object_version:
             params["VersionId"] = self.s3_object_version
@@ -239,7 +234,7 @@ class S3Code(ArchiveCode):
         """
         LOG.debug("Final code destruction for %s", self.id)
         self.destroy_cached()
-        s3_client: "S3Client" = aws_stack.connect_to_service("s3", region_name="us-east-1")
+        s3_client = connect_to(region_name="us-east-1").s3
         kwargs = {"VersionId": self.s3_object_version} if self.s3_object_version else {}
         try:
             s3_client.delete_object(Bucket=self.s3_bucket, Key=self.s3_key, **kwargs)

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -176,7 +176,7 @@ class S3Code(ArchiveCode):
         """
         Generates a presigned url pointing to the code archive
         """
-        s3_client = connect_to(region_name="us-east-1", endpoint_url=endpoint_url)
+        s3_client = connect_to(region_name="us-east-1", endpoint_url=endpoint_url).s3
         params = {"Bucket": self.s3_bucket, "Key": self.s3_key}
         if self.s3_object_version:
             params["VersionId"] = self.s3_object_version

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -413,11 +413,11 @@ class ContainerConfiguration:
     command: Optional[List[str]] = None
     env_vars: Dict[str, str] = dataclasses.field(default_factory=dict)
 
-    privileged: Optional[bool] = None
-    remove: Optional[bool] = None
-    interactive: Optional[bool] = None
-    tty: Optional[bool] = None
-    detach: Optional[bool] = None
+    privileged: bool = False
+    remove: bool = False
+    interactive: bool = False
+    tty: bool = False
+    detach: bool = False
 
     stdin: Optional[str] = None
     user: Optional[str] = None
@@ -492,6 +492,14 @@ class ContainerClient(metaclass=ABCMeta):
         network_attrs = self.inspect_network(container_network)
         containers = network_attrs.get("Containers") or {}
         if container_id not in containers:
+            LOG.debug("Network attributes: %s", network_attrs)
+            try:
+                inspection = self.inspect_container(container_name_or_id=container_name_or_id)
+                LOG.debug("Container %s Attributes: %s", container_name_or_id, inspection)
+                logs = self.get_container_logs(container_name_or_id=container_name_or_id)
+                LOG.debug("Container %s Logs: %s", container_name_or_id, logs)
+            except ContainerException as e:
+                LOG.debug("Cannot inspect container %s: %s", container_name_or_id, e)
             raise ContainerException(
                 "Container %s is not connected to target network %s",
                 container_name_or_id,


### PR DESCRIPTION
## Motivation
* We got the case where we could not find the container in the list of connected endpoints in the network right after start with this network. If this happens, we want all the information we can get.

## Changes
* Add additional debug logs in error case
* Proper defaults for different container configuration flags.
* Sneaked in using new clients for retrieving code archives
