### PR TITLE
8701 enhancement request custom lambda authorizer apikeysource is not validated

### DIFF
--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from typing import Dict
 
 from jsonschema import ValidationError, validate
 from requests.models import Response
@@ -35,7 +34,6 @@ from localstack.services.apigateway.integration import (
     StepFunctionIntegration,
 )
 from localstack.services.apigateway.models import ApiGatewayStore
-from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
 
@@ -142,21 +140,6 @@ class RequestValidator:
 # ------------
 
 
-def run_authorizer(invocation_context: ApiInvocationContext, authorizer: Dict):
-    # TODO implement authorizers
-    pass
-
-
-def authorize_invocation(invocation_context: ApiInvocationContext):
-    region_name = invocation_context.region_name or aws_stack.get_region()
-    client = connect_to(region_name=region_name).apigateway
-    authorizers = client.get_authorizers(restApiId=invocation_context.api_id, limit=100).get(
-        "items", []
-    )
-    for authorizer in authorizers:
-        run_authorizer(invocation_context, authorizer)
-
-
 def validate_api_key(api_key: str, invocation_context: ApiInvocationContext):
 
     usage_plan_ids = []
@@ -167,13 +150,14 @@ def validate_api_key(api_key: str, invocation_context: ApiInvocationContext):
     usage_plans = client.get_usage_plans()
     for item in usage_plans.get("items", []):
         api_stages = item.get("apiStages", [])
-        for api_stage in api_stages:
+        usage_plan_ids.extend(
+            item.get("id")
+            for api_stage in api_stages
             if (
                 api_stage.get("stage") == invocation_context.stage
                 and api_stage.get("apiId") == invocation_context.api_id
-            ):
-                usage_plan_ids.append(item.get("id"))
-
+            )
+        )
     for usage_plan_id in usage_plan_ids:
         usage_plan_keys = client.get_usage_plan_keys(usagePlanId=usage_plan_id)
         for key in usage_plan_keys.get("items", []):
@@ -192,18 +176,19 @@ def is_api_key_valid(invocation_context: ApiInvocationContext) -> bool:
     ).apigateway
     rest_api = client.get_rest_api(restApiId=invocation_context.api_id)
 
-    if rest_api.get("apiKeySource") != "HEADER":
-        # When the apiKeySource is set to AUTHORIZER, the authorizer is supposed to return the API key as a field
-        # `usageIdentifierKey`
-        # see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
-        # Authorizers are only mocked, so we can't validate the key. Return True in that case
-        return True
+    # The source of the API key for metering requests according to a usage plan.
+    # Valid values are:
+    # - HEADER to read the API key from the X-API-Key header of a request.
+    # - AUTHORIZER to read the API key from the UsageIdentifierKey from a custom authorizer.
 
-    api_key = invocation_context.headers.get("X-API-Key")
-    if not api_key:
-        return False
-
-    return validate_api_key(api_key, invocation_context)
+    api_key_source = rest_api.get("apiKeySource")
+    match api_key_source:
+        case "HEADER":
+            api_key = invocation_context.headers.get("X-API-Key")
+            return validate_api_key(api_key, invocation_context) if api_key else False
+        case "AUTHORIZER":
+            api_key = invocation_context.auth_identity.get("apiKey")
+            return validate_api_key(api_key, invocation_context) if api_key else False
 
 
 def update_content_length(response: Response):
@@ -254,9 +239,6 @@ def invoke_rest_api(invocation_context: ApiInvocationContext):
     method = invocation_context.method
     headers = invocation_context.headers
 
-    # run gateway authorizers for this request
-    authorize_invocation(invocation_context)
-
     extracted_path, resource = helpers.get_target_resource_details(invocation_context)
     if not resource:
         return make_error_response("Unable to find path %s" % invocation_context.path, 404)
@@ -268,7 +250,7 @@ def invoke_rest_api(invocation_context: ApiInvocationContext):
 
     api_key_required = resource.get("resourceMethods", {}).get(method, {}).get("apiKeyRequired")
     if api_key_required and not is_api_key_valid(invocation_context):
-        return make_error_response("Access denied - invalid API key", 403)
+        return make_error_response("Forbidden", 403)
 
     resource_methods = resource.get("resourceMethods", {})
     resource_method = resource_methods.get(method, {})

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1816,7 +1816,6 @@ def create_rest_apigw(aws_client_factory):
         for usage_plan_id in usage_plan_ids:
             usage_plan_keys = apigateway_client.get_usage_plan_keys(usagePlanId=usage_plan_id)
             for key in usage_plan_keys.get("items", []):
