### PR TITLE
Enhance parity around API Gateway stage patch operations

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -131,14 +131,14 @@ class OpenAPIExt:
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 
 
-def get_apigateway_store(
-    account_id: str = None, region: str = None, context: RequestContext = None
-) -> ApiGatewayStore:
-    if not account_id:
-        account_id = context.account_id if context else get_aws_account_id()
-    if not region:
-        region = context.region if context else aws_stack.get_region()
-    return apigateway_stores[account_id][region]
+def get_apigateway_store(context: RequestContext) -> ApiGatewayStore:
+    return apigateway_stores[context.account_id][context.region]
+
+
+def get_apigateway_store_for_invocation(context: ApiInvocationContext) -> ApiGatewayStore:
+    account_id = context.account_id or get_aws_account_id()
+    region_name = context.region_name or aws_stack.get_region()
+    return apigateway_stores[account_id][region_name]
 
 
 class ApiGatewayIntegrationError(Exception):
@@ -809,10 +809,11 @@ def add_documentation_parts(rest_api_container, documentation):
 
 
 def import_api_from_openapi_spec(
-    rest_api: RestAPI, body: Dict, query_params: Dict, account_id: str = None, region: str = None
+    rest_api: RestAPI, body: dict, context: RequestContext
 ) -> Optional[RestAPI]:
     """Import an API from an OpenAPI spec document"""
 
+    query_params: dict = context.request.values.to_dict()
     resolved_schema = resolve_references(copy.deepcopy(body), rest_api_id=rest_api.id)
 
     # TODO:
@@ -831,7 +832,7 @@ def import_api_from_openapi_spec(
     # authorizers map to avoid duplication
     authorizers = {}
 
-    store = get_apigateway_store(account_id=account_id, region=region)
+    store = get_apigateway_store(context=context)
     rest_api_container = store.rest_apis[rest_api.id]
 
     def is_api_key_required(path_payload: dict) -> bool:

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -20,6 +20,7 @@ from requests.models import Response
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
+from localstack.aws.api import RequestContext
 from localstack.aws.api.apigateway import (
     Authorizer,
     ConnectionType,
@@ -130,8 +131,14 @@ class OpenAPIExt:
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 
 
-def get_apigateway_store(account_id: str = None, region: str = None) -> ApiGatewayStore:
-    return apigateway_stores[account_id or get_aws_account_id()][region or aws_stack.get_region()]
+def get_apigateway_store(
+    account_id: str = None, region: str = None, context: RequestContext = None
+) -> ApiGatewayStore:
+    if not account_id:
+        account_id = context.account_id if context else get_aws_account_id()
+    if not region:
+        region = context.region if context else aws_stack.get_region()
+    return apigateway_stores[account_id][region]
 
 
 class ApiGatewayIntegrationError(Exception):

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -14,7 +14,7 @@ from localstack.services.apigateway.helpers import (
     ModelResolver,
     extract_path_params,
     extract_query_string_params,
-    get_apigateway_store,
+    get_apigateway_store_for_invocation,
     get_cors_response,
     make_error_response,
     select_integration_response,
@@ -57,9 +57,7 @@ class RequestValidator:
 
     def __init__(self, context: ApiInvocationContext, store: ApiGatewayStore = None):
         self.context = context
-        store = store or get_apigateway_store(
-            account_id=context.account_id, region=context.region_name
-        )
+        store = store or get_apigateway_store_for_invocation(context=context)
         if not (container := store.rest_apis.get(context.api_id)):
             # TODO: find the right exception
             raise NotFound()

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -5,6 +5,7 @@ from requests.structures import CaseInsensitiveDict
 from localstack.aws.api.apigateway import (
     Authorizer,
     DocumentationPart,
+    DocumentationVersion,
     DomainName,
     GatewayResponse,
     Model,
@@ -29,6 +30,8 @@ class RestApiContainer:
     validators: Dict[str, RequestValidator]
     # map DocumentationPartId -> DocumentationPart
     documentation_parts: Dict[str, DocumentationPart]
+    # map doc version name -> DocumentationVersion
+    documentation_versions: Dict[str, DocumentationVersion]
     # not used yet, still in moto
     gateway_responses: Dict[str, GatewayResponse]
     # maps Model name -> Model
@@ -43,6 +46,7 @@ class RestApiContainer:
         self.authorizers = {}
         self.validators = {}
         self.documentation_parts = {}
+        self.documentation_versions = {}
         self.gateway_responses = {}
         self.models = {}
         self.resolved_models = {}

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -235,6 +235,15 @@ def apply_patches():
 
         return resp
 
+    @patch(apigateway_models.Stage.to_json)
+    def apigateway_models_stage_to_json(fn, self):
+        result = fn(self)
+
+        if "documentationVersion" not in result:
+            result["documentationVersion"] = getattr(self, "documentation_version", None)
+
+        return result
+
     @patch(APIGatewayResponse.individual_deployment)
     def individual_deployment(fn, self, request, full_url, headers, *args, **kwargs):
         result = fn(self, request, full_url, headers, *args, **kwargs)

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -77,7 +77,6 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
     ThrottleSettings,
-    UpdateStageRequest,
     UsagePlan,
     UsagePlans,
     VpcLink,

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -346,13 +346,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         rest_api = get_moto_rest_api(context, request["restApiId"])
 
         openapi_spec = parse_json_or_yaml(to_str(body_data))
-        rest_api = import_api_from_openapi_spec(
-            rest_api,
-            openapi_spec,
-            context.request.values.to_dict(),
-            account_id=context.account_id,
-            region=context.region,
-        )
+        rest_api = import_api_from_openapi_spec(rest_api, openapi_spec, context=context)
 
         response = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response)

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -36,6 +36,8 @@ from localstack.aws.api.apigateway import (
     DocumentationPartIds,
     DocumentationPartLocation,
     DocumentationParts,
+    DocumentationVersion,
+    DocumentationVersions,
     DomainName,
     DomainNames,
     DomainNameStatus,
@@ -227,7 +229,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         rest_api.version = request.get("version")
         response: RestApi = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response)
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = RestApiContainer(rest_api=response)
         store.rest_apis[result["id"]] = rest_api_container
         # add the 2 default models
@@ -332,7 +334,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         response = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response, remove_tags=False)
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         store.rest_apis[rest_api_id].rest_api = response
         return response
 
@@ -354,7 +356,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         response = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response)
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         store.rest_apis[request["restApiId"]].rest_api = response
         # TODO: verify this
         response = to_rest_api_response_json(response)
@@ -382,7 +384,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if not domain_name:
             raise BadRequestException("No Domain Name specified")
 
-        store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
+        store: ApiGatewayStore = get_apigateway_store(context=context)
         if store.domain_names.get(domain_name):
             raise ConflictException(f"Domain name with ID {domain_name} already exists")
 
@@ -410,7 +412,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("GetDomainName")
     def get_domain_name(self, context: RequestContext, domain_name: String) -> DomainName:
-        store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
+        store: ApiGatewayStore = get_apigateway_store(context=context)
         if domain := store.domain_names.get(domain_name):
             return domain
         raise NotFoundException("Invalid domain name identifier specified")
@@ -419,19 +421,19 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_domain_names(
         self, context: RequestContext, position: String = None, limit: NullableInteger = None
     ) -> DomainNames:
-        store = get_apigateway_store(context.account_id, context.region)
+        store = get_apigateway_store(context=context)
         domain_names = store.domain_names.values()
         return DomainNames(items=list(domain_names), position=position)
 
     @handler("DeleteDomainName")
     def delete_domain_name(self, context: RequestContext, domain_name: String) -> None:
-        store: ApiGatewayStore = get_apigateway_store(context.account_id, context.region)
+        store: ApiGatewayStore = get_apigateway_store(context=context)
         if not store.domain_names.pop(domain_name, None):
             raise NotFoundException("Invalid domain name identifier specified")
 
     def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
         try:
-            store = get_apigateway_store(context.account_id, context.region)
+            store = get_apigateway_store(context=context)
             store.rest_apis.pop(rest_api_id, None)
             call_moto(context)
         except KeyError as e:
@@ -466,7 +468,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 f"Cannot create a child of a resource with a greedy path variable: {parent_path}"
             )
 
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api = store.rest_apis.get(rest_api_id)
         children = rest_api.resource_children.setdefault(parent_id, [])
 
@@ -494,7 +496,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if not moto_resource:
             raise NotFoundException("Invalid Resource identifier specified")
 
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api = store.rest_apis.get(rest_api_id)
         api_resources = rest_api.resource_children
         # we need to recursively delete all children resources of the resource we're deleting
@@ -525,7 +527,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if not moto_resource:
             raise NotFoundException("Invalid Resource identifier specified")
 
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
 
         rest_api = store.rest_apis.get(rest_api_id)
         api_resources = rest_api.resource_children
@@ -651,7 +653,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     "Parameter names must be unique across querystring, header and path"
                 )
         need_authorizer_id = authorization_type in ("CUSTOM", "COGNITO_USER_POOLS")
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis[rest_api_id]
         if need_authorizer_id and (
             not authorizer_id or authorizer_id not in rest_api_container.authorizers
@@ -704,7 +706,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         if not (moto_method := moto_resource.resource_methods.get(http_method)):
             raise NotFoundException("Invalid Method identifier specified")
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api = store.rest_apis[rest_api_id]
         applicable_patch_operations = []
         modifying_auth_type = False
@@ -839,11 +841,21 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     # TODO: add createdDate / lastUpdatedDate in Stage operations below!
     @handler("CreateStage", expand=False)
     def create_stage(self, context: RequestContext, request: CreateStageRequest) -> Stage:
-        response = call_moto(context)
+        call_moto(context)
+        moto_api = get_moto_rest_api(context, rest_api_id=request["restApiId"])
+        stage = moto_api.stages.get(request["stageName"])
+        if not stage:
+            raise NotFoundException("Invalid Stage identifier specified")
+
+        if not hasattr(stage, "documentation_version"):
+            stage.documentation_version = request.get("documentationVersion")
+
+        response = stage.to_json()
         response.setdefault("cacheClusterStatus", "NOT_AVAILABLE")
         response.setdefault("tracingEnabled", False)
         if not response.get("variables"):
             response.pop("variables", None)
+
         return response
 
     def get_stage(self, context: RequestContext, rest_api_id: String, stage_name: String) -> Stage:
@@ -896,7 +908,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     ) -> Authorizer:
         # TODO: add validation
         api_id = request["restApiId"]
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if api_id not in store.rest_apis:
             # this seems like a weird exception to throw, but couldn't get anything different
             # we might need to have a look again
