### PR TITLE
fix api gateway domains not being saved between versions

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -47,7 +48,7 @@ from localstack.utils.aws import resources as resource_utils
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
 from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
-from localstack.utils.strings import long_uid, short_uid, to_str
+from localstack.utils.strings import long_uid, short_uid, to_bytes, to_str
 from localstack.utils.time import TIMESTAMP_FORMAT_TZ, timestamp
 from localstack.utils.urls import localstack_host
 
@@ -1554,3 +1555,21 @@ def log_template(
         response_headers=response_headers,
         status_code=status_code,
     )
+
+
+def get_domain_name_hash(domain_name: str) -> str:
+    """
+    Return a hash of the given domain name, which help construct regional domain names for APIs.
+    TODO: use this in the future to dispatch API Gateway API invocations made to the regional domain name
+    """
+    return hashlib.shake_128(to_bytes(domain_name)).hexdigest(4)
+
+
+def get_regional_domain_name(domain_name: str) -> str:
+    """
+    Return the regional domain name for the given domain name.
+    In real AWS, this would look something like: "d-oplm2qchq0.execute-api.us-east-1.amazonaws.com"
+    In LocalStack, we're returning this format: "d-<domain_hash>.execute-api.localhost.localstack.cloud"
+    """
+    domain_name_hash = get_domain_name_hash(domain_name)
+    return f"d-{domain_name_hash}.execute-api.localhost.localstack.cloud"

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1572,4 +1572,4 @@ def get_regional_domain_name(domain_name: str) -> str:
     In LocalStack, we're returning this format: "d-<domain_hash>.execute-api.localhost.localstack.cloud"
     """
     domain_name_hash = get_domain_name_hash(domain_name)
-    return f"d-{domain_name_hash}.execute-api.localhost.localstack.cloud"
+    return f"d-{domain_name_hash}.execute-api.{LOCALHOST_HOSTNAME}"

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -66,10 +66,11 @@ class ApiGatewayStore(BaseStore):
     # maps cert ID to client certificate details
     client_certificates: Dict[str, Dict] = LocalAttribute(default=dict)
 
+    # maps domain name to domain name model
+    domain_names: Dict[str, DomainName] = LocalAttribute(default=dict)
+
     # maps resource ARN to tags
     TAGS: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
-
-    domain_names: Dict[str, DomainName] = LocalAttribute(default=dict)
 
     def __init__(self):
         super().__init__()

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -5,10 +5,11 @@ from requests.structures import CaseInsensitiveDict
 from localstack.aws.api.apigateway import (
     Authorizer,
     DocumentationPart,
+    DomainName,
     GatewayResponse,
     Model,
     RequestValidator,
-    RestApi, DomainName,
+    RestApi,
 )
 from localstack.services.stores import (
     AccountRegionBundle,

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -8,7 +8,7 @@ from localstack.aws.api.apigateway import (
     GatewayResponse,
     Model,
     RequestValidator,
-    RestApi,
+    RestApi, DomainName,
 )
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -67,6 +67,8 @@ class ApiGatewayStore(BaseStore):
 
     # maps resource ARN to tags
     TAGS: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
+
+    domain_names: Dict[str, DomainName] = LocalAttribute(default=dict)
 
     def __init__(self):
         super().__init__()

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -332,6 +332,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         domain: DomainName = DomainName(
             domainName=domain_name,
+            certificateName=certificate_name,
+            certificateArn=certificate_arn,
             regionalDomainName=get_regional_domain_name(domain_name),
             domainNameStatus=DomainNameStatus.AVAILABLE,
             regionalHostedZoneId=zone_id,

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -337,6 +337,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             regionalDomainName=get_regional_domain_name(domain_name),
             domainNameStatus=DomainNameStatus.AVAILABLE,
             regionalHostedZoneId=zone_id,
+            regionalCertificateName=regional_certificate_name,
             regionalCertificateArn=regional_certificate_arn,
             securityPolicy=SecurityPolicy.TLS_1_2,
             endpointConfiguration=endpoint_configuration,

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -319,6 +319,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         mutual_tls_authentication: MutualTlsAuthenticationInput = None,
         ownership_verification_certificate_arn: String = None,
     ) -> DomainName:
+        if not domain_name:
+            raise BadRequestException("No Domain Name specified")
+
         store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
         if store.domain_names.get(domain_name):
             raise ConflictException(f"Domain name with ID {domain_name} already exists")

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from typing import IO, Any
 
 from moto.apigateway import models as apigw_models
-from moto.apigateway.models import Resource as MotoResource, DomainName
+from moto.apigateway.models import DomainName
+from moto.apigateway.models import Resource as MotoResource
 from moto.apigateway.models import RestAPI as MotoRestAPI
 from moto.core.utils import camelcase_to_underscores
 
@@ -34,6 +35,7 @@ from localstack.aws.api.apigateway import (
     DocumentationPartIds,
     DocumentationPartLocation,
     DocumentationParts,
+    DomainNames,
     ExportResponse,
     GetDocumentationPartsRequest,
     Integration,
@@ -65,7 +67,7 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
     VpcLink,
-    VpcLinks, DomainNames,
+    VpcLinks,
 )
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError, create_aws_request_context
 from localstack.constants import APPLICATION_JSON
@@ -84,7 +86,7 @@ from localstack.services.apigateway.helpers import (
     resolve_references,
 )
 from localstack.services.apigateway.invocations import invoke_rest_api_from_request
-from localstack.services.apigateway.models import RestApiContainer, ApiGatewayStore
+from localstack.services.apigateway.models import ApiGatewayStore, RestApiContainer
 from localstack.services.apigateway.patches import apply_patches
 from localstack.services.apigateway.router_asf import ApigatewayRouter, to_invocation_context
 from localstack.services.edge import ROUTER
@@ -302,12 +304,11 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("GetDomainNames")
     def get_domain_names(
-            self, context: RequestContext, position: String = None, limit: NullableInteger = None
+        self, context: RequestContext, position: String = None, limit: NullableInteger = None
     ) -> DomainNames:
         store = get_apigateway_store(context.account_id, context.region)
         domain_names = store.domain_names.values()
         return DomainNames(items=list(domain_names), position=position)
-
 
     def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
         try:

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import IO, Any
 
 from moto.apigateway import models as apigw_models
-from moto.apigateway.models import Resource as MotoResource
+from moto.apigateway.models import Resource as MotoResource, DomainName
 from moto.apigateway.models import RestAPI as MotoRestAPI
 from moto.core.utils import camelcase_to_underscores
 
@@ -65,7 +65,7 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
     VpcLink,
-    VpcLinks,
+    VpcLinks, DomainNames,
 )
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError, create_aws_request_context
 from localstack.constants import APPLICATION_JSON
@@ -84,7 +84,7 @@ from localstack.services.apigateway.helpers import (
     resolve_references,
 )
 from localstack.services.apigateway.invocations import invoke_rest_api_from_request
-from localstack.services.apigateway.models import RestApiContainer
+from localstack.services.apigateway.models import RestApiContainer, ApiGatewayStore
 from localstack.services.apigateway.patches import apply_patches
 from localstack.services.apigateway.router_asf import ApigatewayRouter, to_invocation_context
 from localstack.services.edge import ROUTER
@@ -292,6 +292,22 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response = to_rest_api_response_json(response)
         response.setdefault("tags", {})
         return response
+
+    @handler("GetDomainName")
+    def get_domain_name(self, context: RequestContext, domain_name: String) -> DomainName:
+        store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
+        if domain := store.domain_names.get(domain_name):
+            return domain
+        raise NotFoundException("Invalid domain name identifier specified")
+
+    @handler("GetDomainNames")
+    def get_domain_names(
+            self, context: RequestContext, position: String = None, limit: NullableInteger = None
+    ) -> DomainNames:
+        store = get_apigateway_store(context.account_id, context.region)
+        domain_names = store.domain_names.values()
+        return DomainNames(items=list(domain_names), position=position)
+
 
     def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
         try:

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -297,6 +297,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("GetDomainName")
     def get_domain_name(self, context: RequestContext, domain_name: String) -> DomainName:
+        if domain_name := call_moto(context):
+            return domain_name
+
         store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
         if domain := store.domain_names.get(domain_name):
             return domain
@@ -306,6 +309,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_domain_names(
         self, context: RequestContext, position: String = None, limit: NullableInteger = None
     ) -> DomainNames:
+        if domain_names := call_moto(context):
+            return domain_names
+
         store = get_apigateway_store(context.account_id, context.region)
         domain_names = store.domain_names.values()
         return DomainNames(items=list(domain_names), position=position)

--- a/tests/integration/apigateway/test_apigateway_extended.py
+++ b/tests/integration/apigateway/test_apigateway_extended.py
@@ -69,7 +69,7 @@ def test_export_oas30_openapi(aws_client):
 
 
 def test_create_domain_names(aws_client):
-    domain_name = "testDomain"
+    domain_name = f"{short_uid()}-testDomain"
     test_certificate_name = "test.certificate"
     test_certificate_private_key = "testPrivateKey"
     # success case with valid params
@@ -109,7 +109,7 @@ def test_get_domain_names(aws_client):
 
 
 def test_get_domain_name(aws_client):
-    domain_name = "testDomain"
+    domain_name = f"{short_uid()}-testDomain"
     # adding a domain name
     aws_client.apigateway.create_domain_name(domainName=domain_name)
     # retrieving the data of added domain name.


### PR DESCRIPTION
Custom domains created on any version of API Gateway should be visible across APIs. For example, using aws cli with apigatewayv2 client to create a custom domain and query the same domain using aws cli with apigateway client after, should return the previous domain created.

## Changes

- Add a new field to the ApiGw model to hold the created domains.
- Implements the `create_domain_name,` `get_domain_name` and `get_domain_names` API calls to fetch the domains from the model. 
- Move away from moto store and use localstack apigw store to store created domains
- Almost all operations but update domains act on both APIs, for example deleting a domain happen in both stores, same as create and fetch.