### PR TITLE
implement S3 native Bucket Policy and AccelerateConfig

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -875,6 +875,13 @@ class NoSuchPublicAccessBlockConfiguration(ServiceException):
     BucketName: Optional[BucketName]
 
 
+class NoSuchBucketPolicy(ServiceException):
+    code: str = "NoSuchBucketPolicy"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1094,7 +1094,7 @@
         "exception": true
       }
     },
-        {
+    {
       "op": "add",
       "path": "/shapes/NoSuchPublicAccessBlockConfiguration",
       "value": {
@@ -1108,6 +1108,23 @@
           "httpStatusCode": 404
         },
         "documentation": "<p>The public access block configuration was not found</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchBucketPolicy",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The bucket policy does not exist</p>",
         "exception": true
       }
     }

--- a/localstack/services/s3/exceptions.py
+++ b/localstack/services/s3/exceptions.py
@@ -41,3 +41,8 @@ class InvalidBucketState(CommonServiceException):
 class NoSuchObjectLockConfiguration(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("NoSuchObjectLockConfiguration", status_code=404, message=message)
+
+
+class MalformedPolicy(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("MalformedPolicy", status_code=400, message=message)

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -145,6 +145,7 @@ class S3Bucket:
         self.cors_rules = None
         self.lifecycle_rules = None
         self.website_configuration = None
+        self.policy = None
         self.intelligent_tiering_configurations = {}
         self.analytics_configurations = {}
         self.inventory_configurations = {}

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -146,6 +146,7 @@ class S3Bucket:
         self.lifecycle_rules = None
         self.website_configuration = None
         self.policy = None
+        self.accelerate_status = None
         self.intelligent_tiering_configurations = {}
         self.analytics_configurations = {}
         self.inventory_configurations = {}

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -2497,5 +2497,98 @@
   "tests/aws/s3/test_s3_api.py::TestS3PublicAccessBlock::test_public_access_block_exc": {
     "recorded-date": "10-08-2023, 03:30:54",
     "recorded-content": {}
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketPolicy::test_bucket_policy_crud": {
+    "recorded-date": "10-08-2023, 17:27:26",
+    "recorded-content": {
+      "get-bucket-default-policy": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucketPolicy",
+          "Message": "The bucket policy does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-bucket-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-policy": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "<resource:1>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-bucket-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-policy-after-delete": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucketPolicy",
+          "Message": "The bucket policy does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketPolicy::test_bucket_policy_exc": {
+    "recorded-date": "10-08-2023, 17:35:26",
+    "recorded-content": {
+      "put-empty-bucket-policy": {
+        "Error": {
+          "Code": "MalformedPolicy",
+          "Message": "Policies must be valid JSON and the first byte must be '{'"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-policy-randomstring": {
+        "Error": {
+          "Code": "MalformedPolicy",
+          "Message": "Policies must be valid JSON and the first byte must be '{'"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-policy-empty-json": {
+        "Error": {
+          "Code": "MalformedPolicy",
+          "Message": "Missing required field Statement"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/s3/test_s3_api.snapshot.json
+++ b/tests/aws/s3/test_s3_api.snapshot.json
@@ -2590,5 +2590,77 @@
         }
       }
     }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketAccelerateConfiguration::test_bucket_acceleration_configuration_crud": {
+    "recorded-date": "10-08-2023, 18:26:06",
+    "recorded-content": {
+      "get-bucket-default-accelerate-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-accelerate-config-enabled": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-accelerate-config-enabled": {
+        "Status": "Enabled",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-accelerate-config-disabled": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-accelerate-config-disabled": {
+        "Status": "Suspended",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3_api.py::TestS3BucketAccelerateConfiguration::test_bucket_acceleration_configuration_exc": {
+    "recorded-date": "10-08-2023, 18:01:50",
+    "recorded-content": {
+      "put-bucket-accelerate-config-lowercase": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-accelerate-config-random": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-accelerate-config-dot-bucket": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "S3 Transfer Acceleration is not supported for buckets with periods (.) in their names"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR implements the BucketPolicy and BucketAccelerateConfiguration to the new S3 provider.

<!-- What notable changes does this PR make? -->
## Changes
Those operations were only implemented in moto. Added a tiny bit of validation for the Bucket Policy, but we should/could go a bit further. 
Implemented operations:
- `PutBucketPolicy`
- `GetPolicyPolicy`
- `DeletePolicyPolicy`
- `GetBucketAccelerateConfiguration`
- `PutBucketAccelerateConfiguration`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

