### PR TITLE
transcribe: fix transcription file uri

### DIFF
--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -354,4 +354,3 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
             job["TranscriptionJobStatus"] = TranscriptionJobStatus.FAILED
 
             LOG.exception("Transcription job %s failed: %s", job_name, job["FailureReason"])
-

--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -133,10 +133,7 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
         output_bucket = request.get("OutputBucketName", get_bucket_and_key_from_s3_uri(s3_path)[0])
         output_key = request.get("OutputKey")
 
-        if output_key:
-            if not output_key.endswith(".json"):
-                output_key = f"{output_key}/{job_name}.json"
-        else:
+        if not output_key:
             output_key = f"{job_name}.json"
 
         transcript = Transcript(TranscriptFileUri=f"s3://{output_bucket}/{output_key}")
@@ -357,3 +354,4 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
             job["TranscriptionJobStatus"] = TranscriptionJobStatus.FAILED
 
             LOG.exception("Transcription job %s failed: %s", job_name, job["FailureReason"])
+


### PR DESCRIPTION
This PR focuses to fix a special case of `TranscriptFileUri` where output key is not null and the file doesn't end with .json. 
The earlier implementation was as per the AWS transcribe docs, but the actual AWS behaviour was different. 

FYI: we are currently skipping the check for `TranscriptFileUri` in all the test cases of transcribe due to other parity issues in the service. 

This will fix a part of #8089.