@@ -923,12 +935,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         limit: NullableInteger = None,
     ) -> Authorizers:
         # TODO add paging, validation
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
-        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
-            raise NotFoundException(
-                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
-            )
-
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
         result = [
             to_authorizer_response_json(rest_api_id, a)
             for a in rest_api_container.authorizers.values()
@@ -938,7 +945,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_authorizer(
         self, context: RequestContext, rest_api_id: String, authorizer_id: String
     ) -> Authorizer:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         authorizer = (
@@ -953,7 +960,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         self, context: RequestContext, rest_api_id: String, authorizer_id: String
     ) -> None:
         # TODO: add validation if authorizer does not exist
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         if rest_api_container:
             rest_api_container.authorizers.pop(authorizer_id, None)
@@ -966,7 +973,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         patch_operations: ListOfPatchOperation = None,
     ) -> Authorizer:
         # TODO: add validation
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         authorizer = (
@@ -994,14 +1001,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         self,
         context: RequestContext,
     ) -> Account:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         result = to_account_response_json(region_details.account)
         return Account(**result)
 
     def update_account(
         self, context: RequestContext, patch_operations: ListOfPatchOperation = None
     ) -> Account:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         apply_json_patch_safe(region_details.account, patch_operations, in_place=True)
         result = to_account_response_json(region_details.account)
         return Account(**result)
@@ -1013,11 +1020,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     ) -> DocumentationParts:
         # TODO: add validation
         api_id = request["restApiId"]
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
-        if not (rest_api_container := store.rest_apis.get(api_id)):
-            raise NotFoundException(
-                f"Invalid API identifier specified {context.account_id}:{api_id}"
-            )
+        rest_api_container = _get_rest_api_container(context, rest_api_id=api_id)
 
         result = [
             to_documentation_part_response_json(api_id, a)
@@ -1029,7 +1032,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         self, context: RequestContext, rest_api_id: String, documentation_part_id: String
     ) -> DocumentationPart:
         # TODO: add validation
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         documentation_part = (
@@ -1050,11 +1053,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         properties: String,
     ) -> DocumentationPart:
         entity_id = short_uid()[:6]  # length 6 for AWS parity / Terraform compatibility
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
-        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
-            raise NotFoundException(
-                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
-            )
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
 
         # TODO: add complete validation for
         # location parameter: https://docs.aws.amazon.com/apigateway/latest/api/API_DocumentationPartLocation.html
@@ -1102,7 +1101,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         patch_operations: ListOfPatchOperation = None,
     ) -> DocumentationPart:
         # TODO: add validation
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         doc_part = (
@@ -1143,11 +1142,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         self, context: RequestContext, rest_api_id: String, documentation_part_id: String
     ) -> None:
         # TODO: add validation if document_part does not exist, or rest_api
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
-        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
-            raise NotFoundException(
-                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
-            )
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
 
         documentation_part = rest_api_container.documentation_parts.get(documentation_part_id)
 
@@ -1169,11 +1164,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         body_data = body.read()
         openapi_spec = parse_json_or_yaml(to_str(body_data))
 
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
-        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
-            raise NotFoundException(
-                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
-            )
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
 
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api-quick-start-import-export.html
         resolved_schema = resolve_references(openapi_spec, rest_api_id=rest_api_id)
@@ -1192,6 +1183,73 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         # TODO: implement the merge mode
         return DocumentationPartIds(ids=ids)
 
+    # documentation versions
+
+    def create_documentation_version(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        documentation_version: String,
+        stage_name: String = None,
+        description: String = None,
+    ) -> DocumentationVersion:
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
+
+        result = DocumentationVersion(
+            version=documentation_version, createdDate=datetime.now(), description=description
+        )
+        rest_api_container.documentation_versions[documentation_version] = result
+
+        return result
+
+    def get_documentation_version(
+        self, context: RequestContext, rest_api_id: String, documentation_version: String
+    ) -> DocumentationVersion:
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
+
+        result = rest_api_container.documentation_versions.get(documentation_version)
+        if not result:
+            raise NotFoundException(f"Documentation version not found: {documentation_version}")
+
+        return result
+
+    def get_documentation_versions(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        position: String = None,
+        limit: NullableInteger = None,
+    ) -> DocumentationVersions:
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
+        result = list(rest_api_container.documentation_versions.values())
+        return DocumentationVersions(items=result)
+
+    def delete_documentation_version(
+        self, context: RequestContext, rest_api_id: String, documentation_version: String
+    ) -> None:
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
+
+        result = rest_api_container.documentation_versions.pop(documentation_version, None)
+        if not result:
+            raise NotFoundException(f"Documentation version not found: {documentation_version}")
+
+    def update_documentation_version(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        documentation_version: String,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> DocumentationVersion:
+        rest_api_container = _get_rest_api_container(context, rest_api_id=rest_api_id)
+
+        result = rest_api_container.documentation_versions.get(documentation_version)
+        if not result:
+            raise NotFoundException(f"Documentation version not found: {documentation_version}")
+
+        _patch_api_gateway_entity(result, patch_operations)
+
+        return result
+
     # base path mappings
 
     def get_base_path_mappings(
@@ -1201,7 +1259,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         position: String = None,
         limit: NullableInteger = None,
     ) -> BasePathMappings:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
 
         mappings_list = region_details.base_path_mappings.get(domain_name) or []
 
@@ -1213,7 +1271,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_base_path_mapping(
         self, context: RequestContext, domain_name: String, base_path: String
     ) -> BasePathMapping:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
 
         mappings_list = region_details.base_path_mappings.get(domain_name) or []
         mapping = ([m for m in mappings_list if m["basePath"] == base_path] or [None])[0]
@@ -1231,7 +1289,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         base_path: String = None,
         stage: String = None,
     ) -> BasePathMapping:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
 
         # Note: "(none)" is a special value in API GW:
         # https://docs.aws.amazon.com/apigateway/api-reference/link-relation/basepathmapping-by-base-path
@@ -1255,7 +1313,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         base_path: String,
         patch_operations: ListOfPatchOperation = None,
     ) -> BasePathMapping:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
 
         mappings_list = region_details.base_path_mappings.get(domain_name) or []
 
@@ -1282,7 +1340,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def delete_base_path_mapping(
         self, context: RequestContext, domain_name: String, base_path: String
     ) -> None:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
 
         mappings_list = region_details.base_path_mappings.get(domain_name) or []
         for i in range(len(mappings_list)):
@@ -1297,7 +1355,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_client_certificate(
         self, context: RequestContext, client_certificate_id: String
     ) -> ClientCertificate:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         result = region_details.client_certificates.get(client_certificate_id)
         if result is None:
             raise NotFoundException(f"Client certificate ID {client_certificate_id} not found")
@@ -1306,14 +1364,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_client_certificates(
         self, context: RequestContext, position: String = None, limit: NullableInteger = None
     ) -> ClientCertificates:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         result = list(region_details.client_certificates.values())
         return ClientCertificates(items=result)
 
     def generate_client_certificate(
         self, context: RequestContext, description: String = None, tags: MapOfStringToString = None
     ) -> ClientCertificate:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         cert_id = short_uid()
         creation_time = now_utc()
         entry = {
@@ -1334,7 +1392,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         client_certificate_id: String,
         patch_operations: ListOfPatchOperation = None,
     ) -> ClientCertificate:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         entity = region_details.client_certificates.get(client_certificate_id)
         if entity is None:
             raise NotFoundException(f'Client certificate ID "{client_certificate_id}" not found')
@@ -1345,7 +1403,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def delete_client_certificate(
         self, context: RequestContext, client_certificate_id: String
     ) -> None:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         entity = region_details.client_certificates.pop(client_certificate_id, None)
         if entity is None:
             raise NotFoundException(f'VPC link ID "{client_certificate_id}" not found for deletion')
@@ -1360,7 +1418,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         description: String = None,
         tags: MapOfStringToString = None,
     ) -> VpcLink:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         link_id = short_uid()
         entry = {"id": link_id, "status": "AVAILABLE"}
         region_details.vpc_links[link_id] = entry
@@ -1370,14 +1428,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_vpc_links(
         self, context: RequestContext, position: String = None, limit: NullableInteger = None
     ) -> VpcLinks:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         result = region_details.vpc_links.values()
         result = [to_vpc_link_response_json(r) for r in result]
         result = {"items": result}
         return result
 
     def get_vpc_link(self, context: RequestContext, vpc_link_id: String) -> VpcLink:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         vpc_link = region_details.vpc_links.get(vpc_link_id)
         if vpc_link is None:
             raise NotFoundException(f'VPC link ID "{vpc_link_id}" not found')
@@ -1390,7 +1448,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         vpc_link_id: String,
         patch_operations: ListOfPatchOperation = None,
     ) -> VpcLink:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         vpc_link = region_details.vpc_links.get(vpc_link_id)
         if vpc_link is None:
             raise NotFoundException(f'VPC link ID "{vpc_link_id}" not found')
@@ -1399,7 +1457,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         return VpcLink(**result)
 
     def delete_vpc_link(self, context: RequestContext, vpc_link_id: String) -> None:
-        region_details = get_apigateway_store()
+        region_details = get_apigateway_store(context=context)
         vpc_link = region_details.vpc_links.pop(vpc_link_id, None)
         if vpc_link is None:
             raise NotFoundException(f'VPC link ID "{vpc_link_id}" not found for deletion')
@@ -1414,7 +1472,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         limit: NullableInteger = None,
     ) -> RequestValidators:
         # TODO: add validation and pagination?
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if not (rest_api_container := store.rest_apis.get(rest_api_id)):
             raise NotFoundException(
                 f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
@@ -1429,7 +1487,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_request_validator(
         self, context: RequestContext, rest_api_id: String, request_validator_id: String
     ) -> RequestValidator:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         validator = (
@@ -1451,7 +1509,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         validate_request_parameters: Boolean = None,
     ) -> RequestValidator:
         # TODO: add validation (ex: name cannot be blank)
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if not (rest_api_container := store.rest_apis.get(rest_api_id)):
             raise BadRequestException("Invalid REST API identifier specified")
         # length 6 for AWS parity and TF compatibility
@@ -1477,7 +1535,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         patch_operations: ListOfPatchOperation = None,
     ) -> RequestValidator:
         # TODO: add validation
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         # TODO: validate the restAPI id to remove the conditional
         validator = (
@@ -1521,7 +1579,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         self, context: RequestContext, rest_api_id: String, request_validator_id: String
     ) -> None:
         # TODO: add validation if rest api does not exist
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         rest_api_container = store.rest_apis.get(rest_api_id)
         if not rest_api_container:
             raise NotFoundException("Invalid Request Validator identifier specified")