-
                 apigateway_client.delete_api_key(apiKey=key["id"])
             apigateway_client.delete_usage_plan(usagePlanId=usage_plan_id)
 

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -370,6 +370,9 @@ class TestUsagePlans:
 
         retry(_assert_with_key, retries=retries, sleep=sleep, expected_status_code=403)
 
+        for usage_plan in aws_client.apigateway.get_usage_plans()["items"]:
+            aws_client.apigateway.delete_usage_plan(usagePlanId=usage_plan["id"])
+
     @markers.parity.aws_validated
     def test_usage_plan_crud(self, create_rest_apigw, snapshot, aws_client, echo_http_server_post):
         snapshot.add_transformer(snapshot.transform.key_value("id", reference_replacement=True))

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -379,6 +379,11 @@ class TestUsagePlans:
         snapshot.add_transformer(snapshot.transform.key_value("description"))
         snapshot.add_transformer(snapshot.transform.key_value("apiId", reference_replacement=True))
 
+        # clean up any existing usage plans
+        old_usage_plans = aws_client.apigateway.get_usage_plans().get("items", [])
+        for usage_plan in old_usage_plans:
+            aws_client.apigateway.delete_usage_plan(usagePlanId=usage_plan["id"])
+
         api_id, _, root = create_rest_apigw(
             name=f"test-api-{short_uid()}",
             description="this is my api",

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -8,7 +8,13 @@ from localstack.testing.pytest import markers
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
-from tests.integration.apigateway.apigateway_fixtures import api_invoke_url
+from tests.integration.apigateway.apigateway_fixtures import (
+    api_invoke_url,
+    create_rest_api_deployment,
+    create_rest_api_integration,
+    create_rest_api_stage,
+    create_rest_resource_method,
+)
 from tests.integration.awslambda.test_lambda import TEST_LAMBDA_AWS_PROXY
 
 
@@ -250,12 +256,9 @@ class TestApiGatewayCommon:
         response_get = requests.get(url)
         assert response_get.ok
 
+
+class TestUsagePlans:
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.create-usage-plan.throttle.rateLimit",  # TODO: wrong type, should be `float` but is `int`
-        ]
-    )
     def test_api_key_required_for_methods(
         self,
         aws_client,
@@ -366,3 +369,66 @@ class TestApiGatewayCommon:
         snapshot.match("update-api-key-disabled", response)
 
         retry(_assert_with_key, retries=retries, sleep=sleep, expected_status_code=403)
+
+    @markers.parity.aws_validated
+    def test_usage_plan_crud(self, create_rest_apigw, snapshot, aws_client, echo_http_server_post):
+        snapshot.add_transformer(snapshot.transform.key_value("id", reference_replacement=True))
+        snapshot.add_transformer(snapshot.transform.key_value("description"))
+        snapshot.add_transformer(snapshot.transform.key_value("apiId", reference_replacement=True))
+
+        api_id, _, root = create_rest_apigw(
+            name=f"test-api-{short_uid()}",
+            description="this is my api",
+        )
+
+        create_rest_resource_method(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=root,
+            httpMethod="GET",
+            authorizationType="none",
+        )
+
+        create_rest_api_integration(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=root,
+            httpMethod="GET",
+            integrationHttpMethod="POST",
+            type="HTTP",
+            uri=echo_http_server_post,
+        )
+
+        deployment_id, _ = create_rest_api_deployment(aws_client.apigateway, restApiId=api_id)
+        stage = create_rest_api_stage(
+            aws_client.apigateway, restApiId=api_id, stageName="dev", deploymentId=deployment_id
+        )
+
+        # create usage plan
+        response = aws_client.apigateway.create_usage_plan(
+            name=f"test-usage-plan-{short_uid()}",
+            description="this is my usage plan",
+            apiStages=[
+                {"apiId": api_id, "stage": stage},
+            ],
+        )
+        snapshot.match("create-usage-plan", response)
+        usage_plan_id = response["id"]
+
+        # get usage plan
+        response = aws_client.apigateway.get_usage_plan(usagePlanId=usage_plan_id)
+        snapshot.match("get-usage-plan", response)
+
+        # get usage plans
+        response = aws_client.apigateway.get_usage_plans()
+        snapshot.match("get-usage-plans", response)
+
+        # update usage plan
+        response = aws_client.apigateway.update_usage_plan(
+            usagePlanId=usage_plan_id,
+            patchOperations=[
+                {"op": "replace", "path": "/throttle/burstLimit", "value": "100"},
+                {"op": "replace", "path": "/throttle/rateLimit", "value": "200"},
+            ],
+        )
+        snapshot.match("update-usage-plan", response)

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -370,12 +370,10 @@ class TestUsagePlans:
 
         retry(_assert_with_key, retries=retries, sleep=sleep, expected_status_code=403)
 
-        for usage_plan in aws_client.apigateway.get_usage_plans()["items"]:
-            aws_client.apigateway.delete_usage_plan(usagePlanId=usage_plan["id"])
-
     @markers.parity.aws_validated
     def test_usage_plan_crud(self, create_rest_apigw, snapshot, aws_client, echo_http_server_post):
         snapshot.add_transformer(snapshot.transform.key_value("id", reference_replacement=True))
+        snapshot.add_transformer(snapshot.transform.key_value("name"))
         snapshot.add_transformer(snapshot.transform.key_value("description"))
         snapshot.add_transformer(snapshot.transform.key_value("apiId", reference_replacement=True))
 

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -296,7 +296,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_common.py::TestUsagePlans::test_usage_plan_crud": {
-    "recorded-date": "27-07-2023, 17:57:22",
+    "recorded-date": "28-07-2023, 08:30:23",
     "recorded-content": {
       "create-usage-plan": {
         "apiStages": [
@@ -307,7 +307,7 @@
         ],
         "description": "<description:1>",
         "id": "<id:1>",
-        "name": "test-usage-plan-176fa351",
+        "name": "<name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -322,7 +322,7 @@
         ],
         "description": "<description:1>",
         "id": "<id:1>",
-        "name": "test-usage-plan-176fa351",
+        "name": "<name:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -334,36 +334,13 @@
           {
             "apiStages": [
               {
-                "apiId": "<api-id:2>",
-                "stage": "dev"
-              }
-            ],
-            "description": "<description:2>",
-            "id": "<id:2>",
-            "name": "test-plan-ae4de511",
-            "quota": {
-              "limit": 10,
-              "offset": 0,
-              "period": "DAY"
-            },
-            "tags": {
-              "tag_key": "tag_value"
-            },
-            "throttle": {
-              "burstLimit": 1,
-              "rateLimit": 2.0
-            }
-          },
-          {
-            "apiStages": [
-              {
                 "apiId": "<api-id:1>",
                 "stage": "dev"
               }
             ],
             "description": "<description:1>",
             "id": "<id:1>",
-            "name": "test-usage-plan-176fa351"
+            "name": "<name:1>"
           }
         ],
         "ResponseMetadata": {
@@ -380,7 +357,7 @@
         ],
         "description": "<description:1>",
         "id": "<id:1>",
-        "name": "test-usage-plan-176fa351",
+        "name": "<name:1>",
         "tags": {},
         "throttle": {
           "burstLimit": 100,

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
-    "recorded-date": "26-05-2023, 22:48:51",
+    "recorded-date": "27-07-2023, 17:59:26",
     "recorded-content": {
       "register-lambda": {
         "fn_arn": "arn:aws:lambda:<region>:111111111111:function:<fn_name:1>",
@@ -155,7 +155,7 @@
         }
       },
       "invalid-request-body": {
-        "message": "Invalid request body"
+        "message": "Missing required request parameters: [issuer]"
       },
       "remove-validator-GET": {
         "apiKeyRequired": false,
@@ -227,8 +227,8 @@
       }
     }
   },
