### PR TITLE
add pods support for plugin discovery

### DIFF
--- a/localstack/state/pods.py
+++ b/localstack/state/pods.py
@@ -1,0 +1,28 @@
+import zipfile
+
+from plugin import Plugin
+
+from .core import Decoder, Encoder, StateVisitor
+
+
+class PodsPersistencePlugin(Plugin):
+    """
+    A plugin for the pods persistence mechanism, which allows you to return custom visitors for saving or loading
+    pods state, if the service has a particular logic.
+    """
+
+    namespace: str = "localstack.persistence.pods"
+    """Plugin namespace"""
+
+    name: str
+    """Name of the plugin corresponds to the name of the service this plugin is loaded for. To be set by the Plugin."""
+
+    def create_create_pod_visitor(
+        self, pod_archive: zipfile.ZipFile, encoder: Encoder = None
+    ) -> StateVisitor:
+        raise NotImplementedError
+
+    def create_inject_pod_visitor(
+        self, pod_archive: zipfile.ZipFile, decoder: Decoder = None
+    ) -> StateVisitor:
+        raise NotImplementedError


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on the S3 persistence workaround for mounted volumes, I would need to set up a specific pod logic when creating/injecting pods.
Basically, the data in S3 would live inside the container and not in the default `assets` folder (`config.dirs.data`). There's some custom logic needed, and I would need to be able to set up a plugin for it. This is the first step to be able to introduce it. 

<!-- What notable changes does this PR make? -->
## Changes
Creating a simple plugin to be able then declare and discover specific service related pod visitor. 

## TODO

What's left to do:

- [ ] run benchmarks with and without the S3 persistence workaround to see if this is really needed (still need to merge the last PRs to be able to run them)
- [ ] ...

