### PR TITLE
fix s3_empty_bucket fixture to delete DeleteMarkers

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -231,8 +231,9 @@ def s3_empty_bucket(aws_client):
     # FIXME: this won't work when bucket has more than 1000 objects
     def factory(bucket_name: str):
         response = aws_client.s3.list_objects_v2(Bucket=bucket_name)
-        objects = [{"Key": obj["Key"]} for obj in response["Contents"]]
-        aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": objects})
+        objects = [{"Key": obj["Key"]} for obj in response.get("Contents", [])]
+        if objects:
+            aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": objects})
 
         response = aws_client.s3.list_object_versions(Bucket=bucket_name)
         versions = response.get("Versions", [])

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -235,10 +235,10 @@ def s3_empty_bucket(aws_client):
         aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": objects})
 
         response = aws_client.s3.list_object_versions(Bucket=bucket_name)
-        object_versions = [
-            {"Key": obj["Key"], "VersionId": obj["VersionId"]}
-            for obj in response.get("Versions", [])
-        ]
+        versions = response.get("Versions", [])
+        versions.extend(response.get("DeleteMarkers", []))
+
+        object_versions = [{"Key": obj["Key"], "VersionId": obj["VersionId"]} for obj in versions]
         if object_versions:
             aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": object_versions})
 


### PR DESCRIPTION
Just realised I had 101 buckets in my AWS account after doing some S3 testing, and seeing `TooManyBuckets` rang a bell somewhere 😄🚨 

You need to even delete `DeleteMarkers`, otherwise your bucket is not considered empty. It's weird, but that's how it is 🤷‍♂️
I tried the fixture against my 101 buckets and it worked, cleaned them up and deleted them.  