### PR TITLE
Move lambda multiruntime test logic to testing module

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 import sys
 import threading
-from typing import Dict, List, Optional, TypeVar
+from typing import List, Optional, TypeVar
 from urllib.parse import urlparse
 
 from requests.models import Response
@@ -531,12 +531,10 @@ def run_module_as_sudo(
     # prepare environment
     env_vars = env_vars or {}
     env_vars["PYTHONPATH"] = f".:{LOCALSTACK_ROOT_FOLDER}"
-    env_vars_str = env_vars_to_string(env_vars)
 
     # start the process as sudo
-    sudo_cmd = "sudo -n"
     python_cmd = sys.executable
-    cmd = [sudo_cmd, env_vars_str, python_cmd, "-m", module]
+    cmd = ["sudo", "-n", "--preserve-env", python_cmd, "-m", module]
     arguments = arguments or []
     shell_cmd = shlex.join(cmd + arguments)
 
@@ -555,10 +553,6 @@ def run_module_as_sudo(
         start_thread(run_command, quiet=True, name="sudo-edge") if asynchronous else run_command()
     )
     return result
-
-
-def env_vars_to_string(env_vars: Dict) -> str:
-    return " ".join(f"{k}='{v}'" for k, v in env_vars.items())
 
 
 def parse_gateway_listen(listen: str, default_host: str, default_port: int) -> List[HostAndPort]:

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -1,11 +1,241 @@
+import itertools
 import json
+import logging
 import os
-from typing import Literal
+import subprocess
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Mapping, Optional, Sequence, overload
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.services.lambda_.lambda_api import use_docker
 from localstack.utils.common import to_str
+from localstack.utils.files import load_file
+from localstack.utils.strings import short_uid
 from localstack.utils.sync import ShortCircuitWaitException, retry
 from localstack.utils.testutil import get_lambda_log_events
+
+if TYPE_CHECKING:
+    from mypy_boto3_lambda import LambdaClient
+    from mypy_boto3_lambda.literals import ArchitectureType, PackageTypeType, RuntimeType
+    from mypy_boto3_lambda.type_defs import (
+        DeadLetterConfigTypeDef,
+        EnvironmentTypeDef,
+        EphemeralStorageTypeDef,
+        FileSystemConfigTypeDef,
+        FunctionCodeTypeDef,
+        FunctionConfigurationResponseMetadataTypeDef,
+        ImageConfigTypeDef,
+        TracingConfigTypeDef,
+        VpcConfigTypeDef,
+    )
+
+LOG = logging.getLogger(__name__)
+
+# Supported Runtimes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+# NOTE: missing support for `dotnet7` (container only)
+RUNTIMES_AGGREGATED = {
+    "python": [
+        Runtime.python3_7,
+        Runtime.python3_8,
+        Runtime.python3_9,
+        Runtime.python3_10,
+        Runtime.python3_11,
+    ],
+    "nodejs": [Runtime.nodejs14_x, Runtime.nodejs16_x, Runtime.nodejs18_x],
+    "ruby": [Runtime.ruby2_7, Runtime.ruby3_2],
+    "java": [Runtime.java8, Runtime.java8_al2, Runtime.java11, Runtime.java17],
+    "dotnet": [Runtime.dotnet6],
+    "go": [Runtime.go1_x],
+    "custom": [Runtime.provided, Runtime.provided_al2],
+}
+
+HANDLERS = {
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("python"), "handler.handler"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("nodejs"), "index.handler"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("ruby"), "function.handler"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("java"), "echo.Handler"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("custom"), "function.handler"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("go"), "main"),
+    "dotnetcore3.1": "dotnetcore31::dotnetcore31.Function::FunctionHandler",  # TODO lets see if we can accumulate those
+    "dotnet6": "dotnet6::dotnet6.Function::FunctionHandler",
+}
+
+PACKAGE_FOR_RUNTIME = {
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("python"), "python"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("nodejs"), "nodejs"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("ruby"), "ruby"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("java"), "java"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("custom"), "provided"),
+    **dict.fromkeys(RUNTIMES_AGGREGATED.get("go"), "go"),
+    "dotnet6": "dotnet6",
+    "dotnetcore3.1": "dotnetcore3.1",
+}
+
+
+def generate_tests(metafunc):
+    i = next(metafunc.definition.iter_markers("multiruntime"), None)
+    if not i:
+        return
+    if i.args:
+        raise ValueError("doofus")
+
+    scenario = i.kwargs["scenario"]
+    runtimes = i.kwargs.get("runtimes")
+    if not runtimes:
+        runtimes = list(RUNTIMES_AGGREGATED.keys())
+    ids = list(
+        itertools.chain.from_iterable(
+            RUNTIMES_AGGREGATED.get(runtime) or [runtime] for runtime in runtimes
+        )
+    )
+    arg_values = [(scenario, runtime, HANDLERS[runtime]) for runtime in ids]
+
+    metafunc.parametrize(
+        argvalues=arg_values,
+        argnames="multiruntime_lambda",
+        indirect=True,
+        ids=ids,
+    )
+
+
+def package_for_lang(scenario: str, runtime: str, root_folder: Path) -> str:
+    """
+    :param scenario: which scenario to run
+    :param runtime: which runtime to build
+    :param root_folder: The root folder for the scenarios
+    :return: path to built zip file
+    """
+    runtime_folder = PACKAGE_FOR_RUNTIME[runtime]
+
+    common_dir = root_folder / "functions" / "common"
+    scenario_dir = common_dir / scenario
+    runtime_dir_candidate = scenario_dir / runtime
+    generic_runtime_dir_candidate = scenario_dir / runtime_folder
+
+    # if a more specific folder exists, use that one
+    # otherwise: try to fall back to generic runtime (e.g. python for python3.9)
+    if runtime_dir_candidate.exists() and runtime_dir_candidate.is_dir():
+        runtime_dir = runtime_dir_candidate
+    else:
+        runtime_dir = generic_runtime_dir_candidate
+
+    build_dir = runtime_dir / "build"
+    package_path = runtime_dir / "handler.zip"
+
+    # caching step
+    # TODO: add invalidation (e.g. via storing a hash besides this of all files in src)
+    if os.path.exists(package_path) and os.path.isfile(package_path):
+        return package_path
+
+    # packaging
+    result = subprocess.run(["make", "build"], cwd=runtime_dir)
+    if result.returncode != 0:
+        raise Exception(
+            f"Failed to build multiruntime {scenario=} for {runtime=} with error code: {result.returncode}"
+        )
+
+    # check again if the zip file is now present
+    if os.path.exists(package_path) and os.path.isfile(package_path):
+        return package_path
+
+    # check something is in build now
+    target_empty = len(os.listdir(build_dir)) <= 0
+    if target_empty:
+        raise Exception(f"Failed to build multiruntime {scenario=} for {runtime=} ")
+
+    with zipfile.ZipFile(package_path, "w", strict_timestamps=True) as zf:
+        for root, dirs, files in os.walk(build_dir):
+            rel_dir = os.path.relpath(root, build_dir)
+            for f in files:
+                zf.write(os.path.join(root, f), arcname=os.path.join(rel_dir, f))
+
+    # make sure package file has been generated
+    assert package_path.exists() and package_path.is_file()
+    return package_path
+
+
+class ParametrizedLambda:
+    lambda_client: "LambdaClient"
+    function_names: list[str]
+    scenario: str
+    runtime: str
+    handler: str
+    zip_file_path: str
+    role: str
+
+    def __init__(
+        self,
+        lambda_client: "LambdaClient",
+        scenario: str,
+        runtime: str,
+        handler: str,
+        zip_file_path: str,
+        role: str,
+    ):
+        self.function_names = []
+        self.lambda_client = lambda_client
+        self.scenario = scenario
+        self.runtime = runtime
+        self.handler = handler
+        self.zip_file_path = zip_file_path
+        self.role = role
+
+    @overload
+    def create_function(
+        self,
+        *,
+        FunctionName: Optional[str] = None,
+        Role: Optional[str] = None,
+        Code: Optional["FunctionCodeTypeDef"] = None,
+        Runtime: Optional["RuntimeType"] = None,
+        Handler: Optional[str] = None,
+        Description: Optional[str] = None,
+        Timeout: Optional[int] = None,
+        MemorySize: Optional[int] = None,
+        Publish: Optional[bool] = None,
+        VpcConfig: Optional["VpcConfigTypeDef"] = None,
+        PackageType: Optional["PackageTypeType"] = None,
+        DeadLetterConfig: Optional["DeadLetterConfigTypeDef"] = None,
+        Environment: Optional["EnvironmentTypeDef"] = None,
+        KMSKeyArn: Optional[str] = None,
+        TracingConfig: Optional["TracingConfigTypeDef"] = None,
+        Tags: Optional[Mapping[str, str]] = None,
+        Layers: Optional[Sequence[str]] = None,
+        FileSystemConfigs: Optional[Sequence["FileSystemConfigTypeDef"]] = None,
+        ImageConfig: Optional["ImageConfigTypeDef"] = None,
+        CodeSigningConfigArn: Optional[str] = None,
+        Architectures: Optional[Sequence["ArchitectureType"]] = None,
+        EphemeralStorage: Optional["EphemeralStorageTypeDef"] = None,
+    ) -> "FunctionConfigurationResponseMetadataTypeDef":
+        ...
+
+    def create_function(self, **kwargs):
+        kwargs.setdefault("FunctionName", f"{self.scenario}-{short_uid()}")
+        kwargs.setdefault("Runtime", self.runtime)
+        kwargs.setdefault("Handler", self.handler)
+        kwargs.setdefault("Role", self.role)
+        kwargs.setdefault("Code", {"ZipFile": load_file(self.zip_file_path, mode="rb")})
+
+        def _create_function():
+            return self.lambda_client.create_function(**kwargs)
+
+        # @AWS, takes about 10s until the role/policy is "active", until then it will fail
+        # localstack should normally not require the retries and will just continue here
+        result = retry(_create_function, retries=3, sleep=4)
+        self.function_names.append(result["FunctionArn"])
+        self.lambda_client.get_waiter("function_active_v2").wait(
+            FunctionName=kwargs.get("FunctionName")
+        )
+
+        return result
+
+    def destroy(self):
+        for function_name in self.function_names:
+            try:
+                self.lambda_client.delete_function(FunctionName=function_name)
+            except Exception as e:
+                LOG.debug("Error deleting function %s: %s", function_name, e)
 
 
 def update_done(client, function_name):

