### PR TITLE
fix: S3 multipart upload part 10000

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -789,7 +789,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
             )
-        elif (part_number := request.get("PartNumber", 0)) < 1 or part_number >= 10000:
+        elif (part_number := request.get("PartNumber", 0)) < 1 or part_number > 10000:
             raise InvalidArgument(
                 "Part number must be an integer between 1 and 10000, inclusive",
                 ArgumentName="partNumber",


### PR DESCRIPTION
Include part number 10000 in allowed part numbers when checking for PartNumber in UploadPart handler.

Fixes #8869

## Motivation

Fix a non-conformity with respect to AWS S3 API. Without this fix `localstack` doesn't allow part number 10000 in multipart upload.

## Changes

Fix part number validation in UploadPart handler