### PR TITLE
Cfn: Multi-accounts compatibility

### DIFF
--- a/localstack/services/cloudformation/cfn_utils.py
+++ b/localstack/services/cloudformation/cfn_utils.py
@@ -5,8 +5,12 @@ from localstack.utils.objects import recurse_object
 
 
 def rename_params(func, rename_map):
-    def do_rename(params, logical_resource_id, *args, **kwargs):
-        values = func(params, logical_resource_id, *args, **kwargs) if func else params
+    def do_rename(account_id, region_name, params, logical_resource_id, *args, **kwargs):
+        values = (
+            func(account_id, region_name, params, logical_resource_id, *args, **kwargs)
+            if func
+            else params
+        )
         for old_param, new_param in rename_map.items():
             values[new_param] = values.pop(old_param, None)
         return values
@@ -15,13 +19,17 @@ def rename_params(func, rename_map):
 
 
 def lambda_convert_types(func, types):
-    return lambda params, logical_resource_id, *args, **kwargs: convert_types(
-        func(params, *args, **kwargs), types
+    return (
+        lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: convert_types(
+            func(account_id, region_name, params, *args, **kwargs), types
+        )
     )
 
 
 def lambda_to_json(attr):
-    return lambda params, logical_resource_id, *args, **kwargs: json.dumps(params[attr])
+    return lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: json.dumps(
+        params[attr]
+    )
 
 
 def lambda_rename_attributes(attrs, func=None):
@@ -33,9 +41,9 @@ def lambda_rename_attributes(attrs, func=None):
                         o[attrs[k]] = o.pop(k)
         return o
 
-    func = func or (lambda x, logical_resource_id, *args, **kwargs: x)
-    return lambda params, logical_resource_id, *args, **kwargs: recurse_object(
-        func(params, logical_resource_id, *args, **kwargs), recurse
+    func = func or (lambda account_id, region_name, x, logical_resource_id, *args, **kwargs: x)
+    return lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: recurse_object(
+        func(account_id, region_name, params, logical_resource_id, *args, **kwargs), recurse
     )
 
 
@@ -59,7 +67,7 @@ def convert_types(obj, types):
 def get_tags_param(resource_type: str) -> Callable:
     """Return a tag parameters creation function for the given resource type"""
 
-    def _param(params, logical_resource_id, *args, **kwargs):
+    def _param(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
         tags = params.get("Tags")
         if not tags:
             return None

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -21,8 +21,12 @@ LOG = logging.getLogger(__name__)
 
 
 def dump_json_params(param_func=None, *param_names):
-    def replace(params, logical_resource_id, *args, **kwargs):
-        result = param_func(params, logical_resource_id, *args, **kwargs) if param_func else params
+    def replace(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
+        result = (
+            param_func(account_id, region_name, params, logical_resource_id, *args, **kwargs)
+            if param_func
+            else params
+        )
         for name in param_names:
             if isinstance(result.get(name), (dict, list)):
                 # Fix for https://github.com/localstack/localstack/issues/2022
@@ -36,8 +40,17 @@ def dump_json_params(param_func=None, *param_names):
 
 # TODO: remove
 def param_defaults(param_func, defaults):
-    def replace(properties: dict, logical_resource_id: str, *args, **kwargs):
-        result = param_func(properties, logical_resource_id, *args, **kwargs)
+    def replace(
+        account_id: str,
+        region_name: str,
+        properties: dict,
+        logical_resource_id: str,
+        *args,
+        **kwargs,
+    ):
+        result = param_func(
+            account_id, region_name, properties, logical_resource_id, *args, **kwargs
+        )
         for key, value in defaults.items():
             if result.get(key) in ["", None]:
                 result[key] = value
@@ -64,7 +77,7 @@ def remove_none_values(params):
 
 
 def params_list_to_dict(param_name, key_attr_name="Key", value_attr_name="Value"):
-    def do_replace(params, logical_resource_id, *args, **kwargs):
+    def do_replace(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
         result = {}
         for entry in params.get(param_name, []):
             key = entry[key_attr_name]
@@ -76,15 +89,15 @@ def params_list_to_dict(param_name, key_attr_name="Key", value_attr_name="Value"
 
 
 def lambda_keys_to_lower(key=None, skip_children_of: List[str] = None):
-    return lambda params, logical_resource_id, *args, **kwargs: common.keys_to_lower(
+    return lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: common.keys_to_lower(
         obj=(params.get(key) if key else params), skip_children_of=skip_children_of
     )
 
 
 def merge_parameters(func1, func2):
-    return lambda properties, logical_resource_id, *args, **kwargs: common.merge_dicts(
-        func1(properties, logical_resource_id, *args, **kwargs),
-        func2(properties, logical_resource_id, *args, **kwargs),
+    return lambda account_id, region_name, properties, logical_resource_id, *args, **kwargs: common.merge_dicts(
+        func1(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
+        func2(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
     )
 
 
@@ -93,7 +106,7 @@ def str_or_none(o):
 
 
 def params_dict_to_list(param_name, key_attr_name="Key", value_attr_name="Value", wrapper=None):
-    def do_replace(params, logical_resource_id, *args, **kwargs):
+    def do_replace(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
         result = []
         for key, value in params.get(param_name, {}).items():
             result.append({key_attr_name: key, value_attr_name: value})
@@ -106,7 +119,7 @@ def params_dict_to_list(param_name, key_attr_name="Key", value_attr_name="Value"
 
 # TODO: remove
 def params_select_attributes(*attrs):
-    def do_select(params, logical_resource_id, *args, **kwargs):
+    def do_select(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
         result = {}
         for attr in attrs:
             if params.get(attr) is not None:
@@ -117,7 +130,7 @@ def params_select_attributes(*attrs):
 
 
 def param_json_to_str(name):
-    def _convert(params, logical_resource_id, *args, **kwargs):
+    def _convert(account_id: str, region_name: str, params, logical_resource_id, *args, **kwargs):
         result = params.get(name)
         if result:
             result = json.dumps(result)
@@ -132,7 +145,7 @@ def lambda_select_params(*selected):
 
 
 def select_parameters(*param_names):
-    return lambda properties, logical_resource_id, *args, **kwargs: select_attributes(
+    return lambda account_id, region_name, properties, logical_resource_id, *args, **kwargs: select_attributes(
         properties, param_names
     )
 

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -51,6 +51,8 @@ class StackParameter(Parameter):
 
 
 def resolve_parameters(
+    account_id: str,
+    region_name: str,
     parameter_declarations: dict[str, ParameterDeclaration],
     new_parameters: dict[str, Parameter],
     old_parameters: dict[str, Parameter],
@@ -116,7 +118,7 @@ def resolve_parameters(
             ]:
                 # TODO: error handling (e.g. no permission to lookup SSM parameter or SSM parameter doesn't exist)
                 resolved_param["ResolvedValue"] = resolve_ssm_parameter(
-                    resolved_param["ParameterValue"]
+                    account_id, region_name, resolved_param["ParameterValue"]
                 )
             else:
                 raise Exception(f"Unsupported stack parameter type: {pm['ParameterType']}")
@@ -125,11 +127,13 @@ def resolve_parameters(
 
 
 # TODO: inject credentials / client factory for proper account/region lookup
-def resolve_ssm_parameter(stack_parameter_value: str) -> str:
+def resolve_ssm_parameter(account_id: str, region_name: str, stack_parameter_value: str) -> str:
     """
     Resolve the SSM stack parameter from the SSM service with a name equal to the stack parameter value.
     """
-    return connect_to().ssm.get_parameter(Name=stack_parameter_value)["Parameter"]["Value"]
+    return connect_to(aws_access_key_id=account_id, region_name=region_name).ssm.get_parameter(
+        Name=stack_parameter_value
+    )["Parameter"]["Value"]
 
 
 def strip_parameter_type(in_param: StackParameter) -> Parameter:

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -7,7 +7,6 @@ import uuid
 from typing import Literal, Optional, Type, TypedDict
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
@@ -32,7 +31,6 @@ from localstack.services.cloudformation.service_models import (
     GenericBaseModel,
 )
 from localstack.services.cloudformation.stores import exports_map
-from localstack.utils.aws import aws_stack
 from localstack.utils.functions import prevent_stack_overflow
 from localstack.utils.json import clone_safe
 from localstack.utils.objects import get_all_subclasses
@@ -118,6 +116,8 @@ def get_attr_from_model_instance(
 
 
 def resolve_ref(
+    account_id: str,
+    region_name: str,
     stack_name: str,
     resources: dict,
     parameters: dict[str, StackParameter],
@@ -132,7 +132,7 @@ def resolve_ref(
     """
     # pseudo parameter
     if ref == "AWS::Region":
-        return aws_stack.get_region()
+        return region_name
     if ref == "AWS::Partition":
         return "aws"
     if ref == "AWS::StackName":
@@ -141,7 +141,7 @@ def resolve_ref(
         # TODO return proper stack id!
         return stack_name
     if ref == "AWS::AccountId":
-        return get_aws_account_id()
+        return account_id
     if ref == "AWS::NoValue":
         return PLACEHOLDER_AWS_NO_VALUE
     if ref == "AWS::NotificationARNs":
@@ -173,6 +173,8 @@ def resolve_ref(
 # TODO: Potentially think about a better approach in the future
 @prevent_stack_overflow(match_parameters=True)
 def resolve_refs_recursively(
+    account_id: str,
+    region_name: str,
     stack_name: str,
     resources: dict,
     mappings: dict,
@@ -181,7 +183,7 @@ def resolve_refs_recursively(
     value,
 ):
     result = _resolve_refs_recursively(
-        stack_name, resources, mappings, conditions, parameters, value
+        account_id, region_name, stack_name, resources, mappings, conditions, parameters, value
     )
 
     # localstack specific patches
@@ -206,10 +208,10 @@ def resolve_refs_recursively(
 
             # only these 3 services are supported for dynamic references right now
             if service_name == "ssm":
-                ssm_client = connect_to().ssm
+                ssm_client = connect_to(aws_access_key_id=account_id, region_name=region_name).ssm
                 return ssm_client.get_parameter(Name=reference_key)["Parameter"]["Value"]
             elif service_name == "ssm-secure":
-                ssm_client = connect_to().ssm
+                ssm_client = connect_to(aws_access_key_id=account_id, region_name=region_name).ssm
                 return ssm_client.get_parameter(Name=reference_key, WithDecryption=True)[
                     "Parameter"
                 ]["Value"]
@@ -235,7 +237,9 @@ def resolve_refs_recursively(
                 if version_stage:
                     kwargs["VersionStage"] = version_stage
 
-                secretsmanager_client = connect_to().secretsmanager
+                secretsmanager_client = connect_to(
+                    aws_access_key_id=account_id, region_name=region_name
+                ).secretsmanager
                 secret_value = secretsmanager_client.get_secret_value(SecretId=secret_id, **kwargs)[
                     "SecretString"
                 ]
@@ -257,6 +261,8 @@ def resolve_refs_recursively(
 
 @prevent_stack_overflow(match_parameters=True)
 def _resolve_refs_recursively(
+    account_id: str,
+    region_name: str,
     stack_name: str,
     resources: dict,
     mappings: dict,
@@ -270,13 +276,22 @@ def _resolve_refs_recursively(
 
         # process special operators
         if keys_list == ["Ref"]:
-            ref = resolve_ref(stack_name, resources, parameters, value["Ref"])
+            ref = resolve_ref(
+                account_id, region_name, stack_name, resources, parameters, value["Ref"]
+            )
             if ref is None:
                 msg = 'Unable to resolve Ref for resource "%s" (yet)' % value["Ref"]
                 LOG.debug("%s - %s", msg, resources.get(value["Ref"]) or set(resources.keys()))
                 raise DependencyNotYetSatisfied(resource_ids=value["Ref"], message=msg)
             ref = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, ref
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                ref,
             )
             return ref
 
@@ -288,7 +303,14 @@ def _resolve_refs_recursively(
 
             # the attribute name can be a Ref
             attribute_name = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, attribute_name
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                attribute_name,
             )
             resource = resources.get(resource_logical_id)
 
@@ -306,11 +328,27 @@ def _resolve_refs_recursively(
             # this can actually be another ref that produces a list as output
             if isinstance(join_values, dict):
                 join_values = resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, join_values
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    join_values,
                 )
 
             join_values = [
-                resolve_refs_recursively(stack_name, resources, mappings, conditions, parameters, v)
+                resolve_refs_recursively(
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    v,
+                )
                 for v in join_values
             ]
 
@@ -332,7 +370,14 @@ def _resolve_refs_recursively(
 
             for key, val in item_to_sub[1].items():
                 val = resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, val
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    val,
                 )
                 if not isinstance(val, str):
                     # We don't have access to the resource that's a dependency in this case,
@@ -342,7 +387,14 @@ def _resolve_refs_recursively(
 
             # resolve placeholders
             result = resolve_placeholders_in_string(
-                result, stack_name, resources, mappings, conditions, parameters
+                account_id,
+                region_name,
+                result,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
             )
             return result
 
@@ -352,7 +404,9 @@ def _resolve_refs_recursively(
 
             if isinstance(mapping_id, dict) and "Ref" in mapping_id:
                 # TODO: ??
-                mapping_id = resolve_ref(stack_name, resources, parameters, mapping_id["Ref"])
+                mapping_id = resolve_ref(
+                    account_id, region_name, stack_name, resources, parameters, mapping_id["Ref"]
+                )
 
             selected_map = mappings.get(mapping_id)
             if not selected_map:
@@ -362,22 +416,43 @@ def _resolve_refs_recursively(
 
             first_level_attribute = value[keys_list[0]][1]
             first_level_attribute = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, first_level_attribute
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                first_level_attribute,
             )
 
             second_level_attribute = value[keys_list[0]][2]
             if not isinstance(second_level_attribute, str):
                 second_level_attribute = resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, second_level_attribute
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    second_level_attribute,
                 )
 
             return selected_map.get(first_level_attribute).get(second_level_attribute)
 
         if stripped_fn_lower == "importvalue":
             import_value_key = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, value[keys_list[0]]
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                value[keys_list[0]],
             )
-            exports = exports_map()
+            exports = exports_map(account_id, region_name)
             stack_export = exports.get(import_value_key) or {}
             if not stack_export.get("Value"):
                 LOG.info(
@@ -393,6 +468,8 @@ def _resolve_refs_recursively(
             condition, option1, option2 = value[keys_list[0]]
             condition = conditions[condition]
             result = resolve_refs_recursively(
+                account_id,
+                region_name,
                 stack_name,
                 resources,
                 mappings,
@@ -410,7 +487,14 @@ def _resolve_refs_recursively(
         if stripped_fn_lower == "not":
             condition = value[keys_list[0]][0]
             condition = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, condition
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                condition,
             )
             return not condition
 
@@ -418,7 +502,14 @@ def _resolve_refs_recursively(
             conditions = value[keys_list[0]]
             results = [
                 resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, cond
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    cond,
                 )
                 for cond in conditions
             ]
@@ -428,10 +519,24 @@ def _resolve_refs_recursively(
         if stripped_fn_lower == "equals":
             operand1, operand2 = value[keys_list[0]]
             operand1 = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, operand1
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                operand1,
             )
             operand2 = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, operand2
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                operand2,
             )
             # TODO: investigate type coercion here
             return fn_equals_type_conversion(operand1) == fn_equals_type_conversion(operand2)
@@ -439,10 +544,24 @@ def _resolve_refs_recursively(
         if stripped_fn_lower == "select":
             index, values = value[keys_list[0]]
             index = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, index
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                index,
             )
             values = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, values
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                values,
             )
             try:
                 return values[index]
@@ -452,19 +571,40 @@ def _resolve_refs_recursively(
         if stripped_fn_lower == "split":
             delimiter, string = value[keys_list[0]]
             delimiter = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, delimiter
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                delimiter,
             )
             string = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, string
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                string,
             )
             return string.split(delimiter)
 
         if stripped_fn_lower == "getazs":
             region = (
                 resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, value["Fn::GetAZs"]
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    value["Fn::GetAZs"],
                 )
-                or aws_stack.get_region()
+                or region_name
             )
             azs = []
             for az in ("a", "b", "c", "d"):
@@ -475,13 +615,27 @@ def _resolve_refs_recursively(
         if stripped_fn_lower == "base64":
             value_to_encode = value[keys_list[0]]
             value_to_encode = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, value_to_encode
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                value_to_encode,
             )
             return to_str(base64.b64encode(to_bytes(value_to_encode)))
 
         for key, val in dict(value).items():
             value[key] = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, val
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                val,
             )
 
     if isinstance(value, list):
@@ -490,6 +644,8 @@ def _resolve_refs_recursively(
             inner_list = value[0]
             if str(inner_list[0]).lower().startswith("fn::"):
                 return resolve_refs_recursively(
+                    account_id,
+                    region_name,
                     stack_name,
                     resources,
                     mappings,
@@ -500,13 +656,22 @@ def _resolve_refs_recursively(
 
         for i in range(len(value)):
             value[i] = resolve_refs_recursively(
-                stack_name, resources, mappings, conditions, parameters, value[i]
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                parameters,
+                value[i],
             )
 
     return value
 
 
 def resolve_placeholders_in_string(
+    account_id: str,
+    region_name: str,
     result,
     stack_name: str,
     resources: dict,
@@ -543,7 +708,9 @@ def resolve_placeholders_in_string(
         if len(parts) == 1:
             if parts[0] in resources:
                 # Logical resource ID or parameter name specified => Use Ref for lookup
-                result = resolve_ref(stack_name, resources, parameters, parts[0])
+                result = resolve_ref(
+                    account_id, region_name, stack_name, resources, parameters, parts[0]
+                )
 
                 if result is None:
                     raise DependencyNotYetSatisfied(
@@ -553,7 +720,14 @@ def resolve_placeholders_in_string(
                 # TODO: is this valid?
                 # make sure we resolve any functions/placeholders in the extracted string
                 result = resolve_refs_recursively(
-                    stack_name, resources, mappings, conditions, parameters, result
+                    account_id,
+                    region_name,
+                    stack_name,
+                    resources,
+                    mappings,
+                    conditions,
+                    parameters,
+                    result,
                 )
                 # make sure we convert the result to string
                 # TODO: do this more systematically
@@ -611,8 +785,10 @@ class ChangeConfig(TypedDict):
 
 
 class TemplateDeployer:
-    def __init__(self, stack):
+    def __init__(self, account_id: str, region_name: str, stack):
         self.stack = stack
+        self.account_id = account_id
+        self.region_name = region_name
 
         try:
             self.provider_config = json.loads(config.CFN_RESOURCE_PROVIDER_OVERRIDES)
@@ -1086,7 +1262,7 @@ class TemplateDeployer:
             stack.template["Resources"].pop(delete["ResourceChange"]["LogicalResourceId"], None)
 
         # resolve outputs
-        stack.resolved_outputs = resolve_outputs(stack)
+        stack.resolved_outputs = resolve_outputs(self.account_id, self.region_name, stack)
 
         return changes_done
 
@@ -1108,6 +1284,8 @@ class TemplateDeployer:
 
         # resolve refs in resource details
         resolve_refs_recursively(
+            self.account_id,
+            self.region_name,
             stack.stack_name,
             stack.resources,
             stack.mappings,
@@ -1183,15 +1361,14 @@ class TemplateDeployer:
         resource = self.resources[logical_resource_id]
 
         resource_provider_payload: ResourceProviderPayload = {
-            "awsAccountId": "000000000000",
+            "awsAccountId": self.account_id,
             "callbackContext": {},
             "stackId": self.stack.stack_name,
             "resourceType": resource["Type"],
             "resourceTypeVersion": "000000",
             # TODO: not actually a UUID
             "bearerToken": str(uuid.uuid4()),
-            # TODO: get the current region
-            "region": "us-east-1",
+            "region": self.region_name,
             "action": action,
             "requestData": {
                 "logicalResourceId": logical_resource_id,
@@ -1209,12 +1386,14 @@ class TemplateDeployer:
 
 
 # FIXME: resolve_refs_recursively should not be needed, the resources themselves should have those values available already
-def resolve_outputs(stack) -> list[dict]:
+def resolve_outputs(account_id: str, region_name: str, stack) -> list[dict]:
     result = []
     for k, details in stack.outputs.items():
         value = None
         try:
             resolve_refs_recursively(
+                account_id,
+                region_name,
                 stack.stack_name,
                 stack.resources,
                 stack.mappings,
@@ -1232,6 +1411,8 @@ def resolve_outputs(stack) -> list[dict]:
         exports = details.get("Export") or {}
         export = exports.get("Name")
         export = resolve_refs_recursively(
+            account_id,
+            region_name,
             stack.stack_name,
             stack.resources,
             stack.mappings,

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -23,7 +23,9 @@ class GatewayResponse(GenericBaseModel):
         api_id = props.get("RestApiId")
         if not api_id:
             return
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         result = client.get_gateway_response(restApiId=api_id, responseType=props["ResponseType"])
         return result if "responseType" in result else None
 
@@ -49,7 +51,9 @@ class GatewayRequestValidator(GenericBaseModel):
         return "AWS::ApiGateway::RequestValidator"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         props = self.props
         api_id = props["RestApiId"]
         name = props["Name"]
@@ -67,7 +71,13 @@ class GatewayRequestValidator(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -97,7 +107,9 @@ class GatewayRestAPI(GenericBaseModel):
         if not self.props.get("id"):
             return None
 
-        return connect_to().apigateway.get_rest_api(restApiId=self.props.get("id"))
+        return connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway.get_rest_api(restApiId=self.props.get("id"))
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
@@ -110,11 +122,24 @@ class GatewayRestAPI(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _api_id(properties: dict, logical_resource_id: str, resource: dict, stack_name: str):
+        def _api_id(
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
             return resource["PhysicalResourceId"]
 
-        def _create(logical_resource_id: str, resource: dict, stack_name: str):
-            client = connect_to().apigateway
+        def _create(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
+            client = connect_to(aws_access_key_id=account_id, region_name=region_name).apigateway
             props = resource["Properties"]
 
             kwargs = select_attributes(
@@ -136,7 +161,9 @@ class GatewayRestAPI(GenericBaseModel):
             kwargs = keys_to_lower(kwargs, skip_children_of=["policy"])
             kwargs["tags"] = {tag["key"]: tag["value"] for tag in kwargs.get("tags", [])}
 
-            cfn_client = connect_to().cloudformation
+            cfn_client = connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).cloudformation
             stack_id = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]["StackId"]
             kwargs["tags"].update(
                 {
@@ -165,7 +192,7 @@ class GatewayRestAPI(GenericBaseModel):
                         get_obj_kwargs["VersionId"] = version_id
 
                     # what is the approach when client call fail? Do we bubble it up?
-                    s3_client = connect_to().s3
+                    s3_client = connect_to(aws_access_key_id=account_id, region_name=region_name).s3
                     get_obj_req = s3_client.get_object(
                         Bucket=s3_body_location.get("Bucket"),
                         Key=s3_body_location.get("Key"),
@@ -195,10 +222,18 @@ class GatewayRestAPI(GenericBaseModel):
             props["id"] = result["id"]
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
-            resources = connect_to().apigateway.get_resources(restApiId=result["id"])["items"]
+            resources = connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).apigateway.get_resources(restApiId=result["id"])["items"]
             for res in resources:
                 if res["path"] == "/" and not res.get("parentId"):
                     resource["Properties"]["RootResourceId"] = res["id"]
@@ -225,7 +260,9 @@ class GatewayDeployment(GenericBaseModel):
         if not api_id:
             return None
 
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         result = client.get_deployments(restApiId=api_id)["items"]
         # TODO possibly filter results by stage name or other criteria
 
@@ -233,7 +270,13 @@ class GatewayDeployment(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -263,7 +306,9 @@ class GatewayResource(GenericBaseModel):
         if not api_id or not parent_id:
             return None
 
-        api_resources = connect_to().apigateway.get_resources(restApiId=api_id)["items"]
+        api_resources = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway.get_resources(restApiId=api_id)["items"]
         target_resource = list(
             filter(
                 lambda res: res.get("parentId") == parent_id
@@ -284,7 +329,12 @@ class GatewayResource(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def get_apigw_resource_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             result = {
                 "restApiId": properties.get("RestApiId"),
@@ -293,7 +343,7 @@ class GatewayResource(GenericBaseModel):
             }
             if not result.get("parentId"):
                 # get root resource id
-                apigw = connect_to().apigateway
+                apigw = connect_to(aws_access_key_id=account_id, region_name=region_name).apigateway
                 resources = apigw.get_resources(restApiId=result["restApiId"])["items"]
                 root_resource = ([r for r in resources if r["path"] == "/"] or [None])[0]
                 if not root_resource:
@@ -303,7 +353,13 @@ class GatewayResource(GenericBaseModel):
                 result["parentId"] = root_resource["id"]
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -328,7 +384,9 @@ class GatewayMethod(GenericBaseModel):
         if not api_id or not res_id:
             return None
 
-        res_obj = connect_to().apigateway.get_resource(restApiId=api_id, resourceId=res_id)
+        res_obj = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway.get_resource(restApiId=api_id, resourceId=res_id)
         match = [
             v
             for (k, v) in res_obj.get("resourceMethods", {}).items()
@@ -349,7 +407,9 @@ class GatewayMethod(GenericBaseModel):
 
     def update_resource(self, new_resource, stack_name, resources):
         props = new_resource["Properties"]
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         integration = props.get("Integration")
         kwargs = {
             "restApiId": props["RestApiId"],
@@ -380,7 +440,12 @@ class GatewayMethod(GenericBaseModel):
         """
 
         def get_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             result = keys_to_lower(properties)
             param_names = [
@@ -400,9 +465,17 @@ class GatewayMethod(GenericBaseModel):
             result["requestParameters"] = result.get("requestParameters") or {}
             return result
 
-        def _subresources(logical_resource_id: str, resource: dict, stack_name: str):
-            apigateway = connect_to().apigateway
-            provider = cls(resource)
+        def _subresources(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
+            apigateway = connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).apigateway
+            provider = cls(account_id, region_name, resource)
             props = provider.props
 
             integration = props.get("Integration")
@@ -461,7 +534,13 @@ class GatewayMethod(GenericBaseModel):
                     responseModels=response.get("responseModels") or {},
                 )
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource = resource
             rest_api_id = resource["Properties"]["RestApiId"]
             apigw_resource_id = resource["Properties"]["ResourceId"]
@@ -491,15 +570,20 @@ class GatewayStage(GenericBaseModel):
         api_id = self.props.get("RestApiId") or self.logical_resource_id
         if not api_id:
             return None
-        result = connect_to().apigateway.get_stage(
-            restApiId=api_id, stageName=self.props["StageName"]
-        )
+        result = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway.get_stage(restApiId=api_id, stageName=self.props["StageName"])
         return result
 
     @staticmethod
     def get_deploy_templates():
         def get_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             stage_name = properties.get("StageName", "default")
             result = keys_to_lower(properties)
@@ -520,7 +604,13 @@ class GatewayStage(GenericBaseModel):
             result["stageName"] = stage_name
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["stageName"]
             resource["Properties"]["StageName"] = result["stageName"]
 
@@ -540,7 +630,11 @@ class GatewayUsagePlan(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         plan_name = self.props.get("UsagePlanName")
-        result = connect_to().apigateway.get_usage_plans().get("items", [])
+        result = (
+            connect_to(aws_access_key_id=self.account_id, region_name=self.region_name)
+            .apigateway.get_usage_plans()
+            .get("items", [])
+        )
         result = [r for r in result if r["name"] == plan_name]
         return (result or [None])[0]
 
@@ -554,7 +648,13 @@ class GatewayUsagePlan(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -636,7 +736,9 @@ class GatewayUsagePlan(GenericBaseModel):
                 patch_operations.append(
                     {"op": "replace", "path": f"/{first_char_to_lower(parameter)}", "value": value}
                 )
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         client.update_usage_plan(usagePlanId=usage_plan_id, patchOperations=patch_operations)
 
 
@@ -649,7 +751,11 @@ class GatewayApiKey(GenericBaseModel):
         props = self.props
         key_name = props.get("Name")
         cust_id = props.get("CustomerId")
-        result = connect_to().apigateway.get_api_keys().get("items", [])
+        result = (
+            connect_to(aws_access_key_id=self.account_id, region_name=self.region_name)
+            .apigateway.get_api_keys()
+            .get("items", [])
+        )
         result = [
             r
             for r in result
@@ -667,7 +773,13 @@ class GatewayApiKey(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -694,7 +806,9 @@ class GatewayUsagePlanKey(GenericBaseModel):
         return "AWS::ApiGateway::UsagePlanKey"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         key_id = self.props.get("KeyId")
         key_type = self.props.get("KeyType")
         plan_id = self.props.get("UsagePlanId")
@@ -704,7 +818,13 @@ class GatewayUsagePlanKey(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["id"]
 
         return {
@@ -723,11 +843,19 @@ class GatewayDomain(GenericBaseModel):
         return "AWS::ApiGateway::DomainName"
 
     def fetch_state(self, stack_name, resources):
-        return connect_to().apigateway.get_domain_name(domainName=self.props["DomainName"])
+        return connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway.get_domain_name(domainName=self.props["DomainName"])
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["domainName"]
 
         return {
@@ -758,7 +886,7 @@ class GatewayBasePathMapping(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         resources = (
-            connect_to()
+            connect_to(aws_access_key_id=self.account_id, region_name=self.region_name)
             .apigateway.get_base_path_mappings(domainName=self.props.get("DomainName"))
             .get("items", [])
         )
@@ -771,8 +899,14 @@ class GatewayBasePathMapping(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create_base_path_mapping(logical_resource_id: str, resource: dict, stack_name: str):
-            provider = cls(resource)
+        def _create_base_path_mapping(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
+            provider = cls(account_id, region_name, resource)
             props = provider.props
 
             kwargs = {
@@ -782,9 +916,17 @@ class GatewayBasePathMapping(GenericBaseModel):
                 **({"stage": props.get("Stage")} if props.get("Stage") else {}),
             }
 
-            return connect_to().apigateway.create_base_path_mapping(**kwargs)
+            return connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).apigateway.create_base_path_mapping(**kwargs)
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["restApiId"]
 
         return {
@@ -801,7 +943,9 @@ class GatewayModel(GenericBaseModel):
         return "AWS::ApiGateway::Model"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         api_id = self.props["RestApiId"]
 
         items = client.get_models(restApiId=api_id)["items"]
@@ -827,11 +971,22 @@ class GatewayModel(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["name"]
 
         def _jsonify_schema(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> str:
             return json.dumps(properties.get("Schema", {}))
 
@@ -858,17 +1013,27 @@ class GatewayAccount(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         if not self.physical_resource_id:
             return None
-        client = connect_to().apigateway
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).apigateway
         return client.get_account()
 
     @classmethod
     def get_deploy_templates(cls):
-        def _create(logical_resource_id: str, resource: dict, stack_name: str):
-            props = cls(resource).props
+        def _create(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
+            props = cls(account_id, region_name, resource).props
 
             role_arn = props["CloudWatchRoleArn"]
 
-            connect_to().apigateway.update_account(
+            connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).apigateway.update_account(
                 patchOperations=[{"op": "replace", "path": "/cloudwatchRoleArn", "value": role_arn}]
             )
 

--- a/localstack/services/cloudformation/models/cdk.py
+++ b/localstack/services/cloudformation/models/cdk.py
@@ -21,7 +21,13 @@ class CDKMetadata(GenericBaseModel):
         def _no_op(*args, **kwargs):
             pass
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = md5(canonical_json(resource["Properties"]))
 
         return {

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -9,7 +9,7 @@ class CertificateManagerCertificate(GenericBaseModel):
         return "AWS::CertificateManager::Certificate"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().acm
+        client = connect_to(aws_access_key_id=self.account_id, region_name=self.region_name).acm
         result = client.list_certificates().get("CertificateSummaryList", [])
         domain_name = self.props.get("DomainName")
         result = [c for c in result if c["DomainName"] == domain_name]
@@ -18,7 +18,12 @@ class CertificateManagerCertificate(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _create_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             result = select_attributes(
                 properties,
@@ -50,7 +55,13 @@ class CertificateManagerCertificate(GenericBaseModel):
 
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["Properties"]["CertificateArn"] = resource["PhysicalResourceId"] = result[
                 "CertificateArn"
             ]

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -26,7 +26,7 @@ class ECRRepository(GenericBaseModel):
         if repo_name:
             return {
                 "repositoryArn": arns.get_ecr_repository_arn(repo_name),
-                "registryId": "000000000000",
+                "registryId": self.account_id,
                 "repositoryName": repo_name,
                 "repositoryUri": "http://localhost:4566",
                 "createdAt": datetime.time(),
@@ -38,17 +38,35 @@ class ECRRepository(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_repo(logical_resource_id: str, resource: dict, stack_name: str):
+        def _create_repo(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
             default_repos_per_stack[stack_name] = resource["Properties"]["RepositoryName"]
             LOG.warning(
                 "Creating a Mock ECR Repository for CloudFormation. This is only intended to be used for allowing a successful CDK bootstrap and does not provision any underlying ECR repository."
             )
 
-        def _delete_repo(logical_resource_id: str, resource: dict, stack_name: str):
+        def _delete_repo(
+            account_id: str,
+            region_name: str,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
+        ):
             if default_repos_per_stack.get(stack_name):
                 del default_repos_per_stack[stack_name]
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             repo_name = resource["Properties"]["RepositoryName"]
             resource["PhysicalResourceId"] = arns.get_ecr_repository_arn(repo_name)
 

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -12,7 +12,9 @@ class FirehoseDeliveryStream(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         stream_name = self.props.get("DeliveryStreamName") or self.logical_resource_id
-        return connect_to().firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
+        return connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
@@ -25,11 +27,17 @@ class FirehoseDeliveryStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             stream_name = resource["Properties"]["DeliveryStreamName"]
 
             # TODO: fix the polling here and check the response, might not actually be ACTIVE
-            client = connect_to().firehose
+            client = connect_to(aws_access_key_id=account_id, region_name=region_name).firehose
 
             def check_stream_state():
                 stream = client.describe_delivery_stream(DeliveryStreamName=stream_name)

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -10,7 +10,7 @@ class LogsLogGroup(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         group_name = self.props.get("LogGroupName")
-        logs = connect_to().logs
+        logs = connect_to(aws_access_key_id=self.account_id, region_name=self.region_name).logs
         groups = logs.describe_log_groups(logGroupNamePrefix=group_name)["logGroups"]
         return ([g for g in groups if g["logGroupName"] == group_name] or [None])[0]
 
@@ -24,11 +24,17 @@ class LogsLogGroup(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             log_group_name = resource["Properties"]["LogGroupName"]
-            describe_result = connect_to().logs.describe_log_groups(
-                logGroupNamePrefix=log_group_name
-            )
+            describe_result = connect_to(
+                aws_access_key_id=account_id, region_name=region_name
+            ).logs.describe_log_groups(logGroupNamePrefix=log_group_name)
             resource["Properties"]["Arn"] = describe_result["logGroups"][0]["arn"]
             resource["PhysicalResourceId"] = log_group_name
 
@@ -53,7 +59,7 @@ class LogsLogStream(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         group_name = self.props.get("LogGroupName")
         stream_name = self.props.get("LogStreamName")
-        logs = connect_to().logs
+        logs = connect_to(aws_access_key_id=self.account_id, region_name=self.region_name).logs
         streams = logs.describe_log_streams(
             logGroupName=group_name, logStreamNamePrefix=stream_name
         )["logStreams"]
@@ -69,7 +75,13 @@ class LogsLogStream(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = resource["Properties"]["LogStreamName"]
 
         return {
@@ -94,14 +106,20 @@ class LogsSubscriptionFilter(GenericBaseModel):
         props = self.props
         group_name = props.get("LogGroupName")
         filter_pattern = props.get("FilterPattern")
-        logs = connect_to().logs
+        logs = connect_to(aws_access_key_id=self.account_id, region_name=self.region_name).logs
         groups = logs.describe_subscription_filters(logGroupName=group_name)["subscriptionFilters"]
         groups = [g for g in groups if g.get("filterPattern") == filter_pattern]
         return (groups or [None])[0]
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = resource["Properties"]["LogGroupName"]
 
         return {

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -14,7 +14,12 @@ from localstack.utils.collections import convert_to_typed_dict
 # See examples in:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
 def opensearch_add_tags_params(
-    properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+    account_id: str,
+    region_name: str,
+    properties: dict,
+    logical_resource_id: str,
+    resource: dict,
+    stack_name: str,
 ):
     es_arn = arns.es_domain_arn(properties.get("DomainName"))
     tags = properties.get("Tags", [])
@@ -28,7 +33,9 @@ class OpenSearchDomain(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         domain_name = self._domain_name()
-        return connect_to().opensearch.describe_domain(DomainName=domain_name)
+        return connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).opensearch.describe_domain(DomainName=domain_name)
 
     def _domain_name(self):
         return self.props.get("DomainName") or self.logical_resource_id
@@ -36,7 +43,12 @@ class OpenSearchDomain(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _create_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ):
             properties = remove_none_values(properties)
             result = convert_to_typed_dict(CreateDomainRequest, properties)
@@ -51,7 +63,13 @@ class OpenSearchDomain(GenericBaseModel):
                 )
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["DomainStatus"]["DomainName"]
 
         return {

--- a/localstack/services/cloudformation/models/redshift.py
+++ b/localstack/services/cloudformation/models/redshift.py
@@ -9,7 +9,9 @@ class RedshiftCluster(GenericBaseModel):
         return "AWS::Redshift::Cluster"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().redshift
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).redshift
         cluster_id = self.props.get("ClusterIdentifier")
         result = client.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"]
         return (result or [None])[0]
@@ -24,7 +26,13 @@ class RedshiftCluster(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["Cluster"]["ClusterIdentifier"]
 
         return {"create": {"function": "create_cluster", "result_handler": _handle_result}}

--- a/localstack/services/cloudformation/models/resourcegroups.py
+++ b/localstack/services/cloudformation/models/resourcegroups.py
@@ -9,14 +9,22 @@ class ResourceGroupsGroup(GenericBaseModel):
         return "AWS::ResourceGroups::Group"
 
     def fetch_state(self, stack_name, resources):
-        client = connect_to().resource_groups
+        client = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).resource_groups
         result = client.list_groups().get("Groups", [])
         result = [g for g in result if g["Name"] == self.props["Name"]]
         return (result or [None])[0]
 
     @classmethod
     def get_deploy_templates(cls):
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["Properties"]["Arn"] = result["Group"]["GroupArn"]
             resource["PhysicalResourceId"] = result["Group"]["Name"]
 

--- a/localstack/services/cloudformation/models/route53.py
+++ b/localstack/services/cloudformation/models/route53.py
@@ -9,7 +9,9 @@ class Route53RecordSet(GenericBaseModel):
         return "AWS::Route53::RecordSet"
 
     def fetch_state(self, stack_name, resources):
-        route53 = connect_to().route53
+        route53 = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).route53
         props = self.props
         result = route53.list_resource_record_sets(HostedZoneId=props["HostedZoneId"])[
             "ResourceRecordSets"
@@ -20,7 +22,12 @@ class Route53RecordSet(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def param_change_batch(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ):
             attr_names = [
                 "Name",
@@ -51,9 +58,14 @@ class Route53RecordSet(GenericBaseModel):
             }
 
         def hosted_zone_id_change_batch(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ):
-            route53 = connect_to().route53
+            route53 = connect_to(aws_access_key_id=account_id, region_name=region_name).route53
             hosted_zone_id = properties.get("HostedZoneId")
             if not hosted_zone_id:
                 hosted_zone_name = properties.get("HostedZoneName")
@@ -71,7 +83,13 @@ class Route53RecordSet(GenericBaseModel):
                 hosted_zone_id = hosted_zone.get("Id")
             return hosted_zone_id
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = resource["Properties"]["Name"]
 
         return {

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -18,7 +18,9 @@ class SecretsManagerSecret(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         secret_name = self.props.get("Name") or self.logical_resource_id
-        result = connect_to().secretsmanager.describe_secret(SecretId=secret_name)
+        result = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).secretsmanager.describe_secret(SecretId=secret_name)
         return result
 
     @staticmethod
@@ -71,7 +73,12 @@ class SecretsManagerSecret(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _create_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             attributes = ["Name", "Description", "KmsKeyId", "SecretString", "Tags"]
             result = select_attributes(properties, attributes)
@@ -104,7 +111,13 @@ class SecretsManagerSecret(GenericBaseModel):
                 result["SecretString"] = secret_value
             return result
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["Properties"]["Id"] = result["ARN"]
             resource["PhysicalResourceId"] = result["ARN"]
 
@@ -145,13 +158,20 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         secret_id = self.props.get("SecretId")
-        result = connect_to().secretsmanager.get_resource_policy(SecretId=secret_id)
+        result = connect_to(
+            aws_access_key_id=self.account_id, region_name=self.region_name
+        ).secretsmanager.get_resource_policy(SecretId=secret_id)
         return result
 
     @staticmethod
     def get_deploy_templates():
         def create_params(
-            properties: dict, logical_resource_id: str, resource: dict, stack_name: str
+            account_id: str,
+            region_name: str,
+            properties: dict,
+            logical_resource_id: str,
+            resource: dict,
+            stack_name: str,
         ) -> dict:
             return {
                 "SecretId": properties["SecretId"],
@@ -159,7 +179,13 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
                 "BlockPublicPolicy": properties.get("BlockPublicPolicy"),
             }
 
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = result["ARN"]
 
         return {

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -26,7 +26,6 @@ from localstack.services.cloudformation.deployment_utils import (
 )
 from localstack.services.cloudformation.engine.quirks import PHYSICAL_RESOURCE_ID_SPECIAL_CASES
 from localstack.services.cloudformation.service_models import KEY_RESOURCE_STATE, GenericBaseModel
-from localstack.utils.aws import aws_stack
 
 if TYPE_CHECKING:
     from localstack.services.cloudformation.engine.types import (
@@ -117,7 +116,7 @@ def convert_payload(
         request_token=str(uuid.uuid4()),  # TODO: not actually a UUID
         stack_name=stack_name,
         stack_id=stack_id,
-        account_id="000000000000",
+        account_id=payload["awsAccountId"],
         region_name=payload["region"],
         desired_state=desired_state,
         logical_resource_id=payload["requestData"]["logicalResourceId"],
@@ -195,6 +194,8 @@ def get_resource_type(resource: dict) -> str:
 
 
 def invoke_function(
+    account_id: str,
+    region_name: str,
     function: Callable,
     params: dict,
     resource_type: str,
@@ -204,9 +205,10 @@ def invoke_function(
 ) -> Any:
     try:
         LOG.debug(
-            'Request for resource type "%s" in region %s: %s %s',
+            'Request for resource type "%s" in account %s region %s: %s %s',
             resource_type,
-            aws_stack.get_region(),
+            account_id,
+            region_name,
             func_details["function"],
             params,
         )
@@ -259,6 +261,8 @@ def get_service_name(resource):
 
 
 def resolve_resource_parameters(
+    account_id_: str,
+    region_name_: str,
     stack_name: str,
     resource_definition: ResourceDefinition,
     resources: dict[str, ResourceDefinition],
@@ -266,7 +270,7 @@ def resolve_resource_parameters(
     func_details: FuncDetailsValue,
 ) -> dict | None:
     params = func_details.get("parameters") or (
-        lambda properties, logical_resource_id, *args, **kwargs: properties
+        lambda account_id, region_name, properties, logical_resource_id, *args, **kwargs: properties
     )
     resource_props = resource_definition["Properties"] = resource_definition.get("Properties", {})
     resource_props = dict(resource_props)
@@ -274,7 +278,9 @@ def resolve_resource_parameters(
 
     if callable(params):
         # resolve parameter map via custom function
-        params = params(resource_props, resource_id, resource_definition, stack_name)
+        params = params(
+            account_id_, region_name_, resource_props, resource_id, resource_definition, stack_name
+        )
     else:
         # it could be a list like ['param1', 'param2', {'apiCallParamName': 'cfResourcePropName'}]
         if isinstance(params, list):
@@ -295,6 +301,8 @@ def resolve_resource_parameters(
             for prop_key in prop_keys:
                 if callable(prop_key):
                     prop_value = prop_key(
+                        account_id_,
+                        region_name_,
                         resource_props,
                         resource_id,
                         resource_definition,
@@ -360,6 +368,7 @@ class LegacyResourceProvider(ResourceProvider):
                 "PhysicalResourceId": physical_resource_id,
                 "LogicalResourceId": request.logical_resource_id,
             },
+            account_id=request.account_id,
             region_name=request.region_name,
         )
         if not resource_provider.is_updatable():
@@ -403,6 +412,8 @@ class LegacyResourceProvider(ResourceProvider):
 
     def create_or_delete(self, request: ResourceRequest[Properties]) -> ProgressEvent[Properties]:
         resource_provider = self.resource_provider_cls(
+            account_id=request.account_id,
+            region_name=request.region_name,
             # TODO: other top level keys
             resource_json={
                 "Type": self.resource_type,
@@ -413,7 +424,6 @@ class LegacyResourceProvider(ResourceProvider):
                 "_state_": request.previous_state,
                 "LogicalResourceId": request.logical_resource_id,
             },
-            region_name=request.region_name,
         )
         # TODO: only really necessary for the create and update operation
         resource_provider.add_defaults(
@@ -453,20 +463,32 @@ class LegacyResourceProvider(ResourceProvider):
             executed = False
             # TODO(srw) 3 - callable function
             if callable(func.get("function")):
-                result = func["function"](request.logical_resource_id, resource, request.stack_name)
+                result = func["function"](
+                    request.account_id,
+                    request.region_name,
+                    request.logical_resource_id,
+                    resource,
+                    request.stack_name,
+                )
 
                 results.append(result)
                 executed = True
             elif not executed:
                 service = get_service_name(resource)
                 try:
-                    client = connect_to.get_client(service)
+                    client = connect_to.get_client(
+                        aws_access_key_id=request.account_id,
+                        region_name=request.region_name,
+                        service_name=service,
+                    )
                     if client:
                         # get the method on that function
                         function = getattr(client, func["function"])
 
                         # unify the resource parameters
                         params = resolve_resource_parameters(
+                            request.account_id,
+                            request.region_name,
                             request.stack_name,
                             resource,
                             self.all_resources,
@@ -477,6 +499,8 @@ class LegacyResourceProvider(ResourceProvider):
                             result = None
                         else:
                             result = invoke_function(
+                                request.account_id,
+                                request.region_name,
                                 function,
                                 params,
                                 self.resource_type,
@@ -497,6 +521,8 @@ class LegacyResourceProvider(ResourceProvider):
                 )
                 result_handler = func["result_handler"]
                 result_handler(
+                    request.account_id,
+                    request.region_name,
                     result,
                     request.logical_resource_id,
                     self.all_resources[request.logical_resource_id],

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from localstack.services.cloudformation.deployment_utils import check_not_found_exception
-from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
 
@@ -35,9 +34,10 @@ class GenericBaseModel:
     e.g., fetching the latest deployment state, getting the resource name, etc.
     """
 
-    def __init__(self, resource_json: dict, region_name: Optional[str] = None, **params):
+    def __init__(self, account_id: str, region_name: str, resource_json: dict, **params):
         # self.stack_name = stack_name # TODO: add stack name to params
-        self.region_name = region_name or aws_stack.get_region()
+        self.account_id = account_id
+        self.region_name = region_name
         self.resource_json = resource_json
         self.resource_type = resource_json["Type"]
         # Properties, as defined in the resource template


### PR DESCRIPTION
This PR adds account and region awareness to Cloudformation.

It will now be possible to deploy Cfn stack in any arbitrary account ID and any region.

Specifically, this PR makes the following changes:
- Take the account ID and region name from Request Context and explicitly pass it down the call stack
- Use these values when instantiating `connect_to()` clients and doing internal cross-service calls
- Remove use of `aws_stack.get_region()` and `get_account_id()`