### PR TITLE
improve S3 v3 storage layer

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -443,6 +443,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     "Your previous request to create the named bucket succeeded and you already own it.",
                     BucketName=bucket_name,
                 )
+            else:
+                # CreateBucket is idempotent in us-east-1
+                return CreateBucketOutput(Location=f"/{bucket_name}")
 
         if (
             object_ownership := request.get("ObjectOwnership")

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -265,7 +265,7 @@ from localstack.services.s3.v3.models import (
     VersionedKeyStore,
     s3_stores,
 )
-from localstack.services.s3.v3.storage.core import LimitedIterableStream
+from localstack.services.s3.v3.storage.core import LimitedIterableStream, S3ObjectStore
 from localstack.services.s3.v3.storage.ephemeral import EphemeralS3ObjectStore
 from localstack.services.s3.validation import (
     parse_grants_in_headers,
@@ -293,9 +293,9 @@ DEFAULT_S3_TMP_DIR = "/tmp/localstack-s3-storage"
 
 
 class S3Provider(S3Api, ServiceLifecycleHook):
-    def __init__(self) -> None:
+    def __init__(self, storage_backend: S3ObjectStore = None) -> None:
         super().__init__()
-        self._storage_backend = EphemeralS3ObjectStore(DEFAULT_S3_TMP_DIR)
+        self._storage_backend = storage_backend or EphemeralS3ObjectStore(DEFAULT_S3_TMP_DIR)
         self._notification_dispatcher = NotificationDispatcher()
         self._cors_handler = S3CorsHandler(BucketCorsIndex())
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -145,7 +145,7 @@ class S3StoredMultipart(abc.ABC):
         src_bucket: BucketName,
         src_s3_object: S3Object,
         range_data: ObjectRange,
-    ) -> S3StoredObject:
+    ) -> None:
         pass
 
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -181,6 +181,15 @@ class S3ObjectStore(abc.ABC):
     def remove_multipart(self, bucket: BucketName, s3_multipart: S3Multipart):
         pass
 
+    def create_bucket(self, bucket: BucketName):
+        pass
+
+    def delete_bucket(self, bucket: BucketName):
+        pass
+
+    def flush(self):
+        pass
+
     @abc.abstractmethod
     def close(self):
         pass

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -190,6 +190,8 @@ class S3ObjectStore(abc.ABC):
     def flush(self):
         pass
 
-    @abc.abstractmethod
     def close(self):
+        pass
+
+    def reset(self):
         pass

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -23,6 +23,8 @@ class LimitedIterableStream(Iterable[bytes]):
             if self.max_length - read >= 0:
                 self.max_length -= read
                 yield chunk
+            elif self.max_length == 0:
+                break
             else:
                 yield chunk[: self.max_length]
                 break

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -190,10 +190,20 @@ class S3ObjectStore(abc.ABC):
         pass
 
     def flush(self):
+        """
+        Calling `flush()` should force the `S3ObjectStore` to dump its state to disk, depending on the implementation.
+        """
         pass
 
     def close(self):
+        """
+        Closing the `S3ObjectStore` allows freeing resources up (like file descriptors for example) when stopping the
+        linked provider.
+        """
         pass
 
     def reset(self):
+        """
+        Resetting the `S3ObjectStore` will delete all the contained resources.
+        """
         pass

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -283,7 +283,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         src_bucket: BucketName,
         src_s3_object: S3Object,
         range_data: ObjectRange,
-    ) -> EphemeralS3StoredObject:
+    ) -> None:
         """
         Create and add an EphemeralS3StoredObject to the Multipart collection, with an S3Object as input. This will
         take a slice of the S3Object to create a part.
@@ -298,7 +298,6 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
 
         object_slice = LimitedStream(src_stored_object, range_data=range_data)
         stored_part.write(object_slice)
-        return stored_part
 
 
 class BucketTemporaryFileSystem(TypedDict):

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -422,7 +422,7 @@ class EphemeralS3ObjectStore(S3ObjectStore):
 
     def close(self):
         """
-        Close the Store and clean up all underlying objecs. This will effectively remove all data from the filesystem
+        Close the Store and clean up all underlying objects. This will effectively remove all data from the filesystem
         and memory.
         :return:
         """
@@ -436,6 +436,9 @@ class EphemeralS3ObjectStore(S3ObjectStore):
                 for multipart in multiparts.values():
                     multipart.close()
                 multiparts.clear()
+
+    def reset(self):
+        self.close()
 
     @staticmethod
     def _key_from_s3_object(s3_object: S3Object) -> str:

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -412,6 +412,7 @@ class EphemeralS3ObjectStore(S3ObjectStore):
         if multiparts := self._filesystem.get(bucket, {}).get("multiparts", {}):
             if multipart := multiparts.pop(s3_multipart.id, None):
                 multipart.close()
+        self._delete_upload_directory(bucket, s3_multipart.id)
 
     def create_bucket(self, bucket: BucketName):
         mkdir(os.path.join(self.root_directory, bucket))

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -212,9 +212,6 @@ class EphemeralS3StoredObject(S3StoredObject):
 
                 yield data
 
-    def delete(self):
-        self.file.close()
-
 
 class EphemeralS3StoredMultipart(S3StoredMultipart):
     upload_dir: str
@@ -254,7 +251,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         """
         stored_part = self.parts.pop(s3_part.part_number, None)
         if stored_part:
