### PR TITLE
fix OpenSearch proxy for GZIP encoded responses

### DIFF
--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -14,7 +14,7 @@ from localstack.aws.api.opensearch import (
     EngineType,
     ValidationException,
 )
-from localstack.http.client import SimpleRequestsClient
+from localstack.http.client import SimpleStreamingRequestsClient
 from localstack.http.proxy import ProxyHandler
 from localstack.services.edge import ROUTER
 from localstack.services.infra import DEFAULT_BACKEND_HOST
@@ -229,7 +229,7 @@ def register_cluster(
     forward_url = config.OPENSEARCH_CUSTOM_BACKEND or forward_url
 
     # if the opensearch security plugin is enabled, only TLS connections are allowed, but the cert cannot be verified
-    client = SimpleRequestsClient()
+    client = SimpleStreamingRequestsClient()
     client.session.verify = False
     endpoint = ProxyHandler(forward_url, client)
 
@@ -416,7 +416,8 @@ class OpensearchCluster(Server):
             "http.publish_port": self.port,
             "transport.port": "0",
             "network.host": self.host,
-            "http.compression": "false",
+            # TODO this breaks the cluster check?!
+            "http.compression": "true",
             "path.data": f'"{dirs.data}"',
             "path.repo": f'"{dirs.backup}"',
             "discovery.type": "single-node",

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import logging
 import os
@@ -472,6 +473,13 @@ class TestOpensearchProvider:
         response = aws_client.opensearch.describe_domains(DomainNames=[opensearch_domain])
         assert len(response["DomainStatusList"]) == 1
         assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
+
+    def test_gzip_responses(self, opensearch_endpoint):
+        gzip_response = requests.get(opensearch_endpoint, stream=True)
+        # get the raw data, don't let requests decode the response
+        raw_data = b"".join(chunk for chunk in gzip_response.raw.stream(1024, decode_content=False))
+        # force the gzip decoding here (which would raise an exception if it's not actually gzip)
+        assert gzip.decompress(raw_data)
 
     def test_domain_version(self, opensearch_domain, opensearch_create_domain, aws_client):
         response = aws_client.opensearch.describe_domain(DomainName=opensearch_domain)


### PR DESCRIPTION
This PR fixes a small issue where GZIP encoded responses from an OpenSearch backend were decompressed by the proxies before sending them to the requesting client.
This is fixed by using the `SimpleStreamingRequestsClient` introduced by @bentsku in #8148.
It also enables the GZIP feature on internal OpenSearch domains (which is only used if the client sends the appropriate `Accept-Encoding` header).
In the future we could think about removing this separate implementation and making this the default implementation.

Fixes #7742