### PR TITLE
Add back support for type hints in PyCharm for snapshot fixture

### DIFF
--- a/localstack/testing/pytest/fixture_conflicts.py
+++ b/localstack/testing/pytest/fixture_conflicts.py
@@ -32,6 +32,6 @@ def pytest_runtest_setup(item: Item):
             # the fixture names only include a single entry even when multiple definitions are found
             # so we need to check the internal name2fixturedefs dict instead
             defs = item._fixtureinfo.name2fixturedefs
-            multi_defs = [k for k, v in defs.items() if len(v) > 1]
+            multi_defs = [k for k, v in defs.items() if len(v) > 1 and "snapshot" not in k]
             if multi_defs:
                 pytest.exit(f"Aborting. Detected multiple defs for fixtures: {multi_defs}")

--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -104,8 +104,8 @@ def fixture_region(aws_client):
     return aws_client.sts.meta.region_name
 
 
-@pytest.fixture(name="snapshot", scope="function")
-def fixture_snapshot(request: SubRequest, account_id, region):
+@pytest.fixture(scope="function")
+def _snapshot_session(request: SubRequest, account_id, region):
     update_overwrite = os.environ.get("SNAPSHOT_UPDATE", None) == "1"
 
     sm = SnapshotSession(
@@ -123,3 +123,9 @@ def fixture_snapshot(request: SubRequest, account_id, region):
     yield sm
 
     sm._persist_state()
+
+
+# FIXME: remove after fixture is added in -ext
+@pytest.fixture(scope="function")
+def snapshot(_snapshot_session):
+    return _snapshot_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import os
+from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.config import PytestPluginManager
 from _pytest.config.argparsing import Parser
 
-from localstack.testing.snapshots import SnapshotSession
+if TYPE_CHECKING:
+    from localstack.testing.snapshots import SnapshotSession
 
 os.environ["LOCALSTACK_INTERNAL_TEST_RUN"] = "1"
 
@@ -86,7 +88,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="function")
-def snapshot(_snapshot_session: SnapshotSession):
+def snapshot(_snapshot_session: "SnapshotSession"):
     return _snapshot_session
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 from _pytest.config import PytestPluginManager
 from _pytest.config.argparsing import Parser
 
+from localstack.testing.snapshots import SnapshotSession
+
 os.environ["LOCALSTACK_INTERNAL_TEST_RUN"] = "1"
 
 pytest_plugins = [
@@ -81,6 +83,11 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "skip_offline" in item.keywords:
             item.add_marker(skip_offline)
+
+
+@pytest.fixture(scope="function")
+def snapshot(_snapshot_session: SnapshotSession):
+    return _snapshot_session
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Motivation
It seems we lost the type hinting in PyCharm for the snapshot fixture in our tests, which makes especially adding new tests much less intuitive.


## Changes

- Introduce new _snapshot_session fixture
- Add (technically redundant) snapshot fixture so that PyCharm picks up the correct typing.


## Coming up

-ext will receive a similar fixture that will expose the typed _snapshot_session and thus allow  us to have types again.
