### PR TITLE
implement S3 native ACL

### DIFF
--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -1,6 +1,5 @@
 from localstack.aws.api.s3 import (
-    BucketCannedACL,
-    ObjectCannedACL,
+    Grantee,
     Permission,
     PublicAccessBlockConfiguration,
     ServerSideEncryption,
@@ -8,6 +7,7 @@ from localstack.aws.api.s3 import (
     ServerSideEncryptionRule,
     StorageClass,
 )
+from localstack.aws.api.s3 import Type as GranteeType
 
 S3_VIRTUAL_HOST_FORWARDED_HEADER = "x-s3-vhost-forwarded-for"
 
@@ -16,23 +16,14 @@ S3_UPLOAD_PART_MIN_SIZE = 5242880
 This is minimum size allowed by S3 when uploading more than one part for a Multipart Upload, except for the last part
 """
 
-VALID_CANNED_ACLS_BUCKET = {
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
-    # bucket-owner-read + bucket-owner-full-control are allowed, but ignored for buckets
-    ObjectCannedACL.private,
-    ObjectCannedACL.authenticated_read,
-    ObjectCannedACL.aws_exec_read,
-    ObjectCannedACL.bucket_owner_full_control,
-    ObjectCannedACL.bucket_owner_read,
-    ObjectCannedACL.public_read,
-    ObjectCannedACL.public_read_write,
-    BucketCannedACL.log_delivery_write,
-}
+AUTHENTICATED_USERS_ACL_GROUP = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+ALL_USERS_ACL_GROUP = "http://acs.amazonaws.com/groups/global/AllUsers"
+LOG_DELIVERY_ACL_GROUP = "http://acs.amazonaws.com/groups/s3/LogDelivery"
 
 VALID_ACL_PREDEFINED_GROUPS = {
-    "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
-    "http://acs.amazonaws.com/groups/global/AllUsers",
-    "http://acs.amazonaws.com/groups/s3/LogDelivery",
+    AUTHENTICATED_USERS_ACL_GROUP,
+    ALL_USERS_ACL_GROUP,
+    LOG_DELIVERY_ACL_GROUP,
 }
 
 VALID_GRANTEE_PERMISSIONS = {
@@ -117,3 +108,7 @@ DEFAULT_PUBLIC_BLOCK_ACCESS = PublicAccessBlockConfiguration(
     RestrictPublicBuckets=True,
     IgnorePublicAcls=True,
 )
+
+AUTHENTICATED_USERS_ACL_GRANTEE = Grantee(URI=AUTHENTICATED_USERS_ACL_GROUP, Type=GranteeType.Group)
+ALL_USERS_ACL_GRANTEE = Grantee(URI=ALL_USERS_ACL_GROUP, Type=GranteeType.Group)
+LOG_DELIVERY_ACL_GRANTEE = Grantee(URI=LOG_DELIVERY_ACL_GROUP, Type=GranteeType.Group)

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9822,5 +9822,289 @@
         }
       }
     }
+  },
+  "tests/aws/s3/test_s3.py::TestS3::test_s3_object_acl": {
+    "recorded-date": "15-08-2023, 23:41:05",
+    "recorded-content": {
+      "put-object-default-acl": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-acl-default": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-acl": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          },
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+            },
+            "Permission": "READ"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-grant-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "READ"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-acp-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          },
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "WRITE"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
+    "recorded-date": "15-08-2023, 23:47:00",
+    "recorded-content": {
+      "put-object-canned-acl": {
+        "Error": {
+          "ArgumentName": "x-amz-acl",
+          "ArgumentValue": "fake-acl",
+          "Code": "InvalidArgument",
+          "Message": null
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acl-canned-acl": {
+        "Error": {
+          "ArgumentName": "x-amz-acl",
+          "ArgumentValue": "fake-acl",
+          "Code": "InvalidArgument",
+          "Message": null
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-fake-uri": {
+        "Error": {
+          "ArgumentName": "uri",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-fake-key": {
+        "Error": {
+          "ArgumentName": "x-amz-grant-write",
+          "ArgumentValue": "fakekey=\"1234\"",
+          "Code": "InvalidArgument",
+          "Message": "Argument format not recognized"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-wrong-id": {
+        "Error": {
+          "ArgumentName": "id",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-1": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-2": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-3": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-4": {
+        "Error": {
+          "ArgumentName": "Group/URI",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-5": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-6": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-empty-acp": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acl-empty": {
+        "Error": {
+          "Code": "MissingSecurityHeader",
+          "Message": "Your request was missing a required header",
+          "MissingHeaderName": "x-amz-acl"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-two-type-acl": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Specifying both Canned ACLs and Header Grants is not allowed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-two-type-acl-acp": {
+        "Error": {
+          "Code": "UnexpectedContent",
+          "Message": "This request does not support content"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5373,7 +5373,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_acl_on_delete_marker": {
-    "recorded-date": "04-08-2023, 23:53:09",
+    "recorded-date": "13-08-2023, 02:27:00",
     "recorded-content": {
       "put-obj-1": {
         "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
@@ -5394,23 +5394,53 @@
         }
       },
       "delete-object": {
-        "Deleted": [
-          {
-            "DeleteMarker": true,
-            "DeleteMarkerVersionId": "PY9ezDfMH8Xgs0AK1ri_1goNuAwSqcbA",
-            "Key": "test-key-versioned"
-          }
-        ],
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 204
         }
       },
-      "key-delete-marker": {
+      "put-acl-delete-marker": {
         "Error": {
           "Code": "MethodNotAllowed",
           "Message": "The specified method is not allowed against this resource.",
           "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "get-acl-delete-marker": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "test-key-versioned",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-acl-delete-marker-version-id": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      },
+      "get-acl-delete-marker-version-id": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "GET",
           "ResourceType": "DeleteMarker"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9823,7 +9823,7 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_object_acl": {
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
     "recorded-date": "15-08-2023, 23:41:05",
     "recorded-content": {
       "put-object-default-acl": {
@@ -9935,7 +9935,7 @@
       }
     }
   },
-  "tests/aws/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
     "recorded-date": "15-08-2023, 23:47:00",
     "recorded-content": {
       "put-object-canned-acl": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implement S3 Bucket and Object ACL, even if not enforced, in the new S3 provider.

<!-- What notable changes does this PR make? -->
## Changes
This combines Moto ACL implementation with the fixes we have in moto-ext. For this we are not going the extra miles, keeping the same functionality as we had. As we do not enforce ACL at the moment, this is fine. AWS does not encourage the use of ACL now.
Also added some tests for `GetObjectACL`/`PutObjectACL` which were missing.
This PR implements:
- `PutBucketACL`
- `GetObjectACL`
- `PutObjectACL`
- `GetObjectACL`
- Support for ACL in following operations:
  - `PutObject`
  - `CreateMultipartUpload`
  - `CopyObject`

