### PR TITLE
Update kinesis-mock to 0.4.4

### DIFF
--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -5,7 +5,7 @@ from typing import List
 from localstack.packages import Package, PackageInstaller
 from localstack.packages.core import NodePackageInstaller
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.2"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.4"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
See

https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.4

and

https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.3

Notice that these releases introduce some interesting new items:

- http2 support
- Fix for persistence path

I have not updated anything outside of the version. But I'd be happy to have some guidance to update any related items here.

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Bump kinesis-mock

<!-- What notable changes does this PR make? -->
## Changes

Updates kinesis-mock to 0.4.4

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