--- a/tests/aws/services/lambda_/conftest.py
+++ b/tests/aws/services/lambda_/conftest.py
@@ -1,76 +1,10 @@
-import itertools
-import logging
 import os
-import subprocess
-import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Optional, Sequence, overload
 
 import pytest
 from _pytest.python import Metafunc
 
-from localstack.aws.api.lambda_ import Runtime
-from localstack.utils.files import load_file
-from localstack.utils.strings import short_uid
-from localstack.utils.sync import retry
-
-if TYPE_CHECKING:
-    from mypy_boto3_lambda import LambdaClient
-    from mypy_boto3_lambda.literals import ArchitectureType, PackageTypeType, RuntimeType
-    from mypy_boto3_lambda.type_defs import (
-        DeadLetterConfigTypeDef,
-        EnvironmentTypeDef,
-        EphemeralStorageTypeDef,
-        FileSystemConfigTypeDef,
-        FunctionCodeTypeDef,
-        FunctionConfigurationResponseMetadataTypeDef,
-        ImageConfigTypeDef,
-        TracingConfigTypeDef,
-        VpcConfigTypeDef,
-    )
-
-LOG = logging.getLogger(__name__)
-
-
-# Supported Runtimes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-# NOTE: missing support for `dotnet7` (container only)
-RUNTIMES_AGGREGATED = {
-    "python": [
-        Runtime.python3_7,
-        Runtime.python3_8,
-        Runtime.python3_9,
-        Runtime.python3_10,
-        Runtime.python3_11,
-    ],
-    "nodejs": [Runtime.nodejs14_x, Runtime.nodejs16_x, Runtime.nodejs18_x],
-    "ruby": [Runtime.ruby2_7, Runtime.ruby3_2],
-    "java": [Runtime.java8, Runtime.java8_al2, Runtime.java11, Runtime.java17],
-    "dotnet": [Runtime.dotnet6],
-    "go": [Runtime.go1_x],
-    "custom": [Runtime.provided, Runtime.provided_al2],
-}
-
-HANDLERS = {
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("python"), "handler.handler"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("nodejs"), "index.handler"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("ruby"), "function.handler"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("java"), "echo.Handler"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("custom"), "function.handler"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("go"), "main"),
-    "dotnetcore3.1": "dotnetcore31::dotnetcore31.Function::FunctionHandler",  # TODO lets see if we can accumulate those
-    "dotnet6": "dotnet6::dotnet6.Function::FunctionHandler",
-}
-
-PACKAGE_FOR_RUNTIME = {
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("python"), "python"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("nodejs"), "nodejs"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("ruby"), "ruby"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("java"), "java"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("custom"), "provided"),
-    **dict.fromkeys(RUNTIMES_AGGREGATED.get("go"), "go"),
-    "dotnet6": "dotnet6",
-    "dotnetcore3.1": "dotnetcore3.1",
-}
+from localstack.testing.aws.lambda_utils import ParametrizedLambda, generate_tests, package_for_lang
 
 
 def pytest_configure(config):
