### PR TITLE
add refactor PRs to ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,7 @@
 8c006f122803dd06811343782b34f067f0622baf
 # reorganize utility package
 a7602821ac8666c9ab3a253457eb99570908ac8e
+# standardize Lambda package structure
+9de01149af6584c8104bd6a02cd87687f6b85083
+# standardize tests folder structure
+1ec4e7ff5126f2d7a85b536e70b432502b5bad25


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds the two recent commits that improve standardization of our folder structure to ignore-revs, since these PRs touch a lot of files without changing functionality

<!-- What notable changes does this PR make? -->
## Changes
adds https://github.com/localstack/localstack/pull/8867 and https://github.com/localstack/localstack/pull/8861 to .git-blame-ignore-revs

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

