### PR TITLE
fix SNS subscribe idempotency with different attrs

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -557,10 +557,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             raise InvalidParameterException(
                 "Invalid parameter: Invalid parameter: Endpoint Reason: FIFO SQS Queues can not be subscribed to standard SNS topics"
             )
-        # elif ".fifo" in topic_arn and ".fifo" not in endpoint:
-        #     raise InvalidParameterException(
-        #         "Invalid parameter: Invalid parameter: Endpoint Reason: Please use FIFO SQS queue"
-        #     )
+
         if attributes:
             for attr_name, attr_value in attributes.items():
                 validate_subscription_attribute(
@@ -577,10 +574,16 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store = self.get_store(account_id=parsed_topic_arn["account"], region_name=context.region)
 
         # An endpoint may only be subscribed to a topic once. Subsequent
-        # subscribe calls do nothing (subscribe is idempotent).
+        # subscribe calls do nothing (subscribe is idempotent), except if its attributes are different.
         for existing_topic_subscription in store.topic_subscriptions.get(topic_arn, []):
             sub = store.subscriptions.get(existing_topic_subscription, {})
             if sub.get("Endpoint") == endpoint:
+                for attr in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
+                    if sub.get(attr) != attributes.get(attr):
+                        raise InvalidParameterException(
+                            "Invalid parameter: Attributes Reason: Subscription already exists with different attributes"
+                        )
+
                 return SubscribeResponse(SubscriptionArn=sub["SubscriptionArn"])
 
         principal = sns_constants.DUMMY_SUBSCRIPTION_PRINCIPAL.replace(
@@ -595,6 +598,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             PendingConfirmation="true",
             Owner=context.account_id,
             RawMessageDelivery="false",  # default value, will be overriden if set
+            FilterPolicyScope="MessageAttributes",  # default value, will be overriden if set
             SubscriptionPrincipal=principal,  # dummy value, could be fetched with a call to STS?
         )
         if attributes:

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -729,6 +729,72 @@ class TestSNSSubscriptionCrud:
 
         assert all((sub["TopicArn"], sub["Endpoint"]) in sorting_list for sub in all_subs)
 
+    @markers.aws.validated
+    def test_subscribe_idempotency(
+        self, aws_client, sns_create_topic, sqs_create_queue, sqs_queue_arn, snapshot
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_queue_arn(queue_url)
+
+        subscribe_resp = aws_client.sns.subscribe(
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            Attributes={
+                "RawMessageDelivery": "true",
+            },
+            ReturnSubscriptionArn=True,
+        )
+        snapshot.match("subscribe", subscribe_resp)
+
+        get_attrs_resp = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscribe_resp["SubscriptionArn"]
+        )
+        snapshot.match("get-sub-attrs", get_attrs_resp)
+
+        subscribe_resp = aws_client.sns.subscribe(
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            Attributes={
+                "RawMessageDelivery": "true",
+                "FilterPolicyScope": "MessageAttributes",  # test if it also matches default values
+            },
+            ReturnSubscriptionArn=True,
+        )
+        snapshot.match("subscribe-idempotent", subscribe_resp)
+
+        get_attrs_resp = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscribe_resp["SubscriptionArn"]
+        )
+        snapshot.match("get-sub-attrs-2", get_attrs_resp)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.subscribe(
+                TopicArn=topic_arn,
+                Protocol="sqs",
+                Endpoint=queue_arn,
+                Attributes={
+                    "RawMessageDelivery": "false",
+                    "FilterPolicyScope": "MessageBody",
+                },
+                ReturnSubscriptionArn=True,
+            )
+        snapshot.match("subscribe-diff-attributes", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.subscribe(
+                TopicArn=topic_arn,
+                Protocol="sqs",
+                Endpoint=queue_arn,
+                Attributes={
+                    "RawMessageDelivery": "false",
+                },
+                ReturnSubscriptionArn=True,
+            )
+        snapshot.match("subscribe-missing-attributes", e.value.response)
+
 
 class TestSNSSubscriptionLambda:
     @markers.aws.validated

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4165,6 +4165,81 @@
       }
     }
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_idempotency": {
+    "recorded-date": "29-08-2023, 15:02:07",
+    "recorded-content": {
+      "subscribe": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-sub-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscribe-idempotent": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-sub-attrs-2": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscribe-diff-attributes": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: Subscription already exists with different attributes",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "subscribe-missing-attributes": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: Subscription already exists with different attributes",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[True]": {
     "recorded-date": "25-08-2023, 17:28:02",
     "recorded-content": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This issue was raised in #8816, SNS would not raise an exception if the `Subscribe` call had different attributes when the subscription already exists.

<!-- What notable changes does this PR make? -->
## Changes
We now check if the found subscription if it exists would have the same attributes, and if it doesn't, raise an exception. Added a validated AWS test with it. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

