### PR TITLE
add S3 native bucket encryption and AWS key managed key

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -587,7 +587,7 @@ class BucketAlreadyExists(ServiceException):
 class BucketAlreadyOwnedByYou(ServiceException):
     code: str = "BucketAlreadyOwnedByYou"
     sender_fault: bool = False
-    status_code: int = 400
+    status_code: int = 409
     BucketName: Optional[BucketName]
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -107,6 +107,13 @@
     },
     {
       "op": "add",
+      "path": "/shapes/BucketAlreadyOwnedByYou/error",
+      "value": {
+        "httpStatusCode": 409
+      }
+    },
+    {
+      "op": "add",
       "path": "/shapes/GetObjectOutput/members/StatusCode",
       "value": {
         "shape": "GetObjectResponseStatusCode",

--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -1,4 +1,12 @@
-from localstack.aws.api.s3 import BucketCannedACL, ObjectCannedACL, Permission, StorageClass
+from localstack.aws.api.s3 import (
+    BucketCannedACL,
+    ObjectCannedACL,
+    Permission,
+    ServerSideEncryption,
+    ServerSideEncryptionByDefault,
+    ServerSideEncryptionRule,
+    StorageClass,
+)
 
 S3_VIRTUAL_HOST_FORWARDED_HEADER = "x-s3-vhost-forwarded-for"
 
@@ -94,3 +102,10 @@ SIGNATURE_V4_PARAMS = [
 # This is AWS recommended size when uploading chunks
 # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
 S3_CHUNK_SIZE = 65536
+
+DEFAULT_BUCKET_ENCRYPTION = ServerSideEncryptionRule(
+    ApplyServerSideEncryptionByDefault=ServerSideEncryptionByDefault(
+        SSEAlgorithm=ServerSideEncryption.AES256,
+    ),
+    BucketKeyEnabled=False,
+)

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -2591,6 +2591,12 @@ class TestS3:
         assert chunk_size == len(content)
         snapshot.match("get-object", resp)
 
+        range_header = f"bytes={chunk_size}-2048"
+        resp = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key, Range=range_header)
+        content = resp["Body"].read()
+        assert chunk_size == len(content)
+        snapshot.match("get-object-2", resp)
+
     @markers.aws.validated
     def test_download_fileobj_multiple_range_requests(self, s3_bucket, aws_client):
         object_key = "test-download_fileobj"
@@ -3675,11 +3681,10 @@ class TestS3:
         rs = aws_client.s3.get_object(Bucket=bucket_name, Key=object_key)
         snapshot.match("get_object", rs)
 
-        range_content = 17
         rs = aws_client.s3.get_object(
             Bucket=bucket_name,
             Key=object_key,
-            Range=f"bytes=0-{range_content-1}",
+            Range="bytes=0-16",
         )
         snapshot.match("get_object_range", rs)
 

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -1362,13 +1362,28 @@
     }
   },
   "tests/aws/s3/test_s3.py::TestS3::test_range_header_body_length": {
-    "recorded-date": "03-08-2023, 04:16:36",
+    "recorded-date": "07-08-2023, 16:17:23",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
         "Body": "",
         "ContentLength": 1024,
         "ContentRange": "bytes 0-1023/2048",
+        "ContentType": "binary/octet-stream",
+        "ETag": "<e-tag:1>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-object-2": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentLength": 1024,
+        "ContentRange": "bytes 1024-2047/2048",
         "ContentType": "binary/octet-stream",
         "ETag": "<e-tag:1>",
         "LastModified": "datetime",

--- a/tests/aws/s3/test_s3_api.py
+++ b/tests/aws/s3/test_s3_api.py
@@ -500,7 +500,7 @@ class TestS3BucketVersioning:
     reason="These are WIP tests for the new native S3 provider",
 )
 class TestS3BucketEncryption:
-    @markers.parity.aws_validated
+    @markers.aws.validated
     def test_s3_default_bucket_encryption(self, s3_bucket, aws_client, snapshot):
         get_default_encryption = aws_client.s3.get_bucket_encryption(Bucket=s3_bucket)
         snapshot.match("default-bucket-encryption", get_default_encryption)