@@ -1539,19 +1597,19 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         position: String = None,
         limit: NullableInteger = None,
     ) -> Tags:
-        result = get_apigateway_store().TAGS.get(resource_arn, {})
+        result = get_apigateway_store(context=context).TAGS.get(resource_arn, {})
         return Tags(tags=result)
 
     def tag_resource(
         self, context: RequestContext, resource_arn: String, tags: MapOfStringToString
     ) -> None:
-        resource_tags = get_apigateway_store().TAGS.setdefault(resource_arn, {})
+        resource_tags = get_apigateway_store(context=context).TAGS.setdefault(resource_arn, {})
         resource_tags.update(tags)
 
     def untag_resource(
         self, context: RequestContext, resource_arn: String, tag_keys: ListOfString
     ) -> None:
-        resource_tags = get_apigateway_store().TAGS.setdefault(resource_arn, {})
+        resource_tags = get_apigateway_store(context=context).TAGS.setdefault(resource_arn, {})
         for key in tag_keys:
             resource_tags.pop(key, None)
 
@@ -1576,7 +1634,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response = self.create_rest_api(create_api_context, create_api_request)
         api_id = response.get("id")
         # remove the 2 default models automatically created, but not when importing
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         store.rest_apis[api_id].models = {}
 
         # put rest api
@@ -1764,7 +1822,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         description: String = None,
         schema: String = None,
     ) -> Model:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if rest_api_id not in store.rest_apis:
             raise NotFoundException(
                 f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
@@ -1797,7 +1855,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         position: String = None,
         limit: NullableInteger = None,
     ) -> Models:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if rest_api_id not in store.rest_apis:
             raise NotFoundException(
                 f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
@@ -1816,7 +1874,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         model_name: String,
         flatten: Boolean = None,
     ) -> Model:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if rest_api_id not in store.rest_apis or not (
             model := store.rest_apis[rest_api_id].models.get(model_name)
         ):
@@ -1834,7 +1892,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         # manually update the model, not need for JSON patch, only 2 path supported with replace operation
         # /schema
         # /description
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
         if rest_api_id not in store.rest_apis or not (
             model := store.rest_apis[rest_api_id].models.get(model_name)
         ):
@@ -1867,7 +1925,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def delete_model(
         self, context: RequestContext, rest_api_id: String, model_name: String
     ) -> None:
-        store = get_apigateway_store(account_id=context.account_id, region=context.region)
+        store = get_apigateway_store(context=context)
 
         if (
             rest_api_id not in store.rest_apis
@@ -2072,12 +2130,18 @@ def create_custom_context(
 
 
 def _patch_api_gateway_entity(entity: Any, patch_operations: ListOfPatchOperation):
-    if not isinstance(entity.__dict__, DelSafeDict):
-        entity.__dict__ = DelSafeDict(entity.__dict__)
+    patch_operations = patch_operations or []
+
+    if isinstance(entity, dict):
+        entity_dict = entity
+    else:
+        if not isinstance(entity.__dict__, DelSafeDict):
+            entity.__dict__ = DelSafeDict(entity.__dict__)
+        entity_dict = entity.__dict__
 
     not_supported_attributes = {"/id", "/region_name", "/create_date"}
 
-    model_attributes = list(entity.__dict__.keys())
+    model_attributes = list(entity_dict.keys())
     for operation in patch_operations:
         path_start = operation["path"].strip("/").split("/")[0]
         path_start_usc = camelcase_to_underscores(path_start)
@@ -2086,7 +2150,7 @@ def _patch_api_gateway_entity(entity: Any, patch_operations: ListOfPatchOperatio
         if operation["path"] in not_supported_attributes:
             raise BadRequestException(f"Invalid patch path {operation['path']}")
 
-    apply_json_patch_safe(entity.__dict__, patch_operations, in_place=True)
+    apply_json_patch_safe(entity_dict, patch_operations, in_place=True)
 
 
 def to_authorizer_response_json(api_id, data):
@@ -2190,6 +2254,15 @@ DEFAULT_ERROR_MODEL = Model(
         }
     ),
 )
+
+
+def _get_rest_api_container(context: RequestContext, rest_api_id: str) -> RestApiContainer:
+    store = get_apigateway_store(context=context)
+    if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+        raise NotFoundException(
+            f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+        )
+    return rest_api_container
 
 
 # TODO: maybe extract this in its own files, or find a better generalizable way

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1778,6 +1778,7 @@ def create_rest_apigw(aws_client_factory):
     def _create_apigateway_function(**kwargs):
         region_name = kwargs.pop("region_name", None)
         apigateway_client = aws_client_factory(region_name=region_name).apigateway
+        kwargs.setdefault("name", f"api-{short_uid()}")
 
         response = apigateway_client.create_rest_api(**kwargs)
         api_id = response.get("id")

--- a/tests/aws/apigateway/conftest.py
+++ b/tests/aws/apigateway/conftest.py
@@ -168,3 +168,8 @@ def import_apigw(aws_client):
 
     for rest_api_id in rest_api_ids:
         delete_rest_api(aws_client.apigateway, restApiId=rest_api_id)
+
+
+@pytest.fixture
+def apigw_add_transformers(snapshot):
+    snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))

--- a/tests/aws/apigateway/conftest.py
+++ b/tests/aws/apigateway/conftest.py
@@ -172,4 +172,5 @@ def import_apigw(aws_client):
 
 @pytest.fixture
 def apigw_add_transformers(snapshot):
+    snapshot.add_transformer(snapshot.transform.key_value("id"))
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))

--- a/tests/aws/apigateway/conftest.py
+++ b/tests/aws/apigateway/conftest.py
@@ -172,5 +172,5 @@ def import_apigw(aws_client):
 
 @pytest.fixture
 def apigw_add_transformers(snapshot):
-    snapshot.add_transformer(snapshot.transform.key_value("id"))
+    snapshot.add_transformer(snapshot.transform.jsonpath("$..items..id", "id"))
     snapshot.add_transformer(snapshot.transform.key_value("deploymentId"))

--- a/tests/aws/apigateway/test_apigateway_basic.py
+++ b/tests/aws/apigateway/test_apigateway_basic.py
@@ -15,6 +15,7 @@ from requests.structures import CaseInsensitiveDict
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
+from localstack.aws.connect import connect_to
 from localstack.aws.handlers import cors
 from localstack.config import get_edge_url
 from localstack.constants import APPLICATION_JSON, LOCALHOST_HOSTNAME
@@ -71,6 +72,7 @@ from tests.aws.awslambda.test_lambda import (
 
 # TODO: split up the tests in this file into more specific test sub-modules
 
+TEST_STAGE_NAME = "testing"
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_SWAGGER_FILE_JSON = os.path.join(THIS_FOLDER, "../files", "swagger.json")
@@ -89,54 +91,42 @@ ApiGatewayLambdaProxyIntegrationTestResult = namedtuple(
         "path_with_replace",
     ],
 )
+# template used to transform incoming requests at the API Gateway (stream name to be filled in later)
+APIGATEWAY_DATA_INBOUND_TEMPLATE = """{
+    "StreamName": "%s",
+    "Records": [
+        #set( $numRecords = $input.path('$.records').size() )
+        #if($numRecords > 0)
+        #set( $maxIndex = $numRecords - 1 )
+        #foreach( $idx in [0..$maxIndex] )
+        #set( $elem = $input.path("$.records[${idx}]") )
+        #set( $elemJsonB64 = $util.base64Encode($elem.data) )
+        {
+            "Data": "$elemJsonB64",
+            "PartitionKey": #if( $elem.partitionKey != '')"$elem.partitionKey"
+                            #else"$elemJsonB64.length()"#end
+        }#if($foreach.hasNext),#end
+        #end
+        #end
+    ]
+}"""
+
+
+@pytest.fixture
+def integration_lambda(create_lambda_function):
+    function_name = f"apigw-int-{short_uid()}"
+    create_lambda_function(handler_file=TEST_LAMBDA_PYTHON, func_name=function_name)
+    return function_name
 
 
 class TestAPIGateway:
-    # template used to transform incoming requests at the API Gateway (stream name to be filled
-    # in later)
-    APIGATEWAY_DATA_INBOUND_TEMPLATE = """{
-        "StreamName": "%s",
-        "Records": [
-            #set( $numRecords = $input.path('$.records').size() )
-            #if($numRecords > 0)
-            #set( $maxIndex = $numRecords - 1 )
-            #foreach( $idx in [0..$maxIndex] )
-            #set( $elem = $input.path("$.records[${idx}]") )
-            #set( $elemJsonB64 = $util.base64Encode($elem.data) )
-            {
-                "Data": "$elemJsonB64",
-                "PartitionKey": #if( $elem.partitionKey != '')"$elem.partitionKey"
-                                #else"$elemJsonB64.length()"#end
-            }#if($foreach.hasNext),#end
-            #end
-            #end
-        ]
-    }"""
 
     # endpoint paths
-    API_PATH_DATA_INBOUND = "/data"
-    API_PATH_HTTP_BACKEND = "/hello_world"
     API_PATH_LAMBDA_PROXY_BACKEND = "/lambda/foo1"
     API_PATH_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM = "/lambda/{test_param1}"
-
     API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD = "/lambda-any-method/foo1"
     API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM = "/lambda-any-method/{test_param1}"
-
     API_PATH_LAMBDA_PROXY_BACKEND_WITH_IS_BASE64 = "/lambda-is-base64/foo1"
