### PR TITLE
implement S3 BucketInventoryConfiguration mocking

### DIFF
--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -850,6 +850,21 @@
         "documentation": "<p>The target bucket for logging does not exist</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/operations/PutBucketInventoryConfiguration/http/responseCode",
+      "value": 204
+    },
+    {
+      "op": "add",
+      "path": "/operations/PutBucketAnalyticsConfiguration/http/responseCode",
+      "value": 204
+    },
+    {
+      "op": "add",
+      "path": "/operations/PutBucketIntelligentTieringConfiguration/http/responseCode",
+      "value": 204
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 from collections import defaultdict
+from operator import itemgetter
 from typing import IO, Dict, List, Optional
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 from zoneinfo import ZoneInfo
@@ -1665,14 +1666,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store = self.get_store(context)
         bucket_inventory_configurations = store.bucket_inventory_configurations.get(bucket, {})
 
-        # bucket_inventory_configurations = sorted(
-        #     bucket_inventory_configurations.values(), key=lambda x: x["Id"]
-        # )
-        # TODO: verify the sorting?
-
         return ListBucketInventoryConfigurationsOutput(
             IsTruncated=False,
-            InventoryConfigurationList=list(bucket_inventory_configurations.values()),
+            InventoryConfigurationList=sorted(
+                bucket_inventory_configurations.values(), key=itemgetter("Id")
+            ),
         )
 
     def delete_bucket_inventory_configuration(

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 from zoneinfo import ZoneInfo
 
 import moto.s3.responses as moto_s3_responses
+from botocore.utils import InvalidArnException
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
@@ -164,6 +165,7 @@ from localstack.services.s3.utils import (
     is_key_expired,
     is_valid_canonical_id,
     serialize_expiration_header,
+    validate_dict_fields,
     validate_kms_key_id,
     verify_checksum,
 )
@@ -1920,7 +1922,84 @@ def validate_website_configuration(website_config: WebsiteConfiguration) -> None
 def validate_inventory_configuration(
     config_id: InventoryId, inventory_configuration: InventoryConfiguration
 ):
-    pass
+    """
+    Validate the Inventory Configuration following AWS docs
+    Validation order is XML then `Id` then S3DestinationBucket
+    https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory.html
+    :param config_id: the passed Id parameter passed to the provider method
+    :param inventory_configuration: InventoryConfiguration
+    :raises MalformedXML: when the file doesn't follow the basic structure/required fields
+    :raises IdMismatch: if the `Id` parameter is different from the `Id` field from the configuration
+    :raises InvalidS3DestinationBucket: if S3 bucket is not provided as an ARN
+    :return: None
+    """
+    required_root_fields = {"Destination", "Id", "IncludedObjectVersions", "IsEnabled", "Schedule"}
+    optional_root_fields = {"Filter", "OptionalFields"}
+
+    if not validate_dict_fields(
+        inventory_configuration, required_root_fields, optional_root_fields
+    ):
+        raise MalformedXML()
+
+    required_s3_bucket_dest_fields = {"Bucket", "Format"}
+    optional_s3_bucket_dest_fields = {"AccountId", "Encryption", "Prefix"}
+
+    if not (
+        s3_bucket_destination := inventory_configuration["Destination"].get("S3BucketDestination")
+    ) or not validate_dict_fields(
+        s3_bucket_destination, required_s3_bucket_dest_fields, optional_s3_bucket_dest_fields
+    ):
+        raise MalformedXML()
+
+    if inventory_configuration["Destination"]["S3BucketDestination"]["Format"] not in (
+        "CSV",
+        "ORC",
+        "Parquet",
+    ):
+        raise MalformedXML()
+
+    if not (frequency := inventory_configuration["Schedule"].get("Frequency")) or frequency not in (
+        "Daily",
+        "Weekly",
+    ):
+        raise MalformedXML()
+
+    if inventory_configuration["IncludedObjectVersions"] not in ("All", "Current"):
+        raise MalformedXML()
+
+    possible_optional_fields = {
+        "Size",
+        "LastModifiedDate",
+        "StorageClass",
+        "ETag",
+        "IsMultipartUploaded",
+        "ReplicationStatus",
+        "EncryptionStatus",
+        "ObjectLockRetainUntilDate",
+        "ObjectLockMode",
+        "ObjectLockLegalHoldStatus",
+        "IntelligentTieringAccessTier",
+        "BucketKeyStatus",
+        "ChecksumAlgorithm",
+    }
+    if (opt_fields := inventory_configuration.get("OptionalFields")) and set(
+        opt_fields
+    ) - possible_optional_fields:
+        raise MalformedXML()
+
+    if inventory_configuration.get("Id") != config_id:
+        raise CommonServiceException(
+            code="IdMismatch", message="Document ID does not match the specified configuration ID."
+        )
+
+    bucket_arn = inventory_configuration["Destination"]["S3BucketDestination"]["Bucket"]
+    try:
+        arns.parse_arn(bucket_arn)
+    except InvalidArnException:
+        raise CommonServiceException(
+            code="InvalidS3DestinationBucket", message="Invalid bucket ARN."
+        )
 
 
 def is_object_expired(

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -411,3 +411,19 @@ def parse_expiration_header(
 
     except (IndexError, ValueError, KeyError):
         return None, None
+
+
+def validate_dict_fields(data: dict, required_fields: set, optional_fields: set):
+    """
+    Validate whether the `data` dict contains at least the required fields and not more than the union of the required
+    and optional fields
+    TODO: we could pass the TypedDict to also use its required/optional properties, but it could be sensitive to
+     mistake/changes in the specs and not always right
+    :param data: the dict we want to validate
+    :param required_fields: a set containing the required fields
+    :param optional_fields: a set containing the optional fields
+    :return: bool, whether the dict is valid or not
+    """
+    return (set_fields := set(data)) >= required_fields and set_fields <= (
+        required_fields | optional_fields
+    )

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8348,7 +8348,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_inventory_report_crud": {
-    "recorded-date": "13-07-2023, 18:24:52",
+    "recorded-date": "14-07-2023, 00:15:43",
     "recorded-content": {
       "put-inventory-config": {
         "ResponseMetadata": {
@@ -8368,6 +8368,10 @@
             "Id": "test-inventory",
             "IncludedObjectVersions": "All",
             "IsEnabled": true,
+            "OptionalFields": [
+              "Size",
+              "ETag"
+            ],
             "Schedule": {
               "Frequency": "Daily"
             }
@@ -8390,6 +8394,10 @@
           "Id": "test-inventory",
           "IncludedObjectVersions": "All",
           "IsEnabled": true,
+          "OptionalFields": [
+            "Size",
+            "ETag"
+          ],
           "Schedule": {
             "Frequency": "Daily"
           }
@@ -8420,6 +8428,71 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_put_inventory_report_exceptions": {
+    "recorded-date": "13-07-2023, 23:26:28",
+    "recorded-content": {
+      "wrong-id": {
+        "Error": {
+          "Code": "IdMismatch",
+          "Message": "Document ID does not match the specified configuration ID."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-destination-arn": {
+        "Error": {
+          "Code": "InvalidS3DestinationBucket",
+          "Message": "Invalid bucket ARN."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-destination-format": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-schedule-frequency": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-object-versions": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-optional-field": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8496,5 +8496,104 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_inventory_config_order": {
+    "recorded-date": "14-07-2023, 17:13:52",
+    "recorded-content": {
+      "list-inventory-config": {
+        "InventoryConfigurationList": [
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "a-test",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          },
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "test-1",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          },
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "z-test",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-inventory-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-inventory-config-after-del": {
+        "InventoryConfigurationList": [
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "a-test",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          },
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "test-1",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -6934,7 +6934,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
-    "recorded-date": "26-05-2023, 12:15:26",
+    "recorded-date": "13-07-2023, 18:45:37",
     "recorded-content": {
       "put_config_with_storage_analysis_err": {
         "Error": {
@@ -6964,6 +6964,12 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      },
+      "put_config_with_storage_analysis_1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       },
       "get_config_with_storage_analysis_1": {
@@ -7113,7 +7119,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_intelligent_tier_config": {
-    "recorded-date": "26-05-2023, 19:17:48",
+    "recorded-date": "13-07-2023, 18:44:40",
     "recorded-content": {
       "put_bucket_intelligent_tiering_configuration_err_1`": {
         "Error": {
@@ -7123,6 +7129,12 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "put_bucket_intelligent_tiering_configuration_1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       },
       "get_bucket_intelligent_tiering_configuration_1": {
@@ -8331,6 +8343,83 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_inventory_report_crud": {
+    "recorded-date": "13-07-2023, 18:24:52",
+    "recorded-content": {
+      "put-inventory-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-inventory-config": {
+        "InventoryConfigurationList": [
+          {
+            "Destination": {
+              "S3BucketDestination": {
+                "Bucket": "arn:aws:s3:::<resource:1>",
+                "Format": "CSV"
+              }
+            },
+            "Id": "test-inventory",
+            "IncludedObjectVersions": "All",
+            "IsEnabled": true,
+            "Schedule": {
+              "Frequency": "Daily"
+            }
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-inventory-config": {
+        "InventoryConfiguration": {
+          "Destination": {
+            "S3BucketDestination": {
+              "Bucket": "arn:aws:s3:::<resource:1>",
+              "Format": "CSV"
+            }
+          },
+          "Id": "test-inventory",
+          "IncludedObjectVersions": "All",
+          "IsEnabled": true,
+          "Schedule": {
+            "Frequency": "Daily"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-inventory-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-inventory-config-after-del": {
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-nonexistent-inv-config": {
+        "Error": {
+          "Code": "NoSuchConfiguration",
+          "Message": "The specified configuration does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -729,6 +729,44 @@ class TestS3UtilsAsf:
         )
         assert serialized_header == header
 
+    @pytest.mark.parametrize(
+        "data, required, optional, result",
+        [
+            (
+                {"field1": "", "field2": "", "field3": ""},
+                {"field1"},
+                {"field2", "field3"},
+                True,
+            ),
+            (
+                {"field1": ""},
+                {"field1"},
+                {"field2", "field3"},
+                True,
+            ),
+            (
+                {"field1": "", "field2": "", "field3": ""},  # field3 is not a field
+                {"field1"},
+                {"field2"},
+                False,
+            ),
+            (
+                {"field2": ""},  # missing field1
+                {"field1"},
+                {"field2"},
+                False,
+            ),
+            (
+                {"field3": ""},  # missing field1 and field3 is not a field
+                {"field1"},
+                {"field2"},
+                False,
+            ),
+        ],
+    )
+    def test_validate_dict_fields(self, data, required, optional, result):
+        assert s3_utils_asf.validate_dict_fields(data, required, optional) == result
+
 
 class TestS3PresignedUrlAsf:
     """


### PR DESCRIPTION
This PR partly implements #8694, at least the mocking part. We were actually not supporting any CRUD operations, as it was not implemented in moto. 

Also made use of the `context` in every `get_store` call, as we should remove any use of the `threadlocal` and make use of the nicely provided context. 

## TODO

- [x] implement Get/Put/List/Delete, happy path
- [x] implement validation and negative testing

## Added operations:
- `PutBucketInventoryConfiguration`
- `ListBucketInventoryConfigurations`
- `GetBucketInventoryConfiguration`
- `DeleteBucketInventoryConfiguration`