### PR TITLE
fix CmdDockerClient not raising DockerNotAvailable exception

### DIFF
--- a/tests/integration/docker_utils/conftest.py
+++ b/tests/integration/docker_utils/conftest.py
@@ -1,4 +1,5 @@
 import os
+from typing import Type
 
 import pytest
 
@@ -17,13 +18,15 @@ def _check_skip(client: ContainerClient):
 
 
 @pytest.fixture(
-    params=[CmdDockerClient, SdkDockerClient], ids=["CmdDockerClient", "SdkDockerClient"]
+    params=[CmdDockerClient, SdkDockerClient],
+    ids=["CmdDockerClient", "SdkDockerClient"],
+    scope="class",
 )
-def docker_client_class(request):
-    yield request.param
+def docker_client_class(request) -> Type[ContainerClient]:
+    return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def docker_client(docker_client_class):
     client = docker_client_class()
     _check_skip(

--- a/tests/integration/docker_utils/conftest.py
+++ b/tests/integration/docker_utils/conftest.py
@@ -17,10 +17,15 @@ def _check_skip(client: ContainerClient):
 
 
 @pytest.fixture(
-    params=[CmdDockerClient(), SdkDockerClient()], ids=["CmdDockerClient", "SdkDockerClient"]
+    params=[CmdDockerClient, SdkDockerClient], ids=["CmdDockerClient", "SdkDockerClient"]
 )
-def docker_client(request):
-    client = request.param
+def docker_client_class(request):
+    yield request.param
+
+
+@pytest.fixture
+def docker_client(docker_client_class):
+    client = docker_client_class()
     _check_skip(
         client
     )  # this is a hack to get a global skip for all tests that require the docker client


### PR DESCRIPTION
This PR performs a small fix to the `CmdDockerClient` (which is basically only used by the CLI), such that it raises a `DockerNotAvailable` exception in case the `DOCKER_CMD` (by default `docker`) is not available on the system.

Contrary to the `SdkDockerClient`, this is done only once (the result is cached) to avoid checking the command existence on every single usage of the client. We basically assume that, if the `DOCKER_CMD` is not available once, it won't become available during this python session lifetime.

This fixes the CLI error handling in this case (introduced in #8564).