### PR TITLE
implement S3 native tagging

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -831,6 +831,21 @@ class InvalidPart(ServiceException):
     PartNumber: Optional[PartNumber]
 
 
+class NoSuchTagSet(ServiceException):
+    code: str = "NoSuchTagSet"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
+class InvalidTag(ServiceException):
+    code: str = "InvalidTag"
+    sender_fault: bool = False
+    status_code: int = 400
+    TagKey: Optional[ObjectKey]
+    TagValue: Optional[Value]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -992,6 +992,45 @@
         "documentation": "<p>One or more of the specified parts could not be found. The part might not have been uploaded, or the specified entity tag might not have matched the part's entity tag.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchTagSet",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>There is no tag set associated with the bucket.</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/operations/PutBucketTagging/http/responseCode",
+      "value": 204
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidTag",
+      "value": {
+        "type": "structure",
+        "members": {
+          "TagKey": {
+            "shape": "ObjectKey"
+          },
+          "TagValue": {
+            "shape": "Value"
+          }
+        },
+        "documentation": "<p>The tag provided was not a valid tag. This error can occur if the tag did not pass input validation.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -68,6 +68,8 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
+from localstack.utils.aws import arns
+from localstack.utils.tagging import TaggingService
 
 # TODO: beware of timestamp data, we need the snapshot to be more precise for S3, with the different types
 # moto had a lot of issue with it? not sure about our parser/serializer
@@ -127,19 +129,23 @@ class S3Bucket:
 
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html
         self.owner = get_owner_for_account_id(account_id)
+        self.bucket_arn = arns.s3_bucket_arn(self.name)
 
     def get_object(
         self,
         key: ObjectKey,
         version_id: ObjectVersionId = None,
-        http_method: Literal["GET", "PUT", "HEAD"] = "GET",
-    ) -> "S3Object":
+        http_method: Literal["GET", "PUT", "HEAD", "DELETE"] = "GET",
+        raise_for_delete_marker: bool = True,
+    ) -> Union["S3Object", "S3DeleteMarker"]:
         """
         :param key: the Object Key
         :param version_id: optional, the versionId of the object
         :param http_method: the HTTP method of the original call. This is necessary for the exception if the bucket is
         versioned or suspended
         see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html
+        :param raise_for_delete_marker: optional, indicates if the method should raise an exception if the found object
+        is a S3DeleteMarker. If False, it can return a S3DeleteMarker
         :return:
         :raises NoSuchKey if the object key does not exist at all, or if the object is a DeleteMarker
         :raises MethodNotAllowed if the object is a DeleteMarker and the operation is not allowed against it
@@ -168,7 +174,7 @@ class S3Bucket:
                         Key=key,
                         VersionId=version_id,
                     )
-                elif isinstance(s3_object_version, S3DeleteMarker):
+                elif raise_for_delete_marker and isinstance(s3_object_version, S3DeleteMarker):
                     raise MethodNotAllowed(
                         "The specified method is not allowed against this resource.",
                         Method=http_method,
@@ -184,7 +190,7 @@ class S3Bucket:
             if not s3_object:
                 raise NoSuchKey("The specified key does not exist.", Key=key)
 
-            elif isinstance(s3_object, S3DeleteMarker):
+            elif raise_for_delete_marker and isinstance(s3_object, S3DeleteMarker):
                 raise NoSuchKey(
                     "The specified key does not exist.",
                     Key=key,
@@ -572,6 +578,9 @@ class S3Store(BaseStore):
     buckets: dict[BucketName, S3Bucket] = CrossRegionAttribute(default=dict)
     global_bucket_map: dict[BucketName, AccountId] = CrossAccountAttribute(default=dict)
     aws_managed_kms_key_id: SSEKMSKeyId = LocalAttribute(default=str)
+
+    # static tagging service instance
+    TAGS: TaggingService = CrossAccountAttribute(default=TaggingService)
 
 
 class BucketCorsIndex:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -38,18 +38,21 @@ from localstack.aws.api.s3 import (
     DeleteMarkerEntry,
     DeleteObjectOutput,
     DeleteObjectsOutput,
+    DeleteObjectTaggingOutput,
     Delimiter,
     EncodingType,
     Error,
     FetchOwner,
     GetBucketEncryptionOutput,
     GetBucketLocationOutput,
+    GetBucketTaggingOutput,
     GetBucketVersioningOutput,
     GetObjectAttributesOutput,
     GetObjectAttributesParts,
     GetObjectAttributesRequest,
     GetObjectOutput,
     GetObjectRequest,
+    GetObjectTaggingOutput,
     HeadBucketOutput,
     HeadObjectOutput,
     HeadObjectRequest,
@@ -72,6 +75,8 @@ from localstack.aws.api.s3 import (
     MultipartUpload,
     MultipartUploadId,
     NoSuchBucket,
+    NoSuchKey,
+    NoSuchTagSet,
     NoSuchUpload,
     NotificationConfiguration,
     Object,
@@ -86,6 +91,7 @@ from localstack.aws.api.s3 import (
     Prefix,
     PutObjectOutput,
     PutObjectRequest,
+    PutObjectTaggingOutput,
     RequestPayer,
     RestoreObjectOutput,
     RestoreRequest,
@@ -98,6 +104,7 @@ from localstack.aws.api.s3 import (
     SSECustomerKeyMD5,
     StartAfter,
     StorageClass,
+    Tagging,
     Token,
     UploadIdMarker,
     UploadPartCopyOutput,
@@ -125,9 +132,12 @@ from localstack.services.s3.utils import (
     get_kms_key_arn,
     get_owner_for_account_id,
     get_system_metadata_from_request,
+    get_unique_key_id,
     is_bucket_name_valid,
     parse_range_header,
+    parse_tagging_header,
     validate_kms_key_id,
+    validate_tag_set,
 )
 from localstack.services.s3.v3.models import (
     EncryptionParameters,
@@ -349,7 +359,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #  grant_write_acp: GrantWriteACP = None,
         #  -
         #  request_payer: RequestPayer = None,
-        #  tagging: TaggingHeader = None,
         #  object_lock_mode: ObjectLockMode = None,
         #  object_lock_retain_until_date: ObjectLockRetainUntilDate = None,
         #  object_lock_legal_hold_status: ObjectLockLegalHoldStatus = None,
@@ -431,7 +440,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         s3_bucket.objects.set(key, s3_object)
 
-        # TODO: tags: do we have tagging service or do we manually handle? see utils TaggingService
+        # in case we are overriding an object, delete the tags entry
+        key_id = get_unique_key_id(bucket_name, key, version_id)
+        store.TAGS.tags.pop(key_id, None)
+        if tagging_header := request.get("Tagging"):
+            tagging = parse_tagging_header(tagging_header)
+            store.TAGS.tags[key_id] = tagging
 
         # TODO: returned fields
         # RequestCharged: Optional[RequestCharged]  # TODO
@@ -476,6 +490,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
         object_key = request["Key"]
+        version_id = request.get("VersionId")
         if not (s3_bucket := store.buckets.get(bucket_name)):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket_name)
 
@@ -483,7 +498,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         s3_object = s3_bucket.get_object(
             key=object_key,
-            version_id=request.get("VersionId"),
+            version_id=version_id,
             http_method="GET",
         )
 
@@ -526,11 +541,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         add_encryption_to_response(response, s3_object=s3_object)
 
+        if object_tags := store.TAGS.tags.get(
+            get_unique_key_id(bucket_name, object_key, version_id)
+        ):
+            response["TagCount"] = len(object_tags)
+
         # TODO: missing returned fields
         #     Expiration: Optional[Expiration]
         #     RequestCharged: Optional[RequestCharged]
         #     ReplicationStatus: Optional[ReplicationStatus]
-        #     TagCount: Optional[TagCount]
         #     ObjectLockMode: Optional[ObjectLockMode]
         #     ObjectLockRetainUntilDate: Optional[ObjectLockRetainUntilDate]
         #     ObjectLockLegalHoldStatus: Optional[ObjectLockLegalHoldStatus]
@@ -632,6 +651,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             if found_object:
                 self._storage_backend.remove(bucket, found_object)
                 self._notify(context, s3_bucket=s3_bucket, s3_object=found_object)
+                store.TAGS.tags.pop(get_unique_key_id(bucket, key, version_id), None)
+
             return DeleteObjectOutput()
 
         if not version_id:
@@ -663,6 +684,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         else:
             self._storage_backend.remove(bucket, found_object)
             self._notify(context, s3_bucket=s3_bucket, s3_object=found_object)
+            store.TAGS.tags.pop(get_unique_key_id(bucket, key, version_id), None)
 
         return response
 
@@ -714,6 +736,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 if found_object:
                     to_remove.append(found_object)
                     self._notify(context, s3_bucket=s3_bucket, s3_object=found_object)
+                    store.TAGS.tags.pop(get_unique_key_id(bucket, object_key, version_id), None)
                 # small hack to not create a fake object for nothing
                 elif s3_bucket.notification_configuration:
                     # DeleteObjects is a bit weird, even if the object didn't exist, S3 will trigger a notification
@@ -771,6 +794,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 to_remove.append(found_object)
 
             self._notify(context, s3_bucket=s3_bucket, s3_object=found_object)
+            store.TAGS.tags.pop(get_unique_key_id(bucket, object_key, version_id), None)
 
         # TODO: request charged
         self._storage_backend.remove(bucket, to_remove)
@@ -801,10 +825,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # copy_source_if_none_match: CopySourceIfNoneMatch = None,
         # copy_source_if_unmodified_since: CopySourceIfUnmodifiedSince = None,
         #
-        # tagging_directive: TaggingDirective = None,
-        #
         # request_payer: RequestPayer = None,
-        # tagging: TaggingHeader = None,
         # object_lock_mode: ObjectLockMode = None,
         # object_lock_retain_until_date: ObjectLockRetainUntilDate = None,
         # object_lock_legal_hold_status: ObjectLockLegalHoldStatus = None,
@@ -851,6 +872,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "This copy request is illegal because it is trying to copy an object to itself without changing the "
                 "object's metadata, storage class, website redirect location or encryption attributes."
             )
+
+        if tagging := request.get("Tagging"):
+            tagging = parse_tagging_header(tagging)
 
         if metadata_directive == "REPLACE":
             user_metadata = request.get("Metadata")
@@ -901,6 +925,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # Object copied from Glacier object should not have expiry
         # TODO: verify this assumption from moto?
         dest_s3_bucket.objects.set(dest_key, s3_object)
+
+        dest_key_id = get_unique_key_id(dest_bucket, dest_key, dest_version_id)
+        if (request.get("TaggingDirective")) == "REPLACE":
+            store.TAGS.tags[dest_key_id] = tagging
+        else:
+            src_key_id = get_unique_key_id(src_bucket, src_key, src_version_id)
+            store.TAGS.tags[dest_key_id] = copy.copy(store.TAGS.tags.get(src_key_id, {}))
 
         copy_object_result = CopyObjectResult(
             ETag=s3_object.quoted_etag,
@@ -1377,7 +1408,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #  grant_read_acp: GrantReadACP = None,
         #  grant_write_acp: GrantWriteACP = None,
         #  request_payer: RequestPayer = None,
-        #  tagging: TaggingHeader = None,
         store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
         if not (s3_bucket := store.buckets.get(bucket_name)):
@@ -1392,6 +1422,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, s3_bucket)
+
+        if tagging := request.get("Tagging"):
+            tagging = parse_tagging_header(tagging_header=tagging)
 
         key = request["Key"]
 
@@ -1431,6 +1464,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             expiration=None,  # TODO, from lifecycle, or should it be updated with config?
             acl=None,
             initiator=get_owner_for_account_id(context.account_id),
+            tagging=tagging,
         )
 
         s3_bucket.multiparts[s3_multipart.id] = s3_multipart
@@ -1670,6 +1704,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # remove the multipart now that it's complete
         self._storage_backend.remove_multipart(bucket, s3_multipart)
         s3_bucket.multiparts.pop(s3_multipart.id, None)
+
+        key_id = get_unique_key_id(bucket, key, version_id)
+        store.TAGS.tags.pop(key_id, None)
+        if s3_multipart.tagging:
+            store.TAGS.tags[key_id] = s3_multipart.tagging
 
         # TODO: validate if you provide wrong checksum compared to the given algorithm? should you calculate it anyway
         #  when you complete? sounds weird, not sure how that works?
@@ -1974,6 +2013,152 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
 
         return s3_bucket.notification_configuration or NotificationConfiguration()
+
+    def put_bucket_tagging(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        tagging: Tagging,
+        content_md5: ContentMD5 = None,
+        checksum_algorithm: ChecksumAlgorithm = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> None:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        if "TagSet" not in tagging:
+            raise MalformedXML()
+
+        validate_tag_set(tagging["TagSet"], type_set="bucket")
+
+        # remove the previous tags before setting the new ones, it overwrites the whole TagSet
+        store.TAGS.tags.pop(s3_bucket.bucket_arn, None)
+        store.TAGS.tag_resource(s3_bucket.bucket_arn, tags=tagging["TagSet"])
+
+    def get_bucket_tagging(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketTaggingOutput:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        tag_set = store.TAGS.list_tags_for_resource(s3_bucket.bucket_arn, root_name="Tags")["Tags"]
+        if not tag_set:
+            raise NoSuchTagSet(
+                "The TagSet does not exist",
+                BucketName=bucket,
+            )
+
+        return GetBucketTaggingOutput(TagSet=tag_set)
+
+    def delete_bucket_tagging(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> None:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        store.TAGS.tags.pop(s3_bucket.bucket_arn, None)
+
+    def put_object_tagging(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        key: ObjectKey,
+        tagging: Tagging,
+        version_id: ObjectVersionId = None,
+        content_md5: ContentMD5 = None,
+        checksum_algorithm: ChecksumAlgorithm = None,
+        expected_bucket_owner: AccountId = None,
+        request_payer: RequestPayer = None,
+    ) -> PutObjectTaggingOutput:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        s3_object = s3_bucket.get_object(
+            key=key,
+            version_id=version_id,
+            raise_for_delete_marker=False,  # We can tag DeleteMarker
+        )
+
+        if "TagSet" not in tagging:
+            raise MalformedXML()
+
+        validate_tag_set(tagging["TagSet"], type_set="object")
+
+        key_id = get_unique_key_id(bucket, key, version_id)
+        # remove the previous tags before setting the new ones, it overwrites the whole TagSet
+        store.TAGS.tags.pop(key_id, None)
+        store.TAGS.tag_resource(key_id, tags=tagging["TagSet"])
+        response = PutObjectTaggingOutput()
+        if s3_object.version_id:
+            response["VersionId"] = s3_object.version_id
+
+        self._notify(context, s3_bucket=s3_bucket, s3_object=s3_object)
+
+        return response
+
+    def get_object_tagging(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        key: ObjectKey,
+        version_id: ObjectVersionId = None,
+        expected_bucket_owner: AccountId = None,
+        request_payer: RequestPayer = None,
+    ) -> GetObjectTaggingOutput:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        try:
+            s3_object = s3_bucket.get_object(
+                key=key,
+                version_id=version_id,
+                raise_for_delete_marker=False,  # We can tag DeleteMarker
+            )
+        except NoSuchKey as e:
+            # There a weird AWS validated bug in S3: the returned key contains the bucket name as well
+            # follow AWS on this one
+            e.Key = f"{bucket}/{key}"
+            raise e
+
+        tag_set = store.TAGS.list_tags_for_resource(get_unique_key_id(bucket, key, version_id))[
+            "Tags"
+        ]
+        response = GetObjectTaggingOutput(TagSet=tag_set)
+        if s3_object.version_id:
+            response["VersionId"] = s3_object.version_id
+
+        return response
+
+    def delete_object_tagging(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        key: ObjectKey,
+        version_id: ObjectVersionId = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> DeleteObjectTaggingOutput:
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        s3_object = s3_bucket.get_object(
+            key=key,
+            version_id=version_id,
+            raise_for_delete_marker=False,
+        )
+
+        store.TAGS.tags.pop(get_unique_key_id(bucket, key, version_id), None)
+        response = DeleteObjectTaggingOutput()
+        if s3_object.version_id:
+            response["VersionId"] = s3_object.version_id
+
+        self._notify(context, s3_bucket=s3_bucket, s3_object=s3_object)
+
+        return response
 
 
 def generate_version_id(bucket_versioning_status: str) -> str | None:

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -1491,5 +1491,624 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_crud": {
+    "recorded-date": "02-08-2023, 22:18:20",
+    "recorded-content": {
+      "get-bucket-tags-empty": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchTagSet",
+          "Message": "The TagSet does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-bucket-tags": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-tags": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          },
+          {
+            "Key": "tag2",
+            "Value": ""
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-tags-overwrite": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-tags-overwritten": {
+        "TagSet": [
+          {
+            "Key": "tag3",
+            "Value": "tag3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-bucket-tags": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-bucket-tags-empty": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_crud": {
+    "recorded-date": "02-08-2023, 23:23:45",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-empty": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-tags": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          },
+          {
+            "Key": "tag2",
+            "Value": ""
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-tags-overwrite": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-overwritten": {
+        "TagSet": [
+          {
+            "Key": "tag3",
+            "Value": "tag3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-after-tags": {
+        "AcceptRanges": "bytes",
+        "Body": "test-tagging",
+        "ContentLength": 12,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "TagCount": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object-tags": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-object-tags-deleted": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-after-tags-deleted": {
+        "AcceptRanges": "bytes",
+        "Body": "test-tagging",
+        "ContentLength": 12,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_with_tags": {
+    "recorded-date": "03-08-2023, 01:21:13",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags": {
+        "TagSet": [
+          {
+            "Key": "tag",
+            "Value": ""
+          },
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "tag2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-tags": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-override": {
+        "TagSet": [
+          {
+            "Key": "tag3",
+            "Value": "tag3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-obj": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 12,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj": {
+        "AcceptRanges": "bytes",
+        "Body": "test-tagging",
+        "ContentLength": 12,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"b635a7fc30aa9091e0d236bee77e6844\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "TagCount": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-wrong-format-qs": {
+        "TagSet": [
+          {
+            "Key": "wrongagain",
+            "Value": ""
+          },
+          {
+            "Key": "wrongquery",
+            "Value": ""
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-wrong-format-qs-2": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": ""
+          },
+          {
+            "Key": "key2",
+            "Value": ""
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_exc": {
+    "recorded-date": "02-08-2023, 22:32:41",
+    "recorded-content": {
+      "get-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
+    "recorded-date": "02-08-2023, 23:14:16",
+    "recorded-content": {
+      "put-obj-0": {
+        "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-1": {
+        "ETag": "\"70a37754eb5a2e7db8cd887aaf11cda7\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-tags-current-version": {
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-current-version": {
+        "TagSet": [
+          {
+            "Key": "tag3",
+            "Value": "tag3"
+          }
+        ],
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-tags-previous-version": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-previous-version": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          }
+        ],
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-object-tags-delete-marker": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-delete-marker": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          }
+        ],
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_exc": {
+    "recorded-date": "03-08-2023, 00:04:47",
+    "recorded-content": {
+      "get-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-no-bucket-tags": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-no-key-tags": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "<bucket:1>/fake-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-no-key-tags": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "fake-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-no-key-tags": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "fake-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-obj-duplicate-tagging": {
+        "Error": {
+          "ArgumentName": "x-amz-tagging",
+          "ArgumentValue": "key1=val1&key1=val2",
+          "Code": "InvalidArgument",
+          "Message": "The header 'x-amz-tagging' shall be encoded as UTF-8 then URLEncoded URL query parameters without tag name duplicates."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-wrong-format": {
+        "Error": {
+          "ArgumentName": "x-amz-tagging",
+          "ArgumentValue": "key1=val1,key2=val2",
+          "Code": "InvalidArgument",
+          "Message": "The header 'x-amz-tagging' shall be encoded as UTF-8 then URLEncoded URL query parameters without tag name duplicates."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
+    "recorded-date": "02-08-2023, 23:52:10",
+    "recorded-content": {
+      "get-object-after-creation": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "val1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-after-overwrite": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-after-recreation": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_tagging_validation": {
+    "recorded-date": "03-08-2023, 01:07:47",
+    "recorded-content": {
+      "put-bucket-tags-duplicate-keys": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "Cannot provide multiple Tags with the same key",
+          "TagKey": "Key1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-tags-invalid-key": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "The TagKey you have provided is invalid",
+          "TagKey": "Key1,Key2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-tags-invalid-value": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "The TagValue you have provided is invalid",
+          "TagKey": "Key1",
+          "TagValue": "Val1,Val2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-tags-aws-prefixed": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "System tags cannot be added/updated by requester",
+          "TagKey": "aws:prefixed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-tags-duplicate-keys": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "Cannot provide multiple Tags with the same key",
+          "TagKey": "Key1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-tags-invalid-field": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "The TagKey you have provided is invalid",
+          "TagKey": "Key1,Key2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-tags-aws-prefixed": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "Your TagKey cannot be prefixed with aws:",
+          "TagKey": "aws:prefixed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR implements all tagging related operations and usage:

Tagging with:
- PutObject
- CopyObject (and `TaggingDirective`) 
- PutObjectTagging
- DeleteObjectTagging
- GetObjectTagging
- PutBucketTagging
- DeleteBucketTagging
- GetBucketTagging

As well as S3 notifications support for Put/Delete object tagging. 