### PR TITLE
Remove GenericBaseModel.get_cfn_attribute and improve stack failure reporting

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -150,11 +150,13 @@ class Stack:
             result.setdefault(attr, [])
         return result
 
-    def set_stack_status(self, status):
+    def set_stack_status(self, status: str, status_reason: Optional[str] = None):
         self.metadata["StackStatus"] = status
         if "FAILED" in status:
-            self.metadata["StackStatusReason"] = "Deployment failed"
-        self.add_stack_event(self.stack_name, self.stack_id, status)
+            self.metadata["StackStatusReason"] = status_reason or "Deployment failed"
+        self.add_stack_event(
+            self.stack_name, self.stack_id, status, status_reason=status_reason or ""
+        )
 
     def set_time_attribute(self, attribute, new_time=None):
         self.metadata[attribute] = new_time or timestamp_millis()

--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -22,23 +22,23 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
 VALID_GETATT_PROPERTIES = {
     # Other Examples
     # "AWS::ApiGateway::Resource": ["ResourceId"],
-    "AWS::IAM::User": ["Arn"],  # TODO: not validated yet
-    "AWS::SSM::Parameter": ["Type", "Value"],  # TODO: not validated yet
-    "AWS::OpenSearchService::Domain": [
-        "AdvancedSecurityOptions.AnonymousAuthDisableDate",
-        "Arn",
-        "DomainArn",
-        "DomainEndpoint",
-        "DomainEndpoints",
-        "Id",
-        "ServiceSoftwareOptions",
-        "ServiceSoftwareOptions.AutomatedUpdateDate",
-        "ServiceSoftwareOptions.Cancellable",
-        "ServiceSoftwareOptions.CurrentVersion",
-        "ServiceSoftwareOptions.Description",
-        "ServiceSoftwareOptions.NewVersion",
-        "ServiceSoftwareOptions.OptionalDeployment",
-        "ServiceSoftwareOptions.UpdateAvailable",
-        "ServiceSoftwareOptions.UpdateStatus",
-    ],  # TODO: not validated yet
+    # "AWS::IAM::User": ["Arn"],  # TODO: not validated yet
+    # "AWS::SSM::Parameter": ["Type", "Value"],  # TODO: not validated yet
+    # "AWS::OpenSearchService::Domain": [
+    #     "AdvancedSecurityOptions.AnonymousAuthDisableDate",
+    #     "Arn",
+    #     "DomainArn",
+    #     "DomainEndpoint",
+    #     "DomainEndpoints",
+    #     "Id",
+    #     "ServiceSoftwareOptions",
+    #     "ServiceSoftwareOptions.AutomatedUpdateDate",
+    #     "ServiceSoftwareOptions.Cancellable",
+    #     "ServiceSoftwareOptions.CurrentVersion",
+    #     "ServiceSoftwareOptions.Description",
+    #     "ServiceSoftwareOptions.NewVersion",
+    #     "ServiceSoftwareOptions.OptionalDeployment",
+    #     "ServiceSoftwareOptions.UpdateAvailable",
+    #     "ServiceSoftwareOptions.UpdateStatus",
+    # ],  # TODO: not validated yet
 }

--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -23,7 +23,7 @@ VALID_GETATT_PROPERTIES = {
     # Other Examples
     # "AWS::ApiGateway::Resource": ["ResourceId"],
     # "AWS::IAM::User": ["Arn"],  # TODO: not validated yet
-    # "AWS::SSM::Parameter": ["Type", "Value"],  # TODO: not validated yet
+    "AWS::SSM::Parameter": ["Type", "Value"],  # TODO: not validated yet
     # "AWS::OpenSearchService::Domain": [
     #     "AdvancedSecurityOptions.AnonymousAuthDisableDate",
     #     "Arn",

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -78,25 +78,6 @@ class GenericBaseModel:
         """Set any defaults required, including auto-generating names. Must be called before deploying the resource"""
         pass
 
-    # ----------------------
-    # GENERIC BASE METHODS
-    # ----------------------
-
-    def get_cfn_attribute(self, attribute_name):
-        """Retrieve the given CF attribute for this resource"""
-        attribute_candidate = self.props.get(attribute_name)
-        if "." in attribute_name:
-            if attribute_candidate:
-                # in case we explicitly add a property with a dot, e.g. resource["Properties"]["Endpoint.Port"]
-                return attribute_candidate
-            parts = attribute_name.split(".")
-            attribute = self.props
-            for part in parts:
-                attribute = attribute.get(part)
-            return attribute
-
-        return attribute_candidate
-
     # ---------------------
     # GENERIC UTIL METHODS
     # ---------------------

--- a/tests/integration/cloudformation/engine/test_attributes.py
+++ b/tests/integration/cloudformation/engine/test_attributes.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.testing.pytest.fixtures import StackDeployError
+
+
+class TestResourceAttributes:
+    @markers.snapshot.skip_snapshot_verify
+    @markers.parity.aws_validated
+    def test_invalid_getatt_fails(self, aws_client, deploy_cfn_template, snapshot):
+        """
+        Check how CloudFormation behaves on invalid attribute names for resources in a Fn::GetAtt
+
+        Not yet completely correct yet since this should actually initiate a rollback and the stack resource status should be set accordingly
+        """
+        snapshot.add_transformer(snapshot.transform.cloudformation_api())
+        with pytest.raises(StackDeployError) as exc_info:
+            deploy_cfn_template(
+                template_path=os.path.join(
+                    os.path.dirname(__file__), "../../templates/engine/cfn_invalid_getatt.yaml"
+                )
+            )
+        stack_events = exc_info.value.events
+        snapshot.match("stack_events", {"events": stack_events})

--- a/tests/integration/cloudformation/engine/test_attributes.snapshot.json
+++ b/tests/integration/cloudformation/engine/test_attributes.snapshot.json
@@ -1,0 +1,54 @@
+{
+  "tests/integration/cloudformation/engine/test_attributes.py::TestResourceAttributes::test_invalid_getatt_fails": {
+    "recorded-date": "01-08-2023, 11:54:31",
+    "recorded-content": {
+      "stack_events": {
+        "events": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "ROLLBACK_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "ROLLBACK_IN_PROGRESS",
+            "ResourceStatusReason": "[Error] /Outputs/InvalidOutput/Value/Fn::GetAtt: Resource type AWS::SSM::Parameter does not support attribute {Invalid}. Rollback requested by user.",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration/templates/engine/cfn_invalid_getatt.yaml
+++ b/tests/integration/templates/engine/cfn_invalid_getatt.yaml
@@ -1,0 +1,10 @@
+Resources:
+  MyResource:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: unimportant
+
+Outputs:
+  InvalidOutput:
+    Value: !GetAtt MyResource.Invalid


### PR DESCRIPTION
## Changes
- Remove `GenericBaseModel.get_cfn_attribute` and unify code paths between legacy and new providers
- Improve stack failure reporting a tiny bit


Previously the ResourceStatusReason on the stack failure was empty, now it's set to the string representation of the caught exception. This is currently only enabled when CFN_VERBOSE_ERRORS is set though. We should probably make this the default though in the next minor release to increase parity. 

New stack status:
```
{"LogicalResourceId": "stack-9645eb0a", "ResourceType": "AWS::CloudFormation::Stack", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Resource type AWS::SSM::Parameter does not support attribute {Invalid}"}
```

We might also want to by start failing stacks by default when outputs can't be resolved but since this differs quite a bit from the current behavior I think we should have a deprecation path for this.