### PR TITLE
implement S3 native RequestPayment, GetObject Part, Preconditions

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -853,6 +853,14 @@ class ObjectLockConfigurationNotFoundError(ServiceException):
     BucketName: Optional[BucketName]
 
 
+class InvalidPartNumber(ServiceException):
+    code: str = "InvalidPartNumber"
+    sender_fault: bool = False
+    status_code: int = 416
+    PartNumberRequested: Optional[PartNumber]
+    ActualPartCount: Optional[PartNumber]
+
+
 AbortDate = datetime
 
 
@@ -2233,6 +2241,7 @@ class HeadObjectOutput(TypedDict, total=False):
     ObjectLockMode: Optional[ObjectLockMode]
     ObjectLockRetainUntilDate: Optional[ObjectLockRetainUntilDate]
     ObjectLockLegalHoldStatus: Optional[ObjectLockLegalHoldStatus]
+    StatusCode: Optional[GetObjectResponseStatusCode]
 
 
 class HeadObjectRequest(ServiceRequest):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -122,6 +122,14 @@
     },
     {
       "op": "add",
+      "path": "/shapes/HeadObjectOutput/members/StatusCode",
+      "value": {
+        "shape": "GetObjectResponseStatusCode",
+        "location": "statusCode"
+      }
+    },
+    {
+      "op": "add",
       "path": "/shapes/NoSuchKey/members/Key",
       "value": {
         "shape": "ObjectKey"
@@ -1046,6 +1054,26 @@
           "httpStatusCode": 404
         },
         "documentation": "<p>Object Lock configuration does not exist for this bucket</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidPartNumber",
+      "value": {
+        "type": "structure",
+        "members": {
+          "PartNumberRequested": {
+            "shape": "PartNumber"
+          },
+          "ActualPartCount": {
+            "shape": "PartNumber"
+          }
+        },
+        "error": {
+          "httpStatusCode": 416
+        },
+        "documentation": "<p>The requested partnumber is not satisfiable</p>",
         "exception": true
       }
     }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -166,6 +166,7 @@ from localstack.services.s3.utils import (
     capitalize_header_name_from_snake_case,
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
+    get_failed_precondition_copy_source,
     get_key_from_moto_bucket,
     get_lifecycle_rule_from_object,
     get_object_checksum_for_algorithm,
@@ -599,36 +600,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
 
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
-        condition = None
         source_object_last_modified = source_key_object.last_modified.replace(
             tzinfo=ZoneInfo("GMT")
         )
-        if (cs_if_match := request.get("CopySourceIfMatch")) and source_key_object.etag.strip(
-            '"'
-        ) != cs_if_match.strip('"'):
-            condition = "x-amz-copy-source-If-Match"
-
-        elif (
-            cs_id_unmodified_since := request.get("CopySourceIfUnmodifiedSince")
-        ) and source_object_last_modified > cs_id_unmodified_since:
-            condition = "x-amz-copy-source-If-Unmodified-Since"
-
-        elif (
-            cs_if_none_match := request.get("CopySourceIfNoneMatch")
-        ) and source_key_object.etag.strip('"') == cs_if_none_match.strip('"'):
-            condition = "x-amz-copy-source-If-None-Match"
-
-        elif (
-            cs_id_modified_since := request.get("CopySourceIfModifiedSince")
-        ) and source_object_last_modified < cs_id_modified_since < datetime.datetime.now(
-            tz=ZoneInfo("GMT")
+        if failed_condition := get_failed_precondition_copy_source(
+            request, source_object_last_modified, source_key_object.etag
         ):
-            condition = "x-amz-copy-source-If-Modified-Since"
-
-        if condition:
             raise PreconditionFailed(
                 "At least one of the pre-conditions you specified did not hold",
-                Condition=condition,
+                Condition=failed_condition,
             )
 
         response: CopyObjectOutput = call_moto(context)

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -170,7 +170,7 @@ class S3CRC32Checksum:
         return self.checksum.to_bytes(4, "big")
 
 
-class ParsedRange(NamedTuple):
+class ObjectRange(NamedTuple):
     """
     NamedTuple representing a parsed Range header with the requested S3 object size
     https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
@@ -182,13 +182,13 @@ class ParsedRange(NamedTuple):
     end: int  # the end of the end
 
 
-def parse_range_header(range_header: str, object_size: int) -> ParsedRange:
+def parse_range_header(range_header: str, object_size: int) -> ObjectRange:
     """
     Takes a Range header, and returns a dataclass containing the necessary information to return only a slice of an
     S3 object
     :param range_header: a Range header
     :param object_size: the requested S3 object total size
-    :return: ParsedRange
+    :return: ObjectRange
     """
     last = object_size - 1
     _, rspec = range_header.split("=")
@@ -212,7 +212,7 @@ def parse_range_header(range_header: str, object_size: int) -> ParsedRange:
             RangeRequested=range_header,
         )
 
-    return ParsedRange(
+    return ObjectRange(
         content_range=f"bytes {begin}-{end}/{object_size}",
         content_length=end - begin + 1,
         begin=begin,

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -19,7 +19,11 @@ from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api.s3 import (
     BucketName,
     ChecksumAlgorithm,
+    CopyObjectRequest,
     CopySource,
+    ETag,
+    GetObjectRequest,
+    HeadObjectRequest,
     InvalidArgument,
     InvalidRange,
     InvalidTag,
@@ -34,6 +38,7 @@ from localstack.aws.api.s3 import (
     ObjectSize,
     ObjectVersionId,
     Owner,
+    PreconditionFailed,
     SSEKMSKeyId,
     TaggingHeader,
     TagSet,
@@ -79,6 +84,7 @@ _s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
 
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"
+_gmt_zone_info = ZoneInfo("GMT")
 
 
 def get_owner_for_account_id(account_id: str):
@@ -585,7 +591,7 @@ def rfc_1123_datetime(src: datetime.datetime) -> str:
 
 
 def str_to_rfc_1123_datetime(value: str) -> datetime.datetime:
-    return datetime.datetime.strptime(value, RFC1123).replace(tzinfo=ZoneInfo("GMT"))
+    return datetime.datetime.strptime(value, RFC1123).replace(tzinfo=_gmt_zone_info)
 
 
 def iso_8601_datetime_without_milliseconds_s3(
@@ -776,10 +782,81 @@ def get_retention_from_now(days: int = None, years: int = None) -> datetime.date
     """
     if not days and not years:
         raise ValueError("Either 'days' or 'years' needs to be provided")
-    now = datetime.datetime.now(tz=ZoneInfo("GMT"))
+    now = datetime.datetime.now(tz=_gmt_zone_info)
     if days:
         retention = now + datetime.timedelta(days=days)
     else:
         retention = now.replace(year=now.year + years)
 
     return retention
+
+
+def get_failed_precondition_copy_source(
+    request: CopyObjectRequest, last_modified: datetime.datetime, etag: ETag
+) -> Optional[str]:
+    """
+    Validate if the source object LastModified and ETag matches a precondition, and if it does, return the failed
+    precondition
+    # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+    :param request: the CopyObjectRequest
+    :param last_modified: source object LastModified
+    :param etag: source object ETag
+    :return str: the failed precondition to raise
+    """
+    if (cs_if_match := request.get("CopySourceIfMatch")) and etag.strip('"') != cs_if_match.strip(
+        '"'
+    ):
+        return "x-amz-copy-source-If-Match"
+
+    elif (
+        cs_if_unmodified_since := request.get("CopySourceIfUnmodifiedSince")
+    ) and last_modified > cs_if_unmodified_since:
+        return "x-amz-copy-source-If-Unmodified-Since"
+
+    elif (cs_if_none_match := request.get("CopySourceIfNoneMatch")) and etag.strip(
+        '"'
+    ) == cs_if_none_match.strip('"'):
+        return "x-amz-copy-source-If-None-Match"
+
+    elif (
+        cs_if_modified_since := request.get("CopySourceIfModifiedSince")
+    ) and last_modified < cs_if_modified_since < datetime.datetime.now(tz=_gmt_zone_info):
+        return "x-amz-copy-source-If-Modified-Since"
+
+
+def validate_failed_precondition(
+    request: GetObjectRequest | HeadObjectRequest, last_modified: datetime.datetime, etag: ETag
+) -> None:
+    """
+    Validate if the object LastModified and ETag matches a precondition, and if it does, return the failed
+    precondition
+    :param request: the GetObjectRequest or HeadObjectRequest
+    :param last_modified: S3 object LastModified
+    :param etag: S3 object ETag
+    :raises PreconditionFailed
+    :raises NotModified, 304 with an empty body
+    """
+    precondition_failed = None
+    if (if_match := request.get("IfMatch")) and etag != if_match.strip('"'):
+        precondition_failed = "If-Match"
+
+    elif (
+        if_unmodified_since := request.get("IfUnmodifiedSince")
+    ) and last_modified > if_unmodified_since:
+        precondition_failed = "If-Unmodified-Since"
+
+    if precondition_failed:
+        raise PreconditionFailed(
+            "At least one of the pre-conditions you specified did not hold",
+            Condition=precondition_failed,
+        )
+
+    if ((if_none_match := request.get("IfNoneMatch")) and etag == if_none_match.strip('"')) or (
+        (if_modified_since := request.get("IfModifiedSince"))
+        and last_modified < if_modified_since < datetime.datetime.now(tz=_gmt_zone_info)
+    ):
+        raise CommonServiceException(
+            message="Not Modified",
+            code="NotModified",
+            status_code=304,
+        )

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -82,7 +82,7 @@ from localstack.utils.tagging import TaggingService
 
 LOG = logging.getLogger(__name__)
 
-gmt_zone_info = ZoneInfo("GMT")
+_gmt_zone_info = ZoneInfo("GMT")
 
 
 # note: not really a need to use a dataclass here, as it has a lot of fields, but only a few are set at creation
@@ -133,7 +133,7 @@ class S3Bucket:
         self.object_ownership = object_ownership
         self.object_lock_enabled = object_lock_enabled_for_bucket
         self.encryption_rule = DEFAULT_BUCKET_ENCRYPTION
-        self.creation_date = datetime.now(tz=gmt_zone_info)
+        self.creation_date = datetime.now(tz=_gmt_zone_info)
         self.multiparts = {}
         self.notification_configuration = {}
         self.cors_rules = None
@@ -296,7 +296,7 @@ class S3Object:
         self.expiration = expiration
         self.website_redirect_location = website_redirect_location
         self.is_current = True
-        self.last_modified = datetime.now(tz=gmt_zone_info)
+        self.last_modified = datetime.now(tz=_gmt_zone_info)
         self.parts = []
         self.restore = None
 
@@ -349,7 +349,7 @@ class S3Object:
             return False
 
         if self.lock_until:
-            return self.lock_until > datetime.now(tz=gmt_zone_info)
+            return self.lock_until > datetime.now(tz=_gmt_zone_info)
 
         return False
 
@@ -364,7 +364,7 @@ class S3DeleteMarker:
     def __init__(self, key: ObjectKey, version_id: ObjectVersionId):
         self.key = key
         self.version_id = version_id
-        self.last_modified = datetime.now(tz=gmt_zone_info)
+        self.last_modified = datetime.now(tz=_gmt_zone_info)
         self.is_current = True
 
     @staticmethod
@@ -390,7 +390,7 @@ class S3Part:
         checksum_algorithm: Optional[ChecksumAlgorithm] = None,
         checksum_value: Optional[str] = None,
     ):
-        self.last_modified = datetime.now(tz=gmt_zone_info)
+        self.last_modified = datetime.now(tz=_gmt_zone_info)
         self.part_number = part_number
         self.size = size
         self.etag = etag
@@ -430,7 +430,7 @@ class S3Multipart:
         tagging: Optional[dict[str, str]] = None,
     ):
         self.id = token_urlsafe(96)  # MultipartUploadId is 128 characters long
