### PR TITLE
add validated marker to snapshotted tests

### DIFF
--- a/tests/aws/apigateway/test_apigateway_import.py
+++ b/tests/aws/apigateway/test_apigateway_import.py
@@ -645,7 +645,7 @@ class TestApiGatewayImportRestApi:
             # TODO: this is really weird, after importing, AWS returns them empty?
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_import_with_circular_models_and_request_validation(
         self, import_apigw, apigw_snapshot_imported_resources, aws_client, snapshot
     ):

--- a/tests/aws/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/apigateway/test_apigateway_integrations.py
@@ -485,7 +485,7 @@ def create_vpc_endpoint(default_vpc, aws_client):
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..endpointConfiguration.types", "$..policy.Statement..Resource"]
 )
-@markers.aws.unknown
+@markers.aws.validated
 def test_create_execute_api_vpc_endpoint(
     create_rest_api_with_integration,
     dynamodb_create_table,

--- a/tests/aws/apigateway/test_apigateway_kinesis.py
+++ b/tests/aws/apigateway/test_apigateway_kinesis.py
@@ -11,7 +11,7 @@ from tests.aws.apigateway.conftest import DEFAULT_STAGE_NAME
 # PutRecord does not return EncryptionType, but it's documented as such.
 # xxx requires further investigation
 @markers.snapshot.skip_snapshot_verify(paths=["$..EncryptionType", "$..ChildShards"])
-@markers.aws.unknown
+@markers.aws.validated
 def test_apigateway_to_kinesis(
     kinesis_create_stream,
     wait_for_stream_ready,

--- a/tests/aws/awslambda/test_lambda_api.py
+++ b/tests/aws/awslambda/test_lambda_api.py
@@ -299,7 +299,7 @@ class TestLambdaFunction:
             method(FunctionName=wrong_region_arn)
         snapshot.match("wrong_region_exception", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_lambda_code_location_zipfile(
         self, snapshot, create_lambda_function_aws, lambda_su_role, aws_client
     ):
@@ -346,7 +346,7 @@ class TestLambdaFunction:
             == get_function_response_updated["Configuration"]["CodeSize"]
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_lambda_code_location_s3(
         self, s3_bucket, snapshot, create_lambda_function_aws, lambda_su_role, aws_client
     ):
@@ -3706,7 +3706,7 @@ class TestCodeSigningConfig:
         )
         snapshot.match("delete_code_signing_config", response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_code_signing_not_found_excs(
         self, snapshot, create_lambda_function, account_id, aws_client
     ):
@@ -4050,7 +4050,7 @@ class TestLambdaEventSourceMappings:
             "$..UUID",
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_event_source_mapping_lifecycle(
         self,
         create_lambda_function,
@@ -4124,7 +4124,7 @@ class TestLambdaEventSourceMappings:
         # lambda_client.delete_event_source_mapping(UUID=uuid)
 
     @pytest.mark.skipif(is_old_provider(), reason="new provider only")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_event_source_validation(
         self, create_lambda_function, lambda_su_role, dynamodb_create_table, snapshot, aws_client
     ):
@@ -4156,7 +4156,7 @@ class TestLambdaEventSourceMappings:
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not correctly supported")
 class TestLambdaTags:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_tag_exceptions(self, create_lambda_function, snapshot, account_id, aws_client):
         function_name = f"fn-tag-{short_uid()}"
         create_lambda_function(
@@ -4257,7 +4257,7 @@ class TestLambdaTags:
             aws_client.awslambda.tag_resource(Resource=function_arn, Tags={"a_key": "a_value"})
         snapshot.match("tag_lambda_too_many_tags_additional", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_tag_versions(self, create_lambda_function, snapshot, aws_client):
         function_name = f"fn-tag-{short_uid()}"
         create_function_result = create_lambda_function(
@@ -4608,7 +4608,7 @@ class TestLambdaLayer:
             )
         snapshot.match("create_function_with_layer_in_different_region", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_layer_function_quota_exception(
         self, create_lambda_function, snapshot, dummylayer, cleanups, aws_client
     ):

--- a/tests/aws/awslambda/test_lambda_destinations.py
+++ b/tests/aws/awslambda/test_lambda_destinations.py
@@ -170,7 +170,7 @@ class TestLambdaDestinationSqs:
     @pytest.mark.skipif(
         condition=is_old_provider(), reason="config variable only supported in new provider"
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_lambda_destination_default_retries(
         self,
         create_lambda_function,

--- a/tests/aws/awslambda/test_lambda_legacy.py
+++ b/tests/aws/awslambda/test_lambda_legacy.py
@@ -266,7 +266,7 @@ class TestRubyRuntimes:
         reason="ruby runtimes not supported in local invocation",
     )
     @markers.snapshot.skip_snapshot_verify
-    @markers.aws.unknown
+    @markers.aws.validated
     # general invocation test
     def test_ruby_lambda_running_in_docker(self, create_lambda_function, snapshot, aws_client):
         """Test simple ruby lambda invocation"""
@@ -291,7 +291,7 @@ class TestRubyRuntimes:
 class TestGolangRuntimes:
     @markers.snapshot.skip_snapshot_verify
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.validated
     # general invocation test
     def test_golang_lambda(self, tmp_path, create_lambda_function, snapshot, aws_client):
         """Test simple golang lambda invocation"""

--- a/tests/aws/awslambda/test_lambda_runtimes.py
+++ b/tests/aws/awslambda/test_lambda_runtimes.py
@@ -321,7 +321,7 @@ class TestJavaRuntimes:
         ],
     )
     @pytest.mark.xfail(is_old_provider(), reason="Test flaky with local executor.")
-    @markers.aws.unknown
+    @markers.aws.validated
     # TODO maybe snapshot payload as well
     def test_java_lambda_subscribe_sns_topic(
         self,

--- a/tests/aws/cloudcontrol/test_cloudcontrol_api.py
+++ b/tests/aws/cloudcontrol/test_cloudcontrol_api.py
@@ -264,7 +264,7 @@ class TestCloudControlResourceApi:
         snapshot.match("list_typenotfound_exc", e.value.response)
 
     @pytest.mark.skip(reason="advanced feature, will be added later")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_list_resources_with_resource_model(self, create_resource, snapshot, aws_client):
         """
         See: https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-operations-list.html

--- a/tests/aws/cloudformation/api/test_changesets.py
+++ b/tests/aws/cloudformation/api/test_changesets.py
@@ -69,7 +69,7 @@ def test_create_change_set_without_parameters(
 
 # TODO: implement
 @pytest.mark.xfail(condition=not is_aws_cloud(), reason="Not properly implemented")
-@markers.aws.unknown
+@markers.aws.validated
 def test_create_change_set_update_without_parameters(
     cleanup_stacks,
     cleanup_changesets,

--- a/tests/aws/cloudformation/api/test_extensions_api.py
+++ b/tests/aws/cloudformation/api/test_extensions_api.py
@@ -29,7 +29,7 @@ class TestExtensionsApi:
             ("HOOK", "LocalStack::Testing::TestHook", "hooks/localstack-testing-testhook.zip"),
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_crud_extension(
         self,
         deploy_cfn_template,
@@ -91,7 +91,7 @@ class TestExtensionsApi:
         snapshot.match("deregister_response", deregister_response)
 
     @pytest.mark.skip(reason="test not completed")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_extension_versioning(self, s3_bucket, snapshot, aws_client):
         """
         This tests validates some api behaviours and errors resulting of creating and deleting versions of extensions.
@@ -169,7 +169,7 @@ class TestExtensionsApi:
         snapshot.match("deleting_default_response", delete_default_response)
 
     @pytest.mark.skip(reason="feature not implemented")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_extension_not_complete(self, s3_bucket, snapshot, aws_client):
         """
         This tests validates the error of Extension not found using the describe_type operation when the registration
@@ -204,7 +204,7 @@ class TestExtensionsApi:
         )
 
     @pytest.mark.skip(reason="feature not implemented")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_extension_type_configuration(self, register_extension, snapshot, aws_client):
         artifact_path = os.path.join(
             os.path.dirname(__file__),

--- a/tests/aws/cloudformation/api/test_extensions_hooks.py
+++ b/tests/aws/cloudformation/api/test_extensions_hooks.py
@@ -12,7 +12,7 @@ from localstack.utils.strings import short_uid
 class TestExtensionsHooks:
     @pytest.mark.skip(reason="feature not implemented")
     @pytest.mark.parametrize("failure_mode", ["FAIL", "WARN"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_hook_deployment(
         self, failure_mode, register_extension, snapshot, cleanups, aws_client
     ):

--- a/tests/aws/cloudformation/api/test_extensions_modules.py
+++ b/tests/aws/cloudformation/api/test_extensions_modules.py
@@ -8,7 +8,7 @@ from localstack.utils.strings import short_uid
 
 class TestExtensionsModules:
     @pytest.mark.skip(reason="feature not supported")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_module_usage(self, deploy_cfn_template, register_extension, snapshot, aws_client):
 
         artifact_path = os.path.join(

--- a/tests/aws/cloudformation/api/test_extensions_resourcetypes.py
+++ b/tests/aws/cloudformation/api/test_extensions_resourcetypes.py
@@ -8,7 +8,7 @@ from localstack.utils.strings import short_uid
 
 class TestExtensionsResourceTypes:
     @pytest.mark.skip(reason="feature not implemented")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_deploy_resource_type(
         self, deploy_cfn_template, register_extension, snapshot, aws_client
     ):

--- a/tests/aws/cloudformation/api/test_stacks.py
+++ b/tests/aws/cloudformation/api/test_stacks.py
@@ -227,7 +227,7 @@ class TestStacksApi:
         assert "No updates are to be performed." in error_message
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..StackEvents"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_list_events_after_deployment(self, deploy_cfn_template, snapshot, aws_client):
         snapshot.add_transformer(SortingTransformer("StackEvents", lambda x: x["Timestamp"]))
         snapshot.add_transformer(snapshot.transform.cloudformation_api())

--- a/tests/aws/cloudformation/resource_providers/iam/aws_iam_user/test_exploration.py
+++ b/tests/aws/cloudformation/resource_providers/iam/aws_iam_user/test_exploration.py
@@ -12,7 +12,7 @@ RESOURCE_GETATT_TARGETS = ["Path", "UserName", "Id", "Arn", "PermissionsBoundary
 class TestAttributeAccess:
     @pytest.mark.parametrize("attribute", RESOURCE_GETATT_TARGETS)
     @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Exploratory test only")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_getatt(
         self,
         aws_client,

--- a/tests/aws/cloudformation/resource_providers/opensearch/test_domain.py
+++ b/tests/aws/cloudformation/resource_providers/opensearch/test_domain.py
@@ -24,7 +24,7 @@ class TestAttributeAccess:
         raises=StackDeployError,
     )
     @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Exploratory test only")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_getattr(
         self,
         aws_client: ServiceLevelClientFactory,

--- a/tests/aws/cloudformation/resource_providers/ssm/test_parameter.py
+++ b/tests/aws/cloudformation/resource_providers/ssm/test_parameter.py
@@ -10,7 +10,7 @@ from localstack.testing.pytest import markers
 class TestBasicCRD:
     @pytest.mark.skip(reason="re-enable after fixing schema extraction")
     @markers.snapshot.skip_snapshot_verify(paths=["$..error-message"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_black_box(self, deploy_cfn_template, aws_client: ServiceLevelClientFactory, snapshot):
         stack = deploy_cfn_template(
             template_path=os.path.join(
@@ -37,7 +37,7 @@ class TestBasicCRD:
 
 class TestUpdates:
     @pytest.mark.skip(reason="TODO")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_update_without_replacement(self, deploy_cfn_template, aws_client, snapshot):
         stack = deploy_cfn_template(
             template_path=os.path.join(

--- a/tests/aws/cloudformation/resource_providers/ssm/test_parameter_getatt_exploration.py
+++ b/tests/aws/cloudformation/resource_providers/ssm/test_parameter_getatt_exploration.py
@@ -22,7 +22,7 @@ RESOURCE_GETATT_TARGETS = [
 class TestAttributeAccess:
     @pytest.mark.parametrize("attribute", RESOURCE_GETATT_TARGETS)
     @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Exploratory test only")
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_getattr(
         self,
         aws_client: ServiceLevelClientFactory,

--- a/tests/aws/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/cloudformation/resources/test_apigateway.py
@@ -411,7 +411,7 @@ def test_update_usage_plan(deploy_cfn_template, aws_client):
         aws_client.apigateway.delete_usage_plan(usagePlanId=plan["id"])
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_api_gateway_with_policy_as_dict(deploy_cfn_template, snapshot, aws_client):
     template = """
     Parameters:

--- a/tests/aws/cloudformation/resources/test_cloudformation.py
+++ b/tests/aws/cloudformation/resources/test_cloudformation.py
@@ -61,7 +61,7 @@ class SignalSuccess(Thread):
 
 
 @markers.snapshot.skip_snapshot_verify(paths=["$..WaitConditionName"])
-@markers.aws.unknown
+@markers.aws.validated
 def test_waitcondition(deploy_cfn_template, snapshot, aws_client):
     """
     Complicated test, since we have a wait condition that must signal

--- a/tests/aws/cloudformation/resources/test_logs.py
+++ b/tests/aws/cloudformation/resources/test_logs.py
@@ -3,7 +3,7 @@ import os.path
 from localstack.testing.pytest import markers
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_logstream(deploy_cfn_template, snapshot, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(

--- a/tests/aws/cloudformation/test_template_engine.py
+++ b/tests/aws/cloudformation/test_template_engine.py
@@ -948,7 +948,7 @@ class TestMacros:
             "raise_error.py",
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_failed_state(
         self,
         deploy_cfn_template,

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -3322,7 +3322,7 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(
         condition=lambda: LEGACY_S3_PROVIDER, paths=["$..Error.RequestID"]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_bucket_does_not_exist(self, s3_vhost_client, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = f"bucket-does-not-exist-{short_uid()}"
@@ -5537,7 +5537,7 @@ class TestS3:
         [True, False],
     )
     @markers.snapshot.skip_snapshot_verify(paths=["$..x-amz-server-side-encryption"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_get_object_content_length_with_virtual_host(
         self,
         s3_bucket,

--- a/tests/aws/s3/test_s3_api.py
+++ b/tests/aws/s3/test_s3_api.py
@@ -12,7 +12,7 @@ from localstack.testing.pytest import markers
     reason="These are WIP tests for the new native S3 provider",
 )
 class TestS3BucketCRUD:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         key_name = "test-delete"
@@ -29,7 +29,7 @@ class TestS3BucketCRUD:
         snapshot.match("delete-bucket", delete_bucket)
         # TODO: write a test with a multipart upload that is not completed?
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_versioned_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # enable versioning on the bucket
@@ -70,7 +70,7 @@ class TestS3BucketCRUD:
     reason="These are WIP tests for the new native S3 provider",
 )
 class TestS3ObjectCRUD:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_object(self, s3_bucket, aws_client, snapshot):
         key_name = "test-delete"
         put_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test-delete")
@@ -88,7 +88,7 @@ class TestS3ObjectCRUD:
             )
         snapshot.match("delete-nonexistent-object-versionid", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_objects(self, s3_bucket, aws_client, snapshot):
         key_name = "test-delete"
         put_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Body="test-delete")
@@ -117,7 +117,7 @@ class TestS3ObjectCRUD:
 
         snapshot.match("delete-objects", delete_objects)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_object_versioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # enable versioning on the bucket
@@ -215,7 +215,7 @@ class TestS3ObjectCRUD:
         delete_wrong_key = aws_client.s3.delete_object(Bucket=s3_bucket, Key="wrong-key")
         snapshot.match("delete-wrong-key", delete_wrong_key)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_objects_versioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformer(snapshot.transform.key_value("DeleteMarkerVersionId"))
@@ -296,7 +296,7 @@ class TestS3ObjectCRUD:
     def test_delete_object_on_suspended_bucket(self):
         pass
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_get_object_with_version_unversioned_bucket(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -313,7 +313,7 @@ class TestS3ObjectCRUD:
         get_obj = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name, VersionId="null")
         snapshot.match("get-obj-with-null-version", get_obj)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_list_object_versions_order_unversioned(self, s3_bucket, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
 

--- a/tests/aws/stepfunctions/v2/error_handling/test_task_service_dynamodb.py
+++ b/tests/aws/stepfunctions/v2/error_handling/test_task_service_dynamodb.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceDynamoDB:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invalid_param(
         self,
         aws_client,
@@ -54,7 +54,7 @@ class TestTaskServiceDynamoDB:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_put_item_no_such_table(
         self,
         aws_client,
@@ -89,7 +89,7 @@ class TestTaskServiceDynamoDB:
             "$..error"  # TODO: LS returns a ResourceNotFoundException instead of reflecting the validation error
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_put_item_invalid_table_name(
         self,
         aws_client,

--- a/tests/aws/stepfunctions/v2/error_handling/test_task_service_sqs.py
+++ b/tests/aws/stepfunctions/v2/error_handling/test_task_service_sqs.py
@@ -119,7 +119,7 @@ class TestTaskServiceSqs:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_sqs_failure_in_wait_for_task_tok(
         self,
         aws_client,

--- a/tests/aws/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -40,7 +40,7 @@ class TestTaskServiceAwsSdk:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_dynamodb_put_get_item(
         self,
         aws_client,
@@ -73,7 +73,7 @@ class TestTaskServiceAwsSdk:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_dynamodb_put_delete_item(
         self,
         aws_client,
@@ -106,7 +106,7 @@ class TestTaskServiceAwsSdk:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_dynamodb_put_update_get_item(
         self,
         aws_client,

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -1653,7 +1653,7 @@ class TestDynamoDB:
             "$..PointInTimeRecoveryDescription..LatestRestorableDateTime",
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_continuous_backup_update(self, dynamodb_create_table, snapshot, aws_client):
         table_name = f"table-{short_uid()}"
         dynamodb_create_table(

--- a/tests/aws/test_logs.py
+++ b/tests/aws/test_logs.py
@@ -151,7 +151,7 @@ class TestCloudWatchLogs:
             "$..describe-log-groups-pattern.nextToken",
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_and_delete_log_stream(self, logs_log_group, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.logs_api())
         test_name = f"test-log-stream-{short_uid()}"

--- a/tests/aws/test_redshift.py
+++ b/tests/aws/test_redshift.py
@@ -32,7 +32,7 @@ class TestRedshift:
             aws_client.redshift.describe_clusters(ClusterIdentifier=cluster_id)
         assert "ClusterNotFound" in str(e)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_cluster_security_groups(self, snapshot, aws_client):
         # Note: AWS parity testing not easily possible with our account, due to error message
         #  "VPC-by-Default customers cannot use cluster security groups"

--- a/tests/aws/test_ses.py
+++ b/tests/aws/test_ses.py
@@ -585,7 +585,7 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_cannot_create_event_for_no_topic(
         self, ses_configuration_set, snapshot, account_id, aws_client
     ):
@@ -693,7 +693,7 @@ class TestSES:
         messages = sqs_receive_num_messages(sqs_queue, 1)
         snapshot.match("messages", messages)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_creating_event_destination_without_configuration_set(
         self, sns_topic, snapshot, aws_client
     ):
@@ -716,7 +716,7 @@ class TestSES:
             )
         snapshot.match("create-error", e_info.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_deleting_non_existent_configuration_set(self, snapshot, aws_client):
         config_set_name = f"config-set-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(config_set_name, "<config-set>"))
@@ -725,7 +725,7 @@ class TestSES:
             aws_client.ses.delete_configuration_set(ConfigurationSetName=config_set_name)
         snapshot.match("delete-error", e_info.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_deleting_non_existent_configuration_set_event_destination(
         self, ses_configuration_set, snapshot, aws_client
     ):
@@ -742,7 +742,7 @@ class TestSES:
             )
         snapshot.match("delete-error", e_info.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_trying_to_delete_event_destination_from_non_existent_configuration_set(
         self,
         ses_configuration_set,

--- a/tests/aws/test_sqs.py
+++ b/tests/aws/test_sqs.py
@@ -1696,7 +1696,7 @@ class TestSqsProvider:
 
         snapshot.match("error", e.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_fifo_set_content_based_deduplication_strategy(
         self, sqs_create_queue, aws_client, snapshot
     ):


### PR DESCRIPTION

## Motivation

We currently assume any tests that use snapshots have been validated as a fairly simply heuristic to find validated tests that haven't been properly marked in the past.

## Changes

Any test with a `snapshot` in its arguments and a `@markers.aws.unknown` is now marked as `@markers.aws.validated`


