### PR TITLE
implement Precondition checks for CopyObject

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import IO, Dict, List, Optional
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
+from zoneinfo import ZoneInfo
 
 import moto.s3.responses as moto_s3_responses
 
@@ -91,6 +92,7 @@ from localstack.aws.api.s3 import (
     ObjectLockToken,
     ObjectVersionId,
     PostResponse,
+    PreconditionFailed,
     PutBucketAclRequest,
     PutBucketLifecycleConfigurationRequest,
     PutBucketLifecycleRequest,
@@ -488,8 +490,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, dest_moto_bucket)
 
-        response: CopyObjectOutput = call_moto(context)
-
         src_bucket, src_key, src_version_id = extract_bucket_key_version_id_from_copy_source(
             request["CopySource"]
         )
@@ -497,6 +497,41 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         source_key_object = get_key_from_moto_bucket(
             src_moto_bucket, key=src_key, version_id=src_version_id
         )
+
+        # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+        condition = None
+        source_object_last_modified = source_key_object.last_modified.replace(
+            tzinfo=ZoneInfo("GMT")
+        )
+        if (cs_if_match := request.get("CopySourceIfMatch")) and source_key_object.etag.strip(
+            '"'
+        ) != cs_if_match.strip('"'):
+            condition = "x-amz-copy-source-If-Match"
+
+        elif (
+            cs_id_unmodified_since := request.get("CopySourceIfUnmodifiedSince")
+        ) and source_object_last_modified > cs_id_unmodified_since:
+            condition = "x-amz-copy-source-If-Unmodified-Since"
+
+        elif (
+            cs_if_none_match := request.get("CopySourceIfNoneMatch")
+        ) and source_key_object.etag.strip('"') == cs_if_none_match.strip('"'):
+            condition = "x-amz-copy-source-If-None-Match"
+
+        elif (
+            cs_id_modified_since := request.get("CopySourceIfModifiedSince")
+        ) and source_object_last_modified < cs_id_modified_since < datetime.datetime.now(
+            tz=ZoneInfo("GMT")
+        ):
+            condition = "x-amz-copy-source-If-Modified-Since"
+
+        if condition:
+            raise PreconditionFailed(
+                "At least one of the pre-conditions you specified did not hold",
+                Condition=condition,
+            )
+
+        response: CopyObjectOutput = call_moto(context)
 
         # we properly calculate the Checksum for the destination Key
         checksum_algorithm = (

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -546,7 +546,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 or checksum_algorithm == ChecksumAlgorithm.CRC32C
             ):
                 dest_key_object.checksum_value = get_object_checksum_for_algorithm(
-                    checksum_algorithm, source_key_object.value
+                    checksum_algorithm, dest_key_object.value
                 )
             else:
                 dest_key_object.checksum_value = source_key_object.checksum_value

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1832,10 +1832,7 @@ class TestS3:
         snapshot.match("head-object", head_obj)
 
         # wait for the condition to pass