@@ -80,178 +14,17 @@ def pytest_configure(config):
     )
 
 
-def pytest_generate_tests(metafunc: Metafunc) -> Optional[object]:
-
-    i = next(metafunc.definition.iter_markers("multiruntime"), None)
-    if not i:
-        return
-    if i.args:
-        raise ValueError("doofus")
-
-    scenario = i.kwargs["scenario"]
-    runtimes = i.kwargs.get("runtimes")
-    if not runtimes:
-        runtimes = list(RUNTIMES_AGGREGATED.keys())
-    ids = list(
-        itertools.chain.from_iterable(
-            RUNTIMES_AGGREGATED.get(runtime) or [runtime] for runtime in runtimes
-        )
-    )
-    arg_values = [(scenario, runtime, HANDLERS[runtime]) for runtime in ids]
-
-    metafunc.parametrize(
-        argvalues=arg_values,
-        argnames="multiruntime_lambda",
-        indirect=True,
-        ids=ids,
-    )
-
-
-def package_for_lang(scenario: str, runtime: str) -> str:
-    """
-    :param lang: which language
-    :param path: directory to build
-    :return: path to built zip file
-    """
-    runtime_folder = PACKAGE_FOR_RUNTIME[runtime]
-
-    common_dir = (
-        Path(os.path.dirname(__file__)) / "functions" / "common"
-    )  # TODO: remove implicit relative location to this file
-    scenario_dir = common_dir / scenario
-    runtime_dir_candidate = scenario_dir / runtime
-    generic_runtime_dir_candidate = scenario_dir / runtime_folder
-
-    # if a more specific folder exists, use that one
-    # otherwise: try to fall back to generic runtime (e.g. python for python3.9)
-    if runtime_dir_candidate.exists() and runtime_dir_candidate.is_dir():
-        runtime_dir = runtime_dir_candidate
-    else:
-        runtime_dir = generic_runtime_dir_candidate
-
-    build_dir = runtime_dir / "build"
-    package_path = runtime_dir / "handler.zip"
-
-    # caching step
-    # TODO: add invalidation (e.g. via storing a hash besides this of all files in src)
-    if os.path.exists(package_path) and os.path.isfile(package_path):
-        return package_path
-
-    # packaging
-    result = subprocess.run(["make", "build"], cwd=runtime_dir)
-    if result.returncode != 0:
-        raise Exception(
-            f"Failed to build multiruntime {scenario=} for {runtime=} with error code: {result.returncode}"
-        )
-
-    # check again if the zip file is now present
-    if os.path.exists(package_path) and os.path.isfile(package_path):
-        return package_path
-
-    # check something is in build now
-    target_empty = len(os.listdir(build_dir)) <= 0
-    if target_empty:
-        raise Exception(f"Failed to build multiruntime {scenario=} for {runtime=} ")
-
-    with zipfile.ZipFile(package_path, "w", strict_timestamps=True) as zf:
-        for root, dirs, files in os.walk(build_dir):
-            rel_dir = os.path.relpath(root, build_dir)
-            for f in files:
-                zf.write(os.path.join(root, f), arcname=os.path.join(rel_dir, f))
-
-    # make sure package file has been generated
-    assert package_path.exists() and package_path.is_file()
-    return package_path
-
-
-class ParametrizedLambda:
-    lambda_client: "LambdaClient"
-    function_names: list[str]
-    scenario: str
-    runtime: str
-    handler: str
-    zip_file_path: str
-    role: str
-
-    def __init__(
-        self,
-        lambda_client: "LambdaClient",
-        scenario: str,
-        runtime: str,
-        handler: str,
-        zip_file_path: str,
-        role: str,
-    ):
-        self.function_names = []
-        self.lambda_client = lambda_client
-        self.scenario = scenario
-        self.runtime = runtime
-        self.handler = handler
-        self.zip_file_path = zip_file_path
-        self.role = role
-
-    @overload
-    def create_function(
-        self,
-        *,
-        FunctionName: Optional[str] = None,
-        Role: Optional[str] = None,
-        Code: Optional["FunctionCodeTypeDef"] = None,
-        Runtime: Optional["RuntimeType"] = None,
-        Handler: Optional[str] = None,
-        Description: Optional[str] = None,
-        Timeout: Optional[int] = None,
-        MemorySize: Optional[int] = None,
-        Publish: Optional[bool] = None,
-        VpcConfig: Optional["VpcConfigTypeDef"] = None,
-        PackageType: Optional["PackageTypeType"] = None,
-        DeadLetterConfig: Optional["DeadLetterConfigTypeDef"] = None,
-        Environment: Optional["EnvironmentTypeDef"] = None,
-        KMSKeyArn: Optional[str] = None,
-        TracingConfig: Optional["TracingConfigTypeDef"] = None,
-        Tags: Optional[Mapping[str, str]] = None,
-        Layers: Optional[Sequence[str]] = None,
-        FileSystemConfigs: Optional[Sequence["FileSystemConfigTypeDef"]] = None,
-        ImageConfig: Optional["ImageConfigTypeDef"] = None,
-        CodeSigningConfigArn: Optional[str] = None,
-        Architectures: Optional[Sequence["ArchitectureType"]] = None,
-        EphemeralStorage: Optional["EphemeralStorageTypeDef"] = None,
-    ) -> "FunctionConfigurationResponseMetadataTypeDef":
-        ...
-
-    def create_function(self, **kwargs):
-        kwargs.setdefault("FunctionName", f"{self.scenario}-{short_uid()}")
-        kwargs.setdefault("Runtime", self.runtime)
-        kwargs.setdefault("Handler", self.handler)
-        kwargs.setdefault("Role", self.role)
-        kwargs.setdefault("Code", {"ZipFile": load_file(self.zip_file_path, mode="rb")})
-
-        def _create_function():
-            return self.lambda_client.create_function(**kwargs)
-
-        # @AWS, takes about 10s until the role/policy is "active", until then it will fail
-        # localstack should normally not require the retries and will just continue here
-        result = retry(_create_function, retries=3, sleep=4)
-        self.function_names.append(result["FunctionArn"])
-        self.lambda_client.get_waiter("function_active_v2").wait(
-            FunctionName=kwargs.get("FunctionName")
-        )
-
-        return result
-
-    def destroy(self):
-        for function_name in self.function_names:
-            try:
-                self.lambda_client.delete_function(FunctionName=function_name)
-            except Exception as e:
-                LOG.debug("Error deleting function %s: %s", function_name, e)
+def pytest_generate_tests(metafunc: Metafunc):
+    generate_tests(metafunc)
 
 
 @pytest.fixture
 def multiruntime_lambda(aws_client, request, lambda_su_role) -> ParametrizedLambda:
     scenario, runtime, handler = request.param
 
