### PR TITLE
Fix community test against Pro runs

### DIFF
--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -31,8 +31,10 @@ class TestOpenSearch:
         self, opensearch_create_domain, assert_host_customisation, aws_client
     ):
         domain_name = f"domain-{short_uid()}"
-        res = opensearch_create_domain(DomainName=domain_name)
-        endpoint = res["DomainStatus"]["Endpoint"]
+        opensearch_create_domain(DomainName=domain_name)
+        endpoint = aws_client.opensearch.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "Endpoint"
+        ]
 
         assert_host_customisation(endpoint, use_localstack_cloud=True)
 
@@ -47,8 +49,10 @@ class TestOpenSearch:
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
 
         domain_name = f"domain-{short_uid()}"
-        res = opensearch_create_domain(DomainName=domain_name)
-        endpoint = res["DomainStatus"]["Endpoint"]
+        opensearch_create_domain(DomainName=domain_name)
+        endpoint = aws_client.opensearch.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "Endpoint"
+        ]
 
         if config.is_in_docker:
             assert_host_customisation(endpoint, use_localhost=True)
@@ -66,8 +70,10 @@ class TestOpenSearch:
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
 
         domain_name = f"domain-{short_uid()}"
-        res = opensearch_create_domain(DomainName=domain_name)
-        endpoint = res["DomainStatus"]["Endpoint"]
+        opensearch_create_domain(DomainName=domain_name)
+        endpoint = aws_client.opensearch.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "Endpoint"
+        ]
 
         assert_host_customisation(endpoint, use_localstack_hostname=True)
 

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -28,12 +28,10 @@ class TestOpenSearch:
 
     @markers.aws.only_localstack
     def test_default_strategy(
-        self, opensearch_wait_for_cluster, assert_host_customisation, aws_client, cleanups
+        self, opensearch_create_domain, assert_host_customisation, aws_client
     ):
         domain_name = f"domain-{short_uid()}"
-        res = aws_client.opensearch.create_domain(DomainName=domain_name)
-        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
-        opensearch_wait_for_cluster(domain_name)
+        res = opensearch_create_domain(DomainName=domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
         assert_host_customisation(endpoint, use_localstack_cloud=True)
@@ -42,17 +40,14 @@ class TestOpenSearch:
     def test_port_strategy(
         self,
         monkeypatch,
-        opensearch_wait_for_cluster,
+        opensearch_create_domain,
         assert_host_customisation,
         aws_client,
-        cleanups,
     ):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
 
         domain_name = f"domain-{short_uid()}"
-        res = aws_client.opensearch.create_domain(DomainName=domain_name)
-        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
-        opensearch_wait_for_cluster(domain_name)
+        res = opensearch_create_domain(DomainName=domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
         if config.is_in_docker:
@@ -64,17 +59,14 @@ class TestOpenSearch:
     def test_path_strategy(
         self,
         monkeypatch,
-        opensearch_wait_for_cluster,
+        opensearch_create_domain,
         assert_host_customisation,
         aws_client,
-        cleanups,
     ):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
 
         domain_name = f"domain-{short_uid()}"
-        res = aws_client.opensearch.create_domain(DomainName=domain_name)
-        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
-        opensearch_wait_for_cluster(domain_name)
+        res = opensearch_create_domain(DomainName=domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
         assert_host_customisation(endpoint, use_localstack_hostname=True)

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -28,10 +28,11 @@ class TestOpenSearch:
 
     @markers.aws.only_localstack
     def test_default_strategy(
-        self, opensearch_wait_for_cluster, assert_host_customisation, aws_client
+        self, opensearch_wait_for_cluster, assert_host_customisation, aws_client, cleanups
     ):
         domain_name = f"domain-{short_uid()}"
         res = aws_client.opensearch.create_domain(DomainName=domain_name)
+        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
         opensearch_wait_for_cluster(domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
@@ -39,12 +40,18 @@ class TestOpenSearch:
 
     @markers.aws.only_localstack
     def test_port_strategy(
-        self, monkeypatch, opensearch_wait_for_cluster, assert_host_customisation, aws_client
+        self,
+        monkeypatch,
+        opensearch_wait_for_cluster,
+        assert_host_customisation,
+        aws_client,
+        cleanups,
     ):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
 
         domain_name = f"domain-{short_uid()}"
         res = aws_client.opensearch.create_domain(DomainName=domain_name)
+        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
         opensearch_wait_for_cluster(domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
@@ -55,12 +62,18 @@ class TestOpenSearch:
 
     @markers.aws.only_localstack
     def test_path_strategy(
-        self, monkeypatch, opensearch_wait_for_cluster, assert_host_customisation, aws_client
+        self,
+        monkeypatch,
+        opensearch_wait_for_cluster,
+        assert_host_customisation,
+        aws_client,
+        cleanups,
     ):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
 
         domain_name = f"domain-{short_uid()}"
         res = aws_client.opensearch.create_domain(DomainName=domain_name)
+        cleanups.append(lambda: aws_client.opensearch.delete_domain(DomainName=domain_name))
         opensearch_wait_for_cluster(domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 import pytest
@@ -12,6 +13,9 @@ from localstack.utils.testutil import get_lambda_log_events
 
 def get_base_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "serverless")
+
+
+LOG = logging.getLogger(__name__)
 
 
 class TestServerless:
@@ -31,8 +35,11 @@ class TestServerless:
 
         yield existing_api_ids
 
-        # TODO uncomment once removal via the sls plugin is fixed
-        # run('cd %s; npm run undeploy -- --region=%s' % (cls.get_base_dir(), aws_stack.get_region()))
+        try:
+            # TODO the cleanup still fails due to inability to find ECR service in community
+            run(["npm", "run", "undeploy", "--", f"--region={TEST_AWS_REGION_NAME}"], cwd=base_dir)
+        except Exception:
+            LOG.error("Unable to clean up serverless stack")
 
     @markers.skip_offline
     @markers.aws.unknown

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 
 class TestServerless:
-    @pytest.fixture(scope="session")
+    @pytest.fixture(scope="class")
     def setup_and_teardown(self, aws_client):
         base_dir = get_base_dir()
         if not os.path.exists(os.path.join(base_dir, "node_modules")):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently running out of memory in our test runs.
This is a combination of the recent test reordering, which showed us this issue, and insufficient test cleanup.

<!-- What notable changes does this PR make? -->
## Changes
* Cleanup serverless tests, even if the command fails
* Cleanup opensearch instances after starting them for endpoint strategy tests

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

