### PR TITLE
S3 AWS-chunked stream decoder

### DIFF
--- a/localstack/services/s3/codec.py
+++ b/localstack/services/s3/codec.py
@@ -96,4 +96,4 @@ class AwsChunkedDecoder(io.RawIOBase):
         while line := self._stream.readline():
             if trailing_header := line.strip():
                 header_key, header_value = trailing_header.decode("utf-8").split(":", maxsplit=1)
-                self._trailing_headers[header_key] = header_value.strip()
+                self._trailing_headers[header_key.lower()] = header_value.strip().lower()

--- a/localstack/services/s3/codec.py
+++ b/localstack/services/s3/codec.py
@@ -96,4 +96,4 @@ class AwsChunkedDecoder(io.RawIOBase):
         while line := self._stream.readline():
             if trailing_header := line.strip():
                 header_key, header_value = trailing_header.decode("utf-8").split(":", maxsplit=1)
-                self._trailing_headers[header_key.lower()] = header_value.strip().lower()
+                self._trailing_headers[header_key.lower()] = header_value.strip()

--- a/localstack/services/s3/codec.py
+++ b/localstack/services/s3/codec.py
@@ -1,0 +1,99 @@
+import io
+from typing import IO
+
+
+class AwsChunkedDecoder(io.RawIOBase):
+    """
+    This helper class takes a IO[bytes] stream, and decodes it on the fly, so that S3 can directly access the stream
+    without worrying about implementation details of `aws-chunked`.
+    It does need access to the trailing headers, which are going to be available once the stream is fully read.
+    See `aws-chunked` format here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
+    """
+
+    def readable(self):
+        return True
+
+    def __init__(self, stream: IO[bytes], decoded_content_length: int):
+        self._stream = stream
+
+        self._decoded_length = decoded_content_length  # Length of the encoded object
+        self._new_chunk = True
+        self._end_chunk = False
+        self._chunk_size = 0
+        self._trailing_headers = {}
+
+    @property
+    def trailing_headers(self):
+        return self._trailing_headers
+
+    def seekable(self):
+        return self._stream.seekable()
+
+    def readinto(self, b):
+        with memoryview(b) as view, view.cast("B") as byte_view:
+            data = self.read(len(byte_view))
+            byte_view[: len(data)] = data
+        return len(data)
+
+    def read(self, size=-1):
+        """
+        Read from the underlying stream, and return at most `size` decoded bytes.
+        If a chunk is smaller than `size`, we will return less than asked, but we will always return data if there
+        are chunks left
+        :param size:
+        :return:
+        """
+        if size < 0:
+            return self.readall()
+
+        if not size:
+            return b""
+
+        if self._end_chunk:
+            # if it's the end of a chunk we need to strip the newline at the end of the chunk
+            # before jumping to the new one
+            self._strip_chunk_new_lines()
+            self._new_chunk = True
+
+        if self._new_chunk:
+            # If the _new_chunk flag is set, we have to jump to the next chunk, if there's one
+            self._get_next_chunk_length()
+            self._new_chunk = False
+
+        if self._chunk_size == 0 and self._decoded_length <= 0:
+            # If the next chunk is 0, and we decoded everything, try to get the trailing headers
+            self._get_trailing_headers()
+            return b""
+
+        # take the minimum account between the requested size, and the left chunk size
+        # (to not over read from the chunk)
+        amount = min(self._chunk_size, size)
+        data = self._stream.read(amount)
+
+        if data == b"":
+            raise EOFError("Encoded file ended before the " "end-of-stream marker was reached")
+
+        read = len(data)
+        self._chunk_size -= read
+        if self._chunk_size <= 0:
+            self._end_chunk = True
+
+        self._decoded_length -= read
+
+        return data
+
+    def _strip_chunk_new_lines(self):
+        self._stream.read(2)
+
+    def _get_next_chunk_length(self):
+        line = self._stream.readline()
+        # TODO: try except?
+        chunk_length = int(line.split(b";")[0], 16)
+        self._chunk_size = chunk_length
+
+    def _get_trailing_headers(self):
+        # try to get all trailing headers until the end of the stream
+        while line := self._stream.readline():
+            if trailing_header := line.strip():
+                header_key, header_value = trailing_header.decode("utf-8").split(":", maxsplit=1)
+                self._trailing_headers[header_key] = header_value.strip()

--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -69,4 +69,6 @@ SIGNATURE_V4_PARAMS = [
 
 # The chunk size to use when iterating over and writing to S3 streams.
 # chosen as middle ground between memory usage and amount of iterations over the S3 object body
+# This is AWS recommended size when uploading chunks
+# https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
 S3_CHUNK_SIZE = 65536

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -139,7 +139,8 @@ class S3ProviderStream(S3Provider):
         try:
             key_object.value = body
         except Exception:
-            # cleanup the created key in case we can't set the value
+            # the value attribute has a setter method which will validate the object checksum, so it can raise
+            # exceptions. We catch any exception happening so that we can properly clean up in case that happens.
             moto_backend.delete_object(
                 bucket_name=request["Bucket"],
                 key_name=request["Key"],


### PR DESCRIPTION
This PR implements a stream decoder which will decode on the fly the `aws-chunked` encoding, so that we only have one way to set the stream to the S3 objects value, which simplifies the code a lot, even for the new provider.

One of the main issue around this decoder is that we're getting data only after we read the whole stream, as the necessary headers for checksum calculation are appended at the end of the response.

We then need a way to access those headers for our logic to go forward. One way for this to be transparent is to pass the s3 object to the stream, so that once it has finish decoding, it will automatically set the trailing checksum to the object attribute.

Maybe one idea could also be to be able to register callback, but as it's always the same, I thought we don't need to make it extendable for now. 
