### PR TITLE
Add status: in progress mapping to label -> project status sync

### DIFF
--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -31,6 +31,7 @@ jobs:
                 "status: accepted": "status: backlog 🗃",
                 "status: stale": "status: stale 😴",
                 "status: response required": "status: response required 🗨",
+                "status: in progress": "status: in progress 🧑‍💻",
                 "status: resolved/stale": "status: stale 😴",
                 "status: resolved/fixed": "status: closed ✔",
                 "status: resolved/workaround": "status: closed ✔"


### PR DESCRIPTION
This is a first try, as the emoji part of the target is a bit tricky since it is a zero-width joined emoji, in contrast to the other once.

According to the github preview, however, it seems to render correctly, still not sure if it will create an issue with finding the correct category.