### PR TITLE
fix support for object retention

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -2239,7 +2239,7 @@ def apply_moto_patches():
 
     def key_is_locked(self):
         """
-        Apply a patch to disable/enable enforcement of S3 bucket policies
+        Apply a patch to check if a key is locked
         """
         if self.lock_legal_status == "ON":
             return True

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -4865,56 +4865,102 @@ class TestS3:
         snapshot.match("if_match_err_1", e.value.response["Error"])
 
     def test_s3_object_hold(self, aws_client, s3_create_bucket, snapshot):
-        bucket_name = f"bucket-{short_uid()}"
-        s3_create_bucket(Bucket=bucket_name, ObjectLockEnabledForBucket=True)
-        key = "test.txt"
-        aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body="test")
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.get_object_retention(Bucket=bucket_name, Key=key)
-        snapshot.match("get_object_retention_1", exc.value.response["Error"])
+        bucket_name_with_lock = f"bucket-with-lock-{short_uid()}"
+        bucket_name_without_lock = f"bucket-without-lock-{short_uid()}"
+        key_1 = "test1.txt"
+        key_2 = "test2.txt"
+
+        s3_create_bucket(Bucket=bucket_name_with_lock, ObjectLockEnabledForBucket=True)
+        aws_client.s3.put_object(Bucket=bucket_name_with_lock, Key=key_1, Body="test")
+        key_1_version_id = aws_client.s3.get_object(Bucket=bucket_name_with_lock, Key=key_1)[
+            "VersionId"
+        ]
+        key_2_version_id = aws_client.s3.put_object(Bucket=bucket_name_with_lock, Key=key_2)[
+            "VersionId"
+        ]
+
+        s3_create_bucket(Bucket=bucket_name_without_lock, ObjectLockEnabledForBucket=False)
+        aws_client.s3.put_object(Bucket=bucket_name_without_lock, Key=key_1, Body="test")
 
         # non-existing bucket
         with pytest.raises(ClientError) as exc:
             aws_client.s3.put_object_retention(
                 Bucket="non-existing-bucket",
-                Key=key,
-                Retention={"Mode": "COMPLIANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+                Key=key_1,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
             )
         snapshot.match("put_object_retention_1", exc.value.response["Error"])
 
         # non-existing key
         with pytest.raises(ClientError) as exc:
             aws_client.s3.put_object_retention(
-                Bucket=bucket_name,
+                Bucket=bucket_name_with_lock,
                 Key="non-existing-key",
-                Retention={"Mode": "COMPLIANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
             )
         snapshot.match("put_object_retention_2", exc.value.response["Error"])
 
+        # no lock on bucket
         with pytest.raises(ClientError) as exc:
-            aws_client.s3.get_object_retention(Bucket=bucket_name, Key=key)
-        snapshot.match("put_object_retention_3", exc.value.response["Error"])
+            aws_client.s3.get_object_retention(Bucket=bucket_name_without_lock, Key=key_1)
+        snapshot.match("get_object_retention_1", exc.value.response["Error"])
 
         response = aws_client.s3.put_object_retention(
-            Bucket=bucket_name,
-            Key=key,
-            Retention={"Mode": "COMPLIANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+            Bucket=bucket_name_with_lock,
+            Key=key_1,
+            Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
         )
         snapshot.match("put_object_retention_4", response["ResponseMetadata"]["HTTPStatusCode"])
 
-        response = aws_client.s3.get_object_retention(Bucket=bucket_name, Key=key)
+        response = aws_client.s3.get_object_retention(Bucket=bucket_name_with_lock, Key=key_1)
         snapshot.match("get_object_retention_2", response)
 
-        bucket_name_without_lock = f"bucket-{short_uid()}"
-        s3_create_bucket(Bucket=bucket_name_without_lock, ObjectLockEnabledForBucket=False)
+        # delete object with lock without bypass
+        with pytest.raises(ClientError) as exc:
+            aws_client.s3.delete_object(
+                Bucket=bucket_name_with_lock, Key=key_1, VersionId=key_1_version_id
+            )
+        snapshot.match("delete_object_1", exc.value.response["Error"])
 
-        aws_client.s3.put_object(Bucket=bucket_name_without_lock, Key=key, Body="test")
+        # delete object with lock with bypass
+        response = aws_client.s3.delete_object(
+            Bucket=bucket_name_with_lock,
+            Key=key_1,
+            VersionId=key_1_version_id,
+            BypassGovernanceRetention=True,
+        )
+        snapshot.match("delete_object_2", response["ResponseMetadata"]["HTTPStatusCode"])
 
+        # add object retention to key_2 with 5 seconds retention
+        aws_client.s3.put_object_retention(
+            Bucket=bucket_name_with_lock,
+            Key=key_2,
+            Retention={
+                "Mode": "GOVERNANCE",
+                "RetainUntilDate": datetime.datetime.utcnow() + datetime.timedelta(seconds=5),
+            },
+        )
+
+        # delete object with lock without bypass before 5 seconds
+        with pytest.raises(ClientError):
+            aws_client.s3.delete_object(
+                Bucket=bucket_name_with_lock, Key=key_2, VersionId=key_2_version_id
+            )
+
+        # delete object with lock without bypass after 5 seconds
+        time.sleep(6)
+        aws_client.s3.delete_object(
+            Bucket=bucket_name_with_lock,
+            Key=key_2,
+            VersionId=key_2_version_id,
+        )
+
+        # put object retention on bucket without lock configured
         with pytest.raises(ClientError) as exc:
             aws_client.s3.put_object_retention(
                 Bucket=bucket_name_without_lock,
-                Key=key,
-                Retention={"Mode": "COMPLIANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+                Key=key_1,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
             )
         snapshot.match("put_object_retention_5", exc.value.response["Error"])
 

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -4864,6 +4864,7 @@ class TestS3:
             aws_client.s3.get_object(Bucket=bucket, Key=key, IfMatch="etag")
         snapshot.match("if_match_err_1", e.value.response["Error"])
 
+    @pytest.mark.aws_validated
     def test_s3_object_hold(self, aws_client, s3_create_bucket, snapshot):
         bucket_name_with_lock = f"bucket-with-lock-{short_uid()}"
         bucket_name_without_lock = f"bucket-without-lock-{short_uid()}"

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8597,12 +8597,8 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_object_hold": {
-    "recorded-date": "07-07-2023, 14:25:48",
+    "recorded-date": "08-07-2023, 00:52:18",
     "recorded-content": {
-      "get_object_retention_1": {
-        "Code": "NoSuchObjectLockConfiguration",
-        "Message": "The specified object does not have a ObjectLock configuration"
-      },
       "put_object_retention_1": {
         "BucketName": "non-existing-bucket",
         "Code": "NoSuchBucket",
@@ -8613,14 +8609,14 @@
         "Key": "non-existing-key",
         "Message": "The specified key does not exist."
       },
-      "put_object_retention_3": {
-        "Code": "NoSuchObjectLockConfiguration",
-        "Message": "The specified object does not have a ObjectLock configuration"
+      "get_object_retention_1": {
+        "Code": "InvalidRequest",
+        "Message": "Bucket is missing Object Lock Configuration"
       },
       "put_object_retention_4": 200,
       "get_object_retention_2": {
         "Retention": {
-          "Mode": "COMPLIANCE",
+          "Mode": "GOVERNANCE",
           "RetainUntilDate": "datetime"
         },
         "ResponseMetadata": {
@@ -8628,6 +8624,11 @@
           "HTTPStatusCode": 200
         }
       },
+      "delete_object_1": {
+        "Code": "AccessDenied",
+        "Message": "Access Denied"
+      },
+      "delete_object_2": 204,
       "put_object_retention_5": {
         "Code": "InvalidRequest",
         "Message": "Bucket is missing Object Lock Configuration"

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8595,5 +8595,43 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_object_hold": {
+    "recorded-date": "07-07-2023, 14:25:48",
+    "recorded-content": {
+      "get_object_retention_1": {
+        "Code": "NoSuchObjectLockConfiguration",
+        "Message": "The specified object does not have a ObjectLock configuration"
+      },
+      "put_object_retention_1": {
+        "BucketName": "non-existing-bucket",
+        "Code": "NoSuchBucket",
+        "Message": "The specified bucket does not exist"
+      },
+      "put_object_retention_2": {
+        "Code": "NoSuchKey",
+        "Key": "non-existing-key",
+        "Message": "The specified key does not exist."
+      },
+      "put_object_retention_3": {
+        "Code": "NoSuchObjectLockConfiguration",
+        "Message": "The specified object does not have a ObjectLock configuration"
+      },
+      "put_object_retention_4": 200,
+      "get_object_retention_2": {
+        "Retention": {
+          "Mode": "COMPLIANCE",
+          "RetainUntilDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_object_retention_5": {
+        "Code": "InvalidRequest",
+        "Message": "Bucket is missing Object Lock Configuration"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Fixed
- S3 Object Retention
  - `PutObjectRetention` was not in parity with AWS
  - implemented `GetObjectRetention`

## Fixed flow
- `PutObjectRetention` with expired date -> call `DeleteObject` (used errors out)

## Related Issue
- https://github.com/localstack/localstack/issues/7517