-
-    # name of Kinesis stream connected to API Gateway
-    TEST_STREAM_KINESIS_API_GW = "test-stream-api-gw"
-    TEST_STAGE_NAME = "testing"
-    TEST_LAMBDA_PROXY_BACKEND = "test_lambda_apigw_backend"
-    TEST_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM = "test_lambda_apigw_backend_path_param"
-    TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD = "test_lambda_apigw_backend_any_method"
-    TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM = (
-        "test_lambda_apigw_backend_any_method_path_param"
-    )
-    TEST_LAMBDA_PROXY_BACKEND_WITH_IS_BASE64 = "test_lambda_apigw_backend_with_is_base64"
-    TEST_LAMBDA_SQS_HANDLER_NAME = "lambda_sqs_handler"
-    TEST_LAMBDA_AUTHORIZER_HANDLER_NAME = "lambda_authorizer_handler"
-    TEST_API_GATEWAY_ID = "fugvjdxtri"
 
     TEST_API_GATEWAY_AUTHORIZER = {
         "name": "test",
@@ -181,119 +171,6 @@ class TestAPIGateway:
 
         assert response.ok
         assert response._content == b'{"echo": "foobar", "response": "mocked"}'
-
-    def test_api_gateway_kinesis_integration(self, aws_client):
-        # create target Kinesis stream
-        stream = resource_util.create_kinesis_stream(
-            aws_client.kinesis, self.TEST_STREAM_KINESIS_API_GW
-        )
-        stream.wait_for()
-
-        # create API Gateway and connect it to the target stream
-        result = self.connect_api_gateway_to_kinesis(
-            "test_gateway1", self.TEST_STREAM_KINESIS_API_GW
-        )
-
-        # generate test data
-        test_data = {
-            "records": [
-                {"data": '{"foo": "bar1"}'},
-                {"data": '{"foo": "bar2"}'},
-                {"data": '{"foo": "bar3"}'},
-            ]
-        }
-
-        url = path_based_url(
-            api_id=result["id"],
-            stage_name=self.TEST_STAGE_NAME,
-            path=self.API_PATH_DATA_INBOUND,
-        )
-
-        # list Kinesis streams via API Gateway
-        result = requests.get(url)
-        result = json.loads(to_str(result.content))
-        assert "StreamNames" in result
-
-        # post test data to Kinesis via API Gateway
-        result = requests.post(url, data=json.dumps(test_data))
-        result = json.loads(to_str(result.content))
-        assert 0 == result["FailedRecordCount"]
-        assert len(test_data["records"]) == len(result["Records"])
-
-        # clean up
-        aws_client.kinesis.delete_stream(StreamName=self.TEST_STREAM_KINESIS_API_GW)
-
-    def test_api_gateway_sqs_integration_with_event_source(self, aws_client):
-        # create target SQS stream
-        queue_name = f"queue-{short_uid()}"
-        queue_url = resource_util.create_sqs_queue(queue_name)["QueueUrl"]
-
-        # create API Gateway and connect it to the target queue
-        result = connect_api_gateway_to_sqs(
-            "test_gateway4",
-            stage_name=self.TEST_STAGE_NAME,
-            queue_arn=queue_name,
-            path=self.API_PATH_DATA_INBOUND,
-        )
-
-        # create event source for sqs lambda processor
-        self.create_lambda_function(aws_client.awslambda, self.TEST_LAMBDA_SQS_HANDLER_NAME)
-        event_source_data = {
-            "FunctionName": self.TEST_LAMBDA_SQS_HANDLER_NAME,
-            "EventSourceArn": arns.sqs_queue_arn(queue_name),
-            "Enabled": True,
-        }
-        add_event_source(event_source_data)
-
-        # generate test data
-        test_data = {"spam": "eggs & beans"}
-
-        url = path_based_url(
-            api_id=result["id"],
-            stage_name=self.TEST_STAGE_NAME,
-            path=self.API_PATH_DATA_INBOUND,
-        )
-        result = requests.post(url, data=json.dumps(test_data))
-        assert 200 == result.status_code
-
-        parsed_json = xmltodict.parse(result.content)
-        result = parsed_json["SendMessageResponse"]["SendMessageResult"]
-
-        body_md5 = result["MD5OfMessageBody"]
-
-        assert "b639f52308afd65866c86f274c59033f" == body_md5
-
-        # clean up
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
-        aws_client.awslambda.delete_function(FunctionName=self.TEST_LAMBDA_SQS_HANDLER_NAME)
-
-    def test_api_gateway_sqs_integration(self, aws_client):
-        # create target SQS stream
-        queue_name = f"queue-{short_uid()}"
-        resource_util.create_sqs_queue(queue_name)
-
-        # create API Gateway and connect it to the target queue
-        result = connect_api_gateway_to_sqs(
-            "test_gateway4",
-            stage_name=self.TEST_STAGE_NAME,
-            queue_arn=queue_name,
-            path=self.API_PATH_DATA_INBOUND,
-        )
-
-        # generate test data
-        test_data = {"spam": "eggs"}
-
-        url = path_based_url(
-            api_id=result["id"],
-            stage_name=self.TEST_STAGE_NAME,
-            path=self.API_PATH_DATA_INBOUND,
-        )
-        result = requests.post(url, data=json.dumps(test_data))
-        assert 200 == result.status_code
-
-        messages = queries.sqs_receive_message(queue_name)["Messages"]
-        assert 1 == len(messages)
-        assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))
 
     def test_update_rest_api_deployment(self, create_rest_apigw, aws_client):
         api_id, _, root = create_rest_apigw(name="test_gateway5")
@@ -474,60 +351,6 @@ class TestAPIGateway:
         assert response.headers["Content-Type"] == "text/html"
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
-    @pytest.mark.parametrize("int_type", ["custom", "proxy"])
-    def test_api_gateway_http_integrations(
-        self, int_type, echo_http_server, monkeypatch, aws_client
-    ):
-        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)
-
-        backend_base_url = echo_http_server
-        backend_url = f"{backend_base_url}/{self.API_PATH_HTTP_BACKEND}"
-
-        # create API Gateway and connect it to the HTTP_PROXY/HTTP backend
-        result = self.connect_api_gateway_to_http(
-            int_type, "test_gateway2", backend_url, path=self.API_PATH_HTTP_BACKEND
-        )
-
-        url = path_based_url(
-            api_id=result["id"],
-            stage_name=self.TEST_STAGE_NAME,
-            path=self.API_PATH_HTTP_BACKEND,
-        )
-
-        # make sure CORS headers are present
-        origin = "localhost"
-        result = requests.options(url, headers={"origin": origin})
-        assert result.status_code == 200
-        assert re.match(result.headers["Access-Control-Allow-Origin"].replace("*", ".*"), origin)
-        assert "POST" in result.headers["Access-Control-Allow-Methods"]
-        assert "PATCH" in result.headers["Access-Control-Allow-Methods"]
-
-        custom_result = json.dumps({"foo": "bar"})
-
-        # make test GET request to gateway
-        result = requests.get(url)
-        assert 200 == result.status_code
-        expected = custom_result if int_type == "custom" else "{}"
-        assert expected == json.loads(to_str(result.content))["data"]
-
-        # make test POST request to gateway
-        data = json.dumps({"data": 123})
-        result = requests.post(url, data=data)
-        assert 200 == result.status_code
-        expected = custom_result if int_type == "custom" else data
-        assert expected == json.loads(to_str(result.content))["data"]
-
-        # make test POST request with non-JSON content type
-        data = "test=123"
-        ctype = "application/x-www-form-urlencoded"
-        result = requests.post(url, data=data, headers={"content-type": ctype})
-        assert 200 == result.status_code
-        content = json.loads(to_str(result.content))
-        headers = CaseInsensitiveDict(content["headers"])
-        expected = custom_result if int_type == "custom" else data
-        assert expected == content["data"]
-        assert ctype == headers["content-type"]
-
     @pytest.mark.parametrize("use_hostname", [True, False])
     @pytest.mark.parametrize("disable_custom_cors", [True, False])
     @pytest.mark.parametrize("origin", ["http://allowed", "http://denied"])
@@ -553,12 +376,12 @@ class TestAPIGateway:
             aws_client.apigateway,
             integration_type="MOCK",
             integration_responses=responses,
-            stage_name=self.TEST_STAGE_NAME,
+            stage_name=TEST_STAGE_NAME,
         )
 
         # invoke endpoint with Origin header
         endpoint = self._get_invoke_endpoint(
-            api_id, stage=self.TEST_STAGE_NAME, path="/", use_hostname=use_hostname
+            api_id, stage=TEST_STAGE_NAME, path="/", use_hostname=use_hostname
         )
         response = requests.options(endpoint, headers={"Origin": origin})
 
@@ -573,19 +396,18 @@ class TestAPIGateway:
             assert response.status_code == 200
             assert "http://test.com" in response.headers["Access-Control-Allow-Origin"]
 
-    def test_api_gateway_lambda_proxy_integration(self, aws_client):
+    def test_api_gateway_lambda_proxy_integration(self, integration_lambda):
         self._test_api_gateway_lambda_proxy_integration(
-            aws_client.awslambda, self.TEST_LAMBDA_PROXY_BACKEND, self.API_PATH_LAMBDA_PROXY_BACKEND
+            integration_lambda, self.API_PATH_LAMBDA_PROXY_BACKEND
         )
 
-    def test_api_gateway_lambda_proxy_integration_with_path_param(self, aws_client):
+    def test_api_gateway_lambda_proxy_integration_with_path_param(self, integration_lambda):
         self._test_api_gateway_lambda_proxy_integration(
-            aws_client.awslambda,
-            self.TEST_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM,
+            integration_lambda,
             self.API_PATH_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM,
         )
 
-    def test_api_gateway_lambda_proxy_integration_with_is_base_64_encoded(self, aws_client):
+    def test_api_gateway_lambda_proxy_integration_with_is_base_64_encoded(self, integration_lambda):
         # Test the case where `isBase64Encoded` is enabled.
         content = b"hello, please base64 encode me"
 
@@ -594,8 +416,7 @@ class TestAPIGateway:
             data["return_raw_body"] = base64.b64encode(content).decode("utf8")
 
         test_result = self._test_api_gateway_lambda_proxy_integration_no_asserts(
-            aws_client.awslambda,
-            self.TEST_LAMBDA_PROXY_BACKEND_WITH_IS_BASE64,
+            integration_lambda,
             self.API_PATH_LAMBDA_PROXY_BACKEND_WITH_IS_BASE64,
             data_mutator_fn=_mutate_data,
         )
