### PR TITLE
Small fixes to support CLI use with Python 3.8

### DIFF
--- a/localstack/utils/venv.py
+++ b/localstack/utils/venv.py
@@ -74,9 +74,9 @@ class VirtualEnvironment:
         return matches[0]
 
     def inject_to_sys_path(self):
-        if path := str(self.site_dir):
-            if path not in sys.path:
-                sys.path.append(path)
+        path = str(self.site_dir)
+        if path and path not in sys.path:
+            sys.path.append(path)
 
     def add_pth(self, name, path: Union[str, os.PathLike, "VirtualEnvironment"]) -> None:
         """

--- a/localstack/utils/venv.py
+++ b/localstack/utils/venv.py
@@ -11,7 +11,7 @@ class VirtualEnvironment:
     Encapsulates methods to operate and navigate on a python virtual environment.
     """
 
-    def __init__(self, venv_dir: str | os.PathLike[str]):
+    def __init__(self, venv_dir: Union[str, os.PathLike]):
         self._venv_dir = venv_dir
 
     def create(self):
@@ -78,7 +78,7 @@ class VirtualEnvironment:
             if path not in sys.path:
                 sys.path.append(path)
 
-    def add_pth(self, name, path: Union[str, os.PathLike[str], "VirtualEnvironment"]) -> None:
+    def add_pth(self, name, path: Union[str, os.PathLike, "VirtualEnvironment"]) -> None:
         """
         Add a <name>.pth file into the virtual environment and append the given path to it. Does nothing if the path
         is already in the file.

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -228,4 +228,5 @@ class TestImports:
 
     def test_import_venv(self):
         from localstack.utils.venv import VirtualEnvironment
+
         assert VirtualEnvironment

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -221,3 +221,11 @@ class TestHooks:
         # cache dir should exist and be writeable
         assert os.path.exists(dirs.cache)
         assert os.access(dirs.cache, os.W_OK)
+
+
+class TestImports:
+    """Simple tests to assert that certain code paths can be imported from the CLI"""
+
+    def test_import_venv(self):
+        from localstack.utils.venv import VirtualEnvironment
+        assert VirtualEnvironment

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -227,6 +227,13 @@ class TestImports:
     """Simple tests to assert that certain code paths can be imported from the CLI"""
 
     def test_import_venv(self):
+        try:
+            from functools import cached_property  # noqa
+        except Exception:
+            pytest.skip(
+                "Skip test in Python <= 3.7 (cached_property is required for VirtualEnvironment)"
+            )
+
         from localstack.utils.venv import VirtualEnvironment
 
         assert VirtualEnvironment


### PR DESCRIPTION
Tiny fixes to support CLI use with Python 3.8. Discovered this while working on a support case of a customer who attempted to install the AWS replicator/proxy extension.

Can be replicated when installing Python 3.8 via `pyenv`, and then:
```
$ DEBUG_PLUGINS=1 localstack -d extensions install localstack-extension-aws-replicator
DEBUG:stevedore._cache:reading /Users/whummer/Library/Caches/Python Entry Points/5e2a6eb1bdd93e1d7b62ee754448916f77349878c2468e3c113c4965f6f6e4d7
DEBUG:stevedore.extension:found extension EntryPoint(name='ext-all', value='localstack_ext.cli.localstack:ExtCliPlugin', group='localstack.plugins.cli')
ERROR:plugin.manager:error importing entrypoint EntryPoint(name='ext-all', value='localstack_ext.cli.localstack:ExtCliPlugin', group='localstack.plugins.cli'): 'type' object is not subscriptable
DEBUG:stevedore.extension:found extension EntryPoint(name='pro', value='localstack_ext.cli.localstack:ProLoggedInCliPlugin', group='localstack.plugins.cli')
ERROR:plugin.manager:error importing entrypoint EntryPoint(name='pro', value='localstack_ext.cli.localstack:ProLoggedInCliPlugin', group='localstack.plugins.cli'): 'type' object is not subscriptable
```

Added a simple test to assert that the module can get imported, which should be picked up by our `cli-tests` GH Action (which is parametrized for different Python versions). Over time we could consider adding an extensions CLI test for different Python versions (but probably not really high prio).