### PR TITLE
upgrade kinesis-mock to scalajs release, add node installer

### DIFF
--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -2,14 +2,16 @@ import logging
 import os
 from abc import ABC
 from functools import lru_cache
+from typing import Optional
 
 import requests
 
 from localstack import config
 
 from ..utils.archives import download_and_extract
-from ..utils.files import chmod_r, mkdir, rm_rf
+from ..utils.files import chmod_r, chown_r, mkdir, rm_rf
 from ..utils.http import download
+from ..utils.run import is_root, run
 from .api import InstallTarget, PackageException, PackageInstaller
 
 LOG = logging.getLogger(__name__)
@@ -178,3 +180,52 @@ class GitHubReleaseInstaller(PermissionDownloadInstaller):
         :return: name of the asset to download from the GitHub project's tag / version
         """
         raise NotImplementedError()
+
+
+class NodePackageInstaller(ExecutableInstaller):
+    """Package installer for Node / NPM packages."""
+
+    def __init__(
+        self,
+        package_name: str,
+        version: str,
+        package_spec: Optional[str] = None,
+        main_module: str = "main.js",
+    ):
+        """
+        Initializes the Node / NPM package installer.
+        :param package_name: npm package name
+        :param version: version of the package which should be installed
+        :param package_spec: optional package spec for the installation.
+                If not set, the package name and version will be used for the installation.
+        :param main_module: main module file of the package
+        """
+        super().__init__(package_name, version)
+        self.package_name = package_name
+        # If the package spec is not explicitly set (f.e. to a repo), we build it and pin the version
+        self.package_spec = package_spec or f"{self.package_name}@{version}"
+        self.main_module = main_module
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "node_modules", self.package_name, self.main_module)
+
+    def _install(self, target: InstallTarget) -> None:
+        target_dir = self._get_install_dir(target)
+
+        run(
+            [
+                "npm",
+                "install",
+                "--prefix",
+                target_dir,
+                self.package_spec,
+            ]
+        )
+        # npm 9+ does _not_ set the ownership of files anymore if run as root
+        # - https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/
+        # - https://github.com/npm/cli/pull/5704
+        # - https://github.com/localstack/localstack/issues/7620
+        if is_root():
+            # if the package was installed as root, set the ownership manually
+            LOG.debug("Setting ownership root:root on %s", target_dir)
+            chown_r(target_dir, "root")

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -5,13 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 from localstack import config
 from localstack.services.kinesis.packages import kinesismock_package
-from localstack.utils.common import (
-    TMP_THREADS,
-    ShellCommandThread,
-    chmod_r,
-    get_free_tcp_port,
-    mkdir,
-)
+from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 
@@ -26,7 +20,7 @@ class KinesisMockServer(Server):
     def __init__(
         self,
         port: int,
-        bin_path: str,
+        js_path: str,
         latency: str,
         account_id: str,
         host: str = "localhost",
@@ -39,7 +33,7 @@ class KinesisMockServer(Server):
         self._initialize_streams = initialize_streams
         self._data_dir = data_dir
         self._data_filename = f"{self._account_id}.json"
-        self._bin_path = bin_path
+        self._js_path = js_path
         self._log_level = log_level
         super().__init__(port, host)
 
@@ -63,6 +57,8 @@ class KinesisMockServer(Server):
         Helper method for creating kinesis mock invocation command
         :return: returns a tuple containing the command list and a dictionary with the environment variables
         """
