### PR TITLE
regenerate S3 snapshots

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -454,11 +454,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
         key_object = get_key_from_moto_bucket(moto_bucket, key=key)
 
-        if checksum_algorithm := key_object.checksum_algorithm:
-            # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
-            response["ContentEncoding"] = ""
-
-        if (request.get("ChecksumMode") or "").upper() == "ENABLED" and checksum_algorithm:
+        if (
+            request.get("ChecksumMode") or ""
+        ).upper() == "ENABLED" and key_object.checksum_algorithm:
             response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
 
         if not request.get("VersionId"):
@@ -504,12 +502,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not config.S3_SKIP_KMS_KEY_VALIDATION and key_object.kms_key_id:
             validate_kms_key_id(kms_key=key_object.kms_key_id, bucket=moto_bucket)
 
-        if checksum_algorithm := key_object.checksum_algorithm:
-            # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
-            response["ContentEncoding"] = ""
-
-        if (request.get("ChecksumMode") or "").upper() == "ENABLED" and checksum_algorithm:
-            response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
+        if (
+            request.get("ChecksumMode") or ""
+        ).upper() == "ENABLED" and key_object.checksum_algorithm:
+            response[f"Checksum{key_object.checksum_algorithm.upper()}"] = key_object.checksum_value
 
         if not version_id and (
             (bucket_lifecycle_config := store.bucket_lifecycle_configuration.get(request["Bucket"]))

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -454,7 +454,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
         key_object = get_key_from_moto_bucket(moto_bucket, key=key)
 
-        if checksum_algorithm := key_object.checksum_algorithm and not response.get(
+        if (checksum_algorithm := key_object.checksum_algorithm) and not response.get(
             "ContentEncoding"
         ):
             # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested) if it's not
@@ -507,7 +507,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not config.S3_SKIP_KMS_KEY_VALIDATION and key_object.kms_key_id:
             validate_kms_key_id(kms_key=key_object.kms_key_id, bucket=moto_bucket)
 
-        if checksum_algorithm := key_object.checksum_algorithm and not response.get(
+        if (checksum_algorithm := key_object.checksum_algorithm) and not response.get(
             "ContentEncoding"
         ):
             # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested) if it's not

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -22,7 +22,6 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config, constants
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -106,14 +105,6 @@ def aws_http_client_factory(aws_session):
 @pytest.fixture(scope="class")
 def s3_vhost_client(aws_client_factory):
     return aws_client_factory(config=botocore.config.Config(s3={"addressing_style": "virtual"})).s3
-
-
-# TODO: remove
-@pytest.fixture(scope="class")
-def s3_presigned_client(aws_client_factory):
-    return aws_client_factory(
-        aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY
-    ).s3
 
 
 @pytest.fixture

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -7,7 +7,6 @@ import io
 import json
 import logging
 import os
-import re
 import shutil
 import tempfile
 import time
@@ -60,6 +59,7 @@ from localstack.utils.strings import (
     checksum_crc32c,
     hash_sha1,
     hash_sha256,
+    long_uid,
     short_uid,
     to_bytes,
     to_str,
@@ -118,6 +118,10 @@ def is_old_provider():
 
 def is_asf_provider():
     return not LEGACY_S3_PROVIDER
+
+
+def is_native_provider():
+    return False
 
 
 @pytest.fixture
@@ -275,6 +279,17 @@ def create_tmp_folder_lambda():
             shutil.rmtree(folder)
         except Exception:
             LOG.warning(f"could not delete folder {folder}")
+
+
+@pytest.fixture
+def allow_bucket_acl(s3_bucket, aws_client):
+    """
+    # Since April 2023, AWS will by default block setting ACL to your bucket and object. You need to manually disable
+    # the BucketOwnershipControls and PublicAccessBlock to make your objects public.
+    # See https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
+    """
+    aws_client.s3.delete_bucket_ownership_controls(Bucket=s3_bucket)
+    aws_client.s3.delete_public_access_block(Bucket=s3_bucket)
 
 
 def _filter_header(param: dict) -> dict:
@@ -449,6 +464,10 @@ class TestS3:
         condition=is_old_provider,
         paths=["$..VersionId", "$..ContentLanguage", "$..BucketKeyEnabled"],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_copy_object_kms(self, s3_bucket, kms_create_key, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # because of the kms-key, the etag will be different on AWS
@@ -525,6 +544,10 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage"]
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_put_and_get_object_with_utf8_key(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -537,6 +560,7 @@ class TestS3:
         assert response["Body"].read() == b"abc123"
 
     @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..MaxAttemptsReached"])
     @markers.snapshot.skip_snapshot_verify(
         condition=is_asf_provider,
         paths=[
@@ -562,7 +586,13 @@ class TestS3:
             "$..HTTPHeaders.content-type",
             "$..HTTPHeaders.last-modified",
             "$..HTTPHeaders.location",
-            "$..MaxAttemptsReached",
+        ],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=[
+            "$..HTTPHeaders.x-amz-server-side-encryption",
+            "$..ServerSideEncryption",
         ],
     )
     def test_put_and_get_object_with_content_language_disposition(
@@ -610,6 +640,10 @@ class TestS3:
         assert response["Body"].read() == b"test"
 
     @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_metadata_header_character_decoding(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # Object metadata keys should accept keys with underscores
@@ -618,15 +652,19 @@ class TestS3:
         object_key = "key-with-metadata"
         metadata = {"TEST_META_1": "foo", "__meta_2": "bar"}
         aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Metadata=metadata, Body="foo")
-        metadata_saved = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)["Metadata"]
+        metadata_saved = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
         snapshot.match("head-object", metadata_saved)
 
         # note that casing is removed (since headers are case-insensitive)
-        assert metadata_saved == {"test_meta_1": "foo", "__meta_2": "bar"}
+        assert metadata_saved["Metadata"] == {"test_meta_1": "foo", "__meta_2": "bar"}
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage"]
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_upload_file_multipart(self, s3_bucket, tmpdir, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -646,7 +684,10 @@ class TestS3:
         snapshot.match("get_object", obj)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     @pytest.mark.parametrize("key", ["file%2Fname", "test@key/"])
     def test_put_get_object_special_character(self, s3_bucket, aws_client, snapshot, key):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -958,6 +999,10 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage"]
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_put_and_get_object_with_hash_prefix(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         key_name = "#key-with-hash-prefix"
@@ -1013,7 +1058,7 @@ class TestS3:
             s3_vhost_client.delete_bucket(Bucket=bucket_name)
 
     @markers.parity.aws_validated
-    def test_put_and_get_bucket_policy(self, s3_bucket, snapshot, aws_client):
+    def test_put_and_get_bucket_policy(self, s3_bucket, snapshot, aws_client, allow_bucket_acl):
         # just for the joke: Response syntax HTTP/1.1 200
         # sample response: HTTP/1.1 204 No Content
         # https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketPolicy.html
@@ -1063,7 +1108,10 @@ class TestS3:
         snapshot.match("deleted-object-tags", object_tags)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     @pytest.mark.skipif(
         condition=LEGACY_S3_PROVIDER,
         reason="see https://github.com/localstack/localstack/issues/6218",
@@ -1081,6 +1129,10 @@ class TestS3:
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..Error.RequestID"]
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_get_object_after_deleted_in_versioned_bucket(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
@@ -1109,6 +1161,10 @@ class TestS3:
             "$.get-object-with-checksum.*",  # not implemented in legacy provider
             "$..VersionId",
         ],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_put_object_checksum(self, s3_create_bucket, algorithm, snapshot, aws_client):
         bucket = s3_create_bucket()
@@ -1179,7 +1235,10 @@ class TestS3:
     @markers.parity.aws_validated
     @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "SHA1", "SHA256", None])
     @pytest.mark.xfail(condition=LEGACY_S3_PROVIDER, reason="Patched only in ASF provider")
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_get_object_checksum(self, s3_bucket, snapshot, algorithm, aws_client):
         key = "test-checksum-retrieval"
         body = b"test-checksum"
@@ -1212,6 +1271,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @pytest.mark.xfail(condition=LEGACY_S3_PROVIDER, reason="Patched only in ASF provider")
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_checksum_with_content_encoding(self, s3_bucket, snapshot, aws_client):
         data = "1234567890 " * 100
         key = "test.gz"
@@ -1253,6 +1316,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_metadata_replace(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -1264,6 +1331,7 @@ class TestS3:
             Body='{"key": "value"}',
             ContentType="application/json",
             Metadata={"key": "value"},
+            ContentLanguage="en-US",
         )
         snapshot.match("put_object", resp)
 
@@ -1276,7 +1344,7 @@ class TestS3:
             CopySource=f"{bucket_name}/{object_key}",
             Key=object_key_copy,
             Metadata={"another-key": "value"},
-            ContentType="application/javascript",
+            ContentType="image/jpg",
             MetadataDirective="REPLACE",
         )
         snapshot.match("copy_object", resp)
@@ -1285,7 +1353,10 @@ class TestS3:
         snapshot.match("head_object_copy", head_object)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_metadata_directive_copy(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -1296,6 +1367,7 @@ class TestS3:
             Key=object_key,
             Body="test",
             Metadata={"key": "value"},
+            ContentLanguage="en-US",
         )
         snapshot.match("put-object", resp)
 
@@ -1308,6 +1380,8 @@ class TestS3:
             CopySource=f"{bucket_name}/{object_key}",
             Key=object_key_copy,
             Metadata={"another-key": "value"},  # this will be ignored
+            ContentLanguage="en-GB",
+            ContentType="image/jpg",
             MetadataDirective="COPY",
         )
         snapshot.match("copy-object", resp)
@@ -1316,7 +1390,44 @@ class TestS3:
         snapshot.match("head-object-copy", head_object)
 
     @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
+    @pytest.mark.parametrize("tagging_directive", ["COPY", "REPLACE", None])
+    def test_s3_copy_tagging_directive(self, s3_bucket, snapshot, aws_client, tagging_directive):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+
+        object_key = "source-object"
+        resp = aws_client.s3.put_object(
+            Bucket=s3_bucket, Key=object_key, Body="test", Tagging="key1=value1"
+        )
+        snapshot.match("put-object", resp)
+
+        get_object_tags = aws_client.s3.get_object_tagging(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("get-object-tag", get_object_tags)
+
+        kwargs = {"TaggingDirective": tagging_directive} if tagging_directive else {}
+
+        object_key_copy = f"{object_key}-copy"
+        resp = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
+            Key=object_key_copy,
+            Tagging="key2=value2",
+            **kwargs,
+        )
+        snapshot.match("copy-object", resp)
+
+        get_object_tags = aws_client.s3.get_object_tagging(Bucket=s3_bucket, Key=object_key_copy)
+        snapshot.match("get-copy-object-tag", get_object_tags)
+
+    @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_content_type_and_metadata(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1361,8 +1472,11 @@ class TestS3:
         snapshot.match("head_object_second_copy", head_object)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
-    def test_s3_copy_object_in_place(self, s3_create_bucket, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
+    def test_s3_copy_object_in_place(self, s3_bucket, allow_bucket_acl, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformer(
             [
@@ -1371,13 +1485,9 @@ class TestS3:
             ]
         )
         object_key = "source-object"
-        bucket_name = s3_create_bucket()
-        # need to delete to allow public-read ACL on the bucket
-        aws_client.s3.delete_bucket_ownership_controls(Bucket=bucket_name)
-        aws_client.s3.delete_public_access_block(Bucket=bucket_name)
 
         resp = aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key,
             Body='{"key": "value"}',
             ContentType="application/json",
@@ -1385,11 +1495,11 @@ class TestS3:
         )
         snapshot.match("put_object", resp)
 
-        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=object_key)
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
         snapshot.match("head_object", head_object)
 
         object_attrs = aws_client.s3.get_object_attributes(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key,
             ObjectAttributes=["StorageClass"],
         )
@@ -1397,7 +1507,7 @@ class TestS3:
 
         with pytest.raises(ClientError) as e:
             aws_client.s3.copy_object(
-                Bucket=bucket_name, CopySource=f"{bucket_name}/{object_key}", Key=object_key
+                Bucket=s3_bucket, CopySource=f"{s3_bucket}/{object_key}", Key=object_key
             )
         snapshot.match("copy-object-in-place-no-change", e.value.response)
 
@@ -1406,35 +1516,38 @@ class TestS3:
 
         # copy the object with the same StorageClass as the source object
         resp = aws_client.s3.copy_object(
-            Bucket=bucket_name,
-            CopySource=f"{bucket_name}/{object_key}",
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
             Key=object_key,
             ChecksumAlgorithm="SHA256",
             StorageClass=StorageClass.STANDARD,
         )
         snapshot.match("copy-object-in-place-with-storage-class", resp)
         object_attrs = aws_client.s3.get_object_attributes(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key,
             ObjectAttributes=["StorageClass"],
         )
         snapshot.match("object-attrs-after-copy", object_attrs)
 
         # get source object ACl, private
-        object_acl = aws_client.s3.get_object_acl(Bucket=bucket_name, Key=object_key)
+        object_acl = aws_client.s3.get_object_acl(Bucket=s3_bucket, Key=object_key)
         snapshot.match("object-acl", object_acl)
         # copy the object with any ACL does not work, even if different from source object
         with pytest.raises(ClientError) as e:
             aws_client.s3.copy_object(
-                Bucket=bucket_name,
-                CopySource=f"{bucket_name}/{object_key}",
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
                 Key=object_key,
                 ACL="public-read",
             )
         snapshot.match("copy-object-in-place-with-acl", e.value.response)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_in_place_storage_class(self, s3_bucket, snapshot, aws_client):
         # this test will validate that setting StorageClass (even the same as source) allows a copy in place
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -1566,7 +1679,10 @@ class TestS3:
         snapshot.match("copy-obj", response)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_in_place_metadata_directive(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1639,7 +1755,10 @@ class TestS3:
         snapshot.match("head-replace-directive-empty", head_object)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_in_place_website_redirect_location(
         self, s3_bucket, snapshot, aws_client
     ):
@@ -1671,7 +1790,10 @@ class TestS3:
         snapshot.match("head-object-after-copy", head_object)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_legal_hold(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1709,7 +1831,10 @@ class TestS3:
                 )
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_lock(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1741,7 +1866,10 @@ class TestS3:
         snapshot.match("head-dest-key", head_object)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_storage_class(self, s3_bucket, snapshot, aws_client):
         # this test will validate that setting StorageClass (even the same as source) allows a copy in place
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -1792,7 +1920,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "SHA1", "SHA256"])
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_with_checksum(self, s3_create_bucket, snapshot, aws_client, algorithm):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1841,7 +1972,10 @@ class TestS3:
         snapshot.match("copy-object-to-dest-keep-checksum", resp)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_preconditions(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1944,7 +2078,7 @@ class TestS3:
         paths=["$..Grants..Grantee.DisplayName", "$.permission-acl-key1.Grants"],
     )
     def test_s3_multipart_upload_acls(
-        self, s3_create_bucket, s3_multipart_upload, snapshot, aws_client
+        self, s3_bucket, allow_bucket_acl, s3_multipart_upload, snapshot, aws_client
     ):
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html
         # > Bucket and object permissions are independent of each other. An object does not inherit the permissions
@@ -1956,28 +2090,28 @@ class TestS3:
                 snapshot.transform.key_value("ID", value_replacement="owner-id"),
             ]
         )
-        bucket_name = f"test-bucket-{short_uid()}"
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
-        response = aws_client.s3.get_bucket_acl(Bucket=bucket_name)
+
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
+        response = aws_client.s3.get_bucket_acl(Bucket=s3_bucket)
         snapshot.match("bucket-acl", response)
 
         def check_permissions(key):
-            acl_response = aws_client.s3.get_object_acl(Bucket=bucket_name, Key=key)
+            acl_response = aws_client.s3.get_object_acl(Bucket=s3_bucket, Key=key)
             snapshot.match(f"permission-{key}", acl_response)
 
         # perform uploads (multipart and regular) and check ACLs
-        aws_client.s3.put_object(Bucket=bucket_name, Key="acl-key0", Body="something")
+        aws_client.s3.put_object(Bucket=s3_bucket, Key="acl-key0", Body="something")
         check_permissions("acl-key0")
-        s3_multipart_upload(bucket=bucket_name, key="acl-key1")
+        s3_multipart_upload(bucket=s3_bucket, key="acl-key1")
         check_permissions("acl-key1")
-        s3_multipart_upload(bucket=bucket_name, key="acl-key2", acl="public-read-write")
+        s3_multipart_upload(bucket=s3_bucket, key="acl-key2", acl="public-read-write")
         check_permissions("acl-key2")
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..Grants..Grantee.DisplayName", "$..Grants..Grantee.ID"]
     )
-    def test_s3_bucket_acl(self, s3_create_bucket, snapshot, aws_client):
+    def test_s3_bucket_acl(self, s3_bucket, allow_bucket_acl, snapshot, aws_client):
         # loosely based on
         # https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAcl.html
         snapshot.add_transformer(
@@ -1989,20 +2123,21 @@ class TestS3:
         list_bucket_output = aws_client.s3.list_buckets()
         owner = list_bucket_output["Owner"]
 
-        bucket_name = s3_create_bucket(ACL="public-read")
-        response = aws_client.s3.get_bucket_acl(Bucket=bucket_name)
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
+
+        response = aws_client.s3.get_bucket_acl(Bucket=s3_bucket)
         snapshot.match("get-bucket-acl", response)
 
-        aws_client.s3.put_bucket_acl(Bucket=bucket_name, ACL="private")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="private")
 
-        response = aws_client.s3.get_bucket_acl(Bucket=bucket_name)
+        response = aws_client.s3.get_bucket_acl(Bucket=s3_bucket)
         snapshot.match("get-bucket-canned-acl", response)
 
         aws_client.s3.put_bucket_acl(
-            Bucket=bucket_name, GrantRead='uri="http://acs.amazonaws.com/groups/s3/LogDelivery"'
+            Bucket=s3_bucket, GrantRead='uri="http://acs.amazonaws.com/groups/s3/LogDelivery"'
         )
 
-        response = aws_client.s3.get_bucket_acl(Bucket=bucket_name)
+        response = aws_client.s3.get_bucket_acl(Bucket=s3_bucket)
         snapshot.match("get-bucket-grant-acl", response)
 
         # Owner is mandatory, otherwise raise MalformedXML
@@ -2022,9 +2157,9 @@ class TestS3:
                 },
             ],
         }
