### PR TITLE
Add pytest marker report plugin

### DIFF
--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -1,7 +1,6 @@
 name: Generate pytest marker report
 on:
   workflow_dispatch:
-  pull_request:  # TODO: remove before merge
   push:
     paths:
       - "tests/**"

--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -23,7 +23,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install CLI test dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools

--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -31,7 +31,7 @@ jobs:
           pip install pytest
       - name: Run CLI tests
         env:
-          PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s --marker-report --marker-report-tinybird-upload"
+          PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s --co --disable-warnings --marker-report --marker-report-tinybird-upload"
           MARKER_REPORT_PROJECT_NAME: localstack
           MARKER_REPORT_TINYBIRD_TOKEN: ${{ secrets.MARKER_REPORT_TINYBIRD_TOKEN }}
           MARKER_REPORT_COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -1,0 +1,39 @@
+name: Generate pytest marker report
+on:
+  workflow_dispatch:
+  pull_request:  # TODO: remove before merge
+  push:
+    paths:
+      - "tests/**"
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  marker-report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install CLI test dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .
+          pip install pytest
+      - name: Run CLI tests
+        env:
+          PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s --marker-report --marker-report-tinybird-upload"
+          MARKER_REPORT_PROJECT_NAME: localstack
+          MARKER_REPORT_TINYBIRD_TOKEN: ${{ secrets.MARKER_REPORT_TINYBIRD_TOKEN }}
+          MARKER_REPORT_COMMIT_SHA: ${{ github.sha }}
+        run: |
+          python -m pytest tests/aws/

--- a/.github/workflows/marker-report.yml
+++ b/.github/workflows/marker-report.yml
@@ -19,21 +19,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Install CLI test dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          pip install -e .
-          pip install pytest
-      - name: Run CLI tests
+
+      - name: Cache LocalStack community dependencies (venv)
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('setup.cfg') }}
+
+      - name: Install dependencies
+        run: make install-dev
+
+      - name: Collect marker report
         env:
           PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s --co --disable-warnings --marker-report --marker-report-tinybird-upload"
           MARKER_REPORT_PROJECT_NAME: localstack
           MARKER_REPORT_TINYBIRD_TOKEN: ${{ secrets.MARKER_REPORT_TINYBIRD_TOKEN }}
           MARKER_REPORT_COMMIT_SHA: ${{ github.sha }}
         run: |
+          . ./.venv/bin/activate
           python -m pytest tests/aws/

