### PR TITLE
implement S3 native object lock

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -846,6 +846,13 @@ class InvalidTag(ServiceException):
     TagValue: Optional[Value]
 
 
+class ObjectLockConfigurationNotFoundError(ServiceException):
+    code: str = "ObjectLockConfigurationNotFoundError"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1031,6 +1031,23 @@
         "documentation": "<p>The tag provided was not a valid tag. This error can occur if the tag did not pass input validation.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ObjectLockConfigurationNotFoundError",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>Object Lock configuration does not exist for this bucket</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/exceptions.py
+++ b/localstack/services/s3/exceptions.py
@@ -31,3 +31,13 @@ class UnexpectedContent(CommonServiceException):
 class NoSuchConfiguration(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("NoSuchConfiguration", status_code=404, message=message)
+
+
+class InvalidBucketState(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("InvalidBucketState", status_code=409, message=message)
+
+
+class NoSuchObjectLockConfiguration(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("NoSuchObjectLockConfiguration", status_code=404, message=message)

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -683,7 +683,7 @@ def parse_expiration_header(
         return None, None
 
 
-def validate_dict_fields(data: dict, required_fields: set, optional_fields: set):
+def validate_dict_fields(data: dict, required_fields: set, optional_fields: set = None):
     """
     Validate whether the `data` dict contains at least the required fields and not more than the union of the required
     and optional fields
@@ -694,6 +694,8 @@ def validate_dict_fields(data: dict, required_fields: set, optional_fields: set)
     :param optional_fields: a set containing the optional fields
     :return: bool, whether the dict is valid or not
     """
+    if optional_fields is None:
+        optional_fields = set()
     return (set_fields := set(data)) >= required_fields and set_fields <= (
         required_fields | optional_fields
     )
@@ -763,3 +765,21 @@ def get_unique_key_id(
     bucket: BucketName, object_key: ObjectKey, version_id: ObjectVersionId
 ) -> str:
     return f"{bucket}/{object_key}/{version_id or 'null'}"
+
+
+def get_retention_from_now(days: int = None, years: int = None) -> datetime.datetime:
+    """
+    This calculates a retention date from now, adding days or years to it
+    :param days: provided days
+    :param years: provided years, exclusive with days
+    :return: return a datetime object
+    """
+    if not days and not years:
+        raise ValueError("Either 'days' or 'years' needs to be provided")
+    now = datetime.datetime.now(tz=ZoneInfo("GMT"))
+    if days:
+        retention = now + datetime.timedelta(days=days)
+    else:
+        retention = now.replace(year=now.year + years)
+
+    return retention

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -4,8 +4,10 @@ from collections import defaultdict
 from datetime import datetime
 from secrets import token_urlsafe
 from typing import Literal, NamedTuple, Optional, Union
+from zoneinfo import ZoneInfo
 
 from localstack import config
+from localstack.aws.api import CommonServiceException
 from localstack.aws.api.s3 import (
     AccountId,
     AnalyticsConfiguration,
@@ -18,6 +20,7 @@ from localstack.aws.api.s3 import (
     ChecksumAlgorithm,
     CompletedPartList,
     CORSConfiguration,
+    DefaultRetention,
     EntityTooSmall,
     ETag,
     Expiration,
@@ -36,9 +39,10 @@ from localstack.aws.api.s3 import (
     NoSuchVersion,
     NotificationConfiguration,
     ObjectKey,
-    ObjectLockConfiguration,
     ObjectLockLegalHoldStatus,
     ObjectLockMode,
+    ObjectLockRetainUntilDate,
+    ObjectLockRetentionMode,
     ObjectOwnership,
     ObjectStorageClass,
     ObjectVersionId,
@@ -78,6 +82,8 @@ from localstack.utils.tagging import TaggingService
 
 LOG = logging.getLogger(__name__)
 
+gmt_zone_info = ZoneInfo("GMT")
+
 
 # note: not really a need to use a dataclass here, as it has a lot of fields, but only a few are set at creation
 class S3Bucket:
@@ -90,7 +96,7 @@ class S3Bucket:
     versioning_status: BucketVersioningStatus | None
     lifecycle_rules: Optional[LifecycleRules]
     policy: Optional[Policy]
-    website_configuration: WebsiteConfiguration
+    website_configuration: Optional[WebsiteConfiguration]
     acl: str  # TODO: change this
     cors_rules: Optional[CORSConfiguration]
     logging: LoggingEnabled
@@ -99,12 +105,12 @@ class S3Bucket:
     encryption_rule: Optional[ServerSideEncryptionRule]
     public_access_block: PublicAccessBlockConfiguration
     accelerate_status: BucketAccelerateStatus
-    object_ownership: ObjectOwnership
-    object_lock_configuration: Optional[ObjectLockConfiguration]
     object_lock_enabled: bool
+    object_ownership: ObjectOwnership
     intelligent_tiering_configurations: dict[IntelligentTieringId, IntelligentTieringConfiguration]
     analytics_configurations: dict[AnalyticsId, AnalyticsConfiguration]
     inventory_configurations: dict[InventoryId, InventoryConfiguration]
+    object_lock_default_retention: Optional[DefaultRetention]
     replication: ReplicationConfiguration
     owner: Owner
 
@@ -121,13 +127,14 @@ class S3Bucket:
         self.name = name
         self.bucket_account_id = account_id
         self.bucket_region = bucket_region
-        self.objects = KeyStore()
+        # If ObjectLock is enabled, it forces the bucket to be versioned as well
+        self.versioning_status = None if not object_lock_enabled_for_bucket else "Enabled"
+        self.objects = KeyStore() if not object_lock_enabled_for_bucket else VersionedKeyStore()
         self.object_ownership = object_ownership
         self.object_lock_enabled = object_lock_enabled_for_bucket
         self.encryption_rule = DEFAULT_BUCKET_ENCRYPTION
-        self.creation_date = datetime.utcnow()
+        self.creation_date = datetime.now(tz=gmt_zone_info)
         self.multiparts = {}
-        self.versioning_status = None
         self.notification_configuration = {}
         self.cors_rules = None
         self.lifecycle_rules = None
@@ -135,6 +142,7 @@ class S3Bucket:
         self.intelligent_tiering_configurations = {}
         self.analytics_configurations = {}
         self.inventory_configurations = {}
+        self.object_lock_default_retention = {}
 
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html
         self.owner = get_owner_for_account_id(account_id)
@@ -184,6 +192,13 @@ class S3Bucket:
                         VersionId=version_id,
                     )
                 elif raise_for_delete_marker and isinstance(s3_object_version, S3DeleteMarker):
+                    if http_method == "HEAD":
+                        raise CommonServiceException(
+                            code="405",
+                            message="Method Not Allowed",
+                            status_code=405,
+                        )
+
                     raise MethodNotAllowed(
                         "The specified method is not allowed against this resource.",
                         Method=http_method,
@@ -228,7 +243,7 @@ class S3Object:
     bucket_key_enabled: Optional[bool]  # inherit bucket
     checksum_algorithm: ChecksumAlgorithm
     checksum_value: str
-    lock_mode: Optional[ObjectLockMode]
+    lock_mode: Optional[ObjectLockMode | ObjectLockRetentionMode]
     lock_legal_status: Optional[ObjectLockLegalHoldStatus]
     lock_until: Optional[datetime]
     website_redirect_location: Optional[WebsiteRedirectLocation]
@@ -253,7 +268,7 @@ class S3Object:
         encryption: Optional[ServerSideEncryption] = None,
         kms_key_id: Optional[SSEKMSKeyId] = None,
         bucket_key_enabled: bool = False,
-        lock_mode: Optional[ObjectLockMode] = None,
+        lock_mode: Optional[ObjectLockMode | ObjectLockRetentionMode] = None,
         lock_legal_status: Optional[ObjectLockLegalHoldStatus] = None,
         lock_until: Optional[datetime] = None,
         website_redirect_location: Optional[WebsiteRedirectLocation] = None,
@@ -281,7 +296,7 @@ class S3Object:
         self.expiration = expiration
         self.website_redirect_location = website_redirect_location
         self.is_current = True
-        self.last_modified = datetime.utcnow()
+        self.last_modified = datetime.now(tz=gmt_zone_info)
         self.parts = []
         self.restore = None
 
@@ -300,6 +315,9 @@ class S3Object:
         # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
         if "ContentEncoding" not in headers and self.checksum_algorithm:
             headers["ContentEncoding"] = ""
+
+        if self.storage_class != StorageClass.STANDARD:
+            headers["StorageClass"] = self.storage_class
 
         return headers
 
@@ -323,6 +341,18 @@ class S3Object:
     def quoted_etag(self) -> str:
         return f'"{self.etag}"'
 
+    def is_locked(self, bypass_governance: bool = False) -> bool:
+        if self.lock_legal_status == "ON":
+            return True
+
+        if bypass_governance and self.lock_mode == ObjectLockMode.GOVERNANCE:
+            return False
+
+        if self.lock_until:
+            return self.lock_until > datetime.now(tz=gmt_zone_info)
+
+        return False
+
 
 # TODO: could use dataclass, validate after models are set
 class S3DeleteMarker:
@@ -334,8 +364,13 @@ class S3DeleteMarker:
     def __init__(self, key: ObjectKey, version_id: ObjectVersionId):
         self.key = key
         self.version_id = version_id
-        self.last_modified = datetime.utcnow()
+        self.last_modified = datetime.now(tz=gmt_zone_info)
         self.is_current = True
+
+    @staticmethod
+    def is_locked(*_, **__) -> bool:
+        # an S3DeleteMarker cannot be lock protected
+        return False
 
 
 # TODO: could use dataclass, validate after models are set
@@ -355,7 +390,7 @@ class S3Part:
         checksum_algorithm: Optional[ChecksumAlgorithm] = None,
         checksum_value: Optional[str] = None,
     ):
-        self.last_modified = datetime.utcnow()
+        self.last_modified = datetime.now(tz=gmt_zone_info)
         self.part_number = part_number
         self.size = size
         self.etag = etag
@@ -395,7 +430,7 @@ class S3Multipart:
         tagging: Optional[dict[str, str]] = None,
     ):
         self.id = token_urlsafe(96)  # MultipartUploadId is 128 characters long
-        self.initiated = datetime.utcnow()
+        self.initiated = datetime.now(tz=gmt_zone_info)
         self.parts = {}
         self.initiator = initiator
         self.tagging = tagging
@@ -635,6 +670,12 @@ class EncryptionParameters(NamedTuple):
     encryption: ServerSideEncryption
     kms_key_id: SSEKMSKeyId
     bucket_key_enabled: BucketKeyEnabled
+
+
+class ObjectLockParameters(NamedTuple):
+    lock_until: ObjectLockRetainUntilDate
+    lock_legal_status: ObjectLockLegalHoldStatus
+    lock_mode: ObjectLockMode | ObjectLockRetentionMode
 
 
 s3_stores = AccountRegionBundle[S3Store]("s3", S3Store)

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -368,7 +368,7 @@ class S3DeleteMarker:
         self.is_current = True
 
     @staticmethod
-    def is_locked(*_, **__) -> bool:
+    def is_locked(*args, **kwargs) -> bool:
         # an S3DeleteMarker cannot be lock protected
         return False
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -24,7 +24,7 @@ class LimitedIterableStream(Iterable[bytes]):
                 self.max_length -= read
                 yield chunk
             else:
-                yield chunk[: self.max_length + 1]
+                yield chunk[: self.max_length]
                 break
 
         return

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -151,6 +151,8 @@ class EphemeralS3StoredObject(S3StoredObject):
                 self.file.write(data)
                 read += len(data)
 
+        self.size += read
+        self.s3_object.size = self.size
         return read
 
     def close(self):
@@ -401,10 +403,6 @@ class EphemeralS3ObjectStore(S3ObjectStore):
             upload_key = self._resolve_upload_directory(bucket, s3_multipart.id)
             if multipart := multiparts.pop(upload_key, None):
                 multipart.close()
-
-        # if the bucket is now empty after removing, we can delete the directory
-        if not multiparts and not self._filesystem.get(bucket, {}).get("keys"):
-            self._delete_bucket_directory(bucket)
 
     def close(self):
         """

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -224,7 +224,9 @@ def s3_empty_bucket(aws_client):
         response = aws_client.s3.list_objects_v2(Bucket=bucket_name)
         objects = [{"Key": obj["Key"]} for obj in response.get("Contents", [])]
         if objects:
-            aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": objects})
+            aws_client.s3.delete_objects(
+                Bucket=bucket_name, Delete={"Objects": objects}, BypassGovernanceRetention=True
+            )
 
         response = aws_client.s3.list_object_versions(Bucket=bucket_name)
         versions = response.get("Versions", [])
@@ -232,7 +234,11 @@ def s3_empty_bucket(aws_client):
 
         object_versions = [{"Key": obj["Key"], "VersionId": obj["VersionId"]} for obj in versions]
         if object_versions:
-            aws_client.s3.delete_objects(Bucket=bucket_name, Delete={"Objects": object_versions})
+            aws_client.s3.delete_objects(
+                Bucket=bucket_name,
+                Delete={"Objects": object_versions},
+                BypassGovernanceRetention=True,
+            )
 
     yield factory
 

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -1866,82 +1866,6 @@ class TestS3:
         condition=lambda: not is_native_provider(),
         paths=["$..ServerSideEncryption"],
     )
-    def test_s3_copy_object_legal_hold(self, s3_create_bucket, snapshot, aws_client):
-        snapshot.add_transformer(snapshot.transform.s3_api())
-        object_key = "source-object"
-        dest_key = "dest-key"
-        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default, as it's not allowed otherwise
-        # write test for this
-        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
-
-        resp = aws_client.s3.put_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            Body='{"key": "value"}',
-            ObjectLockLegalHoldStatus="ON",
-        )
-        snapshot.match("put_object", resp)
-
-        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=object_key)
-        snapshot.match("head_object", head_object)
-
-        resp = aws_client.s3.copy_object(
-            Bucket=bucket_name,
-            CopySource=f"{bucket_name}/{object_key}",
-            Key=dest_key,
-        )
-        snapshot.match("copy-legal-hold", resp)
-        # the destination key did not keep the legal hold from the source key
-        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=dest_key)
-        snapshot.match("head-dest-key", head_object)
-
-        # disabled the Legal Hold so that the fixture can clean up
-        for key in (object_key, dest_key):
-            with contextlib.suppress(ClientError):
-                aws_client.s3.put_object_legal_hold(
-                    Bucket=bucket_name, Key=key, LegalHold={"Status": "OFF"}
-                )
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=lambda: not is_native_provider(),
-        paths=["$..ServerSideEncryption"],
-    )
-    def test_s3_copy_object_lock(self, s3_create_bucket, snapshot, aws_client):
-        snapshot.add_transformer(snapshot.transform.s3_api())
-        object_key = "source-object"
-        dest_key = "dest-key"
-        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default, as it's not allowed otherwise
-        # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
-        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
-
-        resp = aws_client.s3.put_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            Body='{"key": "value"}',
-            ObjectLockMode="GOVERNANCE",  # allows the root user to delete it
-            ObjectLockRetainUntilDate=datetime.datetime.now() + datetime.timedelta(milliseconds=1),
-        )
-        snapshot.match("put-source-object", resp)
-
-        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=object_key)
-        snapshot.match("head-source-object", head_object)
-
-        resp = aws_client.s3.copy_object(
-            Bucket=bucket_name,
-            CopySource=f"{bucket_name}/{object_key}",
-            Key=dest_key,
-        )
-        snapshot.match("copy-lock", resp)
-        # the destination key did not keep the lock nor lock until from the source key
-        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=dest_key)
-        snapshot.match("head-dest-key", head_object)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=lambda: not is_native_provider(),
-        paths=["$..ServerSideEncryption"],
-    )
     def test_s3_copy_object_storage_class(self, s3_bucket, snapshot, aws_client):
         # this test will validate that setting StorageClass (even the same as source) allows a copy in place
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -4654,11 +4578,12 @@ class TestS3:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
         paths=[
             "$..ServerSideEncryption",
             "$..NextKeyMarker",
             "$..NextUploadIdMarker",
-        ]
+        ],
     )
     def test_list_multipart_uploads_parameters(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
@@ -4998,92 +4923,6 @@ class TestS3:
         snapshot.match("list_config_with_storage_analysis_2", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=lambda: not is_native_provider(),
-        paths=["$..ServerSideEncryption"],
-    )
-    def test_s3_legal_hold_lock_versioned(self, aws_client, s3_create_bucket, snapshot):
-        snapshot.add_transformer(snapshot.transform.s3_api())
-        object_key = "locked-object"
-        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default, as it's not allowed otherwise
-        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
-
-        # create an object, get version1
-        resp = aws_client.s3.put_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            Body='{"key": "value"}',
-        )
-        snapshot.match("put-object", resp)
-        version_id = resp["VersionId"]
-
-        # put a legal hold on the object with version1
-        resp = aws_client.s3.put_object_legal_hold(
-            Bucket=bucket_name,
-            Key=object_key,
-            VersionId=version_id,
-            LegalHold={"Status": "ON"},
-        )
-        snapshot.match("put-object-legal-hold-ver1", resp)
-
-        head_object = aws_client.s3.head_object(
-            Bucket=bucket_name, Key=object_key, VersionId=version_id
-        )
-        snapshot.match("head-object-ver1", head_object)
-
-        resp = aws_client.s3.put_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            Body='{"key": "value"}',
-        )
-        snapshot.match("put-object-2", resp)
-        version_id_2 = resp["VersionId"]
-
-        # put a legal hold on the object with version2
-        resp = aws_client.s3.put_object_legal_hold(
-            Bucket=bucket_name,
-            Key=object_key,
-            VersionId=version_id_2,
-            LegalHold={"Status": "ON"},
-        )
-        snapshot.match("put-object-legal-hold-ver2", resp)
-
-        head_object = aws_client.s3.head_object(
-            Bucket=bucket_name, Key=object_key, VersionId=version_id_2
-        )
-        snapshot.match("head-object-ver2", head_object)
-
-        # remove the legal hold from the version1
-        resp = aws_client.s3.put_object_legal_hold(
-            Bucket=bucket_name,
-            Key=object_key,
-            VersionId=version_id,
-            LegalHold={"Status": "OFF"},
-        )
-        snapshot.match("remove-object-legal-hold-ver1", resp)
-
-        head_object = aws_client.s3.head_object(
-            Bucket=bucket_name, Key=object_key, VersionId=version_id
-        )
-        snapshot.match("head-object-ver1-no-lock", head_object)
-
-        # now delete the object with version1, the legal hold should be off
-        resp = aws_client.s3.delete_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            VersionId=version_id,
-        )
-        snapshot.match("delete-object-ver1", resp)
-
-        # disabled the Legal Hold so that the fixture can clean up
-        aws_client.s3.put_object_legal_hold(
-            Bucket=bucket_name,
-            Key=object_key,
-            LegalHold={"Status": "OFF"},
-            VersionId=version_id_2,
-        )
-
-    @markers.aws.validated
     def test_s3_intelligent_tier_config(self, aws_client, s3_create_bucket, snapshot):
         bucket = s3_create_bucket()
         intelligent_tier_configuration = {
@@ -5209,107 +5048,6 @@ class TestS3:
         with pytest.raises(ClientError) as e:
             aws_client.s3.get_object(Bucket=bucket, Key=key, IfMatch="etag")
         snapshot.match("if_match_err_1", e.value.response["Error"])
-
-    @markers.aws.validated
-    def test_s3_object_hold(self, aws_client, s3_create_bucket, snapshot):
-        bucket_name_with_lock = f"bucket-with-lock-{short_uid()}"
-        bucket_name_without_lock = f"bucket-without-lock-{short_uid()}"
-        key_1 = "test1.txt"
-        key_2 = "test2.txt"
-
-        s3_create_bucket(Bucket=bucket_name_with_lock, ObjectLockEnabledForBucket=True)
-        aws_client.s3.put_object(Bucket=bucket_name_with_lock, Key=key_1, Body="test")
-        key_1_version_id = aws_client.s3.get_object(Bucket=bucket_name_with_lock, Key=key_1)[
-            "VersionId"
-        ]
-        key_2_version_id = aws_client.s3.put_object(Bucket=bucket_name_with_lock, Key=key_2)[
-            "VersionId"
-        ]
-
-        s3_create_bucket(Bucket=bucket_name_without_lock, ObjectLockEnabledForBucket=False)
-        aws_client.s3.put_object(Bucket=bucket_name_without_lock, Key=key_1, Body="test")
-
-        # non-existing bucket
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.put_object_retention(
-                Bucket="non-existing-bucket",
-                Key=key_1,
-                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
-            )
-        snapshot.match("put_object_retention_1", exc.value.response["Error"])
-
-        # non-existing key
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.put_object_retention(
-                Bucket=bucket_name_with_lock,
-                Key="non-existing-key",
-                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
-            )
-        snapshot.match("put_object_retention_2", exc.value.response["Error"])
-
-        # no lock on bucket
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.get_object_retention(Bucket=bucket_name_without_lock, Key=key_1)
-        snapshot.match("get_object_retention_1", exc.value.response["Error"])
-
-        response = aws_client.s3.put_object_retention(
-            Bucket=bucket_name_with_lock,
-            Key=key_1,
-            Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
-        )
-        snapshot.match("put_object_retention_4", response["ResponseMetadata"]["HTTPStatusCode"])
-
-        response = aws_client.s3.get_object_retention(Bucket=bucket_name_with_lock, Key=key_1)
-        snapshot.match("get_object_retention_2", response)
-
-        # delete object with lock without bypass
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.delete_object(
-                Bucket=bucket_name_with_lock, Key=key_1, VersionId=key_1_version_id
-            )
-        snapshot.match("delete_object_1", exc.value.response["Error"])
-
-        # delete object with lock with bypass
-        response = aws_client.s3.delete_object(
-            Bucket=bucket_name_with_lock,
-            Key=key_1,
-            VersionId=key_1_version_id,
-            BypassGovernanceRetention=True,
-        )
-        snapshot.match("delete_object_2", response["ResponseMetadata"]["HTTPStatusCode"])
-
-        # add object retention to key_2 with 5 seconds retention
-        aws_client.s3.put_object_retention(
-            Bucket=bucket_name_with_lock,
-            Key=key_2,
-            Retention={
-                "Mode": "GOVERNANCE",
-                "RetainUntilDate": datetime.datetime.utcnow() + datetime.timedelta(seconds=5),
-            },
-        )
-
-        # delete object with lock without bypass before 5 seconds
-        with pytest.raises(ClientError):
-            aws_client.s3.delete_object(
-                Bucket=bucket_name_with_lock, Key=key_2, VersionId=key_2_version_id
-            )
-
-        # delete object with lock without bypass after 5 seconds
-        time.sleep(6)
-        aws_client.s3.delete_object(
-            Bucket=bucket_name_with_lock,
-            Key=key_2,
-            VersionId=key_2_version_id,
-        )
-
-        # put object retention on bucket without lock configured
-        with pytest.raises(ClientError) as exc:
-            aws_client.s3.put_object_retention(
-                Bucket=bucket_name_without_lock,
-                Key=key_1,
-                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
-            )
-        snapshot.match("put_object_retention_5", exc.value.response["Error"])
 
     @markers.aws.validated
     def test_put_bucket_logging(self, aws_client, s3_create_bucket, snapshot):
@@ -8887,6 +8625,622 @@ class TestS3BucketLifecycle:
 
         response = aws_client.s3.head_object(Bucket=s3_bucket, Key=key)
         snapshot.match("head-object", response)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    condition=lambda: not is_native_provider(),
+    paths=["$..ServerSideEncryption"],
+)
+class TestS3ObjectLockRetention:
+    @markers.aws.validated
+    def test_s3_object_retention_exc(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        s3_bucket_locked = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        # non-existing bucket
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=f"non-existing-bucket-{long_uid()}",
+                Key="fake-key",
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+            )
+        snapshot.match("put-object-retention-no-bucket", e.value.response)
+
+        # non-existing key
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_locked,
+                Key="non-existing-key",
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+            )
+        snapshot.match("put-object-retention-no-key", e.value.response)
+
+        object_key = "test-key"
+        put_obj_locked = aws_client.s3.put_object(
+            Bucket=s3_bucket_locked, Key=object_key, Body="test"
+        )
+        version_id = put_obj_locked["VersionId"]
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object_retention(
+                Bucket=s3_bucket_locked, Key=object_key, VersionId=version_id
+            )
+        snapshot.match("get-object-retention-never-set", e.value.response)
+
+        # missing fields
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_locked,
+                Key=object_key,
+                Retention={"Mode": "GOVERNANCE"},
+                BypassGovernanceRetention=True,
+            )
+        snapshot.match("put-object-missing-retention-fields", e.value.response)
+
+        # set a retention
+        aws_client.s3.put_object_retention(
+            Bucket=s3_bucket_locked,
+            Key=object_key,
+            Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+        )
+        # update a retention without bypass
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_locked,
+                Key=object_key,
+                VersionId=version_id,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2025, 1, 1)},
+            )
+        snapshot.match("update-retention-no-bypass", e.value.response)
+
+        s3_bucket_basic = s3_create_bucket(ObjectLockEnabledForBucket=False)  # same as default
+        aws_client.s3.put_object(Bucket=s3_bucket_basic, Key=object_key, Body="test")
+        # put object retention in a object in bucket without lock configured
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_basic,
+                Key=object_key,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+            )
+        snapshot.match("put-object-retention-regular-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object_retention(
+                Bucket=s3_bucket_basic,
+                Key=object_key,
+            )
+        snapshot.match("get-object-retention-regular-bucket", e.value.response)
+
+    @markers.aws.validated
+    def test_s3_object_retention(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        object_key = "test-retention-locked-object"
+
+        s3_bucket_lock = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        put_obj_1 = aws_client.s3.put_object(Bucket=s3_bucket_lock, Key=object_key, Body="test")
+        snapshot.match("put-obj-locked-1", put_obj_1)
+
+        version_id = put_obj_1["VersionId"]
+
+        response = aws_client.s3.put_object_retention(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+        )
+        snapshot.match("put-object-retention-on-key-1", response)
+
+        response = aws_client.s3.get_object_retention(Bucket=s3_bucket_lock, Key=object_key)
+        snapshot.match("get-object-retention-on-key-1", response)
+
+        head_object_locked = aws_client.s3.head_object(Bucket=s3_bucket_lock, Key=object_key)
+        snapshot.match("head-object-locked", head_object_locked)
+
+        # delete object with retention lock without bypass
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_object(Bucket=s3_bucket_lock, Key=object_key, VersionId=version_id)
+        snapshot.match("delete-obj-locked", e.value.response)
+
+        # delete object with retention lock with bypass
+        response = aws_client.s3.delete_object(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            VersionId=version_id,
+            BypassGovernanceRetention=True,
+        )
+        snapshot.match("delete-obj-locked-bypass", response)
+        # TODO: add retention on delete marker? todo add delete marker on locked object?
+
+        put_obj_2 = aws_client.s3.put_object(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            Body="test",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=datetime.datetime(2030, 1, 1),
+        )
+        snapshot.match("put-obj-locked-2", put_obj_2)
+        version_id = put_obj_2["VersionId"]
+
+        # update object retention with 5 seconds retention, no bypass
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket_lock,
+                Key=object_key,
+                Retention={
+                    "Mode": "GOVERNANCE",
+                    "RetainUntilDate": datetime.datetime.utcnow() + datetime.timedelta(seconds=5),
+                },
+            )
+        snapshot.match("update-retention-locked-object", e.value.response)
+
+        # update with empty retention
+        empty_retention = aws_client.s3.put_object_retention(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            Retention={},
+            BypassGovernanceRetention=True,
+        )
+        snapshot.match("put-object-empty-retention", empty_retention)
+
+        update_retention = aws_client.s3.put_object_retention(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            Retention={
+                "Mode": "GOVERNANCE",
+                "RetainUntilDate": datetime.datetime.utcnow() + datetime.timedelta(seconds=5),
+            },
+        )
+        snapshot.match("update-retention-object", update_retention)
+
+        # delete object with retention lock without bypass before 5 seconds
+        with pytest.raises(ClientError):
+            aws_client.s3.delete_object(Bucket=s3_bucket_lock, Key=object_key, VersionId=version_id)
+
+        # delete object with lock without bypass after 5 seconds
+        sleep = 10 if is_aws_cloud() else 6
+        time.sleep(sleep)
+
+        aws_client.s3.delete_object(
+            Bucket=s3_bucket_lock,
+            Key=object_key,
+            VersionId=version_id,
+        )
+
+    @markers.aws.validated
+    def test_s3_copy_object_retention_lock(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        object_key = "source-object"
+        dest_key = "dest-key"
+        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default, as it's not allowed otherwise
+        # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
+        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
+
+        put_locked_objected = aws_client.s3.put_object(
+            Bucket=bucket_name,
+            Key=object_key,
+            Body='{"key": "value"}',
+            ObjectLockMode="GOVERNANCE",  # allows the root user to delete it
+            ObjectLockRetainUntilDate=datetime.datetime.now() + datetime.timedelta(minutes=10),
+        )
+        snapshot.match("put-source-object", put_locked_objected)
+
+        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=object_key)
+        snapshot.match("head-source-object", head_object)
+
+        resp = aws_client.s3.copy_object(
+            Bucket=bucket_name,
+            CopySource=f"{bucket_name}/{object_key}",
+            Key=dest_key,
+        )
+        snapshot.match("copy-lock", resp)
+        # the destination key did not keep the lock nor lock until from the source key
+        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=dest_key)
+        snapshot.match("head-dest-key", head_object)
+
+    @markers.aws.validated
+    def test_bucket_config_default_retention(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        object_key = "default-object"
+        put_lock_config = aws_client.s3.put_object_lock_configuration(
+            Bucket=s3_bucket,
+            ObjectLockConfiguration={
+                "ObjectLockEnabled": "Enabled",
+                "Rule": {
+                    "DefaultRetention": {
+                        "Mode": "GOVERNANCE",
+                        "Days": 1,
+                    }
+                },
+            },
+        )
+        snapshot.match("put-lock-config", put_lock_config)
+
+        put_locked_object_default = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body="test-default-lock",
+        )
+        snapshot.match("put-object-default", put_locked_object_default)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-default", head_object)
+
+        # add one day to LastModified to validate the Retain date is precise or rounding (it is precise, exactly 1 day
+        # after the LastModified (created date)
+        last_modified_and_one_day = head_object["LastModified"] + datetime.timedelta(days=1)
+        delta_2_min = datetime.timedelta(minutes=2)  # to add a bit of margin
+        assert (
+            last_modified_and_one_day - delta_2_min
+            <= head_object["ObjectLockRetainUntilDate"]
+            <= last_modified_and_one_day + delta_2_min
+        )
+
+        put_locked_object = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body="test-put-object-lock",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=datetime.datetime.now() + datetime.timedelta(minutes=10),
+        )
+        snapshot.match("put-object-with-lock", put_locked_object)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-lock", head_object)
+
+    @markers.aws.validated
+    def test_object_lock_delete_markers(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        object_key = "default-object"
+
+        put_locked_object = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body="test-put-object-lock",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=datetime.datetime.now() + datetime.timedelta(minutes=10),
+        )
+        snapshot.match("put-object-with-lock", put_locked_object)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-lock", head_object)
+
+        put_delete_marker = aws_client.s3.delete_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("put-delete-marker", put_delete_marker)
+        delete_marker_version = put_delete_marker["VersionId"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket,
+                Key=object_key,
+                VersionId=delete_marker_version,
+                Retention={"Mode": "GOVERNANCE", "RetainUntilDate": datetime.datetime(2030, 1, 1)},
+            )
+        snapshot.match("put-object-retention-delete-marker", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object_retention(
+                Bucket=s3_bucket, Key=object_key, VersionId=delete_marker_version
+            )
+        snapshot.match("get-object-retention-delete-marker", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.head_object(
+                Bucket=s3_bucket, Key=object_key, VersionId=delete_marker_version
+            )
+        snapshot.match("head-object-locked-delete-marker", e.value.response)
+
+    @markers.aws.validated
+    def test_object_lock_extend_duration(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        object_key = "default-object"
+
+        put_locked_object = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body="test-put-object-lock",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=datetime.datetime.now() + datetime.timedelta(minutes=10),
+        )
+        snapshot.match("put-object-with-lock", put_locked_object)
+        version_id = put_locked_object["VersionId"]
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-lock", head_object)
+
+        # not putting BypassGovernanceRetention=True on purpose, to see if you can extend the duration by default
+        put_locked_object_extend = aws_client.s3.put_object_retention(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            Retention={
+                "Mode": "GOVERNANCE",
+                "RetainUntilDate": datetime.datetime.now() + datetime.timedelta(minutes=20),
+            },
+        )
+        snapshot.match("put-object-retention-extend", put_locked_object_extend)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-lock-extended", head_object)
+
+        # assert that reducing the duration again won't work
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_retention(
+                Bucket=s3_bucket,
+                Key=object_key,
+                VersionId=version_id,
+                Retention={
+                    "Mode": "GOVERNANCE",
+                    "RetainUntilDate": datetime.datetime.now() + datetime.timedelta(minutes=10),
+                },
+            )
+        snapshot.match("put-object-retention-reduce", e.value.response)
+
+
+@markers.snapshot.skip_snapshot_verify(
+    condition=lambda: not is_native_provider(),
+    paths=["$..ServerSideEncryption"],
+)
+class TestS3ObjectLockLegalHold:
+    @markers.aws.validated
+    def test_put_get_object_legal_hold(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        object_key = "locked-object"
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body="test")
+        snapshot.match("put-obj", put_obj)
+        version_id = put_obj["VersionId"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object_legal_hold(
+                Bucket=s3_bucket, Key=object_key, VersionId=version_id
+            )
+        snapshot.match("get-legal-hold-unset", e.value.response)
+
+        put_legal_hold = aws_client.s3.put_object_legal_hold(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "ON"},
+        )
+        snapshot.match("put-object-legal-hold", put_legal_hold)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-legal-hold", head_object)
+
+        get_legal_hold = aws_client.s3.get_object_legal_hold(
+            Bucket=s3_bucket, Key=object_key, VersionId=version_id
+        )
+        snapshot.match("get-legal-hold-set", get_legal_hold)
+
+        # disable the LegalHold so that the fixture can clean up
+        put_legal_hold = aws_client.s3.put_object_legal_hold(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "OFF"},
+        )
+        snapshot.match("put-object-legal-hold-off", put_legal_hold)
+
+    @markers.aws.validated
+    def test_put_object_with_legal_hold(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        object_key = "locked-object"
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+
+        put_obj = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body="test",
+            ObjectLockLegalHoldStatus="ON",
+        )
+        snapshot.match("put-obj", put_obj)
+        version_id = put_obj["VersionId"]
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-with-legal-hold", head_object)
+
+        # disable the LegalHold so that the fixture can clean up
+        put_legal_hold = aws_client.s3.put_object_legal_hold(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "OFF"},
+        )
+        snapshot.match("put-object-legal-hold-off", put_legal_hold)
+
+    @markers.aws.validated
+    def test_put_object_legal_hold_exc(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        s3_bucket_locked = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        # non-existing bucket
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_legal_hold(
+                Bucket=f"non-existing-bucket-{long_uid()}",
+                Key="fake-key",
+                LegalHold={"Status": "ON"},
+            )
+        snapshot.match("put-object-legal-hold-no-bucket", e.value.response)
+
+        # non-existing key
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_legal_hold(
+                Bucket=s3_bucket_locked,
+                Key="non-existing-key",
+                LegalHold={"Status": "ON"},
+            )
+        snapshot.match("put-object-legal-hold-no-key", e.value.response)
+
+        object_key = "test-legal-hold"
+        s3_bucket_basic = s3_create_bucket(ObjectLockEnabledForBucket=False)  # same as default
+        aws_client.s3.put_object(Bucket=s3_bucket_basic, Key=object_key, Body="test")
+        # put object retention in a object in bucket without lock configured
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_legal_hold(
+                Bucket=s3_bucket_basic,
+                Key=object_key,
+                LegalHold={"Status": "ON"},
+            )
+        snapshot.match("put-object-retention-regular-bucket", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_object_legal_hold(
+                Bucket=s3_bucket_basic,
+                Key=object_key,
+            )
+        snapshot.match("put-object-retention-empty", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_object_legal_hold(
+                Bucket=s3_bucket_basic,
+                Key=object_key,
+            )
+        snapshot.match("get-object-retention-regular-bucket", e.value.response)
+
+    @markers.aws.validated
+    def test_delete_locked_object(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
+        s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
+        object_key = "test-delete-locked"
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key, Body="test")
+        snapshot.match("put-obj", put_obj)
+        version_id = put_obj["VersionId"]
+
+        put_legal_hold = aws_client.s3.put_object_legal_hold(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "ON"},
+        )
+        snapshot.match("put-object-legal-hold", put_legal_hold)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_object(Bucket=s3_bucket, Key=object_key, VersionId=version_id)
+        snapshot.match("delete-object-locked", e.value.response)
+
+        delete_objects = aws_client.s3.delete_objects(
+            Bucket=s3_bucket, Delete={"Objects": [{"Key": object_key, "VersionId": version_id}]}
+        )
+        snapshot.match("delete-objects-locked", delete_objects)
+
+        # disable the LegalHold so that the fixture can clean up
+        put_legal_hold = aws_client.s3.put_object_legal_hold(
+            Bucket=s3_bucket,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "OFF"},
+        )
+        snapshot.match("put-object-legal-hold-off", put_legal_hold)
+
+    @markers.aws.validated
+    def test_s3_legal_hold_lock_versioned(self, aws_client, s3_create_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        object_key = "locked-object"
+        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default, as it's not allowed otherwise
+        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
+
+        # create an object, get version1
+        resp = aws_client.s3.put_object(Bucket=bucket_name, Key=object_key, Body="test")
+        snapshot.match("put-object", resp)
+        version_id = resp["VersionId"]
+
+        # put a legal hold on the object with version1
+        resp = aws_client.s3.put_object_legal_hold(
+            Bucket=bucket_name,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "ON"},
+        )
+        snapshot.match("put-object-legal-hold-ver1", resp)
+
+        head_object = aws_client.s3.head_object(
+            Bucket=bucket_name, Key=object_key, VersionId=version_id
+        )
+        snapshot.match("head-object-ver1", head_object)
+
+        resp = aws_client.s3.put_object(Bucket=bucket_name, Key=object_key, Body="test")
+        snapshot.match("put-object-2", resp)
+        version_id_2 = resp["VersionId"]
+
+        # put a legal hold on the object with version2
+        resp = aws_client.s3.put_object_legal_hold(
+            Bucket=bucket_name,
+            Key=object_key,
+            VersionId=version_id_2,
+            LegalHold={"Status": "ON"},
+        )
+        snapshot.match("put-object-legal-hold-ver2", resp)
+
+        head_object = aws_client.s3.head_object(
+            Bucket=bucket_name, Key=object_key, VersionId=version_id_2
+        )
+        snapshot.match("head-object-ver2", head_object)
+
+        # remove the legal hold from the version1
+        resp = aws_client.s3.put_object_legal_hold(
+            Bucket=bucket_name,
+            Key=object_key,
+            VersionId=version_id,
+            LegalHold={"Status": "OFF"},
+        )
+        snapshot.match("remove-object-legal-hold-ver1", resp)
+
+        head_object = aws_client.s3.head_object(
+            Bucket=bucket_name, Key=object_key, VersionId=version_id
+        )
+        snapshot.match("head-object-ver1-no-lock", head_object)
+
+        # now delete the object with version1, the legal hold should be off
+        resp = aws_client.s3.delete_object(
+            Bucket=bucket_name,
+            Key=object_key,
+            VersionId=version_id,
+        )
+        snapshot.match("delete-object-ver1", resp)
+
+        # disabled the Legal Hold so that the fixture can clean up
+        aws_client.s3.put_object_legal_hold(
+            Bucket=bucket_name,
+            Key=object_key,
+            LegalHold={"Status": "OFF"},
+            VersionId=version_id_2,
+        )
+
+    @markers.aws.validated
+    def test_s3_copy_object_legal_hold(self, s3_create_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        object_key = "source-object"
+        dest_key = "dest-key"
+        # creating a bucket with ObjectLockEnabledForBucket enables versioning by default
+        bucket_name = s3_create_bucket(ObjectLockEnabledForBucket=True)
+
+        resp = aws_client.s3.put_object(
+            Bucket=bucket_name,
+            Key=object_key,
+            Body='{"key": "value"}',
+            ObjectLockLegalHoldStatus="ON",
+        )
+        snapshot.match("put-object", resp)
+
+        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=object_key)
+        snapshot.match("head-object", head_object)
+
+        resp = aws_client.s3.copy_object(
+            Bucket=bucket_name,
+            CopySource=f"{bucket_name}/{object_key}",
+            Key=dest_key,
+        )
+        snapshot.match("copy-legal-hold", resp)
+        # the destination key did not keep the legal hold from the source key
+        head_object = aws_client.s3.head_object(Bucket=bucket_name, Key=dest_key)
+        snapshot.match("head-dest-key", head_object)
+
+        # disable the Legal Hold so that the fixture can clean up
+        for key in (object_key, dest_key):
+            with contextlib.suppress(ClientError):
+                aws_client.s3.put_object_legal_hold(
+                    Bucket=bucket_name, Key=key, LegalHold={"Status": "OFF"}
+                )
 
 
 def _s3_client_custom_config(conf: Config, endpoint_url: str = None):

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -8633,6 +8633,10 @@ class TestS3BucketLifecycle:
 )
 class TestS3ObjectLockRetention:
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not validate properly",
+    )
     def test_s3_object_retention_exc(self, aws_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         s3_bucket_locked = s3_create_bucket(ObjectLockEnabledForBucket=True)
@@ -8710,6 +8714,10 @@ class TestS3ObjectLockRetention:
         snapshot.match("get-object-retention-regular-bucket", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not validate properly",
+    )
     def test_s3_object_retention(self, aws_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         object_key = "test-retention-locked-object"
@@ -8886,6 +8894,10 @@ class TestS3ObjectLockRetention:
         snapshot.match("head-object-with-lock", head_object)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not validate properly",
+    )
     def test_object_lock_delete_markers(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
@@ -8929,6 +8941,10 @@ class TestS3ObjectLockRetention:
         snapshot.match("head-object-locked-delete-marker", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not implemented",
+    )
     def test_object_lock_extend_duration(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)
@@ -8982,6 +8998,10 @@ class TestS3ObjectLockRetention:
 )
 class TestS3ObjectLockLegalHold:
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not implemented, does not validate",
+    )
     def test_put_get_object_legal_hold(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         object_key = "locked-object"
@@ -9050,6 +9070,10 @@ class TestS3ObjectLockLegalHold:
         snapshot.match("put-object-legal-hold-off", put_legal_hold)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not implemented, does not validate",
+    )
     def test_put_object_legal_hold_exc(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         s3_bucket_locked = s3_create_bucket(ObjectLockEnabledForBucket=True)
@@ -9098,6 +9122,10 @@ class TestS3ObjectLockLegalHold:
         snapshot.match("get-object-retention-regular-bucket", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not implemented, does not validate",
+    )
     def test_delete_locked_object(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         s3_bucket = s3_create_bucket(ObjectLockEnabledForBucket=True)

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -6163,119 +6163,6 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_copy_object_legal_hold": {
-    "recorded-date": "03-08-2023, 04:15:38",
-    "recorded-content": {
-      "put_object": {
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head_object": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ObjectLockLegalHoldStatus": "ON",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "copy-legal-hold": {
-        "CopyObjectResult": {
-          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-          "LastModified": "datetime"
-        },
-        "CopySourceVersionId": "<version-id:1>",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-dest-key": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_copy_object_lock": {
-    "recorded-date": "03-08-2023, 04:15:42",
-    "recorded-content": {
-      "put-source-object": {
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-source-object": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ObjectLockMode": "GOVERNANCE",
-        "ObjectLockRetainUntilDate": "datetime",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "copy-lock": {
-        "CopyObjectResult": {
-          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-          "LastModified": "datetime"
-        },
-        "CopySourceVersionId": "<version-id:1>",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-dest-key": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_storage_class": {
     "recorded-date": "03-08-2023, 04:15:24",
     "recorded-content": {
@@ -6844,99 +6731,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_legal_hold_lock_versioned": {
-    "recorded-date": "03-08-2023, 04:25:43",
-    "recorded-content": {
-      "put-object": {
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-legal-hold-ver1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-object-ver1": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ObjectLockLegalHoldStatus": "ON",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-2": {
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-legal-hold-ver2": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-object-ver2": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ObjectLockLegalHoldStatus": "ON",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "remove-object-legal-hold-ver1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "head-object-ver1-no-lock": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 16,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ObjectLockLegalHoldStatus": "OFF",
-        "ServerSideEncryption": "AES256",
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-object-ver1": {
-        "VersionId": "<version-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
         }
       }
     }
@@ -8620,45 +8414,6 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_object_hold": {
-    "recorded-date": "03-08-2023, 04:26:05",
-    "recorded-content": {
-      "put_object_retention_1": {
-        "BucketName": "non-existing-bucket",
-        "Code": "NoSuchBucket",
-        "Message": "The specified bucket does not exist"
-      },
-      "put_object_retention_2": {
-        "Code": "NoSuchKey",
-        "Key": "non-existing-key",
-        "Message": "The specified key does not exist."
-      },
-      "get_object_retention_1": {
-        "Code": "InvalidRequest",
-        "Message": "Bucket is missing Object Lock Configuration"
-      },
-      "put_object_retention_4": 200,
-      "get_object_retention_2": {
-        "Retention": {
-          "Mode": "GOVERNANCE",
-          "RetainUntilDate": "datetime"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_object_1": {
-        "Code": "AccessDenied",
-        "Message": "Access Denied"
-      },
-      "delete_object_2": 204,
-      "put_object_retention_5": {
-        "Code": "InvalidRequest",
-        "Message": "Bucket is missing Object Lock Configuration"
-      }
-    }
-  },
   "tests/aws/s3/test_s3.py::TestS3BucketLifecycle::test_lifecycle_expired_object_delete_marker": {
     "recorded-date": "26-07-2023, 15:14:49",
     "recorded-content": {
@@ -8950,6 +8705,780 @@
         "x-amz-id-2": "<x-amz-id-2:1>",
         "x-amz-request-id": "<x-amz-request-id:1>",
         "x-amz-server-side-encryption": "AES256"
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
+    "recorded-date": "09-08-2023, 17:58:37",
+    "recorded-content": {
+      "put-object-retention-no-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-retention-no-key": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "non-existing-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-object-retention-never-set": {
+        "Error": {
+          "Code": "NoSuchObjectLockConfiguration",
+          "Message": "The specified object does not have a ObjectLock configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-missing-retention-fields": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-retention-no-bypass": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-object-retention-regular-bucket": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Bucket is missing Object Lock Configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-object-retention-regular-bucket": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Bucket is missing Object Lock Configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_copy_object_retention_lock": {
+    "recorded-date": "09-08-2023, 17:58:47",
+    "recorded-content": {
+      "put-source-object": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-source-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-lock": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "CopySourceVersionId": "<version-id:1>",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-dest-key": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention": {
+    "recorded-date": "09-08-2023, 18:56:37",
+    "recorded-content": {
+      "put-obj-locked-1": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-retention-on-key-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-retention-on-key-1": {
+        "Retention": {
+          "Mode": "GOVERNANCE",
+          "RetainUntilDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-locked": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-obj-locked": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "delete-obj-locked-bypass": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-obj-locked-2": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-retention-locked-object": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-object-empty-retention": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-retention-object": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_bucket_config_default_retention": {
+    "recorded-date": "09-08-2023, 22:42:40",
+    "recorded-content": {
+      "put-lock-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-default": {
+        "ETag": "\"1df86997d49364e87360e3831d87cc46\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-default": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 17,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"1df86997d49364e87360e3831d87cc46\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-with-lock": {
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-lock": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 20,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_object_lock_delete_markers": {
+    "recorded-date": "09-08-2023, 22:24:23",
+    "recorded-content": {
+      "put-object-with-lock": {
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-lock": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 20,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-delete-marker": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-object-retention-delete-marker": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "get-object-retention-delete-marker": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "GET",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "head-object-locked-delete-marker": {
+        "Error": {
+          "Code": "405",
+          "Message": "Method Not Allowed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockRetention::test_object_lock_extend_duration": {
+    "recorded-date": "09-08-2023, 23:09:03",
+    "recorded-content": {
+      "put-object-with-lock": {
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-lock": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 20,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-retention-extend": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-lock-extended": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 20,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f4b85168936b954f2d82998d6d3775c5\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockMode": "GOVERNANCE",
+        "ObjectLockRetainUntilDate": "datetime",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-retention-reduce": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_put_get_object_legal_hold": {
+    "recorded-date": "10-08-2023, 00:17:23",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-legal-hold-unset": {
+        "Error": {
+          "Code": "NoSuchObjectLockConfiguration",
+          "Message": "The specified object does not have a ObjectLock configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-legal-hold": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-legal-hold": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "ON",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-legal-hold-set": {
+        "LegalHold": {
+          "Status": "ON"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold-off": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_put_object_legal_hold_exc": {
+    "recorded-date": "10-08-2023, 00:17:30",
+    "recorded-content": {
+      "put-object-legal-hold-no-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-legal-hold-no-key": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "non-existing-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-retention-regular-bucket": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Bucket is missing Object Lock Configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-retention-empty": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-object-retention-regular-bucket": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Bucket is missing Object Lock Configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_delete_locked_object": {
+    "recorded-date": "10-08-2023, 00:17:33",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object-locked": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Message": "Access Denied"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "delete-objects-locked": {
+        "Errors": [
+          {
+            "Code": "AccessDenied",
+            "Key": "test-delete-locked",
+            "Message": "Access Denied",
+            "VersionId": "<version-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold-off": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_s3_legal_hold_lock_versioned": {
+    "recorded-date": "10-08-2023, 00:17:37",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold-ver1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-ver1": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "ON",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-2": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold-ver2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-ver2": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "ON",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-object-legal-hold-ver1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-ver1-no-lock": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "OFF",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object-ver1": {
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_s3_copy_object_legal_hold": {
+    "recorded-date": "10-08-2023, 00:17:41",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "ON",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-legal-hold": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "CopySourceVersionId": "<version-id:1>",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-dest-key": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3ObjectLockLegalHold::test_put_object_with_legal_hold": {
+    "recorded-date": "10-08-2023, 00:17:26",
+    "recorded-content": {
+      "put-obj": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-with-legal-hold": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ObjectLockLegalHoldStatus": "ON",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-legal-hold-off": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -1177,7 +1177,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption": {
     "recorded-date": "02-08-2023, 00:10:29",
     "recorded-content": {
       "default-bucket-encryption": {
@@ -1216,7 +1216,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption_exc": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_default_bucket_encryption_exc": {
     "recorded-date": "02-08-2023, 00:12:29",
     "recorded-content": {
       "get-bucket-enc-no-bucket": {
@@ -1285,7 +1285,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_s3": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_s3": {
     "recorded-date": "02-08-2023, 01:37:10",
     "recorded-content": {
       "put-bucket-enc": {
@@ -1331,7 +1331,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms_aws_managed_key": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms_aws_managed_key": {
     "recorded-date": "02-08-2023, 01:48:16",
     "recorded-content": {
       "put-bucket-enc": {
@@ -1423,7 +1423,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketEncryption::test_s3_bucket_encryption_sse_kms": {
     "recorded-date": "02-08-2023, 02:06:21",
     "recorded-content": {
       "put-bucket-enc": {
@@ -1492,7 +1492,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_crud": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_crud": {
     "recorded-date": "02-08-2023, 22:18:20",
     "recorded-content": {
       "get-bucket-tags-empty": {
@@ -1560,7 +1560,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_crud": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_crud": {
     "recorded-date": "02-08-2023, 23:23:45",
     "recorded-content": {
       "put-object": {
@@ -1662,7 +1662,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_with_tags": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_with_tags": {
     "recorded-date": "03-08-2023, 01:21:13",
     "recorded-content": {
       "put-object": {
@@ -1773,7 +1773,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_exc": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_bucket_tagging_exc": {
     "recorded-date": "02-08-2023, 22:32:41",
     "recorded-content": {
       "get-no-bucket-tags": {
@@ -1811,7 +1811,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
     "recorded-date": "02-08-2023, 23:14:16",
     "recorded-content": {
       "put-obj-0": {
@@ -1902,7 +1902,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_exc": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_exc": {
     "recorded-date": "03-08-2023, 00:04:47",
     "recorded-content": {
       "get-no-bucket-tags": {
@@ -1997,7 +1997,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
     "recorded-date": "02-08-2023, 23:52:10",
     "recorded-content": {
       "get-object-after-creation": {
@@ -2028,7 +2028,7 @@
       }
     }
   },
-  "tests/integration/s3/test_s3_api.py::TestS3BucketObjectTagging::test_tagging_validation": {
+  "tests/aws/s3/test_s3_api.py::TestS3BucketObjectTagging::test_tagging_validation": {
     "recorded-date": "03-08-2023, 01:07:47",
     "recorded-content": {
       "put-bucket-tags-duplicate-keys": {
@@ -2107,6 +2107,188 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_on_existing_bucket": {
+    "recorded-date": "09-08-2023, 01:27:32",
+    "recorded-content": {
+      "put-object-lock-existing-bucket-enabled": {
+        "Error": {
+          "Code": "InvalidBucketState",
+          "Message": "Object Lock configuration cannot be enabled on existing buckets"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "put-object-lock-existing-bucket-rule": {
+        "Error": {
+          "Code": "InvalidBucketState",
+          "Message": "Object Lock configuration cannot be enabled on existing buckets"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3ObjectLock::test_get_put_object_lock_configuration": {
+    "recorded-date": "09-08-2023, 01:40:49",
+    "recorded-content": {
+      "get-lock-config-start": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-lock-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-lock-config": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled",
+          "Rule": {
+            "DefaultRetention": {
+              "Days": 1,
+              "Mode": "GOVERNANCE"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-lock-config-enabled": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-lock-config-only-enabled": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_exc": {
+    "recorded-date": "10-08-2023, 14:13:45",
+    "recorded-content": {
+      "put-lock-config-no-enabled": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-empty": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-empty-rule": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-empty-retention": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-no-days": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-lock-config-both-days-years": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3ObjectLock::test_get_object_lock_configuration_exc": {
+    "recorded-date": "09-08-2023, 01:41:42",
+    "recorded-content": {
+      "get-lock-config-no-enabled": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "ObjectLockConfigurationNotFoundError",
+          "Message": "Object Lock configuration does not exist for this bucket"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-lock-config-bucket-not-exists": {
+        "Error": {
+          "BucketName": "<bucket-name:2>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3ObjectLock::test_disable_versioning_on_locked_bucket": {
+    "recorded-date": "09-08-2023, 03:49:49",
+    "recorded-content": {
+      "disable-versioning-on-locked-bucket": {
+        "Error": {
+          "Code": "InvalidBucketState",
+          "Message": "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement the ObjectLock functionality in the new native S3 provider. This was partially implemented in our provider in order to fix Moto.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html

<!-- What notable changes does this PR make? -->
## Changes
This PR adds the necessary API operations as well as a good amount of snapshot tests.
- `GetObjectLockConfiguration`
- `PutObjectLockConfiguration`
- `GetObjectLegalHold`
- `PutObjectLegalHold`
- `GetObjectRetention`
- `PutObjectRetention`
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

