### PR TITLE
fix credentials handling for capture-not-implemented

### DIFF
--- a/scripts/capture_notimplemented_responses.py
+++ b/scripts/capture_notimplemented_responses.py
@@ -57,6 +57,8 @@ def simulate_call(service: str, op: str) -> RowEntry:
     """generates a mock request based on the service and operation model and sends it to the API"""
     client = connect_externally_to.get_client(
         service,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
         config=botocore.config.Config(
             parameter_validation=False,
             retries={"max_attempts": 0, "total_max_attempts": 1},


### PR DESCRIPTION
This PR explicitly sets credentials in the capture-not-implemented script to avoid any issues if the credentials are not implicitly set via environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
In CircleCI, our test credentials are set globally, but executed in different environments, this caused issues.