### PR TITLE
Fix partition rewriting when body is urlencoded

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -101,8 +101,11 @@ class ArnPartitionRewriteHandler(Handler):
             get_full_raw_path(request), self.DEFAULT_INBOUND_PARTITION, encoded=True
         )
         parsed_forward_rewritten_path = urlparse(full_forward_rewritten_path)
+        body_is_encoded = "application/x-www-form-urlencoded" in request.headers.get(
+            "content-type", ""
+        )
         forward_rewritten_body = self._adjust_partition(
-            restore_payload(request), self.DEFAULT_INBOUND_PARTITION
+            restore_payload(request), self.DEFAULT_INBOUND_PARTITION, encoded=body_is_encoded
         )
         forward_rewritten_headers = self._adjust_partition(
             dict(request.headers), self.DEFAULT_INBOUND_PARTITION


### PR DESCRIPTION
## Motivation
For services which send their data with content type `application/x-www-form-urlencoded`, the partition reworking currently does not work properly, as it will match a urlencoded string with a not-urlencoded regex. 

Example: IAM

## Changes
* Check in content type header if content type is `application/x-www-form-urlencoded`, and use encoded logic for the replacement in these cases.