### PR TITLE
Bump moto-ext to 4.1.12.post2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ runtime =
     jsonpath-ng>=1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-client>=2.0
-    moto-ext[all]==4.1.12.post1
+    moto-ext[all]==4.1.12.post2
     opensearch-py==2.1.1
     pproxy>=2.7.0
     pymongo>=4.2.0

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -21,9 +21,6 @@ def _assert(search_name: str, param_name: str, ssm_client):
 
 class TestSSM:
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(
-        reason="xfail until https://github.com/getmoto/moto/pull/6484 is in moto-ext"
-    )
     def test_describe_parameters(self, aws_client):
         response = aws_client.ssm.describe_parameters()
         assert "Parameters" in response


### PR DESCRIPTION
Also reverts https://github.com/localstack/localstack/pull/8631

Ext tests passing :heavy_check_mark: 