### PR TITLE
Refs are updated on resource deployment completion

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -859,8 +859,7 @@ class Reference:
 
     source_logical_id: str
     destination_logical_id: str
-    value_lookup_function: Callable[[dict], str]
-    source_update_function: Callable[[dict, str], None]
+    source_update_function: Callable[[dict], None]
 
 
 def build_references(resources: dict) -> list[Reference]:
@@ -870,16 +869,12 @@ def build_references(resources: dict) -> list[Reference]:
         for prop_name, prop in props.items():
             if isinstance(prop, dict) and "Ref" in prop:
 
-                def setter(resources: dict, value: str):
-                    resources[resource_id]["Properties"][prop_name] = value
-
-                def getter(resource: dict):
-                    return resource["PhysicalResourceId"]
+                def setter(resources: dict):
+                    resources[resource_id]["Properties"][prop_name] = resource["PhysicalResourceId"]
 
                 ref = Reference(
                     source_logical_id=resource_id,
                     destination_logical_id=prop["Ref"],
-                    value_lookup_function=getter,
                     source_update_function=setter,
                 )
                 refs.append(ref)
@@ -1516,8 +1511,7 @@ class TemplateDeployer:
     def update_references(self, logical_resource_id: str):
         for ref in self.references:
             if ref.destination_logical_id == logical_resource_id:
-                value = ref.value_lookup_function(self.resources[logical_resource_id])
-                ref.source_update_function(self.resources, value)
+                ref.source_update_function(self.resources)
 
     def create_resource_provider_executor(self) -> ResourceProviderExecutor:
         return ResourceProviderExecutor(

--- a/tests/integration/cloudformation/engine/test_references.py
+++ b/tests/integration/cloudformation/engine/test_references.py
@@ -1,9 +1,31 @@
+import json
 import os
 
 import pytest
 
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
+
+
+class TestRef:
+    def test_references(self, deploy_cfn_template):
+        template = json.dumps(
+            {
+                "Resources": {
+                    "Topic": {
+                        "Type": "AWS::SNS::Topic",
+                    },
+                    "Parameter": {
+                        "Type": "AWS::SSM::Parameter",
+                        "Properties": {
+                            "Type": "String",
+                            "Value": {"Ref": "Topic"},
+                        },
+                    },
+                },
+            }
+        )
+        deploy_cfn_template(template=template)
 
 
 class TestDependsOn:


### PR DESCRIPTION
Update refs once a resource has finished deploying. This should reduce the number of calls to `resolve_refs_recursively`.