### PR TITLE
refactor localstack container config hooks

### DIFF
--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -12,7 +12,7 @@ def configure_edge_port(container):
     LOG.debug("configuring container with edge ports: %s", ports)
     for port in ports:
         if port:
-            container.ports.add(port)
+            container.config.ports.add(port)
 
 
 # Register the ArnPartitionRewriteListener only if the feature flag is enabled

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -185,4 +185,4 @@ def _mount_machine_file(container):
     machine_file = os.path.join(config.dirs.cache, "machine.json")
     if os.path.isfile(machine_file):
         target = os.path.join(config.dirs.for_container().cache, "machine.json")
-        container.volumes.add(VolumeBind(machine_file, target, read_only=True))
+        container.config.volumes.add(VolumeBind(machine_file, target, read_only=True))

--- a/tests/bootstrap/test_localstack_container.py
+++ b/tests/bootstrap/test_localstack_container.py
@@ -11,7 +11,7 @@ class TestLocalstackContainerServer:
     def test_lifecycle(self):
 
         server = LocalstackContainerServer()
-        server.container.ports.add(config.EDGE_PORT)
+        server.container.config.ports.add(config.EDGE_PORT)
 
         assert not server.is_up()
         try:


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `LocalstackContainer` abstraction was introduced before `ContainerConfiguration` existed. We recently started unifying this in #8772 and are continuing to clean up container configuration procedure for @simonrw's work on creating bootstrap tests and cleaner abstractions.

<!-- What notable changes does this PR make? -->
## Changes

* Remove the remnants of exposing `ContainerConfiguration` attributes directly through `LocalstackContainer`
* Make sure all configurator hooks operate on `container.config` rather than `container`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

