### PR TITLE
fix ApiGateway Model schema from CFn/CDK

### DIFF
--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -66,7 +66,7 @@ class RequestValidator:
             return True
 
         # check if there is validator for the resource
-        resource = resource_methods.get(self.context.method, {}) or resource_methods.get("ANY", {})
+        resource = resource_methods.get(self.context.method, resource_methods.get("ANY", {}))
         if not (resource.get("requestValidatorId") or "").strip():
             return True
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -62,11 +62,11 @@ class RequestValidator:
             return True
 
         resource_methods = self.context.resource["resourceMethods"]
-        if self.context.method not in resource_methods:
+        if self.context.method not in resource_methods and "ANY" not in resource_methods:
             return True
 
         # check if there is validator for the resource
-        resource = resource_methods[self.context.method]
+        resource = resource_methods.get(self.context.method, {}) or resource_methods.get("ANY", {})
         if not (resource.get("requestValidatorId") or "").strip():
             return True
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -457,7 +457,26 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     ) -> Method:
         response: Method = call_moto(context)
         remove_empty_attributes_from_method(response)
-        remove_empty_attributes_from_integration(response.get("methodIntegration"))
+        method_integration = response.get("methodIntegration")
+        if method_integration:
+            remove_empty_attributes_from_integration(method_integration)
+            # moto will not return `responseParameters` field if it's not truthy, but AWS will return an empty dict
+            # if it was set to an empty dict
+            if "responseParameters" not in method_integration:
+                moto_rest_api = get_moto_rest_api(context, rest_api_id)
+                moto_resource = moto_rest_api.resources[resource_id]
+                moto_method_integration = moto_resource.resource_methods[
+                    http_method
+                ].method_integration
+                for (
+                    status_code,
+                    integration_response,
+                ) in moto_method_integration.integration_responses.items():
+                    if integration_response.response_parameters == {}:
+                        method_integration["integrationResponses"][str(status_code)][
+                            "responseParameters"
+                        ] = {}
+
         return response
 
     def put_method(

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -468,14 +468,15 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 moto_method_integration = moto_resource.resource_methods[
                     http_method
                 ].method_integration
-                for (
-                    status_code,
-                    integration_response,
-                ) in moto_method_integration.integration_responses.items():
-                    if integration_response.response_parameters == {}:
-                        method_integration["integrationResponses"][str(status_code)][
-                            "responseParameters"
-                        ] = {}
+                if moto_method_integration.integration_responses:
+                    for (
+                        status_code,
+                        integration_response,
+                    ) in moto_method_integration.integration_responses.items():
+                        if integration_response.response_parameters == {}:
+                            method_integration["integrationResponses"][str(status_code)][
+                                "responseParameters"
+                            ] = {}
 
         return response
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -457,8 +457,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     ) -> Method:
         response: Method = call_moto(context)
         remove_empty_attributes_from_method(response)
-        method_integration = response.get("methodIntegration")
-        if method_integration:
+        if method_integration := response.get("methodIntegration"):
             remove_empty_attributes_from_integration(method_integration)
             # moto will not return `responseParameters` field if it's not truthy, but AWS will return an empty dict
             # if it was set to an empty dict

