### PR TITLE
Extend Docker client to allow passing --dns user flags

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -21,7 +21,7 @@ else:
     from typing_extensions import Protocol, get_args, Literal
 
 from localstack import config
-from localstack.utils.collections import HashableList
+from localstack.utils.collections import HashableList, ensure_list
 from localstack.utils.files import TMP_FILES, rm_rf, save_file
 from localstack.utils.strings import short_uid
 
@@ -448,6 +448,7 @@ class DockerRunFlags:
     ports: Optional[PortMappings]
     ulimits: Optional[List[Ulimit]]
     user: Optional[str]
+    dns: Optional[str]
 
 
 # TODO: remove Docker/Podman compatibility switches (in particular strip_wellknown_repo_prefixes=...)
@@ -810,7 +811,7 @@ class ContainerClient(metaclass=ABCMeta):
         cap_drop: Optional[List[str]] = None,
         security_opt: Optional[List[str]] = None,
         network: Optional[str] = None,
-        dns: Optional[str] = None,
+        dns: Optional[Union[str, List[str]]] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
@@ -1009,6 +1010,7 @@ class Util:
         privileged: Optional[bool] = None,
         user: Optional[str] = None,
         ulimits: Optional[List[Ulimit]] = None,
+        dns: Optional[Union[str, List[str]]] = None,
     ) -> DockerRunFlags:
         """Parses additional CLI-formatted Docker flags, which could overwrite provided defaults.
         :param additional_flags: String which contains the flag definitions inspired by the Docker CLI reference:
@@ -1022,6 +1024,7 @@ class Util:
         :param privileged: Run the container in privileged mode. Warning will be printed if overwritten in flags.
         :param ulimits: ulimit options in the format <type>=<soft limit>[:<hard limit>]
         :param user: User to run first process. Warning will be printed if user is overwritten in flags.
+        :param dns: List of DNS servers to configure the container with.
         :return: A DockerRunFlags object that will return new objects if respective parameters were None and
                 additional flags contained a flag for that object or the same which are passed otherwise.
         """
@@ -1067,6 +1070,7 @@ class Util:
         parser.add_argument(
             "--volume", "-v", help="Bind mount a volume", dest="volumes", action="append"
         )
+        parser.add_argument("--dns", help="Set custom DNS servers", dest="dns", action="append")
 
         # Parse
         flags = shlex.split(additional_flags)
@@ -1112,7 +1116,9 @@ class Util:
 
         if args.privileged:
             LOG.warning(
-                f"Overwriting Docker container privileged flag {privileged} with new value {args.privileged}"
+                "Overwriting Docker container privileged flag %s with new value %s",
+                privileged,
+                args.privileged,
             )
             privileged = args.privileged
 
@@ -1179,6 +1185,11 @@ class Util:
                     LOG.info("Volume options like :ro or :rw are currently ignored.")
                 mounts.append((host_path, container_path))
 
+        if args.dns:
+            dns = ensure_list(dns or [])
+            LOG.info("Extending Docker container DNS servers %s with new value %s", dns, args.dns)
+            dns.extend(args.dns)
+
         return DockerRunFlags(
             env_vars=env_vars,
             extra_hosts=extra_hosts,
@@ -1190,6 +1201,7 @@ class Util:
             privileged=privileged,
             ulimits=ulimits,
             user=user,
+            dns=dns,
         )
 
     @staticmethod

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -448,7 +448,7 @@ class DockerRunFlags:
     ports: Optional[PortMappings]
     ulimits: Optional[List[Ulimit]]
     user: Optional[str]
-    dns: Optional[str]
+    dns: Optional[List[str]]
 
 
 # TODO: remove Docker/Podman compatibility switches (in particular strip_wellknown_repo_prefixes=...)
@@ -1185,9 +1185,11 @@ class Util:
                     LOG.info("Volume options like :ro or :rw are currently ignored.")
                 mounts.append((host_path, container_path))
 
+        dns = ensure_list(dns or [])
         if args.dns:
