### PR TITLE
added test case for s3 object tagging

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1675,6 +1675,8 @@ def apply_moto_patches():
         """
         try:
             tags: Dict[str, str] = fn(*args, **kwargs)
+            for key in tags:
+                tags[key] = tags[key] if tags[key] else ""
         except TypeError:
             tags = {}
         return tags

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1032,7 +1032,7 @@ class TestS3:
         object_tags = aws_client.s3.get_object_tagging(Bucket=s3_bucket, Key=key)
         snapshot.match("created-object-tags", object_tags)
 
-        tag_set = {"TagSet": [{"Key": "tag1", "Value": "tag1"}]}
+        tag_set = {"TagSet": [{"Key": "tag1", "Value": "tag1"}, {"Key": "tag2", "Value": ""}]}
         aws_client.s3.put_object_tagging(Bucket=s3_bucket, Key=key, Tagging=tag_set)
 
         object_tags = aws_client.s3.get_object_tagging(Bucket=s3_bucket, Key=key)

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -451,7 +451,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_tagging_empty_list": {
-    "recorded-date": "21-09-2022, 13:35:15",
+    "recorded-date": "06-07-2023, 16:54:34",
     "recorded-content": {
       "created-object-tags": {
         "TagSet": [],
@@ -465,6 +465,10 @@
           {
             "Key": "tag1",
             "Value": "tag1"
+          },
+          {
+            "Key": "tag2",
+            "Value": ""
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
S3 can now accept empty value in the tag.

## Fixes
- Added test case for S3 tagging with empty tag

## Issue
https://github.com/localstack/localstack/issues/8598