### PR TITLE
Bind hypercorn to privileged ports if root

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -488,6 +488,11 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
 
     # separate privileged and unprivileged addresses
     unprivileged, privileged = split_list_by(listen, lambda addr: addr.is_unprivileged() or False)
+    if is_root():
+        # we don't need to split since we are already root, so move all
+        # privileged ports to unprivileged and serve via hypercorn
+        unprivileged = unprivileged + privileged
+        privileged = []
 
     # check that we are actually started the gateway server
     if not unprivileged:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We currently split ports by privileged and unprivileged, and start TCP proxies for privileged ports (as root) since we don't want to run the server on the host as root. 
If we are _already_ root, then we do not need to make this split.

<!-- What notable changes does this PR make? -->
## Changes

* If we are running as root, bind the hypercorn server to privileged ports as well.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->
## Questions

* This means that if the privileged ports cannot be bound for some reason, then _no_ ports will be bound, and we won't be able to start LocalStack. Is this a concern in practice?
