### PR TITLE
improve docker integration with localstack start command

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -375,7 +375,7 @@ def _print_service_table(services: Dict[str, str]) -> None:
 
 @localstack.command(name="start", short_help="Start LocalStack")
 @click.option("--docker", is_flag=True, help="Start LocalStack in a docker container [default]")
-@click.option("--host", is_flag=True, help="Start LocalStack directly on the host (Unsupported)")
+@click.option("--host", is_flag=True, help="Start LocalStack directly on the host")
 @click.option("--no-banner", is_flag=True, help="Disable LocalStack banner", default=False)
 @click.option(
     "-d", "--detached", is_flag=True, help="Start LocalStack in the background", default=False

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import traceback
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from localstack import config
 from localstack.utils.analytics.cli import publish_invocation
@@ -375,13 +375,28 @@ def _print_service_table(services: Dict[str, str]) -> None:
 
 @localstack.command(name="start", short_help="Start LocalStack")
 @click.option("--docker", is_flag=True, help="Start LocalStack in a docker container [default]")
-@click.option("--host", is_flag=True, help="Start LocalStack directly on the host")
+@click.option("--host", is_flag=True, help="Start LocalStack directly on the host (Unsupported)")
 @click.option("--no-banner", is_flag=True, help="Disable LocalStack banner", default=False)
 @click.option(
     "-d", "--detached", is_flag=True, help="Start LocalStack in the background", default=False
 )
+@click.option(
+    "--network",
+    type=str,
+    help="The container network the LocalStack container should be started in. By default, the default docker bridge network is used.",
+    required=False,
+)
+@click.option(
+    "--env",
+    "-e",
+    help="Additional environment variables that are passed to the LocalStack container",
+    multiple=True,
+    required=False,
+)
 @publish_invocation
-def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool) -> None:
+def cmd_start(
+    docker: bool, host: bool, no_banner: bool, detached: bool, network: str = None, env: Tuple = ()
+) -> None:
     """
     Start the LocalStack runtime.
 
@@ -407,9 +422,6 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool) -> None
             console.log("starting LocalStack in host mode :laptop_computer:")
         else:
             console.log("starting LocalStack in Docker mode :whale:")
-
-    if not no_banner and not detached:
-        console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")
 
     if host:
         # call hooks to prepare host
@@ -440,10 +452,13 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool) -> None
         # call hooks to prepare host (note that this call should stay below the config overrides above)
         bootstrap.prepare_host(console)
 
+        # pass the parsed cli params to the start infra command
+        params = click.get_current_context().params
+
         if detached:
-            bootstrap.start_infra_in_docker_detached(console)
+            bootstrap.start_infra_in_docker_detached(console, params)
         else:
-            bootstrap.start_infra_in_docker()
+            bootstrap.start_infra_in_docker(console, params)
 
 
 @localstack.command(name="stop", short_help="Stop LocalStack")

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -1116,9 +1116,9 @@ class Util:
                 extra_hosts[hosts_split[0]] = hosts_split[1]
 
         if args.envs:
+            env_vars = env_vars if env_vars is not None else {}
             for env in args.envs:
                 lhs, _, rhs = env.partition("=")
-                env_vars = env_vars if env_vars is not None else {}
                 env_vars[lhs] = rhs
 
         if args.labels:

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -414,7 +414,7 @@ class CmdDockerClient(ContainerClient):
         cmd = self._docker_cmd()
         cmd += ["inspect", "--format", "{{json .}}", object_name_or_id]
         try:
-            cmd_result = run(cmd)
+            cmd_result = run(cmd, print_error=False)
         except subprocess.CalledProcessError as e:
             # note: case-insensitive comparison, to support Docker and Podman output formats
             if "no such object" in to_str(e.stdout).lower():

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -38,7 +38,7 @@ def runner():
 def test_error_handling(runner: CliRunner, monkeypatch, exception, expected_message):
     """Test different globally handled exceptions, their status code, and error message."""
 
-    def mock_call():
+    def mock_call(*args, **kwargs):
         raise exception
 
     from localstack.utils import bootstrap
@@ -88,7 +88,7 @@ def test_start_docker_is_default(runner, monkeypatch):
 
     called = threading.Event()
 
-    def mock_call():
+    def mock_call(*args, **kwargs):
         called.set()
 
     monkeypatch.setattr(bootstrap, "start_infra_in_docker", mock_call)
@@ -101,7 +101,7 @@ def test_start_host(runner, monkeypatch):
 
     called = threading.Event()
 
-    def mock_call():
+    def mock_call(*args, **kwargs):
         called.set()
 
     monkeypatch.setattr(bootstrap, "start_infra_locally", mock_call)


### PR DESCRIPTION
## Motivation

There were a few things that bothered me about the localstack start command:

* No first-class flags for operations i need often (specifying the docker network, adding environment variables), I dislike using the `DOCKER_FLAGS` for common stuff
* If the docker image is not there, localstack didn't really tell you, and would be pulled implicitly sometime during the startup procedure.
* The "Localstack Runtime Log" ruler wasn't placed correctly

## Changes

* added a `--network` and `-e` flag to `localstack start` which are handed down to the docker run command. for that i needed to hand down the CLI parameters to the plumbing
* added a check that creates the specified network if it doesn't exist yet
* added an `ensure_container_image` method that checks whether the requested container image is there, and if not, pulls it explicitly (+status indicator)
* added a console status indicator for while the localstack container is still starting up.

### Startup without docker image

Here's what the startup looks like now 

https://github.com/localstack/localstack/assets/3996682/baeaed4a-5074-4f05-b601-43e743a7db2b

### LocalStack Runtime Log Rule

Before/After (not quite the same startup procedure though, but note the rule is right before the 

![CLI-before](https://github.com/localstack/localstack/assets/3996682/b3ae49a9-8c5a-40ac-a963-8cbb6ceda92e)
![CLI-after](https://github.com/localstack/localstack/assets/3996682/4e4a4e94-4e97-4091-bf32-3caa03769106)

### Network

A custom network is much easier now. `localstack` as network could be the default at some point? (cc @cabeaulac @simonrw).

```console
python -m localstack.cli.main start --network localstack
```

```console
docker run --rm -it --network=localstack curlimages/curl http://localstack_main:4566/_localstack/health
{"services": {"acm": "available", "apigateway": "available", "cloudformation": "available", "cloudwatch": "available", "config": "available", "dynamodb": "available", "dynamodbstreams": "available", "ec2": "available", "es": "available", "events": "available", "firehose": "available", "iam": "available", "kinesis": "available", "kms": "available", "lambda": "available", "logs": "available", "opensearch": "available", "redshift": "available", "resource-groups": "available", "resourcegroupstaggingapi": "available", "route53": "available", "route53resolver": "available", "s3": "available", "s3control": "available", "secretsmanager": "available", "ses": "available", "sns": "available", "sqs": "available", "ssm": "available", "stepfunctions": "available", "sts": "available", "support": "available", "swf": "available", "transcribe": "available", "sso-admin": "available"}, "version": "2.1.1.dev"}
```


## TODO

- [x] builds on #8771