### PR TITLE
add S3 CORS test with referer header and regenerate CORS snaphots

### DIFF
--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -149,7 +149,10 @@ class S3CorsHandler(Handler):
 
                     context.operation = self._get_op_from_request(request)
                     raise AccessForbidden(
-                        message, HostId=FAKE_HOST_ID, Method="OPTIONS", ResourceType="BUCKET"
+                        message,
+                        HostId=FAKE_HOST_ID,
+                        Method=request.headers.get("Access-Control-Request-Method", "OPTIONS"),
+                        ResourceType="BUCKET",
                     )
 
                 # we return without adding any CORS headers, we could even block the request with 403 here
@@ -159,14 +162,13 @@ class S3CorsHandler(Handler):
 
         if not (rule := self.match_rules(request, rules)):
             if is_options_request:
-                ex = AccessForbidden(
-                    "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec."
-                )
-                ex.HostId = FAKE_HOST_ID
-                ex.Method = request.headers.get("Access-Control-Request-Method")
-                ex.ResourceType = "OBJECT"
                 context.operation = self._get_op_from_request(request)
-                raise ex
+                raise AccessForbidden(
+                    "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
+                    HostId=FAKE_HOST_ID,
+                    Method=request.headers.get("Access-Control-Request-Method"),
+                    ResourceType="OBJECT",
+                )
 
             if is_options_request:
                 stop_options_chain()

