### PR TITLE
implement S3 native BucketLogging and BucketReplication

### DIFF
--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -152,6 +152,7 @@ class S3Bucket:
         self.analytics_configurations = {}
         self.inventory_configurations = {}
         self.object_lock_default_retention = {}
+        self.replication = None
 
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html
         self.owner = get_owner_for_account_id(account_id)

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -108,7 +108,7 @@ class S3Bucket:
     payer: Payer
     encryption_rule: Optional[ServerSideEncryptionRule]
     public_access_block: Optional[PublicAccessBlockConfiguration]
-    accelerate_status: BucketAccelerateStatus
+    accelerate_status: Optional[BucketAccelerateStatus]
     object_lock_enabled: bool
     object_ownership: ObjectOwnership
     intelligent_tiering_configurations: dict[IntelligentTieringId, IntelligentTieringConfiguration]
@@ -142,6 +142,7 @@ class S3Bucket:
         self.public_access_block = DEFAULT_PUBLIC_BLOCK_ACCESS
         self.multiparts = {}
         self.notification_configuration = {}
+        self.logging = {}
         self.cors_rules = None
         self.lifecycle_rules = None
         self.website_configuration = None

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -7573,9 +7573,15 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_put_bucket_logging": {
-    "recorded-date": "03-08-2023, 04:26:09",
+  "tests/aws/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging": {
+    "recorded-date": "12-08-2023, 19:54:07",
     "recorded-content": {
+      "get-bucket-logging-default": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get-bucket-default-acl": {
         "Grants": [
           {
@@ -7620,7 +7626,7 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_put_bucket_logging_accept_wrong_grants": {
+  "tests/aws/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging_accept_wrong_grants": {
     "recorded-date": "03-08-2023, 04:26:11",
     "recorded-content": {
       "put-bucket-logging": {
@@ -7657,7 +7663,7 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_put_bucket_logging_wrong_target": {
+  "tests/aws/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging_wrong_target": {
     "recorded-date": "03-08-2023, 04:26:14",
     "recorded-content": {
       "put-bucket-logging-different-regions": {

--- a/tests/aws/s3/test_s3.snapshot.json
+++ b/tests/aws/s3/test_s3.snapshot.json
@@ -4098,8 +4098,8 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_replication_config": {
-    "recorded-date": "03-08-2023, 04:13:08",
+  "tests/aws/s3/test_s3.py::TestS3BucketReplication::test_replication_config": {
+    "recorded-date": "12-08-2023, 20:11:46",
     "recorded-content": {
       "expected_error_no_replication_set": {
         "Error": {
@@ -4152,6 +4152,28 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "put-empty-bucket-replication-rules": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-bucket-replication": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-bucket-replication-idempotent": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
       }
     }
   },
@@ -4166,7 +4188,7 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_replication_config_without_filter": {
+  "tests/aws/s3/test_s3.py::TestS3BucketReplication::test_replication_config_without_filter": {
     "recorded-date": "03-08-2023, 04:13:02",
     "recorded-content": {
       "expected_error_dest_does_not_exist": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement S3 BucketLogging and BucketReplication mocking, only adding validation but not actually emulating the replication.

<!-- What notable changes does this PR make? -->
## Changes
Added a small fix regarding locking when accessing a Multipart, to not create it twice.
Implemented the following API operations:
- `PutBucketLogging`
- `GetBucketLogging`
- `PutBucketReplication`
- `GetBucketReplication`
- `DeleteBucketReplication`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

