### PR TITLE
New pytest parity markers & marker registration

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1732,15 +1732,6 @@ def secondary_account_id(secondary_aws_client):
 
 
 @pytest.hookimpl
-def pytest_configure(config: Config):
-    # TODO: migrate towards "whitebox" or similar structure
-    config.addinivalue_line(
-        "markers",
-        "only_localstack: mark the test as incompatible with AWS / can't be run with AWS_CLOUD target",
-    )
-
-
-@pytest.hookimpl
 def pytest_collection_modifyitems(config: Config, items: list[Item]):
     only_localstack = pytest.mark.skipif(
         os.environ.get("TEST_TARGET") == "AWS_CLOUD",

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -33,3 +33,5 @@ class Markers:
 
     skip_offline = pytest.mark.skip_offline
     only_on_amd64 = pytest.mark.only_on_amd64
+    resource_heavy = pytest.mark.resource_heavy
+    only_in_docker = pytest.mark.only_in_docker

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -23,6 +23,11 @@ class SkipSnapshotVerifyMarker:
         ...
 
 
+class MultiRuntimeMarker:
+    def __call__(self, *, scenario: str, runtimes: Optional[list[str]] = None):
+        ...
+
+
 class SnapshotMarkers:
     skip_snapshot_verify: SkipSnapshotVerifyMarker = pytest.mark.skip_snapshot_verify
 
@@ -31,6 +36,9 @@ class Markers:
     parity = ParityMarkers
     snapshot = SnapshotMarkers
 
+    multiruntime: MultiRuntimeMarker = pytest.mark.multiruntime
+
+    # test selection
     skip_offline = pytest.mark.skip_offline
     only_on_amd64 = pytest.mark.only_on_amd64
     resource_heavy = pytest.mark.resource_heavy

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -8,6 +8,8 @@ import pytest
 
 class ParityMarkers:
     aws_validated = pytest.mark.aws_validated
+    manual_setup_required = pytest.mark.manual_setup_required  # implies aws_validated
+    should_be_aws_validated = pytest.mark.should_be_aws_validated
     only_localstack = pytest.mark.only_localstack
 
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -6,6 +6,14 @@ from typing import Callable, Optional
 import pytest
 
 
+class AwsCompatibilityMarkers:
+    validated = pytest.mark.aws_validated
+    manual_setup_required = pytest.mark.aws__manual_setup_required  # implies aws_validated
+    needs_fixing = pytest.mark.aws__needs_fixing
+    only_localstack = pytest.mark.aws__only_localstack
+    unknown = pytest.mark.aws__unknown
+
+
 class ParityMarkers:
     aws_validated = pytest.mark.aws_validated
     manual_setup_required = pytest.mark.manual_setup_required  # implies aws_validated
@@ -33,7 +41,8 @@ class SnapshotMarkers:
 
 
 class Markers:
-    parity = ParityMarkers
+    aws = AwsCompatibilityMarkers
+    parity = ParityMarkers  # TODO: in here for compatibility sake. Remove when -ext has been refactored to use @markers.aws.*
     snapshot = SnapshotMarkers
 
     multiruntime: MultiRuntimeMarker = pytest.mark.multiruntime

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -16,8 +16,6 @@ class AwsCompatibilityMarkers:
 
 class ParityMarkers:
     aws_validated = pytest.mark.aws_validated
-    manual_setup_required = pytest.mark.manual_setup_required  # implies aws_validated
-    should_be_aws_validated = pytest.mark.should_be_aws_validated
     only_localstack = pytest.mark.only_localstack
 
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -7,19 +7,20 @@ import pytest
 
 
 class AwsCompatibilityMarkers:
-    validated = (
-        pytest.mark.aws_validated
-    )  # test has been successfully run against AWS, ideally multiple times
-    manual_setup_required = (
-        pytest.mark.aws_manual_setup_required
-    )  # implies aws_validated. test needs additional setup, configuration or some other steps not included in the test setup itself
-    needs_fixing = (
-        pytest.mark.aws_needs_fixing
-    )  # fails against AWS but should be made runnable against AWS in the future, basically a TODO
-    only_localstack = pytest.mark.aws_only_localstack  # only runnable against localstack by design
-    unknown = (
-        pytest.mark.aws_unknown
-    )  # it's unknown if the test works (reliably) against AWS or not
+    # test has been successfully run against AWS, ideally multiple times
+    validated = pytest.mark.aws_validated
+
+    # implies aws_validated. test needs additional setup, configuration or some other steps not included in the test setup itself
+    manual_setup_required = pytest.mark.aws_manual_setup_required
+
+    # fails against AWS but should be made runnable against AWS in the future, basically a TODO
+    needs_fixing = pytest.mark.aws_needs_fixing
+
+    # only runnable against localstack by design
+    only_localstack = pytest.mark.aws_only_localstack
+
+    # it's unknown if the test works (reliably) against AWS or not
+    unknown = pytest.mark.aws_unknown
 
 
 class ParityMarkers:

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -7,7 +7,7 @@ import pytest
 
 
 class AwsCompatibilityMarkers:
-    validated = pytest.mark.aws_validated
+    validated = pytest.mark.aws__validated
     manual_setup_required = pytest.mark.aws__manual_setup_required  # implies aws_validated
     needs_fixing = pytest.mark.aws__needs_fixing
     only_localstack = pytest.mark.aws__only_localstack

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -1,7 +1,7 @@
 """
 Custom pytest mark typings
 """
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 import pytest
 
@@ -25,14 +25,14 @@ class SkipSnapshotVerifyMarker:
     def __call__(
         self,
         *,
-        paths: "Optional[list[str]]" = None,
+        paths: "Optional[List[str]]" = None,
         condition: "Optional[Callable[[...], bool]]" = None
     ):
         ...
 
 
 class MultiRuntimeMarker:
-    def __call__(self, *, scenario: str, runtimes: Optional[list[str]] = None):
+    def __call__(self, *, scenario: str, runtimes: Optional[List[str]] = None):
         ...
 
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -7,11 +7,19 @@ import pytest
 
 
 class AwsCompatibilityMarkers:
-    validated = pytest.mark.aws__validated
-    manual_setup_required = pytest.mark.aws__manual_setup_required  # implies aws_validated
-    needs_fixing = pytest.mark.aws__needs_fixing
-    only_localstack = pytest.mark.aws__only_localstack
-    unknown = pytest.mark.aws__unknown
+    validated = (
+        pytest.mark.aws_validated
+    )  # test has been successfully run against AWS, ideally multiple times
+    manual_setup_required = (
+        pytest.mark.aws_manual_setup_required
+    )  # implies aws_validated. test needs additional setup, configuration or some other steps not included in the test setup itself
+    needs_fixing = (
+        pytest.mark.aws_needs_fixing
+    )  # fails against AWS but should be made runnable against AWS in the future, basically a TODO
+    only_localstack = pytest.mark.aws_only_localstack  # only runnable against localstack by design
+    unknown = (
+        pytest.mark.aws_unknown
+    )  # it's unknown if the test works (reliably) against AWS or not
 
 
 class ParityMarkers:

--- a/tests/aws/awslambda/test_lambda_common.py
+++ b/tests/aws/awslambda/test_lambda_common.py
@@ -59,7 +59,7 @@ class TestLambdaRuntimesCommon:
     # * Create a generic parametrizable Makefile per runtime (possibly with an option to provide a specific one)
 
     @markers.parity.aws_validated
-    @pytest.mark.multiruntime(scenario="echo")
+    @markers.multiruntime(scenario="echo")
     def test_echo_invoke(self, multiruntime_lambda, aws_client):
         # provided lambdas take a little longer for large payloads, hence timeout to 5s
         create_function_result = multiruntime_lambda.create_function(MemorySize=1024, Timeout=5)
@@ -138,7 +138,7 @@ class TestLambdaRuntimesCommon:
         ]
     )
     @markers.parity.aws_validated
