### PR TITLE
fix get_raw_path parsing

### DIFF
--- a/tests/unit/http_/test_request.py
+++ b/tests/unit/http_/test_request.py
@@ -137,6 +137,16 @@ def test_get_raw_path_with_query():
     assert get_raw_path(request) == "/foo%2Fbar/ed"
 
 
+def test_get_raw_path_with_full_uri():
+    # raw_path is actually raw_uri in the WSGI environment
+    # it can be a full URL
+    request = Request("GET", "/foo/bar/ed", raw_path="http://localhost:4566/foo%2Fbar/ed")
+
+    assert request.path == "/foo/bar/ed"
+    assert request.environ["RAW_URI"] == "http://localhost:4566/foo%2Fbar/ed"
+    assert get_raw_path(request) == "/foo%2Fbar/ed"
+
+
 def test_headers_retain_dashes():
     request = Request("GET", "/foo/bar/ed", {"X-Amz-Meta--foo_bar-ed": "foobar"})
     assert "x-amz-meta--foo_bar-ed" in request.headers


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR would fix #8928 and #8924. We had an issue with parsing the WSGI environ `RAW_URI`, because an HTTP request can also contain a full URL and not only an absolute path. See the RFC: https://www.ietf.org/rfc/rfc2616.txt
```
   To allow for transition to absoluteURIs in all requests in future
   versions of HTTP, all HTTP/1.1 servers MUST accept the absoluteURI
   form in requests, even though HTTP/1.1 clients will only generate
   them in requests to proxies.
```

We would then have more than the path with `get_raw_path`, which lead to issue down the road when trying to match in our router.

<!-- What notable changes does this PR make? -->
## Changes
We now thanks to @dfangl parse the `RAW_URI` variable with `urllib.parse.urlparse` to then only get the `path` part of the `RAW_URI` in case there's more. 
Added a unit test covering this use case.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

