### PR TITLE
increase WaiterConfig for setting up scenarios on AWS

### DIFF
--- a/localstack/testing/scenario/provisioning.py
+++ b/localstack/testing/scenario/provisioning.py
@@ -16,7 +16,8 @@ from localstack.aws.connect import ServiceLevelClientFactory
 
 LOG = logging.getLogger(__name__)
 CDK_BOOTSTRAP_PARAM = "/cdk-bootstrap/hnb659fds/version"
-WAITER_CONFIG = {"Delay": 10, "MaxAttempts": 1000}
+WAITER_CONFIG_AWS = {"Delay": 10, "MaxAttempts": 1000}
+WAITER_CONFIG_LS = {"Delay": 1, "MaxAttempts": 500}
 
 
 def cleanup_s3_bucket(s3_client: "S3Client", bucket_name: str):
@@ -85,7 +86,7 @@ class InfraProvisioner:
             )
             self.aws_client.cloudformation.get_waiter("stack_create_complete").wait(
                 StackName=stack_name,
-                WaiterConfig=WAITER_CONFIG,
+                WaiterConfig=WAITER_CONFIG_AWS if is_aws_cloud() else WAITER_CONFIG_LS,
             )
             describe_stack = self.aws_client.cloudformation.describe_stacks(StackName=stack_name)
             outputs = describe_stack["Stacks"][0].get("Outputs", {})
@@ -116,7 +117,7 @@ class InfraProvisioner:
             self.aws_client.cloudformation.delete_stack(StackName=stack_name)
             self.aws_client.cloudformation.get_waiter("stack_delete_complete").wait(
                 StackName=stack_name,
-                WaiterConfig=WAITER_CONFIG,
+                WaiterConfig=WAITER_CONFIG_AWS if is_aws_cloud() else WAITER_CONFIG_LS,
             )
         # TODO log-groups created by lambda are not automatically cleaned up by CDK
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The current configuration of the `WaiterConfig` used for the CDK based setup, does have a very limited waiting time configured. 
When running a complex scenario, e.g. setting up several database-cluster with instances, it will timeout on AWS before the deployment finishes, therefore failing the test, potentially starting the teardown. 


<!-- What notable changes does this PR make? -->
## Changes
* Increased the `WaiterConfig` for setup + teardown
* Only delete the CDK_BOOTSTRAP_PARAM for LocalStack runs


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