-    @pytest.mark.multiruntime(scenario="introspection")
+    @markers.multiruntime(scenario="introspection")
     def test_introspection_invoke(self, multiruntime_lambda, snapshot, aws_client):
         create_function_result = multiruntime_lambda.create_function(
             MemorySize=1024, Environment={"Variables": {"TEST_KEY": "TEST_VAL"}}
@@ -176,7 +176,7 @@ class TestLambdaRuntimesCommon:
         ]
     )
     @markers.parity.aws_validated
-    @pytest.mark.multiruntime(scenario="uncaughtexception")
+    @markers.multiruntime(scenario="uncaughtexception")
     def test_uncaught_exception_invoke(self, multiruntime_lambda, snapshot, aws_client):
         # unfortunately the stack trace is quite unreliable and changes when AWS updates the runtime transparently
         # since the stack trace contains references to internal runtime code.
@@ -206,7 +206,7 @@ class TestLambdaRuntimesCommon:
     @markers.parity.aws_validated
     # this does only work on al2 lambdas, except provided.al2.
     # Source: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
-    @pytest.mark.multiruntime(
+    @markers.multiruntime(
         scenario="introspection",
         runtimes=["nodejs"],
         # runtimes=["nodejs", "python3.8", "python3.9", "java8.al2", "java11", "dotnet", "ruby"],
@@ -259,7 +259,7 @@ class TestLambdaRuntimesCommon:
     condition=platform.machine() != "x86_64", reason="build process doesn't support arm64 right now"
 )
 class TestLambdaCallingLocalstack:
-    @pytest.mark.multiruntime(
+    @markers.multiruntime(
         scenario="endpointinjection",
         runtimes=[
             "nodejs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,29 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
+        "only_in_docker: mark the test as running only in Docker (e.g., requires installation of system packages)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "resource_heavy: mark the test as resource-heavy, e.g., downloading very large external dependencies, "
+        "or requiring high amount of RAM/CPU (can be systematically sampled/optimized in the future)",
+    )
+    config.addinivalue_line(
+        "markers",
         "aws_validated: mark the test as validated / verified against real AWS",
+    )
+
+    config.addinivalue_line(
+        "markers",
+        "only_localstack: mark the test as inherently incompatible with AWS, e.g. when testing localstack-specific features",
+    )
+    config.addinivalue_line(
+        "markers",
+        "should_be_aws_validated: test fails against AWS but it shouldn't. Might need refactoring, additional permissions, etc.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "manual_setup_required: validated against real AWS but needs additional setup or account configuration (e.g. increased service quotas)",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,10 @@ def pytest_configure(config):
         "markers",
         "manual_setup_required: validated against real AWS but needs additional setup or account configuration (e.g. increased service quotas)",
     )
+    config.addinivalue_line(
+        "markers",
+        "multiruntime: parametrize test against multiple Lambda runtimes",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,18 +45,21 @@ def pytest_configure(config):
         "markers",
         "aws_validated: mark the test as validated / verified against real AWS",
     )
-
     config.addinivalue_line(
         "markers",
-        "only_localstack: mark the test as inherently incompatible with AWS, e.g. when testing localstack-specific features",
+        "aws_only_localstack: mark the test as inherently incompatible with AWS, e.g. when testing localstack-specific features",
     )
     config.addinivalue_line(
         "markers",
-        "should_be_aws_validated: test fails against AWS but it shouldn't. Might need refactoring, additional permissions, etc.",
+        "aws_needs_fixing: test fails against AWS but it shouldn't. Might need refactoring, additional permissions, etc.",
     )
     config.addinivalue_line(
         "markers",
-        "manual_setup_required: validated against real AWS but needs additional setup or account configuration (e.g. increased service quotas)",
+        "aws_manual_setup_required: validated against real AWS but needs additional setup or account configuration (e.g. increased service quotas)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "aws_unknown: it's unknown if the test works (reliably) against AWS or not",
     )
     config.addinivalue_line(
         "markers",


### PR DESCRIPTION
Introduce new aws markers `@markers.aws.*`

```python
    # test has been successfully run against AWS, ideally multiple times
    validated = pytest.mark.aws_validated

    # implies aws_validated. test needs additional setup, configuration or some other steps not included in the test setup itself
    manual_setup_required = pytest.mark.aws_manual_setup_required

    # fails against AWS but should be made runnable against AWS in the future, basically a TODO
    needs_fixing = pytest.mark.aws_needs_fixing

    # only runnable against localstack by design
    only_localstack = pytest.mark.aws_only_localstack

    # it's unknown if the test works (reliably) against AWS or not
    unknown = pytest.mark.aws_unknown
```