### PR TITLE
Fix ListRoles operation with PermissionsBoundary attached

### DIFF
--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -109,9 +109,6 @@ class IamProvider(IamApi):
         result = call_moto(context)
 
         if not request.get("MaxSessionDuration") and result["Role"].get("MaxSessionDuration"):
-            backend = get_iam_backend(context)
-            role = backend.get_role(request["RoleName"])
-            role.max_session_duration = None
             result["Role"].pop("MaxSessionDuration")
 
         if "RoleLastUsed" in result["Role"] and not result["Role"]["RoleLastUsed"]:
@@ -230,6 +227,8 @@ class IamProvider(IamApi):
         response_roles = []
         for moto_role in moto_roles:
             response_role = self.moto_role_to_role_type(moto_role)
+            # Permission boundary should not be a part of the response
+            response_role.pop("PermissionsBoundary", None)
             response_roles.append(response_role)
             if (
                 path_prefix

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -251,7 +251,12 @@ class TransformerUtility:
         """
         :return: array with Transformers, for iam api.
         """
-        return [TransformerUtility.key_value("UserName"), TransformerUtility.key_value("UserId")]
+        return [
+            TransformerUtility.key_value("UserName"),
+            TransformerUtility.key_value("UserId"),
+            TransformerUtility.key_value("RoleId"),
+            TransformerUtility.key_value("RoleName"),
+        ]
 
     @staticmethod
     def transcribe_api():

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -516,3 +516,74 @@ class TestIAMIntegrations:
             snapshot.match("updated_policy", result)
         finally:
             aws_client.iam.delete_role(RoleName=role_name)
+
+    @pytest.mark.aws_validated
+    def test_create_describe_role(self, snapshot, aws_client, create_role, cleanups):
+        snapshot.add_transformer(snapshot.transform.iam_api())
+        path_prefix = f"/{short_uid()}/"
+        snapshot.add_transformer(snapshot.transform.regex(path_prefix, "/<path-prefix>/"))
+
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+
+        role_name = f"role-{short_uid()}"
+        create_role_result = create_role(
+            RoleName=role_name, AssumeRolePolicyDocument=json.dumps(trust_policy), Path=path_prefix
+        )
+        snapshot.match("create_role_result", create_role_result)
+        get_role_result = aws_client.iam.get_role(RoleName=role_name)
+        snapshot.match("get_role_result", get_role_result)
+
+        list_roles_result = aws_client.iam.list_roles(PathPrefix=path_prefix)
+        snapshot.match("list_roles_result", list_roles_result)
+
+    @pytest.mark.aws_validated
+    def test_list_roles_with_permission_boundary(
+        self, snapshot, aws_client, create_role, create_policy, cleanups
+    ):
+        snapshot.add_transformer(snapshot.transform.iam_api())
+        path_prefix = f"/{short_uid()}/"
+        snapshot.add_transformer(snapshot.transform.regex(path_prefix, "/<path-prefix>/"))
+
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        permission_boundary = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": ["lambda:ListFunctions"], "Resource": ["*"]}
+            ],
+        }
+
+        role_name = f"role-{short_uid()}"
+        policy_name = f"policy-{short_uid()}"
+        result = create_role(
+            RoleName=role_name, AssumeRolePolicyDocument=json.dumps(trust_policy), Path=path_prefix
+        )
+        snapshot.match("created_role", result)
+        policy_arn = create_policy(
+            PolicyName=policy_name, PolicyDocument=json.dumps(permission_boundary)
+        )["Policy"]["Arn"]
+
+        aws_client.iam.put_role_permissions_boundary(
+            RoleName=role_name, PermissionsBoundary=policy_arn
+        )
+        cleanups.append(lambda: aws_client.iam.delete_role_permissions_boundary(RoleName=role_name))
+
+        list_roles_result = aws_client.iam.list_roles(PathPrefix=path_prefix)
+        snapshot.match("list_roles_result", list_roles_result)

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -488,8 +488,6 @@ class TestIAMIntegrations:
     @pytest.mark.aws_validated
     def test_update_assume_role_policy(self, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.resource_name("role_name"))
-        snapshot.add_transformer(snapshot.transform.key_value("RoleId", "role_id"))
 
         policy = {
             "Version": "2012-10-17",

--- a/tests/integration/test_iam.snapshot.json
+++ b/tests/integration/test_iam.snapshot.json
@@ -54,5 +54,150 @@
         }
       }
     }
+  },
+  "tests/integration/test_iam.py::TestIAMIntegrations::test_list_roles_with_permission_boundary": {
+    "recorded-date": "04-07-2023, 16:07:42",
+    "recorded-content": {
+      "created_role": {
+        "Role": {
+          "Arn": "arn:aws:iam::111111111111:role/<path-prefix>/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "Path": "/<path-prefix>/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_roles_result": {
+        "IsTruncated": false,
+        "Roles": [
+          {
+            "Arn": "arn:aws:iam::111111111111:role/<path-prefix>/<role-name:1>",
+            "AssumeRolePolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                  }
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "CreateDate": "datetime",
+            "MaxSessionDuration": 3600,
+            "Path": "/<path-prefix>/",
+            "RoleId": "<role-id:1>",
+            "RoleName": "<role-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_iam.py::TestIAMIntegrations::test_create_describe_role": {
+    "recorded-date": "04-07-2023, 16:06:47",
+    "recorded-content": {
+      "create_role_result": {
+        "Role": {
+          "Arn": "arn:aws:iam::111111111111:role/<path-prefix>/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "Path": "/<path-prefix>/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_role_result": {
+        "Role": {
+          "Arn": "arn:aws:iam::111111111111:role/<path-prefix>/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "MaxSessionDuration": 3600,
+          "Path": "/<path-prefix>/",
+          "RoleId": "<role-id:1>",
+          "RoleLastUsed": {},
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_roles_result": {
+        "IsTruncated": false,
+        "Roles": [
+          {
+            "Arn": "arn:aws:iam::111111111111:role/<path-prefix>/<role-name:1>",
+            "AssumeRolePolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                  }
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "CreateDate": "datetime",
+            "MaxSessionDuration": 3600,
+            "Path": "/<path-prefix>/",
+            "RoleId": "<role-id:1>",
+            "RoleName": "<role-name:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_iam.snapshot.json
+++ b/tests/integration/test_iam.snapshot.json
@@ -1,14 +1,10 @@
 {
   "tests/integration/test_iam.py::TestIAMIntegrations::test_update_assume_role_policy": {
-    "recorded-date": "25-08-2022, 10:39:48",
+    "recorded-date": "04-07-2023, 16:48:15",
     "recorded-content": {
       "created_role": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Role": {
-          "Arn": "arn:aws:iam::111111111111:role/<role_name:1>",
+          "Arn": "arn:aws:iam::111111111111:role/<role-name:1>",
           "AssumeRolePolicyDocument": {
             "Statement": [
               {
@@ -27,8 +23,12 @@
           },
           "CreateDate": "datetime",
           "Path": "/",
-          "RoleId": "<role_id:1>",
-          "RoleName": "<role_name:1>"
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "updated_policy": {


### PR DESCRIPTION
## Motivation
Currently, if a role has a `PermissionsBoundary` attached, the `ListRoles` operation fails with a serializer error.

This is due to the returning of the unexpected `PermissionsBoundary` field in the to-be-serialized response.

Fixes #7779

## Changes
* Add new fields to iam_api snapshot transformer
* Remove removal of `MaxSessionDuration` from model, it should only not be returned in the `CreateRole` call
* Add aws validated + snapshotted tests for the `MaxSessionDuration` and the `PermissionsBoundary` behavior.