-        aws_client.s3.put_bucket_acl(Bucket=bucket_name, AccessControlPolicy=acp)
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, AccessControlPolicy=acp)
 
-        response = aws_client.s3.get_bucket_acl(Bucket=bucket_name)
+        response = aws_client.s3.get_bucket_acl(Bucket=s3_bucket)
         snapshot.match("get-bucket-acp-acl", response)
 
     @markers.parity.aws_validated
@@ -2161,6 +2296,10 @@ class TestS3:
             "$..VersionId",
         ],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_object_expiry(self, s3_bucket, snapshot, aws_client):
         # AWS only cleans up S3 expired object once a day usually
         # the object stays accessible for quite a while after being expired
@@ -2215,6 +2354,10 @@ class TestS3:
             "$..VersionId",
         ],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_upload_file_with_xml_preamble(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = f"bucket-{short_uid()}"
@@ -2235,7 +2378,7 @@ class TestS3:
     def test_bucket_availability(self, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         # make sure to have a non created bucket, got some AccessDenied against AWS
-        bucket_name = f"test-bucket-lifecycle-{short_uid()}-{short_uid()}"
+        bucket_name = f"test-bucket-lifecycle-{long_uid()}"
         with pytest.raises(ClientError) as e:
             aws_client.s3.get_bucket_lifecycle(Bucket=bucket_name)
         snapshot.match("bucket-lifecycle", e.value.response)
@@ -2243,24 +2386,6 @@ class TestS3:
         with pytest.raises(ClientError) as e:
             aws_client.s3.get_bucket_replication(Bucket=bucket_name)
         snapshot.match("bucket-replication", e.value.response)
-
-    @markers.parity.aws_validated
-    def test_location_path_url(self, s3_create_bucket, account_id, snapshot, aws_client):
-        region = "us-east-2"
-        bucket_name = s3_create_bucket(
-            CreateBucketConfiguration={"LocationConstraint": region}, ACL="public-read"
-        )
-        response = aws_client.s3.get_bucket_location(Bucket=bucket_name)
-        assert region == response["LocationConstraint"]
-
-        url = _bucket_url(bucket_name, region)
-        # https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
-        # make raw request, assert that newline is contained after XML preamble: <?xml ...>\n
-        response = requests.get(f"{url}?location?x-amz-expected-bucket-owner={account_id}")
-        assert response.ok
-
-        content = to_str(response.content)
-        assert re.match(r"^<\?xml [^>]+>\n<.*", content, flags=re.MULTILINE)
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..Error.RequestID"])
@@ -2321,31 +2446,37 @@ class TestS3:
             "$..VersionId",
         ],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_get_object_with_anon_credentials(
-        self, s3_create_bucket, snapshot, aws_client, anonymous_client
+        self, s3_bucket, allow_bucket_acl, snapshot, aws_client, anonymous_client
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())
-
-        bucket_name = f"bucket-{short_uid()}"
         object_key = f"key-{short_uid()}"
         body = "body data"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key,
             Body=body,
         )
-        aws_client.s3.put_object_acl(Bucket=bucket_name, Key=object_key, ACL="public-read")
+        aws_client.s3.put_object_acl(Bucket=s3_bucket, Key=object_key, ACL="public-read")
         s3_anon_client = anonymous_client("s3")
 
-        response = s3_anon_client.get_object(Bucket=bucket_name, Key=object_key)
+        response = s3_anon_client.get_object(Bucket=s3_bucket, Key=object_key)
         snapshot.match("get_object", response)
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..VersionId", "$..AcceptRanges"]
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_putobject_with_multiple_keys(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -2365,6 +2496,10 @@ class TestS3:
             "$..ContentLanguage",
             "$..VersionId",
         ],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_range_header_body_length(self, s3_bucket, snapshot, aws_client):
         # Test for https://github.com/localstack/localstack/issues/1952
@@ -2638,6 +2773,10 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage"]
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_delete_object_tagging(self, s3_bucket, snapshot, aws_client):
         object_key = "test-key-tagging"
         aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body="something")
@@ -2744,13 +2883,12 @@ class TestS3:
         snapshot.match("delete-object-delete-marker", response)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..Error.RequestID"]
