### PR TITLE
Fix resolving pseudo-parameters in Fn::Sub

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -706,7 +706,7 @@ def resolve_placeholders_in_string(
                 resolved = str(resolved)
             return resolved
         if len(parts) == 1:
-            if parts[0] in resources:
+            if parts[0] in resources or parts[0].startswith("AWS::"):
                 # Logical resource ID or parameter name specified => Use Ref for lookup
                 result = resolve_ref(
                     account_id, region_name, stack_name, resources, parameters, parts[0]

--- a/tests/aws/services/cloudformation/engine/test_references.py
+++ b/tests/aws/services/cloudformation/engine/test_references.py
@@ -40,6 +40,11 @@ class TestFnSub:
         snapshot.add_transformer(
             snapshot.transform.regex(ssm_parameter_name, "<ssm-parameter-name>")
         )
+        snapshot.add_transformer(
+            snapshot.transform.key_value(
+                "UrlSuffixPseudoParam", "<url-suffix>", reference_replacement=False
+            )
+        )
         deployment = deploy_cfn_template(
             template_path=os.path.join(
                 os.path.dirname(__file__), "../../../templates/engine/cfn_fn_sub.yaml"

--- a/tests/aws/services/cloudformation/engine/test_references.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_references.snapshot.json
@@ -16,7 +16,7 @@
     }
   },
   "tests/aws/services/cloudformation/engine/test_references.py::TestFnSub::test_fn_sub_cases": {
-    "recorded-date": "10-07-2023, 17:00:03",
+    "recorded-date": "23-08-2023, 20:41:02",
     "recorded-content": {
       "outputs": {
         "ListRefGetAtt": "unimportant",
@@ -32,7 +32,8 @@
         "StringRefParam": "Param1Value",
         "StringRefPseudoParam": "<region>",
         "StringRefResource": "Param1Value",
-        "StringStatic": "this is a static string"
+        "StringStatic": "this is a static string",
+        "UrlSuffixPseudoParam": "<url-suffix>"
       }
     }
   }

--- a/tests/aws/templates/engine/cfn_fn_sub.yaml
+++ b/tests/aws/templates/engine/cfn_fn_sub.yaml
@@ -63,3 +63,6 @@ Outputs:
     Value: !Sub
       - "${ParamValue}"
       - ParamValue: !GetAtt MyResource.Value
+  UrlSuffixPseudoParam:
+    Value:
+      "Fn::Sub": "${AWS::URLSuffix}"


### PR DESCRIPTION
## Motivation

Fixes the issue multiple people experienced where pseudo-parameter couldn't be resolved correctly when used in `Fn::Sub`.

Example error message: `Unable to resolve attribute ref AWS::URLSuffix`

Resolves https://github.com/localstack/localstack/issues/8726

## Changes

- check for pseudo-parameter when resolving a placeholder in a sub string and resolve them recursively

