### PR TITLE
Add tags support for CloudFormation DynamoDB create table

### DIFF
--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -144,6 +144,7 @@ class DynamoDBTable(GenericBaseModel):
                                 default=None,
                             )
                         ),
+                        "Tags": "Tags",
                     },
                     "result_handler": _handle_result,
                 },

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.py
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.py
@@ -6,7 +6,7 @@ from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_deploy_stack_with_dynamodb_table(deploy_cfn_template, aws_client):
     env = "Staging"
     ddb_table_name_prefix = f"ddb-table-{short_uid()}"
@@ -32,7 +32,7 @@ def test_deploy_stack_with_dynamodb_table(deploy_cfn_template, aws_client):
     assert ddb_table_name not in rs["TableNames"]
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_globalindex_read_write_provisioned_throughput_dynamodb_table(
     deploy_cfn_template, aws_client
 ):
@@ -78,6 +78,9 @@ def test_default_name_for_table(deploy_cfn_template, snapshot, aws_client):
 
     response = aws_client.dynamodb.describe_table(TableName=stack.outputs["TableName"])
     snapshot.match("table_description", response)
+
+    list_tags = aws_client.dynamodb.list_tags_of_resource(ResourceArn=stack.outputs["TableArn"])
+    snapshot.match("list_tags_of_resource", list_tags)
 
 
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_default_name_for_table": {
-    "recorded-date": "23-08-2023, 17:50:06",
+    "recorded-date": "28-08-2023, 12:34:19",
     "recorded-content": {
       "table_description": {
         "Table": {
@@ -34,11 +34,27 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "list_tags_of_resource": {
+        "Tags": [
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": "TagValue2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_billing_mode_as_conditional[PROVISIONED]": {
-    "recorded-date": "23-08-2023, 17:59:11",
+    "recorded-date": "28-08-2023, 12:34:41",
     "recorded-content": {
       "table_description": {
         "Table": {
@@ -82,7 +98,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_billing_mode_as_conditional[PAY_PER_REQUEST]": {
-    "recorded-date": "23-08-2023, 17:59:35",
+    "recorded-date": "28-08-2023, 12:35:02",
     "recorded-content": {
       "table_description": {
         "Table": {

--- a/tests/aws/templates/dynamodb_table_defaults.yml
+++ b/tests/aws/templates/dynamodb_table_defaults.yml
@@ -11,7 +11,14 @@ Resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5
+        Tags:
+          - Key: TagKey1
+            Value: TagValue1
+          - Key: TagKey2
+            Value: TagValue2
 
 Outputs:
   TableName:
     Value: !Ref Table
+  TableArn:
+    Value: !GetAtt Table.Arn


### PR DESCRIPTION
## Motivation

Tags for creating DynamoDB table are not created. The issue was raised in a support case.

## Changes

* Add support for resource tags for the create table operation.
* Add `aws.validated` marker for `test_deploy_stack_with_dynamodb_table` and `test_globalindex_read_write_provisioned_throughput_dynamodb_table` because both tests ran successfully against AWS when executing all tests in the file.

## Testing

Extended an AWS-validated test case to cover tags.
Fixes the sample from the support case.
