### PR TITLE
use LOCALSTACK_HOST var for external service urls

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1264,13 +1264,15 @@ def get_protocol() -> str:
     return "https" if USE_SSL else "http"
 
 
-def service_url(service_key: str, host: str | None = None, port: int | None = None) -> str:
+def service_url(service_key: str, host: Optional[str] = None, port: Optional[int] = None) -> str:
     host = host or LOCALHOST
     port = port or service_port(service_key)
     return f"{get_protocol()}://{host}:{port}"
 
 
-def external_service_url(service_key: str, host: str | None = None, port: int | None = None) -> str:
+def external_service_url(
+    service_key: str, host: Optional[str] = None, port: Optional[int] = None
+) -> str:
     host = host or LOCALSTACK_HOST
     port = port or service_port(service_key, external=True)
     return service_url(service_key, host=host, port=port)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We deprecated `HOSTNAME_EXTERNAL` since 2.0.0. and we replaced it with `LOCALSTACK_HOST`.
Some services rely on `external_service_url` for some use cases (e.g., Cognito uses it to generate the issuer URL generation in JTW tokens).

<!-- What notable changes does this PR make? -->
## Changes
This PR uses now `LOCALSTACK_HOST` as a default host when calling `external_service_url`.
