### PR TITLE
fix decoding aws-chunked request for UploadPart

### DIFF
--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -66,3 +66,5 @@ SIGNATURE_V4_PARAMS = [
     "X-Amz-SignedHeaders",
     "X-Amz-Signature",
 ]
+
+S3_CHUNK_SIZE = 1024 * 16 * 4

--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -67,4 +67,6 @@ SIGNATURE_V4_PARAMS = [
     "X-Amz-Signature",
 ]
 
-S3_CHUNK_SIZE = 1024 * 16 * 4
+# The chunk size to use when iterating over and writing to S3 streams.
+# chosen as middle ground between memory usage and amount of iterations over the S3 object body
+S3_CHUNK_SIZE = 65536

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -42,7 +42,7 @@ from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.provider import S3Provider
 from localstack.services.s3.utils import (
-    InvalidRequest,
+    decode_aws_chunked_object,
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
     get_key_from_moto_bucket,
@@ -125,20 +125,17 @@ class S3ProviderStream(S3Provider):
         key_object.checksum_algorithm = checksum_algorithm
 
         headers = context.request.headers
-        content_sha_256 = context.request.headers.get("x-amz-content-sha256") or ""
-        try:
-            if content_sha_256.startswith("STREAMING-"):
-                # this is a chunked request, we need to properly decode it while setting the key value
-                decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
-                key_object.set_value_from_chunked_payload(body, decoded_content_length)
+        if (
+            content_sha_256 := headers.get("x-amz-content-sha256") or ""
+        ) and content_sha_256.startswith("STREAMING-"):
+            # this is a chunked request, we need to properly decode it while setting the key value
+            decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
+            key_object.set_value_from_chunked_payload(body, decoded_content_length)
 
-            else:
-                # set the stream to be the value of the key
-                key_object.value = body
-        except ChecksumInvalid:
-            raise InvalidRequest(
-                f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
-            )
+        else:
+            # set the stream to be the value of the key
+            key_object.value = body
+
         # the etag is recalculated
         response["ETag"] = key_object.etag
 
@@ -412,74 +409,16 @@ class StreamedFakeKey(s3_models.FakeKey):
         with self.lock:
             self._value_buffer.seek(0)
             self._value_buffer.truncate()
-            # We have 2 cases:
-            # The client gave a checksum value, we will need to compute the value and validate it against
-            # or the client have an algorithm value only and we need to compute the checksum
-            checksum = None
-            calculated_checksum = None
-            if self.checksum_algorithm:
-                checksum = get_s3_checksum(self.checksum_algorithm)
-            etag = hashlib.md5(usedforsecurity=False)
 
-            written = 0
-            while written < content_length:
-                line = new_value.readline()
-                chunk_length = int(line.split(b";")[0], 16)
-
-                while chunk_length > 0:
-                    amount = min(chunk_length, CHUNK_SIZE)
-                    data = new_value.read(amount)
-                    self._value_buffer.write(data)
-
-                    real_amount = len(data)
-                    chunk_length -= real_amount
-                    written += real_amount
-
-                    if self.checksum_algorithm:
-                        checksum.update(data)
-                    etag.update(data)
-
-                # remove trailing \r\n
-                new_value.read(2)
-
-            trailing_headers = []
-            next_line = new_value.readline()
-
-            if next_line:
-                try:
-                    chunk_length = int(next_line.split(b";")[0], 16)
-                    if chunk_length != 0:
-                        LOG.warning("The S3 object body didn't conform to the aws-chunk format")
-                except ValueError:
-                    trailing_headers.append(next_line.strip())
-
-                # try for trailing headers after
-                while line := new_value.readline():
-                    trailing_header = line.strip()
-                    if trailing_header:
-                        trailing_headers.append(trailing_header)
-
-            # look for the checksum header in the trailing headers
-            # TODO: we could get the header key from x-amz-trailer as well
-            for trailing_header in trailing_headers:
-                try:
-                    header_key, header_value = trailing_header.decode("utf-8").split(
-                        ":", maxsplit=1
-                    )
-                    if header_key.lower() == f"x-amz-checksum-{self.checksum_algorithm}".lower():
-                        self.checksum_value = header_value
-                except (IndexError, ValueError, AttributeError):
-                    continue
-
-            if self.checksum_algorithm:
-                calculated_checksum = base64.b64encode(checksum.digest()).decode()
-
-            if self.checksum_value and self.checksum_value != calculated_checksum:
-                self.dispose()
-                raise ChecksumInvalid(self.checksum_algorithm)
-
+            _, checksum_value, etag = decode_aws_chunked_object(
+                stream=new_value,
+                buffer=self._value_buffer,
+                content_length=content_length,
+                checksum_algorithm=self.checksum_algorithm,
+                checksum_value=self.checksum_value,
+            )
             self._etag = (
-                etag.hexdigest() if etag_empty else self._etag
+                etag if etag_empty else self._etag
             )  # if it's already set, from CompleteMultipart for example
             self.contentsize = self._value_buffer.tell()
             self._value_buffer.seek(0)

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -42,6 +42,7 @@ from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.provider import S3Provider
 from localstack.services.s3.utils import (
+    InvalidRequest,
     decode_aws_chunked_object,
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
@@ -277,7 +278,18 @@ class S3ProviderStream(S3Provider):
                 ArgumentValue=part_number,
             )
 
-        key = moto_backend.upload_part(bucket_name, upload_id, part_number, request.get("Body"))
+        body = request.get("Body") or BytesIO()
+        decoded_content_length = None
+        headers = context.request.headers
+        if (
+            content_sha_256 := headers.get("x-amz-content-sha256") or ""
+        ) and content_sha_256.startswith("STREAMING-"):
+            # this is a chunked request, we need to properly decode it while setting the key value
+            decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
+
+        key = moto_backend.upload_part(
+            bucket_name, upload_id, part_number, body, decoded_content_length
+        )
         response = UploadPartOutput(ETag=key.etag)
 
         if key.checksum_algorithm is not None:
@@ -292,16 +304,6 @@ class S3ProviderStream(S3Provider):
             response["BucketKeyEnabled"] = key.bucket_key_enabled
 
         return response
-
-
-class ChecksumInvalid(s3_exceptions.S3ClientError):
-    code = 400
-
-    def __init__(self, algorithm: str):
-        super().__init__(
-            "InvalidRequest",
-            f"Value for x-amz-checksum-{algorithm.lower()} header is invalid.",
-        )
 
 
 class PartialStream(RawIOBase):
@@ -396,7 +398,9 @@ class StreamedFakeKey(s3_models.FakeKey):
 
                 if self.checksum_value and self.checksum_value != calculated_checksum:
                     self.dispose()
-                    raise ChecksumInvalid(self.checksum_algorithm)
+                    raise InvalidRequest(
+                        f"Value for x-amz-checksum-{self.checksum_algorithm.lower()} header is invalid."
+                    )
 
             if etag_empty:
                 self._etag = etag.hexdigest()
@@ -479,13 +483,22 @@ class StreamedFakeMultipart(s3_models.FakeMultipart):
 
         return total, f"{full_etag.hexdigest()}-{count}"
 
-    def set_part(self, part_id: int, value: IO[bytes]) -> StreamedFakeKey:
+    def set_part(
+        self, part_id: int, value: IO[bytes], decoded_content_length: int = None
+    ) -> StreamedFakeKey:
         if part_id < 1:
             raise s3_exceptions.NoSuchUpload(upload_id=part_id)
 
+        # if the request is not aws-chunked, just use the value setter with the stream
+        # else use an empty body as we will use set_value_from_chunked_payload later
+        key_value = value if decoded_content_length is None else BytesIO()
         key = StreamedFakeKey(
-            part_id, value, encryption=self.sse_encryption, kms_key_id=self.kms_key_id
+            part_id, key_value, encryption=self.sse_encryption, kms_key_id=self.kms_key_id
         )
+        # as the request is chunked, we then set the chunked payload
+        if decoded_content_length:
+            key.set_value_from_chunked_payload(value, decoded_content_length)
+
         if part_id in self.parts:
             # We're overwriting the current part - dispose of it first
             self.parts[part_id].dispose()
@@ -535,11 +548,16 @@ def apply_stream_patches():
 
     @patch(s3_models.S3Backend.upload_part, pass_target=False)
     def upload_part(
-        self, bucket_name: str, multipart_id: str, part_id: int, value: IO[bytes]
+        self,
+        bucket_name: str,
+        multipart_id: str,
+        part_id: int,
+        value: IO[bytes],
+        decoded_content_length: int = None,
     ) -> StreamedFakeKey:
         bucket = self.get_bucket(bucket_name)
         multipart = bucket.multiparts[multipart_id]
-        return multipart.set_part(part_id, value)
+        return multipart.set_part(part_id, value, decoded_content_length)
 
     @patch(s3_models.S3Backend.copy_part, pass_target=False)
     def copy_part(

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -43,7 +43,6 @@ from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.provider import S3Provider
 from localstack.services.s3.utils import (
     InvalidRequest,
-    decode_aws_chunked_object,
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
     get_key_from_moto_bucket,
@@ -126,9 +125,7 @@ class S3ProviderStream(S3Provider):
         key_object.checksum_algorithm = checksum_algorithm
 
         headers = context.request.headers
-        if (
-            content_sha_256 := headers.get("x-amz-content-sha256") or ""
-        ) and content_sha_256.startswith("STREAMING-"):
+        if "aws-chunked" in (headers.get("Content-Encoding") or "").lower():
             # this is a chunked request, we need to properly decode it while setting the key value
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
             key_object.set_value_from_chunked_payload(body, decoded_content_length)
@@ -281,9 +278,7 @@ class S3ProviderStream(S3Provider):
         body = request.get("Body") or BytesIO()
         decoded_content_length = None
         headers = context.request.headers
-        if (
-            content_sha_256 := headers.get("x-amz-content-sha256") or ""
-        ) and content_sha_256.startswith("STREAMING-"):
+        if "aws-chunked" in (headers.get("Content-Encoding") or "").lower():
             # this is a chunked request, we need to properly decode it while setting the key value
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
 
@@ -413,16 +408,76 @@ class StreamedFakeKey(s3_models.FakeKey):
         with self.lock:
             self._value_buffer.seek(0)
             self._value_buffer.truncate()
+            # We have 2 cases:
+            # The client gave a checksum value, we will need to compute the value and validate it against
+            # or the client have an algorithm value only and we need to compute the checksum
+            checksum = None
+            calculated_checksum = None
+            if self.checksum_algorithm:
+                checksum = get_s3_checksum(self.checksum_algorithm)
+            etag = hashlib.md5(usedforsecurity=False)
 
-            checksum_value, etag = decode_aws_chunked_object(
-                stream=new_value,
-                buffer=self._value_buffer,
-                content_length=content_length,
-                checksum_algorithm=self.checksum_algorithm,
-                checksum_value=self.checksum_value,
-            )
+            written = 0
+            while written < content_length:
+                line = new_value.readline()
+                chunk_length = int(line.split(b";")[0], 16)
+
+                while chunk_length > 0:
+                    amount = min(chunk_length, CHUNK_SIZE)
+                    data = new_value.read(amount)
+                    self._value_buffer.write(data)
+
+                    real_amount = len(data)
+                    chunk_length -= real_amount
+                    written += real_amount
+
+                    if self.checksum_algorithm:
+                        checksum.update(data)
+                    etag.update(data)
+
+                # remove trailing \r\n
+                new_value.read(2)
+
+            trailing_headers = []
+            next_line = new_value.readline()
+
+            if next_line:
+                try:
+                    chunk_length = int(next_line.split(b";")[0], 16)
+                    if chunk_length != 0:
+                        LOG.warning("The S3 object body didn't conform to the aws-chunk format")
+                except ValueError:
+                    trailing_headers.append(next_line.strip())
+
+                # try for trailing headers after
+                while line := new_value.readline():
+                    trailing_header = line.strip()
+                    if trailing_header:
+                        trailing_headers.append(trailing_header)
+
+            # look for the checksum header in the trailing headers
+            # TODO: we could get the header key from x-amz-trailer as well
+            for trailing_header in trailing_headers:
+                try:
+                    header_key, header_value = trailing_header.decode("utf-8").split(
+                        ":", maxsplit=1
+                    )
+                    if header_key.lower() == f"x-amz-checksum-{self.checksum_algorithm}".lower():
+                        self.checksum_value = header_value
+                except (IndexError, ValueError, AttributeError):
+                    continue
+
+            if self.checksum_algorithm:
+                calculated_checksum = base64.b64encode(checksum.digest()).decode()
+
+            if self.checksum_value and self.checksum_value != calculated_checksum:
+                self.dispose()
+                raise InvalidRequest(
+                    f"Value for x-amz-checksum-{self.checksum_algorithm.lower()} header is invalid."
+                )
+
             self._etag = (
-                etag if etag_empty else self._etag
+                etag.hexdigest() if etag_empty else self._etag
             )  # if it's already set, from CompleteMultipart for example
             self.contentsize = self._value_buffer.tell()
             self._value_buffer.seek(0)

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -410,7 +410,7 @@ class StreamedFakeKey(s3_models.FakeKey):
             self._value_buffer.seek(0)
             self._value_buffer.truncate()
 
-            _, checksum_value, etag = decode_aws_chunked_object(
+            checksum_value, etag = decode_aws_chunked_object(
                 stream=new_value,
                 buffer=self._value_buffer,
                 content_length=content_length,

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2418,6 +2418,7 @@ class TestS3:
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
             "X-Amz-Date": "20190918T051509Z",
             "X-Amz-Decoded-Content-Length": str(len(body)),
+            "Content-Encoding": "aws-chunked",
         }
         data = (
             "d;chunk-signature=af5e6c0a698b0192e9aa5d9083553d4d241d81f69ec62b184d05c509ad5166af\r\n"
@@ -2452,6 +2453,7 @@ class TestS3:
             "X-Amz-Decoded-Content-Length": str(len(body)),
             "x-amz-sdk-checksum-algorithm": "SHA256",
             "x-amz-trailer": "x-amz-checksum-sha256",
+            "Content-Encoding": "aws-chunked",
         }
 
         def get_data(content: str, checksum_value: str) -> str:
@@ -2493,6 +2495,7 @@ class TestS3:
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
             "X-Amz-Date": "20190918T051509Z",
             "X-Amz-Decoded-Content-Length": str(len(body)),
+            "Content-Encoding": "aws-chunked",
         }
 
         data = (

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2480,6 +2480,63 @@ class TestS3:
         assert "Value for x-amz-checksum-sha256 header is invalid." in request.text
 
     @pytest.mark.only_localstack
+    def test_upload_part_chunked_newlines_valid_etag(self, s3_bucket, aws_client):
+        # Boto still does not support chunk encoding, which means we can't test with the client nor
+        # aws_http_client_factory. See open issue: https://github.com/boto/boto3/issues/751
+        # Test for https://github.com/localstack/localstack/issues/8703
+        object_key = "data"
+        body = "Hello Blob"
+        precalculated_etag = hashlib.md5(body.encode()).hexdigest()
+        headers = {
+            "Authorization": aws_stack.mock_aws_request_headers("s3")["Authorization"],
+            "Content-Type": "audio/mpeg",
+            "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
+            "X-Amz-Date": "20190918T051509Z",
+            "X-Amz-Decoded-Content-Length": str(len(body)),
+        }
+
+        data = (
+            "a;chunk-signature=b5311ac60a88890e740a41e74f3d3b03179fd058b1e24bb3ab224042377c4ec9\r\n"
+            f"{body}\r\n"
+            "0;chunk-signature=78fae1c533e34dbaf2b83ad64ff02e4b64b7bc681ea76b6acf84acf1c48a83cb\r\n"
+        )
+
+        key_name = "test-multipart-chunked"
+        response = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key_name,
+        )
+        upload_id = response["UploadId"]
+
+        # # upload the part 1
+        url = f"{config.service_url('s3')}/{s3_bucket}/{object_key}?partNumber={1}&uploadId={upload_id}"
+        response = requests.put(url, data, headers=headers, verify=False)
+        assert response.ok
+        part_etag = response.headers.get("ETag")
+        xml_response = xmltodict.parse(response.content)
+        assert "UploadPartOutput" in xml_response
+
+        # validate that the object etag is the same as the pre-calculated one
+        assert part_etag.strip('"') == precalculated_etag
+
+        multipart_upload_parts = [
+            {
+                "ETag": part_etag,
+                "PartNumber": 1,
+            }
+        ]
+
+        aws_client.s3.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key_name,
+            MultipartUpload={"Parts": multipart_upload_parts},
+            UploadId=upload_id,
+        )
+
+        completed_object = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+        assert completed_object["Body"].read() == to_bytes(body)
+
+    @pytest.mark.only_localstack
     def test_virtual_host_proxy_does_not_decode_gzip(self, aws_client, s3_bucket):
         # Write contents to memory rather than a file.
         data = "123gzipfile"


### PR DESCRIPTION
This PR fixes #8703 (I got confirmation with a code sample), this is a follow up from #8699

We had to set the `body` directly to moto to avoid a persistence bug, but moto has a step that we didn't execute: `_handle_v4_chunk_signatures`, which will decode the `aws-chunked` format. 

I've refactored the code used in the streaming provider that already handles this case, and made use of it in the case of `aws-chunked` requests for `UploadPart`, as we're skipping this moto step (actually one of the only one before actually calling the backend like we're doing in our provider). 

As a example, that is what the Java/.NET SDK would send if you try to upload a part with the following content:

Content: `Hello Blob`
Becomes:
```
a;chunk-signature=b5311ac60a88890e740a41e74f3d3b03179fd058b1e24bb3ab224042377c4ec9\r\n
Hello Blob\r\n
0;chunk-signature=78fae1c533e34dbaf2b83ad64ff02e4b64b7bc681ea76b6acf84acf1c48a83cb\r\n
```
Here's the doc on the `aws-chunked` format: 
https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html

So in the previous PR, we would directly set the encoded body as is, and the `ETag` would not correspond anymore. 