### PR TITLE
add ObjectRestore:Post and :Completed S3 Event Notification

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -572,7 +572,10 @@ def events_handler_put_events(self):
                 event_time = datetime.datetime.utcfromtimestamp(event_timestamp)
             except ValueError:
                 # if we can't parse it, pass and keep using `utcnow`
-                pass
+                LOG.debug(
+                    "Could not parse the `Time` parameter, falling back to `utcnow` for the following Event: '%s'",
+                    event,
+                )
 
         # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
         formatted_event = {

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -565,6 +565,15 @@ def events_handler_put_events(self):
         if not matching_rules:
             continue
 
+        event_time = datetime.datetime.utcnow()
+        if event_timestamp := event.get("Time"):
+            try:
+                # if provided, use the time from event
+                event_time = datetime.datetime.utcfromtimestamp(event_timestamp)
+            except ValueError:
+                # if we can't parse it, pass and keep using `utcnow`
+                pass
+
         # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
         formatted_event = {
             "version": "0",
@@ -572,7 +581,7 @@ def events_handler_put_events(self):
             "detail-type": event.get("DetailType"),
             "source": event.get("Source"),
             "account": get_aws_account_id(),
-            "time": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "time": event_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "region": self.region,
             "resources": event.get("Resources", []),
             "detail": json.loads(event.get("Detail", "{}")),

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -140,9 +140,13 @@ class S3EventNotificationContext:
         if isinstance(key, FakeDeleteMarker):
             etag = ""
             key_size = 0
+            key_expiry = None
+            storage_class = ""
         else:
             etag = key.etag.strip('"')
             key_size = key.contentsize
+            key_expiry = key._expiry
+            storage_class = key.storage_class
 
         return cls(
             request_id=request_context.request_id,
@@ -154,8 +158,8 @@ class S3EventNotificationContext:
             key_name=quote(key.name),
             key_etag=etag,
             key_size=key_size,
-            key_expiry=key._expiry,
-            key_storage_class=key.storage_class,
+            key_expiry=key_expiry,
+            key_storage_class=storage_class,
             key_version_id=key.version_id if bucket.is_versioned else None,  # todo: check this?
             xray=request_context.request.headers.get(HEADER_AMZN_XRAY),
         )

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -26,6 +27,7 @@ from localstack.aws.api.s3 import (
     ObjectKey,
     QueueArn,
     QueueConfiguration,
+    StorageClass,
     TopicArn,
     TopicConfiguration,
 )
@@ -41,7 +43,7 @@ from localstack.utils.aws import arns
 from localstack.utils.aws.arns import parse_arn, s3_bucket_arn
 from localstack.utils.aws.client_types import ServicePrincipal
 from localstack.utils.strings import short_uid
-from localstack.utils.time import timestamp_millis
+from localstack.utils.time import parse_timestamp, timestamp_millis
 
 LOG = logging.getLogger(__name__)
 
@@ -55,6 +57,7 @@ EVENT_OPERATION_MAP = {
     "DeleteObject": Event.s3_ObjectRemoved_Delete,
     "DeleteObjects": Event.s3_ObjectRemoved_Delete,
     "PutObjectAcl": Event.s3_ObjectAcl_Put,
+    "RestoreObject": Event.s3_ObjectRestore_Post,
 }
 
 HEADER_AMZN_XRAY = "X-Amzn-Trace-Id"
@@ -87,6 +90,7 @@ class Notification(TypedDict):
 class S3EventNotificationContext:
     request_id: str
     event_type: str
+    event_time: datetime.datetime
     region: str
     bucket_name: BucketName
     key_name: ObjectKey
@@ -95,6 +99,8 @@ class S3EventNotificationContext:
     key_size: int
     key_etag: str
     key_version_id: str
+    key_expiry: datetime.datetime
+    key_storage_class: Optional[StorageClass]
 
     @classmethod
     def from_request_context(
@@ -141,12 +147,15 @@ class S3EventNotificationContext:
         return cls(
             request_id=request_context.request_id,
             event_type=EVENT_OPERATION_MAP.get(request_context.operation.wire_name, ""),
+            event_time=datetime.datetime.now(),
             region=request_context.region,
             bucket_name=bucket_name,
             bucket_location=bucket.location,
             key_name=quote(key.name),
             key_etag=etag,
             key_size=key_size,
+            key_expiry=key._expiry,
+            key_storage_class=key.storage_class,
             key_version_id=key.version_id if bucket.is_versioned else None,  # todo: check this?
             xray=request_context.request.headers.get(HEADER_AMZN_XRAY),
         )
@@ -310,7 +319,7 @@ class BaseNotifier:
             eventVersion="2.1",
             eventSource="aws:s3",
             awsRegion=ctx.region,
-            eventTime=timestamp_millis(),
+            eventTime=timestamp_millis(ctx.event_time),
             eventName=ctx.event_type.removeprefix("s3:"),
             userIdentity={"principalId": "AIDAJDPLRKLG7UEXAMPLE"},
             requestParameters={
@@ -326,7 +335,9 @@ class BaseNotifier:
                 configurationId=config_id,
                 bucket={
                     "name": ctx.bucket_name,
-                    "ownerIdentity": {"principalId": "A3NL1KOZZKExample"},
+                    "ownerIdentity": {
+                        "principalId": "A3NL1KOZZKExample"
+                    },  # TODO: use proper principal?
                     "arn": f"arn:aws:s3:::{ctx.bucket_name}",
                 },
                 object={
@@ -339,13 +350,30 @@ class BaseNotifier:
         if ctx.key_version_id:
             # object version if bucket is versioning-enabled, otherwise null
             record["s3"]["object"]["versionId"] = ctx.key_version_id
-        if "created" in ctx.event_type.lower():
+
+        event_type = ctx.event_type.lower()
+        if any(e in event_type for e in ("created", "restore")):
             record["s3"]["object"]["size"] = ctx.key_size
             record["s3"]["object"]["eTag"] = ctx.key_etag
         if "ObjectTagging" in ctx.event_type or "ObjectAcl" in ctx.event_type:
             record["eventVersion"] = "2.3"
             record["s3"]["object"]["eTag"] = ctx.key_etag
             record["s3"]["object"].pop("sequencer")
+
+        if "objectrestore:completed" in event_type:
+            record["glacierEventData"] = {
+                "restoreEventData": {
+                    "lifecycleRestorationExpiryTime": timestamp_millis(ctx.key_expiry),
+                    "lifecycleRestoreStorageClass": ctx.key_storage_class,
+                }
+            }
+            record["userIdentity"][
+                "principalId"
+            ] = "AmazonCustomer:A3NL1KOZZKExample"  # TODO: use proper principal?
+            # a bit hacky, it is to ensure the eventTime is a bit after the `Post` event, as its instant in LS
+            # the best would be to delay the publishing of the event
+            event_time = parse_timestamp(record["eventTime"]) + datetime.timedelta(milliseconds=500)
+            record["eventTime"] = timestamp_millis(event_time)
 
         return {"Records": [record]}
 
@@ -562,6 +590,7 @@ class EventBridgeNotifier(BaseNotifier):
         entry: PutEventsRequestEntry = {
             "Source": "aws.s3",
             "Resources": [f"arn:aws:s3:::{ctx.bucket_name}"],
+            "Time": ctx.event_time,
         }
 
         if ctx.xray:
@@ -609,6 +638,22 @@ class EventBridgeNotifier(BaseNotifier):
             entry["DetailType"] = "Object ACL Updated"
             event_details["object"].pop("size")
             event_details["object"].pop("sequencer")
+
+        elif "ObjectRestore" in ctx.event_type:
+            entry["DetailType"] = (
+                "Object Restore Initiated"
+                if "Post" in ctx.event_type
+                else "Object Restore Completed"
+            )
+            event_details["source-storage-class"] = ctx.key_storage_class
+            event_details["object"].pop("sequencer", None)
+            if ctx.event_type.endswith("Completed"):
+                event_details["restore-expiry-time"] = timestamp_millis(ctx.key_expiry)
+                event_details.pop("source-ip-address", None)
+                # a bit hacky, it is to ensure the eventTime is a bit after the `Post` event, as its instant in LS
+                # the best would be to delay the publishing of the event. We need at least 1s as it's the precision
+                # of the event
+                entry["Time"] = entry["Time"] + datetime.timedelta(seconds=1)
 
         entry["Detail"] = json.dumps(event_details)
         return entry

--- a/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -170,5 +170,68 @@
         ]
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_restore_object": {
+    "recorded-date": "13-07-2023, 02:00:37",
+    "recorded-content": {
+      "messages": {
+        "messages": [
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>",
+                "size": 9
+              },
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "source-storage-class": "GLACIER",
+              "version": "0"
+            },
+            "detail-type": "Object Restore Initiated",
+            "id": "<uuid:1>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          },
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>",
+                "size": 9
+              },
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "restore-expiry-time": "date",
+              "source-storage-class": "GLACIER",
+              "version": "0"
+            },
+            "detail-type": "Object Restore Completed",
+            "id": "<uuid:2>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -991,5 +991,88 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_restore_object": {
+    "recorded-date": "13-07-2023, 01:18:19",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectRestore:Post",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "my_key_restore",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          },
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectRestore:Completed",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "glacierEventData": {
+              "restoreEventData": {
+                "lifecycleRestorationExpiryTime": "date",
+                "lifecycleRestoreStorageClass": "GLACIER"
+              }
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:2>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "my_key_restore",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "AmazonCustomer:<principal-id:1>"
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/integration/test_events.snapshot.json
+++ b/tests/integration/test_events.snapshot.json
@@ -171,5 +171,42 @@
         }
       }
     }
+  },
+  "tests/integration/test_events.py::TestEvents::test_put_events_time": {
+    "recorded-date": "13-07-2023, 02:49:20",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "for the default event bus"
+            }
+          }
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
As requested in #8444, this adds support for `ObjectRestore:Post` and `ObjectRestore:Completed`, as well as sneak in a bug fix for EventBridge where we use the time provided to the `Entry` instead of `utcnow()`. 

See: 
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html#AmazonS3-RestoreObject-request-GlacierJobParameters
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html#ev-events-object-restore-complete


_fixes #8444_