### PR TITLE
fix VirtualHost proxy removing ContentLength for GetObject

### DIFF
--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -153,7 +153,8 @@ class SimpleStreamingRequestsClient(SimpleRequestsClient):
             return final_response
 
         response_headers = Headers(dict(response.headers))
-        response_headers.pop("Content-Length", None)
+        if "chunked" in response_headers.get("Transfer-Encoding", ""):
+            response_headers.pop("Content-Length", None)
 
         final_response = Response(
             response=(chunk for chunk in response.raw.stream(1024, decode_content=False)),

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -8852,7 +8852,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[True]": {
+  "tests/aws/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[True]": {
     "recorded-date": "07-08-2023, 19:56:10",
     "recorded-content": {
       "get-obj-content-len-headers": {
@@ -8869,7 +8869,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[False]": {
+  "tests/aws/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[False]": {
     "recorded-date": "07-08-2023, 19:56:13",
     "recorded-content": {
       "get-obj-content-len-headers": {

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -8851,5 +8851,39 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[True]": {
+    "recorded-date": "07-08-2023, 19:56:10",
+    "recorded-content": {
+      "get-obj-content-len-headers": {
+        "accept-ranges": "bytes",
+        "content-length": "3",
+        "content-type": "binary/octet-stream",
+        "date": "date",
+        "etag": "\"202cb962ac59075b964b07152d234b70\"",
+        "last-modified": "last-modified",
+        "server": "<server:1>",
+        "x-amz-id-2": "<x-amz-id-2:1>",
+        "x-amz-request-id": "<x-amz-request-id:1>",
+        "x-amz-server-side-encryption": "AES256"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[False]": {
+    "recorded-date": "07-08-2023, 19:56:13",
+    "recorded-content": {
+      "get-obj-content-len-headers": {
+        "accept-ranges": "bytes",
+        "content-length": "3",
+        "content-type": "binary/octet-stream",
+        "date": "date",
+        "etag": "\"202cb962ac59075b964b07152d234b70\"",
+        "last-modified": "last-modified",
+        "server": "<server:1>",
+        "x-amz-id-2": "<x-amz-id-2:1>",
+        "x-amz-request-id": "<x-amz-request-id:1>",
+        "x-amz-server-side-encryption": "AES256"
+      }
+    }
   }
 }

--- a/tests/aws/s3/test_s3_notifications_lambda.py
+++ b/tests/aws/s3/test_s3_notifications_lambda.py
@@ -105,8 +105,8 @@ class TestS3NotificationsToLambda:
     @markers.snapshot.skip_snapshot_verify(
         condition=lambda: not LEGACY_S3_PROVIDER,
         paths=[
-            "$..data.s3.object.eTag",
-            "$..data.s3.object.size",
+            "$..data.M.s3.M.object.M.eTag.S",
+            "$..data.M.s3.M.object.M.size.N",
         ],  # TODO presigned-post sporadic failures in CI Pipeline
     )
     def test_create_object_by_presigned_request_via_dynamodb(

--- a/tests/unit/http_/test_proxy.py
+++ b/tests/unit/http_/test_proxy.py
@@ -7,7 +7,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request as WerkzeugRequest
 
 from localstack.http import Request, Response, Router
-from localstack.http.client import SimpleRequestsClient
+from localstack.http.client import SimpleRequestsClient, SimpleStreamingRequestsClient
 from localstack.http.dispatcher import handler_dispatcher
 from localstack.http.hypercorn import HypercornServer
 from localstack.http.proxy import Proxy, ProxyHandler, forward
@@ -195,6 +195,37 @@ class TestProxy:
             assert response.json["headers"]["X-My-Custom-Header"] == "hello world"
             assert response.json["headers"]["X-Forwarded-For"] == "127.0.0.10"
             assert response.json["headers"]["Host"] == "127.0.0.1:80"
+
+    @pytest.mark.parametrize("chunked", [True, False])
+    def test_proxy_for_transfer_encoding_chunked(
+        self,
+        httpserver: HTTPServer,
+        chunked,
+    ):
+        body = "enough-for-content-length"
+
+        def _handler(_: WerkzeugRequest):
+            headers = (
+                {"Content-Length": len(body)} if not chunked else {"Transfer-Encoding": "chunked"}
+            )
+
+            return Response(body, headers=headers)
+
+        httpserver.expect_request("").respond_with_handler(_handler)
+
+        with SimpleStreamingRequestsClient() as client:
+            proxy = Proxy(httpserver.url_for("/").lstrip("/"), client)
+
+            request = Request(path="/", method="GET", headers={"Host": "127.0.0.1:80"})
+
+            response = proxy.request(request)
+
+            if chunked:
+                assert response.headers["Transfer-Encoding"] == "chunked"
+                assert "Content-Length" not in response.headers
+            else:
+                assert response.headers["Content-Length"] == str(len(body))
+                assert "Transfer-Encoding" not in response.headers
 
 
 @pytest.mark.parametrize("consume_data", [True, False])


### PR DESCRIPTION
## Motivation
It appears AWS does not support `Transfer-Encoding: chunked` responses for `GetObject`. We always set the `Content-Length` when returning from `GetObject`, but when passing the request through the Virtual Host proxy, we would remove it every time. 

## Changes
Added a check for the `Transfer-Encoding` header, so that we now conditionally remove it. Also added a unit test as well as an AWS validated integration tests for S3.

Also sneaked in a change, updating an already skipped path for `tests.aws.s3.test_s3_notifications_lambda.TestS3NotificationsToLambda.test_create_object_by_presigned_request_via_dynamodb` which seems to fail sporadically in CI. 

_fixes #8841_