### PR TITLE
Add ability to specify custom IDs for KMS keys

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -142,7 +142,7 @@ VALID_OPERATIONS = [
     "GenerateDataKeyPairWithoutPlaintext",
 ]
 
-# special tag name to allow specifying a custom ID for new REST APIs
+# special tag name to allow specifying a custom ID for created keys
 TAG_KEY_CUSTOM_ID = "_custom_id_"
 
 
@@ -203,7 +203,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         store = kms_stores[account_id][region_name]
         key = KmsKey(request, account_id, region_name)
 
-        # check if the _custom_id_ tag is specified, to set a user-defined ID for this key
+        # check if the _custom_id_ tag is specified, to set a user-defined KeyId for this key
         tags_dict = {tag["TagKey"]: tag["TagValue"] for tag in request.get("Tags", [])}
         custom_id = tags_dict.get(TAG_KEY_CUSTOM_ID)
         if custom_id and custom_id.strip():

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -142,6 +142,9 @@ VALID_OPERATIONS = [
     "GenerateDataKeyPairWithoutPlaintext",
 ]
 
+# special tag name to allow specifying a custom ID for new REST APIs
+TAG_KEY_CUSTOM_ID = "_custom_id_"
+
 
 class ValidationError(CommonServiceException):
     """General validation error type (defined in the AWS docs, but not part of the botocore spec)"""
@@ -199,7 +202,15 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> KmsKey:
         store = kms_stores[account_id][region_name]
         key = KmsKey(request, account_id, region_name)
-        key_id = key.metadata.get("KeyId")
+
+        # check if the _custom_id_ tag is specified, to set a user-defined ID for this key
+        tags_dict = {tag["TagKey"]: tag["TagValue"] for tag in request.get("Tags", [])}
+        custom_id = tags_dict.get(TAG_KEY_CUSTOM_ID)
+        if custom_id and custom_id.strip():
+            key.metadata["KeyId"] = custom_id.strip()
+            key.calculate_and_set_arn(account_id=account_id, region=region_name)
+
+        key_id = key.metadata["KeyId"]
         store.keys[key_id] = key
         return key
 


### PR DESCRIPTION
## Motivation

Some users have requested to specify custom IDs for KMS keys. The old `local-kms` KMS provider used to allow preseeding keys on LocalStack startup. This is now a bit more tricky, as with our new provider each key would get a new ID, making it harder for users to create test scripts that rely on static key IDs.

## Changes

* Add ability to specify custom IDs for KMS keys. We're using the `_custom_id_` tag key, which is already used in other places, e.g., for [API Gateway](https://docs.localstack.cloud/user-guide/aws/apigateway/#custom-ids-for-api-gateway-resources-via-tags)
* Add a small integration test (marked as `only_localstack`) to cover this functionality

## TODO

- [ ] Update the docs to cover this new feature
