### PR TITLE
fix PutBucket logging with empty payload

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1634,6 +1634,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         if not (logging_config := bucket_logging_status.get("LoggingEnabled")):
             moto_bucket.logging = {}
+            return
 
         # the target bucket must be in the same account
         if not (target_bucket_name := logging_config.get("TargetBucket")):

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -5062,6 +5062,10 @@ class TestS3:
         resp = aws_client.s3.get_bucket_logging(Bucket=bucket_name)
         snapshot.match("get-bucket-logging", resp)
 
+        # delete BucketLogging
+        resp = aws_client.s3.put_bucket_logging(Bucket=bucket_name, BucketLoggingStatus={})
+        snapshot.match("put-bucket-logging-delete", resp)
+
     @markers.parity.aws_validated
     def test_put_bucket_logging_accept_wrong_grants(self, aws_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -7750,7 +7750,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging": {
-    "recorded-date": "08-07-2023, 02:00:56",
+    "recorded-date": "03-08-2023, 02:13:19",
     "recorded-content": {
       "get-bucket-default-acl": {
         "Grants": [
@@ -7783,6 +7783,12 @@
           "TargetBucket": "<target-bucket:1>",
           "TargetPrefix": "log"
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-logging-delete": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
This PR fixes #8812, we were not returning early if the payload was empty, and we were trying to validate it. 

Added an AWS test validated this. 