+        # TODO handle KINESIS_MOCK_CERT_PATH
+
         env_vars = {
             "KINESIS_MOCK_PLAIN_PORT": self.port,
             # Each kinesis-mock instance listens to two ports - secure and insecure.
@@ -95,14 +91,7 @@ class KinesisMockServer(Server):
             env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
 
         env_vars["LOG_LEVEL"] = self._log_level
-        if self._initialize_streams:
-            env_vars["INITIALIZE_STREAMS"] = self._initialize_streams
-
-        if self._bin_path.endswith(".jar"):
-            cmd = ["java", "-XX:+UseG1GC", "-jar", self._bin_path]
-        else:
-            chmod_r(self._bin_path, 0o777)
-            cmd = [self._bin_path, "--gc=G1"]
+        cmd = ["node", self._js_path]
         return cmd, env_vars
 
     def _log_listener(self, line, **_kwargs):
@@ -149,12 +138,11 @@ class KinesisServerManager:
         """
         port = get_free_tcp_port()
         kinesismock_package.install()
-        kinesis_mock_bin_path = kinesismock_package.get_installer().get_executable_path()
+        kinesis_mock_js_path = kinesismock_package.get_installer().get_executable_path()
 
         # kinesis-mock stores state in json files <account_id>.json, so we can dump everything into `kinesis/`
         persist_path = os.path.join(config.dirs.data, "kinesis")
         mkdir(persist_path)
-
         if config.LS_LOG:
             if config.LS_LOG == "warning":
                 log_level = "WARN"
@@ -162,7 +150,6 @@ class KinesisServerManager:
                 log_level = config.LS_LOG.upper()
         else:
             log_level = "INFO"
-
         latency = config.KINESIS_LATENCY + "ms"
         initialize_streams = (
             config.KINESIS_INITIALIZE_STREAMS if config.KINESIS_INITIALIZE_STREAMS else None
@@ -170,7 +157,7 @@ class KinesisServerManager:
 
         server = KinesisMockServer(
             port=port,
-            bin_path=kinesis_mock_bin_path,
+            js_path=kinesis_mock_js_path,
             log_level=log_level,
             latency=latency,
             initialize_streams=initialize_streams,

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -88,7 +88,9 @@ class KinesisMockServer(Server):
 
         if self._data_dir:
             env_vars["SHOULD_PERSIST_DATA"] = "true"
-            env_vars["PERSIST_PATH"] = self._data_dir
+            # FIXME use relative path to current working directory until
+            #  https://github.com/etspaceman/kinesis-mock/issues/554 is resolved
+            env_vars["PERSIST_PATH"] = os.path.relpath(self._data_dir)
             env_vars["PERSIST_FILE_NAME"] = self._data_filename
             env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
 

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -1,2 +1,0 @@
-# FIXME: remove once ext is refactored to no longer use this
-_SERVERS = {}

--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -5,7 +5,7 @@ from typing import List
 from localstack.packages import Package, PackageInstaller
 from localstack.packages.core import NodePackageInstaller
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.1"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.2"
 
 
 class KinesisMockPackage(Package):

--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -2,11 +2,10 @@ import os
 from functools import lru_cache
 from typing import List
 
-from localstack import config
-from localstack.packages import GitHubReleaseInstaller, Package, PackageInstaller
-from localstack.utils.platform import get_arch, get_os
+from localstack.packages import Package, PackageInstaller
+from localstack.packages.core import NodePackageInstaller
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.10"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.1"
 
 
 class KinesisMockPackage(Package):
@@ -21,28 +20,9 @@ class KinesisMockPackage(Package):
         return [_KINESIS_MOCK_VERSION]
 
 
-class KinesisMockPackageInstaller(GitHubReleaseInstaller):
+class KinesisMockPackageInstaller(NodePackageInstaller):
     def __init__(self, version: str):
-        super().__init__("kinesis-mock", version, "etspaceman/kinesis-mock")
-
-    def _get_github_asset_name(self):
-        arch = get_arch()
-        operating_system = get_os()
-        if config.is_env_true("KINESIS_MOCK_FORCE_JAVA"):
-            # sometimes the static binaries may have problems, and we want to fal back to Java
-            bin_file = "kinesis-mock.jar"
-        elif arch == "amd64":
-            if operating_system == "windows":
-                bin_file = "kinesis-mock-mostly-static.exe"
-            elif operating_system == "linux":
-                bin_file = "kinesis-mock-linux-amd64-static"
-            elif operating_system == "osx":
-                bin_file = "kinesis-mock-macos-amd64-dynamic"
-            else:
-                bin_file = "kinesis-mock.jar"
-        else:
-            bin_file = "kinesis-mock.jar"
-        return bin_file
+        super().__init__(package_name="kinesis-local", version=version)
 
 
 kinesismock_package = KinesisMockPackage()


### PR DESCRIPTION
This PR upgrades `kinesis-mock` to the new version `0.4.1`, which migrates to ScalaJS (with https://github.com/etspaceman/kinesis-mock/pull/531).
It creates a new `NodePackageInstaller` which handles the installation of `npm` packages in LocalStack.

Thanks to @etspaceman for the heads-up, and the discussions prior to the release!
Fixes #8680