-    zip_file_path = package_for_lang(scenario=scenario, runtime=runtime)
+    zip_file_path = package_for_lang(
+        scenario=scenario, runtime=runtime, root_folder=Path(os.path.dirname(__file__))
+    )
     param_lambda = ParametrizedLambda(
         lambda_client=aws_client.lambda_,
         scenario=scenario,

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -15,6 +15,7 @@ from localstack import config
 from localstack.aws.api.lambda_ import Architecture, Runtime
 from localstack.services.lambda_.lambda_api import use_docker
 from localstack.testing.aws.lambda_utils import (
+    RUNTIMES_AGGREGATED,
     concurrency_update_done,
     get_invoke_init_type,
     is_old_local_executor,
@@ -33,7 +34,6 @@ from localstack.utils.platform import Arch, get_arch, is_arm_compatible, standar
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import create_lambda_archive
-from tests.aws.services.lambda_.conftest import RUNTIMES_AGGREGATED
 
 LOG = logging.getLogger(__name__)
 FUNCTION_MAX_UNZIPPED_SIZE = 262144000


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We also want multiruntime tests in -ext, in this case for transparent endpoint injection tests.
This slight refactoring basically moves the logic to the testing/aws/lambda_utils module instead of the conftest.py, which enables us to use the logic with very little duplicated code in -ext.

Also, there were some logical issues recently introduced with changes in edge.py for `run_module_as_sudo` which are corrected with this pr /cc @simonrw 

<!-- What notable changes does this PR make? -->
## Changes
* Move the multiruntime test logic to testing module
* Fix `run_module_as_sudo` logic

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

