### PR TITLE
Bundle lambda init into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/var/lib/localstack/cache \
     source .venv/bin/activate && \
     python -m localstack.cli.lpm install \
+      awslambda-runtime \
       dynamodb-local && \
     chown -R localstack:localstack /usr/lib/localstack && \
     chmod -R 777 /usr/lib/localstack


### PR DESCRIPTION
Certain users seem to have issues fetching the lambda init from GitHub which made us notice that we're not actually bundling it into the built Docker container. 

It's probably sensible to ship the lambda runtime init by default