### PR TITLE
Gather analytics on account ID and region name use

### DIFF
--- a/localstack/aws/handlers/analytics.py
+++ b/localstack/aws/handlers/analytics.py
@@ -49,6 +49,8 @@ class ServiceRequestCounter:
                 service_name,
                 operation_name,
                 response.status_code,
+                context.account_id,
+                context.region,
                 err_type=err_type,
             )
         )

--- a/localstack/utils/analytics/service_request_aggregator.py
+++ b/localstack/utils/analytics/service_request_aggregator.py
@@ -20,6 +20,8 @@ class ServiceRequestInfo(NamedTuple):
     service: str
     operation: str
     status_code: int
+    account_id: str
+    region_name: str
     err_type: Optional[str] = None
 
 

--- a/tests/unit/aws/handlers/analytics.py
+++ b/tests/unit/aws/handlers/analytics.py
@@ -7,6 +7,7 @@ from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.forwarder import create_aws_request_context
 from localstack.aws.handlers.analytics import ServiceRequestCounter
+from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.http import Response
 from localstack.utils.analytics.service_request_aggregator import ServiceRequestInfo
 
@@ -77,8 +78,16 @@ class TestServiceRequestCounter:
 
         aggregator.add_request.assert_has_calls(
             [
-                call(ServiceRequestInfo("s3", "ListBuckets", 200)),
-                call(ServiceRequestInfo("s3", "HeadBucket", 200)),
+                call(
+                    ServiceRequestInfo(
+                        "s3", "ListBuckets", 200, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+                    )
+                ),
+                call(
+                    ServiceRequestInfo(
+                        "s3", "HeadBucket", 200, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+                    )
+                ),
             ]
         )
 
@@ -99,7 +108,12 @@ class TestServiceRequestCounter:
             [
                 call(
                     ServiceRequestInfo(
-                        "opensearch", "DescribeDomain", 404, "ResourceNotFoundException"
+                        "opensearch",
+                        "DescribeDomain",
+                        404,
+                        TEST_AWS_ACCOUNT_ID,
+                        TEST_AWS_REGION_NAME,
+                        "ResourceNotFoundException",
                     )
                 ),
             ]
@@ -118,6 +132,15 @@ class TestServiceRequestCounter:
         # for some reason botocore returns the status as the error Code when it parses an invalid error response
         aggregator.add_request.assert_has_calls(
             [
-                call(ServiceRequestInfo("opensearch", "DescribeDomain", 404, "404")),
+                call(
+                    ServiceRequestInfo(
+                        "opensearch",
+                        "DescribeDomain",
+                        404,
+                        "404",
+                        TEST_AWS_ACCOUNT_ID,
+                        TEST_AWS_REGION_NAME,
+                    )
+                ),
             ]
         )


### PR DESCRIPTION
## Motivation

We currently have no insight on how multi-accounts and multi-region namespacing is used in LocalStack. Moto gets a multi-account related issues reported now and then, but in LocalStack it seems quiet.

## Implementation

This PR collects two additional attributes in analytics events:

- Account ID: This field is populated from the Access Key ID. In its default config, LS ignores any keys that start with `ASIA` or `AKIA` and instead uses `000000000000` account ID. This means that in general, this field will be non-PII. However, a user could choose to disable this behaviour with `PARITY_AWS_ACCESS_KEY_ID`. If that is the case, account ID is potentially PII and this information will not collected.
- Region Name: LS forbids arbitrary region names by default but this can be overridden with `ALLOW_NONSTANDARD_REGIONS`. In either cases, this field should be non-PII. 

Internal calls are ignored as before.