--- a/localstack/testing/pytest/marker_report.py
+++ b/localstack/testing/pytest/marker_report.py
@@ -1,0 +1,156 @@
+import dataclasses
+import datetime
+import json
+import os.path
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, List
+
+import pytest
+import requests
+
+if TYPE_CHECKING:
+    from _pytest.config import Config, PytestPluginManager
+    from _pytest.config.argparsing import Parser
+
+
+@dataclasses.dataclass
+class MarkerReportEntry:
+    node_id: str
+    file_path: str
+    markers: list[str]
+
+
+@dataclasses.dataclass
+class TinybirdReportRow:
+    timestamp: str
+    node_id: str
+    project_name: str
+    # code_owners: str  # comma separated
+    service: str
+    markers: str  # comma separated list
+    aws_marker: str  # TODO: this is a bit redundant but easier for now to process
+    commit_sha: str
+
+
+@dataclasses.dataclass
+class MarkerReport:
+    prefix_filter: str
+    entries: list[MarkerReportEntry] = dataclasses.field(default_factory=list)
+    aggregated_report: dict[str, int] = dataclasses.field(default_factory=dict)
+
+    def create_aggregated_report(self):
+        for entry in self.entries:
+            for marker in entry.markers:
+                self.aggregated_report.setdefault(marker, 0)
+                self.aggregated_report[marker] += 1
+
+
+@pytest.hookimpl
+def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager"):
+    """
+    Standard usage. Will create a report for all markers under ./target/marker-report-<date>.json
+    $ python -m pytest tests/aws/ --marker-report
+
+    Advanced usage. Will create a report for all markers under ./target2/marker-report-<date>.json
+    $ python -m pytest tests/aws/ --marker-report --marker-report-path target2/
+
+    Advanced usage. Only includes markers with `aws_` prefix in the report.
+    $ python -m pytest tests/aws/ --marker-report --marker-report-prefix "aws_"
+    """
+    # TODO: --marker-report-* flags should imply --marker-report
+    parser.addoption("--marker-report", action="store_true")
+    parser.addoption("--marker-report-prefix", action="store")
+    parser.addoption("--marker-report-path", action="store")
+    parser.addoption("--marker-report-summary", action="store_true")
+    parser.addoption("--marker-report-tinybird-upload", action="store_true")
+
+
+def _get_svc_from_node_id(node_id: str) -> str:
+    if node_id.startswith("tests/aws/services/"):
+        parts = node_id.split("/")
+        return parts[3]
+    return ""
+
+
+def _get_aws_marker_from_markers(markers: list[str]) -> str:
+    for marker in markers:
+        if marker.startswith("aws_"):
+            return marker
+    return ""
+
+
+@pytest.hookimpl
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: "Config", items: List[pytest.Item]
+) -> None:
+    """Generate a report about the pytest markers used"""
+
+    if not config.option.marker_report:
+        return
+
+    report = MarkerReport(prefix_filter=config.option.marker_report_prefix or "")
+
+    # go through collected items to collect their markers
+    for item in items:
+        markers = set()
+        for mark in item.iter_markers():
+            if mark.name.startswith(report.prefix_filter):
+                markers.add(mark.name)
+
+        report_entry = MarkerReportEntry(
+            node_id=item.nodeid, file_path=item.fspath.strpath, markers=list(markers)
+        )
+        report.entries.append(report_entry)
+
+    report.create_aggregated_report()
+
+    if config.option.marker_report_path:
+        report_directory = Path(config.option.marker_report_path)
+        if not report_directory.is_absolute():
+            report_directory = config.rootpath / report_directory
+        report_directory.mkdir(parents=True, exist_ok=True)
+        report_path = report_directory / f"marker-report-{time.time_ns()}.json"
+
+        with open(report_path, "w") as fd:
+            json.dump(dataclasses.asdict(report), fd, indent=2, sort_keys=True)
+
+    if config.option.marker_report_tinybird_upload:
+
+        project_name = os.environ.get("MARKER_REPORT_PROJECT_NAME", "localstack")
+        datasource_name = "pytest_markers__v0"
+        token = os.environ.get("MARKER_REPORT_TINYBIRD_TOKEN")
+        url = f"https://api.tinybird.co/v0/events?name={datasource_name}&token={token}"
+
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        tinybird_data = [
+            dataclasses.asdict(
+                TinybirdReportRow(
+                    timestamp=timestamp,
+                    node_id=x.node_id,
+                    project_name=project_name,
+                    service=_get_svc_from_node_id(x.node_id),
+                    markers=",".join(sorted(x.markers)),
+                    aws_marker=_get_aws_marker_from_markers(x.markers),
+                    commit_sha=os.environ.get("MARKER_REPORT_COMMIT_SHA", ""),
+                )
+            )
+            for x in report.entries
+        ]
+
+        data = "\n".join(json.dumps(x) for x in tinybird_data)
+
+        response = requests.post(url, data=data, timeout=20)
+
+        if response.status_code != 202:
+            print(f"Error while uploading marker report to tinybird: {response.status_code}.")
+        else:
+            print("Successfully uploaded marker report to tinybird.")
+
+    if config.option.marker_report_summary:
+        print("\n=========================")
+        print("MARKER REPORT (SUMMARY)")
+        print("=========================")
+        for k, v in report.aggregated_report.items():
+            print(f"{k}: {v}")
+        print("=========================\n")

--- a/localstack/testing/pytest/marker_report.py
+++ b/localstack/testing/pytest/marker_report.py
@@ -27,6 +27,7 @@ class TinybirdReportRow:
     node_id: str
     project_name: str
     # code_owners: str  # comma separated
+    file_path: str  # TODO: recreate data source at some point to remove this?
     service: str
     markers: str  # comma separated list
     aws_marker: str  # TODO: this is a bit redundant but easier for now to process
