### PR TITLE
Update lambda runtime init to handle non-executable bootstrap files

### DIFF
--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.18-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.19-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime


### PR DESCRIPTION
## Motivation
The new lambda init version will automatically set the `bootstrap` file to executable if it is not yet.

This will fix #8459 .
Releases https://github.com/localstack/lambda-runtime-init/pull/21

It will do so unconditionally, even though AWS, in some cases, will refuse to allow a bootstrap file without executable permissions. It is yet to determine, under which circumstances this happens.

This will not work for hot reloading, as the privileges are already dropped when the reload takes place. If you want hot reloading, please make sure to set your bootstrap binary as executable after compilation.

## Changes
* Update lambda runtime init to get new bootstrap executable behavior.