### PR TITLE
Fix parsing of booleans in API Gateway Velocity templates

### DIFF
--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -1,4 +1,3 @@
-import ast
 import base64
 import copy
 import json
@@ -178,7 +177,7 @@ class Templates:
         return self.vtl.render_vtl(template, variables=variables)
 
     @staticmethod
-    def build_variables_mapping(api_context: ApiInvocationContext):
+    def build_variables_mapping(api_context: ApiInvocationContext) -> dict[str, Any]:
         # TODO: make this (dict) an object so usages of "render_vtl" variables are defined
         ctx = copy.deepcopy(api_context.context or {})
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-override-request-response-parameters.html
@@ -213,7 +212,7 @@ class RequestTemplates(Templates):
     def render(
         self, api_context: ApiInvocationContext, template_key: str = APPLICATION_JSON
     ) -> Union[bytes, str]:
-        LOG.info(
+        LOG.debug(
             "Method request body before transformations: %s", to_str(api_context.data_as_string())
         )
         request_templates = api_context.integration.get("requestTemplates", {})
@@ -229,7 +228,7 @@ class RequestTemplates(Templates):
             variables.get("context", {}).get("requestOverride", {}).get("header", {})
         )
 
-        LOG.info(f"Endpoint request body after transformations:\n{result}")
+        LOG.debug(f"Endpoint request body after transformations:\n{result}")
         return result
 
 
@@ -283,9 +282,16 @@ class ResponseTemplates(Templates):
 
         # we render the template with the context data and the response content
         variables = self.build_variables_mapping(api_context)
-        rendered_tpl = self.render_vtl(template, variables=variables)
+        response._content = self._render_json_result(template, variables)
 
-        # TODO: we need to do a parity test for templates that generate invalid JSON
-        response._content = json.dumps(ast.literal_eval(rendered_tpl.strip()))
-        LOG.info("Endpoint response body after transformations:\n%s", response._content)
+        LOG.debug("Endpoint response body after transformations:\n%s", response._content)
         return response._content
+
+    def _render_json_result(self, template: str, variables: dict[str, Any]) -> str:
+        rendered_tpl = self.render_vtl(template, variables=variables)
+        rendered_value = rendered_tpl.strip()
+        try:
+            return json.dumps(json.loads(rendered_value))
+        except Exception as e:
+            LOG.info("Unable to parse template result as JSON: %s - %s", e, rendered_value)
+            raise

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -282,12 +282,17 @@ class ResponseTemplates(Templates):
 
         # we render the template with the context data and the response content
         variables = self.build_variables_mapping(api_context)
-        response._content = self._render_json_result(template, variables)
+        response._content = self._render_as_json(template, variables)
 
         LOG.debug("Endpoint response body after transformations:\n%s", response._content)
         return response._content
 
-    def _render_json_result(self, template: str, variables: dict[str, Any]) -> str:
+    def _render_as_json(self, template: str, variables: dict[str, Any]) -> str:
+        """
+        Render the given Velocity template string + variables into a JSON string.
+        :raise JSONDecodeError: if template result is not valid JSON
+        :return: the template rendering result as a valid JSON string
+        """
         rendered_tpl = self.render_vtl(template, variables=variables)
         rendered_value = rendered_tpl.strip()
         try:

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from json import JSONDecodeError
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock
 
@@ -559,6 +560,21 @@ class TestTemplates:
             "stageVariable1": "value1",
             "stageVariable2": "value2",
         }
+
+    def test_render_valid_booleans_in_json(self):
+        template = ResponseTemplates()
+
+        # assert that boolean results of _render_json_result(..) are JSON-parseable
+        tstring = '{"mybool": $boolTrue}'
+        result = template._render_json_result(tstring, {"boolTrue": "true"})
+        assert json.loads(result) == {"mybool": True}
+        result = template._render_json_result(tstring, {"boolTrue": True})
+        assert json.loads(result) == {"mybool": True}
+
+        # older versions of `airspeed` were rendering booleans as False/True, which is no longer valid now
+        tstring = '{"mybool": False}'
+        with pytest.raises(JSONDecodeError):
+            template._render_json_result(tstring, {})
 
 
 def test_openapi_resolver_given_unresolvable_references():

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -566,15 +566,15 @@ class TestTemplates:
 
         # assert that boolean results of _render_json_result(..) are JSON-parseable
         tstring = '{"mybool": $boolTrue}'
-        result = template._render_json_result(tstring, {"boolTrue": "true"})
+        result = template._render_as_json(tstring, {"boolTrue": "true"})
         assert json.loads(result) == {"mybool": True}
-        result = template._render_json_result(tstring, {"boolTrue": True})
+        result = template._render_as_json(tstring, {"boolTrue": True})
         assert json.loads(result) == {"mybool": True}
 
         # older versions of `airspeed` were rendering booleans as False/True, which is no longer valid now
         tstring = '{"mybool": False}'
         with pytest.raises(JSONDecodeError):
-            template._render_json_result(tstring, {})
+            template._render_as_json(tstring, {})
 
 
 def test_openapi_resolver_given_unresolvable_references():


### PR DESCRIPTION
## Motivation

We recently had a couple of changes in our `airspeed` for, for better AWS parity - see also recent PR #8914 .

One of the main changes is that booleans are now properly rendered as `true`/`false`, and not via the Python syntax `True`/`False`.

This leads to some potential issues in API Gateway (detected by upstream tests in -ext). In the API GW `ResponseTemplates` we were using `ast.literal_eval`, instead of proper `json.loads`, mainly to be able to deal with the booleans in Python syntax. This is fixed in this PR, `ast.literal_eval` is replaced by `json.loads`, and the logic is extended with a small unit test to cover this functionality.

## Changes

* fix parsing of booleans in API Gateway Velocity templates (replace `ast.literal_eval` with `json.loads`)
* add a small unit test to cover this functionality (also a negative test which shows that booleans like `False` are no longer in the templates)