### PR TITLE
fix validation of PutBucketLogging

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -771,6 +771,20 @@ class MethodNotAllowed(ServiceException):
     ResourceType: Optional[ResourceType]
 
 
+class CrossLocationLoggingProhibitted(ServiceException):
+    code: str = "CrossLocationLoggingProhibitted"
+    sender_fault: bool = False
+    status_code: int = 403
+    TargetBucketLocation: Optional[BucketRegion]
+
+
+class InvalidTargetBucketForLogging(ServiceException):
+    code: str = "InvalidTargetBucketForLogging"
+    sender_fault: bool = False
+    status_code: int = 400
+    TargetBucket: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -816,6 +816,40 @@
         "shape":"ObjectList",
         "documentation":"<p>Metadata about each object returned.</p>"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/CrossLocationLoggingProhibitted",
+      "value": {
+        "type": "structure",
+        "members": {
+          "TargetBucketLocation": {
+            "shape": "BucketRegion"
+          }
+        },
+        "error": {
+          "httpStatusCode": 403
+        },
+        "documentation": "<p>Cross S3 location logging not allowed. </p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidTargetBucketForLogging",
+      "value": {
+        "type": "structure",
+        "members": {
+          "TargetBucket": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 400
+        },
+        "documentation": "<p>The target bucket for logging does not exist</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -17,6 +17,7 @@ from localstack.aws.api.s3 import (
     AnalyticsConfigurationList,
     AnalyticsId,
     Body,
+    BucketLoggingStatus,
     BucketName,
     BypassGovernanceRetention,
     ChecksumAlgorithm,
@@ -30,6 +31,7 @@ from localstack.aws.api.s3 import (
     CreateBucketRequest,
     CreateMultipartUploadOutput,
     CreateMultipartUploadRequest,
+    CrossLocationLoggingProhibitted,
     Delete,
     DeleteObjectOutput,
     DeleteObjectRequest,
@@ -65,6 +67,7 @@ from localstack.aws.api.s3 import (
     InvalidBucketName,
     InvalidPartOrder,
     InvalidStorageClass,
+    InvalidTargetBucketForLogging,
     ListBucketAnalyticsConfigurationsOutput,
     ListBucketIntelligentTieringConfigurationsOutput,
     ListMultipartUploadsOutput,
@@ -1374,6 +1377,39 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             IsTruncated=False,
             IntelligentTieringConfigurationList=bucket_intelligent_tiering_configurations,
         )
+
+    def put_bucket_logging(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        bucket_logging_status: BucketLoggingStatus,
+        content_md5: ContentMD5 = None,
+        checksum_algorithm: ChecksumAlgorithm = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> None:
+        moto_backend = get_moto_s3_backend(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+
+        if not (logging_config := bucket_logging_status.get("LoggingEnabled")):
+            moto_bucket.logging = {}
+
+        # TODO: validate the TargetGrants format, not done in moto either
+
+        # the target bucket must be in the same account
+        target_bucket_name = logging_config.get("TargetBucket")
+        if not (target_bucket := moto_backend.buckets.get(target_bucket_name)):
+            raise InvalidTargetBucketForLogging(
+                "The target bucket for logging does not exist",
+                TargetBucket=target_bucket_name,
+            )
+
+        if target_bucket.region_name != moto_bucket.region_name:
+            raise CrossLocationLoggingProhibitted(
+                "Cross S3 location logging not allowed. ",
+                TargetBucketLocation=target_bucket.region_name,
+            )
+
+        moto_bucket.logging = logging_config
 
 
 def validate_bucket_analytics_configuration(

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -4860,7 +4860,15 @@ class TestS3:
 
     @pytest.mark.aws_validated
     def test_put_bucket_logging(self, aws_client, s3_create_bucket, snapshot):
-        snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("TargetBucket"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value(
+                    "ID", value_replacement="owner-id", reference_replacement=False
+                ),
+            ]
+        )
 
         bucket_name = s3_create_bucket()
         target_bucket = s3_create_bucket()

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -4858,6 +4858,108 @@ class TestS3:
             aws_client.s3.get_object(Bucket=bucket, Key=key, IfMatch="etag")
         snapshot.match("if_match_err_1", e.value.response["Error"])
 
+    @pytest.mark.aws_validated
+    def test_put_bucket_logging(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
+
+        bucket_name = s3_create_bucket()
+        target_bucket = s3_create_bucket()
+        bucket_logging_status = {
+            "LoggingEnabled": {
+                "TargetBucket": target_bucket,
+                "TargetPrefix": "log",
+            },
+        }
+        resp = aws_client.s3.get_bucket_acl(Bucket=target_bucket)
+        snapshot.match("get-bucket-default-acl", resp)
+
+        # this might have been failing in the past, as the target bucket does not give access to LogDelivery to
+        # write/read_acp. however, AWS accepts it, because you can also set it with Permissions
+        resp = aws_client.s3.put_bucket_logging(
+            Bucket=bucket_name, BucketLoggingStatus=bucket_logging_status
+        )
+        snapshot.match("put-bucket-logging", resp)
+
+        resp = aws_client.s3.get_bucket_logging(Bucket=bucket_name)
+        snapshot.match("get-bucket-logging", resp)
+
+    @pytest.mark.aws_validated
+    def test_put_bucket_logging_accept_wrong_grants(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
+
+        bucket_name = s3_create_bucket()
+
+        target_bucket = s3_create_bucket()
+        # We need to delete the ObjectOwnership from the bucket, because you otherwise can't set TargetGrants on it
+        # TODO: have the same default as AWS and have ObjectOwnership set
+        aws_client.s3.delete_bucket_ownership_controls(Bucket=target_bucket)
+
+        bucket_logging_status = {
+            "LoggingEnabled": {
+                "TargetBucket": target_bucket,
+                "TargetPrefix": "log",
+                "TargetGrants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                            "Type": "Group",
+                        },
+                        "Permission": "WRITE",
+                    },
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ_ACP",
+                    },
+                ],
+            },
+        }
+
+        # from the documentation, only WRITE | READ | FULL_CONTROL are allowed, but AWS let READ_ACP pass
+        resp = aws_client.s3.put_bucket_logging(
+            Bucket=bucket_name, BucketLoggingStatus=bucket_logging_status
+        )
+        snapshot.match("put-bucket-logging", resp)
+
+        resp = aws_client.s3.get_bucket_logging(Bucket=bucket_name)
+        snapshot.match("get-bucket-logging", resp)
+
+    @pytest.mark.aws_validated
+    def test_put_bucket_logging_wrong_target(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
+        bucket_name = s3_create_bucket()
+        target_bucket = s3_create_bucket(
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+        )
+
+        with pytest.raises(ClientError) as e:
+            bucket_logging_status = {
+                "LoggingEnabled": {
+                    "TargetBucket": target_bucket,
+                    "TargetPrefix": "log",
+                },
+            }
+            aws_client.s3.put_bucket_logging(
+                Bucket=bucket_name, BucketLoggingStatus=bucket_logging_status
+            )
+        snapshot.match("put-bucket-logging-different-regions", e.value.response)
+
+        nonexistent_target_bucket = f"target-bucket-{short_uid()}-{short_uid()}"
+        with pytest.raises(ClientError) as e:
+            bucket_logging_status = {
+                "LoggingEnabled": {
+                    "TargetBucket": nonexistent_target_bucket,
+                    "TargetPrefix": "log",
+                },
+            }
+            aws_client.s3.put_bucket_logging(
+                Bucket=bucket_name, BucketLoggingStatus=bucket_logging_status
+            )
+        snapshot.match("put-bucket-logging-non-existent-bucket", e.value.response)
+        assert e.value.response["Error"]["TargetBucket"] == nonexistent_target_bucket
+
 
 class TestS3MultiAccounts:
     @pytest.fixture

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7563,22 +7563,22 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging": {
-    "recorded-date": "08-07-2023, 00:58:18",
+    "recorded-date": "08-07-2023, 02:00:56",
     "recorded-content": {
       "get-bucket-default-acl": {
         "Grants": [
           {
             "Grantee": {
-              "DisplayName": "aws-sandbox-benjamin-simon-001",
-              "ID": "c32ee542628cfb38f348c508a38f7e82a38b79b25f728d7e262c1d90441b608a",
+              "DisplayName": "display-name",
+              "ID": "owner-id",
               "Type": "CanonicalUser"
             },
             "Permission": "FULL_CONTROL"
           }
         ],
         "Owner": {
-          "DisplayName": "aws-sandbox-benjamin-simon-001",
-          "ID": "c32ee542628cfb38f348c508a38f7e82a38b79b25f728d7e262c1d90441b608a"
+          "DisplayName": "display-name",
+          "ID": "owner-id"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7561,5 +7561,110 @@
         "Message": "At least one of the pre-conditions you specified did not hold"
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging": {
+    "recorded-date": "08-07-2023, 00:58:18",
+    "recorded-content": {
+      "get-bucket-default-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "aws-sandbox-benjamin-simon-001",
+              "ID": "c32ee542628cfb38f348c508a38f7e82a38b79b25f728d7e262c1d90441b608a",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "aws-sandbox-benjamin-simon-001",
+          "ID": "c32ee542628cfb38f348c508a38f7e82a38b79b25f728d7e262c1d90441b608a"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-logging": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-logging": {
+        "LoggingEnabled": {
+          "TargetBucket": "<target-bucket:1>",
+          "TargetPrefix": "log"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging_accept_wrong_grants": {
+    "recorded-date": "08-07-2023, 01:15:17",
+    "recorded-content": {
+      "put-bucket-logging": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-logging": {
+        "LoggingEnabled": {
+          "TargetBucket": "<target-bucket:1>",
+          "TargetGrants": [
+            {
+              "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+              },
+              "Permission": "WRITE"
+            },
+            {
+              "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+              },
+              "Permission": "READ_ACP"
+            }
+          ],
+          "TargetPrefix": "log"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging_wrong_target": {
+    "recorded-date": "08-07-2023, 01:27:18",
+    "recorded-content": {
+      "put-bucket-logging-different-regions": {
+        "Error": {
+          "Code": "CrossLocationLoggingProhibitted",
+          "Message": "Cross S3 location logging not allowed. ",
+          "TargetBucketLocation": "us-west-2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-bucket-logging-non-existent-bucket": {
+        "Error": {
+          "Code": "InvalidTargetBucketForLogging",
+          "Message": "The target bucket for logging does not exist",
+          "TargetBucket": "<target-bucket:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes #6764.

## Features
Moto was a bit overzealous in their validation of the bucket logging configuration. We're keeping the same checks that are made in moto, without the problematic part. We could extend the validation then, as now with Object Ownership, a bucket created without config shouldn't be able to get a config with `TargetGrants`. This would be part of a bigger effort to use the same new defaults as AWS.