### PR TITLE
fix pod save after s3 multipart upload

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -795,10 +795,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 ArgumentValue=part_number,
             )
 
-        if body := request.get("Body"):
-            part = body.read()
-        else:
-            part = b""
+        part = body.read() if (body := request.get("Body")) else b""
 
         # we are directly using moto backend and not calling moto because to get the response, moto calls
         # key.response_dict, which in turns tries to access the tags of part, indirectly creating a BackendDict

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -788,14 +788,35 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
             )
-        elif (part_number := request.get("PartNumber", 0)) < 1:
+        elif (part_number := request.get("PartNumber", 0)) < 1 or part_number >= 10000:
             raise InvalidArgument(
                 "Part number must be an integer between 1 and 10000, inclusive",
                 ArgumentName="partNumber",
                 ArgumentValue=part_number,
             )
 
-        response: UploadPartOutput = call_moto(context)
+        if body := request.get("Body"):
+            part = body.read()
+        else:
+            part = b""
+
+        # we are directly using moto backend and not calling moto because to get the response, moto calls
+        # key.response_dict, which in turns tries to access the tags of part, indirectly creating a BackendDict
+        # with an account_id set to None (because moto does not set an account_id to the FakeKey representing a Part)
+        key = moto_backend.upload_part(bucket_name, upload_id, part_number, part)
+        response = UploadPartOutput(ETag=key.etag)
+
+        if key.checksum_algorithm is not None:
+            response[f"Checksum{key.checksum_algorithm.upper()}"] = key.checksum_value
+
+        if key.encryption is not None:
+            response["ServerSideEncryption"] = key.encryption
+            if key.encryption == "aws:kms" and key.kms_key_id is not None:
+                response["SSEKMSKeyId"] = key.encryption
+
+        if key.encryption == "aws:kms" and key.bucket_key_enabled is not None:
+            response["BucketKeyEnabled"] = key.bucket_key_enabled
+
         return response
 
     @handler("ListMultipartUploads", expand=False)


### PR DESCRIPTION
This PR fixes #8072 

Basically, the issue stems from moto accessing thus creating a BackendDict with an `account_id` set to `None`.

Thanks to @taimourfenris, he discovered that it was after a `MultipartUpload`, the issue would arise. It happens also in lambda because lambda makes use of `upload_fileobj`, which will automatically switch to a multipart upload if the file is big.

I tried to debug moto to see when it would access a backend with an null account id.

I've created a small sample to create a multipart:
```python
# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#multipart-transfers
chunk_size = 5_242_880 * 10  # around 52MB
with io.BytesIO() as data:
    data.write(os.urandom(chunk_size * 2))
    data.seek(0)
    s3_client.upload_fileobj(data, "test-bucket", "test-key")
```
And I could confirm after running this command that `localstack pod save file://test.zip` would fail. 

Added a print statement to the `__get_item__` of `BackendDict` to see when it would be accessed:
```python
 File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/services/s3/provider.py", line 804, in upload_part
    response: UploadPartOutput = call_moto(context)
  File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/services/moto.py", line 47, in call_moto
    return dispatch_to_backend(context, dispatch_to_moto, include_response_metadata)
  File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/aws/forwarder.py", line 120, in dispatch_to_backend
    http_response = http_request_dispatcher(context)
  File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/services/moto.py", line 115, in dispatch_to_moto
    response = dispatch(request, request.url, request.headers)
  File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/utils/patch.py", line 38, in proxy
    return new(target, *args, **kwargs)
  File "/Users/benjaminsimon/Projects/localstack/localstack/localstack/services/s3/provider.py", line 2043, in _fix_key_response
    status_code, resp_headers, key_value = fn(self, *args, **kwargs)
  File "/Users/benjaminsimon/Projects/localstack/moto/moto/utilities/aws_headers.py", line 74, in _wrapper
    response = f(*args, **kwargs)
  File "/Users/benjaminsimon/Projects/localstack/moto/moto/s3/responses.py", line 1208, in key_response
    response = self._key_response(request, full_url, self.headers)
  File "/Users/benjaminsimon/Projects/localstack/moto/moto/s3/responses.py", line 1320, in _key_response
    return self._key_response_put(request, body, bucket_name, query, key_name)
  File "/Users/benjaminsimon/Projects/localstack/moto/moto/s3/responses.py", line 1516, in _key_response_put
    response_headers.update(key.response_dict)
  File "/Users/benjaminsimon/Projects/localstack/moto/moto/s3/models.py", line 278, in response_dict
    tags = s3_backends[self.account_id]["global"].tagger.get_tag_dict_for_resource( 
```

So the faulty part was there, when returning the part (using a `FakeKey` underneath), here:
https://github.com/getmoto/moto/blob/e0ceec9e48fda482f549ad1f8212731ca82b35a1/moto/s3/responses.py#L1507-L1512

Basically, moto will try to get the `tagger` for the `FakeKey`, but it's just a part instantiated with minimal data, and no account id (because it can't have tag and we don't really care about its account id). 

I've had a look to patch it, but it would pretty tricky as it's contained in `s3/responses.py:S3Response:._key_response_put`, which is around 300LOC. 

The easiest is to directly implement it in our provider and calling directly the moto backend, without then calling `key.response_dict`.

I could validate that it worked with my sample and running `localstack pod save file://test.zip`, it would succeed in creating the pod. I could also load the pod afterwards. I'm not sure how to add a test for this as it's pretty specific. 