-  "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_key_required_for_methods": {
-    "recorded-date": "05-06-2023, 20:32:45",
+  "tests/integration/apigateway/test_apigateway_common.py::TestUsagePlans::test_api_key_required_for_methods": {
+    "recorded-date": "27-07-2023, 17:57:20",
     "recorded-content": {
       "create-usage-plan": {
         "apiStages": [
@@ -288,6 +288,104 @@
         "name": "<name:2>",
         "stageKeys": [],
         "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_common.py::TestUsagePlans::test_usage_plan_crud": {
+    "recorded-date": "27-07-2023, 17:57:22",
+    "recorded-content": {
+      "create-usage-plan": {
+        "apiStages": [
+          {
+            "apiId": "<api-id:1>",
+            "stage": "dev"
+          }
+        ],
+        "description": "<description:1>",
+        "id": "<id:1>",
+        "name": "test-usage-plan-176fa351",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-usage-plan": {
+        "apiStages": [
+          {
+            "apiId": "<api-id:1>",
+            "stage": "dev"
+          }
+        ],
+        "description": "<description:1>",
+        "id": "<id:1>",
+        "name": "test-usage-plan-176fa351",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-usage-plans": {
+        "items": [
+          {
+            "apiStages": [
+              {
+                "apiId": "<api-id:2>",
+                "stage": "dev"
+              }
+            ],
+            "description": "<description:2>",
+            "id": "<id:2>",
+            "name": "test-plan-ae4de511",
+            "quota": {
+              "limit": 10,
+              "offset": 0,
+              "period": "DAY"
+            },
+            "tags": {
+              "tag_key": "tag_value"
+            },
+            "throttle": {
+              "burstLimit": 1,
+              "rateLimit": 2.0
+            }
+          },
+          {
+            "apiStages": [
+              {
+                "apiId": "<api-id:1>",
+                "stage": "dev"
+              }
+            ],
+            "description": "<description:1>",
+            "id": "<id:1>",
+            "name": "test-usage-plan-176fa351"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-usage-plan": {
+        "apiStages": [
+          {
+            "apiId": "<api-id:1>",
+            "stage": "dev"
+          }
+        ],
+        "description": "<description:1>",
+        "id": "<id:1>",
+        "name": "test-usage-plan-176fa351",
+        "tags": {},
+        "throttle": {
+          "burstLimit": 100,
+          "rateLimit": 200.0
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -155,7 +155,7 @@
         }
       },
       "invalid-request-body": {
-        "message": "Missing required request parameters: [issuer]"
+        "message": "Invalid request body"
       },
       "remove-validator-GET": {
         "apiKeyRequired": false,

--- a/tests/integration/cloudformation/resources/test_apigateway.py
+++ b/tests/integration/cloudformation/resources/test_apigateway.py
@@ -287,6 +287,10 @@ def test_cfn_deploy_apigateway_integration(deploy_cfn_template, snapshot, aws_cl
     snapshot.match("method", method)
     # TODO: snapshot the authorizer too? it's not attached to the REST API
 
+    usage_plans = aws_client.apigateway.get_usage_plans()["items"]
+    for plan in usage_plans:
+        aws_client.apigateway.delete_usage_plan(usagePlanId=plan["id"])
+
 
 @markers.parity.aws_validated
 @markers.snapshot.skip_snapshot_verify(
@@ -400,10 +404,9 @@ def test_update_usage_plan(deploy_cfn_template, aws_client):
 
     assert 7000 == usage_plan["quota"]["limit"]
 
-    aws_client.apigateway.delete_usage_plan(usagePlanId=stack.outputs["UsagePlanId"])
-
-    usage_plans = aws_client.apigateway.get_usage_plans()
-    assert len(usage_plans["items"]) == 0
+    usage_plans = aws_client.apigateway.get_usage_plans()["items"]
+    for plan in usage_plans:
+        aws_client.apigateway.delete_usage_plan(usagePlanId=plan["id"])
 
 
 def test_api_gateway_with_policy_as_dict(deploy_cfn_template, snapshot, aws_client):

--- a/tests/integration/cloudformation/resources/test_apigateway.py
+++ b/tests/integration/cloudformation/resources/test_apigateway.py
@@ -400,6 +400,11 @@ def test_update_usage_plan(deploy_cfn_template, aws_client):
 
     assert 7000 == usage_plan["quota"]["limit"]
 
+    aws_client.apigateway.delete_usage_plan(usagePlanId=stack.outputs["UsagePlanId"])
+
+    usage_plans = aws_client.apigateway.get_usage_plans()
+    assert len(usage_plans["items"]) == 0
+
 
 def test_api_gateway_with_policy_as_dict(deploy_cfn_template, snapshot, aws_client):
     template = """


### PR DESCRIPTION
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-source.html

> When you associate a usage plan with an API and enable [API key](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-basic-concept.html#apigateway-definition-api-key)s on API methods, every incoming request to the API must contain an API key. API Gateway reads the key and compares it against the keys in the usage plan. If there is a match, API Gateway throttles the requests based on the plan's request limit and quota. Otherwise, it throws an InvalidKeyParameter exception. As a result, the caller receives a 403 Forbidden response.

The changes go a bit beyond the api key authorizer implementation by adding usage plans parity.
  
### Changes

- Override `create_api_key`, `create_usage_plan`, `update_usage_plan`, `get_usage_plan` and `get_usage_plans` and snapshoting.
- Implements and overrides request authorizer (api key)upstream and validates the api key against usage plans. 

### TF sample

https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-rest-lambda-api-key