@@ -514,6 +514,7 @@ class TestS3BucketEncryption:
         bucket_versioning = aws_client.s3.get_bucket_versioning(Bucket=s3_bucket)
         snapshot.match("get-bucket-no-encryption", bucket_versioning)
 
+    @markers.aws.validated
     def test_s3_default_bucket_encryption_exc(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         fake_bucket = f"fakebucket-{short_uid()}-{short_uid()}"
@@ -574,6 +575,7 @@ class TestS3BucketEncryption:
             )
         snapshot.match("put-bucket-encryption-kms-with-aes", e.value.response)
 
+    @markers.aws.validated
     def test_s3_bucket_encryption_sse_s3(self, s3_bucket, aws_client, snapshot):
         # AES256 is already the default
         # so set something with the BucketKey, which should only be set for KMS, to see if it returns
@@ -604,7 +606,7 @@ class TestS3BucketEncryption:
         get_object_encrypted = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
         snapshot.match("get-object-encrypted", get_object_encrypted)
 
-    @markers.parity.aws_validated
+    @markers.aws.validated
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
     def test_s3_bucket_encryption_sse_kms(self, s3_bucket, kms_key, aws_client, snapshot):
@@ -640,7 +642,7 @@ class TestS3BucketEncryption:
         get_object_encrypted = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
         snapshot.match("get-object-encrypted", get_object_encrypted)
 
-    @markers.parity.aws_validated
+    @markers.aws.validated
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(
         paths=[

--- a/tests/aws/s3/test_s3_api.py
+++ b/tests/aws/s3/test_s3_api.py
@@ -9,11 +9,17 @@ from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.strings import short_uid
 
 
+def is_native_provider():
+    return config.NATIVE_S3_PROVIDER
+
+
 @pytest.mark.skipif(
     condition=not config.NATIVE_S3_PROVIDER,
     reason="These are WIP tests for the new native S3 provider",
 )
-@markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])  # TODO: encryption
+@markers.snapshot.skip_snapshot_verify(
+    condition=lambda: not is_native_provider(), paths=["$..ServerSideEncryption"]
+)
 class TestS3BucketCRUD:
     @markers.aws.validated
     def test_delete_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
@@ -72,7 +78,9 @@ class TestS3BucketCRUD:
     condition=not config.NATIVE_S3_PROVIDER,
     reason="These are WIP tests for the new native S3 provider",
 )
-@markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])  # TODO: encryption
+@markers.snapshot.skip_snapshot_verify(
+    condition=lambda: not is_native_provider(), paths=["$..ServerSideEncryption"]
+)
 class TestS3ObjectCRUD:
     @markers.aws.validated
     def test_delete_object(self, s3_bucket, aws_client, snapshot):
@@ -485,3 +493,193 @@ class TestS3BucketVersioning:
         with pytest.raises(ClientError) as e:
             aws_client.s3.get_bucket_versioning(Bucket=fake_bucket)
         snapshot.match("get-versioning-no-bucket", e.value.response)