-        self.initiated = datetime.now(tz=gmt_zone_info)
+        self.initiated = datetime.now(tz=_gmt_zone_info)
         self.parts = {}
         self.initiator = initiator
         self.tagging = tagging

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -134,6 +134,7 @@ class S3Bucket:
         self.object_lock_enabled = object_lock_enabled_for_bucket
         self.encryption_rule = DEFAULT_BUCKET_ENCRYPTION
         self.creation_date = datetime.now(tz=_gmt_zone_info)
+        self.payer = Payer.BucketOwner
         self.multiparts = {}
         self.notification_configuration = {}
         self.cors_rules = None

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -60,6 +60,7 @@ from localstack.aws.api.s3 import (
     GetBucketInventoryConfigurationOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLocationOutput,
+    GetBucketRequestPaymentOutput,
     GetBucketTaggingOutput,
     GetBucketVersioningOutput,
     GetBucketWebsiteOutput,
@@ -141,6 +142,7 @@ from localstack.aws.api.s3 import (
     PutObjectRetentionOutput,
     PutObjectTaggingOutput,
     RequestPayer,
+    RequestPaymentConfiguration,
     RestoreObjectOutput,
     RestoreRequest,
     S3Api,
@@ -2877,6 +2879,36 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         # TODO: return RequestCharged
         return PutObjectRetentionOutput()
+
+    def put_bucket_request_payment(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        request_payment_configuration: RequestPaymentConfiguration,
+        content_md5: ContentMD5 = None,
+        checksum_algorithm: ChecksumAlgorithm = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> None:
+        # TODO: this currently only mock the operation, but its actual effect is not emulated
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        payer = request_payment_configuration.get("Payer")
+        if payer not in ["Requester", "BucketOwner"]:
+            raise MalformedXML()
+
+        s3_bucket.payer = payer
+
+    def get_bucket_request_payment(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketRequestPaymentOutput:
+        # TODO: this currently only mock the operation, but its actual effect is not emulated
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        return GetBucketRequestPaymentOutput(Payer=s3_bucket.payer)
 
     # ###### THIS ARE UNIMPLEMENTED METHODS TO ALLOW TESTING, DO NOT COUNT THEM AS DONE ###### #
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -3,7 +3,7 @@ from io import RawIOBase
 from typing import IO, Iterable, Iterator, Optional
 
 from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
-from localstack.services.s3.utils import ParsedRange
+from localstack.services.s3.utils import ObjectRange
 from localstack.services.s3.v3.models import S3Multipart, S3Object, S3Part
 
 
@@ -35,7 +35,7 @@ class LimitedStream(RawIOBase):
     This utility class allows to return a range from the underlying stream representing an S3 Object.
     """
 
-    def __init__(self, base_stream: IO[bytes] | "S3StoredObject", range_data: ParsedRange):
+    def __init__(self, base_stream: IO[bytes] | "S3StoredObject", range_data: ObjectRange):
         super().__init__()
         self.file = base_stream
         self._pos = range_data.begin
@@ -144,7 +144,7 @@ class S3StoredMultipart(abc.ABC):
         s3_part: S3Part,
         src_bucket: BucketName,
         src_s3_object: S3Object,
-        range_data: ParsedRange,
+        range_data: ObjectRange,
     ) -> S3StoredObject:
         pass
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -90,10 +90,16 @@ class S3StoredObject(abc.ABC, Iterable[bytes]):
     def seek(self, offset: int, whence: int = 0) -> int:
         pass
 
+    @property
     @abc.abstractmethod
     def checksum(self) -> Optional[str]:
         if not self.s3_object.checksum_algorithm:
             return None
+
+    @property
+    @abc.abstractmethod
+    def etag(self) -> str:
+        pass
 
     @abc.abstractmethod
     def __iter__(self) -> Iterator[bytes]:

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -11,7 +11,7 @@ from readerwriterlock import rwlock
 
 from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
 from localstack.services.s3.constants import S3_CHUNK_SIZE
-from localstack.services.s3.utils import ChecksumHash, ParsedRange, get_s3_checksum
+from localstack.services.s3.utils import ChecksumHash, ObjectRange, get_s3_checksum
 from localstack.services.s3.v3.models import S3Multipart, S3Object, S3Part
 
 from .core import LimitedStream, S3ObjectStore, S3StoredMultipart, S3StoredObject
@@ -279,7 +279,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         s3_part: S3Part,
         src_bucket: BucketName,
         src_s3_object: S3Object,
-        range_data: ParsedRange,
+        range_data: ObjectRange,
     ) -> EphemeralS3StoredObject:
         """
         Create and add an EphemeralS3StoredObject to the Multipart collection, with an S3Object as input. This will

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -58,7 +58,7 @@ class EphemeralS3StoredObject(S3StoredObject):
         super().__init__(s3_object=s3_object)
         self.file = file
         self.size = 0
-        self.etag = None
+        self._etag = None
         self.checksum_hash = None
         self._checksum = None
         self._pos = 0
@@ -131,7 +131,7 @@ class EphemeralS3StoredObject(S3StoredObject):
 
             etag = etag.hexdigest()
             self.size = self.s3_object.size = file.tell()
-            self.etag = self.s3_object.etag = etag
+            self._etag = self.s3_object.etag = etag
 
             file.seek(0)
             self._pos = 0
@@ -159,6 +159,7 @@ class EphemeralS3StoredObject(S3StoredObject):
         """Close the underlying fileobject, effectively deleting it"""
         return self.file.close()
 
+    @property
     def checksum(self) -> Optional[str]:
         """
         Return the object checksum base64 encoded, if the S3Object has a checksum algorithm.
@@ -181,6 +182,19 @@ class EphemeralS3StoredObject(S3StoredObject):
             self._checksum = base64.b64encode(self.checksum_hash.digest()).decode()
 
         return self._checksum
+
+    @property
+    def etag(self) -> str:
+        if not self._etag:
+            etag = hashlib.md5(usedforsecurity=False)
+            original_pos = self._pos
+            self._pos = 0
+            while data := self.read(S3_CHUNK_SIZE):
+                etag.update(data)
+            self._pos = original_pos
+            self._etag = etag.hexdigest()
+
+        return self._etag
 
     def __iter__(self) -> Iterator[bytes]:
         """

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -2068,9 +2068,9 @@ class TestS3:
         snapshot.match("copy-success", copy_obj_all_positive)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=lambda: not is_native_provider(),
-        paths=["$..ServerSideEncryption"],
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not validate properly",
     )
     @pytest.mark.parametrize("method", ("get_object", "head_object"))
     def test_s3_get_object_preconditions(self, s3_bucket, snapshot, aws_client, method):
@@ -3259,9 +3259,9 @@ class TestS3:
         assert copy_etag != multipart_etag
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=lambda: not is_native_provider(),
-        paths=["$..ServerSideEncryption"],
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not validate properly",
     )
     def test_get_object_part(self, s3_bucket, s3_multipart_upload, snapshot, aws_client):
         snapshot.add_transformer(

--- a/tests/aws/s3/test_s3.py
+++ b/tests/aws/s3/test_s3.py
@@ -3039,18 +3039,19 @@ class TestS3:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, path="$..Error.BucketName")
     def test_s3_request_payer_exceptions(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_request_payment(
                 Bucket=s3_bucket, RequestPaymentConfiguration={"Payer": "Random"}
             )
         snapshot.match("wrong-payer-type", e.value.response)
 
-        # TODO: check if no luck or AccessDenied is normal?
-        # with pytest.raises(ClientError) as e:
-        #     s3_client.put_bucket_request_payment(
-        #         Bucket="fake_bucket", RequestPaymentConfiguration={"Payer": "Requester"}
-        #     )
-        # snapshot.match("wrong-bucket-name", e.value.response)
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_request_payment(
+                Bucket=f"fake-bucket-{long_uid()}",
+                RequestPaymentConfiguration={"Payer": "Requester"},
+            )
+        snapshot.match("wrong-bucket-name", e.value.response)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -1679,7 +1679,7 @@
     }
   },
   "tests/aws/s3/test_s3.py::TestS3::test_multipart_copy_object_etag": {
-    "recorded-date": "03-08-2023, 04:17:57",
+    "recorded-date": "10-08-2023, 01:22:44",
     "recorded-content": {
       "multipart-upload": {
         "Bucket": "<bucket:1>",
@@ -1693,6 +1693,17 @@
         }
       },
       "copy-object": {
+        "CopyObjectResult": {
+          "ETag": "\"eee506dd7ada7ded524c77e359a0e7c6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place": {
         "CopyObjectResult": {
           "ETag": "\"eee506dd7ada7ded524c77e359a0e7c6\"",
           "LastModified": "datetime"
@@ -9475,6 +9486,172 @@
         }
       },
       "put-object-legal-hold-off": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3::test_s3_get_object_preconditions[get_object]": {
+    "recorded-date": "10-08-2023, 01:14:32",
+    "recorded-content": {
+      "precondition-if-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "precondition-if-unmodified-since": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-Unmodified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "precondition-if-none-match": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "copy-precondition-if-modified-since": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "obj-ignore-future-modified-since": {
+        "AcceptRanges": "bytes",
+        "Body": "data",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "etag-missing-quotes": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "obj-success": {
+        "AcceptRanges": "bytes",
+        "Body": "data",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3::test_s3_get_object_preconditions[head_object]": {
+    "recorded-date": "10-08-2023, 01:14:38",
+    "recorded-content": {
+      "precondition-if-match": {
+        "Error": {
+          "Code": "412",
+          "Message": "Precondition Failed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "precondition-if-unmodified-since": {
+        "Error": {
+          "Code": "412",
+          "Message": "Precondition Failed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "precondition-if-none-match": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "copy-precondition-if-modified-since": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "obj-ignore-future-modified-since": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "etag-missing-quotes": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "obj-success": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -9658,5 +9658,100 @@
         }
       }
     }
+  },
+  "tests/aws/s3/test_s3.py::TestS3::test_get_object_part": {
+    "recorded-date": "10-08-2023, 02:06:55",
+    "recorded-content": {
+      "multipart-upload": {
+        "Bucket": "<bucket:1>",
+        "ETag": "\"2848839dc84e13fa00a0944e760e233b-2\"",
+        "Key": "test.file",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-part": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"2848839dc84e13fa00a0944e760e233b-2\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "PartsCount": 2,
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-object-part": {
+        "AcceptRanges": "bytes",
+        "Body": "test content 123",
+        "ContentLength": 16,
+        "ContentRange": "bytes 5242896-5242911/5242912",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"2848839dc84e13fa00a0944e760e233b-2\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "PartsCount": 2,
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "part-doesnt-exist": {
+        "Error": {
+          "ActualPartCount": "2",
+          "Code": "InvalidPartNumber",
+          "Message": "The requested partnumber is not satisfiable",
+          "PartNumberRequested": "10"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 416
+        }
+      },
+      "part-with-range": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Cannot specify both Range header and partNumber query parameter"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "part-no-multipart": {
+        "Error": {
+          "ActualPartCount": "1",
+          "Code": "InvalidPartNumber",
+          "Message": "The requested partnumber is not satisfiable",
+          "PartNumberRequested": "2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 416
+        }
+      },
+      "get-obj-no-multipart": {
+        "AcceptRanges": "bytes",
+        "Body": "test-123",
+        "ContentLength": 8,
+        "ContentRange": "bytes 0-7/8",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"ca6d00e33edff0e9cb3782d31182de33\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      }
+    }
   }
 }

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -1486,7 +1486,7 @@
     }
   },
   "tests/aws/s3/test_s3.py::TestS3::test_s3_request_payer_exceptions": {
-    "recorded-date": "03-08-2023, 04:17:18",
+    "recorded-date": "10-08-2023, 02:34:43",
     "recorded-content": {
       "wrong-payer-type": {
         "Error": {
@@ -1496,6 +1496,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "wrong-bucket-name": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -1356,6 +1356,7 @@ def test_restxml_headers_location():
             "ContentType": "application/octet-stream",
             # The content length should explicitly be tested here.
             "ContentLength": 159,
+            "StatusCode": 200,
         },
     )
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR implements a small mocked API, BucketPaymentRequest, which is only mocked currently.
It was also an opportunity to add functionality to the "core" operations that were not done. Also, rounds of CI runs showed small issues in the current logic that were hard to spot earlier.

<!-- What notable changes does this PR make? -->
## Changes
This PR implements `BucketRequestPayment` API, which are only mocked and do not have actual effect on the global behaviour of S3 (like moto today).
It also implements preconditions checks for `HeadObject`, `GetObject` and `CopyObject`. 
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Unmodified-Since
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match

It also implements a pretty unknown feature of S3, which allows you to query the individual parts after you created an object using a MultipartUpload. It uses the behaviour of a `Range` request, even returning the same kind of headers. It is done under the hood by keep the necessary range data when completing a multipart, and using it to construct a range request when a part is being requested. It seems it is done the same way in AWS, we did not have any tests but I had a hunch it was working that way. 

Small change on the storage engine as well, the ETag is now a property, allowing to be calculated later on if it wasn't done.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