-        if is_aws_cloud():
-            time.sleep(3)
-        else:
-            time.sleep(1)
+        time.sleep(3)
 
         # we're testing the order of validation at the same time by validating all of them at once, by elimination
         now = datetime.datetime.now().astimezone(tz=ZoneInfo("GMT"))

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1817,6 +1817,92 @@ class TestS3:
         snapshot.match("copy-object-to-dest-keep-checksum", resp)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_s3_copy_object_preconditions(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        object_key = "source-object"
+        dest_key = "dest-object"
+        # create key with no checksum
+        put_object = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body=b"data",
+        )
+        head_obj = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object", head_obj)
+
+        # wait for the condition to pass
+        if is_aws_cloud():
+            time.sleep(3)
+        else:
+            time.sleep(1)
+
+        # we're testing the order of validation at the same time by validating all of them at once, by elimination
+        now = datetime.datetime.now().astimezone(tz=ZoneInfo("GMT"))
+        wrong_unmodified_since = now - datetime.timedelta(days=1)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key=dest_key,
+                CopySourceIfModifiedSince=now,
+                CopySourceIfUnmodifiedSince=wrong_unmodified_since,
+                CopySourceIfMatch="etag123",
+                CopySourceIfNoneMatch=put_object["ETag"],
+            )
+        snapshot.match("copy-precondition-if-match", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key=dest_key,
+                CopySourceIfModifiedSince=now,
+                CopySourceIfUnmodifiedSince=wrong_unmodified_since,
+                CopySourceIfNoneMatch=put_object["ETag"],
+            )
+        snapshot.match("copy-precondition-if-unmodified-since", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key=dest_key,
+                CopySourceIfModifiedSince=now,
+                CopySourceIfNoneMatch=put_object["ETag"],
+            )
+        snapshot.match("copy-precondition-if-none-match", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key=dest_key,
+                CopySourceIfModifiedSince=now,
+            )
+        snapshot.match("copy-precondition-if-modified-since", e.value.response)
+
+        # AWS will ignore the value if it's in the future
+        copy_obj = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
+            Key=dest_key,
+            CopySourceIfModifiedSince=now + datetime.timedelta(days=1),
+        )
+        snapshot.match("copy-ignore-future-modified-since", copy_obj)
+
+        # AWS will ignore the missing quotes around the ETag and still reject the request
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key=dest_key,
+                CopySourceIfNoneMatch=put_object["ETag"].strip('"'),
+            )
+        snapshot.match("copy-etag-missing-quotes", e.value.response)
+
+    @pytest.mark.aws_validated
     # behaviour is wrong in Legacy, we inherit Bucket ACL
     @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider,

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1902,6 +1902,18 @@ class TestS3:
             )
         snapshot.match("copy-etag-missing-quotes", e.value.response)
 
+        # Positive tests with all conditions checked
+        copy_obj_all_positive = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
+            Key=dest_key,
+            CopySourceIfMatch=put_object["ETag"].strip('"'),
+            CopySourceIfNoneMatch="etag123",
+            CopySourceIfModifiedSince=now - datetime.timedelta(days=1),
+            CopySourceIfUnmodifiedSince=now,
+        )
+        snapshot.match("copy-success", copy_obj_all_positive)
+
     @pytest.mark.aws_validated
     # behaviour is wrong in Legacy, we inherit Bucket ACL
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1831,7 +1831,9 @@ class TestS3:
         head_obj = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
         snapshot.match("head-object", head_obj)
 
-        # wait for the condition to pass
+        # wait a bit for the `unmodified_since` value so that it's unvalid.
+        # S3 compares it the last-modified field, but you can't set the value in the future otherwise it ignores it
+        # It needs to be now or less, but the object needs to be a bit more recent than that.
         time.sleep(3)
 
         # we're testing the order of validation at the same time by validating all of them at once, by elimination

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7562,6 +7562,90 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_preconditions": {
+    "recorded-date": "08-07-2023, 00:10:50",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-precondition-if-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "copy-precondition-if-unmodified-since": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Unmodified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "copy-precondition-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "copy-precondition-if-modified-since": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Modified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "copy-ignore-future-modified-since": {
+        "CopyObjectResult": {
+          "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-etag-missing-quotes": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging": {
     "recorded-date": "08-07-2023, 02:00:56",
     "recorded-content": {

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7563,7 +7563,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_preconditions": {
-    "recorded-date": "08-07-2023, 00:10:50",
+    "recorded-date": "08-07-2023, 00:31:31",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",
@@ -7642,6 +7642,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 412
+        }
+      },
+      "copy-success": {
+        "CopyObjectResult": {
+          "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }


### PR DESCRIPTION
This PR fixes and implements #7555

## Features
This implements the different preconditions checks following the documentation here: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
It adds an AWS validated test, checking all wrong assumptions and a positive one.