### PR TITLE
Fix error with non-existent policy for AttachRolePolicy operation

### DIFF
--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime
 from typing import Dict, List, Optional
 from urllib.parse import quote
@@ -26,6 +27,7 @@ from localstack.aws.api.iam import (
     GetServiceLinkedRoleDeletionStatusResponse,
     GetUserResponse,
     IamApi,
+    InvalidInputException,
     ListInstanceProfileTagsResponse,
     ListRolesResponse,
     MalformedPolicyDocumentException,
@@ -88,6 +90,8 @@ ADDITIONAL_MANAGED_POLICIES = {
         "UpdateDate": "2019-05-20T18:22:18+00:00",
     }
 }
+
+POLICY_ARN_REGEX = re.compile(r"arn:[^:]+:iam::\d{12}:policy/.*")
 
 
 def get_iam_backend(context: RequestContext) -> IAMBackend:
@@ -415,6 +419,20 @@ class IamProvider(IamApi):
             )
 
         return response
+
+    def attach_role_policy(
+        self, context: RequestContext, role_name: roleNameType, policy_arn: arnType
+    ) -> None:
+        if not POLICY_ARN_REGEX.match(policy_arn):
+            raise InvalidInputException(f"ARN {policy_arn} is not valid.")
+        return call_moto(context=context)
+
+    def attach_user_policy(
+        self, context: RequestContext, user_name: userNameType, policy_arn: arnType
+    ) -> None:
+        if not POLICY_ARN_REGEX.match(policy_arn):
+            raise InvalidInputException(f"ARN {policy_arn} is not valid.")
+        return call_moto(context=context)
 
     # def get_user(
     #     self, context: RequestContext, user_name: existingUserNameType = None

--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -91,7 +91,7 @@ ADDITIONAL_MANAGED_POLICIES = {
     }
 }
 
-POLICY_ARN_REGEX = re.compile(r"arn:[^:]+:iam::\d{12}:policy/.*")
+POLICY_ARN_REGEX = re.compile(r"arn:[^:]+:iam::(?:\d{12}|aws):policy/.*")
 
 
 def get_iam_backend(context: RequestContext) -> IAMBackend:

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -256,6 +256,8 @@ class TransformerUtility:
             TransformerUtility.key_value("UserId"),
             TransformerUtility.key_value("RoleId"),
             TransformerUtility.key_value("RoleName"),
