### PR TITLE
Fix deprecated pyyaml usage in cloudformation legacy test

### DIFF
--- a/tests/integration/cloudformation/resources/test_legacy.py
+++ b/tests/integration/cloudformation/resources/test_legacy.py
@@ -461,7 +461,7 @@ class TestCloudFormation:
     # TODO: evaluate
     def test_update_conditions(self, deploy_cfn_template, aws_client):
         stack = deploy_cfn_template(template=TEST_TEMPLATE_3)
-        template = yaml.load(TEST_TEMPLATE_3)
+        template = yaml.safe_load(TEST_TEMPLATE_3)
 
         # TODO: avoid changing template here
         # update stack with additional resources and conditions


### PR DESCRIPTION
## Motivation
The upgrade to pyyaml>6 due to the Cython upgrade deprecated `yaml.load` without a loader specified.

## Changes
* Replace `yaml.load` with `yaml.safe_load`, which automatically uses the SafeLoader loader.