### PR TITLE
implement S3 native PublicAccessBlock and ObjectOwnership

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -861,6 +861,13 @@ class InvalidPartNumber(ServiceException):
     ActualPartCount: Optional[PartNumber]
 
 
+class OwnershipControlsNotFoundError(ServiceException):
+    code: str = "OwnershipControlsNotFoundError"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -868,6 +868,13 @@ class OwnershipControlsNotFoundError(ServiceException):
     BucketName: Optional[BucketName]
 
 
+class NoSuchPublicAccessBlockConfiguration(ServiceException):
+    code: str = "NoSuchPublicAccessBlockConfiguration"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1076,6 +1076,23 @@
         "documentation": "<p>The requested partnumber is not satisfiable</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/OwnershipControlsNotFoundError",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The bucket ownership controls were not found</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1093,6 +1093,23 @@
         "documentation": "<p>The bucket ownership controls were not found</p>",
         "exception": true
       }
+    },
+        {
+      "op": "add",
+      "path": "/shapes/NoSuchPublicAccessBlockConfiguration",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The public access block configuration was not found</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -2,6 +2,7 @@ from localstack.aws.api.s3 import (
     BucketCannedACL,
     ObjectCannedACL,
     Permission,
+    PublicAccessBlockConfiguration,
     ServerSideEncryption,
     ServerSideEncryptionByDefault,
     ServerSideEncryptionRule,
@@ -108,4 +109,11 @@ DEFAULT_BUCKET_ENCRYPTION = ServerSideEncryptionRule(
         SSEAlgorithm=ServerSideEncryption.AES256,
     ),
     BucketKeyEnabled=False,
+)
+
+DEFAULT_PUBLIC_BLOCK_ACCESS = PublicAccessBlockConfiguration(
+    BlockPublicAcls=True,
+    BlockPublicPolicy=True,
+    RestrictPublicBuckets=True,
+    IgnorePublicAcls=True,
 )

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -130,7 +130,7 @@ class S3Bucket:
         # If ObjectLock is enabled, it forces the bucket to be versioned as well
         self.versioning_status = None if not object_lock_enabled_for_bucket else "Enabled"
         self.objects = KeyStore() if not object_lock_enabled_for_bucket else VersionedKeyStore()
-        self.object_ownership = object_ownership
+        self.object_ownership = object_ownership or ObjectOwnership.BucketOwnerEnforced
         self.object_lock_enabled = object_lock_enabled_for_bucket
         self.encryption_rule = DEFAULT_BUCKET_ENCRYPTION
         self.creation_date = datetime.now(tz=_gmt_zone_info)

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -61,7 +61,11 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
     WebsiteRedirectLocation,
 )
-from localstack.services.s3.constants import DEFAULT_BUCKET_ENCRYPTION, S3_UPLOAD_PART_MIN_SIZE
+from localstack.services.s3.constants import (
+    DEFAULT_BUCKET_ENCRYPTION,
+    DEFAULT_PUBLIC_BLOCK_ACCESS,
+    S3_UPLOAD_PART_MIN_SIZE,
+)
 from localstack.services.s3.utils import (
     get_owner_for_account_id,
     iso_8601_datetime_without_milliseconds_s3,
@@ -103,7 +107,7 @@ class S3Bucket:
     notification_configuration: NotificationConfiguration
     payer: Payer
     encryption_rule: Optional[ServerSideEncryptionRule]
-    public_access_block: PublicAccessBlockConfiguration
+    public_access_block: Optional[PublicAccessBlockConfiguration]
     accelerate_status: BucketAccelerateStatus
     object_lock_enabled: bool
     object_ownership: ObjectOwnership
@@ -135,6 +139,7 @@ class S3Bucket:
         self.encryption_rule = DEFAULT_BUCKET_ENCRYPTION
         self.creation_date = datetime.now(tz=_gmt_zone_info)
         self.payer = Payer.BucketOwner
+        self.public_access_block = DEFAULT_PUBLIC_BLOCK_ACCESS
         self.multiparts = {}
         self.notification_configuration = {}
         self.cors_rules = None

--- a/tests/aws/s3/test_s3_api.py
+++ b/tests/aws/s3/test_s3_api.py
@@ -1200,3 +1200,82 @@ class TestS3ObjectLock:
                 },
             )
         snapshot.match("disable-versioning-on-locked-bucket", e.value.response)
