### PR TITLE
implement S3 native pre-signed POST (PostObject)

### DIFF
--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -73,7 +73,6 @@ SYSTEM_METADATA_SETTABLE_HEADERS = [
     "ContentDisposition",
     "ContentEncoding",
     "ContentLanguage",
-    "ContentMD5",
     "ContentType",
 ]
 

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from operator import itemgetter
 from secrets import token_urlsafe
-from typing import Union
+from typing import IO, Union
 
 from localstack import config
 from localstack.aws.api import CommonServiceException, RequestContext, handler
@@ -19,6 +19,7 @@ from localstack.aws.api.s3 import (
     AccountId,
     AnalyticsConfiguration,
     AnalyticsId,
+    Body,
     Bucket,
     BucketAlreadyExists,
     BucketAlreadyOwnedByYou,
@@ -154,6 +155,7 @@ from localstack.aws.api.s3 import (
     PartNumber,
     PartNumberMarker,
     Policy,
+    PostResponse,
     PreconditionFailed,
     Prefix,
     PublicAccessBlockConfiguration,
@@ -213,9 +215,11 @@ from localstack.services.s3.exceptions import (
     UnexpectedContent,
 )
 from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
+from localstack.services.s3.presigned_url import validate_post_policy
 from localstack.services.s3.utils import (
     ObjectRange,
     add_expiration_days_to_datetime,
+    create_redirect_for_post_request,
     create_s3_kms_managed_key_for_region,
     extract_bucket_key_version_id_from_copy_source,
     get_canned_acl,
@@ -230,9 +234,11 @@ from localstack.services.s3.utils import (
     get_system_metadata_from_request,
     get_unique_key_id,
     is_bucket_name_valid,
+    parse_post_object_tagging_xml,
     parse_range_header,
     parse_tagging_header,
     serialize_expiration_header,
+    str_to_rfc_1123_datetime,
     validate_dict_fields,
     validate_failed_precondition,
     validate_kms_key_id,
@@ -581,6 +587,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         acl = get_access_control_policy_for_new_resource_request(request, owner=s3_bucket.owner)
 
+        if tagging := request.get("Tagging"):
+            tagging = parse_tagging_header(tagging)
+
         s3_object = S3Object(
             key=key,
             version_id=version_id,
@@ -615,8 +624,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # in case we are overriding an object, delete the tags entry
         key_id = get_unique_key_id(bucket_name, key, version_id)
         store.TAGS.tags.pop(key_id, None)
-        if tagging_header := request.get("Tagging"):
-            tagging = parse_tagging_header(tagging_header)
+        if tagging:
             store.TAGS.tags[key_id] = tagging
 
         # TODO: returned fields
@@ -669,6 +677,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             version_id=version_id,
             http_method="GET",
         )
+        if s3_object.expires and s3_object.expires < datetime.datetime.now(
+            tz=s3_object.expires.tzinfo
+        ):
+            # TODO: old behaviour was deleting key instantly if expired. AWS cleans up only once a day generally
+            #  you can still HeadObject on it and you get the expiry time until scheduled deletion
+            kwargs = {"Key": object_key}
+            if version_id:
+                kwargs["VersionId"] = version_id
+            raise NoSuchKey("The specified key does not exist.", **kwargs)
 
         validate_failed_precondition(request, s3_object.last_modified, s3_object.etag)
 
@@ -1069,6 +1086,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not (src_s3_bucket := store.buckets.get(src_bucket)):
             # TODO: validate this
             raise NoSuchBucket("The specified bucket does not exist", BucketName=src_bucket)
+
+        if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
+            validate_kms_key_id(sse_kms_key_id, dest_s3_bucket)
 
         # validate method not allowed?
         # if the object is a delete marker, get_object will raise, like AWS
@@ -1965,7 +1985,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             Bucket=bucket,
             Key=key,
             ETag=s3_object.quoted_etag,
-            Location=f"{get_full_default_bucket_location(bucket)}{bucket}",
+            Location=f"{get_full_default_bucket_location(bucket)}{key}",
         )
 
         if s3_object.version_id:
@@ -3354,6 +3374,177 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> GetObjectTorrentOutput:
         raise NotImplementedError
+
+    def post_object(
+        self, context: RequestContext, bucket: BucketName, body: IO[Body] = None
+    ) -> PostResponse:
+        # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+        # TODO: signature validation is not implemented for pre-signed POST
+        # policy validation is not implemented either, except expiration and mandatory fields
+        # This operation is the only one using form for storing the request data. We will have to do some manual
+        # parsing here, as no specs are present for this, as no client directly implements this operation.
+        store = self.get_store(context.account_id, context.region)
+        if not (s3_bucket := store.buckets.get(bucket)):
+            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        form = context.request.form
+        validate_post_policy(form)
+
+        fileobj = context.request.files["file"]
+        object_key = context.request.form.get("key")
+        if "${filename}" in object_key:
+            object_key = object_key.replace("${filename}", fileobj.filename)
+
+        if canned_acl := form.get("acl"):
+            validate_canned_acl(canned_acl)
+            acp = get_canned_acl(canned_acl, owner=s3_bucket.owner)
+        else:
+            acp = get_canned_acl(BucketCannedACL.private, owner=s3_bucket.owner)
+
+        post_system_settable_headers = [
+            "Cache-Control",
+            "Content-Type",
+            "Content-Disposition",
+            "Content-Encoding",
+        ]
+        system_metadata = {}
+        for system_metadata_field in post_system_settable_headers:
+            if field_value := form.get(system_metadata_field):
+                system_metadata[system_metadata_field.replace("-", "")] = field_value
+
+        if not system_metadata.get("ContentType"):
+            system_metadata["ContentType"] = "binary/octet-stream"
+
+        user_metadata = {
+            field.removeprefix("x-amz-meta-").lower(): form.get(field)
+            for field in form
+            if field.startswith("x-amz-meta-")
+        }
+
+        if tagging := form.get("tagging"):
+            # this is weird, as it's direct XML in the form, we need to parse it direcly
+            tagging = parse_post_object_tagging_xml(tagging)
+
+        if (storage_class := form.get("x-amz-storage-class")) is not None and (
+            storage_class not in STORAGE_CLASSES or storage_class == StorageClass.OUTPOSTS
+        ):
+            raise InvalidStorageClass(
+                "The storage class you specified is not valid", StorageClassRequested=storage_class
+            )
+
+        encryption_request = {
+            "ServerSideEncryption": form.get("x-amz-server-side-encryption"),
+            "SSEKMSKeyId": form.get("x-amz-server-side-encryption-aws-kms-key-id"),
+            "BucketKeyEnabled": form.get("x-amz-server-side-encryption-bucket-key-enabled"),
+        }
+
+        encryption_parameters = get_encryption_parameters_from_request_and_bucket(
+            encryption_request,
+            s3_bucket,
+            store,
+        )
+
+        checksum_algorithm = form.get("x-amz-checksum-algorithm")
+        checksum_value = (
+            form.get(f"x-amz-checksum-{checksum_algorithm.lower()}") if checksum_algorithm else None
+        )
+        expires = (
+            str_to_rfc_1123_datetime(expires_str) if (expires_str := form.get("Expires")) else None
+        )
+
+        version_id = generate_version_id(s3_bucket.versioning_status)
+
+        s3_object = S3Object(
+            key=object_key,
+            version_id=version_id,
+            storage_class=storage_class,
+            expires=expires,
+            user_metadata=user_metadata,
+            system_metadata=system_metadata,
+            checksum_algorithm=checksum_algorithm,
+            checksum_value=checksum_value,
+            encryption=encryption_parameters.encryption,
+            kms_key_id=encryption_parameters.kms_key_id,
+            bucket_key_enabled=encryption_parameters.bucket_key_enabled,
+            website_redirect_location=form.get("x-amz-website-redirect-location"),
+            acl=acp,
+            owner=s3_bucket.owner,  # TODO: for now we only have one owner, but it can depends on Bucket settings
+        )
+
+        s3_stored_object = self._storage_backend.open(bucket, s3_object)
+        s3_stored_object.write(fileobj.stream)
+
+        if checksum_algorithm and s3_object.checksum_value != s3_stored_object.checksum:
+            self._storage_backend.remove(bucket, s3_object)
+            raise InvalidRequest(
+                f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
+            )
+
+        s3_bucket.objects.set(object_key, s3_object)
+
+        # in case we are overriding an object, delete the tags entry
+        key_id = get_unique_key_id(bucket, object_key, version_id)
+        store.TAGS.tags.pop(key_id, None)
+        if tagging:
+            store.TAGS.tags[key_id] = tagging
+
+        response = PostResponse()
+        # hacky way to set the etag in the headers as well: two locations for one value
+        response["ETagHeader"] = s3_object.quoted_etag
+
+        if redirect := form.get("success_action_redirect"):
+            # we need to create the redirect, as the parser could not return the moto-calculated one
+            try:
+                redirect = create_redirect_for_post_request(
+                    base_redirect=redirect,
+                    bucket=bucket,
+                    object_key=object_key,
+                    etag=s3_object.quoted_etag,
+                )
+                response["LocationHeader"] = redirect
+                response["StatusCode"] = 303
+            except ValueError:
+                # If S3 cannot interpret the URL, it acts as if the field is not present.
+                response["StatusCode"] = form.get("success_action_status", 204)
+
+        elif status_code := form.get("success_action_status"):
+            response["StatusCode"] = status_code
+        else:
+            response["StatusCode"] = 204
+
+        response["LocationHeader"] = response.get(
+            "LocationHeader", f"{get_full_default_bucket_location(bucket)}{object_key}"
+        )
+
+        if s3_bucket.versioning_status == "Enabled":
+            response["VersionId"] = s3_object.version_id
+
+        if s3_object.checksum_algorithm:
+            response[f"Checksum{checksum_algorithm.upper()}"] = s3_object.checksum_value
+
+        if s3_bucket.lifecycle_rules:
+            if expiration_header := self._get_expiration_header(
+                s3_bucket.lifecycle_rules,
+                bucket,
+                s3_object,
+                store.TAGS.tags.get(key_id, {}),
+            ):
+                # TODO: we either apply the lifecycle to existing objects when we set the new rules, or we need to
+                #  apply them everytime we get/head an object
+                response["Expiration"] = expiration_header
+
+        add_encryption_to_response(response, s3_object=s3_object)
+
+        self._notify(context, s3_bucket=s3_bucket, s3_object=s3_object)
+
+        if response["StatusCode"] == "201":
+            # if the StatusCode is 201, S3 returns an XML body with additional information
+            response["ETag"] = s3_object.quoted_etag
+            response["Bucket"] = bucket
+            response["Key"] = object_key
+            response["Location"] = response["LocationHeader"]
+
+        return response
 
 
 def generate_version_id(bucket_versioning_status: str) -> str | None:

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9806,399 +9806,400 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
-    "recorded-date": "14-08-2023, 19:32:11",
-    "recorded-content": {
-      "get-tagging": {
-        "TagSet": [
-          {
-            "Key": "TagName",
-            "Value": "TagValue"
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
+      "recorded-date": "14-08-2023, 19:32:11",
+      "recorded-content": {
+        "get-tagging": {
+          "TagSet": [
+            {
+              "Key": "TagName",
+              "Value": "TagValue"
+            }
+          ],
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
         }
       }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[list]": {
-    "recorded-date": "14-08-2023, 19:32:13",
-    "recorded-content": {
-      "get-tagging": {
-        "TagSet": [
-          {
-            "Key": "TagName",
-            "Value": "TagValue"
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[list]": {
+      "recorded-date": "14-08-2023, 19:32:13",
+      "recorded-content": {
+        "get-tagging": {
+          "TagSet": [
+            {
+              "Key": "TagName",
+              "Value": "TagValue"
+            },
+            {
+              "Key": "TagName2",
+              "Value": "TagValue2"
+            }
+          ],
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      }
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[invalid]": {
+      "recorded-date": "14-08-2023, 19:32:14",
+      "recorded-content": {
+        "get-tagging": {
+          "TagSet": [],
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      }
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[notxml]": {
+      "recorded-date": "14-08-2023, 19:32:16",
+      "recorded-content": {
+        "tagging-error": {
+          "Error": {
+            "Code": "MalformedXML",
+            "HostId": "<host-id:1>",
+            "Message": "The XML you provided was not well-formed or did not validate against our published schema",
+            "RequestId": "<request-id:1>"
+          }
+        }
+      }
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
+      "recorded-date": "14-08-2023, 19:54:15",
+      "recorded-content": {
+        "head-object": {
+          "AcceptRanges": "bytes",
+          "ContentLength": 17,
+          "ContentType": "text/plain",
+          "ETag": "\"a7d8531d918474360de3e2eaeb110cda\"",
+          "Expires": "datetime",
+          "LastModified": "datetime",
+          "Metadata": {
+            "test-1": "test-meta-1",
+            "test-2": "test-meta-2"
           },
-          {
-            "Key": "TagName2",
-            "Value": "TagValue2"
+          "ServerSideEncryption": "AES256",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
         }
       }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[invalid]": {
-    "recorded-date": "14-08-2023, 19:32:14",
-    "recorded-content": {
-      "get-tagging": {
-        "TagSet": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[notxml]": {
-    "recorded-date": "14-08-2023, 19:32:16",
-    "recorded-content": {
-      "tagging-error": {
-        "Error": {
-          "Code": "MalformedXML",
-          "HostId": "<host-id:1>",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema",
-          "RequestId": "<request-id:1>"
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
-    "recorded-date": "14-08-2023, 19:54:15",
-    "recorded-content": {
-      "head-object": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 17,
-        "ContentType": "text/plain",
-        "ETag": "\"a7d8531d918474360de3e2eaeb110cda\"",
-        "Expires": "datetime",
-        "LastModified": "datetime",
-        "Metadata": {
-          "test-1": "test-meta-1",
-          "test-2": "test-meta-2"
-        },
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_storage_class": {
-    "recorded-date": "14-08-2023, 20:14:49",
-    "recorded-content": {
-      "head-object": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 23,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"f73f1a2dbae1bbd6c42f86e771298073\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ServerSideEncryption": "AES256",
-        "StorageClass": "STANDARD_IA",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "invalid-storage-error": {
-        "Error": {
-          "Code": "InvalidStorageClass",
-          "HostId": "<host-id:2>",
-          "Message": "The storage class you specified is not valid",
-          "RequestId": "<request-id:2>",
-          "StorageClassRequested": "FakeClass"
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
-    "recorded-date": "15-08-2023, 23:41:05",
-    "recorded-content": {
-      "put-object-default-acl": {
-        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-acl-default": {
-        "Grants": [
-          {
-            "Grantee": {
-              "DisplayName": "<display-name:1>",
-              "ID": "<owner-id:1>",
-              "Type": "CanonicalUser"
-            },
-            "Permission": "FULL_CONTROL"
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_storage_class": {
+      "recorded-date": "14-08-2023, 20:14:49",
+      "recorded-content": {
+        "head-object": {
+          "AcceptRanges": "bytes",
+          "ContentLength": 23,
+          "ContentType": "binary/octet-stream",
+          "ETag": "\"f73f1a2dbae1bbd6c42f86e771298073\"",
+          "LastModified": "datetime",
+          "Metadata": {},
+          "ServerSideEncryption": "AES256",
+          "StorageClass": "STANDARD_IA",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "Owner": {
-          "DisplayName": "<display-name:1>",
-          "ID": "<owner-id:1>"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+        "invalid-storage-error": {
+          "Error": {
+            "Code": "InvalidStorageClass",
+            "HostId": "<host-id:2>",
+            "Message": "The storage class you specified is not valid",
+            "RequestId": "<request-id:2>",
+            "StorageClassRequested": "FakeClass"
+          }
         }
-      },
-      "put-object-acl": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-acl": {
-        "Grants": [
-          {
-            "Grantee": {
-              "DisplayName": "<display-name:1>",
-              "ID": "<owner-id:1>",
-              "Type": "CanonicalUser"
-            },
-            "Permission": "FULL_CONTROL"
+      }
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
+      "recorded-date": "15-08-2023, 23:41:05",
+      "recorded-content": {
+        "put-object-default-acl": {
+          "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+          "ServerSideEncryption": "AES256",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        },
+        "get-object-acl-default": {
+          "Grants": [
+            {
+              "Grantee": {
+                "DisplayName": "<display-name:1>",
+                "ID": "<owner-id:1>",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "FULL_CONTROL"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "<display-name:1>",
+            "ID": "<owner-id:1>"
           },
-          {
-            "Grantee": {
-              "Type": "Group",
-              "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
-            },
-            "Permission": "READ"
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "Owner": {
-          "DisplayName": "<display-name:1>",
-          "ID": "<owner-id:1>"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-grant-acl": {
-        "Grants": [
-          {
-            "Grantee": {
-              "Type": "Group",
-              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
-            },
-            "Permission": "READ"
+        "put-object-acl": {
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "Owner": {
-          "DisplayName": "<display-name:1>",
-          "ID": "<owner-id:1>"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-acp-acl": {
-        "Grants": [
-          {
-            "Grantee": {
-              "DisplayName": "<display-name:1>",
-              "ID": "<owner-id:1>",
-              "Type": "CanonicalUser"
+        "get-object-acl": {
+          "Grants": [
+            {
+              "Grantee": {
+                "DisplayName": "<display-name:1>",
+                "ID": "<owner-id:1>",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "FULL_CONTROL"
             },
-            "Permission": "FULL_CONTROL"
+            {
+              "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+              },
+              "Permission": "READ"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "<display-name:1>",
+            "ID": "<owner-id:1>"
           },
-          {
-            "Grantee": {
-              "Type": "Group",
-              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
-            },
-            "Permission": "WRITE"
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
           }
-        ],
-        "Owner": {
-          "DisplayName": "<display-name:1>",
-          "ID": "<owner-id:1>"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+        "get-object-grant-acl": {
+          "Grants": [
+            {
+              "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+              },
+              "Permission": "READ"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "<display-name:1>",
+            "ID": "<owner-id:1>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        },
+        "get-object-acp-acl": {
+          "Grants": [
+            {
+              "Grantee": {
+                "DisplayName": "<display-name:1>",
+                "ID": "<owner-id:1>",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "FULL_CONTROL"
+            },
+            {
+              "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+              },
+              "Permission": "WRITE"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "<display-name:1>",
+            "ID": "<owner-id:1>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
         }
       }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
-    "recorded-date": "15-08-2023, 23:47:00",
-    "recorded-content": {
-      "put-object-canned-acl": {
-        "Error": {
-          "ArgumentName": "x-amz-acl",
-          "ArgumentValue": "fake-acl",
-          "Code": "InvalidArgument",
-          "Message": null
+    },
+    "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
+      "recorded-date": "15-08-2023, 23:47:00",
+      "recorded-content": {
+        "put-object-canned-acl": {
+          "Error": {
+            "ArgumentName": "x-amz-acl",
+            "ArgumentValue": "fake-acl",
+            "Code": "InvalidArgument",
+            "Message": null
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acl-canned-acl": {
-        "Error": {
-          "ArgumentName": "x-amz-acl",
-          "ArgumentValue": "fake-acl",
-          "Code": "InvalidArgument",
-          "Message": null
+        "put-object-acl-canned-acl": {
+          "Error": {
+            "ArgumentName": "x-amz-acl",
+            "ArgumentValue": "fake-acl",
+            "Code": "InvalidArgument",
+            "Message": null
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-grant-acl-fake-uri": {
-        "Error": {
-          "ArgumentName": "uri",
-          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
-          "Code": "InvalidArgument",
-          "Message": "Invalid group uri"
+        "put-object-grant-acl-fake-uri": {
+          "Error": {
+            "ArgumentName": "uri",
+            "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+            "Code": "InvalidArgument",
+            "Message": "Invalid group uri"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-grant-acl-fake-key": {
-        "Error": {
-          "ArgumentName": "x-amz-grant-write",
-          "ArgumentValue": "fakekey=\"1234\"",
-          "Code": "InvalidArgument",
-          "Message": "Argument format not recognized"
+        "put-object-grant-acl-fake-key": {
+          "Error": {
+            "ArgumentName": "x-amz-grant-write",
+            "ArgumentValue": "fakekey=\"1234\"",
+            "Code": "InvalidArgument",
+            "Message": "Argument format not recognized"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-grant-acl-wrong-id": {
-        "Error": {
-          "ArgumentName": "id",
-          "ArgumentValue": "wrong-id",
-          "Code": "InvalidArgument",
-          "Message": "Invalid id"
+        "put-object-grant-acl-wrong-id": {
+          "Error": {
+            "ArgumentName": "id",
+            "ArgumentValue": "wrong-id",
+            "Code": "InvalidArgument",
+            "Message": "Invalid id"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-1": {
-        "Error": {
-          "Code": "MalformedACLError",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        "put-object-acp-acl-1": {
+          "Error": {
+            "Code": "MalformedACLError",
+            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-2": {
-        "Error": {
-          "Code": "MalformedACLError",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        "put-object-acp-acl-2": {
+          "Error": {
+            "Code": "MalformedACLError",
+            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-3": {
-        "Error": {
-          "ArgumentName": "CanonicalUser/ID",
-          "ArgumentValue": "wrong-id",
-          "Code": "InvalidArgument",
-          "Message": "Invalid id"
+        "put-object-acp-acl-3": {
+          "Error": {
+            "ArgumentName": "CanonicalUser/ID",
+            "ArgumentValue": "wrong-id",
+            "Code": "InvalidArgument",
+            "Message": "Invalid id"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-4": {
-        "Error": {
-          "ArgumentName": "Group/URI",
-          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
-          "Code": "InvalidArgument",
-          "Message": "Invalid group uri"
+        "put-object-acp-acl-4": {
+          "Error": {
+            "ArgumentName": "Group/URI",
+            "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+            "Code": "InvalidArgument",
+            "Message": "Invalid group uri"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-5": {
-        "Error": {
-          "ArgumentName": "CanonicalUser/ID",
-          "ArgumentValue": "wrong-id",
-          "Code": "InvalidArgument",
-          "Message": "Invalid id"
+        "put-object-acp-acl-5": {
+          "Error": {
+            "ArgumentName": "CanonicalUser/ID",
+            "ArgumentValue": "wrong-id",
+            "Code": "InvalidArgument",
+            "Message": "Invalid id"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acp-acl-6": {
-        "Error": {
-          "Code": "MalformedACLError",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        "put-object-acp-acl-6": {
+          "Error": {
+            "Code": "MalformedACLError",
+            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-empty-acp": {
-        "Error": {
-          "Code": "MalformedACLError",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        "put-object-empty-acp": {
+          "Error": {
+            "Code": "MalformedACLError",
+            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-acl-empty": {
-        "Error": {
-          "Code": "MissingSecurityHeader",
-          "Message": "Your request was missing a required header",
-          "MissingHeaderName": "x-amz-acl"
+        "put-object-acl-empty": {
+          "Error": {
+            "Code": "MissingSecurityHeader",
+            "Message": "Your request was missing a required header",
+            "MissingHeaderName": "x-amz-acl"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-two-type-acl": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "Specifying both Canned ACLs and Header Grants is not allowed"
+        "put-object-two-type-acl": {
+          "Error": {
+            "Code": "InvalidRequest",
+            "Message": "Specifying both Canned ACLs and Header Grants is not allowed"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-two-type-acl-acp": {
-        "Error": {
-          "Code": "UnexpectedContent",
-          "Message": "This request does not support content"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+        "put-object-two-type-acl-acp": {
+          "Error": {
+            "Code": "UnexpectedContent",
+            "Message": "This request does not support content"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 400
+          }
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -3503,7 +3503,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_expires": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_expires": {
     "recorded-date": "04-08-2023, 23:58:47",
     "recorded-content": {
       "exception": {
@@ -3517,25 +3517,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy": {
-    "recorded-date": "04-10-2022, 20:42:19",
-    "recorded-content": {
-      "exception": {
-        "Error": {
-          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
-          "Code": "SignatureDoesNotMatch",
-          "HostId": "host-id",
-          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
-          "RequestId": "<request-id:1>",
-          "SignatureProvided": "<signature-provided:1>",
-          "StringToSign": "<string-to-sign>",
-          "StringToSignBytes": "<string-to-sign-bytes:1>"
-        },
-        "StatusCode": 403
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_malformed_policy[s3]": {
     "recorded-date": "04-08-2023, 23:58:49",
     "recorded-content": {
       "exception-policy": {
@@ -3553,7 +3535,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3v4]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_malformed_policy[s3v4]": {
     "recorded-date": "04-08-2023, 23:58:51",
     "recorded-content": {
       "exception-policy": {
@@ -3571,7 +3553,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_missing_signature[s3]": {
     "recorded-date": "04-08-2023, 23:58:52",
     "recorded-content": {
       "exception-missing-signature": {
@@ -3587,7 +3569,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3v4]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_missing_signature[s3v4]": {
     "recorded-date": "04-08-2023, 23:58:54",
     "recorded-content": {
       "exception-missing-signature": {
@@ -3603,7 +3585,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_missing_fields[s3]": {
     "recorded-date": "04-08-2023, 23:58:56",
     "recorded-content": {
       "exception-missing-fields": {
@@ -3628,7 +3610,7 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3v4]": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_missing_fields[s3v4]": {
     "recorded-date": "04-08-2023, 23:58:58",
     "recorded-content": {
       "exception-missing-fields": {
@@ -9819,6 +9801,120 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 206
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
+    "recorded-date": "14-08-2023, 19:32:11",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [
+          {
+            "Key": "TagName",
+            "Value": "TagValue"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[list]": {
+    "recorded-date": "14-08-2023, 19:32:13",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [
+          {
+            "Key": "TagName",
+            "Value": "TagValue"
+          },
+          {
+            "Key": "TagName2",
+            "Value": "TagValue2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[invalid]": {
+    "recorded-date": "14-08-2023, 19:32:14",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[notxml]": {
+    "recorded-date": "14-08-2023, 19:32:16",
+    "recorded-content": {
+      "tagging-error": {
+        "Error": {
+          "Code": "MalformedXML",
+          "HostId": "<host-id:1>",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema",
+          "RequestId": "<request-id:1>"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
+    "recorded-date": "14-08-2023, 19:54:15",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 17,
+        "ContentType": "text/plain",
+        "ETag": "\"a7d8531d918474360de3e2eaeb110cda\"",
+        "Expires": "datetime",
+        "LastModified": "datetime",
+        "Metadata": {
+          "test-1": "test-meta-1",
+          "test-2": "test-meta-2"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_storage_class": {
+    "recorded-date": "14-08-2023, 20:14:49",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 23,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f73f1a2dbae1bbd6c42f86e771298073\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "STANDARD_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-storage-error": {
+        "Error": {
+          "Code": "InvalidStorageClass",
+          "HostId": "<host-id:2>",
+          "Message": "The storage class you specified is not valid",
+          "RequestId": "<request-id:2>",
+          "StorageClassRequested": "FakeClass"
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9805,401 +9805,399 @@
       }
     }
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
+    "recorded-date": "14-08-2023, 19:32:11",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [
+          {
+            "Key": "TagName",
+            "Value": "TagValue"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[list]": {
+    "recorded-date": "14-08-2023, 19:32:13",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [
+          {
+            "Key": "TagName",
+            "Value": "TagValue"
+          },
+          {
+            "Key": "TagName2",
+            "Value": "TagValue2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[invalid]": {
+    "recorded-date": "14-08-2023, 19:32:14",
+    "recorded-content": {
+      "get-tagging": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[notxml]": {
+    "recorded-date": "14-08-2023, 19:32:16",
+    "recorded-content": {
+      "tagging-error": {
+        "Error": {
+          "Code": "MalformedXML",
+          "HostId": "<host-id:1>",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema",
+          "RequestId": "<request-id:1>"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
+    "recorded-date": "14-08-2023, 19:54:15",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 17,
+        "ContentType": "text/plain",
+        "ETag": "\"a7d8531d918474360de3e2eaeb110cda\"",
+        "Expires": "datetime",
+        "LastModified": "datetime",
+        "Metadata": {
+          "test-1": "test-meta-1",
+          "test-2": "test-meta-2"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_storage_class": {
+    "recorded-date": "14-08-2023, 20:14:49",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 23,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"f73f1a2dbae1bbd6c42f86e771298073\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "STANDARD_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-storage-error": {
+        "Error": {
+          "Code": "InvalidStorageClass",
+          "HostId": "<host-id:2>",
+          "Message": "The storage class you specified is not valid",
+          "RequestId": "<request-id:2>",
+          "StorageClassRequested": "FakeClass"
+        }
+      }
+    }
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
-      "recorded-date": "14-08-2023, 19:32:11",
-      "recorded-content": {
-        "get-tagging": {
-          "TagSet": [
-            {
-              "Key": "TagName",
-              "Value": "TagValue"
-            }
-          ],
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
+    "recorded-date": "15-08-2023, 23:41:05",
+    "recorded-content": {
+      "put-object-default-acl": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[list]": {
-      "recorded-date": "14-08-2023, 19:32:13",
-      "recorded-content": {
-        "get-tagging": {
-          "TagSet": [
-            {
-              "Key": "TagName",
-              "Value": "TagValue"
+      },
+      "get-object-acl-default": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
             },
-            {
-              "Key": "TagName2",
-              "Value": "TagValue2"
-            }
-          ],
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
+            "Permission": "FULL_CONTROL"
           }
-        }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[invalid]": {
-      "recorded-date": "14-08-2023, 19:32:14",
-      "recorded-content": {
-        "get-tagging": {
-          "TagSet": [],
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[notxml]": {
-      "recorded-date": "14-08-2023, 19:32:16",
-      "recorded-content": {
-        "tagging-error": {
-          "Error": {
-            "Code": "MalformedXML",
-            "HostId": "<host-id:1>",
-            "Message": "The XML you provided was not well-formed or did not validate against our published schema",
-            "RequestId": "<request-id:1>"
-          }
-        }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
-      "recorded-date": "14-08-2023, 19:54:15",
-      "recorded-content": {
-        "head-object": {
-          "AcceptRanges": "bytes",
-          "ContentLength": 17,
-          "ContentType": "text/plain",
-          "ETag": "\"a7d8531d918474360de3e2eaeb110cda\"",
-          "Expires": "datetime",
-          "LastModified": "datetime",
-          "Metadata": {
-            "test-1": "test-meta-1",
-            "test-2": "test-meta-2"
-          },
-          "ServerSideEncryption": "AES256",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_storage_class": {
-      "recorded-date": "14-08-2023, 20:14:49",
-      "recorded-content": {
-        "head-object": {
-          "AcceptRanges": "bytes",
-          "ContentLength": 23,
-          "ContentType": "binary/octet-stream",
-          "ETag": "\"f73f1a2dbae1bbd6c42f86e771298073\"",
-          "LastModified": "datetime",
-          "Metadata": {},
-          "ServerSideEncryption": "AES256",
-          "StorageClass": "STANDARD_IA",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
         },
-        "invalid-storage-error": {
-          "Error": {
-            "Code": "InvalidStorageClass",
-            "HostId": "<host-id:2>",
-            "Message": "The storage class you specified is not valid",
-            "RequestId": "<request-id:2>",
-            "StorageClassRequested": "FakeClass"
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
-      }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl": {
-      "recorded-date": "15-08-2023, 23:41:05",
-      "recorded-content": {
-        "put-object-default-acl": {
-          "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-          "ServerSideEncryption": "AES256",
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        },
-        "get-object-acl-default": {
-          "Grants": [
-            {
-              "Grantee": {
-                "DisplayName": "<display-name:1>",
-                "ID": "<owner-id:1>",
-                "Type": "CanonicalUser"
-              },
-              "Permission": "FULL_CONTROL"
-            }
-          ],
-          "Owner": {
-            "DisplayName": "<display-name:1>",
-            "ID": "<owner-id:1>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        },
-        "put-object-acl": {
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        },
-        "get-object-acl": {
-          "Grants": [
-            {
-              "Grantee": {
-                "DisplayName": "<display-name:1>",
-                "ID": "<owner-id:1>",
-                "Type": "CanonicalUser"
-              },
-              "Permission": "FULL_CONTROL"
+      },
+      "put-object-acl": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
             },
-            {
-              "Grantee": {
-                "Type": "Group",
-                "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
-              },
-              "Permission": "READ"
-            }
-          ],
-          "Owner": {
-            "DisplayName": "<display-name:1>",
-            "ID": "<owner-id:1>"
+            "Permission": "FULL_CONTROL"
           },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        },
-        "get-object-grant-acl": {
-          "Grants": [
-            {
-              "Grantee": {
-                "Type": "Group",
-                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
-              },
-              "Permission": "READ"
-            }
-          ],
-          "Owner": {
-            "DisplayName": "<display-name:1>",
-            "ID": "<owner-id:1>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        },
-        "get-object-acp-acl": {
-          "Grants": [
-            {
-              "Grantee": {
-                "DisplayName": "<display-name:1>",
-                "ID": "<owner-id:1>",
-                "Type": "CanonicalUser"
-              },
-              "Permission": "FULL_CONTROL"
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
             },
-            {
-              "Grantee": {
-                "Type": "Group",
-                "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
-              },
-              "Permission": "WRITE"
-            }
-          ],
-          "Owner": {
-            "DisplayName": "<display-name:1>",
-            "ID": "<owner-id:1>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
+            "Permission": "READ"
           }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-grant-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "READ"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-acp-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          },
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "WRITE"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
-    },
-    "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
-      "recorded-date": "15-08-2023, 23:47:00",
-      "recorded-content": {
-        "put-object-canned-acl": {
-          "Error": {
-            "ArgumentName": "x-amz-acl",
-            "ArgumentValue": "fake-acl",
-            "Code": "InvalidArgument",
-            "Message": null
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_object_acl_exceptions": {
+    "recorded-date": "15-08-2023, 23:47:00",
+    "recorded-content": {
+      "put-object-canned-acl": {
+        "Error": {
+          "ArgumentName": "x-amz-acl",
+          "ArgumentValue": "fake-acl",
+          "Code": "InvalidArgument",
+          "Message": null
         },
-        "put-object-acl-canned-acl": {
-          "Error": {
-            "ArgumentName": "x-amz-acl",
-            "ArgumentValue": "fake-acl",
-            "Code": "InvalidArgument",
-            "Message": null
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acl-canned-acl": {
+        "Error": {
+          "ArgumentName": "x-amz-acl",
+          "ArgumentValue": "fake-acl",
+          "Code": "InvalidArgument",
+          "Message": null
         },
-        "put-object-grant-acl-fake-uri": {
-          "Error": {
-            "ArgumentName": "uri",
-            "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
-            "Code": "InvalidArgument",
-            "Message": "Invalid group uri"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-fake-uri": {
+        "Error": {
+          "ArgumentName": "uri",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
         },
-        "put-object-grant-acl-fake-key": {
-          "Error": {
-            "ArgumentName": "x-amz-grant-write",
-            "ArgumentValue": "fakekey=\"1234\"",
-            "Code": "InvalidArgument",
-            "Message": "Argument format not recognized"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-fake-key": {
+        "Error": {
+          "ArgumentName": "x-amz-grant-write",
+          "ArgumentValue": "fakekey=\"1234\"",
+          "Code": "InvalidArgument",
+          "Message": "Argument format not recognized"
         },
-        "put-object-grant-acl-wrong-id": {
-          "Error": {
-            "ArgumentName": "id",
-            "ArgumentValue": "wrong-id",
-            "Code": "InvalidArgument",
-            "Message": "Invalid id"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-grant-acl-wrong-id": {
+        "Error": {
+          "ArgumentName": "id",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
         },
-        "put-object-acp-acl-1": {
-          "Error": {
-            "Code": "MalformedACLError",
-            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-1": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
-        "put-object-acp-acl-2": {
-          "Error": {
-            "Code": "MalformedACLError",
-            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-2": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
-        "put-object-acp-acl-3": {
-          "Error": {
-            "ArgumentName": "CanonicalUser/ID",
-            "ArgumentValue": "wrong-id",
-            "Code": "InvalidArgument",
-            "Message": "Invalid id"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-3": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
         },
-        "put-object-acp-acl-4": {
-          "Error": {
-            "ArgumentName": "Group/URI",
-            "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
-            "Code": "InvalidArgument",
-            "Message": "Invalid group uri"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-4": {
+        "Error": {
+          "ArgumentName": "Group/URI",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
         },
-        "put-object-acp-acl-5": {
-          "Error": {
-            "ArgumentName": "CanonicalUser/ID",
-            "ArgumentValue": "wrong-id",
-            "Code": "InvalidArgument",
-            "Message": "Invalid id"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-5": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
         },
-        "put-object-acp-acl-6": {
-          "Error": {
-            "Code": "MalformedACLError",
-            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acp-acl-6": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
-        "put-object-empty-acp": {
-          "Error": {
-            "Code": "MalformedACLError",
-            "Message": "The XML you provided was not well-formed or did not validate against our published schema"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-empty-acp": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
-        "put-object-acl-empty": {
-          "Error": {
-            "Code": "MissingSecurityHeader",
-            "Message": "Your request was missing a required header",
-            "MissingHeaderName": "x-amz-acl"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-acl-empty": {
+        "Error": {
+          "Code": "MissingSecurityHeader",
+          "Message": "Your request was missing a required header",
+          "MissingHeaderName": "x-amz-acl"
         },
-        "put-object-two-type-acl": {
-          "Error": {
-            "Code": "InvalidRequest",
-            "Message": "Specifying both Canned ACLs and Header Grants is not allowed"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-two-type-acl": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Specifying both Canned ACLs and Header Grants is not allowed"
         },
-        "put-object-two-type-acl-acp": {
-          "Error": {
-            "Code": "UnexpectedContent",
-            "Message": "This request does not support content"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 400
-          }
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-two-type-acl-acp": {
+        "Error": {
+          "Code": "UnexpectedContent",
+          "Message": "This request does not support content"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Implementing the missing PostObject operation, which is needed for pre-signed POST requests. 

<!-- What notable changes does this PR make? -->
## Changes
`PostObject` is a bit of a weird operation in itself because everything is in a form, and the parser doesn't handle this kind of request right now, and maybe it shouldn't just for one operation. So most of the "parsing" is done directly in the provider method. I've added a bit more features than moto, as we now handle encryption parameters, tagging, and more response fields.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

