### PR TITLE
Add @markers.aws.unknown to unmarked tests

### DIFF
--- a/tests/aws/awslambda/test_lambda.py
+++ b/tests/aws/awslambda/test_lambda.py
@@ -1199,6 +1199,7 @@ class TestLambdaMultiAccounts:
         return secondary_aws_client.awslambda
 
     @pytest.mark.skipif(is_old_provider(), reason="Not supported by old provider")
+    @markers.aws.unknown
     def test_cross_account_access(
         self, primary_client, secondary_client, create_lambda_function, dummylayer
     ):

--- a/tests/aws/awslambda/test_lambda_api.py
+++ b/tests/aws/awslambda/test_lambda_api.py
@@ -299,6 +299,7 @@ class TestLambdaFunction:
             method(FunctionName=wrong_region_arn)
         snapshot.match("wrong_region_exception", e.value.response)
 
+    @markers.aws.unknown
     def test_lambda_code_location_zipfile(
         self, snapshot, create_lambda_function_aws, lambda_su_role, aws_client
     ):
@@ -345,6 +346,7 @@ class TestLambdaFunction:
             == get_function_response_updated["Configuration"]["CodeSize"]
         )
 
+    @markers.aws.unknown
     def test_lambda_code_location_s3(
         self, s3_bucket, snapshot, create_lambda_function_aws, lambda_su_role, aws_client
     ):
@@ -701,6 +703,7 @@ class TestLambdaImages:
             )
 
     @pytest.fixture(scope="class")
+    @markers.aws.unknown
     def test_image(self, aws_client, login_docker_client):
         repository_names = []
         image_names = []
@@ -3242,6 +3245,7 @@ class TestLambdaUrl:
         # function name + qualifier tests
         fn_arn_doesnotexist = fn_arn.replace(function_name, "doesnotexist")
 
+        @markers.aws.unknown
         def test_name_and_qualifier(method: Callable, snapshot_prefix: str, tests, **kwargs):
             for t in tests:
                 with pytest.raises(t["exc"]) as e:
@@ -3702,6 +3706,7 @@ class TestCodeSigningConfig:
         )
         snapshot.match("delete_code_signing_config", response)
 
+    @markers.aws.unknown
     def test_code_signing_not_found_excs(
         self, snapshot, create_lambda_function, account_id, aws_client
     ):
@@ -4045,6 +4050,7 @@ class TestLambdaEventSourceMappings:
             "$..UUID",
         ]
     )
+    @markers.aws.unknown
     def test_event_source_mapping_lifecycle(
         self,
         create_lambda_function,
@@ -4118,6 +4124,7 @@ class TestLambdaEventSourceMappings:
         # lambda_client.delete_event_source_mapping(UUID=uuid)
 
     @pytest.mark.skipif(is_old_provider(), reason="new provider only")
+    @markers.aws.unknown
     def test_create_event_source_validation(
         self, create_lambda_function, lambda_su_role, dynamodb_create_table, snapshot, aws_client
     ):
@@ -4149,6 +4156,7 @@ class TestLambdaEventSourceMappings:
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not correctly supported")
 class TestLambdaTags:
+    @markers.aws.unknown
     def test_tag_exceptions(self, create_lambda_function, snapshot, account_id, aws_client):
         function_name = f"fn-tag-{short_uid()}"
         create_lambda_function(
@@ -4249,6 +4257,7 @@ class TestLambdaTags:
             aws_client.awslambda.tag_resource(Resource=function_arn, Tags={"a_key": "a_value"})
         snapshot.match("tag_lambda_too_many_tags_additional", e.value.response)
 
+    @markers.aws.unknown
     def test_tag_versions(self, create_lambda_function, snapshot, aws_client):
         function_name = f"fn-tag-{short_uid()}"
         create_function_result = create_lambda_function(
@@ -4599,6 +4608,7 @@ class TestLambdaLayer:
             )
         snapshot.match("create_function_with_layer_in_different_region", e.value.response)
 
+    @markers.aws.unknown
     def test_layer_function_quota_exception(
         self, create_lambda_function, snapshot, dummylayer, cleanups, aws_client
     ):

--- a/tests/aws/awslambda/test_lambda_common.py
+++ b/tests/aws/awslambda/test_lambda_common.py
@@ -271,6 +271,7 @@ class TestLambdaCallingLocalstack:
             "dotnet6",  # TODO: does not yet support transparent endpoint injection
         ],
     )
+    @markers.aws.unknown
     def test_calling_localstack_from_lambda(self, multiruntime_lambda, tmp_path, aws_client):
         create_function_result = multiruntime_lambda.create_function(
             MemorySize=1024,

--- a/tests/aws/awslambda/test_lambda_destinations.py
+++ b/tests/aws/awslambda/test_lambda_destinations.py
@@ -170,6 +170,7 @@ class TestLambdaDestinationSqs:
     @pytest.mark.skipif(
         condition=is_old_provider(), reason="config variable only supported in new provider"
     )
+    @markers.aws.unknown
     def test_lambda_destination_default_retries(
         self,
         create_lambda_function,

--- a/tests/aws/awslambda/test_lambda_developer_tools.py
+++ b/tests/aws/awslambda/test_lambda_developer_tools.py
@@ -7,6 +7,7 @@ import pytest
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.aws.lambda_utils import is_old_provider
+from localstack.testing.pytest import markers
 from localstack.utils.container_networking import get_main_container_network
 from localstack.utils.docker_utils import DOCKER_CLIENT, get_host_path_for_path_in_docker
 from localstack.utils.files import load_file, mkdir, rm_rf
@@ -34,6 +35,7 @@ class TestHotReloading:
         ],
         ids=["nodejs18.x", "python3.9"],
     )
+    @markers.aws.unknown
     def test_hot_reloading(
         self,
         create_lambda_function_aws,
@@ -102,6 +104,7 @@ class TestHotReloading:
         assert response_dict["counter"] == 1
         assert response_dict["constant"] == "value2"
 
+    @markers.aws.unknown
     def test_hot_reloading_publish_version(
         self, create_lambda_function_aws, lambda_su_role, cleanups, aws_client
     ):
@@ -134,6 +137,7 @@ class TestHotReloading:
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
 class TestDockerFlags:
+    @markers.aws.unknown
     def test_additional_docker_flags(self, create_lambda_function, monkeypatch, aws_client):
         env_value = short_uid()
         monkeypatch.setattr(config, "LAMBDA_DOCKER_FLAGS", f"-e Hello={env_value}")
@@ -150,6 +154,7 @@ class TestDockerFlags:
         result_data = json.loads(to_str(result_data))
         assert {"Hello": env_value} == result_data
 
+    @markers.aws.unknown
     def test_lambda_docker_networks(self, lambda_su_role, monkeypatch, aws_client, cleanups):
         function_name = f"test-network-{short_uid()}"
         container_name = f"server-{short_uid()}"

--- a/tests/aws/awslambda/test_lambda_legacy.py
+++ b/tests/aws/awslambda/test_lambda_legacy.py
@@ -59,6 +59,7 @@ skip_if_pro_enabled = pytest.mark.skipif(
     ],
     ids=["logging", "print"],
 )
+@markers.aws.unknown
 def test_logging_in_local_executor(create_lambda_function, handler_path, aws_client):
     function_name = f"lambda_func-{short_uid()}"
     verification_token = f"verification_token-{short_uid()}"
