### PR TITLE
DynamoDB: Global table support for Scan and Query

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -852,13 +852,18 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                     "type is not ALL",
                 )
 
-        result = self.forward_request(context)
+        table_name = query_input["TableName"]
+        global_table_region = self.get_global_table_region(context, table_name)
+        result = self._forward_request(context=context, region=global_table_region)
         self.fix_consumed_capacity(query_input, result)
         return result
 
     @handler("Scan", expand=False)
     def scan(self, context: RequestContext, scan_input: ScanInput) -> ScanOutput:
-        return self.forward_request(context)
+        table_name = scan_input["TableName"]
+        global_table_region = self.get_global_table_region(context, table_name)
+        result = self._forward_request(context=context, region=global_table_region)
+        return result
 
     #
     # Batch ops

--- a/tests/aws/test_dynamodb.py
+++ b/tests/aws/test_dynamodb.py
@@ -954,7 +954,7 @@ class TestDynamoDB:
             Item={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
         )
 
-        # Ensure item in US and EU
+        # Ensure GetItem in US and EU
         item_us_east = dynamodb_us_east_1.get_item(
             TableName=table_name,
             Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
@@ -965,6 +965,26 @@ class TestDynamoDB:
             Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
         )["Item"]
         assert item_eu_west
+
+        # Ensure Scan in US and EU
+        scan_us_east = dynamodb_us_east_1.scan(TableName=table_name)
+        assert scan_us_east["Items"]
+        scan_eu_west = dynamodb_eu_west_1.scan(TableName=table_name)
+        assert scan_eu_west["Items"]
+
+        # Ensure Query in US and EU
+        query_us_east = dynamodb_us_east_1.query(
+            TableName=table_name,
+            KeyConditionExpression="Artist = :artist",
+            ExpressionAttributeValues={":artist": {"S": "item_1"}},
+        )
+        assert query_us_east["Items"]
+        query_eu_west = dynamodb_eu_west_1.query(
+            TableName=table_name,
+            KeyConditionExpression="Artist = :artist",
+            ExpressionAttributeValues={":artist": {"S": "item_1"}},
+        )
+        assert query_eu_west["Items"]
 
         # Delete EU replica
         dynamodb_ap_south_1.update_table(


### PR DESCRIPTION
### Summary

This PR enables `Scan` and `Query` operations to work on Global Tables.

### Tests

An existing global tables tests is modified to make additional assertions on these operations.

### Related

Closes: #8824