### PR TITLE
fix Response.update_from to also copy close handlers

### DIFF
--- a/localstack/http/response.py
+++ b/localstack/http/response.py
@@ -14,13 +14,14 @@ class Response(WerkzeugResponse):
     def update_from(self, other: WerkzeugResponse):
         """
         Updates this response object with the data from the given response object. It reads the status code,
-        the response data, and updates its own headers (overwrites existing headers, but does not remove ones not
-        present in the given object).
+        the response data, and updates its own headers (overwrites existing headers, but does not remove ones
+        not present in the given object). Also updates ``call_on_close`` callbacks in the same way.
 
         :param other: the response object to read from
         """
         self.status_code = other.status_code
         self.response = other.response
+        self._on_close.extend(other._on_close)
         self.headers.update(other.headers)
 
     def set_json(self, doc: Any):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This is in some sense a follow up to #8926. I wanted to use the close callbacks of werkzeug to properly implement the restarting of localstack after extensions have been installed (see ext PR). I noticed this wasn't working because we actually often create new Response objects and then use `Response.update_from` in the handler chain, which didn't copy the internal on close callbacks correctly

<!-- What notable changes does this PR make? -->
## Changes

* Update our `Response.update_from` method to copy the internal `_on_close` handlers correctly
* Add an integration test to make sure the close callbacks work correctly

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