@@ -84,6 +85,7 @@ def test_logging_in_local_executor(create_lambda_function, handler_path, aws_cli
 
 @pytest.mark.skipif(not is_old_provider(), reason="test does not make valid assertions against AWS")
 class TestLambdaLegacyProvider:
+    @markers.aws.unknown
     def test_add_lambda_multiple_permission(self, create_lambda_function, aws_client):
         """Test adding multiple permissions"""
         function_name = f"lambda_func-{short_uid()}"
@@ -140,6 +142,7 @@ class TestLambdaLegacyProvider:
         )
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
+    @markers.aws.unknown
     def test_add_lambda_permission(self, create_lambda_function, aws_client):
         function_name = f"lambda_func-{short_uid()}"
         lambda_create_response = create_lambda_function(
@@ -191,6 +194,7 @@ class TestLambdaLegacyProvider:
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
     # remove? be aware of partition check
+    @markers.aws.unknown
     def test_create_lambda_function(self, aws_client):
         """Basic test that creates and deletes a Lambda function"""
         func_name = f"lambda_func-{short_uid()}"
@@ -238,6 +242,7 @@ class TestLambdaLegacyProvider:
         assert "ResourceNotFoundException" in str(exc)
 
     @skip_if_pro_enabled
+    @markers.aws.unknown
     def test_update_lambda_with_layers(self, create_lambda_function, aws_client):
         func_name = f"lambda-{short_uid()}"
         create_lambda_function(
@@ -261,6 +266,7 @@ class TestRubyRuntimes:
         reason="ruby runtimes not supported in local invocation",
     )
     @markers.snapshot.skip_snapshot_verify
+    @markers.aws.unknown
     # general invocation test
     def test_ruby_lambda_running_in_docker(self, create_lambda_function, snapshot, aws_client):
         """Test simple ruby lambda invocation"""
@@ -285,6 +291,7 @@ class TestRubyRuntimes:
 class TestGolangRuntimes:
     @markers.snapshot.skip_snapshot_verify
     @markers.skip_offline
+    @markers.aws.unknown
     # general invocation test
     def test_golang_lambda(self, tmp_path, create_lambda_function, snapshot, aws_client):
         """Test simple golang lambda invocation"""

--- a/tests/aws/awslambda/test_lambda_performance.py
+++ b/tests/aws/awslambda/test_lambda_performance.py
@@ -18,6 +18,7 @@ import pytest
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
 from localstack.config import is_env_true
+from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from tests.aws.awslambda.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
@@ -29,6 +30,7 @@ if not is_env_true("TEST_PERFORMANCE"):
 LOG = logging.getLogger(__name__)
 
 
+@markers.aws.unknown
 def test_invoke_warm_start(create_lambda_function, aws_client):
     function_name = f"echo-func-{short_uid()}"
     create_lambda_function(
@@ -51,6 +53,7 @@ def test_invoke_warm_start(create_lambda_function, aws_client):
     export_csv(timings, "test_invoke_warm_start")
 
 
+@markers.aws.unknown
 def test_invoke_cold_start(create_lambda_function, aws_client, monkeypatch):
     monkeypatch.setattr(config, "LAMBDA_KEEPALIVE_MS", 0)
     function_name = f"echo-func-{short_uid()}"

--- a/tests/aws/awslambda/test_lambda_runtimes.py
+++ b/tests/aws/awslambda/test_lambda_runtimes.py
@@ -134,6 +134,7 @@ class TestNodeJSRuntimes:
 
 class TestJavaRuntimes:
     @pytest.fixture(scope="class")
+    @markers.aws.unknown
     def test_java_jar(self) -> bytes:
         lambda_java_testlibs_package.install()
         java_file = load_file(
@@ -142,6 +143,7 @@ class TestJavaRuntimes:
         return java_file
 
     @pytest.fixture(scope="class")
+    @markers.aws.unknown
     def test_java_zip(self, tmpdir_factory, test_java_jar) -> bytes:
         tmpdir = tmpdir_factory.mktemp("tmp-java-zip")
         zip_lib_dir = os.path.join(tmpdir, "lib")
@@ -319,6 +321,7 @@ class TestJavaRuntimes:
         ],
     )
     @pytest.mark.xfail(is_old_provider(), reason="Test flaky with local executor.")
+    @markers.aws.unknown
     # TODO maybe snapshot payload as well
     def test_java_lambda_subscribe_sns_topic(
         self,

--- a/tests/aws/awslambda/test_lambda_whitebox.py
+++ b/tests/aws/awslambda/test_lambda_whitebox.py
@@ -16,6 +16,7 @@ from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.services.awslambda.lambda_api import do_set_function_code, use_docker
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.testing.aws.lambda_utils import is_new_provider
+from localstack.testing.pytest import markers
 from localstack.utils import testutil
 from localstack.utils.files import load_file
 from localstack.utils.functions import run_safe
@@ -75,6 +76,7 @@ class TestLambdaFallbackUrl:
             else:
                 config.LAMBDA_FORWARD_URL = ""
 
+    @markers.aws.unknown
     def test_forward_to_fallback_url_dynamodb(self, aws_client):
         db_table = f"lambda-records-{short_uid()}"
         ddb_client = aws_client.dynamodb
@@ -87,6 +89,7 @@ class TestLambdaFallbackUrl:
         items_after = num_items()
         assert items_before + 3 == items_after
 
+    @markers.aws.unknown
     def test_forward_to_fallback_url_http(self, aws_client):
         lambda_client = aws_client.awslambda
         lambda_result = {"result": "test123"}
@@ -149,6 +152,7 @@ class TestLambdaFallbackUrl:
                 # clean up / shutdown
                 lambda_client.delete_function(FunctionName=lambda_name)
 
+    @markers.aws.unknown
     def test_adding_fallback_function_name_in_headers(self, aws_client):
         lambda_client = aws_client.awslambda
         ddb_client = aws_client.dynamodb
@@ -171,6 +175,7 @@ class TestLambdaFallbackUrl:
 
 class TestDockerExecutors:
     @pytest.mark.skipif(not use_docker(), reason="Only applicable with docker executor")
+    @markers.aws.unknown
     def test_additional_docker_flags(self, aws_client):
         flags_before = config.LAMBDA_DOCKER_FLAGS
         env_value = short_uid()
@@ -196,6 +201,7 @@ class TestDockerExecutors:
         # clean up
         lambda_client.delete_function(FunctionName=function_name)
 
+    @markers.aws.unknown
     def test_code_updated_on_redeployment(self, aws_client):
         lambda_api.LAMBDA_EXECUTOR.cleanup()
 
@@ -235,6 +241,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
+    @markers.aws.unknown
     def test_prime_and_destroy_containers(self, aws_client):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = f"test_prime_and_destroy_containers_{short_uid()}"
@@ -304,6 +311,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
+    @markers.aws.unknown
     def test_destroy_idle_containers(self, aws_client):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = "test_destroy_idle_containers"
@@ -351,6 +359,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
+    @markers.aws.unknown
     def test_logresult_more_than_4k_characters(self, aws_client):
         lambda_api.LAMBDA_EXECUTOR.cleanup()
 
@@ -371,6 +380,7 @@ class TestDockerExecutors:
 
 
 class TestLocalExecutors:
+    @markers.aws.unknown
     def test_python3_runtime_multiple_create_with_conflicting_module(self, aws_client):
         lambda_client = aws_client.awslambda
         original_do_use_docker = lambda_api.DO_USE_DOCKER
@@ -419,6 +429,7 @@ class TestLocalExecutors:
 
 
 class TestFunctionStates:
+    @markers.aws.unknown
     def test_invoke_failure_when_state_pending(self, lambda_su_role, monkeypatch, aws_client):
         """Tests if a lambda invocation fails if state is pending"""
         function_name = f"test-function-{short_uid()}"

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -3322,6 +3322,7 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=lambda: LEGACY_S3_PROVIDER, paths=["$..Error.RequestID"]
     )
+    @markers.aws.unknown
     def test_bucket_does_not_exist(self, s3_vhost_client, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = f"bucket-does-not-exist-{short_uid()}"
@@ -5536,6 +5537,7 @@ class TestS3:
         [True, False],
     )
     @markers.snapshot.skip_snapshot_verify(paths=["$..x-amz-server-side-encryption"])
+    @markers.aws.unknown
     def test_get_object_content_length_with_virtual_host(
         self,
         s3_bucket,
@@ -5581,6 +5583,7 @@ class TestS3MultiAccounts:
         """
         return secondary_aws_client.s3
 
+    @markers.aws.unknown
     def test_shared_bucket_namespace(self, primary_client, secondary_client):
         # Ensure that the bucket name space is shared by all accounts and regions
         primary_client.create_bucket(Bucket="foo")
@@ -5592,6 +5595,7 @@ class TestS3MultiAccounts:
             )
         exc.match("BucketAlreadyExists")
 
+    @markers.aws.unknown
     def test_cross_account_access(self, primary_client, secondary_client):
         # Ensure that following operations can be performed across accounts
         # - ListObjects
@@ -7109,6 +7113,7 @@ class TestS3PresignedUrl:
         "signature_version",
         ["s3", "s3v4"],
     )
+    @markers.aws.unknown
     def test_s3_presign_url_encoding(
         self, aws_client, s3_bucket, signature_version, patch_s3_skip_signature_validation_false
     ):

--- a/tests/aws/s3/test_s3_api.py
+++ b/tests/aws/s3/test_s3_api.py
@@ -4,6 +4,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from localstack import config
+from localstack.testing.pytest import markers
 
 
 @pytest.mark.skipif(
@@ -11,6 +12,7 @@ from localstack import config
     reason="These are WIP tests for the new native S3 provider",
 )
 class TestS3BucketCRUD:
+    @markers.aws.unknown
     def test_delete_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         key_name = "test-delete"
@@ -27,6 +29,7 @@ class TestS3BucketCRUD:
         snapshot.match("delete-bucket", delete_bucket)
         # TODO: write a test with a multipart upload that is not completed?
 
+    @markers.aws.unknown
     def test_delete_versioned_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # enable versioning on the bucket
@@ -67,6 +70,7 @@ class TestS3BucketCRUD:
     reason="These are WIP tests for the new native S3 provider",
 )
 class TestS3ObjectCRUD:
+    @markers.aws.unknown
     def test_delete_object(self, s3_bucket, aws_client, snapshot):
         key_name = "test-delete"
         put_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test-delete")
@@ -84,6 +88,7 @@ class TestS3ObjectCRUD:
             )
         snapshot.match("delete-nonexistent-object-versionid", e.value.response)
 
+    @markers.aws.unknown
     def test_delete_objects(self, s3_bucket, aws_client, snapshot):
         key_name = "test-delete"
         put_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test-delete")
@@ -112,6 +117,7 @@ class TestS3ObjectCRUD:
 
         snapshot.match("delete-objects", delete_objects)
 
+    @markers.aws.unknown
     def test_delete_object_versioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # enable versioning on the bucket
@@ -209,6 +215,7 @@ class TestS3ObjectCRUD:
         delete_wrong_key = aws_client.s3.delete_object(Bucket=s3_bucket, Key="wrong-key")
         snapshot.match("delete-wrong-key", delete_wrong_key)
 
+    @markers.aws.unknown
     def test_delete_objects_versioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformer(snapshot.transform.key_value("DeleteMarkerVersionId"))
@@ -281,12 +288,15 @@ class TestS3ObjectCRUD:
         )
         snapshot.match("delete-objects-version-id", delete_objects_marker)
 
+    @markers.aws.unknown
     def test_delete_object_locked(self):
         pass
 
+    @markers.aws.unknown
     def test_delete_object_on_suspended_bucket(self):
         pass
 
+    @markers.aws.unknown
     def test_get_object_with_version_unversioned_bucket(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -303,6 +313,7 @@ class TestS3ObjectCRUD:
         get_obj = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name, VersionId="null")
         snapshot.match("get-obj-with-null-version", get_obj)
 
+    @markers.aws.unknown
     def test_list_object_versions_order_unversioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
 

--- a/tests/aws/test_acm.py
+++ b/tests/aws/test_acm.py
@@ -29,6 +29,7 @@ JjZ91eQ0hjkCMHw2U/Aw5WJjOpnitqM7mzT6HtoQknFekROn3aRukswy1vUhZscv
 
 
 class TestACM:
+    @markers.aws.unknown
     def test_import_certificate(self, aws_client):
         certs_before = aws_client.acm.list_certificates().get("CertificateSummaryList", [])
 
@@ -57,12 +58,14 @@ class TestACM:
             if result is not None:
                 aws_client.acm.delete_certificate(CertificateArn=result["CertificateArn"])
 
+    @markers.aws.unknown
     def test_domain_validation(self, acm_request_certificate, aws_client):
         certificate_arn = acm_request_certificate()["CertificateArn"]
         result = aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
         options = result["Certificate"]["DomainValidationOptions"]
         assert len(options) == 1
 
+    @markers.aws.unknown
     def test_boto_wait_for_certificate_validation(
         self, acm_request_certificate, aws_client, monkeypatch
     ):

--- a/tests/aws/test_cloudwatch.py
+++ b/tests/aws/test_cloudwatch.py
@@ -19,6 +19,7 @@ PUBLICATION_RETRIES = 5
 
 
 class TestCloudwatch:
+    @markers.aws.unknown
     def test_put_metric_data(self, aws_client):
         metric_name = "metric-%s" % short_uid()
         namespace = "namespace-%s" % short_uid()
@@ -90,6 +91,7 @@ class TestCloudwatch:
         assert poll_condition(lambda: get_stats() >= 1, timeout=10)
         snapshot.match("get_metric_statistics", stats)
 
+    @markers.aws.unknown
     def test_put_metric_data_gzip(self, aws_client):
         metric_name = "test-metric"
         namespace = "namespace"
@@ -121,6 +123,7 @@ class TestCloudwatch:
         assert 1 == len(rs["Metrics"])
         assert namespace == rs["Metrics"][0]["Namespace"]
 
+    @markers.aws.unknown
     def test_get_metric_data(self, aws_client):
 
         aws_client.cloudwatch.put_metric_data(
@@ -209,6 +212,7 @@ class TestCloudwatch:
         result = json.loads(to_str(result.content))
         assert len(result["metrics"]) >= 3
 
+    @markers.aws.unknown
     def test_multiple_dimensions(self, aws_client):
 
         namespaces = [
@@ -241,6 +245,7 @@ class TestCloudwatch:
         assert metrics
         assert len(metrics) == len(namespaces) * num_dimensions
 
+    @markers.aws.unknown
     def test_describe_alarms_converts_date_format_correctly(self, aws_client):
         alarm_name = "a-%s" % short_uid()
         aws_client.cloudwatch.put_metric_alarm(
@@ -256,6 +261,7 @@ class TestCloudwatch:
         finally:
             aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name])
 
+    @markers.aws.unknown
     def test_put_composite_alarm_describe_alarms_converts_date_format_correctly(self, aws_client):
         alarm_name = "a-%s" % short_uid()
         alarm_rule = 'ALARM("my_other_alarm")'
@@ -271,6 +277,7 @@ class TestCloudwatch:
         finally:
             aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name])
 
+    @markers.aws.unknown
     def test_store_tags(self, aws_client):
         alarm_name = "a-%s" % short_uid()
         response = aws_client.cloudwatch.put_metric_alarm(
@@ -296,6 +303,7 @@ class TestCloudwatch:
         # clean up
         aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name])
 
+    @markers.aws.unknown
     def test_list_metrics_uniqueness(self, aws_client):
         # create metrics with same namespace and dimensions but different metric names
         aws_client.cloudwatch.put_metric_data(
@@ -335,6 +343,7 @@ class TestCloudwatch:
         results = aws_client.cloudwatch.list_metrics(Namespace="AWS/EC2")["Metrics"]
         assert 2 == len(results)
 
+    @markers.aws.unknown
     def test_put_metric_alarm_escape_character(self, cleanups, aws_client):
         aws_client.cloudwatch.put_metric_alarm(
             AlarmName="cpu-mon",
@@ -353,6 +362,7 @@ class TestCloudwatch:
         result = aws_client.cloudwatch.describe_alarms(AlarmNames=["cpu-mon"])
         assert result.get("MetricAlarms")[0]["AlarmDescription"] == "<"
 
+    @markers.aws.unknown
     def test_set_alarm(self, sns_create_topic, sqs_create_queue, aws_client):
         # create topics for state 'ALARM' and 'OK'
         sns_topic_alarm = sns_create_topic()

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -1232,6 +1232,7 @@ class TestDynamoDB:
         snapshot.match("BatchWriteResponse", response)
 
     @pytest.mark.xfail(reason="this test flakes regularly in CI")
+    @markers.aws.unknown
     def test_dynamodb_stream_records_with_update_item(
         self, dynamodb_create_table, wait_for_stream_ready, aws_client
     ):
@@ -1549,6 +1550,7 @@ class TestDynamoDB:
             )
         snapshot.match("ValidationException", ctx.value)
 
+    @markers.aws.unknown
     def test_batch_write_not_existing_table(self, aws_client):
         with pytest.raises(Exception) as ctx:
             aws_client.dynamodb.transact_write_items(
@@ -1651,6 +1653,7 @@ class TestDynamoDB:
             "$..PointInTimeRecoveryDescription..LatestRestorableDateTime",
         ]
     )
+    @markers.aws.unknown
     def test_continuous_backup_update(self, dynamodb_create_table, snapshot, aws_client):
         table_name = f"table-{short_uid()}"
         dynamodb_create_table(

--- a/tests/aws/test_ec2.py
+++ b/tests/aws/test_ec2.py
@@ -35,6 +35,7 @@ def create_launch_template(aws_client):
 
 
 class TestEc2Integrations:
+    @markers.aws.unknown
     def test_create_route_table_association(self, cleanups, aws_client):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         cleanups.append(lambda: aws_client.ec2.delete_vpc(VpcId=vpc["Vpc"]["VpcId"]))
@@ -68,6 +69,7 @@ class TestEc2Integrations:
             associations = [a for a in route_tables["Associations"] if not a.get("Main")]
             assert associations == []
 
+    @markers.aws.unknown
     def test_create_vpc_end_point(self, cleanups, aws_client):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         cleanups.append(lambda: aws_client.ec2.delete_vpc(VpcId=vpc["Vpc"]["VpcId"]))
@@ -139,6 +141,7 @@ class TestEc2Integrations:
         assert vpc["Vpc"]["VpcId"] == vpc_end_point["VpcEndpoint"]["VpcId"]
         assert len(vpc_end_point["VpcEndpoint"]["DnsEntries"]) > 0
 
+    @markers.aws.unknown
     def test_reserved_instance_api(self, aws_client):
         rs = aws_client.ec2.describe_reserved_instances_offerings(
             AvailabilityZone="us-east-1a",
@@ -169,6 +172,7 @@ class TestEc2Integrations:
         )
         assert 200 == rs["ResponseMetadata"]["HTTPStatusCode"]
 
+    @markers.aws.unknown
     def test_vcp_peering_difference_regions(self, aws_client_factory):
         region1 = TEST_AWS_REGION_NAME
         region2 = TEST_AWS_REGION_NAME  # When cross-region peering is supported, change to SECONDARY_TEST_AWS_REGION_NAME
@@ -241,6 +245,7 @@ class TestEc2Integrations:
         ec2_client1.delete_vpc(VpcId=peer_vpc1["Vpc"]["VpcId"])
         ec2_client2.delete_vpc(VpcId=peer_vpc2["Vpc"]["VpcId"])
 
+    @markers.aws.unknown
     def test_describe_vpn_gateways_filter_by_vpc(self, aws_client):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         vpc_id = vpc["Vpc"]["VpcId"]
@@ -270,6 +275,7 @@ class TestEc2Integrations:
         aws_client.ec2.delete_vpn_gateway(VpnGatewayId=gateway_id)
         aws_client.ec2.delete_vpc(VpcId=vpc_id)
 
+    @markers.aws.unknown
     def test_describe_vpc_endpoints_with_filter(self, aws_client):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         vpc_id = vpc["Vpc"]["VpcId"]
@@ -404,6 +410,7 @@ def pickle_backends():
     return _can_pickle
 
 
+@markers.aws.unknown
 def test_pickle_ec2_backend(pickle_backends, aws_client):
     _ = aws_client.ec2.describe_account_attributes()
     pickle_backends(ec2_backends)

--- a/tests/aws/test_es.py
+++ b/tests/aws/test_es.py
@@ -67,6 +67,7 @@ def try_cluster_health(cluster_url: str):
 
 
 class TestElasticsearchProvider:
+    @markers.aws.unknown
     def test_list_versions(self, aws_client):
         response = aws_client.es.list_elasticsearch_versions()
 
@@ -77,6 +78,7 @@ class TestElasticsearchProvider:
         assert "OpenSearch_1.1" in versions
         assert "7.10" in versions
 
+    @markers.aws.unknown
     def test_get_compatible_versions(self, aws_client):
         response = aws_client.es.get_compatible_elasticsearch_versions()
 
@@ -113,6 +115,7 @@ class TestElasticsearchProvider:
         } in versions
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_get_compatible_version_for_domain(self, opensearch_domain, aws_client):
         response = aws_client.es.get_compatible_elasticsearch_versions(DomainName=opensearch_domain)
         assert "CompatibleElasticsearchVersions" in response
@@ -121,6 +124,7 @@ class TestElasticsearchProvider:
         assert len(versions) == 0
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_create_domain(self, opensearch_create_domain, aws_client):
         es_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = aws_client.es.list_domain_names(EngineType="Elasticsearch")
@@ -128,6 +132,7 @@ class TestElasticsearchProvider:
         assert es_domain in domain_names
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_create_existing_domain_causes_exception(self, opensearch_create_domain, aws_client):
         domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
 
@@ -136,6 +141,7 @@ class TestElasticsearchProvider:
         assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_describe_domains(self, opensearch_create_domain, aws_client):
         opensearch_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = aws_client.es.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
@@ -143,6 +149,7 @@ class TestElasticsearchProvider:
         assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_domain_version(self, opensearch_domain, opensearch_create_domain, aws_client):
         response = aws_client.es.describe_elasticsearch_domain(DomainName=opensearch_domain)
         assert "DomainStatus" in response
@@ -157,6 +164,7 @@ class TestElasticsearchProvider:
         assert status["ElasticsearchVersion"] == "7.10"
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain, aws_client):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
         monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
@@ -170,6 +178,7 @@ class TestElasticsearchProvider:
         endpoint = status["Endpoint"]
         assert endpoint.endswith(f"/{domain_name}")
 
+    @markers.aws.unknown
     def test_update_domain_config(self, opensearch_domain, aws_client):
         initial_response = aws_client.es.describe_elasticsearch_domain_config(
             DomainName=opensearch_domain

--- a/tests/aws/test_events.py
+++ b/tests/aws/test_events.py
@@ -158,6 +158,7 @@ class TestEvents:
         for field in expected_fields:
             assert field in event
 
+    @markers.aws.unknown
     def test_put_rule(self, aws_client, clean_up):
         rule_name = f"rule-{short_uid()}"
 
@@ -170,6 +171,7 @@ class TestEvents:
         # clean up
         clean_up(rule_name=rule_name)
 
+    @markers.aws.unknown
     def test_events_written_to_disk_are_timestamp_prefixed_for_chronological_ordering(
         self, aws_client
     ):
@@ -205,6 +207,7 @@ class TestEvents:
             == event_details_to_publish
         )
 
+    @markers.aws.unknown
     def test_list_tags_for_resource(self, aws_client, clean_up):
         rule_name = "rule-{}".format(short_uid())
 
@@ -245,6 +248,7 @@ class TestEvents:
             entries_asserts=[(entries, True)],
         )
 
+    @markers.aws.unknown
     def test_put_events_with_values_in_array(self, aws_client, put_events_with_filter_to_sqs):
         pattern = {"detail": {"event": {"data": {"type": ["1", "2"]}}}}
         entries1 = [
@@ -306,6 +310,7 @@ class TestEvents:
             input_path="$.detail",
         )
 
+    @markers.aws.unknown
     def test_put_events_with_target_sqs_event_detail_match(
         self, aws_client, put_events_with_filter_to_sqs
     ):
@@ -427,6 +432,7 @@ class TestEvents:
 
     # TODO: further unify/parameterize the tests for the different target types below
 
+    @markers.aws.unknown
     def test_put_events_with_target_sns(self, sns_subscription, aws_client, clean_up):
         queue_name = "test-%s" % short_uid()
         rule_name = "rule-{}".format(short_uid())
@@ -484,6 +490,7 @@ class TestEvents:
         aws_client.sns.delete_topic(TopicArn=topic_arn)
         clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id, queue_url=queue_url)
 
+    @markers.aws.unknown
     def test_put_events_into_event_bus(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())
         rule_name = "rule-{}".format(short_uid())
@@ -545,6 +552,7 @@ class TestEvents:
         clean_up(bus_name=bus_name_2)
         aws_client.sqs.delete_queue(QueueUrl=queue_url)
 
+    @markers.aws.unknown
     def test_put_events_with_target_lambda(
         self, create_lambda_function, cleanups, aws_client, clean_up
     ):
@@ -607,6 +615,7 @@ class TestEvents:
         self.assert_valid_event(actual_event)
         assert actual_event["detail"] == EVENT_DETAIL
 
+    @markers.aws.unknown
     def test_rule_disable(self, aws_client, clean_up):
         rule_name = "rule-{}".format(short_uid())
         aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minutes)")
@@ -620,6 +629,7 @@ class TestEvents:
         # clean up
         clean_up(rule_name=rule_name)
 
+    @markers.aws.unknown
     def test_scheduled_expression_events(
         self,
         sns_create_topic,
@@ -756,6 +766,7 @@ class TestEvents:
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
 
     @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
+    @markers.aws.unknown
     def test_api_destinations(self, httpserver: HTTPServer, auth, aws_client, clean_up):
         token = short_uid()
         bearer = f"Bearer {token}"
@@ -913,6 +924,7 @@ class TestEvents:
                 assert oauth_request.headers["oauthheader"] == "value2"
                 assert oauth_request.args["oauthquery"] == "value3"
 
+    @markers.aws.unknown
     def test_create_connection_validations(self, aws_client):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 
@@ -932,6 +944,7 @@ class TestEvents:
         assert "must have length less than or equal to 64" in message
         assert "must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]" in message
 
+    @markers.aws.unknown
     def test_put_events_with_target_firehose(self, aws_client, clean_up):
         s3_bucket = "s3-{}".format(short_uid())
         s3_prefix = "testeventdata"
@@ -998,6 +1011,7 @@ class TestEvents:
         aws_client.s3.delete_bucket(Bucket=s3_bucket)
         clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id)
 
+    @markers.aws.unknown
     def test_put_events_with_target_sqs_new_region(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
         queue_name = "queue-{}".format(short_uid())
@@ -1037,6 +1051,7 @@ class TestEvents:
         assert len(response.get("Entries")) == 1
         assert "EventId" in response.get("Entries")[0]
 
+    @markers.aws.unknown
     def test_put_events_with_target_kinesis(self, aws_client):
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
@@ -1107,6 +1122,7 @@ class TestEvents:
         assert data["detail"] == EVENT_DETAIL
         self.assert_valid_event(data)
 
+    @markers.aws.unknown
     def test_put_events_with_input_path(self, aws_client, clean_up):
         queue_name = f"queue-{short_uid()}"
         rule_name = f"rule-{short_uid()}"
@@ -1164,6 +1180,7 @@ class TestEvents:
         # clean up
         clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id, queue_url=queue_url)
 
+    @markers.aws.unknown
     def test_put_events_with_input_path_multiple(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())
         queue_name_1 = "queue-{}".format(short_uid())
@@ -1243,12 +1260,14 @@ class TestEvents:
             queue_url=queue_url,
         )
 
+    @markers.aws.unknown
     def test_put_event_without_source(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
         response = events_client.put_events(Entries=[{"DetailType": "Test", "Detail": "{}"}])
         assert response.get("Entries")
 
+    @markers.aws.unknown
     def test_put_event_without_detail(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
@@ -1261,6 +1280,7 @@ class TestEvents:
         )
         assert response.get("Entries")
 
+    @markers.aws.unknown
     def test_trigger_event_on_ssm_change(self, aws_client, clean_up):
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
@@ -1309,6 +1329,7 @@ class TestEvents:
         # clean up
         clean_up(rule_name=rule_name, target_ids=target_id)
 
+    @markers.aws.unknown
     def test_put_event_with_content_base_rule_in_pattern(self, aws_client, clean_up):
         queue_name = f"queue-{short_uid()}"
         rule_name = f"rule-{short_uid()}"

--- a/tests/aws/test_firehose.py
+++ b/tests/aws/test_firehose.py
@@ -33,6 +33,7 @@ def handler(event, context):
 
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
+@markers.aws.unknown
 def test_firehose_http(
     aws_client, lambda_processor_enabled: bool, create_lambda_function, httpserver: HTTPServer
 ):
@@ -127,6 +128,7 @@ def test_firehose_http(
 
 class TestFirehoseIntegration:
     @markers.skip_offline
+    @markers.aws.unknown
     def test_kinesis_firehose_elasticsearch_s3_backup(
         self, s3_bucket, kinesis_create_stream, cleanups, aws_client
     ):
@@ -230,6 +232,7 @@ class TestFirehoseIntegration:
 
     @markers.skip_offline
     @pytest.mark.parametrize("opensearch_endpoint_strategy", ["domain", "path", "port"])
+    @markers.aws.unknown
     def test_kinesis_firehose_opensearch_s3_backup(
         self,
         s3_bucket,
@@ -341,6 +344,7 @@ class TestFirehoseIntegration:
             aws_client.firehose.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
             aws_client.opensearch.delete_domain(DomainName=domain_name)
 
+    @markers.aws.unknown
     def test_delivery_stream_with_kinesis_as_source(
         self, s3_bucket, kinesis_create_stream, cleanups, aws_client
     ):

--- a/tests/aws/test_iam.py
+++ b/tests/aws/test_iam.py
@@ -25,6 +25,7 @@ GET_USER_POLICY_DOC = """{
 
 
 class TestIAMExtensions:
+    @markers.aws.unknown
     def test_get_user_without_username_as_user(self, create_user, aws_client):
         user_name = f"user-{short_uid()}"
         policy_name = f"policy={short_uid()}"
@@ -50,6 +51,7 @@ class TestIAMExtensions:
         assert user["UserId"] == account_id
         assert user["Arn"] == f"arn:aws:iam::{account_id}:root"
 
+    @markers.aws.unknown
     def test_get_user_without_username_as_role(self, create_role, wait_and_assume_role, aws_client):
         role_name = f"role-{short_uid()}"
         policy_name = f"policy={short_uid()}"
@@ -77,6 +79,7 @@ class TestIAMExtensions:
             iam_client_as_role.get_user()
         e.match("Must specify userName when calling with non-User credentials")
 
+    @markers.aws.unknown
     def test_create_user_with_permission_boundary(self, create_user, create_policy, aws_client):
         user_name = f"user-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
@@ -99,6 +102,7 @@ class TestIAMExtensions:
         get_user_reply = aws_client.iam.get_user(UserName=user_name)
         assert "PermissionsBoundary" not in get_user_reply["User"]
 
+    @markers.aws.unknown
     def test_create_user_add_permission_boundary_afterwards(
         self, create_user, create_policy, aws_client
     ):
@@ -148,6 +152,7 @@ class TestIAMExtensions:
 
 
 class TestIAMIntegrations:
+    @markers.aws.unknown
     def test_attach_iam_role_to_new_iam_user(self, aws_client):
         test_policy_document = {
             "Version": "2012-10-17",
@@ -182,6 +187,7 @@ class TestIAMIntegrations:
         assert ctx.typename == "NoSuchEntityException"
         assert ctx.value.response["Error"]["Code"] == "NoSuchEntity"
 
+    @markers.aws.unknown
     def test_delete_non_existent_policy_returns_no_such_entity(self, aws_client):
         non_existent_policy_arn = "arn:aws:iam::000000000000:policy/non-existent-policy"
 
@@ -190,6 +196,7 @@ class TestIAMIntegrations:
         assert ctx.typename == "NoSuchEntityException"
         assert ctx.value.response["Error"]["Code"] == "NoSuchEntity"
 
+    @markers.aws.unknown
     def test_recreate_iam_role(self, aws_client):
         role_name = "role-{}".format(short_uid())
 
@@ -223,6 +230,7 @@ class TestIAMIntegrations:
         # clean up
         aws_client.iam.delete_role(RoleName=role_name)
 
+    @markers.aws.unknown
     def test_instance_profile_tags(self, aws_client):
         def gen_tag():
             return Tag(Key=f"key-{long_uid()}", Value=f"value-{short_uid()}")
@@ -297,6 +305,7 @@ class TestIAMIntegrations:
 
         aws_client.iam.delete_instance_profile(InstanceProfileName=user_name)
 
+    @markers.aws.unknown
     def test_create_user_with_tags(self, aws_client):
         user_name = "user-role-{}".format(short_uid())
 
@@ -315,6 +324,7 @@ class TestIAMIntegrations:
         # clean up
         aws_client.iam.delete_user(UserName=user_name)
 
+    @markers.aws.unknown
     def test_attach_detach_role_policy(self, aws_client):
         role_name = "s3-role-{}".format(short_uid())
         policy_name = "s3-role-policy-{}".format(short_uid())
@@ -379,6 +389,7 @@ class TestIAMIntegrations:
 
         aws_client.iam.delete_policy(PolicyArn=policy_arn)
 
+    @markers.aws.unknown
     def test_simulate_principle_policy(self, aws_client):
         policy_name = "policy-{}".format(short_uid())
         policy_document = {
@@ -411,6 +422,7 @@ class TestIAMIntegrations:
         assert "s3:GetObjectVersion" in actions
         assert actions["s3:GetObjectVersion"]["EvalDecision"] == "allowed"
 
+    @markers.aws.unknown
     def test_create_role_with_assume_role_policy(self, aws_client):
         role_name_1 = f"role-{short_uid()}"
         role_name_2 = f"role-{short_uid()}"

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 from localstack.testing.aws.util import get_lambda_logs
+from localstack.testing.pytest import markers
 from localstack.utils import testutil
 from localstack.utils.aws import arns
 from localstack.utils.common import (
@@ -77,6 +78,7 @@ def scheduled_test_lambda(aws_client):
 
 @pytest.mark.usefixtures("scheduled_test_lambda")
 class TestIntegration:
+    @markers.aws.unknown
     def test_firehose_s3(self, firehose_create_delivery_stream, s3_create_bucket, aws_client):
         stream_name = f"fh-stream-{short_uid()}"
         bucket_name = s3_create_bucket()
@@ -113,6 +115,7 @@ class TestIntegration:
         for key in all_objects.keys():
             assert re.match(r".*/\d{4}/\d{2}/\d{2}/\d{2}/.*-\d{4}-\d{2}-\d{2}-\d{2}.*", key)
 
+    @markers.aws.unknown
     def test_firehose_extended_s3(
         self, firehose_create_delivery_stream, s3_create_bucket, aws_client
     ):
@@ -149,6 +152,7 @@ class TestIntegration:
         for key in all_objects.keys():
             assert re.match(r".*/\d{4}/\d{2}/\d{2}/\d{2}/.*-\d{4}-\d{2}-\d{2}-\d{2}.*", key)
 
+    @markers.aws.unknown
     def test_firehose_kinesis_to_s3(self, kinesis_create_stream, aws_client):
         stream_name = f"fh-stream-{short_uid()}"
 
@@ -201,6 +205,7 @@ class TestIntegration:
         # clean up
         aws_client.firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
 
+    @markers.aws.unknown
     def test_lambda_streams_batch_and_transactions(
         self,
         kinesis_create_stream,
@@ -527,6 +532,7 @@ class TestIntegration:
             # cleanup
             process.stop()
 
+    @markers.aws.unknown
     def test_scheduled_lambda(self, aws_client, scheduled_test_lambda):
         def check_invocation(*args):
             assert get_lambda_logs(scheduled_test_lambda, aws_client.logs)
@@ -535,6 +541,7 @@ class TestIntegration:
         retry(check_invocation, retries=14, sleep=5)
 
 
+@markers.aws.unknown
 def test_kinesis_lambda_forward_chain(
     kinesis_create_stream, create_lambda_function, cleanups, aws_client
 ):
@@ -592,6 +599,7 @@ parametrize_python_runtimes = pytest.mark.parametrize("runtime", PYTHON_TEST_RUN
 
 class TestLambdaOutgoingSdkCalls:
     @parametrize_python_runtimes
+    @markers.aws.unknown
     def test_lambda_send_message_to_sqs(
         self, create_lambda_function, sqs_create_queue, runtime, lambda_su_role, aws_client
     ):
@@ -625,6 +633,7 @@ class TestLambdaOutgoingSdkCalls:
         assert event["message"] == message["Body"]
 
     @parametrize_python_runtimes
+    @markers.aws.unknown
     def test_lambda_put_item_to_dynamodb(
         self,
         create_lambda_function,
@@ -673,6 +682,7 @@ class TestLambdaOutgoingSdkCalls:
             assert data[item["id"]["S"]] == item["data"]["S"]
 
     @parametrize_python_runtimes
+    @markers.aws.unknown
     def test_lambda_start_stepfunctions_execution(
         self, create_lambda_function, runtime, lambda_su_role, cleanups, aws_client
     ):

--- a/tests/aws/test_kinesis.py
+++ b/tests/aws/test_kinesis.py
@@ -40,6 +40,7 @@ def kinesis_snapshot_transformer(snapshot):
 
 
 class TestKinesis:
+    @markers.aws.unknown
     def test_create_stream_without_stream_name_raises(self, aws_client_factory):
         boto_config = BotoConfig(parameter_validation=False)
         kinesis_client = aws_client_factory(config=boto_config).kinesis
@@ -228,6 +229,7 @@ class TestKinesis:
         # clean up
         aws_client.kinesis.deregister_stream_consumer(StreamARN=stream_arn, ConsumerName="c1")
 
+    @markers.aws.unknown
     def test_get_records(self, kinesis_create_stream, wait_for_stream_ready, aws_client):
         # create stream
         stream_name = kinesis_create_stream(ShardCount=1)
@@ -265,6 +267,7 @@ class TestKinesis:
             == result["Records"][0]["ApproximateArrivalTimestamp"]
         )
 
+    @markers.aws.unknown
     def test_get_records_empty_stream(
         self, kinesis_create_stream, wait_for_stream_ready, aws_client
     ):
@@ -422,6 +425,7 @@ def wait_for_consumer_ready(aws_client):
 
 class TestKinesisPythonClient:
     @markers.skip_offline
+    @markers.aws.unknown
     def test_run_kcl(self, aws_client):
         result = []
 

--- a/tests/aws/test_kms.py
+++ b/tests/aws/test_kms.py
@@ -468,6 +468,7 @@ class TestKMS:
             )
         assert exc.match("ValidationException")
 
+    @markers.aws.unknown
     def test_invalid_key_usage(self, kms_create_key, aws_client):
         key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_4096")["KeyId"]
         with pytest.raises(ClientError) as exc:
@@ -495,6 +496,7 @@ class TestKMS:
             ("RSA_2048", "RSAES_OAEP_SHA_256"),
         ],
     )
+    @markers.aws.unknown
     def test_encrypt_decrypt(self, kms_create_key, key_spec, algo, aws_client):
         key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec=key_spec)["KeyId"]
         message = b"test message 123 !%$@ 1234567890"
@@ -749,6 +751,7 @@ class TestKMS:
         assert alias is not None
         assert alias["TargetKeyId"] == new_key_id
 
+    @markers.aws.unknown
     def test_get_put_list_key_policies(self, kms_create_key, aws_client, account_id):
         base_policy = {
             "Version": "2012-10-17",
@@ -1105,6 +1108,7 @@ class TestKMS:
 
 
 class TestKMSMultiAccounts:
+    @markers.aws.unknown
     def test_cross_accounts_access(
         self, aws_client, secondary_aws_client, kms_create_key, user_arn
     ):

--- a/tests/aws/test_logs.py
+++ b/tests/aws/test_logs.py
@@ -64,6 +64,7 @@ def logs_log_stream(logs_log_group, aws_client):
 
 class TestCloudWatchLogs:
     # TODO make creation and description atomic to avoid possible flake?
+    @markers.aws.unknown
     def test_create_and_delete_log_group(self, aws_client):
         test_name = f"test-log-group-{short_uid()}"
         log_groups_before = aws_client.logs.describe_log_groups(
@@ -150,6 +151,7 @@ class TestCloudWatchLogs:
             "$..describe-log-groups-pattern.nextToken",
         ]
     )
+    @markers.aws.unknown
     def test_create_and_delete_log_stream(self, logs_log_group, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.logs_api())
         test_name = f"test-log-stream-{short_uid()}"
@@ -218,6 +220,7 @@ class TestCloudWatchLogs:
         )
         assert len(log_streams_after) == 0
 
+    @markers.aws.unknown
     def test_put_events_multi_bytes_msg(self, logs_log_group, logs_log_stream, aws_client):
         body_msg = "🙀 - 参よ - 日本語"
         events = [{"timestamp": now_utc(millis=True), "message": body_msg}]
@@ -231,6 +234,7 @@ class TestCloudWatchLogs:
         )["events"]
         assert events[0]["message"] == body_msg
 
+    @markers.aws.unknown
     def test_filter_log_events_response_header(self, logs_log_group, logs_log_stream, aws_client):
         events = [
             {"timestamp": now_utc(millis=True), "message": "log message 1"},
@@ -520,6 +524,7 @@ class TestCloudWatchLogs:
             )
 
     @pytest.mark.skip("TODO: failing against pro")
+    @markers.aws.unknown
     def test_metric_filters(self, logs_log_group, logs_log_stream, aws_client):
         basic_filter_name = f"test-filter-basic-{short_uid()}"
         json_filter_name = f"test-filter-json-{short_uid()}"
@@ -588,6 +593,7 @@ class TestCloudWatchLogs:
         assert basic_filter_name not in filter_names
         assert json_filter_name not in filter_names
 
+    @markers.aws.unknown
     def test_delivery_logs_for_sns(self, sns_create_topic, sns_subscription, aws_client):
         topic_name = f"test-logs-{short_uid()}"
         contact = "+10123456789"

--- a/tests/aws/test_moto.py
+++ b/tests/aws/test_moto.py
@@ -10,9 +10,11 @@ from localstack.aws.api import ServiceException, handler
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
 from localstack.services import moto
 from localstack.services.moto import MotoFallbackDispatcher
+from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
+@markers.aws.unknown
 def test_call_with_sqs_creates_state_correctly():
     qname = f"queue-{short_uid()}"
 
@@ -35,6 +37,7 @@ def test_call_with_sqs_creates_state_correctly():
     assert url not in response.get("QueueUrls", [])
 
 
+@markers.aws.unknown
 def test_call_sqs_invalid_call_raises_http_exception():
     with pytest.raises(ServiceException) as e:
         moto.call_moto(
@@ -49,6 +52,7 @@ def test_call_sqs_invalid_call_raises_http_exception():
     e.match("The specified queue does not exist")
 
 
+@markers.aws.unknown
 def test_call_non_implemented_operation():
     with pytest.raises(NotImplementedError):
         # we'll need to keep finding methods that moto doesn't implement ;-)
@@ -57,6 +61,7 @@ def test_call_non_implemented_operation():
         )
 
 
+@markers.aws.unknown
 def test_call_with_sqs_modifies_state_in_moto_backend():
     """Whitebox test to check that moto backends are populated correctly"""
     from moto.sqs.models import sqs_backends
@@ -75,6 +80,7 @@ def test_call_with_sqs_modifies_state_in_moto_backend():
 @pytest.mark.parametrize(
     "payload", ["foobar", b"foobar", BytesIO(b"foobar")], ids=["str", "bytes", "IO[bytes]"]
 )
+@markers.aws.unknown
 def test_call_s3_with_streaming_trait(payload, monkeypatch):
     monkeypatch.setenv("MOTO_S3_CUSTOM_ENDPOINTS", "s3.localhost.localstack.cloud:4566")
 
@@ -112,6 +118,7 @@ def test_call_s3_with_streaming_trait(payload, monkeypatch):
     moto.call_moto(moto.create_aws_request_context("s3", "DeleteBucket", {"Bucket": bucket_name}))
 
 
+@markers.aws.unknown
 def test_call_include_response_metadata():
     ctx = moto.create_aws_request_context("sqs", "ListQueues")
 
@@ -122,6 +129,7 @@ def test_call_include_response_metadata():
     assert "ResponseMetadata" in response
 
 
+@markers.aws.unknown
 def test_call_with_modified_request():
     from moto.sqs.models import sqs_backends
 
@@ -138,6 +146,7 @@ def test_call_with_modified_request():
     moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
 
 
+@markers.aws.unknown
 def test_call_with_es_creates_state_correctly():
     domain_name = f"domain-{short_uid()}"
     response = moto.call_moto(
@@ -166,6 +175,7 @@ def test_call_with_es_creates_state_correctly():
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
+@markers.aws.unknown
 def test_call_multi_region_backends():
     from moto.sqs.models import sqs_backends
 
@@ -193,6 +203,7 @@ def test_call_multi_region_backends():
     del sqs_backends[DEFAULT_MOTO_ACCOUNT_ID]["eu-central-1"].queues[qname_eu]
 
 
+@markers.aws.unknown
 def test_call_with_sqs_invalid_call_raises_exception():
     with pytest.raises(ServiceException):
         moto.call_moto(
@@ -206,6 +217,7 @@ def test_call_with_sqs_invalid_call_raises_exception():
         )
 
 
+@markers.aws.unknown
 def test_call_with_sqs_returns_service_response():
     qname = f"queue-{short_uid()}"
 
@@ -238,6 +250,7 @@ class FakeSqsProvider(FakeSqsApi):
         return moto.call_moto(context)
 
 
+@markers.aws.unknown
 def test_moto_fallback_dispatcher():
     provider = FakeSqsProvider()
     dispatcher = MotoFallbackDispatcher(provider)
@@ -294,6 +307,7 @@ class FakeS3Provider:
         raise NotImplementedAvoidFallbackError
 
 
+@markers.aws.unknown
 def test_moto_fallback_dispatcher_error_handling(monkeypatch):
     """
     This test checks if the error handling (marshalling / unmarshalling) works correctly on all levels, including
@@ -329,6 +343,7 @@ def test_moto_fallback_dispatcher_error_handling(monkeypatch):
         _dispatch("PutObject", {"Bucket": bucket_name, "Key": "key"})
 
 
+@markers.aws.unknown
 def test_request_with_response_header_location_fields():
     # CreateHostedZoneResponse has a member "Location" that's located in the headers
     zone_name = f"zone-{short_uid()}.com"

--- a/tests/aws/test_multi_accounts.py
+++ b/tests/aws/test_multi_accounts.py
@@ -1,5 +1,6 @@
 import pytest
 
+from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 
 
@@ -17,6 +18,7 @@ def client_factory(aws_client_factory):
 
 
 class TestMultiAccounts:
+    @markers.aws.unknown
     def test_account_id_namespacing_for_moto_backends(self, client_factory):
         #
         # ACM
@@ -68,6 +70,7 @@ class TestMultiAccounts:
         vpcs = ec2_client1.describe_vpcs()["Vpcs"]
         assert all([vpc["OwnerId"] == account_id1 for vpc in vpcs])
 
+    @markers.aws.unknown
     def test_account_id_namespacing_for_localstack_backends(self, client_factory):
         # Ensure resources are isolated by account ID namespaces
         account_id1 = "420420420420"
@@ -101,6 +104,7 @@ class TestMultiAccounts:
         assert len(sns_client2.list_tags_for_resource(ResourceArn=arn2)["Tags"]) == 2
         assert len(sns_client2.list_tags_for_resource(ResourceArn=arn3)["Tags"]) == 1
 
+    @markers.aws.unknown
     def test_multi_accounts_dynamodb(self, client_factory, cleanups):
         """DynamoDB depends on an external service - DynamoDB Local"""
         account_id1 = "420420420420"
@@ -171,6 +175,7 @@ class TestMultiAccounts:
         response = ddb_client3.describe_table(TableName=tab1)
         assert response["Table"]["ItemCount"] == 3
 
+    @markers.aws.unknown
     def test_multi_accounts_kinesis(self, client_factory):
         """Test that multi-accounts work with external dependency, Kinesis Mock."""
         account_id1 = "420420420420"

--- a/tests/aws/test_multiregion.py
+++ b/tests/aws/test_multiregion.py
@@ -6,6 +6,7 @@ import requests
 from localstack import config
 from localstack.constants import PATH_USER_REQUEST
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
+from localstack.testing.pytest import markers
 from localstack.utils.aws import arns, queries
 from localstack.utils.common import short_uid, to_str
 
@@ -16,6 +17,7 @@ REGION4 = "eu-central-1"
 
 
 class TestMultiRegion:
+    @markers.aws.unknown
     def test_multi_region_sns(self, aws_client_factory):
         sns_1 = aws_client_factory(region_name=REGION1).sns
         sns_2 = aws_client_factory(region_name=REGION2).sns
@@ -36,6 +38,7 @@ class TestMultiRegion:
         assert len(result2) == len_2 + 1
         assert REGION2 in result2[0]["TopicArn"]
 
+    @markers.aws.unknown
     def test_multi_region_api_gateway(self, aws_client_factory):
         gw_1 = aws_client_factory(region_name=REGION1).apigateway
         gw_2 = aws_client_factory(region_name=REGION2).apigateway

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -28,6 +28,7 @@ class TestOpenSearch:
     OpenSearch does not respect any customisations and just returns a domain with localhost.localstack.cloud in.
     """
 
+    @markers.aws.unknown
     def test_default_strategy(
         self, opensearch_wait_for_cluster, assert_host_customisation, aws_client
     ):
@@ -38,6 +39,7 @@ class TestOpenSearch:
 
         assert_host_customisation(endpoint, use_localstack_cloud=True)
 
+    @markers.aws.unknown
     def test_port_strategy(
         self, monkeypatch, opensearch_wait_for_cluster, assert_host_customisation, aws_client
     ):
@@ -53,6 +55,7 @@ class TestOpenSearch:
         else:
             assert_host_customisation(endpoint, custom_host="127.0.0.1")
 
+    @markers.aws.unknown
     def test_path_strategy(
         self, monkeypatch, opensearch_wait_for_cluster, assert_host_customisation, aws_client
     ):
@@ -70,6 +73,7 @@ class TestS3:
     @pytest.mark.skipif(
         condition=config.LEGACY_S3_PROVIDER, reason="Not implemented for legacy provider"
     )
+    @markers.aws.unknown
     def test_non_us_east_1_location(
         self, s3_empty_bucket, cleanups, assert_host_customisation, aws_client
     ):
@@ -89,6 +93,7 @@ class TestS3:
 
         assert_host_customisation(res["Location"], use_hostname_external=True)
 
+    @markers.aws.unknown
     def test_multipart_upload(self, s3_bucket, assert_host_customisation, aws_client):
         key_name = f"key-{short_uid()}"
         upload_id = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key_name)[
@@ -106,6 +111,7 @@ class TestS3:
 
         assert_host_customisation(res["Location"], use_hostname_external=True)
 
+    @markers.aws.unknown
     def test_201_response(self, s3_bucket, assert_host_customisation, aws_client):
         key_name = f"key-{short_uid()}"
         body = "body"
@@ -137,6 +143,7 @@ class TestSQS:
     * hostname_external
     """
 
+    @markers.aws.unknown
     def test_off_strategy_without_external_port(
         self, monkeypatch, sqs_create_queue, assert_host_customisation
     ):
@@ -148,6 +155,7 @@ class TestSQS:
         assert_host_customisation(queue_url, use_localhost=True)
         assert queue_name in queue_url
 
+    @markers.aws.unknown
     def test_off_strategy_with_external_port(
         self, monkeypatch, sqs_create_queue, assert_host_customisation
     ):
@@ -162,6 +170,7 @@ class TestSQS:
         assert queue_name in queue_url
         assert f":{external_port}" in queue_url
 
+    @markers.aws.unknown
     def test_domain_strategy(self, monkeypatch, sqs_create_queue, assert_host_customisation):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "domain")
 
@@ -171,6 +180,7 @@ class TestSQS:
         assert_host_customisation(queue_url, use_localstack_cloud=True)
         assert queue_name in queue_url
 
+    @markers.aws.unknown
     def test_path_strategy(self, monkeypatch, sqs_create_queue, assert_host_customisation):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "path")
 
@@ -183,6 +193,7 @@ class TestSQS:
 
 class TestLambda:
     @pytest.mark.skipif(condition=is_old_provider(), reason="Not implemented for legacy provider")
+    @markers.aws.unknown
     def test_function_url(self, assert_host_customisation, create_lambda_function, aws_client):
         function_name = f"function-{short_uid()}"
         handler_code = ""
@@ -203,6 +214,7 @@ class TestLambda:
         assert_host_customisation(function_url, use_localstack_cloud=True)
 
     @pytest.mark.skipif(condition=is_new_provider(), reason="Not implemented for new provider")
+    @markers.aws.unknown
     def test_http_api_for_function_url(
         self, assert_host_customisation, create_lambda_function, aws_http_client_factory
     ):

--- a/tests/aws/test_notifications.py
+++ b/tests/aws/test_notifications.py
@@ -19,6 +19,7 @@ class TestNotifications:
         finally:
             aws_client.sqs.delete_queue(QueueUrl=queue["QueueUrl"])
 
+    @markers.aws.unknown
     def test_sns_to_sqs(
         self, sqs_create_queue, sns_create_topic, sqs_receive_num_messages, aws_client
     ):

--- a/tests/aws/test_redshift.py
+++ b/tests/aws/test_redshift.py
@@ -1,9 +1,11 @@
 import pytest
 
+from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
 class TestRedshift:
+    @markers.aws.unknown
     def test_create_clusters(self, aws_client):
 
         # create
@@ -30,6 +32,7 @@ class TestRedshift:
             aws_client.redshift.describe_clusters(ClusterIdentifier=cluster_id)
         assert "ClusterNotFound" in str(e)
 
+    @markers.aws.unknown
     def test_cluster_security_groups(self, snapshot, aws_client):
         # Note: AWS parity testing not easily possible with our account, due to error message
         #  "VPC-by-Default customers cannot use cluster security groups"

--- a/tests/aws/test_resourcegroups.py
+++ b/tests/aws/test_resourcegroups.py
@@ -1,9 +1,11 @@
 import json
 
+from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
 class TestResourceGroups:
+    @markers.aws.unknown
     def test_create_group(self, aws_client):
         resource_group_client = aws_client.resource_groups
         name = "resource_group-{}".format(short_uid())

--- a/tests/aws/test_rgsa.py
+++ b/tests/aws/test_rgsa.py
@@ -1,4 +1,8 @@
+from localstack.testing.pytest import markers
+
+
 class TestRGSAIntegrations:
+    @markers.aws.unknown
     def test_get_resources(self, aws_client):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         try:

--- a/tests/aws/test_route53.py
+++ b/tests/aws/test_route53.py
@@ -1,12 +1,14 @@
 import pytest
 
 from localstack.aws.accounts import get_aws_account_id
+from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 
 
 # TODO: add proper cleanup
 class TestRoute53:
+    @markers.aws.unknown
     def test_create_hosted_zone(self, aws_client):
         response = aws_client.route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
@@ -14,6 +16,7 @@ class TestRoute53:
         response = aws_client.route53.get_change(Id="string")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
+    @markers.aws.unknown
     def test_crud_health_check(self, aws_client):
         response = aws_client.route53.create_health_check(
             CallerReference="test123",
@@ -39,6 +42,7 @@ class TestRoute53:
             aws_client.route53.delete_health_check(HealthCheckId=health_check_id)
         assert "NoSuchHealthCheck" in str(ctx.value)
 
+    @markers.aws.unknown
     def test_associate_vpc_with_hosted_zone(self, cleanups, aws_client):
         name = "zone123"
         response = aws_client.route53.create_hosted_zone(
@@ -111,6 +115,7 @@ class TestRoute53:
                 VPC={"VPCRegion": vpc_region, "VPCId": vpc2_id},
             )
 
+    @markers.aws.unknown
     def test_reusable_delegation_sets(self, aws_client):
         client = aws_client.route53
 

--- a/tests/aws/test_s3control.py
+++ b/tests/aws/test_s3control.py
@@ -8,6 +8,7 @@ from localstack.constants import (
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
+from localstack.testing.pytest import markers
 
 remote_endpoint = "https://%s:%s" % (LOCALHOST_HOSTNAME, EDGE_PORT)
 
@@ -21,6 +22,7 @@ def s3control_client(aws_client_factory):
     ).s3control
 
 
+@markers.aws.unknown
 def test_lifecycle_public_access_block(s3control_client):
     with pytest.raises(ClientError) as ce:
         s3control_client.get_public_access_block(AccountId=TEST_AWS_ACCOUNT_ID)
@@ -45,6 +47,7 @@ def test_lifecycle_public_access_block(s3control_client):
     s3control_client.delete_public_access_block(AccountId=TEST_AWS_ACCOUNT_ID)
 
 
+@markers.aws.unknown
 def test_public_access_block_validations(s3control_client):
     with pytest.raises(ClientError) as error:
         s3control_client.get_public_access_block(AccountId="111111111111")

--- a/tests/aws/test_scheduler.py
+++ b/tests/aws/test_scheduler.py
@@ -1,3 +1,7 @@
+from localstack.testing.pytest import markers
+
+
+@markers.aws.unknown
 def test_list_schedules(aws_client):
     # simple smoke test to assert that the provider is available, without creating any schedules
     result = aws_client.scheduler.list_schedules()

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -35,6 +35,7 @@ class TestServerless:
         # run('cd %s; npm run undeploy -- --region=%s' % (cls.get_base_dir(), aws_stack.get_region()))
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_event_rules_deployed(self, aws_client, setup_and_teardown):
         events = aws_client.events
         rules = events.list_rules()["Rules"]
@@ -52,6 +53,7 @@ class TestServerless:
         assert {"source": ["customSource"]} == json.loads(rule["EventPattern"])
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_dynamodb_stream_handler_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-dynamodbStreamHandler"
         table_name = "Test"
@@ -72,6 +74,7 @@ class TestServerless:
         assert event_source_arn == resp["Table"]["LatestStreamArn"]
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_kinesis_stream_handler_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-kinesisStreamHandler"
         function_name2 = "sls-test-local-kinesisConsumerHandler"
@@ -101,6 +104,7 @@ class TestServerless:
         retry(assert_invocations, sleep=2, retries=20)
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_queue_handler_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-queueHandler"
         queue_name = "sls-test-local-CreateQueue"
@@ -128,6 +132,7 @@ class TestServerless:
         assert 3 == redrive_policy["maxReceiveCount"]
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_lambda_with_configs_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-test"
 
@@ -145,6 +150,7 @@ class TestServerless:
         assert 7200 == resp.get("MaximumEventAgeInSeconds")
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_apigateway_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-router"
         existing_api_ids = setup_and_teardown
@@ -174,6 +180,7 @@ class TestServerless:
             )
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_s3_bucket_deployed(self, aws_client, setup_and_teardown):
         s3_client = aws_client.s3
         bucket_name = "testing-bucket"

--- a/tests/aws/test_ses.py
+++ b/tests/aws/test_ses.py
@@ -92,6 +92,7 @@ def sort_mail_sqs_messages(message):
 
 
 class TestSES:
+    @markers.aws.unknown
     def test_list_templates(self, create_template, aws_client):
         create_template(Template=SAMPLE_TEMPLATE)
         templ_list = aws_client.ses.list_templates()["TemplatesMetadata"]
@@ -107,6 +108,7 @@ class TestSES:
         assert SAMPLE_TEMPLATE["TemplateName"] == created_template["Name"]
         assert type(created_template["CreatedTimestamp"]) in (date, datetime)
 
+    @markers.aws.unknown
     def test_delete_template(self, create_template, aws_client):
         templ_list = aws_client.ses.list_templates()["TemplatesMetadata"]
         assert 0 == len(templ_list)
@@ -117,6 +119,7 @@ class TestSES:
         templ_list = aws_client.ses.list_templates()["TemplatesMetadata"]
         assert 0 == len(templ_list)
 
+    @markers.aws.unknown
     def test_get_identity_verification_attributes(self, aws_client):
         domain = "example.com"
         email = f"user-{short_uid()}@example.com"
@@ -130,6 +133,7 @@ class TestSES:
         assert "VerificationToken" in response[domain]
         assert "VerificationToken" not in response[email]
 
+    @markers.aws.unknown
     def test_send_email_can_retrospect(self, aws_client):
         # Test that sent emails can be retrospected through saved file and API access
 
@@ -206,6 +210,7 @@ class TestSES:
         assert requests.delete(emails_url + f"?id={message2_id}").status_code == 204
         assert requests.get(emails_url).json() == {"messages": []}
 
+    @markers.aws.unknown
     def test_send_templated_email_can_retrospect(self, create_template, aws_client):
         # Test that sent emails can be retrospected through saved file and API access
         data_dir = config.dirs.data or config.dirs.tmp
@@ -242,6 +247,7 @@ class TestSES:
         assert requests.delete("http://localhost:4566/_aws/ses").status_code == 204
         assert requests.get("http://localhost:4566/_aws/ses").json() == {"messages": []}
 
+    @markers.aws.unknown
     def test_sent_message_counter(self, create_template, aws_client):
         # Ensure all email send operations correctly update the sent email counter
         email = f"user-{short_uid()}@example.com"
@@ -280,6 +286,7 @@ class TestSES:
         new_counter = aws_client.ses.get_send_quota()["SentLast24Hours"]
         assert new_counter == counter + 1
 
+    @markers.aws.unknown
     def test_clone_receipt_rule_set(self, aws_client):
         # Test that rule set is cloned properly
 
@@ -578,6 +585,7 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
+    @markers.aws.unknown
     def test_cannot_create_event_for_no_topic(
         self, ses_configuration_set, snapshot, account_id, aws_client
     ):
@@ -685,6 +693,7 @@ class TestSES:
         messages = sqs_receive_num_messages(sqs_queue, 1)
         snapshot.match("messages", messages)
 
+    @markers.aws.unknown
     def test_creating_event_destination_without_configuration_set(
         self, sns_topic, snapshot, aws_client
     ):
@@ -707,6 +716,7 @@ class TestSES:
             )
         snapshot.match("create-error", e_info.value.response)
 
+    @markers.aws.unknown
     def test_deleting_non_existent_configuration_set(self, snapshot, aws_client):
         config_set_name = f"config-set-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(config_set_name, "<config-set>"))
@@ -715,6 +725,7 @@ class TestSES:
             aws_client.ses.delete_configuration_set(ConfigurationSetName=config_set_name)
         snapshot.match("delete-error", e_info.value.response)
 
+    @markers.aws.unknown
     def test_deleting_non_existent_configuration_set_event_destination(
         self, ses_configuration_set, snapshot, aws_client
     ):
@@ -731,6 +742,7 @@ class TestSES:
             )
         snapshot.match("delete-error", e_info.value.response)
 
+    @markers.aws.unknown
     def test_trying_to_delete_event_destination_from_non_existent_configuration_set(
         self,
         ses_configuration_set,

--- a/tests/aws/test_sns.py
+++ b/tests/aws/test_sns.py
@@ -3592,6 +3592,7 @@ class TestSNSMultiAccounts:
     def sqs_secondary_client(self, secondary_aws_client):
         return secondary_aws_client.sqs
 
+    @markers.aws.unknown
     def test_cross_account_access(self, sns_primary_client, sns_secondary_client):
         # Cross-account access is supported for below operations.
         # This list is taken from ActionName param of the AddPermissions operation
@@ -3635,6 +3636,7 @@ class TestSNSMultiAccounts:
 
         assert sns_secondary_client.delete_topic(TopicArn=topic_arn)
 
+    @markers.aws.unknown
     def test_cross_account_publish_to_sqs(
         self,
         sns_primary_client,
@@ -3874,6 +3876,7 @@ class TestSNSPublishDelivery:
 
 @markers.aws.only_localstack
 class TestSNSRetrospectionEndpoints:
+    @markers.aws.unknown
     def test_publish_to_platform_endpoint_can_retrospect(
         self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
     ):
@@ -3992,6 +3995,7 @@ class TestSNSRetrospectionEndpoints:
         msg_with_region = requests.get(msgs_url, params={"region": "us-east-1"}).json()
         assert not msg_with_region["platform_endpoint_messages"]
 
+    @markers.aws.unknown
     def test_publish_sms_can_retrospect(self, sns_create_topic, sns_subscription, aws_client):
         sns_store = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
 

--- a/tests/aws/test_sqs.py
+++ b/tests/aws/test_sqs.py
@@ -969,6 +969,7 @@ class TestSqsProvider:
         response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert len(response["Messages"]) == 1
 
+    @markers.aws.unknown
     def test_delete_message_batch_from_lambda(
         self, sqs_create_queue, create_lambda_function, aws_client
     ):
@@ -1695,6 +1696,7 @@ class TestSqsProvider:
 
         snapshot.match("error", e.value.response)
 
+    @markers.aws.unknown
     def test_fifo_set_content_based_deduplication_strategy(
         self, sqs_create_queue, aws_client, snapshot
     ):
@@ -2028,6 +2030,7 @@ class TestSqsProvider:
         e.match("InvalidParameterValue")
 
     @pytest.mark.xfail
+    @markers.aws.unknown
     def test_redrive_policy_attribute_validity(self, sqs_create_queue, sqs_queue_arn, aws_client):
         dl_queue_name = f"dl-queue-{short_uid()}"
         dl_queue_url = sqs_create_queue(QueueName=dl_queue_name)
@@ -2288,6 +2291,7 @@ class TestSqsProvider:
         send_invalid(invalid_attribute)
 
     @pytest.mark.xfail
+    @markers.aws.unknown
     def test_send_message_with_invalid_fifo_parameters(self, sqs_create_queue, aws_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(
@@ -2441,6 +2445,7 @@ class TestSqsProvider:
             == result_send["MessageId"]
         )
 
+    @markers.aws.unknown
     def test_dead_letter_queue_chain(self, sqs_create_queue, aws_client):
         # test a chain of 3 queues, with DLQ flow q1 -> q2 -> q3
 
@@ -2773,6 +2778,7 @@ class TestSqsProvider:
             == "5ae4d5d7636402d80f4eb6d213245a88"
         )
 
+    @markers.aws.unknown
     def test_inflight_message_requeue(self, sqs_create_queue, aws_client):
         visibility_timeout = 3
         queue_name = f"queue-{short_uid()}"
@@ -2913,6 +2919,7 @@ class TestSqsProvider:
         assert "Messages" not in result_recv_2.keys()
 
     @pytest.mark.skip
+    @markers.aws.unknown
     def test_dead_letter_queue_execution_lambda_mapping_preserves_id(
         self, sqs_create_queue, create_lambda_function, aws_client
     ):
@@ -2967,6 +2974,7 @@ class TestSqsProvider:
     # verification of community posted issue
     # FIXME: \r gets lost
     @pytest.mark.skip
+    @markers.aws.unknown
     def test_message_with_carriage_return(self, sqs_create_queue, aws_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -3187,6 +3195,7 @@ class TestSqsProvider:
     @pytest.mark.skip(
         reason="this is an AWS behaviour test that requires 5 minutes to run. Only execute manually"
     )
+    @markers.aws.unknown
     def test_deduplication_interval(self, sqs_create_queue, aws_client):
         # TODO: AWS behaviour here "seems" inconsistent -> current code might need adaption
         fifo_queue_name = f"queue-{short_uid()}.fifo"
@@ -3914,6 +3923,7 @@ class TestSqsQueryApi:
         assert response.ok
         assert "foobar" in response.text
 
+    @markers.aws.unknown
     def test_queue_url_format_path_strategy(self, sqs_create_queue, monkeypatch):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "path")
         queue_name = f"path_queue_{short_uid()}"
@@ -4002,6 +4012,7 @@ class TestSqsQueryApi:
 
 class TestSQSMultiAccounts:
     @pytest.mark.parametrize("strategy", ["domain", "path"])
+    @markers.aws.unknown
     def test_cross_account_access(
         self, monkeypatch, sqs_create_queue, secondary_aws_client, strategy
     ):
@@ -4035,6 +4046,7 @@ class TestSQSMultiAccounts:
         # - UntagQueue
 
     @pytest.mark.parametrize("strategy", ["domain", "path"])
+    @markers.aws.unknown
     def test_cross_account_get_queue_url(
         self, monkeypatch, sqs_create_queue, secondary_aws_client, strategy
     ):

--- a/tests/aws/test_sts.py
+++ b/tests/aws/test_sts.py
@@ -91,6 +91,7 @@ TEST_SAML_ASSERTION = """
 
 
 class TestSTSIntegrations:
+    @markers.aws.unknown
     def test_assume_role(self, aws_client):
         test_role_session_name = "s3-access-example"
         test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
@@ -104,6 +105,7 @@ class TestSTSIntegrations:
             assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
             assert assume_role_id_parts[1] == test_role_session_name
 
+    @markers.aws.unknown
     def test_assume_role_with_web_identity(self, aws_client):
         test_role_session_name = "web_token"
         test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
@@ -120,6 +122,7 @@ class TestSTSIntegrations:
             assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
             assert assume_role_id_parts[1] == test_role_session_name
 
+    @markers.aws.unknown
     def test_assume_role_with_saml(self, aws_client):
         account_id = "000000000000"
         role_name = "test-role"
@@ -152,6 +155,7 @@ class TestSTSIntegrations:
             assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
             assert assume_role_id_parts[1] == fed_name
 
+    @markers.aws.unknown
     def test_get_federation_token(self, aws_client):
         token_name = "TestName"
         response = aws_client.sts.get_federation_token(Name=token_name)

--- a/tests/aws/test_support.py
+++ b/tests/aws/test_support.py
@@ -1,6 +1,7 @@
 import pytest
 
 from localstack.constants import AWS_REGION_US_EAST_1
+from localstack.testing.pytest import markers
 
 TEST_SUPPORT_CASE = {
     "subject": "Urgent - DynamoDB is down",
@@ -31,6 +32,7 @@ class TestConfigService:
         )
         return response["caseId"]
 
+    @markers.aws.unknown
     def test_create_support_case(self, support_client, case_id_test):
         support_cases = support_client.describe_cases()["cases"]
         assert len(support_cases) == 1
@@ -38,6 +40,7 @@ class TestConfigService:
         for key in TEST_SUPPORT_CASE.keys():
             assert support_cases[0][key] == TEST_SUPPORT_CASE[key]
 
+    @markers.aws.unknown
     def test_resolve_case(self, support_client, case_id_test):
         response = support_client.resolve_case(caseId=case_id_test)
         assert response["finalCaseStatus"] == "resolved"

--- a/tests/aws/test_swf.py
+++ b/tests/aws/test_swf.py
@@ -1,3 +1,4 @@
+from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 
 DEFAULT_TASK_LIST = {"name": "default"}
@@ -5,6 +6,7 @@ SWF_VERSION = "1.0"
 
 
 class TestSwf:
+    @markers.aws.unknown
     def test_run_workflow(self, aws_client):
         swf_client = aws_client.swf
 

--- a/tests/aws/test_terraform.py
+++ b/tests/aws/test_terraform.py
@@ -95,6 +95,7 @@ class TestTerraform:
         start_worker_thread(_run)
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_bucket_exists(self, aws_client):
         response = aws_client.s3.head_bucket(Bucket=BUCKET_NAME)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -114,6 +115,7 @@ class TestTerraform:
         assert response["Status"] == "Enabled"
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_sqs(self, aws_client):
         queue_url = aws_client.sqs.get_queue_url(QueueName=QUEUE_NAME)["QueueUrl"]
         response = aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
@@ -124,6 +126,7 @@ class TestTerraform:
         assert response["Attributes"]["ReceiveMessageWaitTimeSeconds"] == "10"
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_lambda(self, aws_client):
         account_id = get_aws_account_id()
         response = aws_client.awslambda.get_function(FunctionName=LAMBDA_NAME)
@@ -133,6 +136,7 @@ class TestTerraform:
         assert response["Configuration"]["Role"] == LAMBDA_ROLE.format(account_id=account_id)
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_event_source_mapping(self, aws_client):
         queue_arn = QUEUE_ARN.format(account_id=get_aws_account_id())
         lambda_arn = LAMBDA_ARN.format(account_id=get_aws_account_id(), lambda_name=LAMBDA_NAME)
@@ -145,6 +149,7 @@ class TestTerraform:
 
     @markers.skip_offline
     @pytest.mark.xfail(reason="flaky")
+    @markers.aws.unknown
     def test_apigateway(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()
 
@@ -174,6 +179,7 @@ class TestTerraform:
         assert res2[0]["resourceMethods"]["GET"]["methodIntegration"]["uri"]
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_route53(self, aws_client):
         response = aws_client.route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
@@ -183,6 +189,7 @@ class TestTerraform:
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_acm(self, aws_client):
         certs = aws_client.acm.list_certificates()["CertificateSummaryList"]
         certs = [c for c in certs if c.get("DomainName") == "example.com"]
@@ -190,6 +197,7 @@ class TestTerraform:
 
     @markers.skip_offline
     @pytest.mark.xfail(reason="flaky")
+    @markers.aws.unknown
     def test_apigateway_escaped_policy(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()
 
@@ -202,6 +210,7 @@ class TestTerraform:
         assert len(service_apis) == 1
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_dynamodb(self, aws_client):
         def _table_exists(tablename, dynamotables):
             return any(name for name in dynamotables["TableNames"] if name == tablename)
@@ -212,6 +221,7 @@ class TestTerraform:
         assert _table_exists("tf_dynamotable3", tables)
 
     @markers.skip_offline
+    @markers.aws.unknown
     def test_security_groups(self, aws_client):
         rules = aws_client.ec2.describe_security_groups(MaxResults=100)["SecurityGroups"]
         matching = [r for r in rules if r["Description"] == "TF SG with ingress / egress rules"]

--- a/tests/aws/test_transcribe.py
+++ b/tests/aws/test_transcribe.py
@@ -95,6 +95,7 @@ class TestTranscribe:
             "files/en-gb.webm",
         ],
     )
+    @markers.aws.unknown
     def test_transcribe_supported_media_formats(
         self, transcribe_create_job, media_file, aws_client
     ):
@@ -120,6 +121,7 @@ class TestTranscribe:
 
         retry(_assert_transcript, retries=30, sleep=2)
 
+    @markers.aws.unknown
     def test_transcribe_unsupported_media_format_failure(self, transcribe_create_job, aws_client):
         # Ensure transcribing an empty file fails
         file_path = new_tmp_file()


### PR DESCRIPTION
## Motivation

We want to start enforcing each test being marked with one of the `@markers.aws.*` pytest markers. As a sort of "todo"-marker the `@markers.aws.unknown` marker is added for all tests that so far didn't have either `aws_validated` or `only_localstack` markers

## Changes

- Marks each test case that doesn't already have an `markers.aws.*` pytest marker with `@markers.aws.unknown`

## TODO

- [ ] Identify places where classes have markers assigned
- [ ] Identify places where a module has a marker assigned via `pytestmark`

