### PR TITLE
Add basic invoke test for AWS::Lambda::Function with code package on S3

### DIFF
--- a/tests/integration/templates/cfn_lambda_s3_code.yaml
+++ b/tests/integration/templates/cfn_lambda_s3_code.yaml
@@ -1,0 +1,48 @@
+Parameters:
+  LambdaCodeBucket:
+    Type: String
+  LambdaRuntime:
+    Type: String
+  LambdaHandler:
+    Type: String
+Resources:
+  FunctionServiceRole675BB04A:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  Function76856677:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket:
+          Ref: LambdaCodeBucket
+        S3Key: handler.zip
+      Role:
+        Fn::GetAtt:
+          - FunctionServiceRole675BB04A
+          - Arn
+      Handler: !Ref LambdaHandler
+      Runtime: !Ref LambdaRuntime
+    DependsOn:
+      - FunctionServiceRole675BB04A
+Outputs:
+  LambdaName:
+    Value:
+      Ref: Function76856677
+  LambdaArn:
+    Value:
+      Fn::GetAtt:
+        - Function76856677
+        - Arn


### PR DESCRIPTION
We didn't really have any tests that used `AWS::Lambda::Function` with the code uploaded to an s3 bucket. Instead the tests usually directly embedded the code in the template.