-            stored_part.delete()
+            stored_part.file.close()
 
     def complete_multipart(self, parts: list[S3Part]) -> EphemeralS3StoredObject:
         """
@@ -276,7 +273,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :return:
         """
         for part in self.parts.values():
-            part.delete()
+            part.file.close()
         self.parts.clear()
 
     def copy_from_object(

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -159,8 +159,8 @@ class EphemeralS3StoredObject(S3StoredObject):
         return read
 
     def close(self):
-        """Close the underlying fileobject, effectively deleting it"""
-        return self.file.close()
+        """This is a noop, because closing the underlying file object will delete it"""
+        pass
 
     @property
     def checksum(self) -> Optional[str]:
@@ -212,6 +212,9 @@ class EphemeralS3StoredObject(S3StoredObject):
 
                 yield data
 
+    def delete(self):
+        self.file.close()
+
 
 class EphemeralS3StoredMultipart(S3StoredMultipart):
     upload_dir: str
@@ -251,7 +254,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         """
         stored_part = self.parts.pop(s3_part.part_number, None)
         if stored_part:
-            stored_part.close()
+            stored_part.delete()
 
     def complete_multipart(self, parts: list[S3Part]) -> EphemeralS3StoredObject:
         """
@@ -273,8 +276,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :return:
         """
         for part in self.parts.values():
-            part.close()
-
+            part.delete()
         self.parts.clear()
 
     def copy_from_object(

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1083,16 +1083,16 @@ class TestS3TemporaryStorageBackend:
         fake_multipart = S3Multipart(key="test-multipart")
 
         s3_stored_multipart = temp_storage_backend.get_multipart("test-bucket", fake_multipart)
-        parts_numbers = []
+        parts = []
         stored_parts = []
         for i in range(1, 6):
             fake_s3_part = S3Part(part_number=i)
             stored_part = s3_stored_multipart.open(fake_s3_part)
             stored_part.write(BytesIO(b"abc"))
-            parts_numbers.append(i)
+            parts.append(fake_s3_part)
             stored_parts.append(stored_part)
 
-        s3_stored_object = s3_stored_multipart.complete_multipart(parts=parts_numbers)
+        s3_stored_object = s3_stored_multipart.complete_multipart(parts=parts)
         temp_storage_backend.remove_multipart("test-bucket", fake_multipart)
 
         assert s3_stored_object.read() == b"abc" * 5
@@ -1101,3 +1101,28 @@ class TestS3TemporaryStorageBackend:
 
         temp_storage_backend.close()
         assert s3_stored_object.file.closed
+
+    def test_concurrent_file_access(self, tmpdir):
+        temp_storage_backend = EphemeralS3ObjectStore(root_directory=tmpdir)
+        fake_object = S3Object(key="test-key")
+        s3_stored_object_1 = temp_storage_backend.open("test-bucket", fake_object)
+        s3_stored_object_2 = temp_storage_backend.open("test-bucket", fake_object)
+
+        s3_stored_object_1.write(BytesIO(b"abc"))
+
+        assert s3_stored_object_1.read() == b"abc"
+
+        # assert that another StoredObject moving the position does not influence the other object
+        s3_stored_object_1.seek(1)
+        s3_stored_object_2.seek(2)
+        assert s3_stored_object_1.read() == b"bc"
+        assert s3_stored_object_2.read() == b"c"
+
+        s3_stored_object_1.seek(0)
+        assert s3_stored_object_1.read(1) == b"a"
+
+        temp_storage_backend.remove("test-bucket", fake_object)
+        assert s3_stored_object_1.file.closed
+        assert s3_stored_object_2.file.closed
+
+        temp_storage_backend.close()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Improving the current S3 storage layer, introduce 2 more operations to allow easier cleanup of resources with bucket creation and deletion. Also separate between `close` and `reset` the store, to have better semantics between these 2 operations (closing does not always mean deleting all underlying objects, especially with persistence enabled). 
Separate between the `close` call for the Ephemeral object, so that it doesn't close the underlying file object, which would delete it in Ephemeral mode, following the fix to the response with #8926. 

<!-- What notable changes does this PR make? -->
## Changes
Introduce said changes above, `create_bucket` and `delete_bucket` for the storage layer, and preparing support for persistence. 

Also added a quick fix regarding creating bucket in `us-east-1`, I wasn't returning early from the method and ended up overwriting the bucket in the store.

Make `close` a noop for `EphemeralS3StoredObject`, and implement a `delete` method for cleaning up.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

