### PR TITLE
change default timestream variant in router

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -277,7 +277,7 @@ def resolve_conflicts(candidates: Set[str], request: Request):
     These conflicts need to be resolved manually.
     """
     if candidates == {"timestream-query", "timestream-write"}:
-        return "timestream-query"
+        return "timestream-write"
     if candidates == {"docdb", "neptune", "rds"}:
         return "rds"
 

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -72,7 +72,7 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
             # Exclude services / operations which have ambiguities and where the service routing needs to resolve those
             elif (
                 service.service_name in ["docdb", "neptune"]  # maps to rds
-                or service.service_name in "timestream-write"  # maps to timestream-query
+                or service.service_name in "timestream-query"  # maps to timestream-write
                 or (
                     service.service_name == "sesv2"
                     and operation_name == "PutEmailIdentityDkimSigningAttributes"


### PR DESCRIPTION
This fix arose from the following problem:
I wanted to implement [list_tags_for_resource](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/timestream-write/client/list_tags_for_resource.html) for timestream, as tags are within the demanded operations. When desperately trying to snapshot the new test, it finally occurred to me, there's an equivalent operation (but with pagination) in the [query provider](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/timestream-query/client/list_tags_for_resource.html).

This overlap is also present when directly calling aws, but with a strange twist. If you first create a database:
```
$ aws timestream-write create-database --database-name test 
{
    "Database": {
        "Arn": "arn:aws:timestream:eu-central-1:000000000000:database/test",
        "DatabaseName": "test",
        "TableCount": 0,
        "KmsKeyId": "arn:aws:kms:eu-central-1:000000000000:key/00000000-0000-0000-0000-000000000000",
        "CreationTime": 1690215389.562,
        "LastUpdatedTime": 1690215389.562
    }
}
```

Then try to call `list_tags_for_resource`, only one provider actually works:
```
$ aws timestream-query list-tags-for-resource --resource-arn arn:aws:timestream:eu-central-1:000000000000:database/test
An error occurred (ValidationException) when calling the ListTagsForResource operation: Unsupported ARN: arn:aws:timestream:eu-central-1:000000000000:database/test.

$ aws timestream-write list-tags-for-resource --resource-arn arn:aws:timestream:eu-central-1:000000000000:database/test
{
    "Tags": []
}

```
(as you might can guess, this ate up some hours :upside_down_face: )
As a random (and desperate attempt) I simply set the default conflict resolution to `-write` instead of `-query`, which is what this PR proposes. 
I then tried to execute the timestream-testsuite, and everything passes fine with the new default (including the mentioned example of `DescribeEndpoints` within the function).
So all in all, what I'm trying to say is, that I think & hope that `-write` is a better default for now, while knowing full well that we probably need to revise this in the near future and split it up operation-wise.


/cc thx to @bentsku for pointing out the router