### PR TITLE
Enforce exactly one AWS pytest marker on each test case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ jobs:
       - run:
           name: Linting
           command: make lint
+      - run:
+          name: Checking AWS compatibility markers
+          command: make check-aws-markers
 
   unit-tests:
     executor: ubuntu-machine-amd64

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,9 @@ lint:              		  ## Run code linter to check code style
 lint-modified:     		  ## Run code linter on modified files
 	($(VENV_RUN); python -m pflake8 --show-source `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs` )
 
+check-aws-markers:     		  ## Lightweight check to ensure all AWS tests have proper compatibilty markers set
+	($(VENV_RUN); python -m pytest --co tests/aws/)
+
 format:            		  ## Run black and isort code formatter
 	($(VENV_RUN); python -m isort localstack tests; python -m black localstack tests )
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -66,12 +66,12 @@ class Markers:
 
 @pytest.hookimpl
 def pytest_collection_modifyitems(
-    session: pytest.Session, config: Any, items: list[pytest.Item]
+    session: pytest.Session, config: Any, items: List[pytest.Item]
 ) -> None:
     """Enforce that each test has exactly one"""
     marker_errors = []
     for item in items:
-        # TODO: we should only concern ourselves with tests in tests/aws/
+        # we should only concern ourselves with tests in tests/aws/
         if "tests/aws" not in item.fspath.dirname:
             continue
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -68,7 +68,7 @@ class Markers:
 def pytest_collection_modifyitems(
     session: pytest.Session, config: Any, items: List[pytest.Item]
 ) -> None:
-    """Enforce that each test has exactly one"""
+    """Enforce that each test has exactly one aws compatibility marker"""
     marker_errors = []
     for item in items:
         # we should only concern ourselves with tests in tests/aws/

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -1,7 +1,7 @@
 """
 Custom pytest mark typings
 """
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import pytest
 
@@ -33,7 +33,7 @@ class SkipSnapshotVerifyMarker:
         self,
         *,
         paths: "Optional[List[str]]" = None,
-        condition: "Optional[Callable[[...], bool]]" = None
+        condition: "Optional[Callable[[...], bool]]" = None,
     ):
         ...
 
@@ -59,3 +59,33 @@ class Markers:
     only_on_amd64 = pytest.mark.only_on_amd64
     resource_heavy = pytest.mark.resource_heavy
     only_in_docker = pytest.mark.only_in_docker
+
+
+# pytest plugin
+
+
+@pytest.hookimpl
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: Any, items: list[pytest.Item]
+) -> None:
+    """Enforce that each test has exactly one"""
+    marker_errors = []
+    for item in items:
+        # TODO: we should only concern ourselves with tests in tests/aws/
+        if "tests/aws" not in item.fspath.dirname:
+            continue
+
+        aws_markers = list()
+        for mark in item.iter_markers():
+            if mark.name.startswith("aws_"):
+                aws_markers.append(mark.name)
+
+        if len(aws_markers) > 1:
+            marker_errors.append(f"{item.nodeid}: Too many aws markers specified: {aws_markers}")
+        elif len(aws_markers) == 0:
+            marker_errors.append(
+                f"{item.nodeid}: Missing aws marker. Specify at least one marker, e.g. @markers.aws.validated"
+            )
+
+    if marker_errors:
+        raise pytest.UsageError(*marker_errors)

--- a/tests/aws/test_ses.py
+++ b/tests/aws/test_ses.py
@@ -348,8 +348,7 @@ class TestSES:
         assert original_rule_set["Rules"] == rule_set["Rules"]
         assert [x["Name"] for x in rule_set["Rules"]] == rule_names
 
-    @markers.aws.only_localstack
-    @markers.aws.validated
+    @markers.aws.only_localstack  # TODO: clarify
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -429,8 +428,7 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-    @markers.aws.only_localstack
-    @markers.aws.validated
+    @markers.aws.only_localstack  # TODO: clarify
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -510,8 +508,7 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-    @markers.aws.only_localstack
-    @markers.aws.validated
+    @markers.aws.only_localstack  # TODO: clarify
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",

--- a/tests/aws/test_sns.py
+++ b/tests/aws/test_sns.py
@@ -2272,8 +2272,7 @@ class TestSNSProvider:
         # binary payload in base64 encoded by AWS, UTF-8 for JSON
         # https://docs.aws.amazon.com/sns/latest/api/API_MessageAttributeValue.html
 
-    @markers.aws.only_localstack
-    @markers.aws.validated
+    @markers.aws.only_localstack  # TODO: clarify
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     def test_subscribe_external_http_endpoint(
         self, sns_create_http_endpoint, raw_message_delivery, aws_client, snapshot

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ pytest_plugins = [
     "localstack.testing.pytest.filters",
     "localstack.testing.pytest.fixture_conflicts",
     "localstack.testing.pytest.detect_thread_leakage",
+    "localstack.testing.pytest.marking",
 ]
 
 


### PR DESCRIPTION
## Motivation

To make sure we don't forget to properly mark tests in `tests/aws/` a new guard in the pytest collection step is introduced which will fail in the collect step, i.e. before attempting to execute any tests.

## Changes

- Tests will immediately fail when they have no `@markers.aws.*` attached
- Tests will also immediately fail when they have more than one `@markers.aws.*` attached
- A new step has been added to the preflight job in circleci to fail as early as possible.

