### PR TITLE
Pin Cython<3 to fix PyYaml build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ install_requires =
     psutil>=5.4.8,<6.0.0
     python-dotenv>=0.19.1
     pyyaml>=5.1
+    # remove once https://github.com/yaml/pyyaml/issues/601 is fixed
+    Cython<3
     rich>=12.3.0
     requests>=2.20.0
     semver>=2.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,7 @@ install_requires =
     plux>=1.3.1
     psutil>=5.4.8,<6.0.0
     python-dotenv>=0.19.1
-    pyyaml>=5.1
-    # remove once https://github.com/yaml/pyyaml/issues/601 is fixed
-    Cython<3
+    pyyaml>=5.1,<5.4
     rich>=12.3.0
     requests>=2.20.0
     semver>=2.10


### PR DESCRIPTION
## Motivation
Since the release of Cython 3.0.0 an hour ago: https://pypi.org/project/Cython/#history , the installation of our dependency PyYaml broke.

See https://github.com/yaml/pyyaml/issues/601

## Changes
* Pin cython<3 for now, to ensure pyyaml builds correctly. We should remove the pin once the incompatibility is fixed.