+
+
+@pytest.mark.skipif(
+    condition=not config.NATIVE_S3_PROVIDER,
+    reason="These are WIP tests for the new native S3 provider",
+)
+class TestS3BucketOwnershipControls:
+    @markers.aws.validated
+    def test_crud_bucket_ownership_controls(self, s3_create_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        default_s3_bucket = s3_create_bucket()
+        get_default_ownership = aws_client.s3.get_bucket_ownership_controls(
+            Bucket=default_s3_bucket
+        )
+        snapshot.match("default-ownership", get_default_ownership)
+
+        put_ownership = aws_client.s3.put_bucket_ownership_controls(
+            Bucket=default_s3_bucket,
+            OwnershipControls={"Rules": [{"ObjectOwnership": "ObjectWriter"}]},
+        )
+        snapshot.match("put-ownership", put_ownership)
+
+        get_ownership = aws_client.s3.get_bucket_ownership_controls(Bucket=default_s3_bucket)
+        snapshot.match("get-ownership", get_ownership)
+
+        delete_ownership = aws_client.s3.delete_bucket_ownership_controls(Bucket=default_s3_bucket)
+        snapshot.match("delete-ownership", delete_ownership)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.get_bucket_ownership_controls(Bucket=default_s3_bucket)
+        snapshot.match("get-ownership-after-delete", e.value.response)
+
+        delete_idempotent = aws_client.s3.delete_bucket_ownership_controls(Bucket=default_s3_bucket)
+        snapshot.match("delete-ownership-after-delete", delete_idempotent)
+
+        s3_bucket = s3_create_bucket(ObjectOwnership="BucketOwnerPreferred")
+        get_ownership_at_creation = aws_client.s3.get_bucket_ownership_controls(Bucket=s3_bucket)
+        snapshot.match("get-ownership-at-creation", get_ownership_at_creation)
+
+    @markers.aws.validated
+    def test_bucket_ownership_controls_exc(self, s3_create_bucket, aws_client, snapshot):
+        default_s3_bucket = s3_create_bucket()
+        get_default_ownership = aws_client.s3.get_bucket_ownership_controls(
+            Bucket=default_s3_bucket
+        )
+        snapshot.match("default-ownership", get_default_ownership)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_ownership_controls(
+                Bucket=default_s3_bucket,
+                OwnershipControls={
+                    "Rules": [
+                        {"ObjectOwnership": "BucketOwnerPreferred"},
+                        {"ObjectOwnership": "ObjectWriter"},
+                    ]
+                },
+            )
+        snapshot.match("put-ownership-multiple-rules", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_ownership_controls(
+                Bucket=default_s3_bucket,
+                OwnershipControls={"Rules": [{"ObjectOwnership": "RandomValue"}]},
+            )
+        snapshot.match("put-ownership-wrong-value", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.put_bucket_ownership_controls(
+                Bucket=default_s3_bucket, OwnershipControls={"Rules": []}
+            )
+        snapshot.match("put-ownership-empty-rule", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            s3_create_bucket(ObjectOwnership="RandomValue")
+        snapshot.match("ownership-wrong-value-at-creation", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            s3_create_bucket(ObjectOwnership="")
+        snapshot.match("ownership-non-value-at-creation", e.value.response)

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -2435,5 +2435,67 @@
         }
       }
     }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3PublicAccessBlock::test_crud_public_access_block": {
+    "recorded-date": "10-08-2023, 03:29:18",
+    "recorded-content": {
+      "get-default-public-access-block": {
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-public-access-block": {
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-public-access-block-after-delete": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchPublicAccessBlockConfiguration",
+          "Message": "The public access block configuration was not found"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "idempotent-delete-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3PublicAccessBlock::test_public_access_block_exc": {
+    "recorded-date": "10-08-2023, 03:30:54",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -2292,5 +2292,148 @@
         }
       }
     }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketOwnershipControls::test_crud_bucket_ownership_controls": {
+    "recorded-date": "10-08-2023, 02:57:08",
+    "recorded-content": {
+      "default-ownership": {
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "BucketOwnerEnforced"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-ownership": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-ownership": {
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-ownership": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-ownership-after-delete": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "OwnershipControlsNotFoundError",
+          "Message": "The bucket ownership controls were not found"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-ownership-after-delete": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-ownership-at-creation": {
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "BucketOwnerPreferred"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketOwnershipControls::test_bucket_ownership_controls_exc": {
+    "recorded-date": "10-08-2023, 03:08:54",
+    "recorded-content": {
+      "default-ownership": {
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "BucketOwnerEnforced"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-ownership-multiple-rules": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-ownership-wrong-value": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-ownership-empty-rule": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "ownership-wrong-value-at-creation": {
+        "Error": {
+          "ArgumentName": "x-amz-object-ownership",
+          "Code": "InvalidArgument",
+          "Message": "Invalid x-amz-object-ownership header: RandomValue"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "ownership-non-value-at-creation": {
+        "Error": {
+          "ArgumentName": "x-amz-object-ownership",
+          "Code": "InvalidArgument",
+          "Message": "Invalid x-amz-object-ownership header: "
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement Bucket API operations, those are currently only mocked and do not influence S3 behaviour. ObjectOwnership should have some impact, as it should prevent some ACLs to be set on Object, like in AWS. PublicAccessBlock cannot really be enforced, as we do not have the concept of public/anonymous access to S3 (credentials are always being set). It also has some logic tied to `s3control`, where the settings would be the most restrictive between the bucket PublicAccessBlock and the owner ones. As it's only mocked, we currently do not implemented this.

<!-- What notable changes does this PR make? -->
## Changes
Implement the following API operations:
- `GetBucketOwnershipControls`
- `PutBucketOwnershipControls`
- `DeleteBucketOwnershipControls`
- `GetPublicAccessBlock`
- `PutPublicAccessBlock`
- `DeletePublicAccessBlock`

And the validation snapshot tests that go with it.
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

