### PR TITLE
fix S3 checksum mode casing + SelectObjectContent signature

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -435,7 +435,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
             response["ContentEncoding"] = ""
 
-        if request.get("ChecksumMode") == "ENABLED" and checksum_algorithm:
+        if request.get("ChecksumMode", "").upper() == "ENABLED" and checksum_algorithm:
             response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
 
         if not request.get("VersionId"):
@@ -485,7 +485,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
             response["ContentEncoding"] = ""
 
-        if request.get("ChecksumMode") == "ENABLED" and checksum_algorithm:
+        if request.get("ChecksumMode", "").upper() == "ENABLED" and checksum_algorithm:
             response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
 
         if not version_id and (

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -43,6 +43,8 @@ from localstack.aws.api.s3 import (
     DeleteObjectTaggingRequest,
     ETag,
     Expiration,
+    Expression,
+    ExpressionType,
     GetBucketAclOutput,
     GetBucketAnalyticsConfigurationOutput,
     GetBucketCorsOutput,
@@ -65,6 +67,7 @@ from localstack.aws.api.s3 import (
     GetObjectTaggingRequest,
     HeadObjectOutput,
     HeadObjectRequest,
+    InputSerialization,
     IntelligentTieringConfiguration,
     IntelligentTieringConfigurationList,
     IntelligentTieringId,
@@ -95,6 +98,7 @@ from localstack.aws.api.s3 import (
     ObjectKey,
     ObjectLockToken,
     ObjectVersionId,
+    OutputSerialization,
     PostResponse,
     PreconditionFailed,
     PutBucketAclRequest,
@@ -111,10 +115,14 @@ from localstack.aws.api.s3 import (
     ReplicationConfiguration,
     ReplicationConfigurationNotFoundError,
     RequestPayer,
+    RequestProgress,
     S3Api,
+    ScanRange,
     SelectObjectContentOutput,
-    SelectObjectContentRequest,
     SkipValidation,
+    SSECustomerAlgorithm,
+    SSECustomerKey,
+    SSECustomerKeyMD5,
     StorageClass,
     Token,
 )
@@ -1558,11 +1566,21 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         return GetBucketLoggingOutput(LoggingEnabled=moto_bucket.logging)
 
-    @handler("SelectObjectContent", expand=False)
     def select_object_content(
         self,
         context: RequestContext,
-        request: SelectObjectContentRequest,
+        bucket: BucketName,
+        key: ObjectKey,
+        expression: Expression,
+        expression_type: ExpressionType,
+        input_serialization: InputSerialization,
+        output_serialization: OutputSerialization,
+        sse_customer_algorithm: SSECustomerAlgorithm = None,
+        sse_customer_key: SSECustomerKey = None,
+        sse_customer_key_md5: SSECustomerKeyMD5 = None,
+        request_progress: RequestProgress = None,
+        scan_range: ScanRange = None,
+        expected_bucket_owner: AccountId = None,
     ) -> SelectObjectContentOutput:
         # this operation is currently implemented by moto, but raises a 500 error because of the format necessary,
         # and streaming capability.

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1180,8 +1180,9 @@ class TestS3:
         )
         snapshot.match("get-object-with-checksum", get_object_with_checksum)
 
+        # test that the casing of ChecksumMode is not important, the spec indicate only ENABLED
         head_object_with_checksum = aws_client.s3.get_object(
-            Bucket=s3_bucket, Key=key, ChecksumMode="ENABLED"
+            Bucket=s3_bucket, Key=key, ChecksumMode="enabled"
         )
         snapshot.match("head-object-with-checksum", head_object_with_checksum)
 

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4544,7 +4544,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA256]": {
-    "recorded-date": "11-07-2023, 16:50:49",
+    "recorded-date": "13-07-2023, 15:46:58",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA256": "1YQo81vx2VFUl0q5ccWISq8AkSBQQ0WO80S82TmfdIQ=",
@@ -4615,7 +4615,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[None]": {
-    "recorded-date": "11-07-2023, 16:50:53",
+    "recorded-date": "13-07-2023, 15:47:02",
     "recorded-content": {
       "put-object": {
         "ETag": "\"f2081dd61dfa700a0fd5e29b9c3cc23d\"",
@@ -6628,7 +6628,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32]": {
-    "recorded-date": "11-07-2023, 16:50:37",
+    "recorded-date": "13-07-2023, 15:46:47",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32": "lVk/nw==",
@@ -6699,7 +6699,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32C]": {
-    "recorded-date": "11-07-2023, 16:50:41",
+    "recorded-date": "13-07-2023, 15:46:50",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32C": "Fz3epA==",
@@ -6770,7 +6770,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA1]": {
-    "recorded-date": "11-07-2023, 16:50:45",
+    "recorded-date": "13-07-2023, 15:46:54",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA1": "jbXkHAsXUrubtL3dqDQ4w+7WXc0=",


### PR DESCRIPTION
Follow up from #8689, it seems the casing was not important in the end when specifying `ChecksumMode` even if the specs said the possible value was `ENABLED` only.

Also added a fix concerning `SelectObjectContent`, the signature was different between community and pro (expanded or not), and it made pro fail. 