### PR TITLE
fix ddbstreams list-streams table filtering

### DIFF
--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -142,4 +142,6 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
     ) -> ListStreamsOutput:
         store = get_dynamodbstreams_store(context.account_id, context.region)
         result = [select_from_typed_dict(Stream, res) for res in store.ddb_streams.values()]
+        if table_name:
+            result = [res for res in result if res["TableName"] == table_name]
         return ListStreamsOutput(Streams=result)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -195,9 +195,14 @@ class TestDynamoDB:
         assert table["TableArn"].startswith(expected_arn_prefix)
         assert table["LatestStreamArn"].startswith(expected_arn_prefix)
 
+        # test list_streams filtering
+        stream_tables = ddbstreams.list_streams(TableName="foo")
+        assert len(stream_tables) == 0
+
         # assert stream has been created
-        stream_tables = [s["TableName"] for s in ddbstreams.list_streams()["Streams"]]
+        stream_tables = [s["TableName"] for s in ddbstreams.list_streams(TableName=table_name)["Streams"]]
         assert table_name in stream_tables
+        assert len(stream_tables) == 1
         stream_name = get_kinesis_stream_name(table_name)
         assert stream_name in kinesis.list_streams()["StreamNames"]
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -200,7 +200,9 @@ class TestDynamoDB:
         assert len(stream_tables) == 0
 
         # assert stream has been created
-        stream_tables = [s["TableName"] for s in ddbstreams.list_streams(TableName=table_name)["Streams"]]
+        stream_tables = [
+            s["TableName"] for s in ddbstreams.list_streams(TableName=table_name)["Streams"]
+        ]
         assert table_name in stream_tables
         assert len(stream_tables) == 1
         stream_name = get_kinesis_stream_name(table_name)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -196,7 +196,7 @@ class TestDynamoDB:
         assert table["LatestStreamArn"].startswith(expected_arn_prefix)
 
         # test list_streams filtering
-        stream_tables = ddbstreams.list_streams(TableName="foo")
+        stream_tables = ddbstreams.list_streams(TableName="foo")["Streams"]
         assert len(stream_tables) == 0
 
         # assert stream has been created


### PR DESCRIPTION
Dynamodbstream's `list-streams` has a filter option on the `TableName` - [see here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodbstreams/client/list_streams.html).

this is easily double-checked with AWS, thanks to the nicely [detailed issue report](https://github.com/localstack/localstack/issues/8759):
```
$ aws dynamodb create-table --table-name 'table1' --attribute-definitions 'AttributeName=pk,AttributeType=S' 'AttributeName=sk,AttributeType=S' --key-schema 'AttributeName=pk,KeyType=HASH' 'AttributeName=sk,KeyType=RANGE'  --billing-mode PAY_PER_REQUEST
[...]
$ aws dynamodb update-table --table-name table1 --stream-specification '{"StreamEnabled": true, "StreamViewType": "NEW_AND_OLD_IMAGES"}'
[...]
$ aws dynamodbstreams list-streams --table-name=foo
{
    "Streams": []
}
```
whereas within localstack:
```
$ awslocal dynamodb create-table --table-name 'table1' --attribute-definitions 'AttributeName=pk,AttributeType=S' 'AttributeName=sk,AttributeType=S' --key-schema 'AttributeName=pk,KeyType=HASH' 'AttributeName=sk,KeyType=RANGE'  --billing-mode PAY_PER_REQUEST
[...]
$ awslocal dynamodb update-table --table-name table1 --stream-specification '{"StreamEnabled": true, "StreamViewType": "NEW_AND_OLD_IMAGES"}'
[...]
$ awslocal dynamodbstreams list-streams --table-name=foo
{
    "Streams": [
        {
            "StreamArn": "arn:aws:dynamodb:eu-central-1:000000000000:table/table1/stream/2023-07-28T17:04:04.940",
            "TableName": "table1",
            "StreamLabel": "2023-07-28T17:04:04.940"
        }
    ]
}
```

The problem here is the testing - I momentarily can't test it locally. I can use dynamodb&dynamodbstreams through CLI normally, but curiously the moment I use it within the test-suite, 6 tests break. I currently can't fix it within reasonable time.

So I'm hoping either CI is green & reviewer is happy, or if anybody else could co-author this. Thanks

fixes: #8759