### PR TITLE
Add x-api-key to allowed CORS headers to enable access from Web app

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -645,11 +645,11 @@ class TemplateDeployer:
                 initialize=True,
                 action="CREATE",
             )
-        except Exception:
+        except Exception as e:
             log_method = getattr(LOG, "info")
             if config.CFN_VERBOSE_ERRORS:
                 log_method = getattr(LOG, "exception")
-            log_method("Unable to create stack %s: %s", self.stack.stack_name)
+            log_method("Unable to create stack %s: %s", self.stack.stack_name, e)
             self.stack.set_stack_status("CREATE_FAILED")
             raise
 

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -52,6 +52,7 @@ CORS_ALLOWED_HEADERS = [
     "content-type",
     "etag",
     "location",
+    # AWS specific headers
     "x-amz-acl",
     "x-amz-content-sha256",
     "x-amz-date",
@@ -62,6 +63,8 @@ CORS_ALLOWED_HEADERS = [
     "x-amz-user-agent",
     "x-amz-version-id",
     "x-amzn-requestid",
+    "x-api-key",  # for API Gateway or AppSync GraphQL request
+    # LocalStack specific headers
     "x-localstack-target",
     # for AWS SDK v3
     "amz-sdk-invocation-id",


### PR DESCRIPTION
Add `x-api-key` to the list of allowed CORS headers, to enable passing this header from the LocalStack Web app.

This header is used, among others, for API Gateway and AppSync GraphQL APIs. For AppSync, we've recently extended our resource browser to make requests directly from the Web app. Currently this requires starting LS with `EXTRA_CORS_ALLOWED_HEADERS=x-api-key` configured, and with the changes in this PR it works out of the box.

This PR also contains a minor fix for a logging statement (missing parameter for placeholder in format string), which was detected during testing.