### PR TITLE
Remove deprecation for re-implemented DNS feature

### DIFF
--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -203,12 +203,6 @@ DEPRECATIONS = [
         "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2",
     ),
     EnvVarDeprecation(
-        "LAMBDA_DOCKER_DNS",
-        "2.0.0",
-        "This feature is currently not supported in the new lambda provider "
-        "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2",
-    ),
-    EnvVarDeprecation(
         "LAMBDA_CONTAINER_REGISTRY",
         "2.0.0",
         "The new lambda provider uses LAMBDA_RUNTIME_IMAGE_MAPPING instead "


### PR DESCRIPTION
Removes `LAMBDA_DOCKER_DNS` from the deprecation list.

The feature was re-implemented for the new Lambda provider in https://github.com/localstack/localstack/pull/8448 but I missed removing it from the deprecation list.

## Related Documentation Updates

* Updated in the Lambda Discuss post: https://discuss.localstack.cloud/t/new-lambda-implementation-in-localstack-2-0/258
* Pending PR to be merged after the v2.2 release: https://github.com/localstack/docs/pull/666