-            dns = ensure_list(dns or [])
-            LOG.info("Extending Docker container DNS servers %s with new value %s", dns, args.dns)
+            LOG.info(
+                "Extending Docker container DNS servers %s with additional values %s", dns, args.dns
+            )
             dns.extend(args.dns)
 
         return DockerRunFlags(

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -707,7 +707,7 @@ class CmdDockerClient(ContainerClient):
         cap_drop: Optional[List[str]] = None,
         security_opt: Optional[List[str]] = None,
         network: Optional[str] = None,
-        dns: Optional[str] = None,
+        dns: Optional[Union[str, List[str]]] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
@@ -755,7 +755,8 @@ class CmdDockerClient(ContainerClient):
         if network:
             cmd += ["--network", network]
         if dns:
-            cmd += ["--dns", dns]
+            for dns_server in ensure_list(dns):
+                cmd += ["--dns", dns_server]
         if workdir:
             cmd += ["--workdir", workdir]
         if labels:

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -16,6 +16,7 @@ from docker.errors import APIError, ContainerError, DockerException, ImageNotFou
 from docker.models.containers import Container
 from docker.utils.socket import STDERR, STDOUT, frames_iter
 
+from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
     CancellableStream,
@@ -594,7 +595,7 @@ class SdkDockerClient(ContainerClient):
         cap_drop: Optional[List[str]] = None,
         security_opt: Optional[List[str]] = None,
         network: Optional[str] = None,
-        dns: Optional[str] = None,
+        dns: Optional[Union[str, List[str]]] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
@@ -615,6 +616,7 @@ class SdkDockerClient(ContainerClient):
                 ports=ports,
                 ulimits=ulimits,
                 user=user,
+                dns=dns,
             )
             env_vars = parsed_flags.env_vars
             extra_hosts = parsed_flags.extra_hosts
@@ -626,6 +628,7 @@ class SdkDockerClient(ContainerClient):
             ports = parsed_flags.ports
             ulimits = parsed_flags.ulimits
             user = parsed_flags.user
+            dns = parsed_flags.dns
 
         try:
             kwargs = {}
@@ -636,7 +639,7 @@ class SdkDockerClient(ContainerClient):
             if security_opt:
                 kwargs["security_opt"] = security_opt
             if dns:
-                kwargs["dns"] = [dns]
+                kwargs["dns"] = ensure_list(dns)
             if ports:
                 kwargs["ports"] = ports.to_dict()
             if workdir:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -204,13 +204,17 @@ class TestArgumentParsing:
         assert flags.user == "nobody"
 
     def test_dns(self):
-        argument_string = r"--dns 1.2.3.4"
+        argument_string = "--dns 1.2.3.4"
         flags = Util.parse_additional_flags(argument_string)
         assert flags.dns == ["1.2.3.4"]
 
-        argument_string = r"--dns 1.2.3.4 --dns 5.6.7.8"
+        argument_string = "--dns 1.2.3.4 --dns 5.6.7.8"
         flags = Util.parse_additional_flags(argument_string)
         assert flags.dns == ["1.2.3.4", "5.6.7.8"]
+
+        argument_string = ""
+        flags = Util.parse_additional_flags(argument_string)
+        assert flags.dns == []
 
     def test_windows_paths(self):
         argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task"'

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -77,6 +77,7 @@ class TestArgumentParsing:
         test_port_string_many_to_one = "-p 9230-9231:9230"
         test_ulimit_string = "--ulimit nofile=768:1024 --ulimit nproc=3"
         test_user_string = "-u sbx_user1051"
+        test_dns_string = "--dns 1.2.3.4 --dns 5.6.7.8"
         argument_string = " ".join(
             [
                 test_env_string,
@@ -89,6 +90,7 @@ class TestArgumentParsing:
                 test_privileged_string,
                 test_ulimit_string,
                 test_user_string,
+                test_dns_string,
             ]
         )
         env_vars = {}
@@ -121,6 +123,7 @@ class TestArgumentParsing:
             Ulimit(name="nofile", soft_limit=768, hard_limit=1024),
         ]
         assert flags.user == "sbx_user1051"
+        assert flags.dns == ["1.2.3.4", "5.6.7.8"]
 
         argument_string = (
             "--add-host host.docker.internal:host-gateway --add-host arbitrary.host:127.0.0.1"
@@ -199,6 +202,15 @@ class TestArgumentParsing:
         argument_string = r"-u nobody"
         flags = Util.parse_additional_flags(argument_string)
         assert flags.user == "nobody"
+
+    def test_dns(self):
+        argument_string = r"--dns 1.2.3.4"
+        flags = Util.parse_additional_flags(argument_string)
+        assert flags.dns == ["1.2.3.4"]
+
+        argument_string = r"--dns 1.2.3.4 --dns 5.6.7.8"
+        flags = Util.parse_additional_flags(argument_string)
+        assert flags.dns == ["1.2.3.4", "5.6.7.8"]
 
     def test_windows_paths(self):
         argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task"'


### PR DESCRIPTION
Extend Docker client to allow passing `--dns` user flags, e.g., via `DOCKER_FLAGS` or `ECS_DOCKER_FLAGS`.

Summary of changes:
* Turn the existing `dns` references from a `str` into a `List[str]`, as this is a multi-value attribute. Should be backward-compatible, and type hints were adjusted to `[Union[str, List[str]]]`
* Extend the `Util.parse_additional_flags(..)` utility to support parsing of `--dns ...` arguments
* Add a test to cover the new functionality
* Slightly restructure the tests and group the `test_run_with_additional_arguments_*` tests into a `TestRunWithAdditionalArgs` class