### PR TITLE
Allow multiple lambda docker networks configured

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -24,7 +24,7 @@ from localstack.runtime.hooks import hook_spec
 from localstack.services.awslambda.lambda_utils import (
     API_PATH_ROOT,
     LAMBDA_RUNTIME_PROVIDED,
-    get_container_network_for_lambda,
+    get_main_container_network_for_lambda,
     get_main_endpoint_from_container,
     is_java_lambda,
     is_nodejs_runtime,
@@ -1024,7 +1024,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         env_vars.pop("AWS_LAMBDA_EVENT_BODY", None)
         container_config.env_vars = env_vars
 
-        container_config.network = get_container_network_for_lambda()
+        container_config.network = get_main_container_network_for_lambda()
         container_config.additional_flags = docker_flags
 
         container_config.dns = config.LAMBDA_DOCKER_DNS
@@ -1242,7 +1242,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
             inv_context.lambda_command = inv_context.handler
 
         # add Docker Lambda env vars
-        container_config.network = get_container_network_for_lambda()
+        container_config.network = get_main_container_network_for_lambda()
         if container_config.network == "host":
             port = get_free_tcp_port()
             container_config.env_vars["DOCKER_LAMBDA_API_PORT"] = port

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -190,14 +190,21 @@ def store_lambda_logs(
 def get_main_endpoint_from_container() -> str:
     if config.HOSTNAME_FROM_LAMBDA:
         return config.HOSTNAME_FROM_LAMBDA
-    return get_endpoint_for_network(network=get_container_network_for_lambda())
+    return get_endpoint_for_network(network=get_main_container_network_for_lambda())
 
 
-def get_container_network_for_lambda() -> str:
+def get_main_container_network_for_lambda() -> str:
     global LAMBDA_CONTAINER_NETWORK
     if config.LAMBDA_DOCKER_NETWORK:
-        return config.LAMBDA_DOCKER_NETWORK
+        return config.LAMBDA_DOCKER_NETWORK.split(",")[0]
     return get_main_container_network()
+
+
+def get_all_container_networks_for_lambda() -> list[str]:
+    global LAMBDA_CONTAINER_NETWORK
+    if config.LAMBDA_DOCKER_NETWORK:
+        return config.LAMBDA_DOCKER_NETWORK.split(",")
+    return [get_main_container_network()]
 
 
 def rm_docker_container(container_name_or_id, check_existence=False, safe=False):

--- a/tests/integration/awslambda/functions/lambda_networks.py
+++ b/tests/integration/awslambda/functions/lambda_networks.py
@@ -1,0 +1,10 @@
+from urllib.request import Request, urlopen
+
+
+def handler(event, context):
+    url = event.get("url")
+
+    httprequest = Request(url, headers={"Accept": "application/json"})
+
+    with urlopen(httprequest) as response:
+        return {"status": response.status, "response": response.read().decode()}


### PR DESCRIPTION
## Motivation
This PR will extend the functionality of `LAMBDA_DOCKER_NETWORK` to provide more than one network, as requested in #7338 .

Networks need to be provided comma separated, like this: `LAMBDA_DOCKER_NETWORK=network1,network2`.
As long as only one network is provided, the behavior does not change.

Fixes #7338.

## Changes
* Allow multiple docker networks to be respected (only new provider)
* Add test for LAMBDA_DOCKER_NETWORK with multiple networks.

## TODOs
* After this is merged, we should document this.