### PR TITLE
unpin hypercorn, set h11_pass_raw_headers

### DIFF
--- a/localstack/aws/serving/hypercorn.py
+++ b/localstack/aws/serving/hypercorn.py
@@ -29,6 +29,7 @@ def serve(
     :param kwargs: any oder parameters that can be passed to the hypercorn.Config object
     """
     config = Config()
+    config.h11_pass_raw_headers = True
     config.bind = f"{host}:{port}"
     config.use_reloader = use_reloader
 

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -93,6 +93,7 @@ class GatewayServer(HypercornServer):
         """
         # build server config
         config = Config()
+        config.h11_pass_raw_headers = True
         setup_hypercorn_logger(config)
 
         bind_address = ensure_list(bind_address)

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -242,6 +242,7 @@ def run_server(
             kwargs["keyfile"] = key_file_name
             config.keyfile = key_file_name
         setup_quart_logging()
+        config.h11_pass_raw_headers = True
         config.bind = [f"{bind_address}:{port}" for bind_address in bind_addresses]
         config.workers = len(bind_addresses)
         loop = loop or ensure_event_loop()

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ runtime =
     flask>=2.3.2
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
-    hypercorn==0.14.2
+    hypercorn>=0.14.4
     json5==0.9.11
     jsonpatch>=1.24,<2.0
     jsonpath-ng>=1.5.3

--- a/tests/unit/aws/test_gateway.py
+++ b/tests/unit/aws/test_gateway.py
@@ -20,6 +20,7 @@ def serve_gateway_hypercorn():
 
     def _create(gateway: Gateway) -> HypercornServer:
         config = Config()
+        config.h11_pass_raw_headers = True
         config.bind = f"localhost:{net.get_free_tcp_port()}"
         loop = asyncio.new_event_loop()
         srv = HypercornServer(AsgiGateway(gateway, event_loop=loop), config, loop=loop)

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -26,6 +26,7 @@ def serve_asgi_app():
     ) -> HypercornServer:
         if not config:
             config = Config()
+            config.h11_pass_raw_headers = True
             config.bind = f"localhost:{net.get_free_tcp_port()}"
 
         srv = HypercornServer(app, config, loop=event_loop)


### PR DESCRIPTION
With #6778, Hypercorn has been pinned to `0.14.2`, since hypercorn reverted a fix to preserve header casing with https://github.com/pgjones/hypercorn/commit/68e832af53b55bcd7798eac1e84c974eb5753827 / `0.14.3` (since the spec defines that they should not be preserved).
@thrau suggested a config to enable preserving the headers with https://github.com/pgjones/hypercorn/pull/117, which is contained in the latest release: `0.14.4`.

This PR unpins `hypercorn` in the `setup.cfg` and enables the header preserving in the configs.
#6778 introduced a regression test which ensures that the gateway properly preserves the HTTP header casing (which is why this PR does not contain any tests).

Fixes #6849.