### PR TITLE
add SNS retrospection endpoints for SMS

### DIFF
--- a/localstack/services/sns/constants.py
+++ b/localstack/services/sns/constants.py
@@ -31,3 +31,4 @@ GCM_URL = "https://fcm.googleapis.com/fcm/send"
 
 # Endpoint to access all the PlatformEndpoint sent Messages
 PLATFORM_ENDPOINT_MSGS_ENDPOINT = "/_aws/sns/platform-endpoint-messages"
+SMS_MSGS_ENDPOINT = "/_aws/sns/sms-messages"

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -125,7 +125,7 @@ class SnsStore(BaseStore):
     # cache of topic ARN to platform endpoint messages (used primarily for testing)
     platform_endpoint_messages: Dict[str, List[Dict]] = LocalAttribute(default=dict)
 
-    # list of sent SMS messages - TODO: expose via internal API
+    # list of sent SMS messages
     sms_messages: List[Dict] = LocalAttribute(default=list)
 
     # filter policy are stored as JSON string in subscriptions, store the decoded result Dict

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -882,52 +882,15 @@ def _format_messages(sent_messages: List[Dict[str, str]], validated_keys: List[s
     formatted_messages = []
     for sent_message in sent_messages:
         msg = {
-            key: value if key != "Message" or isinstance(value, str) else json.dumps(value)
+            key: json.dumps(value)
+            if key == "Message" and sent_message.get("MessageStructure") == "json"
+            else value
             for key, value in sent_message.items()
             if key in validated_keys
         }
         formatted_messages.append(msg)
 
     return formatted_messages
-
-
-def _format_platform_endpoint_messages(sent_messages: List[Dict[str, str]]):
-    """
-    This method format the messages to be more readable and undo the format change that was needed for Moto
-    Should be removed once we refactor SNS.
-    """
-    return _format_messages(
-        sent_messages,
-        [
-            "TargetArn",
-            "TopicArn",
-            "Message",
-            "MessageAttributes",
-            "MessageStructure",
-            "Subject",
-            "MessageId",
-        ],
-    )
-
-
-def _format_sms_messages(sent_messages: List[Dict[str, str]]):
-    """
-    This method format the messages to be more readable and undo the format change that was needed for Moto
-    Should be removed once we refactor SNS.
-    """
-    return _format_messages(
-        sent_messages,
-        [
-            "PhoneNumber",
-            "TopicArn",
-            "SubscriptionArn",
-            "MessageId",
-            "Message",
-            "MessageAttributes",
-            "MessageStructure",
-            "Subject",
-        ],
-    )
 
 
 class SNSServicePlatformEndpointMessagesApiResource:
@@ -944,6 +907,16 @@ class SNSServicePlatformEndpointMessagesApiResource:
     - DELETE param `endpointArn`: will delete saved messages for `endpointArn`
     """
 
+    _PAYLOAD_FIELDS = [
+        "TargetArn",
+        "TopicArn",
+        "Message",
+        "MessageAttributes",
+        "MessageStructure",
+        "Subject",
+        "MessageId",
+    ]
+
     @route(sns_constants.PLATFORM_ENDPOINT_MSGS_ENDPOINT, methods=["GET"])
     def on_get(self, request: Request):
         account_id = request.args.get("accountId", get_aws_account_id())
@@ -952,14 +925,14 @@ class SNSServicePlatformEndpointMessagesApiResource:
         store: SnsStore = sns_stores[account_id][region]
         if filter_endpoint_arn:
             messages = store.platform_endpoint_messages.get(filter_endpoint_arn, [])
-            messages = _format_platform_endpoint_messages(messages)
+            messages = _format_messages(messages, self._PAYLOAD_FIELDS)
             return {
                 "platform_endpoint_messages": {filter_endpoint_arn: messages},
                 "region": region,
             }
 
         platform_endpoint_messages = {
-            endpoint_arn: _format_platform_endpoint_messages(messages)
+            endpoint_arn: _format_messages(messages, self._PAYLOAD_FIELDS)
             for endpoint_arn, messages in store.platform_endpoint_messages.items()
         }
         return {
@@ -977,7 +950,7 @@ class SNSServicePlatformEndpointMessagesApiResource:
             store.platform_endpoint_messages.pop(filter_endpoint_arn, None)
             return Response("", status=204)
 
-        store.platform_endpoint_messages = {}
+        store.platform_endpoint_messages.clear()
         return Response("", status=204)
 
 
@@ -992,6 +965,17 @@ class SNSServiceSMSMessagesApiResource:
     - GET param `phoneNumber`: filter for `phoneNumber` resource in SNS
     """
 
+    _PAYLOAD_FIELDS = [
+        "PhoneNumber",
+        "TopicArn",
+        "SubscriptionArn",
+        "MessageId",
+        "Message",
+        "MessageAttributes",
+        "MessageStructure",
+        "Subject",
+    ]
+
     @route(sns_constants.SMS_MSGS_ENDPOINT, methods=["GET"])
     def on_get(self, request: Request):
         account_id = request.args.get("accountId", get_aws_account_id())
@@ -1002,17 +986,33 @@ class SNSServiceSMSMessagesApiResource:
             messages = [
                 m for m in store.sms_messages if m.get("PhoneNumber") == filter_phone_number
             ]
-            messages = _format_sms_messages(messages)
+            messages = _format_messages(messages, self._PAYLOAD_FIELDS)
             return {
                 "sms_messages": {filter_phone_number: messages},
                 "region": region,
             }
 
         sms_messages = {}
-        for m in _format_sms_messages(store.sms_messages):
+
+        for m in _format_messages(store.sms_messages, self._PAYLOAD_FIELDS):
             sms_messages.setdefault(m.get("PhoneNumber"), []).append(m)
 
         return {
             "sms_messages": sms_messages,
             "region": region,
         }
+
+    @route(sns_constants.SMS_MSGS_ENDPOINT, methods=["DELETE"])
+    def on_delete(self, request: Request) -> Response:
+        account_id = request.args.get("accountId", get_aws_account_id())
+        region = request.args.get("region", "us-east-1")
+        filter_phone_number = request.args.get("phoneNumber")
+        store: SnsStore = sns_stores[account_id][region]
+        if filter_phone_number:
+            store.sms_messages = [
+                m for m in store.sms_messages if m.get("PhoneNumber") != filter_phone_number
+            ]
+            return Response("", status=204)
+
+        store.sms_messages.clear()
+        return Response("", status=204)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -869,8 +869,26 @@ def get_region_from_subscription_token(token: str) -> str:
 
 
 def register_sns_api_resource(router: Router):
-    """Register the platform endpointmessages retrospection endpoint as an internal LocalStack endpoint."""
+    """Register the retrospection endpoints as internal LocalStack endpoints."""
     router.add(SNSServicePlatformEndpointMessagesApiResource())
+    router.add(SNSServiceSMSMessagesApiResource())
+
+
+def _format_messages(sent_messages: List[Dict[str, str]], validated_keys: List[str]):
+    """
+    This method format the messages to be more readable and undo the format change that was needed for Moto
+    Should be removed once we refactor SNS.
+    """
+    formatted_messages = []
+    for sent_message in sent_messages:
+        msg = {
+            key: value if key != "Message" or isinstance(value, str) else json.dumps(value)
+            for key, value in sent_message.items()
+            if key in validated_keys
+        }
+        formatted_messages.append(msg)
+
+    return formatted_messages
 
 
 def _format_platform_endpoint_messages(sent_messages: List[Dict[str, str]]):
@@ -878,25 +896,38 @@ def _format_platform_endpoint_messages(sent_messages: List[Dict[str, str]]):
     This method format the messages to be more readable and undo the format change that was needed for Moto
     Should be removed once we refactor SNS.
     """
-    validated_keys = [
-        "TargetArn",
-        "TopicArn",
-        "Message",
-        "MessageAttributes",
-        "MessageStructure",
-        "Subject",
-        "MessageId",
-    ]
-    formatted_messages = []
-    for sent_message in sent_messages:
-        msg = {
-            key: value if key != "Message" else json.dumps(value)
-            for key, value in sent_message.items()
-            if key in validated_keys
-        }
-        formatted_messages.append(msg)
+    return _format_messages(
+        sent_messages,
+        [
+            "TargetArn",
+            "TopicArn",
+            "Message",
+            "MessageAttributes",
+            "MessageStructure",
+            "Subject",
+            "MessageId",
+        ],
+    )
 
-    return formatted_messages
+
+def _format_sms_messages(sent_messages: List[Dict[str, str]]):
+    """
+    This method format the messages to be more readable and undo the format change that was needed for Moto
+    Should be removed once we refactor SNS.
+    """
+    return _format_messages(
+        sent_messages,
+        [
+            "PhoneNumber",
+            "TopicArn",
+            "SubscriptionArn",
+            "MessageId",
+            "Message",
+            "MessageAttributes",
+            "MessageStructure",
+            "Subject",
+        ],
+    )
 
 
 class SNSServicePlatformEndpointMessagesApiResource:
@@ -948,3 +979,40 @@ class SNSServicePlatformEndpointMessagesApiResource:
 
         store.platform_endpoint_messages = {}
         return Response("", status=204)
+
+
+class SNSServiceSMSMessagesApiResource:
+    """Provides a REST API for retrospective access to SMS messages sent via SNS.
+
+    This is registered as a LocalStack internal HTTP resource.
+
+    This endpoint accepts:
+    - GET param `accountId`: selector for AWS account. If not specified, return fallback `000000000000` test ID
+    - GET param `region`: selector for AWS `region`. If not specified, return default "us-east-1"
+    - GET param `phoneNumber`: filter for `phoneNumber` resource in SNS
+    """
+
+    @route(sns_constants.SMS_MSGS_ENDPOINT, methods=["GET"])
+    def on_get(self, request: Request):
+        account_id = request.args.get("accountId", get_aws_account_id())
+        region = request.args.get("region", "us-east-1")
+        filter_phone_number = request.args.get("phoneNumber")
+        store: SnsStore = sns_stores[account_id][region]
+        if filter_phone_number:
+            messages = [
+                m for m in store.sms_messages if m.get("PhoneNumber") == filter_phone_number
+            ]
+            messages = _format_sms_messages(messages)
+            return {
+                "sms_messages": {filter_phone_number: messages},
+                "region": region,
+            }
+
+        sms_messages = {}
+        for m in _format_sms_messages(store.sms_messages):
+            sms_messages.setdefault(m.get("PhoneNumber"), []).append(m)
+
+        return {
+            "sms_messages": sms_messages,
+            "region": region,
+        }

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -543,9 +543,9 @@ class SmsTopicPublisher(TopicPublisher):
         context.store.sms_messages.append(event)
         LOG.info(
             "Delivering SMS message to %s: %s from topic: %s",
-            event["endpoint"],
-            event["message_content"],
-            event["topic_arn"],
+            event["PhoneNumber"],
+            event["Message"],
+            event["TopicArn"],
         )
 
         # MOCK DATA
@@ -562,9 +562,14 @@ class SmsTopicPublisher(TopicPublisher):
 
     def prepare_message(self, message_context: SnsMessage, subscriber: SnsSubscription) -> dict:
         return {
-            "topic_arn": subscriber["TopicArn"],
-            "endpoint": subscriber["Endpoint"],
-            "message_content": message_context.message_content(subscriber["Protocol"]),
+            "PhoneNumber": subscriber["Endpoint"],
+            "TopicArn": subscriber["TopicArn"],
+            "SubscriptionArn": subscriber["SubscriptionArn"],
+            "MessageId": message_context.message_id,
+            "Message": message_context.message_content(protocol=subscriber["Protocol"]),
+            "MessageAttributes": message_context.message_attributes,
+            "MessageStructure": message_context.message_structure,
+            "Subject": message_context.subject,
         }
 
 
@@ -615,8 +620,8 @@ class SmsPhoneNumberPublisher(EndpointPublisher):
         context.store.sms_messages.append(event)
         LOG.info(
             "Delivering SMS message to %s: %s",
-            event["endpoint"],
-            event["message_content"],
+            event["PhoneNumber"],
+            event["Message"],
         )
 
         # TODO: check about delivery logs for individual call, need a real AWS test
@@ -624,9 +629,14 @@ class SmsPhoneNumberPublisher(EndpointPublisher):
 
     def prepare_message(self, message_context: SnsMessage, endpoint: str) -> dict:
         return {
-            "topic_arn": None,
-            "endpoint": endpoint,
-            "message_content": message_context.message_content("sms"),
+            "PhoneNumber": endpoint,
+            "TopicArn": None,
+            "SubscriptionArn": None,
+            "MessageId": message_context.message_id,
+            "Message": message_context.message_content(protocol="sms"),
+            "MessageAttributes": message_context.message_attributes,
+            "MessageStructure": message_context.message_structure,
+            "Subject": message_context.subject,
         }
 
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -575,9 +575,26 @@ class TestSNSProvider:
 
     @pytest.mark.only_localstack
     def test_publish_sms(self, aws_client):
-        response = aws_client.sns.publish(PhoneNumber="+33000000000", Message="This is a SMS")
+        phone_number = "+33000000000"
+        response = aws_client.sns.publish(PhoneNumber=phone_number, Message="This is a SMS")
         assert "MessageId" in response
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        sns_backend = SnsProvider.get_store(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region_name=TEST_AWS_REGION_NAME,
+        )
+
+        def check_messages():
+            sms_was_found = False
+            for message in sns_backend.sms_messages:
+                if message["PhoneNumber"] == phone_number:
+                    sms_was_found = True
+                    break
+
+            assert sms_was_found
+
+        retry(check_messages, sleep=0.5)
 
     @pytest.mark.aws_validated
     def test_publish_non_existent_target(self, sns_create_topic, snapshot, aws_client):
@@ -1210,7 +1227,7 @@ class TestSNSProvider:
             for contact in list_of_contacts:
                 sms_was_found = False
                 for message in sms_messages:
-                    if message["endpoint"] == contact:
+                    if message["PhoneNumber"] == contact:
                         sms_was_found = True
                         break
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2827,125 +2827,6 @@ class TestSNSProvider:
         snapshot.match("batch-exception", e.value.response)
 
     @pytest.mark.only_localstack
-    def test_publish_to_platform_endpoint_can_retrospect(
-        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
-    ):
-        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
-        # clean up the saved messages
-        sns_backend_endpoint_arns = list(sns_backend.platform_endpoint_messages.keys())
-        for saved_endpoint_arn in sns_backend_endpoint_arns:
-            sns_backend.platform_endpoint_messages.pop(saved_endpoint_arn, None)
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        application_platform_name = f"app-platform-{short_uid()}"
-
-        app_arn = sns_create_platform_application(
-            Name=application_platform_name, Platform="APNS", Attributes={}
-        )["PlatformApplicationArn"]
-
-        endpoint_arn = aws_client.sns.create_platform_endpoint(
-            PlatformApplicationArn=app_arn, Token=short_uid()
-        )["EndpointArn"]
-
-        endpoint_arn_2 = aws_client.sns.create_platform_endpoint(
-            PlatformApplicationArn=app_arn, Token=short_uid()
-        )["EndpointArn"]
-
-        sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="application",
-            Endpoint=endpoint_arn,
-        )
-
-        # example message from
-        # https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
-        message = json.dumps({"APNS": json.dumps({"aps": {"content-available": 1}})})
-        message_for_topic = {
-            "default": "This is the default message which must be present when publishing a message to a topic.",
-            "APNS": json.dumps({"aps": {"content-available": 1}}),
-        }
-        message_for_topic_string = json.dumps(message_for_topic)
-        message_attributes = {
-            "AWS.SNS.MOBILE.APNS.TOPIC": {
-                "DataType": "String",
-                "StringValue": "com.amazon.mobile.messaging.myapp",
-            },
-            "AWS.SNS.MOBILE.APNS.PUSH_TYPE": {
-                "DataType": "String",
-                "StringValue": "background",
-            },
-            "AWS.SNS.MOBILE.APNS.PRIORITY": {
-                "DataType": "String",
-                "StringValue": "5",
-            },
-        }
-        # publish to a topic which has a platform subscribed to it
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message_for_topic_string,
-            MessageAttributes=message_attributes,
-            MessageStructure="json",
-        )
-        # publish directly to the platform endpoint
-        aws_client.sns.publish(
-            TargetArn=endpoint_arn_2,
-            Message=message,
-            MessageAttributes=message_attributes,
-            MessageStructure="json",
-        )
-
-        # assert that message has been received
-        def check_message():
-            assert len(sns_backend.platform_endpoint_messages[endpoint_arn]) > 0
-
-        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-        msgs_url = config.get_edge_url() + PLATFORM_ENDPOINT_MSGS_ENDPOINT
-        api_contents = requests.get(msgs_url).json()
-        api_platform_endpoints_msgs = api_contents["platform_endpoint_messages"]
-
-        assert len(api_platform_endpoints_msgs) == 2
-        assert len(api_platform_endpoints_msgs[endpoint_arn]) == 1
-        assert len(api_platform_endpoints_msgs[endpoint_arn_2]) == 1
-        assert api_contents["region"] == "us-east-1"
-
-        assert api_platform_endpoints_msgs[endpoint_arn][0]["Message"] == json.dumps(
-            message_for_topic["APNS"]
-        )
-        assert (
-            api_platform_endpoints_msgs[endpoint_arn][0]["MessageAttributes"] == message_attributes
-        )
-
-        # Ensure you can select the region
-        msg_with_region = requests.get(msgs_url, params={"region": "eu-west-1"}).json()
-        assert len(msg_with_region["platform_endpoint_messages"]) == 0
-        assert msg_with_region["region"] == "eu-west-1"
-
-        # Ensure messages can be filtered by EndpointArn
-        api_contents_with_endpoint = requests.get(
-            msgs_url, params={"endpointArn": endpoint_arn}
-        ).json()
-        msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
-        assert len(msgs_with_endpoint) == 1
-        assert len(msgs_with_endpoint[endpoint_arn]) == 1
-        assert api_contents_with_endpoint["region"] == "us-east-1"
-
-        # Ensure you can reset the saved messages by EndpointArn
-        delete_res = requests.delete(msgs_url, params={"endpointArn": endpoint_arn})
-        assert delete_res.status_code == 204
-        api_contents_with_endpoint = requests.get(
-            msgs_url, params={"endpointArn": endpoint_arn}
-        ).json()
-        msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
-        assert len(msgs_with_endpoint[endpoint_arn]) == 0
-
-        # Ensure you can reset the saved messages by region
-        delete_res = requests.delete(msgs_url, params={"region": "us-east-1"})
-        assert delete_res.status_code == 204
-        msg_with_region = requests.get(msgs_url, params={"region": "us-east-1"}).json()
-        assert not msg_with_region["platform_endpoint_messages"]
-
-    @pytest.mark.only_localstack
     def test_publish_to_platform_endpoint_is_dispatched(
         self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
     ):
@@ -3988,3 +3869,198 @@ class TestSNSPublishDelivery:
         )
 
         snapshot.match("delivery-events", events)
+
+
+@pytest.mark.only_localstack
+class TestSNSRetrospectionEndpoints:
+    def test_publish_to_platform_endpoint_can_retrospect(
+        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
+    ):
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
+        # clean up the saved messages
+        sns_backend_endpoint_arns = list(sns_backend.platform_endpoint_messages.keys())
+        for saved_endpoint_arn in sns_backend_endpoint_arns:
+            sns_backend.platform_endpoint_messages.pop(saved_endpoint_arn, None)
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        application_platform_name = f"app-platform-{short_uid()}"
+
+        app_arn = sns_create_platform_application(
+            Name=application_platform_name, Platform="APNS", Attributes={}
+        )["PlatformApplicationArn"]
+
+        endpoint_arn = aws_client.sns.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token=short_uid()
+        )["EndpointArn"]
+
+        endpoint_arn_2 = aws_client.sns.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token=short_uid()
+        )["EndpointArn"]
+
+        sns_subscription(
+            TopicArn=topic_arn,
+            Protocol="application",
+            Endpoint=endpoint_arn,
+        )
+
+        # example message from
+        # https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
+        message = json.dumps({"APNS": json.dumps({"aps": {"content-available": 1}})})
+        message_for_topic = {
+            "default": "This is the default message which must be present when publishing a message to a topic.",
+            "APNS": json.dumps({"aps": {"content-available": 1}}),
+        }
+        message_for_topic_string = json.dumps(message_for_topic)
+        message_attributes = {
+            "AWS.SNS.MOBILE.APNS.TOPIC": {
+                "DataType": "String",
+                "StringValue": "com.amazon.mobile.messaging.myapp",
+            },
+            "AWS.SNS.MOBILE.APNS.PUSH_TYPE": {
+                "DataType": "String",
+                "StringValue": "background",
+            },
+            "AWS.SNS.MOBILE.APNS.PRIORITY": {
+                "DataType": "String",
+                "StringValue": "5",
+            },
+        }
+        # publish to a topic which has a platform subscribed to it
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message_for_topic_string,
+            MessageAttributes=message_attributes,
+            MessageStructure="json",
+        )
+        # publish directly to the platform endpoint
+        aws_client.sns.publish(
+            TargetArn=endpoint_arn_2,
+            Message=message,
+            MessageAttributes=message_attributes,
+            MessageStructure="json",
+        )
+
+        # assert that message has been received
+        def check_message():
+            assert len(sns_backend.platform_endpoint_messages[endpoint_arn]) > 0
+
+        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+        msgs_url = config.get_edge_url() + PLATFORM_ENDPOINT_MSGS_ENDPOINT
+        api_contents = requests.get(msgs_url).json()
+        api_platform_endpoints_msgs = api_contents["platform_endpoint_messages"]
+
+        assert len(api_platform_endpoints_msgs) == 2
+        assert len(api_platform_endpoints_msgs[endpoint_arn]) == 1
+        assert len(api_platform_endpoints_msgs[endpoint_arn_2]) == 1
+        assert api_contents["region"] == "us-east-1"
+
+        assert api_platform_endpoints_msgs[endpoint_arn][0]["Message"] == json.dumps(
+            message_for_topic["APNS"]
+        )
+        assert (
+            api_platform_endpoints_msgs[endpoint_arn][0]["MessageAttributes"] == message_attributes
+        )
+
+        # Ensure you can select the region
+        msg_with_region = requests.get(msgs_url, params={"region": "eu-west-1"}).json()
+        assert len(msg_with_region["platform_endpoint_messages"]) == 0
+        assert msg_with_region["region"] == "eu-west-1"
+
+        # Ensure messages can be filtered by EndpointArn
+        api_contents_with_endpoint = requests.get(
+            msgs_url, params={"endpointArn": endpoint_arn}
+        ).json()
+        msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
+        assert len(msgs_with_endpoint) == 1
+        assert len(msgs_with_endpoint[endpoint_arn]) == 1
+        assert api_contents_with_endpoint["region"] == "us-east-1"
+
+        # Ensure you can reset the saved messages by EndpointArn
+        delete_res = requests.delete(msgs_url, params={"endpointArn": endpoint_arn})
+        assert delete_res.status_code == 204
+        api_contents_with_endpoint = requests.get(
+            msgs_url, params={"endpointArn": endpoint_arn}
+        ).json()
+        msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
+        assert len(msgs_with_endpoint[endpoint_arn]) == 0
+
+        # Ensure you can reset the saved messages by region
+        delete_res = requests.delete(msgs_url, params={"region": "us-east-1"})
+        assert delete_res.status_code == 204
+        msg_with_region = requests.get(msgs_url, params={"region": "us-east-1"}).json()
+        assert not msg_with_region["platform_endpoint_messages"]
+
+    def test_publish_sms_can_retrospect(self, sns_create_topic, sns_subscription, aws_client):
+        sns_store = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
+
+        list_of_contacts = [
+            f"+{random.randint(100000000, 9999999999)}",
+            f"+{random.randint(100000000, 9999999999)}",
+            f"+{random.randint(100000000, 9999999999)}",
+        ]
+        phone_number_1 = list_of_contacts[0]
+        message = "Good news everyone!"
+        topic_arn = sns_create_topic()["TopicArn"]
+        for number in list_of_contacts:
+            sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint=number)
+
+        # clean up the saved messages
+        sns_store.sms_messages.clear()
+
+        # publish to a topic which has a PhoneNumbers subscribed to it
+        aws_client.sns.publish(Message=message, TopicArn=topic_arn)
+
+        # publish directly to the PhoneNumber
+        aws_client.sns.publish(
+            PhoneNumber=phone_number_1,
+            Message=message,
+        )
+
+        # assert that message has been received
+        def check_message():
+            assert len(sns_store.sms_messages) == 4
+
+        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+        msgs_url = config.get_edge_url() + SMS_MSGS_ENDPOINT
+        api_contents = requests.get(msgs_url).json()
+        api_sms_msgs = api_contents["sms_messages"]
+
+        assert len(api_sms_msgs) == 3
+        assert len(api_sms_msgs[phone_number_1]) == 2
+        assert len(api_sms_msgs[list_of_contacts[1]]) == 1
+        assert len(api_sms_msgs[list_of_contacts[2]]) == 1
+
+        assert api_contents["region"] == "us-east-1"
+
+        assert api_sms_msgs[phone_number_1][0]["Message"] == "Good news everyone!"
+
+        # Ensure you can select the region
+        msg_with_region = requests.get(msgs_url, params={"region": "eu-west-1"}).json()
+        assert len(msg_with_region["sms_messages"]) == 0
+        assert msg_with_region["region"] == "eu-west-1"
+
+        # Ensure messages can be filtered by EndpointArn
+        api_contents_with_number = requests.get(
+            msgs_url, params={"phoneNumber": phone_number_1}
+        ).json()
+        msgs_with_number = api_contents_with_number["sms_messages"]
+        assert len(msgs_with_number) == 1
+        assert len(msgs_with_number[phone_number_1]) == 2
+        assert api_contents_with_number["region"] == "us-east-1"
+
+        # Ensure you can reset the saved messages by EndpointArn
+        delete_res = requests.delete(msgs_url, params={"phoneNumber": phone_number_1})
+        assert delete_res.status_code == 204
+        api_contents_with_number = requests.get(
+            msgs_url, params={"phoneNumber": phone_number_1}
+        ).json()
+        msgs_with_number = api_contents_with_number["sms_messages"]
+        assert len(msgs_with_number[phone_number_1]) == 0
+
+        # Ensure you can reset the saved messages by region
+        delete_res = requests.delete(msgs_url, params={"region": "us-east-1"})
+        assert delete_res.status_code == 204
+        msg_with_region = requests.get(msgs_url, params={"region": "us-east-1"}).json()
+        assert not msg_with_region["sms_messages"]

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -18,7 +18,7 @@ from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
-from localstack.services.sns.constants import PLATFORM_ENDPOINT_MSGS_ENDPOINT
+from localstack.services.sns.constants import PLATFORM_ENDPOINT_MSGS_ENDPOINT, SMS_MSGS_ENDPOINT
 from localstack.services.sns.provider import SnsProvider
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils import testutil


### PR DESCRIPTION
This PR builds and rebase #7936, and fixes #7935. 

This adds retrospections endpoint for SMS published to SNS, and also adds a test case for the retrospection.