### PR TITLE
xfail flaky ssm describe_parameters test

### DIFF
--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -21,6 +21,9 @@ def _assert(search_name: str, param_name: str, ssm_client):
 
 class TestSSM:
     @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        reason="xfail until https://github.com/getmoto/moto/pull/6484 is in moto-ext"
+    )
     def test_describe_parameters(self, aws_client):
         response = aws_client.ssm.describe_parameters()
         assert "Parameters" in response


### PR DESCRIPTION
This PR aims at unblocking the pipeline on master by marking the currently failing SSM test with xfail.
This is just a temprary measure until https://github.com/getmoto/moto/pull/6484 is merged.
Until then, SSM's `DescribeParameters` might break if `PutParameters` was used without a parameter type before (which is an invalid request, according to the service specifications).