### PR TITLE
transcribe: add presign url to transcript file uri

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -200,7 +200,7 @@ def get_bucket_and_key_from_s3_uri(s3_uri: str) -> Tuple[str, Optional[str]]:
     return output_bucket, output_key
 
 
-def get_bucket_and_key_from_presign_url(presign_url: str) -> Tuple[str, Optional[str]]:
+def get_bucket_and_key_from_presign_url(presign_url: str) -> Tuple[str, str]:
     """
     Extracts the bucket name and key from s3 presign url
     """

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -200,6 +200,16 @@ def get_bucket_and_key_from_s3_uri(s3_uri: str) -> Tuple[str, Optional[str]]:
     return output_bucket, output_key
 
 
+def get_bucket_and_key_from_presign_url(presign_url: str) -> Tuple[str, Optional[str]]:
+    """
+    Extracts the bucket name and key from s3 presign url
+    """
+    parsed_url = urlparser.urlparse(presign_url)
+    bucket = parsed_url.path.split("/")[1]
+    key = "/".join(parsed_url.path.split("/")[2:]).split("?")[0]
+    return bucket, key
+
+
 def _create_invalid_argument_exc(
     message: Union[str, None], name: str, value: str, host_id: str = None
 ) -> InvalidArgument:

--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -104,6 +104,13 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
         store = transcribe_stores[context.account_id][context.region]
 
         if job := store.transcription_jobs.get(transcription_job_name):
