### PR TITLE
add pytest-tinybird to all CI runs on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,25 @@ executors:
     machine:
       image: << pipeline.parameters.ubuntu-amd64-machine-image >>
 
+commands:
+  prepare-pytest-tinybird:
+    steps:
+      - run:
+          name: Setup Environment Variables
+          # TODO change branch to master
+          command: |
+            if [[ $CIRCLE_BRANCH == "add-pytest-tinybird" ]] ; then
+              echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
+            fi
+            echo "export TINYBIRD_DATASOURCE=localstack-tests-circleci" >> $BASH_ENV
+            echo "export TINYBIRD_TOKEN=${TINYBIRD_CI_TOKEN}" >> $BASH_ENV
+            echo "export CI_COMMIT_BRANCH=${CIRCLE_BRANCH}" >> $BASH_ENV
+            echo "export CI_COMMIT_SHA=${CIRCLE_SHA1}" >> $BASH_ENV
+            echo "export CI_JOB_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
+            echo "export CI_JOB_NAME=${CIRCLE_JOB}" >> $BASH_ENV
+            echo "export CI_JOB_ID=${CIRCLE_WORKFLOW_JOB_ID}" >> $BASH_ENV
+            source $BASH_ENV
+
 jobs:
   install:
     executor: ubuntu-machine-amd64
@@ -60,13 +79,14 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - prepare-pytest-tinybird
       - run:
           name: Unit tests
           environment:
             TEST_PATH: "tests/unit"
-            PYTEST_ARGS: "--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests"
             COVERAGE_ARGS: "-p"
-          command: make test-coverage
+          command: |
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests" make test-coverage
       - store_test_results:
           path: target/reports/
       - run:
@@ -84,15 +104,16 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - prepare-pytest-tinybird
       - run:
           name: Test 'local' Lambda executor
           environment:
             LAMBDA_EXECUTOR: "local"
             PROVIDER_OVERRIDE_LAMBDA: "legacy"
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py tests/integration/apigateway/test_apigateway_basic.py tests/integration/cloudformation/resources/test_lambda.py"
-            PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='legacy-lambda-local'"
             COVERAGE_ARGS: "-p"
-          command: make test-coverage
+          command: |
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='legacy-lambda-local'" make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/
@@ -110,14 +131,15 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - prepare-pytest-tinybird
       - run:
           name: Test SFN V2 provider
           environment:
             PROVIDER_OVERRIDE_STEPFUNCTIONS: "v2"
             TEST_PATH: "tests/integration/stepfunctions/v2/"
-            PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/sfn_v2.xml -o junit_suite_name='sfn_v2'"
             COVERAGE_ARGS: "-p"
-          command: make test-coverage
+          command: |
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_v2.xml -o junit_suite_name='sfn_v2'" make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/
@@ -135,14 +157,15 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - prepare-pytest-tinybird
       - run:
           name: Test S3 Streaming provider
           environment:
             PROVIDER_OVERRIDE_S3: "stream"
             TEST_PATH: "tests/integration/s3/"
-            PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/s3_stream.xml -o junit_suite_name='s3_stream'"
             COVERAGE_ARGS: "-p"
-          command: make test-coverage
+          command: |
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/s3_stream.xml -o junit_suite_name='s3_stream'" make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/
@@ -229,12 +252,13 @@ jobs:
                 key: common-functions-{{ checksum "/tmp/common-functions-checksums" }}
                 paths:
                   - "tests/integration/awslambda/functions/common"
+      - prepare-pytest-tinybird
       - run:
           name: Run integration tests
           # circleci split returns newline separated list, so `tr` is necessary to prevent problems in the Makefile
           command: |
             TEST_FILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings | tr '\n' ' ')
-            PYTEST_ARGS="-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
             COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
             TEST_PATH=$TEST_FILES \
             DEBUG=1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,8 @@ commands:
     steps:
       - run:
           name: Setup Environment Variables
-          # TODO change branch to master
           command: |
