### PR TITLE
fix S3 lifecycle rule matching with ExpiredObjectDeleteMarker

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1925,7 +1925,11 @@ def validate_lifecycle_configuration(lifecycle_conf: BucketLifecycleConfiguratio
             if len(rule_filter) > 1:
                 raise MalformedXML()
 
-        if exp_date := (rule.get("Expiration", {}).get("Date")):
+        if (expiration := rule.get("Expiration", {})) and "ExpiredObjectDeleteMarker" in expiration:
+            if len(expiration) > 1:
+                raise MalformedXML()
+
+        if exp_date := (expiration.get("Date")):
             if exp_date.timetz() != datetime.time(
                 hour=0, minute=0, second=0, microsecond=0, tzinfo=ZoneInfo("GMT")
             ):

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -399,7 +399,7 @@ def get_lifecycle_rule_from_object(
     lifecycle_conf_rules: LifecycleRules, moto_object: FakeKey, object_tags: dict[str, str]
 ) -> LifecycleRule:
     for rule in lifecycle_conf_rules:
-        if "Expiration" not in rule:
+        if not (expiration := rule.get("Expiration")) or "ExpiredObjectDeleteMarker" in expiration:
             continue
 
         if not (rule_filter := rule.get("Filter")):

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -8337,6 +8337,24 @@ class TestS3BucketLifecycle:
 
         snapshot.match("duplicate-tag-keys", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            lfc["Rules"] = [
+                {
+                    "ID": "expired-delete-marker-and-days",
+                    "Filter": {},
+                    "Status": "Enabled",
+                    "Expiration": {
+                        "Days": 1,
+                        "ExpiredObjectDeleteMarker": True,
+                    },
+                }
+            ]
+            aws_client.s3.put_bucket_lifecycle_configuration(
+                Bucket=s3_bucket, LifecycleConfiguration=lfc
+            )
+
+        snapshot.match("expired-delete-marker-and-days", e.value.response)
+
     @markers.parity.aws_validated
     def test_bucket_lifecycle_configuration_date(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
@@ -8747,6 +8765,41 @@ class TestS3BucketLifecycle:
         )
         snapshot.match("put-object-no-match", put_object_3)
         assert "Expiration" not in put_object_3
+
+    @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    def test_lifecycle_expired_object_delete_marker(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("BucketName"),
+                snapshot.transform.key_value(
+                    "Expiration", reference_replacement=False, value_replacement="<expiration>"
+                ),
+            ]
+        )
+        rule_id = "rule-marker"
+        lfc = {
+            "Rules": [
+                {
+                    "Expiration": {"ExpiredObjectDeleteMarker": True},
+                    "ID": rule_id,
+                    "Filter": {},
+                    "Status": "Enabled",
+                }
+            ]
+        }
+        aws_client.s3.put_bucket_lifecycle_configuration(
+            Bucket=s3_bucket, LifecycleConfiguration=lfc
+        )
+        result = aws_client.s3.get_bucket_lifecycle_configuration(Bucket=s3_bucket)
+        snapshot.match("get-bucket-lifecycle-conf", result)
+
+        key = "test-expired-object-delete-marker"
+        put_object = aws_client.s3.put_object(Body=b"test", Bucket=s3_bucket, Key=key)
+        snapshot.match("put-object", put_object)
+
+        response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("head-object", response)
 
 
 def _anon_client(service: str):

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -8062,7 +8062,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_put_bucket_lifecycle_conf_exc": {
-    "recorded-date": "07-07-2023, 20:42:44",
+    "recorded-date": "26-07-2023, 15:06:44",
     "recorded-content": {
       "missing-id": {
         "Error": {
@@ -8130,6 +8130,16 @@
         "Error": {
           "Code": "InvalidRequest",
           "Message": "Duplicate Tag Keys are not allowed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "expired-delete-marker-and-days": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8632,6 +8642,46 @@
       "put_object_retention_5": {
         "Code": "InvalidRequest",
         "Message": "Bucket is missing Object Lock Configuration"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3BucketLifecycle::test_lifecycle_expired_object_delete_marker": {
+    "recorded-date": "26-07-2023, 15:14:49",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {},
+            "ID": "rule-marker",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes #8750

We didn't consider the case where `ExpiredObjectDeleteMarker` would be set in the `Expiration` field of rule. Basically, if this is set, you can't set `Days` or `Date` so we would serialize a proper header (and we should not).

Adjusted the logic to properly parse the lifecycle configuration so that we can't have `Days` or `Date` set with `ExpiredObjectDeleteMarker`, and adjusted the matching so that we wouldn't return a rule that contains `ExpiredObjectDeleteMarker`, because you shouldn't serialize a header then. 