### PR TITLE
Rely on S3 create bucket idempotency in us-east-1

### DIFF
--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -48,7 +48,6 @@ from localstack.services.lambda_.invocation.models import lambda_stores
 from localstack.services.lambda_.invocation.version_manager import LambdaVersionManager
 from localstack.services.lambda_.lambda_utils import HINT_LOG
 from localstack.utils.archives import get_unzipped_size, is_zip_file
-from localstack.utils.aws.resources import get_or_create_bucket
 from localstack.utils.container_utils.container_client import ContainerException
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import short_uid, to_str
@@ -568,7 +567,8 @@ def store_lambda_archive(
     # store all buckets in us-east-1 for now
     s3_client = connect_to(region_name=AWS_REGION_US_EAST_1, aws_access_key_id=BUCKET_ACCOUNT).s3
     bucket_name = f"awslambda-{region_name}-tasks"
-    get_or_create_bucket(bucket_name=bucket_name, s3_client=s3_client)
+    # s3 create bucket is idempotent in us-east-1
+    s3_client.create_bucket(Bucket=bucket_name)
     code_id = f"{function_name}-{uuid.uuid4()}"
     key = f"snapshots/{account_id}/{code_id}"
     s3_client.upload_fileobj(Fileobj=io.BytesIO(archive_file), Bucket=bucket_name, Key=key)


### PR DESCRIPTION
## Motivation

S3 `CreateBucket` is supposed to be idempotent in `us-east-1`. However, due to [failing tests](https://github.com/localstack/localstack/pull/8912/commits/6b23f6c114af828496d10507780d9154c9a75203) in a merge commit, a use case of this behaviour was removed in https://github.com/localstack/localstack/pull/8912/commits/cb6c4f196018ef4ab6dbf265ce9f4943d0e5d350.

cc: @dfangl 

## Implementation

This PR attempts to understand why this idempotent behaviour disappeared all of a sudden.