-            if [[ $CIRCLE_BRANCH == "add-pytest-tinybird" ]] ; then
+            if [[ $CIRCLE_BRANCH == "master" ]] ; then
               echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
             fi
             echo "export TINYBIRD_DATASOURCE=localstack-tests-circleci" >> $BASH_ENV

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -36,6 +36,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # Set non-job-specific environment variables for pytest-tinybird
+  TINYBIRD_URL: https://api.tinybird.co
+  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-cli
+  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
+  CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # report to tinybird if executed on master
+  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+
 jobs:
   cli-tests:
     runs-on: ubuntu-latest
@@ -44,6 +56,10 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     timeout-minutes: 10
+    env:
+      # Set job-specific environment variables for pytest-tinybird
+      CI_JOB_NAME: ${{ github.job }}-${{ matrix.python-version }}
+      CI_JOB_ID: ${{ github.job }}-${{ matrix.python-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -56,9 +72,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           pip install -e .
-          pip install pytest
+          pip install pytest pytest-tinybird
       - name: Run CLI tests
         env:
-          PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s"
+          PYTEST_ADDOPTS: "${{ env.TINYBIRD_PYTEST_ARGS }}-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s"
         run: |
           python -m pytest tests/bootstrap/

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -45,8 +45,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # report to tinybird if executed on master
-  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   cli-tests:

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -30,8 +30,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # report to tinybird if executed on master
-  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   podman-tests:

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -21,10 +21,26 @@ on:
       - master
       - release/*
 
+env:
+  # Set non-job-specific environment variables for pytest-tinybird
+  TINYBIRD_URL: https://api.tinybird.co
+  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-podman
+  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
+  CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # report to tinybird if executed on master
+  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+
 jobs:
   podman-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # Set job-specific environment variables for pytest-tinybird
+      CI_JOB_NAME: ${{ github.job }}
+      CI_JOB_ID: ${{ github.job }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,9 +71,13 @@ jobs:
           wait
 
       - name: Run Podman Docker client tests
+        env:
+          DOCKER_CMD: "podman"
+          PYTEST_ARGS: "${{ env.TINYBIRD_PYTEST_ARGS }}"
+          TEST_PATH: "tests/integration/docker_utils"
+          DEBUG: "1"
         run: |
           # determine path of podman socket
           podmanSocket=$(podman system info --format json | jq -r '.host.remoteSocket.path')
           echo "Running tests against local podman socket $podmanSocket"
-
-          DOCKER_CMD=podman DOCKER_HOST=$podmanSocket TEST_PATH=tests/integration/docker_utils DEBUG=1 make test
+          DOCKER_HOST=$podmanSocket make test

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -52,8 +52,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   # report to tinybird if executed on master
-  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   test-pro:
@@ -249,8 +248,6 @@ jobs:
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
-          # TODO REMOVE - will be added to a dependency in localstack-ext
-          (source .venv/bin/activate && pip install pytest-tinybird)
           make test
 
       - name: Archive Test Results

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -43,6 +43,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # Set non-job-specific environment variables for pytest-tinybird
+  TINYBIRD_URL: https://api.tinybird.co
+  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-pro-integration
+  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
+  CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  CI_COMMIT_SHA: ${{ github.sha }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # report to tinybird if executed on master
+  # TODO change the reg to "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+
 jobs:
   test-pro:
     name: "Community Integration Tests against Pro"
@@ -52,6 +64,10 @@ jobs:
       matrix:
         group: [ 1, 2 ]
       fail-fast: false
+    env:
+      # Set job-specific environment variables for pytest-tinybird
+      CI_JOB_NAME: ${{ github.job }}
+      CI_JOB_ID: ${{ github.job }}
     steps:
       - name: Checkout Community
         uses: actions/checkout@v3
@@ -228,11 +244,13 @@ jobs:
           AWS_DEFAULT_REGION: "us-east-1"
           PYTEST_LOGLEVEL: debug
           TEST_PATH: "../localstack/tests/integration/"
-          PYTEST_ARGS: "--splits 2 --group ${{ matrix.group }} --capture=no --reruns 2 --junitxml=pytest-junit-community-${{ matrix.group }}.xml"
+          PYTEST_ARGS: "${{ env.TINYBIRD_PYTEST_ARGS }}--splits 2 --group ${{ matrix.group }} --capture=no --reruns 2 --junitxml=pytest-junit-community-${{ matrix.group }}.xml"
         working-directory: localstack-ext
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
+          # TODO REMOVE - will be added to a dependency in localstack-ext
+          (source .venv/bin/activate && pip install pytest-tinybird)
           make test
 
       - name: Archive Test Results

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ docker-run-tests:		  ## Initializes the test environment and runs the tests in a
 	# Note: running "install-test-only" below, to avoid pulling in [runtime] extras from transitive dependencies
 	docker run -e LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC=1 --entrypoint= -v `pwd`/tests/:/opt/code/localstack/tests/ -v `pwd`/target/:/opt/code/localstack/target/ -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/localstack:/var/lib/localstack \
 		$(IMAGE_NAME) \
-	    bash -c "make install-test-only && pip uninstall -y argparse dataclasses && DEBUG=$(DEBUG) PYTEST_LOGLEVEL=debug PYTEST_ARGS='$(PYTEST_ARGS)' COVERAGE_FILE='$(COVERAGE_FILE)' TEST_PATH='$(TEST_PATH)' LAMBDA_IGNORE_ARCHITECTURE=1 LAMBDA_INIT_POST_INVOKE_WAIT_MS=50 make test-coverage"
+	    bash -c "make install-test-only && pip uninstall -y argparse dataclasses && DEBUG=$(DEBUG) PYTEST_LOGLEVEL=debug PYTEST_ARGS='$(PYTEST_ARGS)' COVERAGE_FILE='$(COVERAGE_FILE)' TEST_PATH='$(TEST_PATH)' LAMBDA_IGNORE_ARCHITECTURE=1 LAMBDA_INIT_POST_INVOKE_WAIT_MS=50 TINYBIRD_PYTEST_ARGS='$(TINYBIRD_PYTEST_ARGS)' TINYBIRD_DATASOURCE='$(TINYBIRD_DATASOURCE)' TINYBIRD_TOKEN='$(TINYBIRD_TOKEN)' TINYBIRD_URL='$(TINYBIRD_URL)' CI_COMMIT_BRANCH='$(CI_COMMIT_BRANCH)' CI_COMMIT_SHA='$(CI_COMMIT_SHA)' CI_JOB_URL='$(CI_JOB_URL)' CI_JOB_NAME='$(CI_JOB_NAME)' CI_JOB_ID='$(CI_JOB_ID)' make test-coverage"
 
 docker-run:        		  ## Run Docker image locally
 	($(VENV_RUN); bin/localstack start)

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,7 @@ test =
     pytest-split>=0.8.0
     pytest-httpserver>=1.0.1
     pytest-rerunfailures==10.0
+    pytest-tinybird>=0.2.0
     aws-cdk-lib>=2.88.0
 
 # for developing localstack


### PR DESCRIPTION
This PR adds the [`pytest-tinybird`](https://github.com/tinybirdco/pytest-tinybird) plugin to the test dependencies and modifies all GitHub and CircleCI test workflows such that they send the test data to the Tinybird workspace `localstack_ci` (if the pipeline is executed on master).
This data-driven approach will help us to gain more insights into our tests (automatically identify flaky tests, create individual health dashboards, setup a notification infrastructure,...).

TODO:
- [x] Check that data from all pipelines is sent correctly.
  - [x]  CircleCI
      - [x]  Run Locally (`make test-coverage`)
          - [x]  itest-s3-stream-provider
          - [x]  itest-lambda-legacy-local
          - [x]  itest-sfn-v2-provider
          - [x]  unit-tests
      - [x]  Run in Docker (`make docker-run-tests`)
          - [x]  docker-test-arm64
          - [x]  docker-test-amd64
  - [x]  GitHub
      - [x]  cli-tests
      - [x]  Community Integration Tests against Pro
      - [x]  tests-podman
- [x] Switch branch filter to master once the changes have been tested.
- [x] (Right before the merge) Truncate all data sources before merging (fresh start).