### PR TITLE
Add max capabilities when creating nested stacks

### DIFF
--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -48,6 +48,11 @@ class CloudFormationStack(GenericBaseModel):
                 "StackName": nested_stack_name,
                 "TemplateURL": properties.get("TemplateURL"),
                 "Parameters": stack_parameters,
+                "Capabilities": [
+                    "CAPABILITY_AUTO_EXPAND",
+                    "CAPABILITY_IAM",
+                    "CAPABILITY_NAMED_IAM",
+                ],
             }
             return result
 

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -48,6 +48,7 @@ class CloudFormationStack(GenericBaseModel):
                 "StackName": nested_stack_name,
                 "TemplateURL": properties.get("TemplateURL"),
                 "Parameters": stack_parameters,
+                # TODO: when migrating to resource provider check parity here
                 "Capabilities": [
                     "CAPABILITY_AUTO_EXPAND",
                     "CAPABILITY_IAM",


### PR DESCRIPTION
## Motivation

Nested stacks can also contain transformations and are thus subject to capability checks.
This caused users to report issues regarding failed stack deployments to pop up in support which this PR aims to prevent.

## Changes

- When creating a nested stack (`AWS::CloudFormation::Stack`) it will now always created with all possible capabilities. This should be fixed when migrating to a resource provider.