-    )  # fixme RequestID not in AWS response
+    @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..Error.RequestID"])
     def test_delete_non_existing_keys_in_non_existing_bucket(self, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         with pytest.raises(ClientError) as e:
             aws_client.s3.delete_objects(
-                Bucket="non-existent-bucket",
+                Bucket=f"non-existent-bucket-{long_uid()}",
                 Delete={"Objects": [{"Key": "dummy1"}, {"Key": "dummy2"}]},
             )
         assert "NoSuchBucket" == e.value.response["Error"]["Code"]
@@ -2758,14 +2896,17 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
         paths=[
             "$..ServerSideEncryption",
-            "$..Deleted..DeleteMarker",  # TODO: missing from response, not implemented in moto
+            "$..Deleted..DeleteMarker",
             "$..Deleted..DeleteMarkerVersionId",
-        ]
+        ],
     )
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
-    def test_put_object_acl_on_delete_marker(self, s3_bucket, snapshot, aws_client):
+    def test_put_object_acl_on_delete_marker(
+        self, s3_bucket, allow_bucket_acl, snapshot, aws_client
+    ):
         # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
         snapshot.add_transformer(snapshot.transform.s3_api())
         aws_client.s3.put_bucket_versioning(
@@ -2855,6 +2996,10 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider,
         paths=["$..VersionId", "$..ContentLanguage", "$..Error.RequestID"],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_s3_uppercase_key_names(self, s3_create_bucket, snapshot, aws_client):
         # bucket name should be case-sensitive
@@ -2946,6 +3091,10 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage"]
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_upload_download_gzip(self, s3_bucket, snapshot, aws_client):
         data = "1234567890 " * 100
 
@@ -2975,6 +3124,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_multipart_copy_object_etag(self, s3_bucket, s3_multipart_upload, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -3001,8 +3154,12 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_set_external_hostname(
-        self, s3_bucket, s3_multipart_upload, monkeypatch, snapshot, aws_client
+        self, s3_bucket, allow_bucket_acl, s3_multipart_upload, monkeypatch, snapshot, aws_client
     ):
         snapshot.add_transformer(
             [
@@ -3251,9 +3408,7 @@ class TestS3:
             )
 
             with pytest.raises(ClientError) as e:
-                response = aws_client.s3.head_bucket(
-                    Bucket=f"does-not-exist-{short_uid()}-{short_uid()}"
-                )
+                aws_client.s3.head_bucket(Bucket=f"does-not-exist-{long_uid()}")
             snapshot.match("head_bucket_not_exist", e.value.response)
         finally:
             aws_client.s3.delete_bucket(Bucket=bucket_1)
@@ -3277,7 +3432,10 @@ class TestS3:
 
         bucket_name = f"my.bucket.name.{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_create_bucket(Bucket=bucket_name)
+        aws_client.s3.delete_bucket_ownership_controls(Bucket=bucket_name)
+        aws_client.s3.delete_public_access_block(Bucket=bucket_name)
+        aws_client.s3.put_bucket_acl(Bucket=bucket_name, ACL="public-read")
         aws_client.s3.put_object(Bucket=bucket_name, Key="my-content", Body="something")
         response = aws_client.s3.list_objects(Bucket=bucket_name)
         assert response["Contents"][0]["Key"] == "my-content"
@@ -3312,33 +3470,33 @@ class TestS3:
         assert content_vhost == content_path_style
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Prefix"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(), paths=["$..ServerSideEncryption", "$..Prefix"]
+    )
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..VersionId"]
     )
-    def test_s3_put_more_than_1000_items(self, s3_create_bucket, snapshot, aws_client):
+    def test_s3_put_more_than_1000_items(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
-        bucket_name = "test" + short_uid()
-        s3_create_bucket(Bucket=bucket_name)
         for i in range(0, 1010, 1):
             body = "test-" + str(i)
             key = "test-key-" + str(i)
-            aws_client.s3.put_object(Bucket=bucket_name, Key=key, Body=body)
+            aws_client.s3.put_object(Bucket=s3_bucket, Key=key, Body=body)
 
         # trying to get the last item of 1010 items added.
-        resp = aws_client.s3.get_object(Bucket=bucket_name, Key="test-key-1009")
+        resp = aws_client.s3.get_object(Bucket=s3_bucket, Key="test-key-1009")
         snapshot.match("get_object-1009", resp)
 
         # trying to get the first item of 1010 items added.
-        resp = aws_client.s3.get_object(Bucket=bucket_name, Key="test-key-0")
+        resp = aws_client.s3.get_object(Bucket=s3_bucket, Key="test-key-0")
         snapshot.match("get_object-0", resp)
 
         # according docs for MaxKeys: the response might contain fewer keys but will never contain more.
         # AWS returns less during testing
-        resp = aws_client.s3.list_objects(Bucket=bucket_name, MaxKeys=1010)
+        resp = aws_client.s3.list_objects(Bucket=s3_bucket, MaxKeys=1010)
         assert 1010 >= len(resp["Contents"])
 
-        resp = aws_client.s3.list_objects(Bucket=bucket_name, Delimiter="/")
+        resp = aws_client.s3.list_objects(Bucket=s3_bucket, Delimiter="/")
         assert 1000 == len(resp["Contents"])
         # way too much content, remove it from this match
         snapshot.add_transformer(
@@ -3350,7 +3508,7 @@ class TestS3:
         next_marker = resp["NextMarker"]
 
         # Second list
-        resp = aws_client.s3.list_objects(Bucket=bucket_name, Marker=next_marker)
+        resp = aws_client.s3.list_objects(Bucket=s3_bucket, Marker=next_marker)
         snapshot.match("list-objects-next_marker", resp)
         assert 10 == len(resp["Contents"])
 
@@ -3365,6 +3523,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_upload_big_file(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = f"bucket-{short_uid()}"
@@ -3419,6 +3581,10 @@ class TestS3:
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..VersionId"]
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_etag_on_get_object_call(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -3499,6 +3665,10 @@ class TestS3:
         condition=is_old_provider,
         paths=["$..ContentLanguage", "$..VersionId"],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_put_object_versioned(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -3578,29 +3748,28 @@ class TestS3:
     @markers.parity.aws_validated
     @pytest.mark.xfail(reason="ACL behaviour is not implemented, see comments")
     def test_s3_batch_delete_objects_using_requests_with_acl(
-        self, s3_create_bucket, snapshot, aws_client, anonymous_client
+        self, s3_bucket, allow_bucket_acl, snapshot, aws_client, anonymous_client
     ):
         # If an object is created in a public bucket by the owner, it can't be deleted by anonymous clients
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#specifying-grantee-predefined-groups
         # only "public" created objects can be deleted by anonymous clients
         snapshot.add_transformer(snapshot.transform.s3_api())
-        bucket_name = f"bucket-{short_uid()}"
         object_key_1 = "key-created-by-owner"
         object_key_2 = "key-created-by-anonymous"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read-write")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read-write")
         aws_client.s3.put_object(
-            Bucket=bucket_name, Key=object_key_1, Body="This body document", ACL="public-read-write"
+            Bucket=s3_bucket, Key=object_key_1, Body="This body document", ACL="public-read-write"
         )
         anon = anonymous_client("s3")
         anon.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key_2,
             Body="This body document #2",
             ACL="public-read-write",
         )
 
-        url = f"{_bucket_url(bucket_name, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
 
         data = f"""
         <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -3626,42 +3795,38 @@ class TestS3:
         assert response["DeleteResult"]["Deleted"]["Key"] == object_key_2
         snapshot.match("multi-delete-with-requests", response)
 
-        response = aws_client.s3.list_objects(Bucket=bucket_name)
+        response = aws_client.s3.list_objects(Bucket=s3_bucket)
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
         assert len(response["Contents"]) == 1
         snapshot.match("list-remaining-objects", response)
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..DeleteResult.Deleted..VersionId",
-            "$..Prefix",
-        ]
+        paths=["$..DeleteResult.Deleted..VersionId", "$..Prefix", "$..DeleteResult.@xmlns"]
     )
     def test_s3_batch_delete_public_objects_using_requests(
-        self, s3_create_bucket, snapshot, aws_client, anonymous_client
+        self, s3_bucket, allow_bucket_acl, snapshot, aws_client, anonymous_client
     ):
         # only "public" created objects can be deleted by anonymous clients
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#specifying-grantee-predefined-groups
         snapshot.add_transformer(snapshot.transform.s3_api())
-        bucket_name = f"bucket-{short_uid()}"
         object_key_1 = "key-created-by-anonymous-1"
         object_key_2 = "key-created-by-anonymous-2"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read-write")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read-write")
         anon = anonymous_client("s3")
         anon.put_object(
-            Bucket=bucket_name, Key=object_key_1, Body="This body document", ACL="public-read-write"
+            Bucket=s3_bucket, Key=object_key_1, Body="This body document", ACL="public-read-write"
         )
         anon.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key=object_key_2,
             Body="This body document #2",
             ACL="public-read-write",
         )
 
         # TODO delete does currently not work with S3_VIRTUAL_HOSTNAME
-        url = f"{_bucket_url(bucket_name, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
 
         data = f"""
             <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -3681,13 +3846,10 @@ class TestS3:
 
         assert 200 == r.status_code
         response = xmltodict.parse(r.content)
-        # TODO: why is that under??
-        if LEGACY_S3_PROVIDER:
-            response["DeleteResult"].pop("@xmlns")
 
         snapshot.match("multi-delete-with-requests", response)
 
-        response = aws_client.s3.list_objects(Bucket=bucket_name)
+        response = aws_client.s3.list_objects(Bucket=s3_bucket)
         snapshot.match("list-remaining-objects", response)
 
     @markers.parity.aws_validated
@@ -3714,6 +3876,10 @@ class TestS3:
 
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_get_object_header_overrides(self, s3_bucket, snapshot, aws_client):
         # Signed requests may include certain header overrides in the querystring
         # https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
@@ -3979,7 +4145,10 @@ class TestS3:
     @pytest.mark.xfail(
         condition=LEGACY_S3_PROVIDER, reason="Validation not implemented in legacy provider"
     )
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_complete_multipart_parts_order(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -4209,13 +4378,13 @@ class TestS3:
         resp_dict = xmltodict.parse(resp.content)
         assert resp_dict["Tagging"]["TagSet"] == {"Tag": {"Key": "tag1", "Value": "tag1"}}
 
-    @markers.parity.aws_validated
+    # This test doesn't work against AWS anymore because of some authorization error.
+    @markers.parity.only_localstack
     def test_s3_delete_objects_trailing_slash(self, aws_http_client_factory, s3_bucket, aws_client):
         object_key = "key-to-delete-trailing-slash"
         # create an object to delete
         aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body=b"123")
 
-        headers = {"x-amz-content-sha256": "UNSIGNED-PAYLOAD"}
         s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
 
         # Endpoint as created by Rust and AWS JS SDK v3
@@ -4227,10 +4396,9 @@ class TestS3:
              </Object>
         </Delete>
         """
-
         # Post the request to delete the objects, with a trailing slash in the URL
-        resp = s3_http_client.post(bucket_url, headers=headers, data=delete_body)
-        assert resp.status_code == 200
+        resp = s3_http_client.post(bucket_url, data=delete_body)
+        assert resp.status_code == 200, (resp.content, resp.headers)
 
         resp_dict = xmltodict.parse(resp.content)
         assert "DeleteResult" in resp_dict
@@ -4448,11 +4616,15 @@ class TestS3:
         snapshot.match("list-uploads-delimiter", response)
 
     @markers.parity.aws_validated
-    @pytest.mark.skip(
-        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882"
+    @pytest.mark.xfail(
+        condition=not is_native_provider(),
+        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882",
     )
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(), paths=["$..ServerSideEncryption"]
+    )
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId"]
     )
@@ -4496,14 +4668,15 @@ class TestS3:
         snapshot.match("get-obj", response)
 
     @markers.parity.aws_validated
-    @pytest.mark.skip(
-        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882"
-    )
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider,
         paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId", "$..KMSMasterKeyID"],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_s3_sse_bucket_key_default(
         self,
@@ -4743,7 +4916,10 @@ class TestS3:
         snapshot.match("list_config_with_storage_analysis_2", response)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_legal_hold_lock_versioned(self, aws_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "locked-object"
@@ -5153,7 +5329,7 @@ class TestS3:
             )
         snapshot.match("put-bucket-logging-different-regions", e.value.response)
 
-        nonexistent_target_bucket = f"target-bucket-{short_uid()}-{short_uid()}"
+        nonexistent_target_bucket = f"target-bucket-{long_uid()}"
         with pytest.raises(ClientError) as e:
             bucket_logging_status = {
                 "LoggingEnabled": {
@@ -5492,6 +5668,10 @@ class TestS3PresignedUrl:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..ContentLanguage", "$..Expires"]
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_put_object(self, s3_bucket, snapshot, aws_client):
         # big bug here in the old provider: PutObject gets the Expires param from the presigned url??
         #  when it's supposed to be in the headers?
@@ -5799,6 +5979,10 @@ class TestS3PresignedUrl:
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..Expires", "$..AcceptRanges"]
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
     )
     def test_put_url_metadata(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -6423,7 +6607,11 @@ class TestS3PresignedUrl:
         assert headers["expires"] in possible_date_formats
 
     @markers.parity.aws_validated
-    def test_s3_copy_md5(self, s3_bucket, snapshot, s3_presigned_client, monkeypatch, aws_client):
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
+    def test_s3_copy_md5(self, s3_bucket, snapshot, monkeypatch, aws_client):
         if not is_aws_cloud() and not LEGACY_S3_PROVIDER:
             monkeypatch.setattr(config, "S3_SKIP_SIGNATURE_VALIDATION", False)
         src_key = "src"
@@ -6440,7 +6628,7 @@ class TestS3PresignedUrl:
 
         # Create copy object to try to match s3a setting Content-MD5
         dest_key2 = "dest"
-        url = s3_presigned_client.generate_presigned_url(
+        url = aws_client.s3.generate_presigned_url(
             "copy_object",
             Params={
                 "Bucket": s3_bucket,
@@ -6920,282 +7108,6 @@ class TestS3PresignedUrl:
         ]
 
 
-@pytest.mark.skipif(
-    condition=is_asf_provider(),
-    reason="ASF provider is tested in test_s3_cors.py, this will be deprecated",
-)
-class TestS3Cors:
-    @markers.parity.aws_validated
-    # TODO x-amzn-requestid should be 'x-amz-request-id'
-    # TODO "Vary" contains more in AWS, other params are added additional in LocalStack
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..Access-Control-Allow-Headers",
-            "$..Connection",
-            "$..Location",
-            "$..Vary",
-            "$..Content-Type",
-            "$..x-amzn-requestid",
-            "$..last-modified",
-            "$..Last-Modified",
-        ]
-    )
-    def test_cors_with_allowed_origins(self, s3_create_bucket, snapshot, monkeypatch, aws_client):
-        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
-        snapshot.add_transformer(self._get_cors_result_header_snapshot_transformer(snapshot))
-        bucket_cors_config = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": ["https://localhost:4200"],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["*"],
-                }
-            ]
-        }
-
-        bucket_name = f"bucket-{short_uid()}"
-        object_key = "424f6bae-c48f-42d8-9e25-52046aecc64d/document.pdf"
-        s3_create_bucket(Bucket=bucket_name)
-        aws_client.s3.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
-
-        # create signed url
-        url = aws_client.s3.generate_presigned_url(
-            ClientMethod="put_object",
-            Params={
-                "Bucket": bucket_name,
-                "Key": object_key,
-                "ContentType": "application/pdf",
-                "ACL": "bucket-owner-full-control",
-            },
-            ExpiresIn=3600,
-        )
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4200",
-                "Content-Type": "application/pdf",
-            },
-        )
-        assert result.status_code == 200
-        # result.headers is type CaseInsensitiveDict and needs to be converted first
-        snapshot.match("raw-response-headers", dict(result.headers))
-
-        bucket_cors_config = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": [
-                        "https://localhost:4200",
-                        "https://localhost:4201",
-                    ],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["*"],
-                }
-            ]
-        }
-
-        aws_client.s3.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
-
-        # create signed url
-        url = aws_client.s3.generate_presigned_url(
-            ClientMethod="put_object",
-            Params={
-                "Bucket": bucket_name,
-                "Key": object_key,
-                "ContentType": "application/pdf",
-                "ACL": "bucket-owner-full-control",
-            },
-            ExpiresIn=3600,
-        )
-
-        # mimic chrome behavior, sending OPTIONS request first for strict-origin-when-cross-origin
-        result = requests.options(
-            url,
-            headers={
-                "Origin": "https://localhost:4200",
-                "Access-Control-Request-Method": "PUT",
-            },
-        )
-        snapshot.match("raw-response-headers-2", dict(result.headers))
-
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4200",
-                "Content-Type": "application/pdf",
-            },
-        )
-        assert result.status_code == 200
-        snapshot.match("raw-response-headers-3", dict(result.headers))
-
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4201",
-                "Content-Type": "application/pdf",
-            },
-        )
-        assert result.status_code == 200
-        snapshot.match("raw-response-headers-4", dict(result.headers))
-
-    @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..Access-Control-Allow-Headers",
-            "$..Connection",
-            "$..Location",
-            "$..Vary",
-            "$..Content-Type",
-            "$..x-amzn-requestid",
-            "$..last-modified",
-            "$..accept-ranges",
-            "$..content-language",
-            "$..content-md5",
-            "$..content-type",
-            "$..x-amz-version-id",
-            "$..Last-Modified",
-            "$..Accept-Ranges",
-            "$..raw-response-headers-2.Access-Control-Allow-Credentials",
-        ]
-    )
-    def test_cors_configurations(self, s3_create_bucket, monkeypatch, snapshot, aws_client):
-        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
-        snapshot.add_transformer(self._get_cors_result_header_snapshot_transformer(snapshot))
-
-        bucket = f"test-cors-{short_uid()}"
-        object_key = "index.html"
-
-        url = "{}/{}".format(_bucket_url(bucket), object_key)
-
-        BUCKET_CORS_CONFIG = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": [config.get_edge_url()],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["x-amz-tagging"],
-                }
-            ]
-        }
-
-        s3_create_bucket(Bucket=bucket, ACL="public-read")
-        aws_client.s3.put_bucket_cors(Bucket=bucket, CORSConfiguration=BUCKET_CORS_CONFIG)
-
-        aws_client.s3.put_object(
-            Bucket=bucket, Key=object_key, Body="<h1>Index</html>", ACL="public-read"
-        )
-
-        response = requests.get(
-            url, headers={"Origin": config.get_edge_url(), "Content-Type": "text/html"}
-        )
-        assert 200 == response.status_code
-
-        snapshot.match("raw-response-headers", dict(response.headers))
-
-        BUCKET_CORS_CONFIG = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": ["https://anydomain.com"],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["x-amz-tagging"],
-                }
-            ]
-        }
-
-        aws_client.s3.put_bucket_cors(Bucket=bucket, CORSConfiguration=BUCKET_CORS_CONFIG)
-        response = requests.get(
-            url, headers={"Origin": config.get_edge_url(), "Content-Type": "text/html"}
-        )
-        assert 200 == response.status_code
-        snapshot.match("raw-response-headers-2", dict(response.headers))
-
-    @markers.parity.aws_validated
-    @pytest.mark.xfail(
-        reason="Access-Control-Allow-Origin returns Origin value in LS",
-    )
-    def test_s3_get_response_headers(self, s3_bucket, snapshot, aws_client):
-        # put object and CORS configuration
-        object_key = "key-by-hostname"
-        aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body="something")
-        aws_client.s3.put_bucket_cors(
-            Bucket=s3_bucket,
-            CORSConfiguration={
-                "CORSRules": [
-                    {
-                        "AllowedMethods": ["GET", "PUT", "POST"],
-                        "AllowedOrigins": ["*"],
-                        "ExposeHeaders": ["ETag", "x-amz-version-id"],
-                    }
-                ]
-            },
-        )
-        bucket_cors_res = aws_client.s3.get_bucket_cors(Bucket=s3_bucket)
-        snapshot.match("bucket-cors-response", bucket_cors_res)
-
-        # get object and assert headers
-        url = aws_client.s3.generate_presigned_url(
-            "get_object", Params={"Bucket": s3_bucket, "Key": object_key}
-        )
-        # need to add Origin headers for S3 to send back the Access-Control-* headers
-        # as CORS is made for browsers
-        response = requests.get(url, verify=False, headers={"Origin": "http://localhost"})
-        assert response.headers["Access-Control-Expose-Headers"] == "ETag, x-amz-version-id"
-        assert response.headers["Access-Control-Allow-Methods"] == "GET, PUT, POST"
-        assert (
-            response.headers["Access-Control-Allow-Origin"] == "*"
-        )  # returns http://localhost in LS
-
-    @markers.parity.aws_validated
-    @pytest.mark.xfail(
-        reason="Behaviour diverges from AWS, Access-Control-* headers always added",
-    )
-    def test_s3_get_response_headers_without_origin(self, s3_bucket, aws_client):
-        # put object and CORS configuration
-        object_key = "key-by-hostname"
-        aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body="something")
-        aws_client.s3.put_bucket_cors(
-            Bucket=s3_bucket,
-            CORSConfiguration={
-                "CORSRules": [
-                    {
-                        "AllowedMethods": ["GET", "PUT", "POST"],
-                        "AllowedOrigins": ["*"],
-                        "ExposeHeaders": ["ETag", "x-amz-version-id"],
-                    }
-                ]
-            },
-        )
-
-        # get object and assert headers
-        url = aws_client.s3.generate_presigned_url(
-            "get_object", Params={"Bucket": s3_bucket, "Key": object_key}
-        )
-        response = requests.get(url, verify=False)
-        assert "Access-Control-Expose-Headers" not in response.headers
-        assert "Access-Control-Allow-Methods" not in response.headers
-        assert "Access-Control-Allow-Origin" not in response.headers
-
-    @staticmethod
-    def _get_cors_result_header_snapshot_transformer(snapshot):
-        return [
-            snapshot.transform.key_value("x-amz-id-2", "<id>", reference_replacement=False),
-            snapshot.transform.key_value(
-                "x-amz-request-id", "<request-id>", reference_replacement=False
-            ),
-            snapshot.transform.key_value("Date", "<date>", reference_replacement=False),
-            snapshot.transform.key_value("Server", "<server>", reference_replacement=False),
-            snapshot.transform.key_value("Last-Modified", "<date>", reference_replacement=False),
-        ]
-
-
 class TestS3DeepArchive:
     """
     Test to cover DEEP_ARCHIVE Storage Class functionality.
@@ -7290,12 +7202,10 @@ class TestS3StaticWebsiteHosting:
     """
 
     @markers.parity.aws_validated
-    def test_s3_static_website_index(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_s3_static_website_index(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="index.html",
             Body="index",
             ContentType="text/html",
@@ -7303,65 +7213,63 @@ class TestS3StaticWebsiteHosting:
         )
 
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
             },
         )
 
-        url = _website_bucket_url(bucket_name)
+        url = _website_bucket_url(s3_bucket)
 
         response = requests.get(url, verify=False)
         assert response.status_code == 200
         assert response.text == "index"
 
     @markers.parity.aws_validated
-    def test_s3_static_website_hosting(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_s3_static_website_hosting(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         index_obj = aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="test/index.html",
             Body="index",
             ContentType="text/html",
             ACL="public-read",
         )
         error_obj = aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="test/error.html",
             Body="error",
             ContentType="text/html",
             ACL="public-read",
         )
         actual_key_obj = aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="actual/key.html",
             Body="key",
             ContentType="text/html",
             ACL="public-read",
         )
         with_content_type_obj = aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="with-content-type/key.js",
             Body="some js",
             ContentType="application/javascript; charset=utf-8",
             ACL="public-read",
         )
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="to-be-redirected.html",
             WebsiteRedirectLocation="/actual/key.html",
             ACL="public-read",
         )
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "test/error.html"},
             },
         )
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
         # actual key
         url = f"{website_url}/actual/key.html"
         response = requests.get(url, verify=False)
@@ -7434,18 +7342,19 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide proper website support",
     )
-    def test_website_hosting_no_such_website(self, s3_create_bucket, snapshot, aws_client):
+    def test_website_hosting_no_such_website(
+        self, s3_bucket, snapshot, aws_client, allow_bucket_acl
+    ):
         snapshot.add_transformers_list(self._get_static_hosting_transformers(snapshot))
-        bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
 
         random_url = _website_bucket_url(f"non-existent-bucket-{short_uid()}")
         response = requests.get(random_url, verify=False)
         assert response.status_code == 404
         snapshot.match("no-such-bucket", response.text)
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
         # actual key
         response = requests.get(website_url, verify=False)
         assert response.status_code == 404
@@ -7461,18 +7370,18 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide proper website support",
     )
-    def test_website_hosting_http_methods(self, s3_create_bucket, snapshot, aws_client):
+    def test_website_hosting_http_methods(self, s3_bucket, snapshot, aws_client, allow_bucket_acl):
         snapshot.add_transformers_list(self._get_static_hosting_transformers(snapshot))
-        bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
+
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
             },
         )
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
         req = requests.post(website_url, data="test")
         assert req.status_code == 405
         error_response = req.text
@@ -7484,14 +7393,14 @@ class TestS3StaticWebsiteHosting:
         snapshot.match("not-allowed-delete", {"content": error_response})
 
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
             },
         )
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="error.html",
             Body="error",
             ContentType="text/html",
@@ -7508,34 +7417,33 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide proper website redirection",
     )
-    def test_website_hosting_index_lookup(self, s3_create_bucket, snapshot, aws_client):
+    def test_website_hosting_index_lookup(self, s3_bucket, snapshot, aws_client, allow_bucket_acl):
         snapshot.add_transformers_list(self._get_static_hosting_transformers(snapshot))
-        bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
             },
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="index.html",
             Body="index",
             ContentType="text/html",
             ACL="public-read",
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
         # actual key
         response = requests.get(website_url)
         assert response.status_code == 200
         assert response.text == "index"
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="directory/index.html",
             Body="index",
             ContentType="text/html",
@@ -7563,26 +7471,25 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide proper website support",
     )
-    def test_website_hosting_404(self, s3_create_bucket, snapshot, aws_client):
+    def test_website_hosting_404(self, s3_bucket, snapshot, aws_client, allow_bucket_acl):
         snapshot.add_transformers_list(self._get_static_hosting_transformers(snapshot))
-        bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
             },
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
 
         response = requests.get(website_url)
         assert response.status_code == 404
         snapshot.match("404-no-such-key", response.text)
 
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7593,7 +7500,7 @@ class TestS3StaticWebsiteHosting:
         snapshot.match("404-no-such-key-nor-custom", response.text)
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="error.html",
             Body="error",
             ContentType="text/html",
@@ -7605,12 +7512,10 @@ class TestS3StaticWebsiteHosting:
         assert response.text == "error"
 
     @markers.parity.aws_validated
-    def test_object_website_redirect_location(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_object_website_redirect_location(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7618,14 +7523,14 @@ class TestS3StaticWebsiteHosting:
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="index.html",
             WebsiteRedirectLocation="/another/index.html",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="error.html",
             Body="error_redirected",
             WebsiteRedirectLocation="/another/error.html",
@@ -7633,13 +7538,13 @@ class TestS3StaticWebsiteHosting:
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="another/error.html",
             Body="error",
             ACL="public-read",
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
 
         response = requests.get(website_url)
         # losing the status code because of the redirection in the error document
@@ -7651,13 +7556,12 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide website routing rules",
     )
-    def test_routing_rules_conditions(self, s3_create_bucket, aws_client):
+    def test_routing_rules_conditions(self, s3_bucket, aws_client, allow_bucket_acl):
         # https://github.com/localstack/localstack/issues/6308
-        bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7682,27 +7586,27 @@ class TestS3StaticWebsiteHosting:
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="redirected.html",
             Body="redirected",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="prefixed-key-test",
             Body="prefixed",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="redirected-both.html",
             Body="redirected-both",
             ACL="public-read",
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
 
         response = requests.get(f"{website_url}/non-existent-key", allow_redirects=False)
         assert response.status_code == 301
@@ -7714,7 +7618,7 @@ class TestS3StaticWebsiteHosting:
         assert response.text == "redirected"
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="error.html",
             Body="error",
             ACL="public-read",
@@ -7737,12 +7641,10 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
         reason="Legacy S3 provider does not provide website routing rules",
     )
-    def test_routing_rules_redirects(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_routing_rules_redirects(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7775,7 +7677,7 @@ class TestS3StaticWebsiteHosting:
             },
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
 
         response = requests.get(f"{website_url}/host/key", allow_redirects=False)
         assert response.status_code == 301
@@ -7798,30 +7700,28 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER,
         reason="Legacy S3 provider does not provide website routing rules",
     )
-    def test_routing_rules_empty_replace_prefix(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_routing_rules_empty_replace_prefix(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="index.html",
             Body="index",
             ACL="public-read",
         )
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="test.html",
             Body="test",
             ACL="public-read",
         )
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="error.html",
             Body="error",
             ACL="public-read",
         )
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="mydocs/test.html",
             Body="mydocs",
             ACL="public-read",
@@ -7829,7 +7729,7 @@ class TestS3StaticWebsiteHosting:
 
         # change configuration
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7846,7 +7746,7 @@ class TestS3StaticWebsiteHosting:
             },
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
 
         # testing that routing rule redirect correctly (by removing the defined prefix)
         response = requests.get(f"{website_url}/docs/test.html")
@@ -7871,12 +7771,10 @@ class TestS3StaticWebsiteHosting:
         condition=LEGACY_S3_PROVIDER,
         reason="Legacy S3 provider does not provide website routing rules",
     )
-    def test_routing_rules_order(self, s3_create_bucket, aws_client):
-        bucket_name = f"bucket-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+    def test_routing_rules_order(self, s3_bucket, aws_client, allow_bucket_acl):
+        aws_client.s3.put_bucket_acl(Bucket=s3_bucket, ACL="public-read")
         aws_client.s3.put_bucket_website(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             WebsiteConfiguration={
                 "IndexDocument": {"Suffix": "index.html"},
                 "ErrorDocument": {"Key": "error.html"},
@@ -7898,35 +7796,35 @@ class TestS3StaticWebsiteHosting:
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="index.html",
             Body="index",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="redirected.html",
             Body="redirected",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="website-redirected.html",
             Body="website-redirected",
             ACL="public-read",
         )
 
         aws_client.s3.put_object(
-            Bucket=bucket_name,
+            Bucket=s3_bucket,
             Key="prefixed-key-test",
             Body="prefixed",
             ACL="public-read",
             WebsiteRedirectLocation="/website-redirected.html",
         )
 
-        website_url = _website_bucket_url(bucket_name)
+        website_url = _website_bucket_url(s3_bucket)
         # testing that routing rules have precedence over individual object redirection
         response = requests.get(f"{website_url}/prefixed-key-test")
         assert response.status_code == 200
@@ -8047,7 +7945,11 @@ class TestS3StaticWebsiteHosting:
         bucket_name_redirected = f"bucket-{short_uid()}"
         bucket_name = f"bucket-{short_uid()}"
 
-        s3_create_bucket(Bucket=bucket_name_redirected, ACL="public-read")
+        s3_create_bucket(Bucket=bucket_name_redirected)
+        aws_client.s3.delete_bucket_ownership_controls(Bucket=bucket_name_redirected)
+        aws_client.s3.delete_public_access_block(Bucket=bucket_name_redirected)
+        aws_client.s3.put_bucket_acl(Bucket=bucket_name_redirected, ACL="public-read")
+
         bucket_website_url = _website_bucket_url(bucket_name)
         bucket_website_host = urlparse(bucket_website_url).netloc
 
@@ -8058,7 +7960,11 @@ class TestS3StaticWebsiteHosting:
             },
         )
 
-        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_create_bucket(Bucket=bucket_name)
+        aws_client.s3.delete_bucket_ownership_controls(Bucket=bucket_name)
+        aws_client.s3.delete_public_access_block(Bucket=bucket_name)
+        aws_client.s3.put_bucket_acl(Bucket=bucket_name, ACL="public-read")
+
         aws_client.s3.put_bucket_website(
             Bucket=bucket_name,
             WebsiteConfiguration={
@@ -8148,6 +8054,7 @@ class TestS3Routing:
 
 
 class TestS3BucketPolicies:
+    @markers.parity.only_localstack
     def test_access_to_bucket_not_denied(self, s3_bucket, monkeypatch, aws_client):
         # mimicking a policy here that is generated by CDK bootstrap on staging bucket creation, see
         # https://github.com/aws/aws-cdk/blob/e8158af34eb6402c79edbc171746fb5501775c68/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml#L217-L233
@@ -8418,7 +8325,10 @@ class TestS3BucketLifecycle:
         snapshot.match("get-bucket-lifecycle-conf", result)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_bucket_lifecycle_configuration_object_expiry(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -8464,7 +8374,10 @@ class TestS3BucketLifecycle:
         assert 6 <= (parsed_exp_date - last_modified).days <= 8
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_bucket_lifecycle_configuration_object_expiry_versioned(
         self, s3_bucket, snapshot, aws_client
     ):
@@ -8549,7 +8462,10 @@ class TestS3BucketLifecycle:
         )
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_object_expiry_after_bucket_lifecycle_configuration(
         self, s3_bucket, snapshot, aws_client
     ):
@@ -8593,7 +8509,10 @@ class TestS3BucketLifecycle:
         snapshot.match("head-object-expiry-after", response)
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_bucket_lifecycle_multiple_rules(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -8657,7 +8576,10 @@ class TestS3BucketLifecycle:
         assert "Expiration" not in put_object_3
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_bucket_lifecycle_object_size_rules(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -8718,7 +8640,10 @@ class TestS3BucketLifecycle:
         assert "Expiration" not in put_object_3
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_bucket_lifecycle_tag_rules(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [
@@ -8802,7 +8727,10 @@ class TestS3BucketLifecycle:
         assert "Expiration" not in put_object_3
 
     @markers.parity.aws_validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_lifecycle_expired_object_delete_marker(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
             [

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3215,6 +3215,10 @@ class TestS3:
     @markers.skip_offline
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_lambda_integration(
         self,
         create_lambda_function,

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3.py::TestS3::test_region_header_exists": {
-    "recorded-date": "21-09-2022, 13:34:35",
+    "recorded-date": "03-08-2023, 04:13:15",
     "recorded-content": {
       "head_bucket": {
         "ResponseMetadata": {
@@ -23,7 +23,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_with_content": {
-    "recorded-date": "21-09-2022, 13:34:41",
+    "recorded-date": "03-08-2023, 04:13:20",
     "recorded-content": {
       "list-objects": {
         "Contents": [
@@ -150,12 +150,7 @@
         }
       },
       "list-buckets": {
-        "Buckets": [
-          {
-            "CreationDate": "datetime",
-            "Name": "<bucket-name:2>"
-          }
-        ],
+        "Buckets": [],
         "Owner": {
           "DisplayName": "<display-name>",
           "ID": "<owner-id>"
@@ -168,10 +163,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_utf8_key": {
-    "recorded-date": "21-09-2022, 13:34:43",
+    "recorded-date": "03-08-2023, 04:13:21",
     "recorded-content": {
       "put-object": {
         "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -185,6 +181,7 @@
         "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -193,16 +190,28 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_metadata_header_character_decoding": {
-    "recorded-date": "21-09-2022, 13:34:49",
+    "recorded-date": "03-08-2023, 04:13:29",
     "recorded-content": {
       "head-object": {
-        "__meta_2": "bar",
-        "test_meta_1": "foo"
+        "AcceptRanges": "bytes",
+        "ContentLength": 3,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"acbd18db4cc2f85cedef654fccc4a4d8\"",
+        "LastModified": "datetime",
+        "Metadata": {
+          "__meta_2": "bar",
+          "test_meta_1": "foo"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_upload_file_multipart": {
-    "recorded-date": "21-09-2022, 13:34:53",
+    "recorded-date": "03-08-2023, 04:13:32",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -212,6 +221,7 @@
         "ETag": "\"8eabe9d6b43316e840b079170916c079-1\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -220,7 +230,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[/]": {
-    "recorded-date": "21-09-2022, 13:34:55",
+    "recorded-date": "03-08-2023, 04:13:39",
     "recorded-content": {
       "list-objects": {
         "CommonPrefixes": [
@@ -243,7 +253,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[%2F]": {
-    "recorded-date": "21-09-2022, 13:34:58",
+    "recorded-date": "03-08-2023, 04:13:41",
     "recorded-content": {
       "list-objects": {
         "Contents": [
@@ -274,7 +284,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_no_such_bucket": {
-    "recorded-date": "21-09-2022, 13:34:59",
+    "recorded-date": "03-08-2023, 04:13:49",
     "recorded-content": {
       "expected_error": {
         "Error": {
@@ -290,7 +300,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_no_such_bucket": {
-    "recorded-date": "21-09-2022, 13:35:00",
+    "recorded-date": "03-08-2023, 04:13:50",
     "recorded-content": {
       "expected_error": {
         "Error": {
@@ -306,7 +316,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_bucket_notification_configuration_no_such_bucket": {
-    "recorded-date": "21-09-2022, 13:35:00",
+    "recorded-date": "03-08-2023, 04:13:50",
     "recorded-content": {
       "expected_error": {
         "Error": {
@@ -322,7 +332,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_attributes": {
-    "recorded-date": "16-02-2023, 17:02:00",
+    "recorded-date": "03-08-2023, 04:14:00",
     "recorded-content": {
       "object-attrs": {
         "ETag": "e92499db864217242396e8ef766079a9",
@@ -363,10 +373,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_hash_prefix": {
-    "recorded-date": "21-09-2022, 13:35:04",
+    "recorded-date": "03-08-2023, 04:14:14",
     "recorded-content": {
       "put-object": {
         "ETag": "\"39d0d586a701e199389d954f2d592720\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -380,6 +391,7 @@
         "ETag": "\"39d0d586a701e199389d954f2d592720\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -388,7 +400,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_invalid_range_error": {
-    "recorded-date": "21-09-2022, 13:35:07",
+    "recorded-date": "03-08-2023, 04:14:17",
     "recorded-content": {
       "exc": {
         "Error": {
@@ -405,7 +417,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_range_key_not_exists": {
-    "recorded-date": "21-09-2022, 13:35:09",
+    "recorded-date": "03-08-2023, 04:14:18",
     "recorded-content": {
       "exc": {
         "Error": {
@@ -421,7 +433,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_bucket_policy": {
-    "recorded-date": "21-09-2022, 13:35:13",
+    "recorded-date": "04-08-2023, 23:56:00",
     "recorded-content": {
       "put-bucket-policy": {
         "ResponseMetadata": {
@@ -451,7 +463,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_tagging_empty_list": {
-    "recorded-date": "06-07-2023, 16:54:34",
+    "recorded-date": "03-08-2023, 04:14:24",
     "recorded-content": {
       "created-object-tags": {
         "TagSet": [],
@@ -486,7 +498,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_after_deleted_in_versioned_bucket": {
-    "recorded-date": "06-10-2022, 22:35:23",
+    "recorded-date": "03-08-2023, 04:14:29",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -496,6 +508,7 @@
         "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -516,7 +529,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
-    "recorded-date": "16-02-2023, 17:34:43",
+    "recorded-date": "03-08-2023, 04:14:32",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -531,6 +544,7 @@
       "put-object-generated": {
         "ChecksumCRC32": "cZWHwQ==",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -550,6 +564,7 @@
       "put-object-autogenerated": {
         "ChecksumCRC32": "cZWHwQ==",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -576,6 +591,7 @@
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -584,7 +600,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
-    "recorded-date": "16-02-2023, 17:34:46",
+    "recorded-date": "03-08-2023, 04:14:35",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -599,6 +615,7 @@
       "put-object-generated": {
         "ChecksumCRC32C": "Pf4upw==",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -618,6 +635,7 @@
       "put-object-autogenerated": {
         "ChecksumCRC32C": "Pf4upw==",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -644,6 +662,7 @@
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -652,7 +671,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
-    "recorded-date": "16-02-2023, 17:34:50",
+    "recorded-date": "03-08-2023, 04:14:38",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -667,6 +686,7 @@
       "put-object-generated": {
         "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -686,6 +706,7 @@
       "put-object-autogenerated": {
         "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -712,6 +733,7 @@
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -720,7 +742,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
-    "recorded-date": "16-02-2023, 17:34:53",
+    "recorded-date": "03-08-2023, 04:14:41",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -735,6 +757,7 @@
       "put-object-generated": {
         "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -754,6 +777,7 @@
       "put-object-autogenerated": {
         "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -780,6 +804,7 @@
         "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -788,10 +813,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_metadata_replace": {
-    "recorded-date": "21-09-2022, 13:35:32",
+    "recorded-date": "03-08-2023, 04:15:04",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -799,6 +825,7 @@
       },
       "head_object": {
         "AcceptRanges": "bytes",
+        "ContentLanguage": "en-US",
         "ContentLength": 16,
         "ContentType": "application/json",
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -806,6 +833,7 @@
         "Metadata": {
           "key": "value"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -816,6 +844,7 @@
           "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
           "LastModified": "datetime"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -824,12 +853,13 @@
       "head_object_copy": {
         "AcceptRanges": "bytes",
         "ContentLength": 16,
-        "ContentType": "application/javascript",
+        "ContentType": "image/jpg",
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
         "LastModified": "datetime",
         "Metadata": {
           "another-key": "value"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -838,10 +868,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_content_type_and_metadata": {
-    "recorded-date": "21-09-2022, 13:35:36",
+    "recorded-date": "03-08-2023, 04:15:17",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -856,6 +887,7 @@
         "Metadata": {
           "key": "value"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -866,6 +898,7 @@
           "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
           "LastModified": "datetime"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -880,6 +913,7 @@
         "Metadata": {
           "key": "value"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -890,6 +924,7 @@
           "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
           "LastModified": "datetime"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -904,6 +939,7 @@
         "Metadata": {
           "key": "value"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -912,7 +948,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_multipart_upload_acls": {
-    "recorded-date": "21-09-2022, 13:35:40",
+    "recorded-date": "03-08-2023, 16:53:20",
     "recorded-content": {
       "bucket-acl": {
         "Grants": [
@@ -1018,7 +1054,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_object_expiry": {
-    "recorded-date": "21-09-2022, 13:35:46",
+    "recorded-date": "03-08-2023, 04:16:18",
     "recorded-content": {
       "head-object-expired": {
         "AcceptRanges": "bytes",
@@ -1028,6 +1064,7 @@
         "Expires": "datetime",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1042,6 +1079,7 @@
         "Expires": "datetime",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1050,7 +1088,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_upload_file_with_xml_preamble": {
-    "recorded-date": "21-09-2022, 13:35:48",
+    "recorded-date": "03-08-2023, 04:16:20",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -1060,6 +1098,7 @@
         "ETag": "\"8a793423f1e69103a7056b99e4ad6c0b\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1068,7 +1107,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_bucket_availability": {
-    "recorded-date": "21-09-2022, 13:35:50",
+    "recorded-date": "03-08-2023, 04:16:22",
     "recorded-content": {
       "bucket-lifecycle": {
         "Error": {
@@ -1095,7 +1134,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "08-02-2023, 12:03:07",
+    "recorded-date": "03-08-2023, 04:16:27",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,
@@ -1150,7 +1189,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_with_anon_credentials": {
-    "recorded-date": "21-09-2022, 13:36:04",
+    "recorded-date": "03-08-2023, 17:03:12",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -1160,6 +1199,7 @@
         "ETag": "\"53ebc26c3ff5decfe9ffc7bdbaa02459\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1168,7 +1208,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_putobject_with_multiple_keys": {
-    "recorded-date": "21-09-2022, 13:36:06",
+    "recorded-date": "03-08-2023, 04:16:33",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -1178,6 +1218,7 @@
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1321,7 +1362,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_range_header_body_length": {
-    "recorded-date": "21-09-2022, 16:11:28",
+    "recorded-date": "03-08-2023, 04:16:36",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -1332,6 +1373,7 @@
         "ETag": "<e-tag:1>",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 206
@@ -1340,7 +1382,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_object_tagging": {
-    "recorded-date": "21-09-2022, 13:36:22",
+    "recorded-date": "03-08-2023, 04:17:04",
     "recorded-content": {
       "get-obj": {
         "AcceptRanges": "bytes",
@@ -1350,6 +1392,7 @@
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1363,6 +1406,7 @@
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1371,7 +1415,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys": {
-    "recorded-date": "21-09-2022, 13:36:25",
+    "recorded-date": "03-08-2023, 04:17:07",
     "recorded-content": {
       "deleted-resp": {
         "Deleted": [
@@ -1393,11 +1437,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys_in_non_existing_bucket": {
-    "recorded-date": "21-09-2022, 13:36:26",
+    "recorded-date": "04-08-2023, 23:51:32",
     "recorded-content": {
       "error-non-existent-bucket": {
         "Error": {
-          "BucketName": "non-existent-bucket",
+          "BucketName": "<bucket-name:1>",
           "Code": "NoSuchBucket",
           "Message": "The specified bucket does not exist"
         },
@@ -1409,7 +1453,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_request_payer": {
-    "recorded-date": "21-09-2022, 13:36:27",
+    "recorded-date": "03-08-2023, 04:17:17",
     "recorded-content": {
       "put-bucket-request-payment": {
         "ResponseMetadata": {
@@ -1427,7 +1471,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_request_payer_exceptions": {
-    "recorded-date": "21-09-2022, 13:36:28",
+    "recorded-date": "03-08-2023, 04:17:18",
     "recorded-content": {
       "wrong-payer-type": {
         "Error": {
@@ -1442,7 +1486,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_bucket_exists": {
-    "recorded-date": "21-09-2022, 13:36:31",
+    "recorded-date": "03-08-2023, 04:17:20",
     "recorded-content": {
       "get-bucket-cors": {
         "CORSRules": [
@@ -1497,7 +1541,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_uppercase_key_names": {
-    "recorded-date": "21-09-2022, 13:36:33",
+    "recorded-date": "03-08-2023, 04:17:22",
     "recorded-content": {
       "response": {
         "AcceptRanges": "bytes",
@@ -1507,6 +1551,7 @@
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1526,7 +1571,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_precondition_failed_error": {
-    "recorded-date": "21-09-2022, 13:37:08",
+    "recorded-date": "03-08-2023, 04:17:50",
     "recorded-content": {
       "get-object-if-match": {
         "Error": {
@@ -1542,7 +1587,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_invalid_content_md5": {
-    "recorded-date": "21-09-2022, 13:37:13",
+    "recorded-date": "03-08-2023, 04:17:53",
     "recorded-content": {
       "md5-error-0": {
         "Error": {
@@ -1591,10 +1636,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_upload_download_gzip": {
-    "recorded-date": "16-02-2023, 18:49:14",
+    "recorded-date": "03-08-2023, 04:17:54",
     "recorded-content": {
       "put-object": {
         "ETag": "\"5287ceabf01e3e9c080606b5a5b9bf70\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1609,6 +1655,7 @@
         "ETag": "\"5287ceabf01e3e9c080606b5a5b9bf70\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1617,13 +1664,14 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_multipart_copy_object_etag": {
-    "recorded-date": "21-09-2022, 13:37:17",
+    "recorded-date": "03-08-2023, 04:17:57",
     "recorded-content": {
       "multipart-upload": {
         "Bucket": "<bucket:1>",
         "ETag": "\"b972025bc34adf8d76d6d51e93c035cc-1\"",
         "Key": "test.file",
         "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1634,6 +1682,7 @@
           "ETag": "\"eee506dd7ada7ded524c77e359a0e7c6\"",
           "LastModified": "datetime"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1642,13 +1691,14 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_set_external_hostname": {
-    "recorded-date": "21-09-2022, 13:37:21",
+    "recorded-date": "03-08-2023, 17:09:20",
     "recorded-content": {
       "multipart-upload": {
         "Bucket": "<bucket:1>",
         "ETag": "\"b972025bc34adf8d76d6d51e93c035cc-1\"",
         "Key": "test.file",
         "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1659,6 +1709,7 @@
         "ETag": "\"b972025bc34adf8d76d6d51e93c035cc-1\"",
         "Key": "test.file",
         "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1667,7 +1718,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_lambda_integration": {
-    "recorded-date": "21-09-2022, 13:38:03",
+    "recorded-date": "03-08-2023, 04:18:58",
     "recorded-content": {
       "head_object": {
         "AcceptRanges": "bytes",
@@ -1676,6 +1727,7 @@
         "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1684,7 +1736,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_uppercase_bucket_name": {
-    "recorded-date": "21-09-2022, 13:38:06",
+    "recorded-date": "03-08-2023, 04:19:01",
     "recorded-content": {
       "uppercase-bucket": {
         "Error": {
@@ -1700,7 +1752,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_with_existing_name": {
-    "recorded-date": "21-09-2022, 13:38:08",
+    "recorded-date": "03-08-2023, 04:19:02",
     "recorded-content": {
       "create-bucket-us-west-1": {
         "Error": {
@@ -1727,7 +1779,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_bucket_does_not_exist": {
-    "recorded-date": "21-09-2022, 13:38:20",
+    "recorded-date": "03-08-2023, 04:19:09",
     "recorded-content": {
       "list_object": {
         "Error": {
@@ -1754,7 +1806,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
-    "recorded-date": "22-03-2023, 16:45:10",
+    "recorded-date": "03-08-2023, 04:19:13",
     "recorded-content": {
       "create_bucket": {
         "Location": "/<bucket-name:1>",
@@ -1809,7 +1861,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_bucket_name_with_dots": {
-    "recorded-date": "21-09-2022, 13:38:25",
+    "recorded-date": "03-08-2023, 17:13:12",
     "recorded-content": {
       "list_objects": {
         "Contents": [
@@ -1868,7 +1920,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_put_more_than_1000_items": {
-    "recorded-date": "21-09-2022, 13:43:01",
+    "recorded-date": "03-08-2023, 04:23:05",
     "recorded-content": {
       "get_object-1009": {
         "AcceptRanges": "bytes",
@@ -1878,6 +1930,7 @@
         "ETag": "\"7d2a1f93cc456846faba49b73eefc5b2\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1891,6 +1944,7 @@
         "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2038,7 +2092,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_list_objects_empty_marker": {
-    "recorded-date": "21-09-2022, 13:43:06",
+    "recorded-date": "03-08-2023, 04:23:09",
     "recorded-content": {
       "list-objects": {
         "EncodingType": "url",
@@ -2055,10 +2109,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_upload_big_file": {
-    "recorded-date": "21-09-2022, 13:43:19",
+    "recorded-date": "03-08-2023, 04:23:23",
     "recorded-content": {
       "put_object_key1": {
         "ETag": "\"a649c4228b2b9e8bfca3510ed9d9a764\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2066,6 +2121,7 @@
       },
       "put_object_key2": {
         "ETag": "\"7095bae098259e0dda4b7acc624de4e2\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2078,6 +2134,7 @@
         "ETag": "\"7095bae098259e0dda4b7acc624de4e2\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2090,6 +2147,7 @@
         "ETag": "\"7095bae098259e0dda4b7acc624de4e2\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2098,7 +2156,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_bucket_versioning_order": {
-    "recorded-date": "21-09-2022, 13:43:23",
+    "recorded-date": "03-08-2023, 04:23:26",
     "recorded-content": {
       "list_object_versions_before": {
         "EncodingType": "url",
@@ -2183,7 +2241,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_etag_on_get_object_call": {
-    "recorded-date": "21-09-2022, 13:43:27",
+    "recorded-date": "03-08-2023, 04:23:29",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -2193,6 +2251,7 @@
         "ETag": "\"c289c6e309be295fe68af649d1e6c6ec\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2207,6 +2266,7 @@
         "ETag": "\"c289c6e309be295fe68af649d1e6c6ec\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 206
@@ -2215,7 +2275,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_delete_object_with_version_id": {
-    "recorded-date": "21-09-2022, 13:43:31",
+    "recorded-date": "03-08-2023, 04:23:32",
     "recorded-content": {
       "get_bucket_versioning": {
         "Status": "Enabled",
@@ -2274,52 +2334,15 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_objects_using_requests_with_acl": {
-    "recorded-date": "21-09-2022, 13:43:35",
-    "recorded-content": {
-      "multi-delete-with-requests": {
-        "DeleteResult": {
-          "Deleted": {
-            "Key": "key-created-by-anonymous"
-          },
-          "Error": {
-            "Code": "AccessDenied",
-            "Key": "key-created-by-owner",
-            "Message": "Access Denied"
-          }
-        }
-      },
-      "list-remaining-objects": {
-        "Contents": [
-          {
-            "ETag": "\"ba29429d259d94823554cb60b325d8fe\"",
-            "Key": "key-created-by-owner",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 18,
-            "StorageClass": "STANDARD"
-          }
-        ],
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "Marker": "",
-        "MaxKeys": 1000,
-        "Name": "<bucket-name:1>",
-        "Prefix": "",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
+    "recorded-date": "03-08-2023, 04:23:41",
+    "recorded-content": {}
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_public_objects_using_requests": {
-    "recorded-date": "21-09-2022, 13:43:39",
+    "recorded-date": "03-08-2023, 17:15:13",
     "recorded-content": {
       "multi-delete-with-requests": {
         "DeleteResult": {
+          "@xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
           "Deleted": [
             {
               "Key": "key-created-by-anonymous-1"
@@ -2345,7 +2368,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_objects": {
-    "recorded-date": "21-09-2022, 13:43:42",
+    "recorded-date": "03-08-2023, 04:23:45",
     "recorded-content": {
       "batch-delete": {
         "Deleted": [
@@ -2385,7 +2408,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object": {
-    "recorded-date": "21-09-2022, 13:43:45",
+    "recorded-date": "04-08-2023, 23:58:39",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -2395,6 +2418,7 @@
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2403,7 +2427,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_url_metadata": {
-    "recorded-date": "21-09-2022, 13:44:01",
+    "recorded-date": "04-08-2023, 23:59:04",
     "recorded-content": {
       "head_object": {
         "AcceptRanges": "bytes",
@@ -2414,6 +2438,7 @@
         "Metadata": {
           "foo": "bar"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2422,13 +2447,14 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_copy_md5": {
-    "recorded-date": "21-09-2022, 13:44:37",
+    "recorded-date": "05-08-2023, 00:08:47",
     "recorded-content": {
       "copy-obj": {
         "CopyObjectResult": {
           "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
           "LastModified": "datetime"
         },
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2436,96 +2462,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_with_allowed_origins": {
-    "recorded-date": "21-09-2022, 13:45:31",
-    "recorded-content": {
-      "raw-response-headers": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-2": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-3": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-4": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4201",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_configurations": {
-    "recorded-date": "21-09-2022, 13:45:35",
-    "recorded-content": {
-      "raw-response-headers": {
-        "Accept-Ranges": "bytes",
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "http://localhost:4566",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "16",
-        "Content-Type": "binary/octet-stream",
-        "Date": "<date>",
-        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
-        "Last-Modified": "<date>",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-2": {
-        "Accept-Ranges": "bytes",
-        "Content-Length": "16",
-        "Content-Type": "binary/octet-stream",
-        "Date": "<date>",
-        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
-        "Last-Modified": "<date>",
-        "Server": "<server>",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      }
-    }
-  },
   "tests/integration/s3/test_s3.py::TestS3DeepArchive::test_s3_get_deep_archive_object_restore": {
-    "recorded-date": "21-09-2022, 13:45:42",
+    "recorded-date": "05-08-2023, 00:17:19",
     "recorded-content": {
       "get_object_invalid_state": {
         "Error": {
@@ -2548,7 +2486,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_head_object_fields": {
-    "recorded-date": "28-03-2023, 15:37:16",
+    "recorded-date": "03-08-2023, 04:14:26",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",
@@ -2576,7 +2514,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_bucket_acl": {
-    "recorded-date": "20-09-2022, 15:12:21",
+    "recorded-date": "03-08-2023, 16:55:21",
     "recorded-content": {
       "get-bucket-acl": {
         "Grants": [
@@ -2674,7 +2612,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_bucket_acl_exceptions": {
-    "recorded-date": "05-01-2023, 21:45:06",
+    "recorded-date": "03-08-2023, 04:16:13",
     "recorded-content": {
       "put-bucket-canned-acl": {
         "Error": {
@@ -2834,7 +2772,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_header_overrides": {
-    "recorded-date": "16-09-2022, 15:54:28",
+    "recorded-date": "03-08-2023, 04:23:46",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -2849,6 +2787,7 @@
         "Expires": "datetime",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2857,10 +2796,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_put_object_versioned": {
-    "recorded-date": "16-09-2022, 16:52:17",
+    "recorded-date": "03-08-2023, 04:23:39",
     "recorded-content": {
       "put-pre-versioned": {
         "ETag": "\"e1474add07e050008472599be0883b17\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2874,6 +2814,7 @@
         "ETag": "\"e1474add07e050008472599be0883b17\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2915,6 +2856,7 @@
         "ETag": "\"e1474add07e050008472599be0883b17\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -2923,6 +2865,7 @@
       },
       "put-obj-versioned-1": {
         "ETag": "\"c43b615a50200509ceccc5f4122da4bf\"",
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -2931,6 +2874,7 @@
       },
       "put-obj-versioned-2": {
         "ETag": "\"a26fe9d9854f719b8865291904326b58\"",
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -2945,6 +2889,7 @@
         "ETag": "\"a26fe9d9854f719b8865291904326b58\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3067,6 +3012,7 @@
         "ETag": "\"a26fe9d9854f719b8865291904326b58\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3081,6 +3027,7 @@
         "ETag": "\"e1474add07e050008472599be0883b17\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3089,6 +3036,7 @@
       },
       "put-non-versioned-post-disable": {
         "ETag": "\"6c0a0d0895ef9829b63848d506a68536\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3102,6 +3050,7 @@
         "ETag": "\"6c0a0d0895ef9829b63848d506a68536\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3111,7 +3060,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3-True]": {
-    "recorded-date": "22-09-2022, 00:02:59",
+    "recorded-date": "04-08-2023, 23:59:09",
     "recorded-content": {
       "with-decoded-content-length": {
         "Error": {
@@ -3140,11 +3089,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3-False]": {
-    "recorded-date": "22-09-2022, 00:03:00",
+    "recorded-date": "04-08-2023, 23:59:11",
     "recorded-content": {}
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3v4-True]": {
-    "recorded-date": "22-09-2022, 00:03:01",
+    "recorded-date": "04-08-2023, 23:59:13",
     "recorded-content": {
       "with-decoded-content-length": {
         "Error": {
@@ -3167,11 +3116,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3v4-False]": {
-    "recorded-date": "22-09-2022, 00:03:02",
+    "recorded-date": "04-08-2023, 23:59:15",
     "recorded-content": {}
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_presigned_url_expired[s3]": {
-    "recorded-date": "21-09-2022, 20:18:10",
+    "recorded-date": "04-08-2023, 23:59:23",
     "recorded-content": {
       "expired-exception": {
         "Error": {
@@ -3186,7 +3135,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_presigned_url_expired[s3v4]": {
-    "recorded-date": "21-09-2022, 20:18:17",
+    "recorded-date": "04-08-2023, 23:59:29",
     "recorded-content": {
       "expired-exception": {
         "Error": {
@@ -3202,7 +3151,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3-False]": {
-    "recorded-date": "21-09-2022, 20:37:44",
+    "recorded-date": "05-08-2023, 00:00:07",
     "recorded-content": {
       "expired": {
         "Error": {
@@ -3217,7 +3166,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3-True]": {
-    "recorded-date": "21-09-2022, 20:37:53",
+    "recorded-date": "05-08-2023, 00:00:11",
     "recorded-content": {
       "expired": {
         "Error": {
@@ -3232,7 +3181,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3v4-False]": {
-    "recorded-date": "21-09-2022, 20:37:57",
+    "recorded-date": "05-08-2023, 00:00:16",
     "recorded-content": {
       "expired": {
         "Error": {
@@ -3248,7 +3197,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3v4-True]": {
-    "recorded-date": "21-09-2022, 20:38:01",
+    "recorded-date": "05-08-2023, 00:00:20",
     "recorded-content": {
       "expired": {
         "Error": {
@@ -3264,7 +3213,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-False]": {
-    "recorded-date": "21-09-2022, 23:43:59",
+    "recorded-date": "05-08-2023, 00:00:25",
     "recorded-content": {
       "invalid-get-1": {
         "Error": {
@@ -3293,7 +3242,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-True]": {
-    "recorded-date": "21-09-2022, 23:44:05",
+    "recorded-date": "05-08-2023, 00:00:29",
     "recorded-content": {
       "invalid-get-1": {
         "Error": {
@@ -3322,7 +3271,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3v4-False]": {
-    "recorded-date": "21-09-2022, 23:44:10",
+    "recorded-date": "05-08-2023, 00:00:34",
     "recorded-content": {
       "invalid-get-1": {
         "Error": {
@@ -3355,7 +3304,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3v4-True]": {
-    "recorded-date": "21-09-2022, 23:44:15",
+    "recorded-date": "05-08-2023, 00:00:38",
     "recorded-content": {
       "invalid-get-1": {
         "Error": {
@@ -3388,7 +3337,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_missing_sig_param[s3]": {
-    "recorded-date": "22-09-2022, 13:32:19",
+    "recorded-date": "04-08-2023, 23:59:43",
     "recorded-content": {
       "missing-param-exception": {
         "Error": {
@@ -3402,7 +3351,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_missing_sig_param[s3v4]": {
-    "recorded-date": "22-09-2022, 13:32:22",
+    "recorded-date": "04-08-2023, 23:59:45",
     "recorded-content": {
       "missing-param-exception": {
         "Error": {
@@ -3416,7 +3365,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_with_different_headers[s3]": {
-    "recorded-date": "14-12-2022, 18:56:23",
+    "recorded-date": "04-08-2023, 23:59:34",
     "recorded-content": {
       "content-type-exception": {
         "Error": {
@@ -3450,7 +3399,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_with_different_headers[s3v4]": {
-    "recorded-date": "14-12-2022, 18:56:29",
+    "recorded-date": "04-08-2023, 23:59:38",
     "recorded-content": {
       "content-type-exception": {
         "Error": {
@@ -3488,7 +3437,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_same_header_and_qs_parameter": {
-    "recorded-date": "22-09-2022, 14:28:14",
+    "recorded-date": "04-08-2023, 23:59:41",
     "recorded-content": {
       "double-header-query-string": {
         "Error": {
@@ -3518,7 +3467,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_expires": {
-    "recorded-date": "04-10-2022, 17:59:26",
+    "recorded-date": "04-08-2023, 23:58:47",
     "recorded-content": {
       "exception": {
         "Error": {
@@ -3550,7 +3499,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3]": {
-    "recorded-date": "05-10-2022, 18:11:44",
+    "recorded-date": "04-08-2023, 23:58:49",
     "recorded-content": {
       "exception-policy": {
         "Error": {
@@ -3568,7 +3517,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3v4]": {
-    "recorded-date": "05-10-2022, 18:11:46",
+    "recorded-date": "04-08-2023, 23:58:51",
     "recorded-content": {
       "exception-policy": {
         "Error": {
@@ -3586,7 +3535,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3]": {
-    "recorded-date": "05-10-2022, 18:14:22",
+    "recorded-date": "04-08-2023, 23:58:52",
     "recorded-content": {
       "exception-missing-signature": {
         "Error": {
@@ -3602,7 +3551,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3v4]": {
-    "recorded-date": "05-10-2022, 18:14:24",
+    "recorded-date": "04-08-2023, 23:58:54",
     "recorded-content": {
       "exception-missing-signature": {
         "Error": {
@@ -3618,7 +3567,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3]": {
-    "recorded-date": "05-10-2022, 18:29:23",
+    "recorded-date": "04-08-2023, 23:58:56",
     "recorded-content": {
       "exception-missing-fields": {
         "Error": {
@@ -3643,7 +3592,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3v4]": {
-    "recorded-date": "05-10-2022, 18:29:26",
+    "recorded-date": "04-08-2023, 23:58:58",
     "recorded-content": {
       "exception-missing-fields": {
         "Error": {
@@ -3831,7 +3780,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
-    "recorded-date": "27-03-2023, 19:46:42",
+    "recorded-date": "03-08-2023, 04:14:05",
     "recorded-content": {
       "create-multipart": {
         "Bucket": "bucket",
@@ -3998,38 +3947,12 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3Cors::test_s3_get_response_headers": {
-    "recorded-date": "24-10-2022, 15:57:19",
-    "recorded-content": {
-      "bucket-cors-response": {
-        "CORSRules": [
-          {
-            "AllowedMethods": [
-              "GET",
-              "PUT",
-              "POST"
-            ],
-            "AllowedOrigins": [
-              "*"
-            ],
-            "ExposeHeaders": [
-              "ETag",
-              "x-amz-version-id"
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_content_language_disposition": {
-    "recorded-date": "18-10-2022, 10:25:38",
+    "recorded-date": "03-08-2023, 04:13:24",
     "recorded-content": {
       "put-object": {
         "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4042,7 +3965,8 @@
           "etag": "\"e99a18c428cb38d5f260853678922e03\"",
           "server": "server",
           "x-amz-id-2": "id-2",
-          "x-amz-request-id": "request-id"
+          "x-amz-request-id": "request-id",
+          "x-amz-server-side-encryption": "AES256"
         },
         "HTTPStatusCode": 200,
         "HostId": "host-id",
@@ -4060,6 +3984,7 @@
         "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4078,7 +4003,8 @@
           "last-modified": "last-modified",
           "server": "server",
           "x-amz-id-2": "id-2",
-          "x-amz-request-id": "request-id"
+          "x-amz-request-id": "request-id",
+          "x-amz-server-side-encryption": "AES256"
         },
         "HTTPStatusCode": 200,
         "HostId": "host-id",
@@ -4088,7 +4014,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_copy_object_kms": {
-    "recorded-date": "17-10-2022, 14:27:01",
+    "recorded-date": "03-08-2023, 04:13:12",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -4098,6 +4024,7 @@
         "ETag": "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4135,7 +4062,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_replication_config": {
-    "recorded-date": "18-10-2022, 14:49:15",
+    "recorded-date": "03-08-2023, 04:13:08",
     "recorded-content": {
       "expected_error_no_replication_set": {
         "Error": {
@@ -4192,7 +4119,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys_quiet": {
-    "recorded-date": "19-10-2022, 10:11:26",
+    "recorded-date": "03-08-2023, 04:17:06",
     "recorded-content": {
       "deleted-resp": {
         "ResponseMetadata": {
@@ -4203,7 +4130,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_replication_config_without_filter": {
-    "recorded-date": "19-10-2022, 15:32:31",
+    "recorded-date": "03-08-2023, 04:13:02",
     "recorded-content": {
       "expected_error_dest_does_not_exist": {
         "Error": {
@@ -4270,7 +4197,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
-    "recorded-date": "09-01-2023, 14:54:21",
+    "recorded-date": "03-08-2023, 04:23:56",
     "recorded-content": {
       "create-kms-key": {
         "AWSAccountId": "111111111111",
@@ -4363,7 +4290,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_complete_multipart_parts_order": {
-    "recorded-date": "03-07-2023, 17:28:01",
+    "recorded-date": "03-08-2023, 04:24:38",
     "recorded-content": {
       "upload-part-negative-part-number": {
         "Error": {
@@ -4413,7 +4340,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD]": {
-    "recorded-date": "24-03-2023, 03:44:20",
+    "recorded-date": "03-08-2023, 04:24:40",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4426,7 +4353,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA]": {
-    "recorded-date": "24-03-2023, 03:44:22",
+    "recorded-date": "03-08-2023, 04:24:42",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4439,7 +4366,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER]": {
-    "recorded-date": "24-03-2023, 03:44:24",
+    "recorded-date": "03-08-2023, 04:24:44",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4452,7 +4379,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR]": {
-    "recorded-date": "24-03-2023, 03:44:26",
+    "recorded-date": "03-08-2023, 04:24:46",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4465,7 +4392,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY]": {
-    "recorded-date": "24-03-2023, 03:44:29",
+    "recorded-date": "03-08-2023, 04:24:48",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4478,7 +4405,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA]": {
-    "recorded-date": "24-03-2023, 03:44:31",
+    "recorded-date": "03-08-2023, 04:24:50",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4491,7 +4418,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING]": {
-    "recorded-date": "24-03-2023, 03:44:33",
+    "recorded-date": "03-08-2023, 04:24:52",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4504,7 +4431,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE]": {
-    "recorded-date": "24-03-2023, 03:44:35",
+    "recorded-date": "03-08-2023, 04:24:54",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4517,7 +4444,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class_outposts": {
-    "recorded-date": "17-01-2023, 14:34:16",
+    "recorded-date": "03-08-2023, 04:24:56",
     "recorded-content": {
       "put-object-outposts": {
         "Error": {
@@ -4544,7 +4471,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA256]": {
-    "recorded-date": "13-07-2023, 15:46:58",
+    "recorded-date": "03-08-2023, 04:14:55",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA256": "1YQo81vx2VFUl0q5ccWISq8AkSBQQ0WO80S82TmfdIQ=",
@@ -4615,7 +4542,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[None]": {
-    "recorded-date": "13-07-2023, 15:47:02",
+    "recorded-date": "03-08-2023, 04:14:59",
     "recorded-content": {
       "put-object": {
         "ETag": "\"f2081dd61dfa700a0fd5e29b9c3cc23d\"",
@@ -4677,11 +4604,12 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_checksum_with_content_encoding": {
-    "recorded-date": "16-02-2023, 18:47:42",
+    "recorded-date": "03-08-2023, 04:15:01",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA256": "WO7lLNG8Mn/d4GkX4DqZXqeaVHJCN+BxvMNJXLOhukg=",
         "ETag": "\"5287ceabf01e3e9c080606b5a5b9bf70\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4690,12 +4618,13 @@
       "get-object": {
         "AcceptRanges": "bytes",
         "Body": "",
-        "ContentEncoding": "",
+        "ContentEncoding": "gzip",
         "ContentLength": 41,
         "ContentType": "binary/octet-stream",
         "ETag": "\"5287ceabf01e3e9c080606b5a5b9bf70\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4705,12 +4634,13 @@
         "AcceptRanges": "bytes",
         "Body": "",
         "ChecksumSHA256": "WO7lLNG8Mn/d4GkX4DqZXqeaVHJCN+BxvMNJXLOhukg=",
-        "ContentEncoding": "",
+        "ContentEncoding": "gzip",
         "ContentLength": 41,
         "ContentType": "binary/octet-stream",
         "ETag": "\"5287ceabf01e3e9c080606b5a5b9bf70\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4729,12 +4659,13 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_complete_multipart_parts_checksum": {
-    "recorded-date": "17-02-2023, 21:42:39",
+    "recorded-date": "03-08-2023, 04:25:24",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
         "ChecksumAlgorithm": "SHA256",
         "Key": "test-multipart-checksum",
+        "ServerSideEncryption": "AES256",
         "UploadId": "<upload-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4744,6 +4675,7 @@
       "upload-part-0": {
         "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
         "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4752,6 +4684,7 @@
       "upload-part-1": {
         "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
         "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4760,6 +4693,7 @@
       "upload-part-2": {
         "ChecksumSHA256": "DjU70AB1bON8k0n0fVHv2PJQVWcA/jWsITp6ti20Tbs=",
         "ETag": "\"c4c753e69bb853187f5854c46cf801c6\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4827,6 +4761,7 @@
         "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
         "Key": "test-multipart-checksum",
         "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4841,6 +4776,7 @@
         "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4859,11 +4795,12 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "recorded-date": "17-02-2023, 21:57:49",
+    "recorded-date": "03-08-2023, 04:25:28",
     "recorded-content": {
       "create-mpu-no-checksum": {
         "Bucket": "bucket",
         "Key": "test-multipart-checksum-exc",
+        "ServerSideEncryption": "AES256",
         "UploadId": "<upload-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4882,6 +4819,7 @@
       },
       "upload-part-no-checksum-ok": {
         "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4904,6 +4842,7 @@
         "Bucket": "bucket",
         "ChecksumAlgorithm": "SHA256",
         "Key": "test-multipart-checksum-exc",
+        "ServerSideEncryption": "AES256",
         "UploadId": "<upload-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4923,7 +4862,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_objects_versions_with_prefix": {
-    "recorded-date": "27-02-2023, 13:35:27",
+    "recorded-date": "04-08-2023, 23:47:58",
     "recorded-content": {
       "list-object-version-1": {
         "CommonPrefixes": [
@@ -5087,7 +5026,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key_state": {
-    "recorded-date": "01-06-2023, 23:39:32",
+    "recorded-date": "03-08-2023, 04:24:07",
     "recorded-content": {
       "create-kms-key": {
         "AWSAccountId": "111111111111",
@@ -5108,7 +5047,7 @@
         "Origin": "AWS_KMS"
       },
       "success-put-object-sse": {
-        "ETag": "\"8fcef97dd418deded0d80da0c9bb9e35\"",
+        "ETag": "\"b81a68cd58c9371a4b5ddce85a8c50d1\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5121,7 +5060,7 @@
         "Body": "test-sse",
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"8fcef97dd418deded0d80da0c9bb9e35\"",
+        "ETag": "\"b81a68cd58c9371a4b5ddce85a8c50d1\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
@@ -5164,7 +5103,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_keys_in_versioned_bucket": {
-    "recorded-date": "24-03-2023, 01:25:18",
+    "recorded-date": "03-08-2023, 04:17:11",
     "recorded-content": {
       "list-objects-v2": {
         "Contents": [
@@ -5323,7 +5262,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_acl_on_delete_marker": {
-    "recorded-date": "24-03-2023, 00:28:23",
+    "recorded-date": "04-08-2023, 23:53:09",
     "recorded-content": {
       "put-obj-1": {
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
@@ -5347,7 +5286,7 @@
         "Deleted": [
           {
             "DeleteMarker": true,
-            "DeleteMarkerVersionId": "0wvrZJFm5uVT3UZ3qpFOZ_MCcWInT.TR",
+            "DeleteMarkerVersionId": "PY9ezDfMH8Xgs0AK1ri_1goNuAwSqcbA",
             "Key": "test-key-versioned"
           }
         ],
@@ -5371,7 +5310,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_attributes_versioned": {
-    "recorded-date": "24-03-2023, 01:39:11",
+    "recorded-date": "03-08-2023, 04:14:03",
     "recorded-content": {
       "put-obj-v1": {
         "ETag": "\"e92499db864217242396e8ef766079a9\"",
@@ -5489,7 +5428,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix": {
-    "recorded-date": "28-03-2023, 13:54:02",
+    "recorded-date": "03-08-2023, 04:13:48",
     "recorded-content": {
       "list-objects-v2-1": {
         "Contents": [
@@ -5564,7 +5503,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_multipart_uploads_parameters": {
-    "recorded-date": "28-03-2023, 18:16:25",
+    "recorded-date": "03-08-2023, 04:25:30",
     "recorded-content": {
       "create-multipart": {
         "Bucket": "bucket",
@@ -5675,7 +5614,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_multipart_upload_sse": {
-    "recorded-date": "03-04-2023, 22:15:25",
+    "recorded-date": "03-08-2023, 04:25:32",
     "recorded-content": {
       "multi-sse-create-multipart": {
         "Bucket": "<bucket>",
@@ -5691,7 +5630,7 @@
       },
       "multi-sse-upload-part": {
         "BucketKeyEnabled": true,
-        "ETag": "\"366ca6af9c03448ebf507675d7a27ecd\"",
+        "ETag": "\"65784ca4497d11e297a2fb55807714b2\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5702,7 +5641,7 @@
       "multi-sse-compete-multipart": {
         "Bucket": "<bucket>",
         "BucketKeyEnabled": true,
-        "ETag": "\"ff65e9b5cbf8e4e5e26d7f39dc4418b1-1\"",
+        "ETag": "\"4582461eadfccba25baeccf1dff3685f-1\"",
         "Key": "test-sse-field-multipart",
         "Location": "<location:1>",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5718,7 +5657,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"ff65e9b5cbf8e4e5e26d7f39dc4418b1-1\"",
+        "ETag": "\"4582461eadfccba25baeccf1dff3685f-1\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5731,7 +5670,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_bucket_key_default": {
-    "recorded-date": "03-04-2023, 22:15:50",
+    "recorded-date": "03-08-2023, 04:25:36",
     "recorded-content": {
       "put-obj-default-before-setting": {
         "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
@@ -5794,7 +5733,7 @@
       },
       "put-obj-after-setting": {
         "BucketKeyEnabled": true,
-        "ETag": "\"da640409167cd01aaeb9ca47d4e20e5d\"",
+        "ETag": "\"0974150952f40577037f6474c338ceea\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5808,7 +5747,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"da640409167cd01aaeb9ca47d4e20e5d\"",
+        "ETag": "\"0974150952f40577037f6474c338ceea\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5922,7 +5861,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place": {
-    "recorded-date": "26-04-2023, 20:27:10",
+    "recorded-date": "03-08-2023, 16:51:58",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6018,7 +5957,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_metadata_directive": {
-    "recorded-date": "26-04-2023, 19:52:10",
+    "recorded-date": "03-08-2023, 04:15:33",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6158,7 +6097,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_legal_hold": {
-    "recorded-date": "24-04-2023, 20:50:01",
+    "recorded-date": "03-08-2023, 04:15:38",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6214,7 +6153,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_lock": {
-    "recorded-date": "25-04-2023, 18:19:22",
+    "recorded-date": "03-08-2023, 04:15:42",
     "recorded-content": {
       "put-source-object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6271,7 +6210,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_storage_class": {
-    "recorded-date": "26-04-2023, 19:51:03",
+    "recorded-date": "03-08-2023, 04:15:24",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6324,11 +6263,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_with_encryption": {
-    "recorded-date": "26-04-2023, 19:51:18",
+    "recorded-date": "03-08-2023, 04:15:27",
     "recorded-content": {
       "put-object-with-kms-encryption": {
         "BucketKeyEnabled": true,
-        "ETag": "\"857476354331170780321daf8404d0bb\"",
+        "ETag": "\"a1bbe074fcc346fea3fb9e3e6fc7dcce\"",
         "SSEKMSKeyId": "<s-s-e-k-m-s-key-id:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -6341,7 +6280,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 4,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"857476354331170780321daf8404d0bb\"",
+        "ETag": "\"a1bbe074fcc346fea3fb9e3e6fc7dcce\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "<s-s-e-k-m-s-key-id:1>",
@@ -6353,7 +6292,7 @@
       },
       "copy-object-in-place-with-sse": {
         "CopyObjectResult": {
-          "ETag": "\"30617745ef1ba990a6cdb6e6144569f8\"",
+          "ETag": "\"2eba5d22eb3a2551d7fd8284afd1a9d0\"",
           "LastModified": "datetime"
         },
         "SSEKMSKeyId": "<s-s-e-k-m-s-key-id:2>",
@@ -6367,7 +6306,7 @@
         "AcceptRanges": "bytes",
         "ContentLength": 4,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"30617745ef1ba990a6cdb6e6144569f8\"",
+        "ETag": "\"2eba5d22eb3a2551d7fd8284afd1a9d0\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "<s-s-e-k-m-s-key-id:2>",
@@ -6428,7 +6367,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_storage_class": {
-    "recorded-date": "26-04-2023, 21:08:21",
+    "recorded-date": "03-08-2023, 04:15:45",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6492,7 +6431,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_metadata_directive_copy": {
-    "recorded-date": "26-04-2023, 22:03:48",
+    "recorded-date": "03-08-2023, 04:15:06",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6504,6 +6443,7 @@
       },
       "head-object": {
         "AcceptRanges": "bytes",
+        "ContentLanguage": "en-US",
         "ContentLength": 4,
         "ContentType": "binary/octet-stream",
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6530,6 +6470,7 @@
       },
       "head-object-copy": {
         "AcceptRanges": "bytes",
+        "ContentLanguage": "en-US",
         "ContentLength": 4,
         "ContentType": "binary/octet-stream",
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6546,7 +6487,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_website_redirect_location": {
-    "recorded-date": "26-04-2023, 22:30:12",
+    "recorded-date": "03-08-2023, 04:15:36",
     "recorded-content": {
       "put-object": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -6598,7 +6539,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_copy_in_place_with_bucket_encryption": {
-    "recorded-date": "09-05-2023, 15:28:00",
+    "recorded-date": "03-08-2023, 04:15:30",
     "recorded-content": {
       "put-bucket-encryption": {
         "ResponseMetadata": {
@@ -6628,7 +6569,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32]": {
-    "recorded-date": "13-07-2023, 15:46:47",
+    "recorded-date": "03-08-2023, 04:14:45",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32": "lVk/nw==",
@@ -6699,7 +6640,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32C]": {
-    "recorded-date": "13-07-2023, 15:46:50",
+    "recorded-date": "03-08-2023, 04:14:48",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32C": "Fz3epA==",
@@ -6770,7 +6711,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA1]": {
-    "recorded-date": "13-07-2023, 15:46:54",
+    "recorded-date": "03-08-2023, 04:14:52",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA1": "jbXkHAsXUrubtL3dqDQ4w+7WXc0=",
@@ -6841,7 +6782,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_legal_hold_lock_versioned": {
-    "recorded-date": "05-05-2023, 19:10:34",
+    "recorded-date": "03-08-2023, 04:25:43",
     "recorded-content": {
       "put-object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6934,7 +6875,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
-    "recorded-date": "13-07-2023, 18:45:37",
+    "recorded-date": "03-08-2023, 04:25:40",
     "recorded-content": {
       "put_config_with_storage_analysis_err": {
         "Error": {
@@ -7119,7 +7060,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_intelligent_tier_config": {
-    "recorded-date": "13-07-2023, 18:44:40",
+    "recorded-date": "03-08-2023, 04:25:47",
     "recorded-content": {
       "put_bucket_intelligent_tiering_configuration_err_1`": {
         "Error": {
@@ -7272,7 +7213,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_multipart_no_such_upload": {
-    "recorded-date": "30-05-2023, 19:51:43",
+    "recorded-date": "03-08-2023, 04:14:08",
     "recorded-content": {
       "upload-exc": {
         "Error": {
@@ -7310,7 +7251,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[CRC32]": {
-    "recorded-date": "21-06-2023, 21:32:59",
+    "recorded-date": "03-08-2023, 04:15:48",
     "recorded-content": {
       "put-object-no-checksum": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -7364,7 +7305,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[CRC32C]": {
-    "recorded-date": "21-06-2023, 21:33:03",
+    "recorded-date": "03-08-2023, 04:15:51",
     "recorded-content": {
       "put-object-no-checksum": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -7418,7 +7359,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[SHA1]": {
-    "recorded-date": "21-06-2023, 21:33:07",
+    "recorded-date": "03-08-2023, 04:15:54",
     "recorded-content": {
       "put-object-no-checksum": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -7472,7 +7413,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[SHA256]": {
-    "recorded-date": "21-06-2023, 21:33:11",
+    "recorded-date": "03-08-2023, 04:15:56",
     "recorded-content": {
       "put-object-no-checksum": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -7526,7 +7467,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_get_object_special_character[file%2Fname]": {
-    "recorded-date": "09-06-2023, 17:15:35",
+    "recorded-date": "03-08-2023, 04:13:34",
     "recorded-content": {
       "put-object-special-char": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -7580,7 +7521,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_get_object_special_character[test@key/]": {
-    "recorded-date": "09-06-2023, 17:15:39",
+    "recorded-date": "03-08-2023, 04:13:37",
     "recorded-content": {
       "put-object-special-char": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -7634,7 +7575,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_get_object_headers": {
-    "recorded-date": "06-07-2023, 12:43:29",
+    "recorded-date": "03-08-2023, 04:25:53",
     "recorded-content": {
       "if_none_match_err_1": {
         "Code": "304",
@@ -7655,7 +7596,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_object_preconditions": {
-    "recorded-date": "08-07-2023, 00:31:31",
+    "recorded-date": "03-08-2023, 04:16:02",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",
@@ -7750,7 +7691,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging": {
-    "recorded-date": "03-08-2023, 02:13:19",
+    "recorded-date": "03-08-2023, 04:26:09",
     "recorded-content": {
       "get-bucket-default-acl": {
         "Grants": [
@@ -7797,7 +7738,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging_accept_wrong_grants": {
-    "recorded-date": "08-07-2023, 01:15:17",
+    "recorded-date": "03-08-2023, 04:26:11",
     "recorded-content": {
       "put-bucket-logging": {
         "ResponseMetadata": {
@@ -7834,7 +7775,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_logging_wrong_target": {
-    "recorded-date": "08-07-2023, 01:27:18",
+    "recorded-date": "03-08-2023, 04:26:14",
     "recorded-content": {
       "put-bucket-logging-different-regions": {
         "Error": {
@@ -8364,7 +8305,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_inventory_report_crud": {
-    "recorded-date": "14-07-2023, 00:15:43",
+    "recorded-date": "03-08-2023, 04:26:19",
     "recorded-content": {
       "put-inventory-config": {
         "ResponseMetadata": {
@@ -8449,7 +8390,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_put_inventory_report_exceptions": {
-    "recorded-date": "13-07-2023, 23:26:28",
+    "recorded-date": "03-08-2023, 04:26:23",
     "recorded-content": {
       "wrong-id": {
         "Error": {
@@ -8514,7 +8455,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_bucket_inventory_config_order": {
-    "recorded-date": "14-07-2023, 17:13:52",
+    "recorded-date": "03-08-2023, 04:26:27",
     "recorded-content": {
       "list-inventory-config": {
         "InventoryConfigurationList": [
@@ -8613,7 +8554,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_object_hold": {
-    "recorded-date": "08-07-2023, 00:52:18",
+    "recorded-date": "03-08-2023, 04:26:05",
     "recorded-content": {
       "put_object_retention_1": {
         "BucketName": "non-existing-bucket",
@@ -8684,6 +8625,226 @@
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_multipart_complete_multipart_too_small": {
+    "recorded-date": "03-08-2023, 04:14:10",
+    "recorded-content": {
+      "upload-part1": {
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part2": {
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-exc-no-parts": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "You must specify at least one part"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-exc-too-small": {
+        "Error": {
+          "Code": "EntityTooSmall",
+          "ETag": "8d777f385d3dfec8815d20f7496026dc",
+          "Message": "Your proposed upload is smaller than the minimum allowed size",
+          "MinSizeAllowed": "5242880",
+          "PartNumber": "1",
+          "ProposedSize": "4"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_multipart_complete_multipart_wrong_part": {
+    "recorded-date": "03-08-2023, 04:14:12",
+    "recorded-content": {
+      "complete-exc-wrong-part-number": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "8d777f385d3dfec8815d20f7496026dc",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "2",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-exc-wrong-etag": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[COPY]": {
+    "recorded-date": "03-08-2023, 04:15:09",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[REPLACE]": {
+    "recorded-date": "03-08-2023, 04:15:11",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[None]": {
+    "recorded-date": "03-08-2023, 04:15:14",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copy-object-tag": {
+        "TagSet": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put": {
-    "recorded-date": "31-12-2022, 00:54:03",
+    "recorded-date": "05-08-2023, 00:41:37",
     "recorded-content": {
       "object_deleted": {
         "account": "111111111111",
@@ -60,7 +60,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_put_acl": {
-    "recorded-date": "31-12-2022, 00:41:34",
+    "recorded-date": "05-08-2023, 01:08:43",
     "recorded-content": {
       "messages": {
         "messages": [
@@ -72,17 +72,14 @@
               },
               "object": {
                 "etag": "437b930db84b8079c2dd804a71936b5f",
-                "key": "<key-name:1>",
-                "sequencer": "object-sequencer",
-                "size": 9
+                "key": "<key-name:1>"
               },
-              "reason": "PutObject",
               "request-id": "request-id",
               "requester": "<requester>",
               "source-ip-address": "<ip-address:1>",
               "version": "0"
             },
-            "detail-type": "Object Created",
+            "detail-type": "Object ACL Updated",
             "id": "<uuid:1>",
             "region": "<region>",
             "resources": [
@@ -150,14 +147,17 @@
               },
               "object": {
                 "etag": "437b930db84b8079c2dd804a71936b5f",
-                "key": "<key-name:1>"
+                "key": "<key-name:1>",
+                "sequencer": "object-sequencer",
+                "size": 9
               },
+              "reason": "PutObject",
               "request-id": "request-id",
               "requester": "<requester>",
               "source-ip-address": "<ip-address:1>",
               "version": "0"
             },
-            "detail-type": "Object ACL Updated",
+            "detail-type": "Object Created",
             "id": "<uuid:4>",
             "region": "<region>",
             "resources": [

--- a/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
@@ -280,7 +280,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_lambda.py::TestS3NotificationsToLambda::test_invalid_lambda_arn": {
-    "recorded-date": "05-05-2023, 16:10:00",
+    "recorded-date": "05-08-2023, 00:51:19",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {

--- a/tests/integration/s3/test_s3_notifications_sns.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sns.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_object_created_put": {
-    "recorded-date": "09-08-2022, 11:38:05",
+    "recorded-date": "05-08-2023, 00:52:31",
     "recorded-content": {
       "receive_messages": {
         "messages": [
@@ -107,7 +107,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_bucket_notifications_with_filter": {
-    "recorded-date": "22-09-2022, 13:28:52",
+    "recorded-date": "05-08-2023, 00:52:37",
     "recorded-content": {
       "message": {
         "Message": {
@@ -161,7 +161,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_invalid_topic_arn": {
-    "recorded-date": "05-05-2023, 16:14:02",
+    "recorded-date": "05-08-2023, 00:52:42",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {
@@ -205,7 +205,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_bucket_not_exist": {
-    "recorded-date": "23-09-2022, 12:38:09",
+    "recorded-date": "05-08-2023, 00:52:39",
     "recorded-content": {
       "bucket_not_exists": {
         "Error": {

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -974,6 +974,8 @@ class TestS3NotificationsToSQS:
 
         # setup fixture
         bucket_name = s3_create_bucket()
+        aws_client.s3.delete_bucket_ownership_controls(Bucket=bucket_name)
+        aws_client.s3.delete_public_access_block(Bucket=bucket_name)
         queue_url = sqs_create_queue()
         key_name = "my_key_acl"
         s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectAcl:Put"])

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -1,77 +1,77 @@
 {
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put": {
-    "recorded-date": "07-06-2022, 17:28:41",
+    "recorded-date": "05-08-2023, 00:55:23",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "my_key_0",
-                "size": 9,
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "versionId": "version-id",
-                "sequencer": "sequencer"
-              }
+                "key": "my_key_0",
+                "sequencer": "sequencer",
+                "size": 9,
+                "versionId": "version-id"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           },
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "my_key_1",
-                "size": 14,
                 "eTag": "6c7ba9c5a141421e1c03cb9807c97c74",
-                "versionId": "version-id",
-                "sequencer": "sequencer"
-              }
+                "key": "my_key_1",
+                "sequencer": "sequencer",
+                "size": 14,
+                "versionId": "version-id"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -79,42 +79,42 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_copy": {
-    "recorded-date": "07-06-2022, 17:28:48",
+    "recorded-date": "05-08-2023, 00:55:27",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Copy",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "<object-key:1>",
-                "size": 9,
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "sequencer": "sequencer"
-              }
+                "key": "<object-key:1>",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -122,108 +122,108 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_and_object_removed": {
-    "recorded-date": "07-06-2022, 17:28:55",
+    "recorded-date": "05-08-2023, 00:55:32",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Copy",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
                 "key": "<object-key:1>",
-                "size": 9,
-                "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "sequencer": "sequencer"
-              }
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           },
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "<object-key:2>",
-                "size": 9,
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "sequencer": "sequencer"
-              }
+                "key": "<object-key:2>",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           },
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectRemoved:Delete",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
                 "key": "<object-key:2>",
                 "sequencer": "sequencer"
-              }
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -231,42 +231,42 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_complete_multipart_upload": {
-    "recorded-date": "07-06-2022, 17:29:02",
+    "recorded-date": "05-08-2023, 00:55:41",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:CompleteMultipartUpload",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "test-key",
-                "size": 6144,
                 "eTag": "8eabe9d6b43316e840b079170916c079-1",
-                "sequencer": "sequencer"
-              }
+                "key": "test-key",
+                "sequencer": "sequencer",
+                "size": 6144
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -274,42 +274,42 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_key_encoding": {
-    "recorded-date": "07-06-2022, 17:29:07",
+    "recorded-date": "05-08-2023, 00:55:45",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "a%40b",
-                "size": 9,
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "sequencer": "sequencer"
-              }
+                "key": "a%40b",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -317,42 +317,42 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
-    "recorded-date": "07-06-2022, 17:29:13",
+    "recorded-date": "05-08-2023, 00:55:49",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "key-by-hostname",
-                "size": 9,
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
-                "sequencer": "sequencer"
-              }
+                "key": "key-by-hostname",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -360,40 +360,40 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_tagging_put_event": {
-    "recorded-date": "07-06-2022, 17:29:18",
+    "recorded-date": "05-08-2023, 00:55:54",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.3",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectTagging:Put",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.3",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "<object-key:1>",
-                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d"
-              }
+                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d",
+                "key": "<object-key:1>"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -401,40 +401,40 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_tagging_delete_event": {
-    "recorded-date": "07-06-2022, 17:29:25",
+    "recorded-date": "05-08-2023, 00:55:58",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "eventVersion": "2.3",
-            "eventSource": "aws:s3",
             "awsRegion": "<region>",
-            "eventTime": "date",
             "eventName": "ObjectTagging:Delete",
-            "userIdentity": {
-              "principalId": "<principal-id:2>"
-            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.3",
             "requestParameters": {
               "sourceIPAddress": "<ip-address:1>"
             },
             "responseElements": {
-              "x-amz-request-id": "amz-request-id",
-              "x-amz-id-2": "amz-id"
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
             },
             "s3": {
-              "s3SchemaVersion": "1.0",
-              "configurationId": "<config-id:1>",
               "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
                 "name": "<resource:1>",
                 "ownerIdentity": {
                   "principalId": "<principal-id:1>"
-                },
-                "arn": "arn:aws:s3:::<resource:1>"
+                }
               },
+              "configurationId": "<config-id:1>",
               "object": {
-                "key": "<object-key:1>",
-                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d"
-              }
+                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d",
+                "key": "<object-key:1>"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
             }
           }
         ]
@@ -442,14 +442,14 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_xray_header": {
-    "recorded-date": "07-06-2022, 17:29:32",
+    "recorded-date": "05-08-2023, 00:56:03",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>",
-            "MD5OfBody": "m-d5-of-body",
+            "Attributes": {
+              "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            },
             "Body": {
               "Records": [
                 {
@@ -488,16 +488,16 @@
                 }
               ]
             },
-            "Attributes": {
-              "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
-            }
+            "MD5OfBody": "m-d5-of-body",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
           }
         ]
       }
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_notifications_with_filter": {
-    "recorded-date": "22-09-2022, 13:52:49",
+    "recorded-date": "05-08-2023, 00:56:08",
     "recorded-content": {
       "config": {
         "QueueConfigurations": [
@@ -633,7 +633,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_filter_rules_case_insensitive": {
-    "recorded-date": "22-09-2022, 14:05:55",
+    "recorded-date": "05-08-2023, 00:56:10",
     "recorded-content": {
       "bucket_notification_configuration": {
         "QueueConfigurations": [
@@ -667,7 +667,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_bucket_notification_with_invalid_filter_rules": {
-    "recorded-date": "22-09-2022, 14:08:25",
+    "recorded-date": "05-08-2023, 00:56:12",
     "recorded-content": {
       "invalid_filter_name": {
         "Error": {
@@ -684,7 +684,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_invalid_sqs_arn": {
-    "recorded-date": "04-05-2023, 18:28:16",
+    "recorded-date": "05-08-2023, 00:56:15",
     "recorded-content": {
       "invalid_not_skip": {
         "Error": {
@@ -740,7 +740,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_delete_objects": {
-    "recorded-date": "19-10-2022, 10:39:20",
+    "recorded-date": "05-08-2023, 00:55:37",
     "recorded-content": {
       "receive_messages": {
         "messages": [
@@ -845,7 +845,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_put_acl": {
-    "recorded-date": "30-12-2022, 23:14:21",
+    "recorded-date": "05-08-2023, 00:56:22",
     "recorded-content": {
       "receive_messages": {
         "messages": [
@@ -950,7 +950,7 @@
     }
   },
   "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_multiple_invalid_sqs_arns": {
-    "recorded-date": "04-05-2023, 18:13:38",
+    "recorded-date": "05-08-2023, 00:56:17",
     "recorded-content": {
       "two-queue-arns-invalid": {
         "Error": {
@@ -978,8 +978,8 @@
       },
       "multiple-queues-do-not-exist": {
         "Error": {
-          "ArgumentName1": "arn:aws:sqs:<region>:111111111111:my-queue-2",
-          "ArgumentName2": "arn:aws:sqs:<region>:111111111111:my-queue",
+          "ArgumentName1": "arn:aws:sqs:<region>:111111111111:my-queue",
+          "ArgumentName2": "arn:aws:sqs:<region>:111111111111:my-queue-2",
           "ArgumentValue1": "The destination queue does not exist",
           "ArgumentValue2": "The destination queue does not exist",
           "Code": "InvalidArgument",


### PR DESCRIPTION
This PR regenerates all S3 snapshots. It might have been nice to actually split the S3 tests before regenerating the snapshots, but there are currently at least 7 open PRs targeting S3, most of them adding tests.

I'll tackle the split of the tests in the next weeks, and I'll move the snapshots manually then. 