### PR TITLE
fix(cfn): add missing FilterPolicyScope for sns subs

### DIFF
--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -149,6 +149,7 @@ class SNSSubscription(GenericBaseModel):
             attrs = [
                 "DeliveryPolicy",
                 "FilterPolicy",
+                "FilterPolicyScope",
                 "RawMessageDelivery",
                 "RedrivePolicy",
             ]


### PR DESCRIPTION
## Summary

Add missing `FilterPolicyScope` to `AWS::SNS::Subscription`

## Simple check

`template.yml`
```yaml
AWSTemplateFormatVersion: 2010-09-09

Resources:
  SNSTopic:
    Type: AWS::SNS::Topic
    Properties:
      TopicName: test-topic

  SQSQueue:
    Type: AWS::SQS::Queue
    Properties:
      QueueName: test-queue

  SNSSubscription:
    Type: AWS::SNS::Subscription
    Properties:
      TopicArn: !Ref SNSTopic
      Endpoint: !GetAtt [SQSQueue, Arn]
      Protocol: sqs
      FilterPolicyScope: MessageBody
      FilterPolicy:
        entityName:
          - Zone
```

`cfn.sh`
```bash
awslocal cloudformation deploy \
  --template-file template.yml \
  --stack-name test-stack \
  --region us-west-2

subscription_arn=$(
  awslocal sns list-subscriptions-by-topic \
    --topic-arn arn:aws:sns:us-west-2:000000000000:test-topic \
    --region us-west-2 | jq -r '.Subscriptions[0].SubscriptionArn'
)

awslocal sns get-subscription-attributes \
  --subscription-arn $subscription_arn \
  --region us-west-2
```

`FilterPolicyScope` must be `MessageBody`