### PR TITLE
Remove get_cfn_attribute from legacy models

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -210,7 +210,7 @@ class GatewayRestAPI(GenericBaseModel):
             resources = connect_to().apigateway.get_resources(restApiId=result["id"])["items"]
             for res in resources:
                 if res["path"] == "/" and not res.get("parentId"):
-                    resources[resource_id]["Properties"]["RootResourceId"] = res["id"]
+                    resource["Properties"]["RootResourceId"] = res["id"]
 
         return {
             "create": {"function": _create, "result_handler": _handle_result},

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -93,15 +93,6 @@ class GatewayRestAPI(GenericBaseModel):
     def cloudformation_type():
         return "AWS::ApiGateway::RestApi"
 
-    def get_cfn_attribute(self, attribute_name):
-        # if attribute_name == "RootResourceId":
-        #     api_id = self.props.get("id")
-        #     resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
-        #     for res in resources:
-        #         if res["path"] == "/" and not res.get("parentId"):
-        #             return res["id"]
-        return super(GatewayRestAPI, self).get_cfn_attribute(attribute_name)
-
     def fetch_state(self, stack_name, resources):
         if not self.props.get("id"):
             return None

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -94,12 +94,12 @@ class GatewayRestAPI(GenericBaseModel):
         return "AWS::ApiGateway::RestApi"
 
     def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "RootResourceId":
-            api_id = self.props.get("id")
-            resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
-            for res in resources:
-                if res["path"] == "/" and not res.get("parentId"):
-                    return res["id"]
+        # if attribute_name == "RootResourceId":
+        #     api_id = self.props.get("id")
+        #     resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
+        #     for res in resources:
+        #         if res["path"] == "/" and not res.get("parentId"):
+        #             return res["id"]
         return super(GatewayRestAPI, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
@@ -206,6 +206,11 @@ class GatewayRestAPI(GenericBaseModel):
 
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = result["id"]
+
+            resources = connect_to().apigateway.get_resources(restApiId=result["id"])["items"]
+            for res in resources:
+                if res["path"] == "/" and not res.get("parentId"):
+                    resources[resource_id]["Properties"]["RootResourceId"] = res["id"]
 
         return {
             "create": {"function": _create, "result_handler": _handle_result},

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -15,12 +15,12 @@ class CloudFormationStack(GenericBaseModel):
     def cloudformation_type():
         return "AWS::CloudFormation::Stack"
 
-    def fetch_state(self, stack_name, resources):
-        client = connect_to().cloudformation
-        child_stack_name = self.props["StackName"]
-        result = client.describe_stacks(StackName=child_stack_name)
-        result = (result.get("Stacks") or [None])[0]
-        return result
+    # def fetch_state(self, stack_name, resources):
+    #     client = connect_to().cloudformation
+    #     child_stack_name = self.props["StackName"]
+    #     result = client.describe_stacks(StackName=child_stack_name)
+    #     result = (result.get("Stacks") or [None])[0]
+    #     return result
 
     @staticmethod
     def add_defaults(resource, stack_name: str):

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -52,15 +52,15 @@ class CloudFormationStack(GenericBaseModel):
             return result
 
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
-            resource["PhysicalResourceId"] = result["StackId"]
             connect_to().cloudformation.get_waiter("stack_create_complete").wait(
                 StackName=result["StackId"]
             )
+            resource["PhysicalResourceId"] = result["StackId"]
             # set outputs
             stack_details = connect_to().cloudformation.describe_stacks(
                 StackName=result["StackId"]
             )["Stacks"][0]
-            if outputs := stack_details["Outputs"]:
+            if outputs := stack_details.get("Outputs"):
                 resource["Properties"]["Outputs"] = {
                     o["OutputKey"]: o["OutputValue"] for o in outputs
                 }

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -22,26 +22,6 @@ class CloudFormationStack(GenericBaseModel):
         result = (result.get("Stacks") or [None])[0]
         return result
 
-    def get_cfn_attribute(self, attribute_name: str):
-        if attribute_name.startswith("Outputs."):
-            parts = attribute_name.split(".")
-            if len(parts) > 2:
-                raise Exception(
-                    f"Too many parts for stack output reference found: {attribute_name=}"
-                )
-            output_key = parts[1]
-            if "Outputs" not in self.props:
-                return None
-            candidates = [
-                o["OutputValue"] for o in self.props["Outputs"] if o["OutputKey"] == output_key
-            ]
-            if len(candidates) == 1:
-                return candidates[0]
-            else:
-                raise Exception(f"Too many output values found for key {output_key=}")
-
-        return super(CloudFormationStack, self).get_cfn_attribute(attribute_name)
-
     @staticmethod
     def add_defaults(resource, stack_name: str):
         role_name = resource.get("Properties", {}).get("StackName")
@@ -80,8 +60,10 @@ class CloudFormationStack(GenericBaseModel):
             stack_details = connect_to().cloudformation.describe_stacks(
                 StackName=result["StackId"]
             )["Stacks"][0]
-            if "Outputs" in stack_details:
-                resource["Properties"]["Outputs"] = stack_details["Outputs"]
+            if outputs := stack_details["Outputs"]:
+                resource["Properties"]["Outputs"] = {
+                    o["OutputKey"]: o["OutputValue"] for o in outputs
+                }
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/cloudwatch.py
+++ b/localstack/services/cloudformation/models/cloudwatch.py
@@ -8,11 +8,6 @@ class CloudWatchAlarm(GenericBaseModel):
     def cloudformation_type():
         return "AWS::CloudWatch::Alarm"
 
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return self.props.get("AlarmArn")
-        return super(CloudWatchAlarm, self).get_cfn_attribute(attribute_name)
-
     def _response_name(self):
         return "MetricAlarms"
 
@@ -37,6 +32,11 @@ class CloudWatchAlarm(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            alarms = connect_to().cloudwatch.describe_alarms(
+                AlarmNames=[resource["Properties"]["AlarmName"]]
+            )
+            arn = alarms["MetricAlarms"][0]["AlarmArn"]
+            resource["Properties"]["Arn"] = arn
             resource["PhysicalResourceId"] = resource["Properties"]["AlarmName"]
 
         def get_delete_params(

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -21,13 +21,6 @@ class ECRRepository(GenericBaseModel):
     def cloudformation_type():
         return "AWS::ECR::Repository"
 
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return self.props.get("repositoryArn")
-        if attribute_name == "RepositoryUri":
-            return self.props.get("repositoryUri")
-        return super(ECRRepository, self).get_cfn_attribute(attribute_name)
-
     def fetch_state(self, stack_name, resources):
         repo_name = default_repos_per_stack.get(stack_name)
         if repo_name:
@@ -60,8 +53,8 @@ class ECRRepository(GenericBaseModel):
             resource["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
 
             # add in some properties required for GetAtt and Ref
-            resource["Properties"]["repositoryArn"] = arns.get_ecr_repository_arn(repo_name)
-            resource["Properties"]["repositoryUri"] = "http://localhost:4566"
+            resource["Properties"]["Arn"] = arns.get_ecr_repository_arn(repo_name)
+            resource["Properties"]["RepositoryUri"] = "http://localhost:4566"
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -159,10 +159,6 @@ class IAMAccessKey(GenericBaseModel):
     def cloudformation_type():
         return "AWS::IAM::AccessKey"
 
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "SecretAccessKey":
-            return self.props.get("SecretAccessKey")
-
     def fetch_state(self, stack_name, resources):
         user_name = self.props.get("UserName")
         access_key_id = self.physical_resource_id
@@ -221,11 +217,6 @@ class IAMRole(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::IAM::Role"
-
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return self.props.get("Arn")
-        return super(IAMRole, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
         role_name = self.props.get("RoleName")
@@ -357,6 +348,7 @@ class IAMRole(GenericBaseModel):
     def get_deploy_templates(cls):
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = result["Role"]["RoleName"]
+            resource["Properties"]["Arn"] = result["Role"]["Arn"]
 
         return {
             "create": [

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -36,10 +36,10 @@ class KinesisStream(GenericBaseModel):
     def cloudformation_type():
         return "AWS::Kinesis::Stream"
 
-    def fetch_state(self, stack_name, resources):
-        stream_name = self.props["Name"]
-        result = connect_to().kinesis.describe_stream(StreamName=stream_name)
-        return result
+    # def fetch_state(self, stack_name, resources):
+    #     stream_name = self.props["Name"]
+    #     result = connect_to().kinesis.describe_stream(StreamName=stream_name)
+    #     return result
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
@@ -63,12 +63,11 @@ class KinesisStream(GenericBaseModel):
             client = connect_to().kinesis
             stream_name = resource["Properties"]["Name"]
 
-            description = client.describe_stream(StreamName=stream_name)
-            while description["StreamDescription"]["StreamStatus"] != "ACTIVE":
-                description = client.describe_stream(StreamName=stream_name)
+            client.get_waiter("stream_exists").wait(StreamName=stream_name)
 
-            resource["PhysicalResourceId"] = stream_name
+            description = client.describe_stream(StreamName=stream_name)
             resource["Properties"]["Arn"] = description["StreamDescription"]["StreamARN"]
+            resource["PhysicalResourceId"] = stream_name
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -1,6 +1,8 @@
 from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.deployment_utils import select_parameters
+from localstack.services.cloudformation.provider_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
+from localstack.utils.sync import poll_condition
 
 
 class FirehoseDeliveryStream(GenericBaseModel):
@@ -13,10 +15,30 @@ class FirehoseDeliveryStream(GenericBaseModel):
         return connect_to().firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
 
     @staticmethod
+    def add_defaults(resource, stack_name: str):
+        # TODO: validate format
+        name = resource.get("Properties", {}).get("DeliveryStreamName")
+        if not name:
+            resource["Properties"]["DeliveryStreamName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
+
+    @staticmethod
     def get_deploy_templates():
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            stream_name = resource["Properties"]["DeliveryStreamName"]
+
+            # TODO: fix the polling here and check the response, might not actually be ACTIVE
+            client = connect_to().firehose
+
+            def check_stream_state():
+                stream = client.describe_delivery_stream(DeliveryStreamName=stream_name)
+                return stream["DeliveryStreamDescription"]["DeliveryStreamStatus"] == "ACTIVE"
+
+            poll_condition(check_stream_state, 45, 1)
+
             resource["Properties"]["Arn"] = result["DeliveryStreamARN"]
-            resource["PhysicalResourceId"] = resource["Properties"]["DeliveryStreamName"]
+            resource["PhysicalResourceId"] = stream_name
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -2,18 +2,12 @@ import json
 
 from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import arns
 
 
 class KMSKey(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::KMS::Key"
-
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return arns.kms_key_arn(self.physical_resource_id)
-        return super(KMSKey, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
         client = connect_to().kms
@@ -58,6 +52,7 @@ class KMSKey(GenericBaseModel):
 
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["PhysicalResourceId"] = result["KeyMetadata"]["KeyId"]
+            resource["Properties"]["Arn"] = result["KeyMetadata"]["Arn"]
 
         return {
             "create": [

--- a/localstack/services/cloudformation/models/resourcegroups.py
+++ b/localstack/services/cloudformation/models/resourcegroups.py
@@ -14,13 +14,10 @@ class ResourceGroupsGroup(GenericBaseModel):
         result = [g for g in result if g["Name"] == self.props["Name"]]
         return (result or [None])[0]
 
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return self.props.get("GroupArn")
-
     @classmethod
     def get_deploy_templates(cls):
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["Properties"]["Arn"] = result["Group"]["GroupArn"]
             resource["PhysicalResourceId"] = result["Group"]["Name"]
 
         return {

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -16,13 +16,6 @@ class SecretsManagerSecret(GenericBaseModel):
     def cloudformation_type():
         return "AWS::SecretsManager::Secret"
 
-    def get_cfn_attribute(self, attribute_name: str):
-        match attribute_name:
-            case "Id":
-                return self.props.get("ARN")
-
-        return super(SecretsManagerSecret, self).get_cfn_attribute(attribute_name)
-
     def fetch_state(self, stack_name, resources):
         secret_name = self.props.get("Name") or self.logical_resource_id
         result = connect_to().secretsmanager.describe_secret(SecretId=secret_name)
@@ -112,7 +105,7 @@ class SecretsManagerSecret(GenericBaseModel):
             return result
 
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
-            resource["Properties"]["ARN"] = result["ARN"]
+            resource["Properties"]["Id"] = result["ARN"]
             resource["PhysicalResourceId"] = result["ARN"]
 
         return {

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -67,11 +67,6 @@ class SQSQueue(GenericBaseModel):
     def cloudformation_type(cls):
         return "AWS::SQS::Queue"
 
-    def get_cfn_attribute(self, attribute_name):
-        if attribute_name == "Arn":
-            return arns.sqs_queue_arn(self.properties["QueueName"])
-        return super().get_cfn_attribute(attribute_name)
-
     def fetch_state(self, stack_name, resources):
         queue_name = self.props["QueueName"]
         sqs_client = connect_to().sqs

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -47,13 +47,6 @@ class SFNStateMachine(GenericBaseModel):
     def cloudformation_type():
         return "AWS::StepFunctions::StateMachine"
 
-    def get_cfn_attribute(self, attribute_name: str):
-        if attribute_name == "Arn":
-            return self.props.get("Arn")
-        if attribute_name == "Name":
-            return self.props.get("StateMachineName")
-        return super(SFNStateMachine, self).get_cfn_attribute(attribute_name)
-
     def fetch_state(self, stack_name, resources):
         sm_name = self.props.get("StateMachineName") or self.logical_resource_id
         sfn_client = connect_to().stepfunctions
@@ -89,6 +82,8 @@ class SFNStateMachine(GenericBaseModel):
     def get_deploy_templates(cls):
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
             resource["Properties"]["Arn"] = result["stateMachineArn"]
+            resource["Properties"]["Name"] = resource["Properties"]["StateMachineName"]
+            # resource["Properties"]["StateMachineRevisionId"] = ?
             resource["PhysicalResourceId"] = result["stateMachineArn"]
 
         def _create_params(

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -84,7 +84,16 @@ class GenericBaseModel:
 
     def get_cfn_attribute(self, attribute_name):
         """Retrieve the given CF attribute for this resource"""
-        return self.props.get(attribute_name)
+        prop_candidate = self.props.get(attribute_name)
+        if prop_candidate:
+            return prop_candidate
+
+        if "." in attribute_name:
+            parts = attribute_name.split(".")
+            attribute = self.props
+            for part in parts:
+                attribute = attribute.get(part)
+            return attribute
 
     # ---------------------
     # GENERIC UTIL METHODS

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -84,16 +84,18 @@ class GenericBaseModel:
 
     def get_cfn_attribute(self, attribute_name):
         """Retrieve the given CF attribute for this resource"""
-        prop_candidate = self.props.get(attribute_name)
-        if prop_candidate:
-            return prop_candidate
-
+        attribute_candidate = self.props.get(attribute_name)
         if "." in attribute_name:
+            if attribute_candidate:
+                # in case we explicitly add a property with a dot, e.g. resource["Properties"]["Endpoint.Port"]
+                return attribute_candidate
             parts = attribute_name.split(".")
             attribute = self.props
             for part in parts:
                 attribute = attribute.get(part)
             return attribute
+
+        return attribute_candidate
 
     # ---------------------
     # GENERIC UTIL METHODS


### PR DESCRIPTION
Removes all usage of `get_cfn_attribute` from the community resource models. 

It does not yet introduce a subset selection for the migrated resources to stay in parity with the previous behavior for now where we nearly always fall back to a direct property/state lookup.


A follow-up PR will soon remove the base method from the GenericBaseModel and unify the code paths between old and legacy providers.