### PR TITLE
fix S3 case where aws-chunked chunk is bigger than read size

### DIFF
--- a/localstack/services/s3/codec.py
+++ b/localstack/services/s3/codec.py
@@ -63,6 +63,7 @@ class AwsChunkedDecoder(io.RawIOBase):
             # before jumping to the new one
             self._strip_chunk_new_lines()
             self._new_chunk = True
+            self._end_chunk = False
 
         if self._new_chunk:
             # If the _new_chunk flag is set, we have to jump to the next chunk, if there's one


### PR DESCRIPTION
This PR fix the newly arised issue #8756

Basically we were missing a reset to the signal for the end of a chunk. Quick fix, and added a test covering this case.