+            # fetch output key and output bucket
+            output_bucket, output_key = get_bucket_and_key_from_presign_url(job["Transcript"]["TranscriptFileUri"])
+            job["Transcript"]["TranscriptFileUri"] = connect_to().s3.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": output_bucket, "Key": output_key},
+                ExpiresIn=60 * 15,
+            )
             return GetTranscriptionJobResponse(TranscriptionJob=job)
 
         raise NotFoundException(

--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -105,7 +105,9 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
 
         if job := store.transcription_jobs.get(transcription_job_name):
             # fetch output key and output bucket
-            output_bucket, output_key = get_bucket_and_key_from_presign_url(job["Transcript"]["TranscriptFileUri"])
+            output_bucket, output_key = get_bucket_and_key_from_presign_url(
+                job["Transcript"]["TranscriptFileUri"]
+            )
             job["Transcript"]["TranscriptFileUri"] = connect_to().s3.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": output_bucket, "Key": output_key},

--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -28,6 +28,7 @@ from localstack.aws.api.transcribe import (
     TranscriptionJobStatus,
     TranscriptionJobSummary,
 )
+from localstack.aws.connect import connect_to
 from localstack.packages.ffmpeg import ffmpeg_package
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.utils import (
@@ -139,11 +140,11 @@ class TranscribeProvider(TranscribeApi, ServiceLifecycleHook):
         if not output_key:
             output_key = f"{job_name}.json"
 
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = connect_to().s3
 
         # the presign url is valid for 15 minutes
         presign_url = s3_client.generate_presigned_url(
-            "put_object",
+            "get_object",
             Params={"Bucket": output_bucket, "Key": output_key},
             ExpiresIn=60 * 15,
         )

--- a/tests/integration/test_transcribe.py
+++ b/tests/integration/test_transcribe.py
@@ -110,7 +110,10 @@ class TestTranscribe:
                 transcription_status["TranscriptionJob"]["Transcript"]["TranscriptFileUri"],
                 allow_fragments=False,
             )
-            data = aws_client.s3.get_object(Bucket=s3_uri.netloc, Key=s3_uri.path.removeprefix("/"))
+            data = aws_client.s3.get_object(
+                Bucket=s3_uri.path.split("/")[1],
+                Key="/".join(s3_uri.path.split("/")[2:]).split("?")[0],
+            )
             content = to_str(data["Body"].read())
             assert "hello my name is" in content
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -252,9 +252,9 @@ class TestS3Utils:
         for bucket_name, expected_result in bucket_names:
             assert s3_utils.validate_bucket_name(bucket_name) == expected_result
 
-    def test_bucket_and_key_presign_url(self):
-        # array description : 'presign_url', 'expected_output_bucket', 'expected_output_key'
-        presign_urls = [
+    @pytest.mark.parametrize(
+        "presign_url, expected_output_bucket, expected_output_key",
+        [
             (
                 "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2/test-transcribe-job-e1895bdf.json?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
                 "test-output-bucket-2",
@@ -270,11 +270,14 @@ class TestS3Utils:
                 "test-output-bucket-2",
                 "",
             ),
-        ]
-        for url, expected_output_bucket, expected_output_key in presign_urls:
-            bucket, key = s3_utils_asf.get_bucket_and_key_from_presign_url(url)
-            assert bucket == expected_output_bucket
-            assert key == expected_output_key
+        ],
+    )
+    def test_bucket_and_key_presign_url(
+        self, presign_url, expected_output_bucket, expected_output_key
+    ):
+        bucket, key = s3_utils_asf.get_bucket_and_key_from_presign_url(presign_url)
+        assert bucket == expected_output_bucket
+        assert key == expected_output_key
 
     def test_is_expired(self):
         offset = datetime.timedelta(seconds=5)

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -255,20 +255,23 @@ class TestS3Utils:
     @pytest.mark.parametrize(
         "presign_url, expected_output_bucket, expected_output_key",
         [
-            (
+            pytest.param(
                 "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2/test-transcribe-job-e1895bdf.json?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
                 "test-output-bucket-2",
                 "test-transcribe-job-e1895bdf.json",
+                id="output key as a single file",
             ),
-            (
+            pytest.param(
                 "http://s3.localhost.localstack.cloud:4566/test-output-bucket-5/test-files/test-output.json?AWSAccessKeyId=000000000000&Signature=F6bwF1M2N%2BLzEXTZnUtjE23S%2Bb0%3D&Expires=1688561920",
                 "test-output-bucket-5",
                 "test-files/test-output.json",
+                id="output key with subdirectories",
             ),
-            (
+            pytest.param(
                 "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
                 "test-output-bucket-2",
                 "",
+                id="output key as None",
             ),
         ],
     )

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -252,6 +252,30 @@ class TestS3Utils:
         for bucket_name, expected_result in bucket_names:
             assert s3_utils.validate_bucket_name(bucket_name) == expected_result
 
+    def test_bucket_and_key_presign_url(self):
+        # array description : 'presign_url', 'expected_output_bucket', 'expected_output_key'
+        presign_urls = [
+            (
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2/test-transcribe-job-e1895bdf.json?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
+                "test-output-bucket-2",
+                "test-transcribe-job-e1895bdf.json",
+            ),
+            (
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-5/test-files/test-output.json?AWSAccessKeyId=000000000000&Signature=F6bwF1M2N%2BLzEXTZnUtjE23S%2Bb0%3D&Expires=1688561920",
+                "test-output-bucket-5",
+                "test-files/test-output.json",
+            ),
+            (
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
+                "test-output-bucket-2",
+                "",
+            ),
+        ]
+        for url, expected_output_bucket, expected_output_key in presign_urls:
+            bucket, key = s3_utils_asf.get_bucket_and_key_from_presign_url(url)
+            assert bucket == expected_output_bucket
+            assert key == expected_output_key
+
     def test_is_expired(self):
         offset = datetime.timedelta(seconds=5)
         assert s3_utils.is_expired(datetime.datetime.now() - offset)


### PR DESCRIPTION
The PR fixes `GetTranscriptionJob` response for transcribe service that contains a presigned S3 URL valid for 15min.

Related issue #8097.

FYI: The related developer hub [sample for transcribe](https://github.com/localstack/sample-serverless-transcribe), needs to be changed accordingly. 