### PR TITLE
Add get_free_udp_port utility + test

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -3,6 +3,7 @@ import gzip
 import json
 import logging
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -537,7 +538,7 @@ def run_module_as_sudo(
     python_cmd = sys.executable
     cmd = [sudo_cmd, env_vars_str, python_cmd, "-m", module]
     arguments = arguments or []
-    shell_cmd = " ".join(cmd + arguments)
+    shell_cmd = shlex.join(cmd + arguments)
 
     # make sure we can run sudo commands
     try:

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -174,6 +174,18 @@ def port_can_be_bound(port: IntOrPort) -> bool:
         return False
 
 
+def get_free_udp_port(blocklist: List[int] = None) -> int:
+    blocklist = blocklist or []
+    for i in range(10):
+        udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp.bind(("", 0))
+        addr, port = udp.getsockname()
+        udp.close()
+        if port not in blocklist:
+            return port
+    raise Exception(f"Unable to determine free TCP port with blocklist {blocklist}")
+
+
 def get_free_tcp_port(blocklist: List[int] = None) -> int:
     blocklist = blocklist or []
     for i in range(10):

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -170,7 +170,11 @@ def port_can_be_bound(port: IntOrPort) -> bool:
             return False
         sock.bind(("", port.port))
         return True
+    except OSError:
+        # either the port is used or we don't have permission to bind it
+        return False
     except Exception:
+        LOG.error(f"cannot bind port {port}", exc_info=LOG.isEnabledFor(logging.DEBUG))
         return False
 
 

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -187,7 +187,7 @@ def get_free_udp_port(blocklist: List[int] = None) -> int:
         udp.close()
         if port not in blocklist:
             return port
-    raise Exception(f"Unable to determine free TCP port with blocklist {blocklist}")
+    raise Exception(f"Unable to determine free UDP port with blocklist {blocklist}")
 
 
 def get_free_tcp_port(blocklist: List[int] = None) -> int:

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -5,7 +5,7 @@ import pytest as pytest
 from localstack.constants import LOCALHOST
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
-from localstack.utils.net import Port, port_can_be_bound, resolve_hostname
+from localstack.utils.net import Port, get_free_udp_port, port_can_be_bound, resolve_hostname
 
 
 @markers.skip_offline
@@ -34,3 +34,8 @@ def test_port_open(protocol):
     # close socket, assert that port can be bound
     sock.close()
     assert port_can_be_bound(port)
+
+
+def test_get_free_udp_port():
+    port = get_free_udp_port()
+    assert port_can_be_bound(Port(port, "udp"))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to test the DNS server on arbitrary ports, we need a way to get random free udp ports, similar to the `get_free_tcp_port` utility for tcp.

<!-- What notable changes does this PR make? -->
## Changes
* Add `get_free_udp_port` utility
* Add a test for said utility
* use `shlex.join` instead of a normal string join for shell commandline in `run_module_as_sudo`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