+
+
+@pytest.mark.skipif(
+    condition=not config.NATIVE_S3_PROVIDER,
+    reason="These are WIP tests for the new native S3 provider",
+)
+class TestS3BucketEncryption:
+    @markers.parity.aws_validated
+    def test_s3_default_bucket_encryption(self, s3_bucket, aws_client, snapshot):
+        get_default_encryption = aws_client.s3.get_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("default-bucket-encryption", get_default_encryption)
+
+        delete_bucket_encryption = aws_client.s3.delete_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("delete-bucket-encryption", delete_bucket_encryption)
+
+        delete_bucket_encryption_2 = aws_client.s3.delete_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("delete-bucket-encryption-idempotent", delete_bucket_encryption_2)
+
+        bucket_versioning = aws_client.s3.get_bucket_versioning(Bucket=s3_bucket)
+        snapshot.match("get-bucket-no-encryption", bucket_versioning)
+
+    def test_s3_default_bucket_encryption_exc(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        fake_bucket = f"fakebucket-{short_uid()}-{short_uid()}"
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_bucket_encryption(Bucket=fake_bucket)
+        snapshot.match("get-bucket-enc-no-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_bucket_encryption(Bucket=fake_bucket)
+        snapshot.match("delete-bucket-enc-no-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_encryption(
+                Bucket=fake_bucket, ServerSideEncryptionConfiguration={"Rules": []}
+            )
+        snapshot.match("put-bucket-enc-no-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_encryption(
+                Bucket=s3_bucket, ServerSideEncryptionConfiguration={"Rules": []}
+            )
+        snapshot.match("put-bucket-encryption-no-rules", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_encryption(
+                Bucket=s3_bucket,
+                ServerSideEncryptionConfiguration={
+                    "Rules": [
+                        {
+                            "ApplyServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "aws:kms",
+                            },
+                            "BucketKeyEnabled": True,
+                        },
+                        {
+                            "ApplyServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256",
+                            },
+                        },
+                    ]
+                },
+            )
+        snapshot.match("put-bucket-encryption-two-rules", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_encryption(
+                Bucket=s3_bucket,
+                ServerSideEncryptionConfiguration={
+                    "Rules": [
+                        {
+                            "ApplyServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256",
+                                "KMSMasterKeyID": "randomkeyid",
+                            },
+                        }
+                    ]
+                },
+            )
+        snapshot.match("put-bucket-encryption-kms-with-aes", e.value.response)
+
+    def test_s3_bucket_encryption_sse_s3(self, s3_bucket, aws_client, snapshot):
+        # AES256 is already the default
+        # so set something with the BucketKey, which should only be set for KMS, to see if it returns
+        put_bucket_enc = aws_client.s3.put_bucket_encryption(
+            Bucket=s3_bucket,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256",
+                        },
+                        "BucketKeyEnabled": True,
+                    }
+                ]
+            },
+        )
+        snapshot.match("put-bucket-enc", put_bucket_enc)
+
+        key_name = "key-encrypted"
+        put_object_encrypted = aws_client.s3.put_object(
+            Bucket=s3_bucket, Key=key_name, Body="test-encrypted"
+        )
+        snapshot.match("put-object-encrypted", put_object_encrypted)
+
+        head_object_encrypted = aws_client.s3.head_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("head-object-encrypted", head_object_encrypted)
+
+        get_object_encrypted = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("get-object-encrypted", get_object_encrypted)
+
+    @markers.parity.aws_validated
+    # there is currently no server side encryption is place in LS, ETag will be different
+    @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
+    def test_s3_bucket_encryption_sse_kms(self, s3_bucket, kms_key, aws_client, snapshot):
+
+        put_bucket_enc = aws_client.s3.put_bucket_encryption(
+            Bucket=s3_bucket,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": kms_key["KeyId"],
+                        },
+                        "BucketKeyEnabled": True,
+                    }
+                ]
+            },
+        )
+        snapshot.match("put-bucket-enc", put_bucket_enc)
+
+        get_bucket_enc = aws_client.s3.get_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("get-bucket-enc", get_bucket_enc)
+
+        key_name = "key-encrypted"
+        put_object_encrypted = aws_client.s3.put_object(
+            Bucket=s3_bucket, Key=key_name, Body="test-encrypted"
+        )
+        snapshot.match("put-object-encrypted", put_object_encrypted)
+
+        head_object_encrypted = aws_client.s3.head_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("head-object-encrypted", head_object_encrypted)
+
+        get_object_encrypted = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("get-object-encrypted", get_object_encrypted)
+
+    @markers.parity.aws_validated
+    # there is currently no server side encryption is place in LS, ETag will be different
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..ETag",
+            "$.managed-kms-key.KeyMetadata.KeyManager",  # TODO: we have no internal way to create KMS key
+        ]
+    )
+    def test_s3_bucket_encryption_sse_kms_aws_managed_key(self, s3_bucket, aws_client, snapshot):
+        # if you don't provide a KMS key, AWS will use an AWS managed one.
+        put_bucket_enc = aws_client.s3.put_bucket_encryption(
+            Bucket=s3_bucket,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                        },
+                        "BucketKeyEnabled": True,
+                    }
+                ]
+            },
+        )
+        snapshot.match("put-bucket-enc", put_bucket_enc)
+
+        get_bucket_enc = aws_client.s3.get_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("get-bucket-enc", get_bucket_enc)
+
+        key_name = "key-encrypted"
+        put_object_encrypted = aws_client.s3.put_object(
+            Bucket=s3_bucket, Key=key_name, Body="test-encrypted"
+        )
+        snapshot.match("put-object-encrypted", put_object_encrypted)
+
+        kms_key_id = put_object_encrypted["SSEKMSKeyId"]
+        kms_key_data = aws_client.kms.describe_key(KeyId=kms_key_id)
+        snapshot.match("managed-kms-key", kms_key_data)
+
+        head_object_encrypted = aws_client.s3.head_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("head-object-encrypted", head_object_encrypted)
+
+        get_object_encrypted = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("get-object-encrypted", get_object_encrypted)

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -1176,5 +1176,320 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption": {
+    "recorded-date": "02-08-2023, 00:10:29",
+    "recorded-content": {
+      "default-bucket-encryption": {
+        "ServerSideEncryptionConfiguration": {
+          "Rules": [
+            {
+              "ApplyServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              },
+              "BucketKeyEnabled": false
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-bucket-encryption": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-bucket-encryption-idempotent": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-no-encryption": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption_exc": {
+    "recorded-date": "02-08-2023, 00:12:29",
+    "recorded-content": {
+      "get-bucket-enc-no-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-bucket-enc-no-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-bucket-enc-no-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-bucket-encryption-no-rules": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-encryption-two-rules": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-encryption-kms-with-aes": {
+        "Error": {
+          "ArgumentName": "ApplyServerSideEncryptionByDefault",
+          "Code": "InvalidArgument",
+          "Message": "a KMSMasterKeyID is not applicable if the default sse algorithm is not aws:kms"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_s3": {
+    "recorded-date": "02-08-2023, 01:37:10",
+    "recorded-content": {
+      "put-bucket-enc": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-encrypted": {
+        "ETag": "\"16b66fb6b9c0e864b0291fa0dbb5a946\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"16b66fb6b9c0e864b0291fa0dbb5a946\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "Body": "test-encrypted",
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"16b66fb6b9c0e864b0291fa0dbb5a946\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms_aws_managed_key": {
+    "recorded-date": "02-08-2023, 01:48:16",
+    "recorded-content": {
+      "put-bucket-enc": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-enc": {
+        "ServerSideEncryptionConfiguration": {
+          "Rules": [
+            {
+              "ApplyServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "aws:kms"
+              },
+              "BucketKeyEnabled": true
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-encrypted": {
+        "BucketKeyEnabled": true,
+        "ETag": "\"dc1b467a7cb371279306a6f710c7ad2d\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "managed-kms-key": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "Default key that protects my S3 objects when no other key is defined",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<uuid:1>",
+          "KeyManager": "AWS",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "AWS_KMS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "BucketKeyEnabled": true,
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"dc1b467a7cb371279306a6f710c7ad2d\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "Body": "test-encrypted",
+        "BucketKeyEnabled": true,
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"dc1b467a7cb371279306a6f710c7ad2d\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms": {
+    "recorded-date": "02-08-2023, 02:06:21",
+    "recorded-content": {
+      "put-bucket-enc": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-enc": {
+        "ServerSideEncryptionConfiguration": {
+          "Rules": [
+            {
+              "ApplyServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": "<uuid:1>",
+                "SSEAlgorithm": "aws:kms"
+              },
+              "BucketKeyEnabled": true
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-encrypted": {
+        "BucketKeyEnabled": true,
+        "ETag": "\"31f9fc96ed971f30ac05dd6eb7b6c2cc\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "BucketKeyEnabled": true,
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"31f9fc96ed971f30ac05dd6eb7b6c2cc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-encrypted": {
+        "AcceptRanges": "bytes",
+        "Body": "test-encrypted",
+        "BucketKeyEnabled": true,
+        "ContentLength": 14,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"31f9fc96ed971f30ac05dd6eb7b6c2cc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR implements Bucket Encryption, and sets the new default to `AES256` like AWS does since April 2023.

It also implements a feature we've been missing, when not specifying a KMS KeyId when using `aws:kms` encryption, we're now creating and keeping the reference to the AWS managed key. We're however missing an internal way to specify that the key is "AWS managed", and not customer managed. 
