### PR TITLE
add PythonPackageInstaller for runtime package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,12 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN echo /var/lib/localstack/lib/extensions/python_venv/lib/python3.10/site-packages > localstack-extensions-venv.pth && \
     mv localstack-extensions-venv.pth .venv/lib/python*/site-packages/
 
+# link the python package installer virtual environments into the localstack venv
+RUN echo /var/lib/localstack/lib/python-packages/lib/python3.10/site-packages > localstack-var-python-packages-venv.pth && \
+    mv localstack-var-python-packages-venv.pth .venv/lib/python*/site-packages/
+RUN echo /usr/lib/localstack/python-packages/lib/python3.10/site-packages > localstack-static-python-packages-venv.pth && \
+    mv localstack-static-python-packages-venv.pth .venv/lib/python*/site-packages/
+
 # Install the latest version of the LocalStack Persistence Plugin
 RUN --mount=type=cache,target=/root/.cache \
     (. .venv/bin/activate && pip3 install --upgrade localstack-plugin-persistence)

--- a/localstack/services/transcribe/packages.py
+++ b/localstack/services/transcribe/packages.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from localstack.packages import Package, PackageInstaller
+from localstack.packages.core import PythonPackageInstaller
+
+_VOSK_DEFAULT_VERSION = "0.3.43"
+
+
+class VoskPackage(Package):
+    def __init__(self, default_version: str = _VOSK_DEFAULT_VERSION):
+        super().__init__(name="Vosk", default_version=default_version)
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return VoskPackageInstaller(version)
+
+    def get_versions(self) -> List[str]:
+        return [_VOSK_DEFAULT_VERSION]
+
+
+class VoskPackageInstaller(PythonPackageInstaller):
+    def __init__(self, version: str):
+        super().__init__("vosk", version)
+
+
+vosk_package = VoskPackage()

--- a/localstack/services/transcribe/plugins.py
+++ b/localstack/services/transcribe/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import Package, package
+
+
+@package(name="vosk")
+def vosk_package() -> Package:
+    from localstack.services.transcribe.packages import vosk_package
+
+    return vosk_package

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,6 @@ runtime =
     Quart>=0.18
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
-    vosk==0.3.43
     Werkzeug>=2.3.4
     xmltodict>=0.11.0
 


### PR DESCRIPTION
This PR adds a new type of `PackageInstaller` which allows the installation of Python packages at runtime for specific services.
The PoC was implemented based on our Transcribe emulator, removing the `vosk` dependency in the `setup.cfg` and instead installing it on demand.
VOSC is one of the bigger dependencies, with ~7MB compressed and ~26MB uncompressed. In my tests this reduced the uncompressed layer size of the `venv` copying layer from 426 MB to 399 MB:
https://github.com/localstack/localstack/blob/10630f07dd838c9b5a71dd087de8bbc044b417fe/Dockerfile#L144

This PR contains the following changes:
- It introduces two new linked virtual environments, one for static (docker build time) and one for var libs (runtime, using a shared folder mounted from the host) in the `Dockerfile`.
  - This is implemented similarly to the extensions venv by adding a [`pth` file to extend the search path](https://docs.python.org/3/install/index.html#modifying-python-s-search-path) of the main virtual environment.
- It introduces a new `PackageInstaller` method which is executed once if the package is already installed (to perform specific installation instructions which are necessary to be done at runtime, even if the package has been installed in previous executions).
  - This is necessary for the `PythonPackageInstaller` to inject the sys path of the already existing virtual environment outside of a Docker image (i.e. in host mode).
- It removes `vosk` from the list of runtime extra dependencies.
- It adds a new `VoskPackage` to the `transcribe` module, which is used in the Transcribe provider to ensure that vosk is installed when needed.
  - The installation of `vosk` as well as `ffmpeg` has been moved from the .`ServiceLifecycleHook#on_before_start` to the async execution which actually performs the transcoding and transcription.
  - This should actually improve the UX, since the service starts instantly, while downloading the additional packages in an async thread when needed (instead of running into a client timeout on the first call).

This is part of our Hackathon, and this was on my backlog to test for quite a while (which is why it's a draft PR). I am happy for any feedback (also to discard the idea completely)!