### PR TITLE
Fix result handler signature AWS::ApiGateway::GatewayResponse result handler

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -32,7 +32,13 @@ class GatewayResponse(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _handle_result(result: dict, logical_resource_id: str, resource: dict):
+        def _handle_result(
+            account_id: str,
+            region_name: str,
+            result: dict,
+            logical_resource_id: str,
+            resource: dict,
+        ):
             resource["PhysicalResourceId"] = generate_default_name_without_stack(
                 logical_resource_id
             )


### PR DESCRIPTION
## Motivation
The signature required for the result handlers has recently been  changed in https://github.com/localstack/localstack/pull/8822 but afterwards https://github.com/localstack/localstack/pull/8925 was merged which added a result handler with the old signature.

## Changes

- fix the signature of the result_handler introduced in https://github.com/localstack/localstack/pull/8925

