### PR TITLE
add get_client method to ServiceLevelClientFactory

### DIFF
--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -141,6 +141,11 @@ class ServiceLevelClientFactory(TypedServiceClientFactory):
         self._factory = factory
         self._client_creation_params = client_creation_params
 
+    def get_client(self, service: str):
+        return MetadataRequestInjector(
+            client=self._factory.get_client(service_name=service, **self._client_creation_params)
+        )
+
     def __getattr__(self, service: str):
         service = attribute_name_to_service_name(service)
         return MetadataRequestInjector(

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -95,9 +95,8 @@ class AlarmScheduler:
         """
         Only used re-create persistent state. Reschedules alarms that already exist
         """
-        service = "cloudwatch"
-        for region in aws_stack.get_valid_regions_for_service(service):
-            client = connect_to(region_name=region).get_client(service)
+        for region in aws_stack.get_valid_regions_for_service("cloudwatch"):
+            client = connect_to(region_name=region).cloudwatch
             result = client.describe_alarms()
             for metric_alarm in result["MetricAlarms"]:
                 arn = metric_alarm["AlarmArn"]


### PR DESCRIPTION
This PR fixes an issue where this code would lead to an exception:

```python
from localstack.aws.connect import connect_to

service = "cloudwatch"
connect_to(region_name="us-east-1").get_client(service)
```

The created `ServiceLevelClientFactory` would try to resolve `get_client` as the service `get-client`, instead of `cloudwatch`.

This surfaced in the persistence tests with the `AlarmScheduler.restart_alarms` method of cloudwatch:
```
2023-07-22T13:46:19.3265223Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/utils/threads.py", line 58, in run
2023-07-22T13:46:19.3265863Z docker-run.sh: result = self.func(self.params, **kwargs)
2023-07-22T13:46:19.3266515Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/services/cloudwatch/provider.py", line 261, in restart_alarms
2023-07-22T13:46:19.3267330Z docker-run.sh: self.alarm_scheduler.restart_existing_alarms()
2023-07-22T13:46:19.3268054Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/services/cloudwatch/alarm_scheduler.py", line 100, in restart_existing_alarms
2023-07-22T13:46:19.3268681Z docker-run.sh: client = connect_to(region_name=region).get_client(service)
2023-07-22T13:46:19.3269307Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/aws/connect.py", line 147, in __getattr__
2023-07-22T13:46:19.3269953Z docker-run.sh: client=self._factory.get_client(service_name=service, **self._client_creation_params)
2023-07-22T13:46:19.3270624Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/aws/connect.py", line 412, in get_client
2023-07-22T13:46:19.3271110Z docker-run.sh: return self._get_client(
2023-07-22T13:46:19.3271670Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/aws/connect.py", line 321, in _get_client
2023-07-22T13:46:19.3272170Z docker-run.sh: client = self._session.client(
2023-07-22T13:46:19.3272732Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/session.py", line 299, in client
2023-07-22T13:46:19.3273231Z docker-run.sh: return self._session.create_client(
2023-07-22T13:46:19.3273822Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/session.py", line 997, in create_client
2023-07-22T13:46:19.3274333Z docker-run.sh: client = client_creator.create_client(
2023-07-22T13:46:19.3274914Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 129, in create_client
2023-07-22T13:46:19.3275481Z docker-run.sh: service_model = self._load_service_model(service_name, api_version)
2023-07-22T13:46:19.3276109Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 231, in _load_service_model
2023-07-22T13:46:19.3276643Z docker-run.sh: json_model = self._loader.load_service_model(
2023-07-22T13:46:19.3277224Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/loaders.py", line 142, in _wrapper
2023-07-22T13:46:19.3277706Z docker-run.sh: data = func(self, *args, **kwargs)
2023-07-22T13:46:19.3278283Z docker-run.sh: File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/loaders.py", line 408, in load_service_model
2023-07-22T13:46:19.3278930Z docker-run.sh: raise UnknownServiceError(
2023-07-22T13:46:19.4181496Z docker-run.sh: botocore.exceptions.UnknownServiceError: Unknown service: 'get-client'.
```

* @dfangl i don't know what the best place for a test for this is, maybe you could add it
* @steffyP seems this code was broken for this reason: https://github.com/localstack/localstack/blob/27edb72e307c4db17a74ae031f27e46359204799/localstack/services/cloudwatch/alarm_scheduler.py#L98-L100
