### PR TITLE
A try fixing Lambda persistence

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -64,6 +64,9 @@ IMAGE_MAPPING = {
 SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11, Runtime.java17]
 
 
+BUCKET_ACCOUNT = "949334387222"
+
+
 # TODO: maybe we should make this more "transient" by always initializing to Pending and *not* persisting it?
 @dataclasses.dataclass(frozen=True)
 class VersionState:
@@ -169,7 +172,7 @@ class S3Code(ArchiveCode):
         """
         s3_client = connect_to(
             region_name=AWS_REGION_US_EAST_1,
-            aws_access_key_id=self.account_id,
+            aws_access_key_id=BUCKET_ACCOUNT,
         ).s3
         extra_args = {"VersionId": self.s3_object_version} if self.s3_object_version else {}
         s3_client.download_fileobj(
@@ -183,7 +186,7 @@ class S3Code(ArchiveCode):
         """
         s3_client = connect_to(
             region_name=AWS_REGION_US_EAST_1,
-            aws_access_key_id=self.account_id,
+            aws_access_key_id=BUCKET_ACCOUNT,
             endpoint_url=endpoint_url,
         ).s3
         params = {"Bucket": self.s3_bucket, "Key": self.s3_key}
@@ -245,7 +248,7 @@ class S3Code(ArchiveCode):
         self.destroy_cached()
         s3_client = connect_to(
             region_name=AWS_REGION_US_EAST_1,
-            aws_access_key_id=self.account_id,
+            aws_access_key_id=BUCKET_ACCOUNT,
         ).s3
         kwargs = {"VersionId": self.s3_object_version} if self.s3_object_version else {}
         try:

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -64,6 +64,9 @@ IMAGE_MAPPING = {
 SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11, Runtime.java17]
 
 
+# this account will be used to store all the internal lambda function archives at
+# it should not be modified by the user, or visible to him, except as through a presigned url with the
+# get-function call.
 BUCKET_ACCOUNT = "949334387222"
 
 

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -564,7 +564,7 @@ def store_lambda_archive(
             Type="User",
         )
     # store all buckets in us-east-1 for now
-    s3_client: "S3Client" = connect_to(region_name=AWS_REGION_US_EAST_1).s3
+    s3_client = connect_to(region_name=AWS_REGION_US_EAST_1, aws_access_key_id=account_id).s3
     bucket_name = f"awslambda-{region_name}-tasks"
     # s3 create bucket is idempotent
     s3_client.create_bucket(Bucket=bucket_name)

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -31,6 +31,7 @@ from localstack.services.awslambda.api_utils import (
     qualifier_is_alias,
 )
 from localstack.services.awslambda.invocation.lambda_models import (
+    BUCKET_ACCOUNT,
     ArchiveCode,
     Function,
     FunctionVersion,
@@ -564,7 +565,7 @@ def store_lambda_archive(
             Type="User",
         )
     # store all buckets in us-east-1 for now
-    s3_client = connect_to(region_name=AWS_REGION_US_EAST_1, aws_access_key_id=account_id).s3
+    s3_client = connect_to(region_name=AWS_REGION_US_EAST_1, aws_access_key_id=BUCKET_ACCOUNT).s3
     bucket_name = f"awslambda-{region_name}-tasks"
     # s3 create bucket is idempotent
     s3_client.create_bucket(Bucket=bucket_name)

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -10,7 +10,7 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from localstack.aws.connect import connect_to
+from localstack.aws.connect import connect_externally_to
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import arns
 from localstack.utils.aws import resources as resource_utils
@@ -236,7 +236,7 @@ def create_lambda_function(
 
     lambda_code = {"ZipFile": zip_file}
     if len(zip_file) > MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE:
-        s3 = s3_client or connect_to().s3
+        s3 = s3_client or connect_externally_to().s3
         resource_utils.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
         asset_key = f"{short_uid()}.zip"
         s3.upload_fileobj(


### PR DESCRIPTION
## Motivation
With PR #8235 , the persistence tests broke.

It seems, that connecting to the bucket from different accounts, made some problems with remote fetched layers. It is not quite clear what causes this behavior (maybe some cross account problem in s3?), but it needs to be solved ASAP to unblock the pipeline.

## Changes
* All code archive buckets are moved to some random account. This is parity with AWS


@giograno 