### PR TITLE
Fix regression for Fn::Sub in condition section

### DIFF
--- a/tests/integration/templates/conditions/intrinsic-functions-in-conditions.yaml
+++ b/tests/integration/templates/conditions/intrinsic-functions-in-conditions.yaml
@@ -1,0 +1,39 @@
+Parameters:
+  TopicName:
+    Type: String
+  TopicPrefix:
+    Type: String
+  TopicNameWithSuffix:
+    Type: String
+  TopicNameSuffix:
+    Type: String
+
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Condition: ShouldCreateTopic
+    Properties:
+      TopicName: !Ref TopicName
+
+  MyTopicWithSuffix:
+    Type: AWS::SNS::Topic
+    Condition: ShouldCreateTopic2
+    Properties:
+      TopicName: !Ref TopicNameWithSuffix
+
+
+Conditions:
+  ShouldCreateTopic: !Equals
+    - !Ref TopicName
+    - !Sub "${TopicPrefix}-${AWS::Region}"
+  ShouldCreateTopic2: !Equals
+    - !Ref TopicNameWithSuffix
+    - "Fn::Sub":
+      - "${TopicPrefix}-${AWS::Region}-${Suffix}"
+      - Suffix: !Ref TopicNameSuffix
+
+Outputs:
+  TopicRef:
+    Value: !Ref MyTopic
+  TopicWithSuffixRef:
+    Value: !Ref MyTopicWithSuffix


### PR DESCRIPTION
Allows for `Fn::Sub` intrinsic function evaluation in the resolving of the conditions. Still very explicit, but this area of code will soon be reworked into a sort of visitor pattern allowing us to structure this a bit better.

This regression was introduced recently when splitting the resolve path for Conditions from resolve_refs_recursively