### PR TITLE
provide result handle to AWS::ApiGateway::GatewayResponse

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
+    generate_default_name_without_stack,
     lambda_keys_to_lower,
     params_list_to_dict,
 )
@@ -30,7 +31,9 @@ class GatewayResponse(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _handle_result(result: dict, logical_resource_id: str, resource: dict):
-            resource["PhysicalResourceId"] = logical_resource_id
+            resource["PhysicalResourceId"] = generate_default_name_without_stack(
+                logical_resource_id
+            )
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -29,6 +29,9 @@ class GatewayResponse(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+            resource["PhysicalResourceId"] = logical_resource_id
+
         return {
             "create": {
                 "function": "put_gateway_response",
@@ -39,6 +42,7 @@ class GatewayResponse(GenericBaseModel):
                     "responseParameters": "ResponseParameters",
                     "responseTemplates": "ResponseTemplates",
                 },
+                "result_handler": _handle_result,
             }
         }
 

--- a/tests/aws/scenario/test_apigateway_scenario.py
+++ b/tests/aws/scenario/test_apigateway_scenario.py
@@ -1,0 +1,83 @@
+import aws_cdk as cdk
+import aws_cdk.aws_apigateway as apigateway
+import aws_cdk.aws_lambda as awslambda
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.testing.scenario.provisioning import InfraProvisioner
+
+FN_CODE = """
+import json
+def handler(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "Hello World!"
+        })
+    }
+"""
+
+
+class TestApigatewayLambdaIntegrationScenario:
+    @pytest.fixture(scope="class", autouse=True)
+    def infrastructure(self, aws_client):
+        app = cdk.App()
+        stack = cdk.Stack(app, "ApiGatewayStack")
+        api = apigateway.RestApi(stack, "rest-api")
+        backend = awslambda.Function(
+            stack,
+            "backend",
+            runtime=awslambda.Runtime.PYTHON_3_10,
+            code=cdk.aws_lambda.Code.from_inline(FN_CODE),
+            handler="index.handler",
+        )
+        resource = api.root.add_resource("v1")
+        resource.add_method("GET", apigateway.LambdaIntegration(backend))
+        api.add_gateway_response(
+            "default-4xx-response",
+            type=apigateway.ResponseType.DEFAULT_4_XX,
+            response_headers={
+                "Access-Control-Allow-Origin": "'*'",
+            },
+        )
+
+        api.add_gateway_response(
+            "default-5xx-response",
+            type=apigateway.ResponseType.DEFAULT_5_XX,
+            response_headers={
+                "Access-Control-Allow-Origin": "'*'",
+            },
+        )
+
+        cdk.CfnOutput(stack, "ApiId", value=api.rest_api_id)
+
+        provisioner = InfraProvisioner(aws_client)
+        provisioner.add_cdk_stack(stack)
+        provisioner.provision()
+
+        yield provisioner
+        provisioner.teardown()
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..restapiEndpointC67DEFEA",
+        ]
+    )
+    def test_scenario_validate_infra(self, aws_client, infrastructure, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("ApiId"))
+        outputs = infrastructure.get_stack_outputs(stack_name="ApiGatewayStack")
+        api_id = outputs["ApiId"]
+        apis = aws_client.apigateway.get_rest_api(restApiId=api_id)
+        assert apis["id"] == api_id
+
+        resources = infrastructure.get_stack_outputs(stack_name="ApiGatewayStack")
+        snapshot.match("resources", resources)
+
+        # makes sure we have a physical resource
+        resources = aws_client.cloudformation.describe_stack_resources(StackName="ApiGatewayStack")[
+            "StackResources"
+        ]
+        for r in resources:
+            if r["ResourceType"] == "AWS::ApiGateway::GatewayResponse":
+                assert r["PhysicalResourceId"]

--- a/tests/aws/scenario/test_apigateway_scenario.snapshot.json
+++ b/tests/aws/scenario/test_apigateway_scenario.snapshot.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/scenario/test_apigateway_scenario.py::TestApigatewayLambdaIntegrationScenario::test_scenario_validate_infra": {
+    "recorded-date": "17-08-2023, 08:43:11",
+    "recorded-content": {
+      "resources": {
+        "ApiId": "<api-id:1>",
+        "restapiEndpointC67DEFEA": "https://<api-id:1>.execute-api.<region>.amazonaws.com/prod/"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Support case https://localstack-community.slack.com/archives/C05HSNXLQ2J. The CF resource "AWS::ApiGateway::GatewayResponse" was missing a physical resource id value.

<!-- What notable changes does this PR make? -->
## Changes

Adds a handler function and generates a physical resource id.

Uses the new cdk based test setup, thanks @dominikschubert for the heads up

Also thanks to @sannya-singal for helping out with the discover and testing :+1: 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