@@ -606,7 +427,6 @@ class TestAPIGateway:
 
     def _test_api_gateway_lambda_proxy_integration_no_asserts(
         self,
-        lambda_client,
         fn_name: str,
         path: str,
         data_mutator_fn: Optional[Callable] = None,
@@ -618,14 +438,13 @@ class TestAPIGateway:
         :param data_mutator_fn: a Callable[[Dict], None] that lets us mutate the
           data dictionary before sending it off to the lambda.
         """
-        self.create_lambda_function(lambda_client, fn_name)
         # create API Gateway and connect it to the Lambda proxy backend
         lambda_uri = arns.lambda_function_arn(fn_name)
         invocation_uri = "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations"
         target_uri = invocation_uri % (aws_stack.get_region(), lambda_uri)
 
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
-            "test_gateway2", target_uri, path=path, stage_name=self.TEST_STAGE_NAME
+            "test_gateway2", target_uri, path=path, stage_name=TEST_STAGE_NAME
         )
 
         api_id = result["id"]
@@ -636,7 +455,7 @@ class TestAPIGateway:
         path_with_replace = path.replace("{test_param1}", "foo1")
         path_with_params = path_with_replace + "?foo=foo&bar=bar&bar=baz"
 
-        url = path_based_url(api_id=api_id, stage_name=self.TEST_STAGE_NAME, path=path_with_params)
+        url = path_based_url(api_id=api_id, stage_name=TEST_STAGE_NAME, path=path_with_params)
 
         # These values get read in `lambda_integration.py`
         data = {"return_status_code": 203, "return_headers": {"foo": "bar123"}}
@@ -659,13 +478,10 @@ class TestAPIGateway:
 
     def _test_api_gateway_lambda_proxy_integration(
         self,
-        lambda_client,
         fn_name: str,
         path: str,
     ) -> None:
-        test_result = self._test_api_gateway_lambda_proxy_integration_no_asserts(
-            lambda_client, fn_name, path
-        )
+        test_result = self._test_api_gateway_lambda_proxy_integration_no_asserts(fn_name, path)
         data, resource, result, url, path_with_replace = test_result
 
         assert result.status_code == 203
@@ -687,12 +503,12 @@ class TestAPIGateway:
 
         assert re.match(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", source_ip)
 
-        expected_path = "/" + self.TEST_STAGE_NAME + "/lambda/foo1"
+        expected_path = f"/{TEST_STAGE_NAME}/lambda/foo1"
         assert expected_path == request_context["path"]
         assert request_context.get("stageVariables") is None
         assert get_aws_account_id() == request_context["accountId"]
         assert resource.get("id") == request_context["resourceId"]
-        assert self.TEST_STAGE_NAME == request_context["stage"]
+        assert request_context["stage"] == TEST_STAGE_NAME
         assert "python-requests/testing" == request_context["identity"]["userAgent"]
         assert "POST" == request_context["httpMethod"]
         assert "HTTP/1.1" == request_context["protocol"]
@@ -722,17 +538,16 @@ class TestAPIGateway:
         assert "/yCqIBE=" == result_content["body"]
         assert ["isBase64Encoded"]
 
-    def test_api_gateway_lambda_proxy_integration_any_method(self, aws_client):
+    def test_api_gateway_lambda_proxy_integration_any_method(self, integration_lambda):
         self._test_api_gateway_lambda_proxy_integration_any_method(
-            aws_client.awslambda,
-            self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD,
-            self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD,
+            integration_lambda, self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD
         )
 
-    def test_api_gateway_lambda_proxy_integration_any_method_with_path_param(self, aws_client):
+    def test_api_gateway_lambda_proxy_integration_any_method_with_path_param(
+        self, integration_lambda
+    ):
         self._test_api_gateway_lambda_proxy_integration_any_method(
-            aws_client.awslambda,
-            self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM,
+            integration_lambda,
             self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM,
         )
 
@@ -769,15 +584,18 @@ class TestAPIGateway:
         assert response._content == b'{"echo": "foobar", "response": "mocked"}'
 
     @pytest.mark.xfail(reason="Behaviour is not AWS compliant, need to recreate this test")
+    # TODO rework or remove this test
     def test_api_gateway_authorizer_crud(self, aws_client):
+        get_api_gateway_id = "fugvjdxtri"
+
         authorizer = aws_client.apigateway.create_authorizer(
-            restApiId=self.TEST_API_GATEWAY_ID, **self.TEST_API_GATEWAY_AUTHORIZER
+            restApiId=get_api_gateway_id, **self.TEST_API_GATEWAY_AUTHORIZER
         )
 
         authorizer_id = authorizer.get("id")
 
         create_result = aws_client.apigateway.get_authorizer(
-            restApiId=self.TEST_API_GATEWAY_ID, authorizerId=authorizer_id
+            restApiId=get_api_gateway_id, authorizerId=authorizer_id
         )
 
         # ignore boto3 stuff
@@ -789,13 +607,13 @@ class TestAPIGateway:
         assert create_expected == create_result
 
         aws_client.apigateway.update_authorizer(
-            restApiId=self.TEST_API_GATEWAY_ID,
+            restApiId=get_api_gateway_id,
             authorizerId=authorizer_id,
             patchOperations=self.TEST_API_GATEWAY_AUTHORIZER_OPS,
         )
 
         update_result = aws_client.apigateway.get_authorizer(
-            restApiId=self.TEST_API_GATEWAY_ID, authorizerId=authorizer_id
+            restApiId=get_api_gateway_id, authorizerId=authorizer_id
         )
 
         # ignore boto3 stuff
@@ -806,12 +624,12 @@ class TestAPIGateway:
         assert update_expected == update_result
 
         aws_client.apigateway.delete_authorizer(
-            restApiId=self.TEST_API_GATEWAY_ID, authorizerId=authorizer_id
+            restApiId=get_api_gateway_id, authorizerId=authorizer_id
         )
 
         with pytest.raises(Exception):
             aws_client.apigateway.get_authorizer(
-                restApiId=self.TEST_API_GATEWAY_ID, authorizerId=authorizer_id
+                restApiId=get_api_gateway_id, authorizerId=authorizer_id
             )
 
     def test_malformed_response_apigw_invocation(self, create_lambda_function, aws_client):
@@ -852,8 +670,7 @@ class TestAPIGateway:
         assert domain_name == rs["domainName"]
         apigw_client.delete_domain_name(domainName=domain_name)
 
-    def _test_api_gateway_lambda_proxy_integration_any_method(self, lambda_client, fn_name, path):
-        self.create_lambda_function(lambda_client, fn_name)
+    def _test_api_gateway_lambda_proxy_integration_any_method(self, fn_name, path):
 
         # create API Gateway and connect it to the Lambda proxy backend
         lambda_uri = arns.lambda_function_arn(fn_name)
@@ -864,12 +681,12 @@ class TestAPIGateway:
             target_uri,
             methods=["ANY"],
             path=path,
-            stage_name=self.TEST_STAGE_NAME,
+            stage_name=TEST_STAGE_NAME,
         )
 
         # make test request to gateway and check response
         path = path.replace("{test_param1}", "foo1")
-        url = path_based_url(api_id=result["id"], stage_name=self.TEST_STAGE_NAME, path=path)
+        url = path_based_url(api_id=result["id"], stage_name=TEST_STAGE_NAME, path=path)
         data = {}
 
         for method in ("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"):
@@ -882,12 +699,12 @@ class TestAPIGateway:
             else:
                 assert 204 == result.status_code
 
-    def test_apigateway_with_custom_authorization_method(self, create_rest_apigw, aws_client):
+    def test_apigateway_with_custom_authorization_method(
+        self, create_rest_apigw, aws_client, integration_lambda
+    ):
 
         # create Lambda function
-        lambda_name = f"apigw-lambda-{short_uid()}"
-        self.create_lambda_function(aws_client.awslambda, lambda_name)
-        lambda_uri = arns.lambda_function_arn(lambda_name)
+        lambda_uri = arns.lambda_function_arn(integration_lambda)
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api")
@@ -917,9 +734,6 @@ class TestAPIGateway:
         )
 
         assert authorizer["id"] == method_response["authorizerId"]
-
-        # clean up
-        aws_client.awslambda.delete_function(FunctionName=lambda_name)
 
     def test_base_path_mapping(self, create_rest_apigw, aws_client):
         rest_api_id, _, _ = create_rest_apigw(name="my_api", description="this is my api")
@@ -1075,7 +889,7 @@ class TestAPIGateway:
         )
 
         assert 200 == response.status_code
-        dynamo_client = aws_stack.connect_to_resource("dynamodb")
+        dynamo_client = connect_to._session.resource("dynamodb")
         table = dynamo_client.Table("MusicCollection")
         result = table.get_item(Key={"id": "id1"})
         assert "foobar123" == result["Item"]["data"]
@@ -1372,40 +1186,6 @@ class TestAPIGateway:
             f"{proto}://localhost:{config.EDGE_PORT}/restapis/{api_id}/{stage}/_user_request_{path}"
         )
 
-    def test_api_gateway_s3_get_integration(self, create_rest_apigw, aws_client):
-        s3_client = aws_client.s3
-
-        bucket_name = f"test-bucket-{short_uid()}"
-        apigateway_name = f"test-api-{short_uid()}"
-        object_name = "test.json"
-        object_content = '{ "success": "true" }'
-        object_content_type = "application/json"
-
-        api_id, _, _ = create_rest_apigw(name=apigateway_name)
-
-        try:
-            resource_util.get_or_create_bucket(bucket_name)
-            s3_client.put_object(
-                Bucket=bucket_name,
-                Key=object_name,
-                Body=object_content,
-                ContentType=object_content_type,
-            )
-
-            self.connect_api_gateway_to_s3(
-                aws_client.apigateway, bucket_name, object_name, api_id, "GET"
-            )
-
-            aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
-            url = path_based_url(api_id, "test", f"/{object_name}")
-            result = requests.get(url)
-            assert 200 == result.status_code
-            assert object_content == result.text
-            assert object_content_type == result.headers["content-type"]
-        finally:
-            s3_client.delete_object(Bucket=bucket_name, Key=object_name)
-            s3_client.delete_bucket(Bucket=bucket_name)
-
     def test_api_mock_integration_response_params(self, aws_client):
         resps = [
             {
@@ -1421,7 +1201,7 @@ class TestAPIGateway:
             aws_client.apigateway, integration_type="MOCK", integration_responses=resps
         )
 
-        url = path_based_url(api_id=api_id, stage_name=self.TEST_STAGE_NAME, path="/")
+        url = path_based_url(api_id=api_id, stage_name=TEST_STAGE_NAME, path="/")
         result = requests.options(url)
         assert result.ok
         assert "Origin" == result.headers.get("vary")
@@ -1467,127 +1247,16 @@ class TestAPIGateway:
             "test_gateway",
             target_uri,
             path=lambda_resource,
-            stage_name=self.TEST_STAGE_NAME,
+            stage_name=TEST_STAGE_NAME,
         )
         api_id = result["id"]
-        url = path_based_url(api_id=api_id, stage_name=self.TEST_STAGE_NAME, path=lambda_path)
+        url = path_based_url(api_id=api_id, stage_name=TEST_STAGE_NAME, path=lambda_path)
         result = requests.get(url)
 
         assert result.status_code == 300
         assert result.headers["Content-Type"] == "application/xml"
         body = xmltodict.parse(result.content)
         assert body.get("message") == "completed"
-
-    # =====================================================================
-    # Helper methods
-    # =====================================================================
-
-    def connect_api_gateway_to_s3(self, apigw_client, bucket_name, file_name, api_id, method):
-        """Connects the root resource of an api gateway to the given object of an s3 bucket."""
-        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
-            aws_stack.get_region(), bucket_name
-        )
-
-        test_role = "test-s3-role"
-        role_arn = arns.role_arn(role_name=test_role)
-        resources = apigw_client.get_resources(restApiId=api_id)
-        # using the root resource '/' directly for this test
-        root_resource_id = resources["items"][0]["id"]
-        proxy_resource = apigw_client.create_resource(
-            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
-        )
-        apigw_client.put_method(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            authorizationType="NONE",
-            apiKeyRequired=False,
-            requestParameters={},
-        )
-        apigw_client.put_integration(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            type="AWS",
-            integrationHttpMethod=method,
-            uri=s3_uri,
-            credentials=role_arn,
-            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
-        )
-
-    def connect_api_gateway_to_kinesis(self, gateway_name, kinesis_stream):
-        template = self.APIGATEWAY_DATA_INBOUND_TEMPLATE % kinesis_stream
-        resource_path = self.API_PATH_DATA_INBOUND.replace("/", "")
-        resources = {
-            resource_path: [
-                {
-                    "httpMethod": "POST",
-                    "authorizationType": "NONE",
-                    "requestModels": {"application/json": "Empty"},
-                    "integrations": [
-                        {
-                            "type": "AWS",
-                            "uri": "arn:aws:apigateway:%s:kinesis:action/PutRecords"
-                            % aws_stack.get_region(),
-                            "requestTemplates": {"application/json": template},
-                        }
-                    ],
-                },
-                {
-                    "httpMethod": "GET",
-                    "authorizationType": "NONE",
-                    "requestModels": {"application/json": "Empty"},
-                    "integrations": [
-                        {
-                            "type": "AWS",
-                            "uri": "arn:aws:apigateway:%s:kinesis:action/ListStreams"
-                            % aws_stack.get_region(),
-                            "requestTemplates": {"application/json": "{}"},
-                        }
-                    ],
-                },
-            ]
-        }
-        return resource_util.create_api_gateway(
-            name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
-        )
-
-    def connect_api_gateway_to_http(
-        self, int_type, gateway_name, target_url, methods=None, path=None
-    ):
-        if methods is None:
-            methods = []
-        if not methods:
-            methods = ["GET", "POST"]
-        if not path:
-            path = "/"
-        resources = {}
-        resource_path = path.replace("/", "")
-        req_templates = (
-            {"application/json": json.dumps({"foo": "bar"})} if int_type == "custom" else {}
-        )
-        resources[resource_path] = [
-            {
-                "httpMethod": method,
-                "integrations": [
-                    {
-                        "type": "HTTP" if int_type == "custom" else "HTTP_PROXY",
-                        "uri": target_url,
-                        "requestTemplates": req_templates,
-                        "responseTemplates": {},
-                    }
-                ],
-            }
-            for method in methods
-        ]
-        return resource_util.create_api_gateway(
-            name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
-        )
-
-    @staticmethod
-    def create_lambda_function(lambda_client, fn_name):
-        testutil.create_lambda_function(handler_file=TEST_LAMBDA_PYTHON, func_name=fn_name)
-        lambda_client.get_waiter("function_active_v2").wait(FunctionName=fn_name)
 
     def test_apigw_test_invoke_method_api(
         self, create_rest_apigw, create_lambda_function, aws_client
@@ -1648,72 +1317,6 @@ class TestAPIGateway:
         assert 200 == response.get("status")
         assert "response from" in json.loads(response.get("body")).get("body")
         assert "val123" in json.loads(response.get("body")).get("body")
-
-    @staticmethod
-    def create_api_gateway_and_deploy(
-        apigw_client,
-        request_templates=None,
-        response_templates=None,
-        is_api_key_required=False,
-        integration_type=None,
-        integration_responses=None,
-        stage_name="staging",
-    ):
-        response_templates = response_templates or {}
-        request_templates = request_templates or {}
-        integration_type = integration_type or "AWS"
-        response = apigw_client.create_rest_api(name="my_api", description="this is my api")
-        api_id = response["id"]
-        resources = apigw_client.get_resources(restApiId=api_id)
-        root_resources = [resource for resource in resources["items"] if resource["path"] == "/"]
-        root_id = root_resources[0]["id"]
-
-        kwargs = {}
-        if integration_type == "AWS":
-            resource_util.create_dynamodb_table("MusicCollection", partition_key="id")
-            kwargs[
-                "uri"
-            ] = "arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection"
-
-        if not integration_responses:
-            integration_responses = [{"httpMethod": "PUT", "statusCode": "200"}]
-
-        for resp_details in integration_responses:
-            apigw_client.put_method(
-                restApiId=api_id,
-                resourceId=root_id,
-                httpMethod=resp_details["httpMethod"],
-                authorizationType="NONE",
-                apiKeyRequired=is_api_key_required,
-            )
-
-            apigw_client.put_method_response(
-                restApiId=api_id,
-                resourceId=root_id,
-                httpMethod=resp_details["httpMethod"],
-                statusCode="200",
-            )
-
-            apigw_client.put_integration(
-                restApiId=api_id,
-                resourceId=root_id,
-                httpMethod=resp_details["httpMethod"],
-                integrationHttpMethod=resp_details["httpMethod"],
-                type=integration_type,
-                requestTemplates=request_templates,
-                **kwargs,
-            )
-
-            apigw_client.put_integration_response(
-                restApiId=api_id,
-                resourceId=root_id,
-                selectionPattern="",
-                responseTemplates=response_templates,
-                **resp_details,
-            )
-
-        apigw_client.create_deployment(restApiId=api_id, stageName=stage_name)
-        return api_id
 
     @markers.parity.aws_validated
     @pytest.mark.parametrize("stage_name", ["local", "dev"])
@@ -1806,6 +1409,90 @@ class TestAPIGateway:
             assert response.json() == {"version": ""}
         else:
             assert response.json() == {"version": "1.0"}
+
+    # TODO replace with fixtures in test_apigateway_integrations
+    @staticmethod
+    def create_api_gateway_and_deploy(
+        apigw_client,
+        request_templates=None,
+        response_templates=None,
+        is_api_key_required=False,
+        integration_type=None,
+        integration_responses=None,
+        stage_name="staging",
+    ):
+        response_templates = response_templates or {}
+        request_templates = request_templates or {}
+        integration_type = integration_type or "AWS"
+        response = apigw_client.create_rest_api(name="my_api", description="this is my api")
+        api_id = response["id"]
+        resources = apigw_client.get_resources(restApiId=api_id)
+        root_resources = [resource for resource in resources["items"] if resource["path"] == "/"]
+        root_id = root_resources[0]["id"]
+
+        kwargs = {}
+        if integration_type == "AWS":
+            resource_util.create_dynamodb_table("MusicCollection", partition_key="id")
+            kwargs[
+                "uri"
+            ] = "arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection"
+
+        if not integration_responses:
+            integration_responses = [{"httpMethod": "PUT", "statusCode": "200"}]
+
+        for resp_details in integration_responses:
+            apigw_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod=resp_details["httpMethod"],
+                authorizationType="NONE",
+                apiKeyRequired=is_api_key_required,
+            )
+
+            apigw_client.put_method_response(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod=resp_details["httpMethod"],
+                statusCode="200",
+            )
+
+            apigw_client.put_integration(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod=resp_details["httpMethod"],
+                integrationHttpMethod=resp_details["httpMethod"],
+                type=integration_type,
+                requestTemplates=request_templates,
+                **kwargs,
+            )
+
+            apigw_client.put_integration_response(
+                restApiId=api_id,
+                resourceId=root_id,
+                selectionPattern="",
+                responseTemplates=response_templates,
+                **resp_details,
+            )
+
+        apigw_client.create_deployment(restApiId=api_id, stageName=stage_name)
+        return api_id
+
+
+class TestTagging:
+    def test_tag_api(self, create_rest_apigw, aws_client):
+        api_name = f"api-{short_uid()}"
+        tags = {"foo": "bar"}
+
+        # add resource tags
+        api_id, _, _ = create_rest_apigw(name=api_name, tags={TAG_KEY_CUSTOM_ID: "c0stIOm1d"})
+        assert api_id == "c0stIOm1d"
+
+        api_arn = arns.apigateway_restapi_arn(api_id=api_id)
+        aws_client.apigateway.tag_resource(resourceArn=api_arn, tags=tags)
+
+        # receive and assert tags
+        tags_saved = aws_client.apigateway.get_tags(resourceArn=api_arn)["tags"]
+        assert tags == tags_saved
 
 
 @pytest.mark.skipif(not use_docker(), reason="Rust lambdas cannot be executed in local executor")
@@ -1968,74 +1655,355 @@ def test_rest_api_multi_region(
     testutil.delete_lambda_function(name=lambda_name, region_name="us-west-1")
 
 
-@pytest.mark.parametrize("method", ["GET", "POST"])
-@pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
-@pytest.mark.parametrize("passthrough_behaviour", ["WHEN_NO_MATCH", "NEVER", "WHEN_NO_TEMPLATES"])
-def test_mock_integration_response(
-    method, url_function, passthrough_behaviour, create_rest_apigw, aws_client
-):
-    api_id, _, root_resource_id = create_rest_apigw(name="mock-api")
-    resource_id, _ = create_rest_resource(
-        aws_client.apigateway, restApiId=api_id, parentId=root_resource_id, pathPart="{id}"
-    )
-    create_rest_resource_method(
-        aws_client.apigateway,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod=method,
-        authorizationType="NONE",
-    )
-    integration_uri, _ = create_rest_api_integration(
-        aws_client.apigateway,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod=method,
-        type="MOCK",
-        integrationHttpMethod=method,
-        passthroughBehavior=passthrough_behaviour,
-        requestTemplates={"application/json": '{"statusCode":200}'},
-    )
-    status_code = create_rest_api_method_response(
-        aws_client.apigateway,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod=method,
-        statusCode="200",
-        responseModels={"application/json": "Empty"},
-    )
-    create_rest_api_integration_response(
-        aws_client.apigateway,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod=method,
-        statusCode=status_code,
-        responseTemplates={
-            "application/json": '{"statusCode": 200, "id": $input.params().path.id}'
-        },
-    )
+class TestIntegrations:
+    def test_api_gateway_s3_get_integration(self, create_rest_apigw, aws_client):
+        s3_client = aws_client.s3
 
-    endpoint = url_function(api_id, stage_name="local", path="/42")
-    result = requests.request(
-        method,
-        endpoint,
-        headers={"Content-Type": "application/json"},
-        verify=False,
+        bucket_name = f"test-bucket-{short_uid()}"
+        apigateway_name = f"test-api-{short_uid()}"
+        object_name = "test.json"
+        object_content = '{ "success": "true" }'
+        object_content_type = "application/json"
+
+        api_id, _, _ = create_rest_apigw(name=apigateway_name)
+
+        try:
+            resource_util.get_or_create_bucket(bucket_name)
+            s3_client.put_object(
+                Bucket=bucket_name,
+                Key=object_name,
+                Body=object_content,
+                ContentType=object_content_type,
+            )
+
+            self.connect_api_gateway_to_s3(
+                aws_client.apigateway, bucket_name, object_name, api_id, "GET"
+            )
+
+            aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
+            url = path_based_url(api_id, "test", f"/{object_name}")
+            result = requests.get(url)
+            assert 200 == result.status_code
+            assert object_content == result.text
+            assert object_content_type == result.headers["content-type"]
+        finally:
+            s3_client.delete_object(Bucket=bucket_name, Key=object_name)
+            s3_client.delete_bucket(Bucket=bucket_name)
+
+    @pytest.mark.parametrize("method", ["GET", "POST"])
+    @pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
+    @pytest.mark.parametrize(
+        "passthrough_behaviour", ["WHEN_NO_MATCH", "NEVER", "WHEN_NO_TEMPLATES"]
     )
-    assert result.status_code == 200
-    assert to_str(result.content) == '{"statusCode": 200, "id": 42}'
+    def test_mock_integration_response(
+        self, method, url_function, passthrough_behaviour, create_rest_apigw, aws_client
+    ):
+        api_id, _, root_resource_id = create_rest_apigw(name="mock-api")
+        resource_id, _ = create_rest_resource(
+            aws_client.apigateway, restApiId=api_id, parentId=root_resource_id, pathPart="{id}"
+        )
+        create_rest_resource_method(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method,
+            authorizationType="NONE",
+        )
+        integration_uri, _ = create_rest_api_integration(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method,
+            type="MOCK",
+            integrationHttpMethod=method,
+            passthroughBehavior=passthrough_behaviour,
+            requestTemplates={"application/json": '{"statusCode":200}'},
+        )
+        status_code = create_rest_api_method_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method,
+            statusCode="200",
+            responseModels={"application/json": "Empty"},
+        )
+        create_rest_api_integration_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method,
+            statusCode=status_code,
+            responseTemplates={
+                "application/json": '{"statusCode": 200, "id": $input.params().path.id}'
+            },
+        )
 
+        endpoint = url_function(api_id, stage_name="local", path="/42")
+        result = requests.request(
+            method,
+            endpoint,
+            headers={"Content-Type": "application/json"},
+            verify=False,
+        )
+        assert result.status_code == 200
+        assert to_str(result.content) == '{"statusCode": 200, "id": 42}'
 
-def test_tag_api(create_rest_apigw, aws_client):
-    api_name = f"api-{short_uid()}"
-    tags = {"foo": "bar"}
+    @pytest.mark.parametrize("int_type", ["custom", "proxy"])
+    def test_api_gateway_http_integrations(
+        self, int_type, echo_http_server, monkeypatch, aws_client
+    ):
+        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)
 
-    # add resource tags
-    api_id, _, _ = create_rest_apigw(name=api_name, tags={TAG_KEY_CUSTOM_ID: "c0stIOm1d"})
-    assert api_id == "c0stIOm1d"
+        api_path_backend = "/hello_world"
+        backend_base_url = echo_http_server
+        backend_url = f"{backend_base_url}/{api_path_backend}"
 
-    api_arn = arns.apigateway_restapi_arn(api_id=api_id)
-    aws_client.apigateway.tag_resource(resourceArn=api_arn, tags=tags)
+        # create API Gateway and connect it to the HTTP_PROXY/HTTP backend
+        result = self.connect_api_gateway_to_http(
+            int_type, "test_gateway2", backend_url, path=api_path_backend
+        )
 
-    # receive and assert tags
-    tags_saved = aws_client.apigateway.get_tags(resourceArn=api_arn)["tags"]
-    assert tags == tags_saved
+        url = path_based_url(
+            api_id=result["id"],
+            stage_name=TEST_STAGE_NAME,
+            path=api_path_backend,
+        )
+
+        # make sure CORS headers are present
+        origin = "localhost"
+        result = requests.options(url, headers={"origin": origin})
+        assert result.status_code == 200
+        assert re.match(result.headers["Access-Control-Allow-Origin"].replace("*", ".*"), origin)
+        assert "POST" in result.headers["Access-Control-Allow-Methods"]
+        assert "PATCH" in result.headers["Access-Control-Allow-Methods"]
+
+        custom_result = json.dumps({"foo": "bar"})
+
+        # make test GET request to gateway
+        result = requests.get(url)
+        assert 200 == result.status_code
+        expected = custom_result if int_type == "custom" else "{}"
+        assert expected == json.loads(to_str(result.content))["data"]
+
+        # make test POST request to gateway
+        data = json.dumps({"data": 123})
+        result = requests.post(url, data=data)
+        assert 200 == result.status_code
+        expected = custom_result if int_type == "custom" else data
+        assert expected == json.loads(to_str(result.content))["data"]
+
+        # make test POST request with non-JSON content type
+        data = "test=123"
+        ctype = "application/x-www-form-urlencoded"
+        result = requests.post(url, data=data, headers={"content-type": ctype})
+        assert 200 == result.status_code
+        content = json.loads(to_str(result.content))
+        headers = CaseInsensitiveDict(content["headers"])
+        expected = custom_result if int_type == "custom" else data
+        assert expected == content["data"]
+        assert ctype == headers["content-type"]
+
+    def test_api_gateway_kinesis_integration(self, kinesis_create_stream):
+        # create target Kinesis stream
+        stream_name = kinesis_create_stream()
+
+        # create API Gateway and connect it to the target stream
+        result = self.connect_api_gateway_to_kinesis("test_gateway1", stream_name)
+
+        # generate test data
+        test_data = {
+            "records": [
+                {"data": '{"foo": "bar1"}'},
+                {"data": '{"foo": "bar2"}'},
+                {"data": '{"foo": "bar3"}'},
+            ]
+        }
+
+        url = path_based_url(
+            api_id=result["id"],
+            stage_name=TEST_STAGE_NAME,
+            path="/data",
+        )
+
+        # list Kinesis streams via API Gateway
+        result = requests.get(url)
+        result = json.loads(to_str(result.content))
+        assert "StreamNames" in result
+
+        # post test data to Kinesis via API Gateway
+        result = requests.post(url, data=json.dumps(test_data))
+        result = json.loads(to_str(result.content))
+        assert 0 == result["FailedRecordCount"]
+        assert len(test_data["records"]) == len(result["Records"])
+
+    def test_api_gateway_sqs_integration_with_event_source(
+        self, aws_client, integration_lambda, sqs_queue
+    ):
+
+        # create API Gateway and connect it to the target queue
+        result = connect_api_gateway_to_sqs(
+            "test_gateway4",
+            stage_name=TEST_STAGE_NAME,
+            queue_arn=sqs_queue,
+            path="/data",
+        )
+
+        # create event source for sqs lambda processor
+        event_source_data = {
+            "FunctionName": integration_lambda,
+            "EventSourceArn": arns.sqs_queue_arn(sqs_queue),
+            "Enabled": True,
+        }
+        add_event_source(event_source_data)
+
+        # generate test data
+        test_data = {"spam": "eggs & beans"}
+
+        url = path_based_url(
+            api_id=result["id"],
+            stage_name=TEST_STAGE_NAME,
+            path="/data",
+        )
+        result = requests.post(url, data=json.dumps(test_data))
+        assert 200 == result.status_code
+
+        parsed_json = xmltodict.parse(result.content)
+        result = parsed_json["SendMessageResponse"]["SendMessageResult"]
+
+        body_md5 = result["MD5OfMessageBody"]
+
+        assert "b639f52308afd65866c86f274c59033f" == body_md5
+
+    def test_api_gateway_sqs_integration(self, aws_client):
+        # create target SQS stream
+        queue_name = f"queue-{short_uid()}"
+        resource_util.create_sqs_queue(queue_name)
+
+        # create API Gateway and connect it to the target queue
+        result = connect_api_gateway_to_sqs(
+            "test_gateway4",
+            stage_name=TEST_STAGE_NAME,
+            queue_arn=queue_name,
+            path="/data",
+        )
+
+        # generate test data
+        test_data = {"spam": "eggs"}
+
+        url = path_based_url(
+            api_id=result["id"],
+            stage_name=TEST_STAGE_NAME,
+            path="/data",
+        )
+        result = requests.post(url, data=json.dumps(test_data))
+        assert 200 == result.status_code
+
+        messages = queries.sqs_receive_message(queue_name)["Messages"]
+        assert 1 == len(messages)
+        assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))
+
+    # ==================
+    # Helper methods
+    # TODO: replace with fixtures, to allow passing aws_client and enable snapshot testing
+    # ==================
+
+    def connect_api_gateway_to_s3(self, apigw_client, bucket_name, file_name, api_id, method):
+        """Connects the root resource of an api gateway to the given object of an s3 bucket."""
+        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
+            aws_stack.get_region(), bucket_name
+        )
+
+        test_role = "test-s3-role"
+        role_arn = arns.role_arn(role_name=test_role)
+        resources = apigw_client.get_resources(restApiId=api_id)
+        # using the root resource '/' directly for this test
+        root_resource_id = resources["items"][0]["id"]
+        proxy_resource = apigw_client.create_resource(
+            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
+        )
+        apigw_client.put_method(
+            restApiId=api_id,
+            resourceId=proxy_resource["id"],
+            httpMethod=method,
+            authorizationType="NONE",
+            apiKeyRequired=False,
+            requestParameters={},
+        )
+        apigw_client.put_integration(
+            restApiId=api_id,
+            resourceId=proxy_resource["id"],
+            httpMethod=method,
+            type="AWS",
+            integrationHttpMethod=method,
+            uri=s3_uri,
+            credentials=role_arn,
+            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
+        )
+
+    def connect_api_gateway_to_kinesis(self, gateway_name, kinesis_stream):
+        template = APIGATEWAY_DATA_INBOUND_TEMPLATE % kinesis_stream
+        resources = {
+            "data": [
+                {
+                    "httpMethod": "POST",
+                    "authorizationType": "NONE",
+                    "requestModels": {"application/json": "Empty"},
+                    "integrations": [
+                        {
+                            "type": "AWS",
+                            "uri": "arn:aws:apigateway:%s:kinesis:action/PutRecords"
+                            % aws_stack.get_region(),
+                            "requestTemplates": {"application/json": template},
+                        }
+                    ],
+                },
+                {
+                    "httpMethod": "GET",
+                    "authorizationType": "NONE",
+                    "requestModels": {"application/json": "Empty"},
+                    "integrations": [
+                        {
+                            "type": "AWS",
+                            "uri": "arn:aws:apigateway:%s:kinesis:action/ListStreams"
+                            % aws_stack.get_region(),
+                            "requestTemplates": {"application/json": "{}"},
+                        }
+                    ],
+                },
+            ]
+        }
+        return resource_util.create_api_gateway(
+            name=gateway_name, resources=resources, stage_name=TEST_STAGE_NAME
+        )
+
+    def connect_api_gateway_to_http(
+        self, int_type, gateway_name, target_url, methods=None, path=None
+    ):
+        if methods is None:
+            methods = []
+        if not methods:
+            methods = ["GET", "POST"]
+        if not path:
+            path = "/"
+        resources = {}
+        resource_path = path.replace("/", "")
+        req_templates = (
+            {"application/json": json.dumps({"foo": "bar"})} if int_type == "custom" else {}
+        )
+        resources[resource_path] = [
+            {
+                "httpMethod": method,
+                "integrations": [
+                    {
+                        "type": "HTTP" if int_type == "custom" else "HTTP_PROXY",
+                        "uri": target_url,
+                        "requestTemplates": req_templates,
+                        "responseTemplates": {},
+                    }
+                ],
+            }
+            for method in methods
+        ]
+        return resource_util.create_api_gateway(
+            name=gateway_name, resources=resources, stage_name=TEST_STAGE_NAME
+        )

--- a/tests/aws/apigateway/test_apigateway_common.py
+++ b/tests/aws/apigateway/test_apigateway_common.py
@@ -1,6 +1,8 @@
 import json
 
+import pytest
 import requests
+from botocore.exceptions import ClientError
 
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.testing.aws.util import is_aws_cloud
@@ -438,3 +440,61 @@ class TestUsagePlans:
             ],
         )
         snapshot.match("update-usage-plan", response)
+
+
+class TestStages:
+    @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
+    def test_create_update_stages(
+        self, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
+    ):
+        client = aws_client.apigateway
+
+        api_id, api_name, root_id = create_rest_apigw()
+
+        client.put_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+        )
+        client.put_integration(restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK")
+
+        response = client.create_deployment(restApiId=api_id)
+        deployment_id = response["id"]
+
+        response = client.create_stage(
+            restApiId=api_id, stageName="s1", deploymentId=deployment_id, description="my stage"
+        )
+        snapshot.match("create-stage", response)
+
+        with pytest.raises(ClientError) as ctx:
+            client.update_stage(
+                restApiId=api_id,
+                stageName="s1",
+                patchOperations=[
+                    {"op": "replace", "path": "/documentation_version", "value": "123"}
+                ],
+            )
+        snapshot.match("error-update-doc-version", ctx.value.response)
+
+        with pytest.raises(ClientError) as ctx:
+            client.update_stage(
+                restApiId=api_id,
+                stageName="s1",
+                patchOperations=[
+                    {"op": "replace", "path": "/tags/tag1", "value": "value1"},
+                ],
+            )
+        snapshot.match("error-update-tags", ctx.value.response)
+
+        response = client.update_stage(
+            restApiId=api_id,
+            stageName="s1",
+            patchOperations=[
+                {"op": "replace", "path": "/description", "value": "stage new"},
+                {"op": "replace", "path": "/variables/var1", "value": "test"},
+                {"op": "replace", "path": "/variables/var2", "value": "test2"},
+            ],
+        )
+        snapshot.match("update-stage", response)
+
+        response = client.get_stage(restApiId=api_id, stageName="s1")
+        snapshot.match("get-stage", response)

--- a/tests/aws/apigateway/test_apigateway_common.py
+++ b/tests/aws/apigateway/test_apigateway_common.py
@@ -442,6 +442,45 @@ class TestUsagePlans:
         snapshot.match("update-usage-plan", response)
 
 
+class TestDocumentations:
+    @markers.parity.aws_validated
+    def test_documentation_parts_and_versions(
+        self, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
+    ):
+        client = aws_client.apigateway
+
+        # create API
+        api_id, api_name, root_id = create_rest_apigw()
+
+        # create documentation part
+        response = client.create_documentation_part(
+            restApiId=api_id,
+            location={"type": "API"},
+            properties=json.dumps({"foo": "bar"}),
+        )
+        snapshot.match("create-part-response", response)
+
+        response = client.get_documentation_parts(restApiId=api_id)
+        snapshot.match("get-parts-response", response)
+
+        # create/update/get documentation version
+
+        response = client.create_documentation_version(
+            restApiId=api_id, documentationVersion="v123"
+        )
+        snapshot.match("create-version-response", response)
+
+        response = client.update_documentation_version(
+            restApiId=api_id,
+            documentationVersion="v123",
+            patchOperations=[{"op": "replace", "path": "/description", "value": "doc version new"}],
+        )
+        snapshot.match("update-version-response", response)
+
+        response = client.get_documentation_version(restApiId=api_id, documentationVersion="v123")
+        snapshot.match("get-version-response", response)
+
+
 class TestStages:
     @markers.parity.aws_validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
@@ -450,20 +489,34 @@ class TestStages:
     ):
         client = aws_client.apigateway
 
+        # create API, method, integration, deployment
         api_id, api_name, root_id = create_rest_apigw()
-
         client.put_method(
             restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
         )
         client.put_integration(restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK")
-
         response = client.create_deployment(restApiId=api_id)
         deployment_id = response["id"]
 
+        # create documentation
+        client.create_documentation_part(
+            restApiId=api_id,
+            location={"type": "API"},
+            properties=json.dumps({"foo": "bar"}),
+        )
+        client.create_documentation_version(restApiId=api_id, documentationVersion="v123")
+
+        # create stage
         response = client.create_stage(
-            restApiId=api_id, stageName="s1", deploymentId=deployment_id, description="my stage"
+            restApiId=api_id,
+            stageName="s1",
+            deploymentId=deployment_id,
+            description="my stage",
+            documentationVersion="v123",
         )
         snapshot.match("create-stage", response)
+
+        # negative tests for immutable/non-updateable attributes
 
         with pytest.raises(ClientError) as ctx:
             client.update_stage(
@@ -484,6 +537,8 @@ class TestStages:
                 ],
             )
         snapshot.match("error-update-tags", ctx.value.response)
+
+        # update & get stage
 
         response = client.update_stage(
             restApiId=api_id,

--- a/tests/aws/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/apigateway/test_apigateway_common.snapshot.json
@@ -370,7 +370,7 @@
       }
     }
   },
-  "tests/integration/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
+  "tests/aws/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
     "recorded-date": "06-08-2023, 18:38:05",
     "recorded-content": {
       "create-stage": {
@@ -453,7 +453,7 @@
       }
     }
   },
-  "tests/integration/apigateway/test_apigateway_common.py::TestDocumentations::test_documentation_parts_and_versions": {
+  "tests/aws/apigateway/test_apigateway_common.py::TestDocumentations::test_documentation_parts_and_versions": {
     "recorded-date": "07-08-2023, 22:02:13",
     "recorded-content": {
       "create-part-response": {

--- a/tests/aws/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/apigateway/test_apigateway_common.snapshot.json
@@ -369,5 +369,85 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
+    "recorded-date": "06-08-2023, 16:59:58",
+    "recorded-content": {
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error-update-doc-version": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid method setting path: /documentation_version. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]"
+        },
+        "message": "Invalid method setting path: /documentation_version. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-update-tags": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid method setting path: /tags/tag1. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]"
+        },
+        "message": "Invalid method setting path: /tags/tag1. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "stage new",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "variables": {
+          "var1": "test",
+          "var2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "stage new",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "variables": {
+          "var1": "test",
+          "var2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/apigateway/test_apigateway_common.snapshot.json
@@ -454,7 +454,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_common.py::TestDocumentations::test_documentation_parts_and_versions": {
-    "recorded-date": "06-08-2023, 18:32:36",
+    "recorded-date": "07-08-2023, 22:02:13",
     "recorded-content": {
       "create-part-response": {
         "id": "<id:1>",

--- a/tests/aws/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/apigateway/test_apigateway_common.snapshot.json
@@ -371,7 +371,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
-    "recorded-date": "06-08-2023, 16:59:58",
+    "recorded-date": "06-08-2023, 18:38:05",
     "recorded-content": {
       "create-stage": {
         "cacheClusterEnabled": false,
@@ -379,6 +379,7 @@
         "createdDate": "datetime",
         "deploymentId": "<deployment-id:1>",
         "description": "my stage",
+        "documentationVersion": "v123",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
         "stageName": "s1",
@@ -416,6 +417,7 @@
         "createdDate": "datetime",
         "deploymentId": "<deployment-id:1>",
         "description": "stage new",
+        "documentationVersion": "v123",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
         "stageName": "s1",
@@ -435,6 +437,7 @@
         "createdDate": "datetime",
         "deploymentId": "<deployment-id:1>",
         "description": "stage new",
+        "documentationVersion": "v123",
         "lastUpdatedDate": "datetime",
         "methodSettings": {},
         "stageName": "s1",
@@ -443,6 +446,67 @@
           "var1": "test",
           "var2": "test2"
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_common.py::TestDocumentations::test_documentation_parts_and_versions": {
+    "recorded-date": "06-08-2023, 18:32:36",
+    "recorded-content": {
+      "create-part-response": {
+        "id": "<id:1>",
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "foo": "bar"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-parts-response": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "location": {
+              "type": "API"
+            },
+            "properties": {
+              "foo": "bar"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-version-response": {
+        "createdDate": "datetime",
+        "version": "v123",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-version-response": {
+        "createdDate": "datetime",
+        "description": "doc version new",
+        "version": "v123",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-version-response": {
+        "createdDate": "datetime",
+        "description": "doc version new",
+        "version": "v123",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
Enhance parity around API Gateway stage patch operations, add implementation for API GW documentation versions. Addresses https://github.com/localstack/localstack/issues/8739

The PR also adds some refactoring to the existing tests in `test_apigateway_basic.py` - grouping related tests into test classes, using proper fixtures for resource creation, getting rid of global constants to make tests more self-contained, etc. Still more work needs to be done to get them on par with our other integration tests - introduce more fixtures, add snapshots, etc.

Summary of changes:
* implement the `update_stage` method in the provider, and perform corresponding patch operations
* adds small changes to fix missing/invalid attributes in the responses for the `create_stage`, `get_stage`, `update_stage` methods
* add implementation for documentation version API methods
* add a snapshot test to validate the behavior of patch operations in stage updates
* add some negative tests for attributes (e.g., `documentation_version`, `tags`)
* refactor some of the tests in `test_apigateway_basic.py` - remove global static constants, add proper fixtures, etc
* left a `TODO` comment in the code to add `createdDate` / `lastUpdatedDate` in Stage operations (to be tackled in a future PR)