+            TransformerUtility.key_value("PolicyName"),
+            TransformerUtility.key_value("PolicyId"),
         ]
 
     @staticmethod

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -18,17 +18,17 @@
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_managed_policy_with_empty_resource": {
-    "recorded-date": "05-09-2022, 10:01:53",
+    "recorded-date": "11-07-2023, 18:10:41",
     "recorded-content": {
       "outputs": {
-        "PolicyArn": "arn:aws:iam::111111111111:policy/<resource:1>",
-        "StreamARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>/stream/<resource:2>",
-        "TableARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>",
-        "TableName": "<resource:3>"
+        "PolicyArn": "arn:aws:iam::111111111111:policy/<policy-name:1>",
+        "StreamARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:2>/stream/<resource:1>",
+        "TableARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:2>",
+        "TableName": "<resource:2>"
       },
       "managed_policy": {
         "Policy": {
-          "Arn": "arn:aws:iam::111111111111:policy/<resource:1>",
+          "Arn": "arn:aws:iam::111111111111:policy/<policy-name:1>",
           "AttachmentCount": 0,
           "CreateDate": "datetime",
           "DefaultVersionId": "v1",
@@ -36,7 +36,7 @@
           "Path": "/",
           "PermissionsBoundaryUsageCount": 0,
           "PolicyId": "<policy-id:1>",
-          "PolicyName": "<resource:1>",
+          "PolicyName": "<policy-name:1>",
           "Tags": [],
           "UpdateDate": "datetime"
         },

--- a/tests/integration/cloudformation/resources/test_sam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_sam.snapshot.json
@@ -1,22 +1,22 @@
 {
   "tests/integration/cloudformation/resources/test_sam.py::test_sam_policies": {
-    "recorded-date": "02-06-2022, 13:13:20",
+    "recorded-date": "11-07-2023, 18:08:53",
     "recorded-content": {
       "list_attached_role_policies": {
         "AttachedPolicies": [
           {
-            "PolicyName": "AWSLambdaBasicExecutionRole",
-            "PolicyArn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+            "PolicyArn": "arn:aws:iam::aws:policy/service-role/<policy-name:1>",
+            "PolicyName": "<policy-name:1>"
           },
           {
-            "PolicyName": "AmazonSNSFullAccess",
-            "PolicyArn": "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
+            "PolicyArn": "arn:aws:iam::aws:policy/<policy-name:2>",
+            "PolicyName": "<policy-name:2>"
           }
         ],
         "IsTruncated": false,
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/test_iam.snapshot.json
+++ b/tests/integration/test_iam.snapshot.json
@@ -199,5 +199,129 @@
         }
       }
     }
+  },
+  "tests/integration/test_iam.py::TestIAMIntegrations::test_role_attach_policy": {
+    "recorded-date": "04-07-2023, 17:04:08",
+    "recorded-content": {
+      "create_policy_response": {
+        "Policy": {
+          "Arn": "arn:aws:iam::111111111111:policy/<policy-name:1>",
+          "AttachmentCount": 0,
+          "CreateDate": "datetime",
+          "DefaultVersionId": "v1",
+          "IsAttachable": true,
+          "Path": "/",
+          "PermissionsBoundaryUsageCount": 0,
+          "PolicyId": "<policy-id:1>",
+          "PolicyName": "<policy-name:1>",
+          "UpdateDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "non_existent_malformed_policy_arn": {
+        "Error": {
+          "Code": "InvalidInput",
+          "Message": "ARN longpolicynamebutnoarn is not valid.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "existing_policy_name_provided": {
+        "Error": {
+          "Code": "InvalidInput",
+          "Message": "ARN <policy-name:1> is not valid.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "valid_arn_not_existent": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "Policy arn:aws:iam::111111111111:policy/<policy-name:1>123 does not exist or is not attachable.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "valid_policy_arn": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
+    "recorded-date": "04-07-2023, 17:16:43",
+    "recorded-content": {
+      "create_policy_response": {
+        "Policy": {
+          "Arn": "arn:aws:iam::111111111111:policy/<policy-name:1>",
+          "AttachmentCount": 0,
+          "CreateDate": "datetime",
+          "DefaultVersionId": "v1",
+          "IsAttachable": true,
+          "Path": "/",
+          "PermissionsBoundaryUsageCount": 0,
+          "PolicyId": "<policy-id:1>",
+          "PolicyName": "<policy-name:1>",
+          "UpdateDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "non_existent_malformed_policy_arn": {
+        "Error": {
+          "Code": "InvalidInput",
+          "Message": "ARN longpolicynamebutnoarn is not valid.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "existing_policy_name_provided": {
+        "Error": {
+          "Code": "InvalidInput",
+          "Message": "ARN <policy-name:1> is not valid.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "valid_arn_not_existent": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "Policy arn:aws:iam::111111111111:policy/<policy-name:1>123 does not exist or is not attachable.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "valid_policy_arn": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
Currently, we do not properly verify the policy arn in the `attach_*_policy` methods, and have not tests for this behavior.

Depens on https://github.com/getmoto/moto/pull/6482 , fixes #7934 .

Ext Test run (due to snapshot transform changes): https://github.com/localstack/localstack-ext/actions/runs/5522309201

## Changes
* Add tests for role/user attach policies and errors of the operation
* Add verification of the policy arn
* Depends on the linked moto PR for correct error handling for the correct arn but policy does not exist case.
* Adds two more transform statements to iam_api transformer.