### PR TITLE
add S3 Lifecycle logic and return Expiration header

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1657,8 +1657,10 @@ def validate_lifecycle_configuration(lifecycle_conf: BucketLifecycleConfiguratio
     Validate the Lifecycle configuration following AWS docs
     See https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html
     https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html
-    :param lifecycle_conf:
-    :raises
+    :param lifecycle_conf: the bucket lifecycle configuration given by the client
+    :raises MalformedXML: when the file doesn't follow the basic structure/required fields
+    :raises InvalidArgument: if the `Date` passed for the Expiration is not at Midnight GMT
+    :raises InvalidRequest: if there are duplicate tags keys in `Tags` field
     :return: None
     """
     # we only add the `Expiration` header, we don't delete objects yet

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -70,6 +70,7 @@ from localstack.aws.api.s3 import (
     InvalidPartOrder,
     InvalidStorageClass,
     InvalidTargetBucketForLogging,
+    LifecycleConfiguration,
     ListBucketAnalyticsConfigurationsOutput,
     ListBucketIntelligentTieringConfigurationsOutput,
     ListMultipartUploadsOutput,
@@ -1565,6 +1566,22 @@ def validate_acl_acp(acp: AccessControlPolicy) -> None:
         ):
             ex = _create_invalid_argument_exc("Invalid id", "CanonicalUser/ID", grantee_id)
             raise ex
+
+
+def validate_lifecycle_configuration(lifecycle_conf: LifecycleConfiguration) -> None:
+    """
+    Validate the Lifecycle configuration following AWS docs
+    See https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html
+    https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html
+    :param lifecycle_conf:
+    :raises
+    :return: None
+    """
+    # we only add the `Expiration` header, we don't delete objects yet
+    # We don't really expire or transition objects
+    # TODO: transition not supported
+
+    pass
 
 
 def validate_website_configuration(website_config: WebsiteConfiguration) -> None:

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -73,7 +73,6 @@ from localstack.aws.api.s3 import (
     InvalidPartOrder,
     InvalidStorageClass,
     InvalidTargetBucketForLogging,
-    LifecycleConfiguration,
     LifecycleRules,
     ListBucketAnalyticsConfigurationsOutput,
     ListBucketIntelligentTieringConfigurationsOutput,
@@ -171,10 +170,6 @@ MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6c
 # max file size for S3 objects kept in memory (500 KB by default)
 S3_MAX_FILE_SIZE_BYTES = 512 * 1024
 
-# runtime cache of Lifecycle Expiration headers, as they need to be calculated everytime we fetch an object in case the
-# rules have changed
-EXPIRATION_CACHE: dict[BucketName, dict[ObjectKey, Expiration]] = defaultdict(dict)
-
 
 class MalformedXML(CommonServiceException):
     def __init__(self, message=None):
@@ -232,7 +227,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store.bucket_website_configuration.pop(bucket, None)
         store.bucket_analytics_configuration.pop(bucket, None)
         store.bucket_intelligent_tiering_configuration.pop(bucket, None)
-        EXPIRATION_CACHE.pop(bucket, None)
+        self._expiration_cache.pop(bucket, None)
 
     def on_after_init(self):
         apply_moto_patches()
@@ -246,6 +241,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         super().__init__()
         self._notification_dispatcher = NotificationDispatcher()
         self._cors_handler = S3CorsHandler()
+        # runtime cache of Lifecycle Expiration headers, as they need to be calculated everytime we fetch an object
+        # in case the rules have changed
+        self._expiration_cache: dict[BucketName, dict[ObjectKey, Expiration]] = defaultdict(dict)
 
     def on_before_stop(self):
         self._notification_dispatcher.shutdown()
@@ -277,6 +275,34 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self._notification_dispatcher.verify_configuration(
             notification_configuration, skip_destination_validation, context, bucket_name
         )
+
+    def _get_expiration_header(
+        self, lifecycle_rules: LifecycleRules, moto_object, object_tags
+    ) -> Expiration:
+        """
+        This method will check if the key matches a Lifecycle filter, and return the serializer header if that's
+        the case. We're caching it because it can change depending on the set rules on the bucket.
+        We can't use `lru_cache` as the parameters needs to be hashable
+        :param lifecycle_rules: the bucket LifecycleRules
+        :param moto_object: FakeKey from moto
+        :param object_tags: the object tags
+        :return: the Expiration header if there's a rule matching
+        """
+        if cached_exp := self._expiration_cache.get(moto_object.bucket_name, {}).get(
+            moto_object.name
+        ):
+            return cached_exp
+
+        if lifecycle_rule := get_lifecycle_rule_from_object(
+            lifecycle_rules, moto_object, object_tags
+        ):
+            expiration_header = serialize_expiration_header(
+                lifecycle_rule["ID"],
+                lifecycle_rule["Expiration"],
+                moto_object.last_modified,
+            )
+            self._expiration_cache[moto_object.bucket_name][moto_object.name] = expiration_header
+            return expiration_header
 
     @handler("CreateBucket", expand=False)
     def create_bucket(
@@ -409,7 +435,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 )
             ) and (rules := bucket_lifecycle_config.get("Rules")):
                 object_tags = moto_backend.tagger.get_tag_dict_for_resource(key_object.arn)
-                if expiration_header := get_expiration_header(rules, key_object, object_tags):
+                if expiration_header := self._get_expiration_header(rules, key_object, object_tags):
                     # TODO: we either apply the lifecycle to existing objects when we set the new rules, or we need to
                     #  apply them everytime we get/head an object
                     response["Expiration"] = expiration_header
@@ -456,7 +482,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             and (rules := bucket_lifecycle_config.get("Rules"))
         ):
             object_tags = moto_backend.tagger.get_tag_dict_for_resource(key_object.arn)
-            if expiration_header := get_expiration_header(rules, key_object, object_tags):
+            if expiration_header := self._get_expiration_header(rules, key_object, object_tags):
                 # TODO: we either apply the lifecycle to existing objects when we set the new rules, or we need to
                 #  apply them everytime we get/head an object
                 response["Expiration"] = expiration_header
@@ -525,7 +551,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             rules := bucket_lifecycle_config.get("Rules")
         ):
             object_tags = moto_backend.tagger.get_tag_dict_for_resource(key_object.arn)
-            if expiration_header := get_expiration_header(rules, key_object, object_tags):
+            if expiration_header := self._get_expiration_header(rules, key_object, object_tags):
                 response["Expiration"] = expiration_header
 
         self._notify(context)
@@ -974,7 +1000,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # for now, we keep a cache and get it everytime we fetch an object
         store = self.get_store()
         store.bucket_lifecycle_configuration[bucket] = lifecycle_conf
-        EXPIRATION_CACHE[bucket].clear()
+        self._expiration_cache[bucket].clear()
 
     def delete_bucket_lifecycle(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
@@ -985,7 +1011,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         store = self.get_store()
         store.bucket_lifecycle_configuration.pop(bucket, None)
-        EXPIRATION_CACHE[bucket].clear()
+        self._expiration_cache[bucket].clear()
 
     def put_bucket_cors(
         self,
@@ -1755,29 +1781,6 @@ def is_object_expired(
     moto_bucket = get_bucket_from_moto(moto_backend, bucket)
     key_object = get_key_from_moto_bucket(moto_bucket, key, version_id=version_id)
     return is_key_expired(key_object=key_object)
-
-
-def get_expiration_header(lifecycle_rules: LifecycleRules, moto_object, object_tags):
-    """
-    This method will check if the key matches a Lifecycle filter, and return the serializer header if that's
-    the case. We're caching it because it can change depending on the set rules on the bucket.
-    We can't use `lru_cache` as the parameters needs to be hashable
-    :param lifecycle_rules: the bucket LifecycleRules
-    :param moto_object: FakeKey from moto
-    :param object_tags: the object tags
-    :return: the Expiration header if there's a rule matching
-    """
-    if cached_exp := EXPIRATION_CACHE.get(moto_object.bucket_name, {}).get(moto_object.name):
-        return cached_exp
-
-    if lifecycle_rule := get_lifecycle_rule_from_object(lifecycle_rules, moto_object, object_tags):
-        expiration_header = serialize_expiration_header(
-            lifecycle_rule["ID"],
-            lifecycle_rule["Expiration"],
-            moto_object.last_modified,
-        )
-        EXPIRATION_CACHE[moto_object.bucket_name][moto_object.name] = expiration_header
-        return expiration_header
 
 
 def _create_redirect_for_post_request(

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -353,7 +353,7 @@ def serialize_expiration_header(
         exp_date = last_modified.replace(
             hour=0, minute=0, second=0, microsecond=0
         ) + datetime.timedelta(days=exp_days + 1)
-    return f'expiry-date="{rfc_1123_datetime(exp_date)}", rule-id={rule_id}'
+    return f'expiry-date="{rfc_1123_datetime(exp_date)}", rule-id="{rule_id}"'
 
 
 def get_lifecycle_rule_from_object(

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -341,7 +341,7 @@ def rfc_1123_datetime(src: datetime.datetime) -> str:
 
 
 def str_to_rfc_1123_datetime(value: str) -> datetime.datetime:
-    return datetime.datetime.strptime(value, RFC1123).astimezone(tz=ZoneInfo("GMT"))
+    return datetime.datetime.strptime(value, RFC1123).replace(tzinfo=ZoneInfo("GMT"))
 
 
 def serialize_expiration_header(

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -4,6 +4,7 @@ import re
 import zlib
 from typing import Dict, Literal, Optional, Tuple, Union
 from urllib import parse as urlparser
+from zoneinfo import ZoneInfo
 
 import moto.s3.models as moto_s3_models
 from botocore.exceptions import ClientError
@@ -16,13 +17,14 @@ from localstack.aws.api import CommonServiceException, RequestContext, ServiceEx
 from localstack.aws.api.s3 import (
     BucketName,
     ChecksumAlgorithm,
-    Expiration,
     InvalidArgument,
+    LifecycleExpiration,
+    LifecycleRule,
+    LifecycleRules,
     MethodNotAllowed,
     NoSuchBucket,
     NoSuchKey,
     ObjectKey,
-    Rules,
 )
 from localstack.services.s3.constants import (
     S3_VIRTUAL_HOST_FORWARDED_HEADER,
@@ -56,6 +58,9 @@ S3_VIRTUAL_HOSTNAME_REGEX = (  # path based refs have at least valid bucket expr
 PATTERN_UUID = re.compile(
     r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 )
+
+
+RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"
 
 
 class InvalidRequest(ServiceException):
@@ -331,7 +336,77 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket) -> None:
         raise
 
 
-def get_lifecycle_expiration_from_object(
-    lifecycle_conf_rules: Rules, moto_object: FakeKey
-) -> Expiration:
-    pass
+def rfc_1123_datetime(src: datetime.datetime) -> str:
+    return src.strftime(RFC1123)
+
+
+def str_to_rfc_1123_datetime(value: str) -> datetime.datetime:
+    return datetime.datetime.strptime(value, RFC1123).astimezone(tz=ZoneInfo("GMT"))
+
+
+def serialize_expiration_header(
+    rule_id: str, lifecycle_exp: LifecycleExpiration, last_modified: datetime.datetime
+):
+    if not (exp_date := lifecycle_exp.get("Date")):
+        exp_days = lifecycle_exp.get("Days")
+        # AWS round to the next day at midnight UTC
+        exp_date = last_modified.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + datetime.timedelta(days=exp_days + 1)
+    return f'expiry-date="{rfc_1123_datetime(exp_date)}", rule-id={rule_id}'
+
+
+def get_lifecycle_rule_from_object(
+    lifecycle_conf_rules: LifecycleRules, moto_object: FakeKey, object_tags: dict[str, str]
+) -> LifecycleRule:
+    for rule in lifecycle_conf_rules:
+        if "Expiration" not in rule:
+            continue
+
+        if not (rule_filter := rule.get("Filter")):
+            return rule
+
+        if and_rules := rule_filter.get("And"):
+            if all(
+                _match_lifecycle_filter(key, value, moto_object, object_tags)
+                for key, value in and_rules.items()
+            ):
+                return rule
+
+        if any(
+            _match_lifecycle_filter(key, value, moto_object, object_tags)
+            for key, value in rule_filter.items()
+        ):
+            # after validation, we can only one of `Prefix`, `Tag`, `ObjectSizeGreaterThan` or `ObjectSizeLessThan` in
+            # the dict. Instead of manually checking, we can iterate of the only key and try to match it
+            return rule
+
+
+def _match_lifecycle_filter(
+    filter_key: str, filter_value, moto_object: FakeKey, object_tags: dict[str, str]
+):
+    match filter_key:
+        case "Prefix":
+            return moto_object.name.startswith(filter_value)
+        case "Tag":
+            return object_tags.get(filter_value.get("Key")) == filter_value.get("Value")
+        case "ObjectSizeGreaterThan":
+            return moto_object.size > filter_value
+        case "ObjectSizeLessThan":
+            return moto_object.size < filter_value
+        case "Tags":  # this is inside the `And` field
+            return all(object_tags.get(tag.get("Key")) == tag.get("Value") for tag in filter_value)
+
+
+def parse_expiration_header(
+    expiration_header: str,
+) -> tuple[Optional[datetime.datetime], Optional[str]]:
+    try:
+        header_values = dict(
+            (p.strip('"') for p in v.split("=")) for v in expiration_header.split('", ')
+        )
+        expiration_date = str_to_rfc_1123_datetime(header_values["expiry-date"])
+        return expiration_date, header_values["rule-id"]
+
+    except (IndexError, ValueError, KeyError):
+        return None, None

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -16,11 +16,13 @@ from localstack.aws.api import CommonServiceException, RequestContext, ServiceEx
 from localstack.aws.api.s3 import (
     BucketName,
     ChecksumAlgorithm,
+    Expiration,
     InvalidArgument,
     MethodNotAllowed,
     NoSuchBucket,
     NoSuchKey,
     ObjectKey,
+    Rules,
 )
 from localstack.services.s3.constants import (
     S3_VIRTUAL_HOST_FORWARDED_HEADER,
@@ -327,3 +329,9 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket) -> None:
                 code="KMS.NotFoundException", message=e.response["Error"]["Message"]
             )
         raise
+
+
+def get_lifecycle_expiration_from_object(
+    lifecycle_conf_rules: Rules, moto_object: FakeKey
+) -> Expiration:
+    pass

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -44,6 +44,7 @@ from localstack.services.awslambda.lambda_utils import (
     LAMBDA_RUNTIME_PYTHON39,
 )
 from localstack.services.s3 import constants as s3_constants
+from localstack.services.s3.utils import parse_expiration_header
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils import testutil
@@ -2331,219 +2332,6 @@ class TestS3:
         aws_client.s3.put_object(Body=b"test", Bucket=bucket, Key=key_by_path)
         result = aws_client.s3.get_object(Bucket=bucket, Key=key_by_path)
         snapshot.match("get_object", result)
-
-    @pytest.mark.aws_validated
-    def test_delete_bucket_lifecycle_configuration(self, s3_bucket, snapshot, aws_client):
-        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
-        with pytest.raises(ClientError) as e:
-            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
-        snapshot.match("get-bucket-lifecycle-exc-1", e.value.response)
-
-        resp = aws_client.s3.delete_bucket_lifecycle(Bucket=s3_bucket)
-        snapshot.match("delete-bucket-lifecycle-no-bucket", resp)
-
-        lfc = {
-            "Rules": [
-                {
-                    "Expiration": {"Days": 7},
-                    "ID": "wholebucket",
-                    "Filter": {"Prefix": ""},
-                    "Status": "Enabled",
-                }
-            ]
-        }
-        aws_client.s3.put_bucket_lifecycle_configuration(
-            Bucket=s3_bucket, LifecycleConfiguration=lfc
-        )
-        result = retry(
-            aws_client.s3.get_bucket_lifecycle_configuration, retries=3, sleep=1, Bucket=s3_bucket
-        )
-        snapshot.match("get-bucket-lifecycle-conf", result)
-        aws_client.s3.delete_bucket_lifecycle(Bucket=s3_bucket)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
-        snapshot.match("get-bucket-lifecycle-exc-2", e.value.response)
-
-    @pytest.mark.aws_validated
-    def test_delete_lifecycle_configuration_on_bucket_deletion(
-        self, s3_create_bucket, snapshot, aws_client
-    ):
-        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
-        bucket_name = f"test-bucket-{short_uid()}"  # keep the same name for both bucket
-        s3_create_bucket(Bucket=bucket_name)
-        lfc = {
-            "Rules": [
-                {
-                    "Expiration": {"Days": 7},
-                    "ID": "wholebucket",
-                    "Filter": {"Prefix": ""},
-                    "Status": "Enabled",
-                }
-            ]
-        }
-        aws_client.s3.put_bucket_lifecycle_configuration(
-            Bucket=bucket_name, LifecycleConfiguration=lfc
-        )
-        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=bucket_name)
-        snapshot.match("get-bucket-lifecycle-conf", result)
-        aws_client.s3.delete_bucket(Bucket=bucket_name)
-        s3_create_bucket(Bucket=bucket_name)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=bucket_name)
-        snapshot.match("get-bucket-lifecycle-exc", e.value.response)
-
-    def test_put_bucket_lifecycle_conf_exc(self, s3_bucket, snapshot, aws_client):
-        pass
-
-    @pytest.mark.aws_validated
-    # @pytest.mark.xfail(
-    #     reason="Bucket lifecycle doesn't affect object expiration in both providers for now"
-    # )
-    def test_bucket_lifecycle_configuration_object_expiry(self, s3_bucket, snapshot, aws_client):
-        snapshot.add_transformer(
-            [
-                snapshot.transform.key_value("BucketName"),
-                snapshot.transform.key_value(
-                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
-                ),
-            ]
-        )
-
-        lfc = {
-            "Rules": [
-                {
-                    "Expiration": {"Days": 7},
-                    "ID": "wholebucket",
-                    "Filter": {"Prefix": ""},
-                    "Status": "Enabled",
-                }
-            ]
-        }
-        aws_client.s3.put_bucket_lifecycle_configuration(
-            Bucket=s3_bucket, LifecycleConfiguration=lfc
-        )
-        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
-        snapshot.match("get-bucket-lifecycle-conf", result)
-
-        key = "test-object-expiry"
-        aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("head-object-expiry", response)
-        response = aws_client.s3.get_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("get-object-expiry", response)
-
-        expiration = response["Expiration"]
-        print(response["LastModified"])
-        print(expiration)
-
-    @pytest.mark.aws_validated
-    @pytest.mark.xfail(
-        reason="Bucket lifecycle doesn't affect object expiration in both providers for now"
-    )
-    def test_bucket_lifecycle_configuration_object_expiry_versioned(
-        self, s3_bucket, snapshot, aws_client
-    ):
-        snapshot.add_transformer(
-            [
-                snapshot.transform.key_value("BucketName"),
-                snapshot.transform.key_value(
-                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
-                ),
-            ]
-        )
-
-        lfc = {
-            "Rules": [
-                {
-                    "ID": "My Rule ID",
-                    "Status": "Enabled",
-                    "Expiration": {"Days": 3},
-                    "NoncurrentVersionExpiration": {"NoncurrentDays": 1},
-                }
-            ]
-        }
-        aws_client.s3.put_bucket_lifecycle_configuration(
-            Bucket=s3_bucket, LifecycleConfiguration=lfc
-        )
-        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
-        snapshot.match("get-bucket-lifecycle-conf", result)
-
-        key = "test-object-expiry"
-        put_object_1 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
-        version_id_1 = put_object_1["VersionId"]
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("head-object-expiry", response)
-        response = aws_client.s3.get_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("get-object-expiry", response)
-        # TODO: parse value
-
-        key = "test-object-expiry"
-        put_object_2 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
-        version_id_2 = put_object_2["VersionId"]
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key, VersionId=version_id_1)
-        snapshot.match("head-object-expiry-noncurrent", response)
-        # TODO: parse value
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key, VersionId=version_id_2)
-        snapshot.match("head-object-expiry-current", response)
-        # TODO: parse value
-
-    @pytest.mark.aws_validated
-    # @pytest.mark.xfail(
-    #     reason="Bucket lifecycle doesn't affect object expiration in both providers for now"
-    # )
-    def test_object_expiry_after_bucket_lifecycle_configuration(
-        self, s3_bucket, snapshot, aws_client
-    ):
-        snapshot.add_transformer(
-            [
-                snapshot.transform.key_value("BucketName"),
-                snapshot.transform.key_value(
-                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
-                ),
-            ]
-        )
-        key = "test-object-expiry"
-        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
-        snapshot.match("put-object-before", put_object)
-
-        lfc = {
-            "Rules": [
-                {
-                    "Expiration": {"Days": 7},
-                    "ID": "wholebucket",
-                    "Filter": {"Prefix": ""},
-                    "Status": "Enabled",
-                }
-            ]
-        }
-        aws_client.s3.put_bucket_lifecycle_configuration(
-            Bucket=s3_bucket, LifecycleConfiguration=lfc
-        )
-        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
-        snapshot.match("get-bucket-lifecycle-conf", result)
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("head-object-expiry", response)
-
-        expiration = response["Expiration"]
-        print(response["LastModified"])
-        print(expiration)
-
-        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
-        snapshot.match("put-object-after", put_object)
-
-        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
-        snapshot.match("head-object-expiry", response)
-
-        expiration = response["Expiration"]
-        print(response["LastModified"])
-        print(expiration)
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
@@ -7994,6 +7782,607 @@ class TestS3BucketPolicies:
             aws_client.s3.get_object(Bucket=s3_bucket, Key="test/123")
         assert exc.value.response["Error"]["Code"] == "403"
         assert exc.value.response["Error"]["Message"] == "Forbidden"
+
+
+class TestS3BucketLifecycle:
+    @pytest.mark.aws_validated
+    def test_delete_bucket_lifecycle_configuration(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-exc-1", e.value.response)
+
+        resp = aws_client.s3.delete_bucket_lifecycle(Bucket=s3_bucket)
+        snapshot.match("delete-bucket-lifecycle-no-bucket", resp)
+
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": 7},
+                    "ID": "wholebucket",
+                    "Filter": {"Prefix": ""},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = retry(
+            aws_client.s3.get_bucket_lifecycle_configuration, retries=3, sleep=1, Bucket=s3_bucket
+        )
+        snapshot.match("get-bucket-lifecycle-conf", result)
+        aws_client.s3.delete_bucket_lifecycle(Bucket=s3_bucket)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-exc-2", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_delete_lifecycle_configuration_on_bucket_deletion(
+        self, s3_create_bucket, snapshot, aws_client
+    ):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        bucket_name = f"test-bucket-{short_uid()}"  # keep the same name for both bucket
+        s3_create_bucket(Bucket=bucket_name)
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": 7},
+                    "ID": "wholebucket",
+                    "Filter": {"Prefix": ""},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=bucket_name, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=bucket_name)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+        aws_client.s3.delete_bucket(Bucket=bucket_name)
+        s3_create_bucket(Bucket=bucket_name)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_bucket_lifecycle_configuration(Bucket=bucket_name)
+        snapshot.match("get-bucket-lifecycle-exc", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_put_bucket_lifecycle_conf_exc(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            snapshot.transform.key_value("ArgumentValue", value_replacement="datetime")
+        )
+        lfc = {"Rules": []}
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {"Days": 7},
+                    "Status": "Enabled",
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("missing-id", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {"Days": 7},
+                    "ID": "wholebucket",
+                    "Status": "Enabled",
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("missing-filter", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {"Days": 7},
+                    "Filter": {},
+                    "ID": "wholebucket",
+                    "Status": "Enabled",
+                    "NoncurrentVersionExpiration": {},  # No NewerNoncurrentVersions or NoncurrentDays
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("missing-noncurrent-version-expiration-data", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {"Days": 7},
+                    "Filter": {
+                        "And": {
+                            "Prefix": "test",
+                        },
+                        "Prefix": "",
+                    },
+                    "ID": "wholebucket",
+                    "Status": "Enabled",
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("wrong-filter-and-plus-prefix", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {"Days": 7},
+                    "Filter": {
+                        "ObjectSizeGreaterThan": 500,
+                        "Prefix": "",
+                    },
+                    "ID": "wholebucket",
+                    "Status": "Enabled",
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("wrong-filter-and-and-object-size", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "Expiration": {
+                        "Date": datetime.datetime(year=2023, month=1, day=1, hour=2, minute=2)
+                    },
+                    "ID": "wrong-data",
+                    "Filter": {},
+                    "Status": "Enabled",
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+        snapshot.match("wrong-data-no-midnight", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "ID": "duplicate-tag-keys",
+                    "Filter": {
+                        "And": {
+                            "Tags": [
+                                {
+                                    "Key": "testlifecycle",
+                                    "Value": "positive",
+                                },
+                                {
+                                    "Key": "testlifecycle",
+                                    "Value": "positive-two",
+                                },
+                            ],
+                        },
+                    },
+                    "Status": "Enabled",
+                    "Expiration": {"Days": 1},
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+
+        snapshot.match("duplicate-tag-keys", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_bucket_lifecycle_configuration_date(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+            ]
+        )
+        rule_id = "rule_number_one"
+
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {
+                        "Date": datetime.datetime(year=2023, month=1, day=1, tzinfo=ZoneInfo("GMT"))
+                    },
+                    "ID": rule_id,
+                    "Filter": {},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_bucket_lifecycle_configuration_object_expiry(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+        rule_id = "rule_number_one"
+
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": 7},
+                    "ID": rule_id,
+                    "Filter": {"Prefix": ""},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key = "test-object-expiry"
+        aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object-expiry", response)
+        response = aws_client.s3.get_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("get-object-expiry", response)
+
+        expiration = response["Expiration"]
+
+        parsed_exp_date, parsed_exp_rule = parse_expiration_header(expiration)
+        assert parsed_exp_rule == rule_id
+        last_modified = response["LastModified"]
+
+        # use a bit of margin for the 7 days expiration, as it can depend on the time of day, but at least we validate
+        assert 6 <= (parsed_exp_date - last_modified).days <= 8
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_bucket_lifecycle_configuration_object_expiry_versioned(
+        self, s3_bucket, snapshot, aws_client
+    ):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"), priority=-1)
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        rule_id = "rule2"
+        current_exp_days = 3
+        non_current_exp_days = 1
+        lfc = {
+            "Rules": [
+                {
+                    "ID": rule_id,
+                    "Status": "Enabled",
+                    "Filter": {},
+                    "Expiration": {"Days": current_exp_days},
+                    "NoncurrentVersionExpiration": {"NoncurrentDays": non_current_exp_days},
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key = "test-object-expiry"
+        put_object_1 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+        version_id_1 = put_object_1["VersionId"]
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object-expiry", response)
+
+        parsed_exp_date, parsed_exp_rule = parse_expiration_header(response["Expiration"])
+        assert parsed_exp_rule == rule_id
+        # use a bit of margin for the days expiration, as it can depend on the time of day, but at least we validate
+        assert (
+            current_exp_days - 1
+            <= (parsed_exp_date - response["LastModified"]).days
+            <= current_exp_days + 1
+        )
+
+        key = "test-object-expiry"
+        put_object_2 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+        version_id_2 = put_object_2["VersionId"]
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key, VersionId=version_id_1)
+        snapshot.match("head-object-expiry-noncurrent", response)
+
+        # This is not in the documentation anymore, but it still seems to be the case
+        # See https://stackoverflow.com/questions/33096697/object-expiration-of-non-current-version
+        # Note that for versioning-enabled buckets, this header applies only to current versions; Amazon S3 does not
+        # provide a header to infer when a noncurrent version will be eligible for permanent deletion.
+        assert "Expiration" not in response
+
+        # if you specify the VersionId, AWS won't return the Expiration header, even if that's the current version
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key, VersionId=version_id_2)
+        snapshot.match("head-object-expiry-current-with-version-id", response)
+        assert "Expiration" not in response
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object-expiry-current-without-version-id", response)
+        # assert that the previous version id which didn't return the Expiration header is the same object
+        assert response["VersionId"] == version_id_2
+
+        parsed_exp_date, parsed_exp_rule = parse_expiration_header(response["Expiration"])
+        assert parsed_exp_rule == rule_id
+        # use a bit of margin for the days expiration, as it can depend on the time of day, but at least we validate
+        assert (
+            current_exp_days - 1
+            <= (parsed_exp_date - response["LastModified"]).days
+            <= current_exp_days + 1
+        )
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_object_expiry_after_bucket_lifecycle_configuration(
+        self, s3_bucket, snapshot, aws_client
+    ):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+        key = "test-object-expiry"
+        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+        snapshot.match("put-object-before", put_object)
+
+        rule_id = "rule3"
+        current_exp_days = 7
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": current_exp_days},
+                    "ID": rule_id,
+                    "Filter": {},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object-expiry-before", response)
+
+        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+        snapshot.match("put-object-after", put_object)
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object-expiry-after", response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_bucket_lifecycle_multiple_rules(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+
+        rule_id_1 = "rule_one"
+        rule_id_2 = "rule_two"
+        rule_id_3 = "rule_three"
+        current_exp_days = 7
+        lfc = {
+            "Rules": [
+                {
+                    "ID": rule_id_1,
+                    "Filter": {"Prefix": "testobject"},
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+                {
+                    "ID": rule_id_2,
+                    "Filter": {"Prefix": "test"},
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+                {
+                    "ID": rule_id_3,
+                    "Filter": {"Prefix": "t"},
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+            ]
+        }
+
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key_match_1 = "testobject-expiry"
+        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key_match_1)
+        snapshot.match("put-object-match-both-rules", put_object)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object["Expiration"])
+        assert parsed_exp_rule == rule_id_1
+
+        key_match_2 = "test-one-rule"
+        put_object_2 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key_match_2)
+        snapshot.match("put-object-match-rule-2", put_object_2)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object_2["Expiration"])
+        assert parsed_exp_rule == rule_id_2
+
+        key_no_match = "no-rules"
+        put_object_3 = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key_no_match)
+        snapshot.match("put-object-no-match", put_object_3)
+        assert "Expiration" not in put_object_3
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_bucket_lifecycle_object_size_rules(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+
+        rule_id_1 = "rule_one"
+        rule_id_2 = "rule_two"
+        current_exp_days = 7
+        lfc = {
+            "Rules": [
+                {
+                    "ID": rule_id_1,
+                    "Filter": {
+                        "ObjectSizeGreaterThan": 20,
+                    },
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+                {
+                    "ID": rule_id_2,
+                    "Filter": {
+                        "ObjectSizeLessThan": 10,
+                    },
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+            ]
+        }
+
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key_match_1 = "testobject-expiry"
+        put_object = aws_client.s3.put_object(Body=b"a" * 22, Bucket=s3_bucket, Key=key_match_1)
+        snapshot.match("put-object-match-rule-1", put_object)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object["Expiration"])
+        assert parsed_exp_rule == rule_id_1
+
+        key_match_2 = "test-one-rule"
+        put_object_2 = aws_client.s3.put_object(Body=b"a" * 5, Bucket=s3_bucket, Key=key_match_2)
+        snapshot.match("put-object-match-rule-2", put_object_2)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object_2["Expiration"])
+        assert parsed_exp_rule == rule_id_2
+
+        key_no_match = "no-rules"
+        put_object_3 = aws_client.s3.put_object(Body=b"a" * 15, Bucket=s3_bucket, Key=key_no_match)
+        snapshot.match("put-object-no-match", put_object_3)
+        assert "Expiration" not in put_object_3
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_bucket_lifecycle_tag_rules(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+
+        rule_id_1 = "rule_one"
+        rule_id_2 = "rule_two"
+        current_exp_days = 7
+        lfc = {
+            "Rules": [
+                {
+                    "ID": rule_id_1,
+                    "Filter": {
+                        "Tag": {
+                            "Key": "testlifecycle",
+                            "Value": "positive",
+                        },
+                    },
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+                {
+                    "ID": rule_id_2,
+                    "Filter": {
+                        "And": {
+                            "Tags": [
+                                {
+                                    "Key": "testlifecycle",
+                                    "Value": "positive",
+                                },
+                                {
+                                    "Key": "testlifecycletwo",
+                                    "Value": "positive-two",
+                                },
+                            ],
+                        },
+                    },
+                    "Status": "Enabled",
+                    "Expiration": {"Days": current_exp_days},
+                },
+            ]
+        }
+
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key_match_1 = "testobject-expiry"
+        tag_set_match = "testlifecycle=positive&testlifecycletwo=positivetwo"
+        put_object = aws_client.s3.put_object(
+            Body=b"test", Bucket=s3_bucket, Key=key_match_1, Tagging=tag_set_match
+        )
+        snapshot.match("put-object-match-both-rules", put_object)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object["Expiration"])
+        assert parsed_exp_rule == rule_id_1
+
+        key_match_2 = "test-one-rule"
+        tag_set_match_one = "testlifecycle=positive"
+        put_object_2 = aws_client.s3.put_object(
+            Body=b"test", Bucket=s3_bucket, Key=key_match_2, Tagging=tag_set_match_one
+        )
+        snapshot.match("put-object-match-rule-1", put_object_2)
+
+        _, parsed_exp_rule = parse_expiration_header(put_object_2["Expiration"])
+        assert parsed_exp_rule == rule_id_1
+
+        key_no_match = "no-rules"
+        tag_set_no_match = "testlifecycle2=positivetwo"
+        put_object_3 = aws_client.s3.put_object(
+            Body=b"test", Bucket=s3_bucket, Key=key_no_match, Tagging=tag_set_no_match
+        )
+        snapshot.match("put-object-no-match", put_object_3)
+        assert "Expiration" not in put_object_3
 
 
 def _anon_client(service: str):

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8192,5 +8192,69 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_object_expiry_after_bucket_lifecycle_configuration": {
+    "recorded-date": "07-07-2023, 21:38:39",
+    "recorded-content": {
+      "put-object-before": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {},
+            "ID": "rule3",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-before": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-after": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-after": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -1185,7 +1185,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_lifecycle_configuration": {
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_delete_bucket_lifecycle_configuration": {
     "recorded-date": "21-09-2022, 13:36:09",
     "recorded-content": {
       "get-bucket-lifecycle-exc-1": {
@@ -1236,7 +1236,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_delete_lifecycle_configuration_on_bucket_deletion": {
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_delete_lifecycle_configuration_on_bucket_deletion": {
     "recorded-date": "21-09-2022, 13:36:12",
     "recorded-content": {
       "get-bucket-lifecycle-conf": {
@@ -1270,8 +1270,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_bucket_lifecycle_configuration_object_expiry": {
-    "recorded-date": "21-09-2022, 13:36:14",
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_configuration_object_expiry": {
+    "recorded-date": "07-07-2023, 15:33:21",
     "recorded-content": {
       "get-bucket-lifecycle-conf": {
         "Rules": [
@@ -1280,7 +1280,7 @@
             "Filter": {
               "Prefix": ""
             },
-            "ID": "wholebucket",
+            "ID": "rule_number_one",
             "Status": "Enabled"
           }
         ],
@@ -1297,6 +1297,7 @@
         "Expiration": "<expiration>",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1311,6 +1312,7 @@
         "Expiration": "<expiration>",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -7758,6 +7760,435 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_configuration_object_expiry_versioned": {
+    "recorded-date": "07-07-2023, 19:44:39",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {},
+            "ID": "rule2",
+            "NoncurrentVersionExpiration": {
+              "NoncurrentDays": 1
+            },
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-noncurrent": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-current-with-version-id": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-current-without-version-id": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_object_expiry_after_bucket_lifecycle_configuration": {
+    "recorded-date": "07-07-2023, 15:52:37",
+    "recorded-content": {
+      "put-object-before": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {},
+            "ID": "rule3",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-before": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-after": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry-after": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_multiple_rules": {
+    "recorded-date": "07-07-2023, 16:43:56",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "Prefix": "testobject"
+            },
+            "ID": "rule_one",
+            "Status": "Enabled"
+          },
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "Prefix": "test"
+            },
+            "ID": "rule_two",
+            "Status": "Enabled"
+          },
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "Prefix": "t"
+            },
+            "ID": "rule_three",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-both-rules": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-rule-2": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-no-match": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_put_bucket_lifecycle_conf_exc": {
+    "recorded-date": "07-07-2023, 20:42:44",
+    "recorded-content": {
+      "missing-id": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-filter": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-noncurrent-version-expiration-data": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-filter-and-plus-prefix": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-filter-and-and-object-size": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-data-no-midnight": {
+        "Error": {
+          "ArgumentName": "Date",
+          "ArgumentValue": "<datetime:1>",
+          "Code": "InvalidArgument",
+          "Message": "'Date' must be at midnight GMT"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "duplicate-tag-keys": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Duplicate Tag Keys are not allowed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_configuration_date": {
+    "recorded-date": "07-07-2023, 18:47:29",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": {
+              "Date": "datetime"
+            },
+            "Filter": {},
+            "ID": "rule_number_one",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_object_size_rules": {
+    "recorded-date": "07-07-2023, 20:26:53",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "ObjectSizeGreaterThan": 20
+            },
+            "ID": "rule_one",
+            "Status": "Enabled"
+          },
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "ObjectSizeLessThan": 10
+            },
+            "ID": "rule_two",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-rule-1": {
+        "ETag": "\"ff49cfac3968dbce26ebe7d4823e58bd\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-rule-2": {
+        "ETag": "\"594f803b380a41396ed63dca39503542\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-no-match": {
+        "ETag": "\"12f9cf6998d52dbe773b06f848bb3608\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_bucket_lifecycle_tag_rules": {
+    "recorded-date": "07-07-2023, 20:53:27",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "Tag": {
+                "Key": "testlifecycle",
+                "Value": "positive"
+              }
+            },
+            "ID": "rule_one",
+            "Status": "Enabled"
+          },
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "And": {
+                "Tags": [
+                  {
+                    "Key": "testlifecycle",
+                    "Value": "positive"
+                  },
+                  {
+                    "Key": "testlifecycletwo",
+                    "Value": "positive-two"
+                  }
+                ]
+              }
+            },
+            "ID": "rule_two",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-both-rules": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-match-rule-1": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-no-match": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -657,12 +657,12 @@ class TestS3UtilsAsf:
         [
             (
                 'expiry-date="Sat, 15 Jul 2023 00:00:00 GMT", rule-id="rule1"',
-                datetime.datetime(day=15, month=7, year=2023, tzinfo=None),
+                datetime.datetime(day=15, month=7, year=2023, tzinfo=zoneinfo.ZoneInfo(key="GMT")),
                 "rule1",
             ),
             (
                 'expiry-date="Mon, 29 Dec 2030 00:00:00 GMT", rule-id="rule2"',
-                datetime.datetime(day=29, month=12, year=2030, tzinfo=None),
+                datetime.datetime(day=29, month=12, year=2030, tzinfo=zoneinfo.ZoneInfo(key="GMT")),
                 "rule2",
             ),
             (

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -687,6 +687,48 @@ class TestS3UtilsAsf:
         assert parsed_dateobj == dateobj
         assert parsed_rule_id == rule_id
 
+    @pytest.mark.parametrize(
+        "rule_id, lifecycle_exp, last_modified, header",
+        [
+            (
+                "rule1",
+                {
+                    "Date": datetime.datetime(
+                        day=15, month=7, year=2023, tzinfo=zoneinfo.ZoneInfo(key="GMT")
+                    )
+                },
+                datetime.datetime(
+                    day=15,
+                    month=9,
+                    year=2024,
+                    hour=0,
+                    minute=0,
+                    second=0,
+                    microsecond=0,
+                    tzinfo=None,
+                ),
+                'expiry-date="Sat, 15 Jul 2023 00:00:00 GMT", rule-id="rule1"',
+            ),
+            (
+                "rule2",
+                {"Days": 5},
+                datetime.datetime(day=15, month=7, year=2023, tzinfo=None),
+                'expiry-date="Fri, 21 Jul 2023 00:00:00 GMT", rule-id="rule2"',
+            ),
+            (
+                "rule3",
+                {"Days": 3},
+                datetime.datetime(day=31, month=12, year=2030, microsecond=1, tzinfo=None),
+                'expiry-date="Sat, 04 Jan 2031 00:00:00 GMT", rule-id="rule3"',
+            ),
+        ],
+    )
+    def test_serialize_expiration_header(self, rule_id, lifecycle_exp, last_modified, header):
+        serialized_header = s3_utils_asf.serialize_expiration_header(
+            rule_id, lifecycle_exp, last_modified
+        )
+        assert serialized_header == header
+
 
 class TestS3PresignedUrlAsf:
     """

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -252,36 +252,6 @@ class TestS3Utils:
         for bucket_name, expected_result in bucket_names:
             assert s3_utils.validate_bucket_name(bucket_name) == expected_result
 
-    @pytest.mark.parametrize(
-        "presign_url, expected_output_bucket, expected_output_key",
-        [
-            pytest.param(
-                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2/test-transcribe-job-e1895bdf.json?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
-                "test-output-bucket-2",
-                "test-transcribe-job-e1895bdf.json",
-                id="output key as a single file",
-            ),
-            pytest.param(
-                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-5/test-files/test-output.json?AWSAccessKeyId=000000000000&Signature=F6bwF1M2N%2BLzEXTZnUtjE23S%2Bb0%3D&Expires=1688561920",
-                "test-output-bucket-5",
-                "test-files/test-output.json",
-                id="output key with subdirectories",
-            ),
-            pytest.param(
-                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
-                "test-output-bucket-2",
-                "",
-                id="output key as None",
-            ),
-        ],
-    )
-    def test_bucket_and_key_presign_url(
-        self, presign_url, expected_output_bucket, expected_output_key
-    ):
-        bucket, key = s3_utils_asf.get_bucket_and_key_from_presign_url(presign_url)
-        assert bucket == expected_output_bucket
-        assert key == expected_output_key
-
     def test_is_expired(self):
         offset = datetime.timedelta(seconds=5)
         assert s3_utils.is_expired(datetime.datetime.now() - offset)
@@ -651,6 +621,71 @@ class TestS3UtilsAsf:
         for checksum_algorithm, data, request in invalid_checksums:
             with pytest.raises(Exception):
                 s3_utils_asf.verify_checksum(checksum_algorithm, data, request)
+
+    @pytest.mark.parametrize(
+        "presign_url, expected_output_bucket, expected_output_key",
+        [
+            pytest.param(
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2/test-transcribe-job-e1895bdf.json?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
+                "test-output-bucket-2",
+                "test-transcribe-job-e1895bdf.json",
+                id="output key as a single file",
+            ),
+            pytest.param(
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-5/test-files/test-output.json?AWSAccessKeyId=000000000000&Signature=F6bwF1M2N%2BLzEXTZnUtjE23S%2Bb0%3D&Expires=1688561920",
+                "test-output-bucket-5",
+                "test-files/test-output.json",
+                id="output key with subdirectories",
+            ),
+            pytest.param(
+                "http://s3.localhost.localstack.cloud:4566/test-output-bucket-2?AWSAccessKeyId=000000000000&Signature=2Yc%2BvwhXx8UzmH8imzySfLOW6OI%3D&Expires=1688561914",
+                "test-output-bucket-2",
+                "",
+                id="output key as None",
+            ),
+        ],
+    )
+    def test_bucket_and_key_presign_url(
+        self, presign_url, expected_output_bucket, expected_output_key
+    ):
+        bucket, key = s3_utils_asf.get_bucket_and_key_from_presign_url(presign_url)
+        assert bucket == expected_output_bucket
+        assert key == expected_output_key
+
+    @pytest.mark.parametrize(
+        "header, dateobj, rule_id",
+        [
+            (
+                'expiry-date="Sat, 15 Jul 2023 00:00:00 GMT", rule-id="rule1"',
+                datetime.datetime(day=15, month=7, year=2023, tzinfo=None),
+                "rule1",
+            ),
+            (
+                'expiry-date="Mon, 29 Dec 2030 00:00:00 GMT", rule-id="rule2"',
+                datetime.datetime(day=29, month=12, year=2030, tzinfo=None),
+                "rule2",
+            ),
+            (
+                'expiry-date="Tes, 32 Jul 2023 00:00:00 GMT", rule-id="rule3"',
+                None,
+                None,
+            ),
+            (
+                'expiry="Sat, 15 Jul 2023 00:00:00 GMT", rule-id="rule4"',
+                None,
+                None,
+            ),
+            (
+                'expiry-date="Sat, 15 Jul 2023 00:00:00 GMT"',
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_parse_expiration_header(self, header, dateobj, rule_id):
+        parsed_dateobj, parsed_rule_id = s3_utils_asf.parse_expiration_header(header)
+        assert parsed_dateobj == dateobj
+        assert parsed_rule_id == rule_id
 
 
 class TestS3PresignedUrlAsf:


### PR DESCRIPTION
This PR will implement the request from #6654.

### Features
We will now validate the `BucketLifecycleConfiguration` when we call `PutBucketLifecycleConfiguration`, but only for the parts we actually use (see limitations).
We will now properly return the `Expiration` header from `PutObject`, `GetObject` and `HeadObject` depending on the lifecycle configuration and its rules/filters. 

Lifecycle configuration is quite the feature, as we can see from the length of the documentation on AWS:
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html
  - https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html#lifecycle-general-considerations-transition-sc

## Limitations
- We won't for now expire objects nor NonCurrentVersion (as AWS don't return `Expiration` headers when you specify `VersionId`). We will only return the `Expiration` header. As expiration is minimum in days, it's rare we would actually expire objects, except when a `Date` in the past is specified. We can iterate over this PR to add the feature, but the `Expiration` header is the most important of all. 
- We only validate the `BucketLifecycleConfiguration` for the parts that we actually use (`Expiration` and `Filter`), we don't validate `Transitions yet.

note: I could still add more unit tests, but I've validated a lot with the integration tests. I might do it during the week-end. 

_fix #6654_