--- a/tests/aws/s3/test_s3_cors.snapshot.json
+++ b/tests/aws/s3/test_s3_cors.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_http_options_no_config": {
-    "recorded-date": "10-10-2022, 16:03:27",
+    "recorded-date": "31-07-2023, 18:24:51",
     "recorded-content": {
       "options-no-origin": {
         "Error": {
@@ -10,24 +10,34 @@
           "RequestId": "<request-id:1>"
         }
       },
-      "options-with-origin": {
+      "options-with-origin-and-method": {
+        "Error": {
+          "Code": "AccessForbidden",
+          "HostId": "host-id",
+          "Message": "CORSResponse: CORS is not enabled for this bucket.",
+          "Method": "PUT",
+          "RequestId": "<request-id:2>",
+          "ResourceType": "BUCKET"
+        }
+      },
+      "options-with-origin-no-method": {
         "Error": {
           "Code": "AccessForbidden",
           "HostId": "host-id",
           "Message": "CORSResponse: CORS is not enabled for this bucket.",
           "Method": "OPTIONS",
-          "RequestId": "<request-id:2>",
+          "RequestId": "<request-id:3>",
           "ResourceType": "BUCKET"
         }
       }
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_http_get_no_config": {
-    "recorded-date": "10-10-2022, 16:03:31",
+    "recorded-date": "31-07-2023, 12:31:37",
     "recorded-content": {}
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_http_options_non_existent_bucket": {
-    "recorded-date": "10-10-2022, 16:03:34",
+    "recorded-date": "31-07-2023, 12:31:40",
     "recorded-content": {
       "options-no-origin": {
         "Error": {
@@ -50,7 +60,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_match_origins": {
-    "recorded-date": "11-10-2022, 23:43:24",
+    "recorded-date": "31-07-2023, 12:31:46",
     "recorded-content": {
       "opt-no-origin": {
         "Body": {
@@ -83,7 +93,44 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:2>",
-          "x-amz-request-id": "<x-amz-request-id:2>"
+          "x-amz-request-id": "<x-amz-request-id:2>",
+          "x-amz-server-side-encryption": "AES256"
+        },
+        "StatusCode": 200
+      },
+      "opt-referer": {
+        "Body": {
+          "Error": {
+            "Code": "BadRequest",
+            "HostId": "<x-amz-id-2:3>",
+            "Message": "Insufficient information. Origin request header needed.",
+            "RequestId": "<x-amz-request-id:3>"
+          }
+        },
+        "Headers": {
+          "Connection": "close",
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:3>",
+          "x-amz-request-id": "<x-amz-request-id:3>"
+        },
+        "StatusCode": 400
+      },
+      "get-referer": {
+        "Body": "test-cors",
+        "Headers": {
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:4>",
+          "x-amz-request-id": "<x-amz-request-id:4>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -98,8 +145,8 @@
           "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:3>",
-          "x-amz-request-id": "<x-amz-request-id:3>"
+          "x-amz-id-2": "<x-amz-id-2:5>",
+          "x-amz-request-id": "<x-amz-request-id:5>"
         },
         "StatusCode": 200
       },
@@ -118,8 +165,9 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:4>",
-          "x-amz-request-id": "<x-amz-request-id:4>"
+          "x-amz-id-2": "<x-amz-id-2:6>",
+          "x-amz-request-id": "<x-amz-request-id:6>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -127,10 +175,10 @@
         "Body": {
           "Error": {
             "Code": "AccessForbidden",
-            "HostId": "<x-amz-id-2:5>",
+            "HostId": "<x-amz-id-2:7>",
             "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
             "Method": "PUT",
-            "RequestId": "<x-amz-request-id:5>",
+            "RequestId": "<x-amz-request-id:7>",
             "ResourceType": "OBJECT"
           }
         },
@@ -139,8 +187,8 @@
           "Transfer-Encoding": "chunked",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:5>",
-          "x-amz-request-id": "<x-amz-request-id:5>"
+          "x-amz-id-2": "<x-amz-id-2:7>",
+          "x-amz-request-id": "<x-amz-request-id:7>"
         },
         "StatusCode": 403
       },
@@ -154,8 +202,9 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:6>",
-          "x-amz-request-id": "<x-amz-request-id:6>"
+          "x-amz-id-2": "<x-amz-id-2:8>",
+          "x-amz-request-id": "<x-amz-request-id:8>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -169,8 +218,8 @@
           "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:7>",
-          "x-amz-request-id": "<x-amz-request-id:7>"
+          "x-amz-id-2": "<x-amz-id-2:9>",
+          "x-amz-request-id": "<x-amz-request-id:9>"
         },
         "StatusCode": 200
       },
@@ -188,15 +237,16 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:8>",
-          "x-amz-request-id": "<x-amz-request-id:8>"
+          "x-amz-id-2": "<x-amz-id-2:10>",
+          "x-amz-request-id": "<x-amz-request-id:10>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       }
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_match_methods": {
-    "recorded-date": "20-10-2022, 23:02:45",
+    "recorded-date": "31-07-2023, 12:34:36",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -225,7 +275,8 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:2>",
-          "x-amz-request-id": "<x-amz-request-id:2>"
+          "x-amz-request-id": "<x-amz-request-id:2>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -245,7 +296,8 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:3>",
-          "x-amz-request-id": "<x-amz-request-id:3>"
+          "x-amz-request-id": "<x-amz-request-id:3>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -278,14 +330,15 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:5>",
-          "x-amz-request-id": "<x-amz-request-id:5>"
+          "x-amz-request-id": "<x-amz-request-id:5>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       }
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
-    "recorded-date": "20-10-2022, 22:58:38",
+    "recorded-date": "31-07-2023, 12:34:42",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -337,7 +390,8 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:3>",
-          "x-amz-request-id": "<x-amz-request-id:3>"
+          "x-amz-request-id": "<x-amz-request-id:3>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -390,7 +444,8 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:6>",
-          "x-amz-request-id": "<x-amz-request-id:6>"
+          "x-amz-request-id": "<x-amz-request-id:6>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       },
@@ -410,14 +465,15 @@
           "date": "date",
           "server": "<server:1>",
           "x-amz-id-2": "<x-amz-id-2:7>",
-          "x-amz-request-id": "<x-amz-request-id:7>"
+          "x-amz-request-id": "<x-amz-request-id:7>",
+          "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
       }
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_get_cors": {
-    "recorded-date": "24-10-2022, 14:11:39",
+    "recorded-date": "31-07-2023, 12:31:54",
     "recorded-content": {
       "get-cors-no-set": {
         "Error": {
@@ -449,7 +505,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_put_cors": {
-    "recorded-date": "25-10-2022, 11:17:15",
+    "recorded-date": "31-07-2023, 12:31:56",
     "recorded-content": {
       "put-cors": {
         "ResponseMetadata": {
@@ -485,7 +541,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_put_cors_default_values": {
-    "recorded-date": "24-10-2022, 14:31:24",
+    "recorded-date": "31-07-2023, 12:34:48",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -525,7 +581,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_put_cors_invalid_rules": {
-    "recorded-date": "28-10-2022, 15:57:45",
+    "recorded-date": "31-07-2023, 12:31:59",
     "recorded-content": {
       "put-cors-exc": {
         "Error": {
@@ -550,7 +606,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_delete_cors": {
-    "recorded-date": "24-10-2022, 14:44:10",
+    "recorded-date": "31-07-2023, 12:32:03",
     "recorded-content": {
       "delete-cors-before-set": {
         "ResponseMetadata": {
@@ -600,7 +656,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_cors_expose_headers": {
-    "recorded-date": "24-10-2022, 15:11:01",
+    "recorded-date": "31-07-2023, 12:34:45",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -620,7 +676,7 @@
     }
   },
   "tests/aws/s3/test_s3_cors.py::TestS3Cors::test_put_cors_empty_origin": {
-    "recorded-date": "25-10-2022, 11:57:55",
+    "recorded-date": "31-07-2023, 12:32:01",
     "recorded-content": {
       "get-cors-empty": {
         "CORSRules": [


### PR DESCRIPTION
Following a support case, added a test case validating that AWS does not return CORS headers if no `Origin` header is present, even if the `referer` one is there.

I took the opportunity to regenerate the snapshots, knowing there was now an issue regarding ACL, so I've added a new fixture to allow ACL on bucket. Something changed on AWS side, so I've fixed a small field for an Exception returned. 

Also refactored a bit the code to use the fix made in #6865, allowing us to add fields to the exception at instantiation as parameters and not by attaching them directly to the exception object like before. 

\cc @steffyP for the snapshot regeneration/fixture allowing AWS tests