@@ -129,6 +130,7 @@ def pytest_collection_modifyitems(
                     timestamp=timestamp,
                     node_id=x.node_id,
                     project_name=project_name,
+                    file_path=x.file_path,
                     service=_get_svc_from_node_id(x.node_id),
                     markers=",".join(sorted(x.markers)),
                     aws_marker=_get_aws_marker_from_markers(x.markers),

--- a/localstack/testing/pytest/marker_report.py
+++ b/localstack/testing/pytest/marker_report.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class MarkerReportEntry:
     node_id: str
     file_path: str
-    markers: list[str]
+    markers: "list[str]"
 
 
 @dataclasses.dataclass

--- a/localstack/testing/pytest/marker_report.py
+++ b/localstack/testing/pytest/marker_report.py
@@ -4,7 +4,7 @@ import json
 import os.path
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
@@ -36,8 +36,8 @@ class TinybirdReportRow:
 @dataclasses.dataclass
 class MarkerReport:
     prefix_filter: str
-    entries: list[MarkerReportEntry] = dataclasses.field(default_factory=list)
-    aggregated_report: dict[str, int] = dataclasses.field(default_factory=dict)
+    entries: "list[MarkerReportEntry]" = dataclasses.field(default_factory=list)
+    aggregated_report: "dict[str, int]" = dataclasses.field(default_factory=dict)
 
     def create_aggregated_report(self):
         for entry in self.entries:
@@ -73,7 +73,7 @@ def _get_svc_from_node_id(node_id: str) -> str:
     return ""
 
 
-def _get_aws_marker_from_markers(markers: list[str]) -> str:
+def _get_aws_marker_from_markers(markers: "list[str]") -> str:
     for marker in markers:
         if marker.startswith("aws_"):
             return marker
@@ -82,7 +82,7 @@ def _get_aws_marker_from_markers(markers: list[str]) -> str:
 
 @pytest.hookimpl
 def pytest_collection_modifyitems(
-    session: pytest.Session, config: "Config", items: List[pytest.Item]
+    session: pytest.Session, config: "Config", items: "list[pytest.Item]"
 ) -> None:
     """Generate a report about the pytest markers used"""
 

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -1,7 +1,7 @@
 """
 Custom pytest mark typings
 """
-from typing import Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import pytest
 
@@ -62,14 +62,17 @@ class Markers:
 
 
 # pytest plugin
+if TYPE_CHECKING:
+    from _pytest.config import Config
 
 
 @pytest.hookimpl
 def pytest_collection_modifyitems(
-    session: pytest.Session, config: Any, items: List[pytest.Item]
+    session: pytest.Session, config: "Config", items: List[pytest.Item]
 ) -> None:
     """Enforce that each test has exactly one aws compatibility marker"""
     marker_errors = []
+
     for item in items:
         # we should only concern ourselves with tests in tests/aws/
         if "tests/aws" not in item.fspath.dirname:

--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -7,7 +7,7 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_sns_topic_fifo_with_deduplication(deploy_cfn_template, aws_client):
     topic_name = f"topic-{short_uid()}.fifo"
 
@@ -24,7 +24,7 @@ def test_sns_topic_fifo_with_deduplication(deploy_cfn_template, aws_client):
     assert len([t for t in topic_arns if topic_name in t]) == 1
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_sns_topic_fifo_without_suffix_fails(deploy_cfn_template, aws_client):
     stack_name = f"stack-{short_uid()}"
     topic_name = f"topic-{short_uid()}"
@@ -46,7 +46,7 @@ def test_sns_topic_fifo_without_suffix_fails(deploy_cfn_template, aws_client):
         assert stack.get("StackStatus") == "CREATE_FAILED"
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_sns_subscription(deploy_cfn_template, aws_client):
     topic_name = f"topic-{short_uid()}"
     queue_name = f"topic-{short_uid()}"
@@ -64,7 +64,7 @@ def test_sns_subscription(deploy_cfn_template, aws_client):
     assert len(subscriptions["Subscriptions"]) > 0
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_deploy_stack_with_sns_topic(deploy_cfn_template, aws_client):
 
     stack = deploy_cfn_template(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ pytest_plugins = [
     "localstack.testing.pytest.fixture_conflicts",
     "localstack.testing.pytest.detect_thread_leakage",
     "localstack.testing.pytest.marking",
+    "localstack.testing.pytest.marker_report",
 ]
 
 


### PR DESCRIPTION
## Motivation
We want to keep track of the state of our AWS tests, especially the correct marking.
A recently introduced plugin already enforces correct exactly-once marking with `aws_` markers, but we still have a lot of `aws_unknown` markers which we should try to get down to 0. 

We also want to track the progress over time.

The plugin has been implemented in a somewhat generic way, so we can use it for other non-aws markers as well.

## Changes

- Add a new plugin to our pytest plugin suite which can be used to generate a json report about the markers used in our pytest tests
- Adds a new workflow that uploads data about marker usage to tinybird
- Adds the plugin to our pytest config

## Testing

```bash
python -m pytest tests/aws/services/lambda_ --marker-report --marker-report-prefix aws_ --co -qqq
```