--- a/tests/integration/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_apigateway.snapshot.json
@@ -166,5 +166,275 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
+    "recorded-date": "05-07-2023, 20:11:14",
+    "recorded-content": {
+      "get-resources": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<id:2>",
+            "parentId": "<id:1>",
+            "path": "/validated",
+            "pathPart": "validated",
+            "resourceMethods": {
+              "ANY": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-models": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "description": "This is a default empty schema model",
+            "id": "<id:3>",
+            "name": "<name:1>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "<name:1> Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "This is a default error schema model",
+            "id": "<id:4>",
+            "name": "<name:2>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "<name:2> Schema",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:5>",
+            "name": "<name:3>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "<name:3>",
+              "type": "object",
+              "properties": {
+                "integer_field": {
+                  "type": "number"
+                },
+                "string_field": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "string_field",
+                "integer_field"
+              ]
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-request-validators": {
+        "items": [
+          {
+            "id": "<id:6>",
+            "name": "<name:4>",
+            "validateRequestBody": true,
+            "validateRequestParameters": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-method-any": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:2>",
+          "integrationResponses": {
+            "200": {
+              "responseParameters": {},
+              "responseTemplates": {},
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "NEVER",
+          "requestParameters": {},
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {},
+            "responseParameters": {},
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "<name:3>"
+        },
+        "requestParameters": {},
+        "requestValidatorId": "<id:6>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/cloudformation/resources/test_apigateway.py::test_cfn_with_apigateway_resources": {
+    "recorded-date": "05-07-2023, 20:54:14",
+    "recorded-content": {
+      "get-method-post": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<cache-namespace:1>",
+          "integrationResponses": {
+            "202": {
+              "responseParameters": {},
+              "responseTemplates": {
+                "application/json": {
+                  "operation": "celeste_account_create",
+                  "data": {
+                    "key": "123e4567-e89b-12d3-a456-426614174000",
+                    "secret": "123e4567-e89b-12d3-a456-426614174000"
+                  }
+                }
+              },
+              "selectionPattern": "2\\d{2}",
+              "statusCode": "202"
+            },
+            "500": {
+              "responseParameters": {},
+              "responseTemplates": {
+                "application/json": {
+                  "message": "Unknown <name:2>"
+                }
+              },
+              "selectionPattern": "5\\d{2}",
+              "statusCode": "500"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_TEMPLATES",
+          "requestParameters": {},
+          "requestTemplates": {
+            "application/json": "<name:3>"
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "202": {
+            "responseModels": {
+              "application/json": "<name:4>"
+            },
+            "responseParameters": {},
+            "statusCode": "202"
+          },
+          "500": {
+            "responseModels": {
+              "application/json": "<name:4>"
+            },
+            "responseParameters": {},
+            "statusCode": "500"
+          }
+        },
+        "operationName": "create_account",
+        "requestModels": {},
+        "requestParameters": {
+          "method.request.path.account": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-models": {
+        "items": [
+          {
+            "contentType": "application/json",
+            "description": "This is a default empty schema model",
+            "id": "<id:1>",
+            "name": "<name:1>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "<name:1> Schema",
+              "type": "object"
+            }
+          },
+          {
+            "contentType": "application/json",
+            "description": "This is a default error schema model",
+            "id": "<id:2>",
+            "name": "<name:2>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "<name:2> Schema",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:3>",
+            "name": "<name:3>",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "title": "AccountCreate",
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "email": {
+                  "format": "email",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "contentType": "application/json",
+            "id": "<id:4>",
+            "name": "<name:4>",
+            "schema": {}
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/apigateway_models.json
+++ b/tests/integration/templates/apigateway_models.json
@@ -1,0 +1,156 @@
+{
+ "Resources": {
+  "apiC8550315": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "test-cdk-models-json"
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/api/Resource"
+   }
+  },
+  "apiDeployment149F12947655b29bb65dd29c4fa41b0e0ff8358d": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    },
+    "Description": "Automatically created by the RestApi construct"
+   },
+   "DependsOn": [
+    "apivalidatedANY5D963C0D",
+    "apivalidatedA453B5EB",
+    "jsonmodelCE5E769A",
+    "requestvalidatorBE19E57D"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/api/Deployment/Resource"
+   }
+  },
+  "apiDeploymentStagelocal2DF7037D": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    },
+    "DeploymentId": {
+     "Ref": "apiDeployment149F12947655b29bb65dd29c4fa41b0e0ff8358d"
+    },
+    "StageName": "local"
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/api/DeploymentStage.local/Resource"
+   }
+  },
+  "apivalidatedA453B5EB": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "apiC8550315",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "validated",
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/api/Default/validated/Resource"
+   }
+  },
+  "apivalidatedANY5D963C0D": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Ref": "apivalidatedA453B5EB"
+    },
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationResponses": [
+      {
+       "StatusCode": "200"
+      }
+     ],
+     "PassthroughBehavior": "NEVER",
+     "RequestTemplates": {
+      "application/json": "{ \"statusCode\": 200 }"
+     },
+     "Type": "MOCK"
+    },
+    "MethodResponses": [
+     {
+      "StatusCode": "200"
+     }
+    ],
+    "RequestModels": {
+     "application/json": {
+      "Ref": "jsonmodelCE5E769A"
+     }
+    },
+    "RequestValidatorId": {
+     "Ref": "requestvalidatorBE19E57D"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/api/Default/validated/ANY/Resource"
+   }
+  },
+  "requestvalidatorBE19E57D": {
+   "Type": "AWS::ApiGateway::RequestValidator",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    },
+    "Name": "require-valid-body",
+    "ValidateRequestBody": true,
+    "ValidateRequestParameters": false
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/request-validator/Resource"
+   }
+  },
+  "jsonmodelCE5E769A": {
+   "Type": "AWS::ApiGateway::Model",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "apiC8550315"
+    },
+    "ContentType": "application/json",
+    "Name": "TestModel",
+    "Schema": {
+     "title": "TestModel",
+     "$schema": "http://json-schema.org/draft-04/schema#",
+     "type": "object",
+     "properties": {
+      "string_field": {
+       "type": "string"
+      },
+      "integer_field": {
+       "type": "number"
+      }
+     },
+     "required": [
+      "string_field",
+      "integer_field"
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "ValidatorExampleStack/json-model/Resource"
+   }
+  }
+ },
+ "Outputs": {
+  "RestApiId": {
+   "Value": {
+    "Ref": "apiC8550315"
+   }
+  }
+ }
+}

--- a/tests/integration/templates/template35.yaml
+++ b/tests/integration/templates/template35.yaml
@@ -37,7 +37,7 @@ Resources:
       - CreateAccount
     Properties:
       RestApiId: !Ref Gateway
-  GatewayEmptyModel:
+  DefaultModel:
     Type: AWS::ApiGateway::Model
     Properties:
       ContentType: 'application/json'
@@ -62,7 +62,7 @@ Resources:
         title: AccountCreate
         type: object
         properties:
-          name:
+          field:
             type: string
           email:
             type: string
@@ -93,10 +93,10 @@ Resources:
         TimeoutInMillis: 29000
       MethodResponses:
         - ResponseModels:
-            application/json: !Ref GatewayEmptyModel
+            application/json: !Ref DefaultModel
           StatusCode: '202'
         - ResponseModels:
-            application/json: !Ref GatewayEmptyModel
+            application/json: !Ref DefaultModel
           StatusCode: '500'
       OperationName: 'create_account'
       ResourceId: !Ref CreateAccountResource


### PR DESCRIPTION
This PR will fix #7060 and a ticket from support. 
It appeared we store the JSON schema from Model directly as is, in Python `dict` format to `str`, without JSON encoding it, which made every request fail when validating against the schema.

### Solution:
- Added a method to jsonify the model before storing it
- snapshot validated tests uncovered additional issues:
  - we didn't check for `ANY` method in `RequestValidator`
  - we were missing `requestParameters` empty value if it was an empty `dict`
  - we were missing `operationName` field when creating `Method` from Cfn
  - the `PhysicalResourceId` of a `Model` is its name, and not its `id` (that's what you are using when calling `GetModel`, added a AWS validated test to verify this behaviour, a CDK stack uncovered the issue)
