### PR TITLE
refresh SNS snapshots

### DIFF
--- a/localstack/services/sns/constants.py
+++ b/localstack/services/sns/constants.py
@@ -32,3 +32,5 @@ GCM_URL = "https://fcm.googleapis.com/fcm/send"
 # Endpoint to access all the PlatformEndpoint sent Messages
 PLATFORM_ENDPOINT_MSGS_ENDPOINT = "/_aws/sns/platform-endpoint-messages"
 SMS_MSGS_ENDPOINT = "/_aws/sns/sms-messages"
+
+DUMMY_SUBSCRIPTION_PRINCIPAL = "arn:aws:iam::{{account_id}}:user/DummySNSPrincipal"

--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -86,7 +86,7 @@ class SnsMessage:
         )
 
 
-class SnsSubscription(TypedDict):
+class SnsSubscription(TypedDict, total=False):
     """
     In SNS, Subscription can be represented with only TopicArn, Endpoint, Protocol, SubscriptionArn and Owner, for
     example in ListSubscriptions. However, when getting a subscription with GetSubscriptionAttributes, it will return

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -278,16 +278,22 @@ class SqsTopicPublisher(TopicPublisher):
         kwargs = {}
         if is_raw_message_delivery(subscriber) and msg_context.message_attributes:
             kwargs["MessageAttributes"] = msg_context.message_attributes
-        if msg_context.message_group_id:
-            kwargs["MessageGroupId"] = msg_context.message_group_id
-        if msg_context.message_deduplication_id:
-            kwargs["MessageDeduplicationId"] = msg_context.message_deduplication_id
-        elif subscriber["TopicArn"].endswith(".fifo"):
-            # Amazon SNS uses the message body provided to generate a unique hash value to use as the deduplication
-            # ID for each message, so you don't need to set a deduplication ID when you send each message.
-            # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
-            content = msg_context.message_content("sqs")
-            kwargs["MessageDeduplicationId"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+        # SNS now allows regular non-fifo subscriptions to FIFO topics. Validate that the subscription target is fifo
+        # before passing the FIFO-only parameters
+        if subscriber["Endpoint"].endswith(".fifo"):
+            if msg_context.message_group_id:
+                kwargs["MessageGroupId"] = msg_context.message_group_id
+            if msg_context.message_deduplication_id:
+                kwargs["MessageDeduplicationId"] = msg_context.message_deduplication_id
+            elif subscriber["TopicArn"].endswith(".fifo"):
+                # Amazon SNS uses the message body provided to generate a unique hash value to use as the deduplication
+                # ID for each message, so you don't need to set a deduplication ID when you send each message.
+                # https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
+                content = msg_context.message_content("sqs")
+                kwargs["MessageDeduplicationId"] = hashlib.sha256(
+                    content.encode("utf-8")
+                ).hexdigest()
 
         # TODO: for message deduplication, we are using the underlying features of the SQS queue
         # however, SQS queue only deduplicate at the Queue level, where the SNS topic deduplicate on the topic level

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -479,6 +479,9 @@ def sns_create_sqs_subscription(sns_allow_topic_sqs_queue, sqs_queue_arn, aws_cl
 
 @pytest.fixture
 def sns_create_http_endpoint(sns_create_topic, sns_subscription, aws_client):
+    # This fixture can be used with manual setup to expose the HTTPServer fixture to AWS. One example is to use a
+    # a service like localhost.run, and set up a specific port to start the `HTTPServer(port=40000)` for example,
+    # and tunnel `localhost:40000` to a specific domain that you can manually return from this fixture.
     http_servers = []
 
     def _create_http_endpoint(

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -45,16 +45,6 @@ PUBLICATION_RETRIES = 4
 @pytest.fixture(autouse=True)
 def sns_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.sns_api())
-    # FIXME: AWS added a new field to subscriptions responses. It has an ARN in the response, which creates
-    # a <resource:id> that we're missing. Regenerate all snapshots without this transformer once this is implemented.
-    snapshot.add_transformer(
-        snapshot.transform.key_value(
-            "SubscriptionPrincipal",
-            value_replacement="<sub-principal>",
-            reference_replacement=False,
-        ),
-        priority=-1,
-    )
 
 
 @pytest.fixture
@@ -90,7 +80,601 @@ def sns_create_platform_application(aws_client):
             LOG.debug("Error cleaning up platform application '%s': %s", platform_application, e)
 
 
-class TestSNSSubscription:
+class TestSNSTopicCrud:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.get-topic-attrs.Attributes.DeliveryPolicy",
+            "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
+            "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
+        ]
+    )
+    def test_create_topic_with_attributes(self, sns_create_topic, snapshot, aws_client):
+        create_topic = sns_create_topic(
+            Name="topictest.fifo",
+            Attributes={
+                "DisplayName": "TestTopic",
+                "SignatureVersion": "2",
+                "FifoTopic": "true",
+            },
+        )
+        topic_arn = create_topic["TopicArn"]
+
+        get_attrs_resp = aws_client.sns.get_topic_attributes(
+            TopicArn=topic_arn,
+        )
+        snapshot.match("get-topic-attrs", get_attrs_resp)
+
+        with pytest.raises(ClientError) as e:
+            wrong_topic_arn = f"{topic_arn[:-8]}{short_uid()}"
+            aws_client.sns.get_topic_attributes(TopicArn=wrong_topic_arn)
+
+        snapshot.match("get-attrs-nonexistent-topic", e.value.response)
+
+    @markers.aws.validated
+    def test_tags(self, sns_create_topic, snapshot, aws_client):
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        with pytest.raises(ClientError) as exc:
+            aws_client.sns.tag_resource(
+                ResourceArn=topic_arn,
+                Tags=[
+                    {"Key": "k1", "Value": "v1"},
+                    {"Key": "k2", "Value": "v2"},
+                    {"Key": "k2", "Value": "v2"},
+                ],
+            )
+        snapshot.match("duplicate-key-error", exc.value.response)
+
+        aws_client.sns.tag_resource(
+            ResourceArn=topic_arn,
+            Tags=[
+                {"Key": "k1", "Value": "v1"},
+                {"Key": "k2", "Value": "v2"},
+            ],
+        )
+
+        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
+        # could not figure out the logic for tag order in AWS, so resorting to sorting it manually in place
+        tags["Tags"].sort(key=itemgetter("Key"))
+        snapshot.match("list-created-tags", tags)
+
+        aws_client.sns.untag_resource(ResourceArn=topic_arn, TagKeys=["k1"])
+        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
+        snapshot.match("list-after-delete-tags", tags)
+
+        # test update tag
+        aws_client.sns.tag_resource(ResourceArn=topic_arn, Tags=[{"Key": "k2", "Value": "v2b"}])
+        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
+        snapshot.match("list-after-update-tags", tags)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.get-topic-attrs.Attributes.DeliveryPolicy",
+            "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
+            "$.get-topic-attrs.Attributes.Policy.Statement..Action",
+            # SNS:Receive is added by moto but not returned in AWS
+        ]
+    )
+    def test_create_topic_test_arn(self, sns_create_topic, snapshot, aws_client):
+        topic_name = "topic-test-create"
+        response = sns_create_topic(Name=topic_name)
+        snapshot.match("create-topic", response)
+        topic_arn = response["TopicArn"]
+        topic_arn_params = topic_arn.split(":")
+        testutil.response_arn_matches_partition(aws_client.sns, topic_arn)
+        # we match the response but need to be sure the resource name is the same
+        assert topic_arn_params[5] == topic_name
+
+        if not is_aws_cloud():
+            assert topic_arn_params[4] == get_aws_account_id()
+
+        topic_attrs = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
+        snapshot.match("get-topic-attrs", topic_attrs)
+
+        response = aws_client.sns.delete_topic(TopicArn=topic_arn)
+        snapshot.match("delete-topic", response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
+        snapshot.match("topic-not-exists", e.value.response)
+
+    @markers.aws.validated
+    def test_create_duplicate_topic_with_more_tags(self, sns_create_topic, snapshot, aws_client):
+        topic_name = "test-duplicated-topic-more-tags"
+        sns_create_topic(Name=topic_name)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.create_topic(Name=topic_name, Tags=[{"Key": "key1", "Value": "value1"}])
+
+        snapshot.match("exception-duplicate", e.value.response)
+
+    @markers.aws.validated
+    def test_create_duplicate_topic_check_idempotency(self, sns_create_topic, snapshot):
+        topic_name = f"test-{short_uid()}"
+        tags = [{"Key": "a", "Value": "1"}, {"Key": "b", "Value": "2"}]
+        kwargs = [
+            {"Tags": tags},  # to create the same topic again with same tags
+            {"Tags": [tags[0]]},  # to create the same topic again with one of the tags from above
+            {"Tags": []},  # to create the same topic again with no tags
+        ]
+
+        # create topic with two tags
+        response = sns_create_topic(Name=topic_name, Tags=tags)
+        snapshot.match("response-created", response)
+
+        for index, arg in enumerate(kwargs):
+            response = sns_create_topic(Name=topic_name, **arg)
+            # we check in the snapshot that they all have the same <resource:1> tag (original topic)
+            snapshot.match(f"response-same-arn-{index}", response)
+
+    @markers.aws.validated
+    def test_create_topic_after_delete_with_new_tags(self, sns_create_topic, snapshot, aws_client):
+        topic_name = f"test-{short_uid()}"
+        topic = sns_create_topic(Name=topic_name, Tags=[{"Key": "Name", "Value": "pqr"}])
+        snapshot.match("topic-0", topic)
+        aws_client.sns.delete_topic(TopicArn=topic["TopicArn"])
+
+        topic1 = sns_create_topic(Name=topic_name, Tags=[{"Key": "Name", "Value": "abc"}])
+        snapshot.match("topic-1", topic1)
+
+
+class TestSNSPublishCrud:
+    """
+    This class contains tests related to the global `Publish` validation, not tied to a particular kind of subscription
+    """
+
+    @markers.aws.validated
+    def test_publish_by_path_parameters(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sns_create_sqs_subscription,
+        aws_http_client_factory,
+        snapshot,
+        aws_client,
+    ):
+        message = "test message direct post request"
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        client = aws_http_client_factory("sns", region="us-east-1")
+
+        if is_aws_cloud():
+            endpoint_url = "https://sns.us-east-1.amazonaws.com"
+        else:
+            endpoint_url = config.get_edge_url()
+
+        response = client.post(
+            endpoint_url,
+            params={
+                "Action": "Publish",
+                "Version": "2010-03-31",
+                "TopicArn": topic_arn,
+                "Message": message,
+            },
+        )
+
+        json_response = xmltodict.parse(response.content)
+        json_response["PublishResponse"].pop("@xmlns")
+        json_response["PublishResponse"]["ResponseMetadata"][
+            "HTTPStatusCode"
+        ] = response.status_code
+        json_response["PublishResponse"]["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
+        snapshot.match("post-request", json_response)
+
+        assert response.status_code == 200
+        assert b"<PublishResponse" in response.content
+
+        rs = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5
+        )
+        snapshot.match("messages", rs)
+        msg_body = json.loads(rs["Messages"][0]["Body"])
+        assert msg_body["TopicArn"] == topic_arn
+        assert msg_body["Message"] == message
+
+    @markers.aws.validated
+    def test_publish_wrong_arn_format(self, snapshot, aws_client):
+        message = "Good news everyone!"
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, TopicArn="randomstring")
+
+        snapshot.match("invalid-topic-arn", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, TopicArn="randomstring:1")
+
+        snapshot.match("invalid-topic-arn-1", e.value.response)
+
+    @markers.aws.validated
+    def test_publish_message_by_target_arn(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        # using an SQS subscription to test TopicArn/TargetArn as it is easier to check against AWS
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        aws_client.sns.publish(TopicArn=topic_arn, Message="test-msg-1")
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            VisibilityTimeout=0,
+            WaitTimeSeconds=4,
+        )
+
+        snapshot.match("receive-topic-arn", response)
+
+        message = response["Messages"][0]
+        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"])
+
+        # publish with TargetArn instead of TopicArn
+        aws_client.sns.publish(TargetArn=topic_arn, Message="test-msg-2")
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            VisibilityTimeout=0,
+            WaitTimeSeconds=4,
+        )
+        snapshot.match("receive-target-arn", response)
+
+    @markers.aws.validated
+    def test_publish_message_before_subscribe_topic(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        rs = aws_client.sns.publish(
+            TopicArn=topic_arn, Subject="test-subject-before-sub", Message="test_message_before"
+        )
+        snapshot.match("publish-before-subscribing", rs)
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        message_subject = "test-subject-after-sub"
+        message_body = "test_message_after"
+
+        rs = aws_client.sns.publish(
+            TopicArn=topic_arn, Subject=message_subject, Message=message_body
+        )
+        snapshot.match("publish-after-subscribing", rs)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5
+        )
+        # nothing was subscribing to the topic, so the first message is lost
+        snapshot.match("receive-messages", response)
+
+    @markers.aws.validated
+    def test_unknown_topic_publish(self, sns_create_topic, snapshot, aws_client):
+        # create topic to get the basic arn structure
+        # otherwise you get InvalidClientTokenId exception because of account id
+        topic_arn = sns_create_topic()["TopicArn"]
+        # append to get an unknown topic
+        fake_arn = f"{topic_arn}-fake"
+        message = "This is a test message"
+
+        # test to send a message with no subscribers
+        response = aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+        snapshot.match("success", response)
+
+        # test to send to a nonexistent topic
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(TopicArn=fake_arn, Message=message)
+
+        snapshot.match("error", e.value.response)
+
+    @markers.aws.validated
+    def test_publish_non_existent_target(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+        account_id = parse_arn(topic_arn)["account"]
+        with pytest.raises(ClientError) as ex:
+            aws_client.sns.publish(
+                TargetArn=f"arn:aws:sns:us-east-1:{account_id}:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66",
+                Message="This is a push notification",
+            )
+        snapshot.match("non-existent-endpoint", ex.value.response)
+
+    @markers.aws.validated
+    def test_publish_with_empty_subject(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        # Publish without subject
+        rs = aws_client.sns.publish(
+            TopicArn=topic_arn, Message=json.dumps({"message": "test_publish"})
+        )
+        snapshot.match("response-without-subject", rs)
+        assert rs["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Subject="",
+                Message=json.dumps({"message": "test_publish"}),
+            )
+
+        snapshot.match("response-with-empty-subject", e.value.response)
+
+    @markers.aws.validated
+    def test_empty_sns_message(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message="", TopicArn=topic_arn)
+
+        snapshot.match("empty-msg-error", e.value.response)
+
+        queue_attrs = aws_client.sqs.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
+        )
+        snapshot.match("queue-attrs", queue_attrs)
+
+    @markers.aws.validated
+    def test_publish_too_long_message(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+        # simulate payload over 256kb
+        message = "This is a test message" * 12000
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+
+        snapshot.match("error", e.value.response)
+
+        assert e.value.response["Error"]["Code"] == "InvalidParameter"
+        assert e.value.response["Error"]["Message"] == "Invalid parameter: Message too long"
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+    @markers.aws.validated
+    def test_message_structure_json_exc(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+        # TODO: add batch
+
+        # missing `default` key for the JSON
+        with pytest.raises(ClientError) as e:
+            message = json.dumps({"sqs": "Test message"})
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                MessageStructure="json",
+            )
+        snapshot.match("missing-default-key", e.value.response)
+
+        # invalid JSON
+        with pytest.raises(ClientError) as e:
+            message = '{"default": "This is a default message"} }'
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                MessageStructure="json",
+            )
+        snapshot.match("invalid-json", e.value.response)
+
+        # duplicate keys: from SNS docs, should fail but does work
+        # https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
+        # `Duplicate keys are not allowed.`
+        message = '{"default": "This is a default message", "default": "Duplicate"}'
+        resp = aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageStructure="json",
+        )
+        snapshot.match("duplicate-json-keys", resp)
+
+        with pytest.raises(ClientError) as e:
+            message = json.dumps({"default": {"object": "test"}})
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                MessageStructure="json",
+            )
+        snapshot.match("key-is-not-string", e.value.response)
+
+
+class TestSNSSubscriptionCrud:
+    @markers.aws.validated
+    def test_subscribe_with_invalid_protocol(self, sns_create_topic, sns_subscription, snapshot):
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        with pytest.raises(ClientError) as e:
+            sns_subscription(
+                TopicArn=topic_arn, Protocol="test-protocol", Endpoint="localstack@yopmail.com"
+            )
+
+        snapshot.match("exception", e.value.response)
+
+    @markers.aws.validated
+    def test_unsubscribe_from_non_existing_subscription(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+        # unsubscribing a second time
+        response = aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+        snapshot.match("empty-unsubscribe", response)
+
+    @markers.aws.validated
+    def test_create_subscriptions_with_attributes(
+        self, sns_create_topic, sqs_create_queue, sqs_queue_arn, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_queue_arn(queue_url)
+
+        subscribe_resp = aws_client.sns.subscribe(
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            Attributes={
+                "RawMessageDelivery": "true",
+                "FilterPolicyScope": "MessageBody",
+            },
+            ReturnSubscriptionArn=True,
+        )
+        snapshot.match("subscribe", subscribe_resp)
+
+        get_attrs_resp = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscribe_resp["SubscriptionArn"]
+        )
+        snapshot.match("get-attrs", get_attrs_resp)
+
+        with pytest.raises(ClientError) as e:
+            wrong_sub_arn = f"{subscribe_resp['SubscriptionArn'][:-8]}{short_uid()}"
+            aws_client.sns.get_subscription_attributes(SubscriptionArn=wrong_sub_arn)
+
+        snapshot.match("get-attrs-nonexistent-sub", e.value.response)
+
+    @markers.aws.validated
+    def test_not_found_error_on_set_subscription_attributes(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_subscription,
+        snapshot,
+        aws_client,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        queue_arn = sqs_queue_arn(queue_url)
+        subscription = sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
+        snapshot.match("sub", subscription)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        response = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
+        subscription_attributes = response["Attributes"]
+        snapshot.match("sub-attrs", response)
+
+        assert subscription_attributes["SubscriptionArn"] == subscription_arn
+
+        subscriptions_by_topic = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+        snapshot.match("subscriptions-for-topic-before-unsub", subscriptions_by_topic)
+        assert len(subscriptions_by_topic["Subscriptions"]) == 1
+
+        aws_client.sns.unsubscribe(SubscriptionArn=subscription_arn)
+
+        def check_subscription_deleted():
+            try:
+                # AWS doesn't give NotFound error on GetSubscriptionAttributes for a while, might be cached
+                aws_client.sns.set_subscription_attributes(
+                    SubscriptionArn=subscription_arn,
+                    AttributeName="RawMessageDelivery",
+                    AttributeValue="true",
+                )
+                raise Exception("Subscription is not deleted")
+            except ClientError as e:
+                assert e.response["Error"]["Code"] == "NotFound"
+                assert e.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+                snapshot.match("sub-not-found", e.response)
+
+        retry(check_subscription_deleted, retries=10, sleep_before=0.2, sleep=3)
+        subscriptions_by_topic = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+        snapshot.match("subscriptions-for-topic-after-unsub", subscriptions_by_topic)
+        assert len(subscriptions_by_topic["Subscriptions"]) == 0
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.invalid-json-redrive-policy.Error.Message",  # message contains java trace in AWS, assert instead
+            "$.invalid-json-filter-policy.Error.Message",  # message contains java trace in AWS, assert instead
+        ]
+    )
+    def test_validate_set_sub_attributes(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_create_sqs_subscription,
+        snapshot,
+        aws_client,
+    ):
+        topic_name = f"topic-{short_uid()}"
+        queue_name = f"queue-{short_uid()}"
+        topic_arn = sns_create_topic(Name=topic_name)["TopicArn"]
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        sub_arn = subscription["SubscriptionArn"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=sub_arn,
+                AttributeName="FakeAttribute",
+                AttributeValue="test-value",
+            )
+        snapshot.match("fake-attribute", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=sub_arn,
+                AttributeName="RedrivePolicy",
+                AttributeValue=json.dumps({"deadLetterTargetArn": "fake-arn"}),
+            )
+        snapshot.match("fake-arn-redrive-policy", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=sub_arn,
+                AttributeName="RedrivePolicy",
+                AttributeValue="{invalidjson}",
+            )
+        snapshot.match("invalid-json-redrive-policy", e.value.response)
+        assert e.value.response["Error"]["Message"].startswith(
+            "Invalid parameter: RedrivePolicy: failed to parse JSON."
+        )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=sub_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue="{invalidjson}",
+            )
+        snapshot.match("invalid-json-filter-policy", e.value.response)
+        assert e.value.response["Error"]["Message"].startswith(
+            "Invalid parameter: FilterPolicy: failed to parse JSON."
+        )
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$.invalid-token.Error.Message"]  # validate the token shape
+    )
+    def test_sns_confirm_subscription_wrong_token(self, sns_create_topic, snapshot, aws_client):
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        with pytest.raises(ClientError) as e:
+            wrong_topic = topic_arn[:-1] + "i"
+            aws_client.sns.confirm_subscription(
+                TopicArn=wrong_topic,
+                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+            )
+
+        snapshot.match("topic-not-exists", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token="randomtoken")
+
+        snapshot.match("invalid-token", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.confirm_subscription(
+                TopicArn=topic_arn,
+                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+            )
+
+        snapshot.match("token-not-exists", e.value.response)
+
+
+class TestSNSSubscriptionLambda:
     @markers.aws.validated
     def test_python_lambda_subscribe_sns_topic(
         self,
@@ -151,558 +735,6 @@ class TestSNSSubscription:
         )
         notification = events[0]["Records"][0]["Sns"]
         snapshot.match("notification", notification)
-
-
-class TestSNSProvider:
-    @markers.aws.validated
-    def test_publish_unicode_chars(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        # publish message to SNS, receive it from SQS, assert that messages are equal
-        message = 'ö§a1"_!?,. £$-'
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-
-        snapshot.match("received-message", response)
-
-    @markers.aws.validated
-    def test_subscribe_with_invalid_protocol(self, sns_create_topic, sns_subscription, snapshot):
-        topic_arn = sns_create_topic()["TopicArn"]
-
-        with pytest.raises(ClientError) as e:
-            sns_subscription(
-                TopicArn=topic_arn, Protocol="test-protocol", Endpoint="localstack@yopmail.com"
-            )
-
-        snapshot.match("exception", e.value.response)
-
-    @markers.aws.validated
-    def test_unsubscribe_from_non_existing_subscription(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
-        # unsubscribing a second time
-        response = aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
-        snapshot.match("empty-unsubscribe", response)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.get-topic-attrs.Attributes.DeliveryPolicy",
-            "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
-        ]
-    )
-    def test_create_topic_with_attributes(self, sns_create_topic, snapshot, aws_client):
-        create_topic = sns_create_topic(
-            Name="topictest.fifo",
-            Attributes={
-                "DisplayName": "TestTopic",
-                "SignatureVersion": "2",
-                "FifoTopic": "true",
-            },
-        )
-        topic_arn = create_topic["TopicArn"]
-
-        get_attrs_resp = aws_client.sns.get_topic_attributes(
-            TopicArn=topic_arn,
-        )
-        snapshot.match("get-topic-attrs", get_attrs_resp)
-
-        with pytest.raises(ClientError) as e:
-            wrong_topic_arn = f"{topic_arn[:-8]}{short_uid()}"
-            aws_client.sns.get_topic_attributes(TopicArn=wrong_topic_arn)
-
-        snapshot.match("get-attrs-nonexistent-topic", e.value.response)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_create_subscriptions_with_attributes(
-        self, sns_create_topic, sqs_create_queue, sqs_queue_arn, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        queue_arn = sqs_queue_arn(queue_url)
-
-        subscribe_resp = aws_client.sns.subscribe(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
-            Attributes={
-                "RawMessageDelivery": "true",
-                "FilterPolicyScope": "MessageBody",
-            },
-            ReturnSubscriptionArn=True,
-        )
-        snapshot.match("subscribe", subscribe_resp)
-
-        get_attrs_resp = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscribe_resp["SubscriptionArn"]
-        )
-        snapshot.match("get-attrs", get_attrs_resp)
-
-        with pytest.raises(ClientError) as e:
-            wrong_sub_arn = f"{subscribe_resp['SubscriptionArn'][:-8]}{short_uid()}"
-            aws_client.sns.get_subscription_attributes(SubscriptionArn=wrong_sub_arn)
-
-        snapshot.match("get-attrs-nonexistent-sub", e.value.response)
-
-    @markers.aws.validated
-    def test_attribute_raw_subscribe(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
-        snapshot.add_transformer(
-            snapshot.transform.key_value(
-                "MD5OfMessageAttributes",
-                value_replacement="<md5-hash>",
-                reference_replacement=False,
-            )
-        )
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(
-            topic_arn=topic_arn, queue_url=queue_url, Attributes={"RawMessageDelivery": "true"}
-        )
-        subscription_arn = subscription["SubscriptionArn"]
-
-        response_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("subscription-attributes", response_attributes)
-
-        # publish message to SNS, receive it from SQS, assert that messages are equal and that they are Raw
-        message = "This is a test message"
-        binary_attribute = b"\x02\x03\x04"
-        # extending this test case to test support for binary message attribute data
-        # https://github.com/localstack/localstack/issues/2432
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes={"store": {"DataType": "Binary", "BinaryValue": binary_attribute}},
-        )
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            MessageAttributeNames=["All"],
-            VisibilityTimeout=0,
-            WaitTimeSeconds=4,
-        )
-        snapshot.match("messages-response", response)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_filter_policy(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps(filter_policy),
-        )
-
-        response_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("subscription-attributes", response_attributes)
-
-        response_0 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
-        )
-        snapshot.match("messages-0", response_0)
-        # get number of messages
-        num_msgs_0 = len(response_0.get("Messages", []))
-
-        # publish message that satisfies the filter policy, assert that message is received
-        message = "This is a test message"
-        message_attributes = {"attr1": {"DataType": "Number", "StringValue": "99"}}
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes=message_attributes,
-        )
-
-        response_1 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-1", response_1)
-
-        num_msgs_1 = len(response_1["Messages"])
-        assert num_msgs_1 == (num_msgs_0 + 1)
-
-        # publish message that does not satisfy the filter policy, assert that message is not received
-        message = "This is another test message"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
-        )
-
-        response_2 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-2", response_2)
-        num_msgs_2 = len(response_2["Messages"])
-        assert num_msgs_2 == num_msgs_1
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_exists_filter_policy(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        filter_policy = {"store": [{"exists": True}]}
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps(filter_policy),
-        )
-
-        response_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("subscription-attributes-policy-1", response_attributes)
-
-        response_0 = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
-        snapshot.match("messages-0", response_0)
-        # get number of messages
-        num_msgs_0 = len(response_0.get("Messages", []))
-
-        # publish message that satisfies the filter policy, assert that message is received
-        message_1 = "message-1"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message_1,
-            MessageAttributes={
-                "store": {"DataType": "Number", "StringValue": "99"},
-                "def": {"DataType": "Number", "StringValue": "99"},
-            },
-        )
-        response_1 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-1", response_1)
-        num_msgs_1 = len(response_1["Messages"])
-        assert num_msgs_1 == (num_msgs_0 + 1)
-
-        # publish message that does not satisfy the filter policy, assert that message is not received
-        message_2 = "message-2"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message_2,
-            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
-        )
-
-        response_2 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-2", response_2)
-        num_msgs_2 = len(response_2["Messages"])
-        assert num_msgs_2 == num_msgs_1
-
-        # delete first message
-        aws_client.sqs.delete_message(
-            QueueUrl=queue_url, ReceiptHandle=response_1["Messages"][0]["ReceiptHandle"]
-        )
-
-        # test with exist operator set to false.
-        filter_policy = json.dumps({"store": [{"exists": False}]})
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=filter_policy,
-        )
-
-        def get_filter_policy():
-            subscription_attrs = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=subscription_arn
-            )
-            return subscription_attrs["Attributes"]["FilterPolicy"]
-
-        # wait for the new filter policy to be in effect
-        poll_condition(lambda: get_filter_policy() == filter_policy, timeout=4)
-        response_attributes_2 = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("subscription-attributes-policy-2", response_attributes_2)
-
-        # publish message that satisfies the filter policy, assert that message is received
-        message_3 = "message-3"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message_3,
-            MessageAttributes={"def": {"DataType": "Number", "StringValue": "99"}},
-        )
-
-        response_3 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-3", response_3)
-        num_msgs_3 = len(response_3["Messages"])
-        assert num_msgs_3 == num_msgs_1
-
-        # publish message that does not satisfy the filter policy, assert that message is not received
-        message_4 = "message-4"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message_4,
-            MessageAttributes={
-                "store": {"DataType": "Number", "StringValue": "99"},
-                "def": {"DataType": "Number", "StringValue": "99"},
-            },
-        )
-
-        response_4 = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
-        )
-        snapshot.match("messages-4", response_4)
-        num_msgs_4 = len(response_4["Messages"])
-        assert num_msgs_4 == num_msgs_3
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_subscribe_sqs_queue(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        # TODO: check with non default external port
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-
-        # create subscription with filter policy
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps(filter_policy),
-        )
-
-        response_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
-        )
-        snapshot.match("subscription-attributes", response_attributes)
-
-        # publish message that satisfies the filter policy
-        message = "This is a test message"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "99.12"}},
-        )
-
-        # assert that message is received
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            VisibilityTimeout=0,
-            MessageAttributeNames=["All"],
-            WaitTimeSeconds=4,
-        )
-        snapshot.match("messages", response)
-
-    @markers.aws.only_localstack
-    def test_subscribe_platform_endpoint(
-        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
-    ):
-
-        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
-        topic_arn = sns_create_topic()["TopicArn"]
-
-        app_arn = sns_create_platform_application(Name="app1", Platform="p1", Attributes={})[
-            "PlatformApplicationArn"
-        ]
-        platform_arn = aws_client.sns.create_platform_endpoint(
-            PlatformApplicationArn=app_arn, Token="token_1"
-        )["EndpointArn"]
-
-        # create subscription with filter policy
-        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
-        sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="application",
-            Endpoint=platform_arn,
-            Attributes={"FilterPolicy": json.dumps(filter_policy)},
-        )
-        # publish message that satisfies the filter policy
-        message = "This is a test message"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "99.12"}},
-        )
-
-        # assert that message has been received
-        def check_message():
-            assert len(sns_backend.platform_endpoint_messages[platform_arn]) > 0
-
-        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-    @markers.aws.validated
-    def test_unknown_topic_publish(self, sns_create_topic, snapshot, aws_client):
-        # create topic to get the basic arn structure
-        # otherwise you get InvalidClientTokenId exception because of account id
-        topic_arn = sns_create_topic()["TopicArn"]
-        # append to get an unknown topic
-        fake_arn = f"{topic_arn}-fake"
-        message = "This is a test message"
-
-        # test to send a message with no subscribers
-        response = aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-        snapshot.match("success", response)
-
-        # test to send to a nonexistent topic
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(TopicArn=fake_arn, Message=message)
-
-        snapshot.match("error", e.value.response)
-
-    @markers.aws.only_localstack
-    def test_publish_sms(self, aws_client):
-        phone_number = "+33000000000"
-        response = aws_client.sns.publish(PhoneNumber=phone_number, Message="This is a SMS")
-        assert "MessageId" in response
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-        sns_backend = SnsProvider.get_store(
-            account_id=TEST_AWS_ACCOUNT_ID,
-            region_name=TEST_AWS_REGION_NAME,
-        )
-
-        def check_messages():
-            sms_was_found = False
-            for message in sns_backend.sms_messages:
-                if message["PhoneNumber"] == phone_number:
-                    sms_was_found = True
-                    break
-
-            assert sms_was_found
-
-        retry(check_messages, sleep=0.5)
-
-    @markers.aws.validated
-    def test_publish_non_existent_target(self, sns_create_topic, snapshot, aws_client):
-        topic_arn = sns_create_topic()["TopicArn"]
-        account_id = parse_arn(topic_arn)["account"]
-        with pytest.raises(ClientError) as ex:
-            aws_client.sns.publish(
-                TargetArn=f"arn:aws:sns:us-east-1:{account_id}:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66",
-                Message="This is a push notification",
-            )
-        snapshot.match("non-existent-endpoint", ex.value.response)
-
-    @markers.aws.validated
-    def test_tags(self, sns_create_topic, snapshot, aws_client):
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        with pytest.raises(ClientError) as exc:
-            aws_client.sns.tag_resource(
-                ResourceArn=topic_arn,
-                Tags=[
-                    {"Key": "k1", "Value": "v1"},
-                    {"Key": "k2", "Value": "v2"},
-                    {"Key": "k2", "Value": "v2"},
-                ],
-            )
-        snapshot.match("duplicate-key-error", exc.value.response)
-
-        aws_client.sns.tag_resource(
-            ResourceArn=topic_arn,
-            Tags=[
-                {"Key": "k1", "Value": "v1"},
-                {"Key": "k2", "Value": "v2"},
-            ],
-        )
-
-        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
-        # could not figure out the logic for tag order in AWS, so resorting to sorting it manually in place
-        tags["Tags"].sort(key=itemgetter("Key"))
-        snapshot.match("list-created-tags", tags)
-
-        aws_client.sns.untag_resource(ResourceArn=topic_arn, TagKeys=["k1"])
-        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
-        snapshot.match("list-after-delete-tags", tags)
-
-        # test update tag
-        aws_client.sns.tag_resource(ResourceArn=topic_arn, Tags=[{"Key": "k2", "Value": "v2b"}])
-        tags = aws_client.sns.list_tags_for_resource(ResourceArn=topic_arn)
-        snapshot.match("list-after-update-tags", tags)
-
-    @markers.aws.only_localstack
-    def test_topic_email_subscription_confirmation(
-        self, sns_create_topic, sns_subscription, aws_client
-    ):
-        # FIXME: we do not send the token to the email endpoint, so they cannot validate it
-        # create AWS validated test for format
-        # for now, access internals
-        topic_arn = sns_create_topic()["TopicArn"]
-        subscription = sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="email",
-            Endpoint="localstack@yopmail.com",
-        )
-        subscription_arn = subscription["SubscriptionArn"]
-        parsed_arn = parse_arn(subscription_arn)
-        store = SnsProvider.get_store(parsed_arn["account"], parsed_arn["region"])
-
-        sub_attr = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
-        assert sub_attr["Attributes"]["PendingConfirmation"] == "true"
-
-        def check_subscription():
-            for token, sub_arn in store.subscription_tokens.items():
-                if sub_arn == subscription_arn:
-                    aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=token)
-
-            sub_attributes = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=subscription_arn
-            )
-            assert sub_attributes["Attributes"]["PendingConfirmation"] == "false"
-
-        retry(check_subscription, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-    @markers.aws.validated
-    def test_sqs_topic_subscription_confirmation(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription_attrs = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        def check_subscription():
-            nonlocal subscription_attrs
-            if not subscription_attrs["PendingConfirmation"] == "false":
-                subscription_arn = subscription_attrs["SubscriptionArn"]
-                subscription_attrs = aws_client.sns.get_subscription_attributes(
-                    SubscriptionArn=subscription_arn
-                )["Attributes"]
-            else:
-                snapshot.match("subscription-attrs", subscription_attrs)
-
-            return subscription_attrs["PendingConfirmation"] == "false"
-
-        # SQS subscriptions are auto confirmed if the endpoint and the topic are in the same AWS account
-        assert poll_condition(check_subscription, timeout=5)
 
     @markers.aws.validated
     def test_sns_topic_as_lambda_dead_letter_queue(
@@ -788,54 +820,6 @@ class TestSNSProvider:
 
         snapshot.match("messages", messages)
 
-    @markers.aws.only_localstack
-    def test_redrive_policy_http_subscription(
-        self, sns_create_topic, sqs_create_queue, sqs_queue_arn, sns_subscription, aws_client
-    ):
-        dlq_name = f"dlq-{short_uid()}"
-        dlq_url = sqs_create_queue(QueueName=dlq_name)
-        dlq_arn = sqs_queue_arn(dlq_url)
-        topic_arn = sns_create_topic()["TopicArn"]
-
-        # create HTTP endpoint and connect it to SNS topic
-        with HTTPServer() as server:
-            server.expect_request("/subscription").respond_with_data(b"", 200)
-            http_endpoint = server.url_for("/subscription")
-            wait_for_port_open(server.port)
-
-            subscription = sns_subscription(
-                TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint
-            )
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription["SubscriptionArn"],
-                AttributeName="RedrivePolicy",
-                AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
-            )
-
-            # wait for subscription notification to arrive at http endpoint
-            poll_condition(lambda: len(server.log) >= 1, timeout=10)
-            request, _ = server.log[0]
-            event = request.get_json(force=True)
-            assert request.path.endswith("/subscription")
-            assert event["Type"] == "SubscriptionConfirmation"
-            assert event["TopicArn"] == topic_arn
-            aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=event["Token"])
-
-        wait_for_port_closed(server.port)
-
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=json.dumps({"message": "test_redrive_policy"}),
-        )
-
-        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
-        assert (
-            len(response["Messages"]) == 1
-        ), f"invalid number of messages in DLQ response {response}"
-        message = json.loads(response["Messages"][0]["Body"])
-        assert message["Type"] == "Notification"
-        assert json.loads(message["Message"])["message"] == "test_redrive_policy"
-
     @markers.aws.validated
     def test_redrive_policy_lambda_subscription(
         self,
@@ -890,67 +874,100 @@ class TestSNSProvider:
         )
         snapshot.match("messages", response)
 
+
+class TestSNSSubscriptionSQS:
     @markers.aws.validated
-    def test_publish_with_empty_subject(self, sns_create_topic, snapshot, aws_client):
+    def test_subscribe_sqs_queue(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        # TODO: check with non default external port
+
         topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
 
-        # Publish without subject
-        rs = aws_client.sns.publish(
-            TopicArn=topic_arn, Message=json.dumps({"message": "test_publish"})
+        # create subscription with filter policy
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
         )
-        snapshot.match("response-without-subject", rs)
-        assert rs["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Subject="",
-                Message=json.dumps({"message": "test_publish"}),
-            )
+        response_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+        )
+        snapshot.match("subscription-attributes", response_attributes)
 
-        snapshot.match("response-with-empty-subject", e.value.response)
+        # publish message that satisfies the filter policy
+        message = "This is a test message"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "99.12"}},
+        )
 
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.get-topic-attrs.Attributes.DeliveryPolicy",
-            "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
-        ]
-    )
-    def test_create_topic_test_arn(self, sns_create_topic, snapshot, aws_client):
-        topic_name = "topic-test-create"
-        response = sns_create_topic(Name=topic_name)
-        snapshot.match("create-topic", response)
-        topic_arn = response["TopicArn"]
-        topic_arn_params = topic_arn.split(":")
-        testutil.response_arn_matches_partition(aws_client.sns, topic_arn)
-        # we match the response but need to be sure the resource name is the same
-        assert topic_arn_params[5] == topic_name
-
-        if not is_aws_cloud():
-            assert topic_arn_params[4] == get_aws_account_id()
-
-        topic_attrs = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
-        snapshot.match("get-topic-attrs", topic_attrs)
-
-        response = aws_client.sns.delete_topic(TopicArn=topic_arn)
-        snapshot.match("delete-topic", response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
-        snapshot.match("topic-not-exists", e.value.response)
+        # assert that message is received
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            VisibilityTimeout=0,
+            MessageAttributeNames=["All"],
+            WaitTimeSeconds=4,
+        )
+        snapshot.match("messages", response)
 
     @markers.aws.validated
-    def test_publish_message_by_target_arn(
+    def test_publish_unicode_chars(
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
     ):
-        # using an SQS subscription to test TopicArn/TargetArn as it is easier to check against AWS
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
         sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
-        aws_client.sns.publish(TopicArn=topic_arn, Message="test-msg-1")
+        # publish message to SNS, receive it from SQS, assert that messages are equal
+        message = 'ö§a1"_!?,. £$-'
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+
+        snapshot.match("received-message", response)
+
+    @markers.aws.validated
+    def test_attribute_raw_subscribe(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
+        snapshot.add_transformer(
+            snapshot.transform.key_value(
+                "MD5OfMessageAttributes",
+                value_replacement="<md5-hash>",
+                reference_replacement=False,
+            )
+        )
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_url, Attributes={"RawMessageDelivery": "true"}
+        )
+        subscription_arn = subscription["SubscriptionArn"]
+
+        response_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("subscription-attributes", response_attributes)
+
+        # publish message to SNS, receive it from SQS, assert that messages are equal and that they are Raw
+        message = "This is a test message"
+        binary_attribute = b"\x02\x03\x04"
+        # extending this test case to test support for binary message attribute data
+        # https://github.com/localstack/localstack/issues/2432
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageAttributes={"store": {"DataType": "Binary", "BinaryValue": binary_attribute}},
+        )
 
         response = aws_client.sqs.receive_message(
             QueueUrl=queue_url,
@@ -958,320 +975,30 @@ class TestSNSProvider:
             VisibilityTimeout=0,
             WaitTimeSeconds=4,
         )
-
-        snapshot.match("receive-topic-arn", response)
-
-        message = response["Messages"][0]
-        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"])
-
-        # publish with TargetArn instead of TopicArn
-        aws_client.sns.publish(TargetArn=topic_arn, Message="test-msg-2")
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            MessageAttributeNames=["All"],
-            VisibilityTimeout=0,
-            WaitTimeSeconds=4,
-        )
-        snapshot.match("receive-target-arn", response)
+        snapshot.match("messages-response", response)
 
     @markers.aws.validated
-    def test_publish_message_before_subscribe_topic(
+    def test_sqs_topic_subscription_confirmation(
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
     ):
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
+        subscription_attrs = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
-        rs = aws_client.sns.publish(
-            TopicArn=topic_arn, Subject="test-subject-before-sub", Message="test_message_before"
-        )
-        snapshot.match("publish-before-subscribing", rs)
+        def check_subscription():
+            nonlocal subscription_attrs
+            if not subscription_attrs["PendingConfirmation"] == "false":
+                subscription_arn = subscription_attrs["SubscriptionArn"]
+                subscription_attrs = aws_client.sns.get_subscription_attributes(
+                    SubscriptionArn=subscription_arn
+                )["Attributes"]
+            else:
+                snapshot.match("subscription-attrs", subscription_attrs)
 
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+            return subscription_attrs["PendingConfirmation"] == "false"
 
-        message_subject = "test-subject-after-sub"
-        message_body = "test_message_after"
-
-        rs = aws_client.sns.publish(
-            TopicArn=topic_arn, Subject=message_subject, Message=message_body
-        )
-        snapshot.match("publish-after-subscribing", rs)
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5
-        )
-        # nothing was subscribing to the topic, so the first message is lost
-        snapshot.match("receive-messages", response)
-
-    @markers.aws.validated
-    def test_create_duplicate_topic_with_more_tags(self, sns_create_topic, snapshot, aws_client):
-        topic_name = "test-duplicated-topic-more-tags"
-        sns_create_topic(Name=topic_name)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.create_topic(Name=topic_name, Tags=[{"Key": "key1", "Value": "value1"}])
-
-        snapshot.match("exception-duplicate", e.value.response)
-
-    @markers.aws.validated
-    def test_create_duplicate_topic_check_idempotency(self, sns_create_topic, snapshot):
-        topic_name = f"test-{short_uid()}"
-        tags = [{"Key": "a", "Value": "1"}, {"Key": "b", "Value": "2"}]
-        kwargs = [
-            {"Tags": tags},  # to create the same topic again with same tags
-            {"Tags": [tags[0]]},  # to create the same topic again with one of the tags from above
-            {"Tags": []},  # to create the same topic again with no tags
-        ]
-
-        # create topic with two tags
-        response = sns_create_topic(Name=topic_name, Tags=tags)
-        snapshot.match("response-created", response)
-
-        for index, arg in enumerate(kwargs):
-            response = sns_create_topic(Name=topic_name, **arg)
-            # we check in the snapshot that they all have the same <resource:1> tag (original topic)
-            snapshot.match(f"response-same-arn-{index}", response)
-
-    @markers.aws.only_localstack
-    @pytest.mark.skip(
-        reason="Idempotency not supported in Moto backend. See bug https://github.com/spulec/moto/issues/2333"
-    )
-    def test_create_platform_endpoint_check_idempotency(
-        self, sns_create_platform_application, aws_client
-    ):
-        response = sns_create_platform_application(
-            Name=f"test-{short_uid()}",
-            Platform="GCM",
-            Attributes={"PlatformCredential": "123"},
-        )
-        kwargs_list = [
-            {"Token": "test1", "CustomUserData": "test-data"},
-            {"Token": "test1", "CustomUserData": "test-data"},
-            {"Token": "test1"},
-            {"Token": "test1"},
-        ]
-        platform_arn = response["PlatformApplicationArn"]
-        responses = []
-        for kwargs in kwargs_list:
-            responses.append(
-                aws_client.sns.create_platform_endpoint(
-                    PlatformApplicationArn=platform_arn, **kwargs
-                )
-            )
-        # Assert endpointarn is returned in every call create platform call
-        for i in range(len(responses)):
-            assert "EndpointArn" in responses[i]
-
-    @markers.aws.validated
-    def test_publish_by_path_parameters(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sns_create_sqs_subscription,
-        aws_http_client_factory,
-        snapshot,
-        aws_client,
-    ):
-        message = "test message direct post request"
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        client = aws_http_client_factory("sns", region="us-east-1")
-
-        if is_aws_cloud():
-            endpoint_url = "https://sns.us-east-1.amazonaws.com"
-        else:
-            endpoint_url = config.get_edge_url()
-
-        response = client.post(
-            endpoint_url,
-            params={
-                "Action": "Publish",
-                "Version": "2010-03-31",
-                "TopicArn": topic_arn,
-                "Message": message,
-            },
-        )
-
-        json_response = xmltodict.parse(response.content)
-        json_response["PublishResponse"].pop("@xmlns")
-        json_response["PublishResponse"]["ResponseMetadata"][
-            "HTTPStatusCode"
-        ] = response.status_code
-        json_response["PublishResponse"]["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
-        snapshot.match("post-request", json_response)
-
-        assert response.status_code == 200
-        assert b"<PublishResponse" in response.content
-
-        rs = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5
-        )
-        snapshot.match("messages", rs)
-        msg_body = json.loads(rs["Messages"][0]["Body"])
-        assert msg_body["TopicArn"] == topic_arn
-        assert msg_body["Message"] == message
-
-    @markers.aws.only_localstack
-    def test_multiple_subscriptions_http_endpoint(
-        self, sns_create_topic, sns_subscription, aws_client
-    ):
-        # create a topic
-        topic_arn = sns_create_topic()["TopicArn"]
-
-        # build fake http server endpoints
-        _requests = queue.Queue()
-
-        # create HTTP endpoint and connect it to SNS topic
-        def handler(request):
-            _requests.put(request)
-            return Response(status=429)
-
-        number_of_endpoints = 4
-
-        servers = []
-        try:
-            for _ in range(number_of_endpoints):
-                server = HTTPServer()
-                server.start()
-                servers.append(server)
-                server.expect_request("/").respond_with_handler(handler)
-                http_endpoint = server.url_for("/")
-                wait_for_port_open(http_endpoint)
-
-                sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
-
-            # fetch subscription information
-            subscription_list = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-            assert subscription_list["ResponseMetadata"]["HTTPStatusCode"] == 200
-            assert (
-                len(subscription_list["Subscriptions"]) == number_of_endpoints
-            ), f"unexpected number of subscriptions {subscription_list}"
-
-            tokens = []
-            for _ in range(number_of_endpoints):
-                request = _requests.get(timeout=2)
-                request_data = request.get_json(True)
-                tokens.append(request_data["Token"])
-                assert request_data["TopicArn"] == topic_arn
-
-            with pytest.raises(queue.Empty):
-                # make sure only four requests are received
-                _requests.get(timeout=1)
-
-            # assert the first subscription is pending confirmation
-            sub_1 = subscription_list["Subscriptions"][0]
-            sub_1_attrs = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=sub_1["SubscriptionArn"]
-            )
-            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "true"
-
-            # assert the second subscription is pending confirmation
-            sub_2 = subscription_list["Subscriptions"][1]
-            sub_2_attrs = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=sub_2["SubscriptionArn"]
-            )
-            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
-
-            # confirm the first subscription
-            response = aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=tokens[0])
-            # assert the confirmed subscription is the first one
-            assert response["SubscriptionArn"] == sub_1["SubscriptionArn"]
-
-            # assert the first subscription is confirmed
-            sub_1_attrs = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=sub_1["SubscriptionArn"]
-            )
-            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "false"
-
-            # assert the second subscription is NOT confirmed
-            sub_2_attrs = aws_client.sns.get_subscription_attributes(
-                SubscriptionArn=sub_2["SubscriptionArn"]
-            )
-            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
-
-        finally:
-            subscription_list = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-            for subscription in subscription_list["Subscriptions"]:
-                aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
-            for server in servers:
-                server.stop()
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_subscribe_sms_endpoint(self, sns_create_topic, sns_subscription, snapshot, aws_client):
-        phone_number = "+123123123"
-        topic_arn = sns_create_topic()["TopicArn"]
-        response = sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint=phone_number)
-        snapshot.match("subscribe-sms-endpoint", response)
-
-        sub_attrs = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=response["SubscriptionArn"]
-        )
-        snapshot.match("subscribe-sms-attrs", sub_attrs)
-
-    @markers.aws.only_localstack
-    def test_publish_sms_endpoint(self, sns_create_topic, sns_subscription, aws_client):
-        list_of_contacts = [
-            f"+{random.randint(100000000, 9999999999)}",
-            f"+{random.randint(100000000, 9999999999)}",
-            f"+{random.randint(100000000, 9999999999)}",
-        ]
-        message = "Good news everyone!"
-        topic_arn = sns_create_topic()["TopicArn"]
-        for number in list_of_contacts:
-            sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint=number)
-
-        aws_client.sns.publish(Message=message, TopicArn=topic_arn)
-
-        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
-
-        def check_messages():
-            sms_messages = sns_backend.sms_messages
-            for contact in list_of_contacts:
-                sms_was_found = False
-                for message in sms_messages:
-                    if message["PhoneNumber"] == contact:
-                        sms_was_found = True
-                        break
-
-                assert sms_was_found
-
-        retry(check_messages, sleep=0.5)
-
-    @markers.aws.validated
-    def test_publish_wrong_phone_format(
-        self, sns_create_topic, sns_subscription, snapshot, aws_client
-    ):
-        message = "Good news everyone!"
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(Message=message, PhoneNumber="+1a234")
-
-        snapshot.match("invalid-number", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(Message=message, PhoneNumber="NAA+15551234567")
-
-        snapshot.match("wrong-format", e.value.response)
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        with pytest.raises(ClientError) as e:
-            sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint="NAA+15551234567")
-        snapshot.match("wrong-endpoint", e.value.response)
-
-    @markers.aws.validated
-    def test_publish_wrong_arn_format(self, snapshot, aws_client):
-        message = "Good news everyone!"
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(Message=message, TopicArn="randomstring")
-
-        snapshot.match("invalid-topic-arn", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(Message=message, TopicArn="randomstring:1")
-
-        snapshot.match("invalid-topic-arn-1", e.value.response)
+        # SQS subscriptions are auto confirmed if the endpoint and the topic are in the same AWS account
+        assert poll_condition(check_subscription, timeout=5)
 
     @markers.aws.validated
     def test_publish_sqs_from_sns(
@@ -1341,7 +1068,6 @@ class TestSNSProvider:
         }
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_publish_batch_messages_from_sns_to_sqs(
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
     ):
@@ -1437,18 +1163,504 @@ class TestSNSProvider:
         snapshot.match("publish-batch-no-topic", e.value.response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.topic-attrs.Attributes.DeliveryPolicy",
-            "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
-            "$.sub-attrs-raw-true.Attributes.SubscriptionPrincipal",
-            "$.republish-batch-response-fifo.Successful..MessageId",  # TODO: SNS doesnt keep track of duplicate
-            "$.republish-batch-response-fifo.Successful..SequenceNumber",  # TODO: SNS doesnt keep track of duplicate
+    def test_publish_batch_exceptions(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        fifo_topic_name = f"topic-{short_uid()}.fifo"
+        topic_arn = sns_create_topic(Name=fifo_topic_name, Attributes={"FifoTopic": "true"})[
+            "TopicArn"
         ]
-    )
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": "Test message without Group ID",
+                    }
+                ],
+            )
+        snapshot.match("no-group-id", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {"Id": f"Id_{i}", "Message": "Too many messages"} for i in range(11)
+                ],
+            )
+        snapshot.match("too-many-msg", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {"Id": "1", "Message": "Messages with the same ID"} for _ in range(2)
+                ],
+            )
+        snapshot.match("same-msg-id", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": "Test message without MessageDeduplicationId",
+                        "MessageGroupId": "msg1",
+                    }
+                ],
+            )
+        snapshot.match("no-dedup-id", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": json.dumps({"sqs": "test sqs"}),
+                        "MessageStructure": "json",
+                    }
+                ],
+            )
+        snapshot.match("no-default-key-json", e.value.response)
+
+    @markers.aws.validated
+    def test_subscribe_to_sqs_with_queue_url(
+        self, sns_create_topic, sqs_create_queue, sns_subscription, snapshot
+    ):
+        topic = sns_create_topic()
+        topic_arn = topic["TopicArn"]
+        queue_url = sqs_create_queue()
+        with pytest.raises(ClientError) as e:
+            sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_url)
+        snapshot.match("sub-queue-url", e.value.response)
+
+    @markers.aws.validated
+    def test_publish_sqs_from_sns_with_xray_propagation(
+        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        def add_xray_header(request, **_kwargs):
+            request.headers[
+                "X-Amzn-Trace-Id"
+            ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+
+        try:
+            aws_client.sns.meta.events.register("before-send.sns.Publish", add_xray_header)
+
+            topic = sns_create_topic()
+            topic_arn = topic["TopicArn"]
+            queue_url = sqs_create_queue()
+            sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+            aws_client.sns.publish(TargetArn=topic_arn, Message="X-Ray propagation test msg")
+
+            response = aws_client.sqs.receive_message(
+                QueueUrl=queue_url,
+                AttributeNames=["SentTimestamp", "AWSTraceHeader"],
+                MaxNumberOfMessages=1,
+                MessageAttributeNames=["All"],
+                VisibilityTimeout=2,
+                WaitTimeSeconds=2,
+            )
+
+            assert len(response["Messages"]) == 1
+            message = response["Messages"][0]
+            snapshot.match("xray-msg", message)
+            assert (
+                message["Attributes"]["AWSTraceHeader"]
+                == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            )
+        finally:
+            aws_client.sns.meta.events.unregister("before-send.sns.Publish", add_xray_header)
+
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    @markers.aws.validated
+    def test_redrive_policy_sqs_queue_subscription(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sqs_queue_exists,
+        sns_create_sqs_subscription,
+        sns_allow_topic_sqs_queue,
+        raw_message_delivery,
+        snapshot,
+        aws_client,
+    ):
+        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
+        snapshot.add_transformer(
+            snapshot.transform.key_value(
+                "MD5OfMessageAttributes",
+                value_replacement="<md5-hash>",
+                reference_replacement=False,
+            )
+        )
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        dlq_url = sqs_create_queue()
+        dlq_arn = sqs_queue_arn(dlq_url)
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+        )
+
+        if raw_message_delivery:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription["SubscriptionArn"],
+                AttributeName="RawMessageDelivery",
+                AttributeValue="true",
+            )
+
+        sns_allow_topic_sqs_queue(
+            sqs_queue_url=dlq_url,
+            sqs_queue_arn=dlq_arn,
+            sns_topic_arn=topic_arn,
+        )
+
+        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+
+        # AWS takes some time to delete the queue, which make the test fails as it delivers the message correctly
+        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
+
+        message = "test_dlq_after_sqs_endpoint_deleted"
+        message_attr = {
+            "attr1": {
+                "DataType": "Number",
+                "StringValue": "111",
+            },
+            "attr2": {
+                "DataType": "Binary",
+                "BinaryValue": b"\x02\x03\x04",
+            },
+        }
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, MessageAttributes=message_attr)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=dlq_url,
+            WaitTimeSeconds=10,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+        )
+        snapshot.match("messages", response)
+
+    @markers.aws.validated
+    def test_message_attributes_not_missing(
+        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
+    ):
+        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
+        snapshot.add_transformer(
+            snapshot.transform.key_value(
+                "MD5OfMessageAttributes",
+                value_replacement="<md5-hash>",
+                reference_replacement=False,
+            )
+        )
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RawMessageDelivery",
+            AttributeValue="true",
+        )
+        attributes = {
+            "an-attribute-key": {"DataType": "String", "StringValue": "an-attribute-value"},
+            "binary-attribute": {"DataType": "Binary", "BinaryValue": b"\x02\x03\x04"},
+        }
+
+        publish_response = aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message="text",
+            MessageAttributes=attributes,
+        )
+        snapshot.match("publish-msg-raw", publish_response)
+
+        msg = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+            WaitTimeSeconds=3,
+        )
+        # as SNS piggybacks on SQS MessageAttributes when RawDelivery is true
+        # BinaryValue depends on SQS implementation, and is decoded automatically
+        snapshot.match("raw-delivery-msg-attrs", msg)
+
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=msg["Messages"][0]["ReceiptHandle"]
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RawMessageDelivery",
+            AttributeValue="false",
+        )
+
+        publish_response = aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message="text",
+            MessageAttributes=attributes,
+        )
+        snapshot.match("publish-msg-json", publish_response)
+
+        msg = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+            WaitTimeSeconds=3,
+        )
+        snapshot.match("json-delivery-msg-attrs", msg)
+        # binary payload in base64 encoded by AWS, UTF-8 for JSON
+        # https://docs.aws.amazon.com/sns/latest/api/API_MessageAttributeValue.html
+
+    @markers.aws.validated
+    def test_subscription_after_failure_to_deliver(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sqs_queue_exists,
+        sns_create_sqs_subscription,
+        sns_allow_topic_sqs_queue,
+        sqs_receive_num_messages,
+        snapshot,
+        aws_client,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_name = f"test-queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        dlq_url = sqs_create_queue()
+        dlq_arn = sqs_queue_arn(dlq_url)
+
+        sns_allow_topic_sqs_queue(
+            sqs_queue_url=dlq_url,
+            sqs_queue_arn=dlq_arn,
+            sns_topic_arn=topic_arn,
+        )
+
+        sub_attrs = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
+        snapshot.match("subscriptions-attrs", sub_attrs)
+
+        message = "test_dlq_before_sqs_endpoint_deleted"
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=4
+        )
+        snapshot.match("messages-before-delete", response)
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+
+        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+
+        # setting up a second queue to be able to poll and know approximately when the message on the deleted queue
+        # have been published
+        queue_test_url = sqs_create_queue()
+        test_subscription = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_test_url
+        )
+        test_subscription_arn = test_subscription["SubscriptionArn"]
+        # try to send a message before setting a DLQ
+        message = "test_dlq_after_sqs_endpoint_deleted"
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+
+        # to avoid race condition, publish is async and the redrive policy can be in effect before the actual publish
+        # we wait until the 2nd subscription received the message
+        poll_condition(
+            lambda: sqs_receive_num_messages(
+                queue_url=queue_test_url, expected_messages=1, max_iterations=2
+            ),
+            timeout=10,
+        )
+        aws_client.sns.unsubscribe(SubscriptionArn=test_subscription_arn)
+        # we still wait a bit to be sure the message is well published
+        time.sleep(1)
+
+        # check the subscription is still there after we deleted the queue
+        subscriptions = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+        snapshot.match("subscriptions", subscriptions)
+
+        # set the RedrivePolicy with a DLQ. Subsequent failing messages to the subscription should go there
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+        )
+
+        sub_attrs = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
+        snapshot.match("subscriptions-attrs-with-redrive", sub_attrs)
+
+        # AWS takes some time to delete the queue, which make the test fails as it delivers the message correctly
+        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
+
+        # test sending and receiving multiple messages
+        for i in range(2):
+            message = f"test_dlq_after_sqs_endpoint_deleted_{i}"
+
+            aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+            response = aws_client.sqs.receive_message(
+                QueueUrl=dlq_url, WaitTimeSeconds=10, MaxNumberOfMessages=4
+            )
+            aws_client.sqs.delete_message(
+                QueueUrl=dlq_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+            )
+
+            snapshot.match(f"message-{i}-after-delete", response)
+
+    @markers.aws.validated
+    def test_empty_or_wrong_message_attributes(
+        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        wrong_message_attributes = {
+            "missing_string_attr": {"attr1": {"DataType": "String", "StringValue": ""}},
+            "missing_binary_attr": {"attr1": {"DataType": "Binary", "BinaryValue": b""}},
+            "str_attr_binary_value": {"attr1": {"DataType": "String", "BinaryValue": b"123"}},
+            "int_attr_binary_value": {"attr1": {"DataType": "Number", "BinaryValue": b"123"}},
+            "binary_attr_string_value": {"attr1": {"DataType": "Binary", "StringValue": "123"}},
+            "invalid_attr_string_value": {
+                "attr1": {"DataType": "InvalidType", "StringValue": "123"}
+            },
+            "too_long_name": {"a" * 257: {"DataType": "String", "StringValue": "123"}},
+            "invalid_name": {"a^*?": {"DataType": "String", "StringValue": "123"}},
+            "invalid_name_2": {".abc": {"DataType": "String", "StringValue": "123"}},
+            "invalid_name_3": {"abc.": {"DataType": "String", "StringValue": "123"}},
+            "invalid_name_4": {"a..bc": {"DataType": "String", "StringValue": "123"}},
+        }
+
+        for error_type, msg_attrs in wrong_message_attributes.items():
+            with pytest.raises(ClientError) as e:
+                aws_client.sns.publish(
+                    TopicArn=topic_arn,
+                    Message="test message",
+                    MessageAttributes=msg_attrs,
+                )
+
+            snapshot.match(error_type, e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish_batch(
+                TopicArn=topic_arn,
+                PublishBatchRequestEntries=[
+                    {
+                        "Id": "1",
+                        "Message": "test-batch",
+                        "MessageAttributes": wrong_message_attributes["missing_string_attr"],
+                    },
+                    {
+                        "Id": "2",
+                        "Message": "test-batch",
+                        "MessageAttributes": wrong_message_attributes["str_attr_binary_value"],
+                    },
+                    {
+                        "Id": "3",
+                        "Message": "valid-batch",
+                    },
+                ],
+            )
+        snapshot.match("batch-exception", e.value.response)
+
+    @markers.aws.validated
+    def test_message_attributes_prefixes(
+        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message="test message",
+                MessageAttributes={"attr1": {"DataType": "String.", "StringValue": "prefixed-1"}},
+            )
+        snapshot.match("publish-error", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message="test message",
+                MessageAttributes={
+                    "attr1": {"DataType": "Stringprefixed", "StringValue": "prefixed-1"}
+                },
+            )
+        snapshot.match("publish-error-2", e.value.response)
+
+        response = aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message="test message",
+            MessageAttributes={
+                "attr1": {"DataType": "String.prefixed", "StringValue": "prefixed-1"}
+            },
+        )
+        snapshot.match("publish-ok-1", response)
+
+        response = aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message="test message",
+            MessageAttributes={
+                "attr1": {"DataType": "String.  prefixed.", "StringValue": "prefixed-1"}
+            },
+        )
+        snapshot.match("publish-ok-2", response)
+
+    @markers.aws.validated
+    def test_message_structure_json_to_sqs(
+        self, aws_client, sns_create_topic, sqs_create_queue, snapshot, sns_create_sqs_subscription
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_name = f"test-queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        message = json.dumps({"default": "default field", "sqs": json.dumps({"field": "value"})})
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageStructure="json",
+        )
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
+        )
+        snapshot.match("get-msg-json-sqs", response)
+        receipt_handle = response["Messages"][0]["ReceiptHandle"]
+        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+
+        # don't json dumps the SQS field, it will be ignored, and the message received will be the `default`
+        message = json.dumps({"default": "default field", "sqs": {"field": "value"}})
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageStructure="json",
+        )
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
+        )
+        snapshot.match("get-msg-json-default", response)
+
+
+class TestSNSSubscriptionSQSFifo:
+    @markers.aws.validated
     @pytest.mark.parametrize("content_based_deduplication", [True, False])
-    def test_publish_batch_messages_from_fifo_topic_to_fifo_queue(
+    def test_message_to_fifo_sqs(
         self,
         sns_create_topic,
         sqs_create_queue,
@@ -1469,118 +1681,190 @@ class TestSNSProvider:
             Name=topic_name,
             Attributes=topic_attributes,
         )["TopicArn"]
-
-        response = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
-        snapshot.match("topic-attrs", response)
-
         queue_url = sqs_create_queue(
             QueueName=queue_name,
             Attributes=queue_attributes,
         )
 
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="RawMessageDelivery",
-            AttributeValue="true",
+        message = "Test"
+        kwargs = {"MessageGroupId": "message-group-id-1"}
+        if not content_based_deduplication:
+            kwargs["MessageDeduplicationId"] = "message-deduplication-id-1"
+
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=10,
+            AttributeNames=["All"],
         )
+        snapshot.match("messages", response)
 
-        response = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
-        snapshot.match("sub-attrs-raw-true", response)
-        message_group_id = "complexMessageGroupId"
-        publish_batch_request_entries = [
-            {
-                "Id": "1",
-                "MessageGroupId": message_group_id,
-                "Message": "Test Message with two attributes",
-                "Subject": "Subject",
-                "MessageAttributes": {
-                    "attr1": {"DataType": "Number", "StringValue": "99.12"},
-                    "attr2": {"DataType": "Number", "StringValue": "109.12"},
-                },
-            },
-            {
-                "Id": "2",
-                "MessageGroupId": message_group_id,
-                "Message": "Test Message with one attribute",
-                "Subject": "Subject",
-                "MessageAttributes": {"attr1": {"DataType": "Number", "StringValue": "19.12"}},
-            },
-            {
-                "Id": "3",
-                "MessageGroupId": message_group_id,
-                "Message": "Test Message without attribute",
-                "Subject": "Subject",
-            },
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+        # republish the message, to check deduplication
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=1,
+            AttributeNames=["All"],
+        )
+        snapshot.match("dedup-messages", response)
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("content_based_deduplication", [True, False])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.dedup-messages.Messages"
+        ],  # FIXME: introduce deduplication at Topic level, not only SQS
+    )
+    def test_fifo_topic_to_regular_sqs(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sns_create_sqs_subscription,
+        snapshot,
+        content_based_deduplication,
+        aws_client,
+    ):
+        # it seems change is coming on AWS, as FIFO topic do not require FIFO queues anymore. This might mean that
+        # the FIFO logic is being migrated to SNS and do not rely on SQS FIFO anymore? or that the FIFO is only
+        # guaranteed with FIFO queues, but you can also subscribe with regular subscribers for deduplication for ex. ?
+        # The change in error message suggest the latter:
+        # "RedrivePolicy: must use a FIFO queue as DLQ for a FIFO topic" became:
+        # -> "RedrivePolicy: must use a FIFO queue as DLQ for a FIFO Subscription to a FIFO Topic."
+
+        topic_name = f"topic-{short_uid()}.fifo"
+        queue_name = f"queue-{short_uid()}"
+        topic_attributes = {"FifoTopic": "true"}
+        if content_based_deduplication:
+            topic_attributes["ContentBasedDeduplication"] = "true"
+
+        topic_arn = sns_create_topic(
+            Name=topic_name,
+            Attributes=topic_attributes,
+        )["TopicArn"]
+        queue_url = sqs_create_queue(QueueName=queue_name)
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        message = "Test"
+        kwargs = {"MessageGroupId": "message-group-id-1"}
+        if not content_based_deduplication:
+            kwargs["MessageDeduplicationId"] = "message-deduplication-id-1"
+
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=10,
+            AttributeNames=["All"],
+        )
+        snapshot.match("messages", response)
+
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
+        # republish the message, to check deduplication
+        # TODO: not implemented in LocalStack yet, only deduplication with FIFO SQS queues
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=3,
+            AttributeNames=["All"],
+        )
+        snapshot.match("dedup-messages", response)
+
+    @markers.aws.validated
+    def test_validations_for_fifo(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_create_sqs_subscription,
+        snapshot,
+        aws_client,
+    ):
+        topic_name = f"topic-{short_uid()}"
+        fifo_topic_name = f"topic-{short_uid()}.fifo"
+        queue_name = f"queue-{short_uid()}"
+        fifo_queue_name = f"queue-{short_uid()}.fifo"
+        not_fifo_dlq_name = f"queue-dlq-{short_uid()}"
+
+        topic_arn = sns_create_topic(Name=topic_name)["TopicArn"]
+
+        fifo_topic_arn = sns_create_topic(Name=fifo_topic_name, Attributes={"FifoTopic": "true"})[
+            "TopicArn"
         ]
 
-        if not content_based_deduplication:
-            for index, message in enumerate(publish_batch_request_entries):
-                message["MessageDeduplicationId"] = f"MessageDeduplicationId-{index}"
-
-        publish_batch_response = aws_client.sns.publish_batch(
-            TopicArn=topic_arn,
-            PublishBatchRequestEntries=publish_batch_request_entries,
+        fifo_queue_url = sqs_create_queue(
+            QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"}
         )
 
-        snapshot.match("publish-batch-response-fifo", publish_batch_response)
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        not_fifo_dlq_url = sqs_create_queue(QueueName=not_fifo_dlq_name)
 
-        assert "Successful" in publish_batch_response
-        assert "Failed" in publish_batch_response
+        with pytest.raises(ClientError) as e:
+            sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=fifo_queue_url)
 
-        for successful_resp in publish_batch_response["Successful"]:
-            assert "Id" in successful_resp
-            assert "MessageId" in successful_resp
+        assert e.match("standard SNS topic")
+        snapshot.match("not-fifo-topic", e.value.response)
 
-        message_ids_received = set()
-        messages = []
+        # SNS does not reject a regular SQS queue subscribed to a FIFO topic anymore
+        subscription_not_fifo = sns_create_sqs_subscription(
+            topic_arn=fifo_topic_arn, queue_url=queue_url
+        )
+        snapshot.match("not-fifo-queue", subscription_not_fifo)
 
-        def get_messages():
-            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
-            # MaxNumberOfMessages could return less than 3 messages
-            sqs_response = aws_client.sqs.receive_message(
-                QueueUrl=queue_url,
-                MessageAttributeNames=["All"],
-                AttributeNames=["All"],
-                MaxNumberOfMessages=10,
-                WaitTimeSeconds=1,
-                VisibilityTimeout=10,
+        not_fifo_queue_arn = sqs_queue_arn(not_fifo_dlq_url)
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_not_fifo["SubscriptionArn"],
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": not_fifo_queue_arn}),
+        )
+
+        subscription = sns_create_sqs_subscription(
+            topic_arn=fifo_topic_arn, queue_url=fifo_queue_url
+        )
+        queue_arn = sqs_queue_arn(queue_url=queue_url)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription["SubscriptionArn"],
+                AttributeName="RedrivePolicy",
+                AttributeValue=json.dumps({"deadLetterTargetArn": queue_arn}),
             )
+        snapshot.match("regular-queue-for-dlq-of-fifo-topic", e.value.response)
 
-            for message in sqs_response["Messages"]:
-                if message["MessageId"] in message_ids_received:
-                    continue
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(TopicArn=fifo_topic_arn, Message="test")
 
-                message_ids_received.add(message["MessageId"])
-                messages.append(message)
-                aws_client.sqs.delete_message(
-                    QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
-                )
+        assert e.match("MessageGroupId")
+        snapshot.match("no-msg-group-id", e.value.response)
 
-            assert len(messages) == 3
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(
+                TopicArn=fifo_topic_arn, Message="test", MessageGroupId=short_uid()
+            )
+        # if ContentBasedDeduplication is not set at the topic level, it needs MessageDeduplicationId for each msg
+        assert e.match("MessageDeduplicationId")
+        assert e.match("ContentBasedDeduplication")
+        snapshot.match("no-dedup-policy", e.value.response)
 
-        retry(get_messages, retries=5, sleep=1)
-        snapshot.match("messages", {"Messages": messages})
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(
+                TopicArn=topic_arn, Message="test", MessageDeduplicationId=short_uid()
+            )
+        assert e.match("MessageDeduplicationId")
+        snapshot.match("no-msg-dedup-regular-topic", e.value.response)
 
-        publish_batch_response = aws_client.sns.publish_batch(
-            TopicArn=topic_arn,
-            PublishBatchRequestEntries=publish_batch_request_entries,
-        )
-
-        snapshot.match("republish-batch-response-fifo", publish_batch_response)
-        get_deduplicated_messages = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            MessageAttributeNames=["All"],
-            AttributeNames=["All"],
-            MaxNumberOfMessages=10,
-            WaitTimeSeconds=3,
-            VisibilityTimeout=0,
-        )
-        # there should not be any messages here, as they are duplicate
-        # see https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
-        snapshot.match("duplicate-messages", get_deduplicated_messages)
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(TopicArn=topic_arn, Message="test", MessageGroupId=short_uid())
+        assert e.match("MessageGroupId")
+        snapshot.match("no-msg-group-id-regular-topic", e.value.response)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
@@ -1746,179 +2030,17 @@ class TestSNSProvider:
         snapshot.match("messages-in-dlq", {"Messages": messages})
 
     @markers.aws.validated
-    def test_publish_batch_exceptions(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        fifo_topic_name = f"topic-{short_uid()}.fifo"
-        topic_arn = sns_create_topic(Name=fifo_topic_name, Attributes={"FifoTopic": "true"})[
-            "TopicArn"
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.topic-attrs.Attributes.DeliveryPolicy",
+            "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
+            "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
+            "$.republish-batch-response-fifo.Successful..MessageId",  # TODO: SNS doesnt keep track of duplicate
+            "$.republish-batch-response-fifo.Successful..SequenceNumber",  # TODO: SNS doesnt keep track of duplicate
         ]
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {
-                        "Id": "1",
-                        "Message": "Test message without Group ID",
-                    }
-                ],
-            )
-        snapshot.match("no-group-id", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {"Id": f"Id_{i}", "Message": "Too many messages"} for i in range(11)
-                ],
-            )
-        snapshot.match("too-many-msg", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {"Id": "1", "Message": "Messages with the same ID"} for i in range(2)
-                ],
-            )
-        snapshot.match("same-msg-id", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {
-                        "Id": "1",
-                        "Message": "Test message without MessageDeduplicationId",
-                        "MessageGroupId": "msg1",
-                    }
-                ],
-            )
-        snapshot.match("no-dedup-id", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {
-                        "Id": "1",
-                        "Message": json.dumps({"sqs": "test sqs"}),
-                        "MessageStructure": "json",
-                    }
-                ],
-            )
-        snapshot.match("no-default-key-json", e.value.response)
-
-    @markers.aws.validated
-    def test_subscribe_to_sqs_with_queue_url(
-        self, sns_create_topic, sqs_create_queue, sns_subscription, snapshot
-    ):
-        topic = sns_create_topic()
-        topic_arn = topic["TopicArn"]
-        queue_url = sqs_create_queue()
-        with pytest.raises(ClientError) as e:
-            sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_url)
-        snapshot.match("sub-queue-url", e.value.response)
-
-    @markers.aws.validated
-    def test_publish_sqs_from_sns_with_xray_propagation(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        def add_xray_header(request, **kwargs):
-            request.headers[
-                "X-Amzn-Trace-Id"
-            ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
-
-        try:
-            aws_client.sns.meta.events.register("before-send.sns.Publish", add_xray_header)
-
-            topic = sns_create_topic()
-            topic_arn = topic["TopicArn"]
-            queue_url = sqs_create_queue()
-            sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-            aws_client.sns.publish(TargetArn=topic_arn, Message="X-Ray propagation test msg")
-
-            response = aws_client.sqs.receive_message(
-                QueueUrl=queue_url,
-                AttributeNames=["SentTimestamp", "AWSTraceHeader"],
-                MaxNumberOfMessages=1,
-                MessageAttributeNames=["All"],
-                VisibilityTimeout=2,
-                WaitTimeSeconds=2,
-            )
-
-            assert len(response["Messages"]) == 1
-            message = response["Messages"][0]
-            snapshot.match("xray-msg", message)
-            assert (
-                message["Attributes"]["AWSTraceHeader"]
-                == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
-            )
-        finally:
-            aws_client.sns.meta.events.unregister("before-send.sns.Publish", add_xray_header)
-
-    @markers.aws.validated
-    def test_create_topic_after_delete_with_new_tags(self, sns_create_topic, snapshot, aws_client):
-        topic_name = f"test-{short_uid()}"
-        topic = sns_create_topic(Name=topic_name, Tags=[{"Key": "Name", "Value": "pqr"}])
-        snapshot.match("topic-0", topic)
-        aws_client.sns.delete_topic(TopicArn=topic["TopicArn"])
-
-        topic1 = sns_create_topic(Name=topic_name, Tags=[{"Key": "Name", "Value": "abc"}])
-        snapshot.match("topic-1", topic1)
-
-    @markers.aws.validated
-    def test_not_found_error_on_set_subscription_attributes(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sns_subscription,
-        snapshot,
-        aws_client,
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        queue_arn = sqs_queue_arn(queue_url)
-        subscription = sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
-        snapshot.match("sub", subscription)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        response = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
-        subscription_attributes = response["Attributes"]
-        snapshot.match("sub-attrs", response)
-
-        assert subscription_attributes["SubscriptionArn"] == subscription_arn
-
-        subscriptions_by_topic = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-        snapshot.match("subscriptions-for-topic-before-unsub", subscriptions_by_topic)
-        assert len(subscriptions_by_topic["Subscriptions"]) == 1
-
-        aws_client.sns.unsubscribe(SubscriptionArn=subscription_arn)
-
-        def check_subscription_deleted():
-            try:
-                # AWS doesn't give NotFound error on GetSubscriptionAttributes for a while, might be cached
-                aws_client.sns.set_subscription_attributes(
-                    SubscriptionArn=subscription_arn,
-                    AttributeName="RawMessageDelivery",
-                    AttributeValue="true",
-                )
-                raise Exception("Subscription is not deleted")
-            except ClientError as e:
-                assert e.response["Error"]["Code"] == "NotFound"
-                assert e.response["ResponseMetadata"]["HTTPStatusCode"] == 404
-                snapshot.match("sub-not-found", e.response)
-
-        retry(check_subscription_deleted, retries=10, sleep_before=0.2, sleep=3)
-        subscriptions_by_topic = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-        snapshot.match("subscriptions-for-topic-after-unsub", subscriptions_by_topic)
-        assert len(subscriptions_by_topic["Subscriptions"]) == 0
-
-    @markers.aws.validated
+    )
     @pytest.mark.parametrize("content_based_deduplication", [True, False])
-    def test_message_to_fifo_sqs(
+    def test_publish_batch_messages_from_fifo_topic_to_fifo_queue(
         self,
         sns_create_topic,
         sqs_create_queue,
@@ -1939,1344 +2061,118 @@ class TestSNSProvider:
             Name=topic_name,
             Attributes=topic_attributes,
         )["TopicArn"]
+
+        response = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
+        snapshot.match("topic-attrs", response)
+
         queue_url = sqs_create_queue(
             QueueName=queue_name,
             Attributes=queue_attributes,
         )
 
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        message = "Test"
-        kwargs = {"MessageGroupId": "message-group-id-1"}
-        if not content_based_deduplication:
-            kwargs["MessageDeduplicationId"] = "message-deduplication-id-1"
-
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            WaitTimeSeconds=10,
-            AttributeNames=["All"],
-        )
-        snapshot.match("messages", response)
-
-        aws_client.sqs.delete_message(
-            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
-        )
-        # republish the message, to check deduplication
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            WaitTimeSeconds=1,
-            AttributeNames=["All"],
-        )
-        snapshot.match("dedup-messages", response)
-
-    @markers.aws.validated
-    def test_validations_for_fifo(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sns_create_sqs_subscription,
-        snapshot,
-        aws_client,
-    ):
-        topic_name = f"topic-{short_uid()}"
-        fifo_topic_name = f"topic-{short_uid()}.fifo"
-        queue_name = f"queue-{short_uid()}"
-        fifo_queue_name = f"queue-{short_uid()}.fifo"
-
-        topic_arn = sns_create_topic(Name=topic_name)["TopicArn"]
-
-        fifo_topic_arn = sns_create_topic(Name=fifo_topic_name, Attributes={"FifoTopic": "true"})[
-            "TopicArn"
-        ]
-
-        fifo_queue_url = sqs_create_queue(
-            QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"}
-        )
-
-        queue_url = sqs_create_queue(QueueName=queue_name)
-
-        with pytest.raises(ClientError) as e:
-            sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=fifo_queue_url)
-
-        assert e.match("standard SNS topic")
-        snapshot.match("not-fifo-topic", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            sns_create_sqs_subscription(topic_arn=fifo_topic_arn, queue_url=queue_url)
-        snapshot.match("not-fifo-queue", e.value.response)
-
-        subscription = sns_create_sqs_subscription(
-            topic_arn=fifo_topic_arn, queue_url=fifo_queue_url
-        )
-        queue_arn = sqs_queue_arn(queue_url=queue_url)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription["SubscriptionArn"],
-                AttributeName="RedrivePolicy",
-                AttributeValue=json.dumps({"deadLetterTargetArn": queue_arn}),
-            )
-        snapshot.match("regular-queue-for-dlq-of-fifo-topic", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(TopicArn=fifo_topic_arn, Message="test")
-
-        assert e.match("MessageGroupId")
-        snapshot.match("no-msg-group-id", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(
-                TopicArn=fifo_topic_arn, Message="test", MessageGroupId=short_uid()
-            )
-        # if ContentBasedDeduplication is not set at the topic level, it needs MessageDeduplicationId for each msg
-        assert e.match("MessageDeduplicationId")
-        assert e.match("ContentBasedDeduplication")
-        snapshot.match("no-dedup-policy", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(
-                TopicArn=topic_arn, Message="test", MessageDeduplicationId=short_uid()
-            )
-        assert e.match("MessageDeduplicationId")
-        snapshot.match("no-msg-dedup-regular-topic", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(TopicArn=topic_arn, Message="test", MessageGroupId=short_uid())
-        assert e.match("MessageGroupId")
-        snapshot.match("no-msg-group-id-regular-topic", e.value.response)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.invalid-json-redrive-policy.Error.Message",  # message contains java trace in AWS, assert instead
-            "$.invalid-json-filter-policy.Error.Message",  # message contains java trace in AWS, assert instead
-        ]
-    )
-    def test_validate_set_sub_attributes(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sns_create_sqs_subscription,
-        snapshot,
-        aws_client,
-    ):
-        topic_name = f"topic-{short_uid()}"
-        queue_name = f"queue-{short_uid()}"
-        topic_arn = sns_create_topic(Name=topic_name)["TopicArn"]
-        queue_url = sqs_create_queue(QueueName=queue_name)
         subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        sub_arn = subscription["SubscriptionArn"]
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=sub_arn,
-                AttributeName="FakeAttribute",
-                AttributeValue="test-value",
-            )
-        snapshot.match("fake-attribute", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=sub_arn,
-                AttributeName="RedrivePolicy",
-                AttributeValue=json.dumps({"deadLetterTargetArn": "fake-arn"}),
-            )
-        snapshot.match("fake-arn-redrive-policy", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=sub_arn,
-                AttributeName="RedrivePolicy",
-                AttributeValue="{invalidjson}",
-            )
-        snapshot.match("invalid-json-redrive-policy", e.value.response)
-        assert (
-            e.value.response["Error"]["Message"]
-            == "Invalid parameter: RedrivePolicy: failed to parse JSON."
-        )
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=sub_arn,
-                AttributeName="FilterPolicy",
-                AttributeValue="{invalidjson}",
-            )
-        snapshot.match("invalid-json-filter-policy", e.value.response)
-        assert (
-            e.value.response["Error"]["Message"]
-            == "Invalid parameter: FilterPolicy: failed to parse JSON."
-        )
-
-    @markers.aws.validated
-    def test_empty_sns_message(
-        self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(Message="", TopicArn=topic_arn)
-
-        snapshot.match("empty-msg-error", e.value.response)
-
-        queue_attrs = aws_client.sqs.get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
-        )
-        snapshot.match("queue-attrs", queue_attrs)
-
-    @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    @markers.aws.validated
-    def test_redrive_policy_sqs_queue_subscription(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sqs_queue_exists,
-        sns_create_sqs_subscription,
-        sns_allow_topic_sqs_queue,
-        raw_message_delivery,
-        snapshot,
-        aws_client,
-    ):
-        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
-        snapshot.add_transformer(
-            snapshot.transform.key_value(
-                "MD5OfMessageAttributes",
-                value_replacement="<md5-hash>",
-                reference_replacement=False,
-            )
-        )
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        dlq_url = sqs_create_queue()
-        dlq_arn = sqs_queue_arn(dlq_url)
+        subscription_arn = subscription["SubscriptionArn"]
 
         aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
-            AttributeName="RedrivePolicy",
-            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
-        )
-
-        if raw_message_delivery:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription["SubscriptionArn"],
-                AttributeName="RawMessageDelivery",
-                AttributeValue="true",
-            )
-
-        sns_allow_topic_sqs_queue(
-            sqs_queue_url=dlq_url,
-            sqs_queue_arn=dlq_arn,
-            sns_topic_arn=topic_arn,
-        )
-
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
-
-        # AWS takes some time to delete the queue, which make the test fails as it delivers the message correctly
-        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
-
-        message = "test_dlq_after_sqs_endpoint_deleted"
-        message_attr = {
-            "attr1": {
-                "DataType": "Number",
-                "StringValue": "111",
-            },
-            "attr2": {
-                "DataType": "Binary",
-                "BinaryValue": b"\x02\x03\x04",
-            },
-        }
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message, MessageAttributes=message_attr)
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=dlq_url,
-            WaitTimeSeconds=10,
-            AttributeNames=["All"],
-            MessageAttributeNames=["All"],
-        )
-        snapshot.match("messages", response)
-
-    @markers.aws.validated
-    def test_message_attributes_not_missing(
-        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
-    ):
-        # the hash isn't the same because of the Binary attributes (maybe decoding order?)
-        snapshot.add_transformer(
-            snapshot.transform.key_value(
-                "MD5OfMessageAttributes",
-                value_replacement="<md5-hash>",
-                reference_replacement=False,
-            )
-        )
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
+            SubscriptionArn=subscription_arn,
             AttributeName="RawMessageDelivery",
             AttributeValue="true",
         )
-        attributes = {
-            "an-attribute-key": {"DataType": "String", "StringValue": "an-attribute-value"},
-            "binary-attribute": {"DataType": "Binary", "BinaryValue": b"\x02\x03\x04"},
-        }
 
-        publish_response = aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message="text",
-            MessageAttributes=attributes,
-        )
-        snapshot.match("publish-msg-raw", publish_response)
-
-        msg = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            AttributeNames=["All"],
-            MessageAttributeNames=["All"],
-            WaitTimeSeconds=3,
-        )
-        # as SNS piggybacks on SQS MessageAttributes when RawDelivery is true
-        # BinaryValue depends on SQS implementation, and is decoded automatically
-        snapshot.match("raw-delivery-msg-attrs", msg)
-
-        aws_client.sqs.delete_message(
-            QueueUrl=queue_url, ReceiptHandle=msg["Messages"][0]["ReceiptHandle"]
-        )
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
-            AttributeName="RawMessageDelivery",
-            AttributeValue="false",
-        )
-
-        publish_response = aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message="text",
-            MessageAttributes=attributes,
-        )
-        snapshot.match("publish-msg-json", publish_response)
-
-        msg = aws_client.sqs.receive_message(
-            QueueUrl=queue_url,
-            AttributeNames=["All"],
-            MessageAttributeNames=["All"],
-            WaitTimeSeconds=3,
-        )
-        snapshot.match("json-delivery-msg-attrs", msg)
-        # binary payload in base64 encoded by AWS, UTF-8 for JSON
-        # https://docs.aws.amazon.com/sns/latest/api/API_MessageAttributeValue.html
-
-    @markers.aws.only_localstack  # TODO: clarify
-    @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    def test_subscribe_external_http_endpoint(
-        self, sns_create_http_endpoint, raw_message_delivery, aws_client, snapshot
-    ):
-        def _get_snapshot_requests_response(response: requests.Response) -> dict:
-            parsed_xml_body = xmltodict.parse(response.content)
-            for root_tag, fields in parsed_xml_body.items():
-                fields.pop("@xmlns", None)
-                if "ResponseMetadata" in fields:
-                    fields["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
-                    fields["ResponseMetadata"]["HTTPStatusCode"] = response.status_code
-            return parsed_xml_body
-
-        snapshot.add_transformer(
-            [
-                snapshot.transform.key_value("RequestId"),
-                snapshot.transform.key_value("Token"),
-                snapshot.transform.regex(
-                    r"(?i)(?<=SubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=ConfirmSubscription)",
-                    replacement="<subscribe-domain>",
-                ),
-            ]
-        )
-
-        # Necessitate manual set up to allow external access to endpoint, only in local testing
-        topic_arn, subscription_arn, endpoint_url, server = sns_create_http_endpoint(
-            raw_message_delivery
-        )
-        assert poll_condition(
-            lambda: len(server.log) >= 1,
-            timeout=5,
-        )
-        sub_request, _ = server.log[0]
-        payload = sub_request.get_json(force=True)
-        snapshot.match("subscription-confirmation", payload)
-        assert payload["Type"] == "SubscriptionConfirmation"
-        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
-        assert "Signature" in payload
-        assert "SigningCertURL" in payload
-
-        token = payload["Token"]
-        subscribe_url = payload["SubscribeURL"]
-        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
-        assert subscribe_url == (
-            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
-        )
-
-        test_broken_confirm_url = (
-            f"{service_url}/?Action=ConfirmSubscription&TopicArn=not-an-arn&Token={token}"
-        )
-        broken_confirm_subscribe_request = requests.get(test_broken_confirm_url)
-        snapshot.match(
-            "broken-topic-arn-confirm",
-            _get_snapshot_requests_response(broken_confirm_subscribe_request),
-        )
-
-        test_broken_token_confirm_url = (
-            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token=abc123"
-        )
-        broken_token_confirm_subscribe_request = requests.get(test_broken_token_confirm_url)
-        snapshot.match(
-            "broken-token-confirm",
-            _get_snapshot_requests_response(broken_token_confirm_subscribe_request),
-        )
-
-        # using the right topic name with a different region will fail when confirming the subscription
-        parsed_arn = parse_arn(topic_arn)
-        different_region = "eu-central-1" if parsed_arn["region"] != "eu-central-1" else "us-east-1"
-        different_region_topic = topic_arn.replace(parsed_arn["region"], different_region)
-        different_region_topic_confirm_url = f"{service_url}/?Action=ConfirmSubscription&TopicArn={different_region_topic}&Token={token}"
-        region_topic_confirm_subscribe_request = requests.get(different_region_topic_confirm_url)
-        snapshot.match(
-            "different-region-arn-confirm",
-            _get_snapshot_requests_response(region_topic_confirm_subscribe_request),
-        )
-
-        # but a nonexistent topic in the right region will succeed
-        last_fake_topic_char = "a" if topic_arn[-1] != "a" else "b"
-        nonexistent = topic_arn[:-1] + last_fake_topic_char
-        assert nonexistent != topic_arn
-        test_wrong_topic_confirm_url = (
-            f"{service_url}/?Action=ConfirmSubscription&TopicArn={nonexistent}&Token={token}"
-        )
-        wrong_topic_confirm_subscribe_request = requests.get(test_wrong_topic_confirm_url)
-        snapshot.match(
-            "nonexistent-token-confirm",
-            _get_snapshot_requests_response(wrong_topic_confirm_subscribe_request),
-        )
-
-        # weirdly, even with a wrong topic, SNS will confirm the topic
-        subscription_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
-
-        confirm_subscribe_request = requests.get(subscribe_url)
-        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
-        assert (
-            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
-                "SubscriptionArn"
-            ]
-            == subscription_arn
-        )
-        # also confirm that ConfirmSubscription is idempotent
-        snapshot.match(
-            "confirm-subscribe", _get_snapshot_requests_response(confirm_subscribe_request)
-        )
-
-        subscription_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
-
-        message = "test_external_http_endpoint"
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-
-        assert poll_condition(
-            lambda: len(server.log) >= 2,
-            timeout=5,
-        )
-        notification_request, _ = server.log[1]
-        assert notification_request.headers["x-amz-sns-message-type"] == "Notification"
-
-        expected_unsubscribe_url = (
-            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={subscription_arn}"
-        )
-        if raw_message_delivery:
-            payload = notification_request.data.decode()
-            assert payload == message
-        else:
-            payload = notification_request.get_json(force=True)
-            assert payload["Type"] == "Notification"
-            assert "Signature" in payload
-            assert "SigningCertURL" in payload
-            assert payload["Message"] == message
-            assert payload["UnsubscribeURL"] == expected_unsubscribe_url
-            snapshot.match("http-message", payload)
-
-        unsub_request = requests.get(expected_unsubscribe_url)
-        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
-        assert "UnsubscribeResponse" in unsubscribe_confirmation
-        snapshot.match("unsubscribe-response", _get_snapshot_requests_response(unsub_request))
-
-        assert poll_condition(
-            lambda: len(server.log) >= 3,
-            timeout=5,
-        )
-        unsub_request, _ = server.log[2]
-
-        payload = unsub_request.get_json(force=True)
-        assert payload["Type"] == "UnsubscribeConfirmation"
-        assert unsub_request.headers["x-amz-sns-message-type"] == "UnsubscribeConfirmation"
-        assert "Signature" in payload
-        assert "SigningCertURL" in payload
-        token = payload["Token"]
-        assert payload["SubscribeURL"] == (
-            f"{service_url}/?" f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
-        )
-        snapshot.match("unsubscribe-request", payload)
-
-    @markers.aws.only_localstack
-    @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    def test_dlq_external_http_endpoint(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sns_subscription,
-        sns_create_http_endpoint,
-        sns_create_sqs_subscription,
-        sns_allow_topic_sqs_queue,
-        raw_message_delivery,
-        aws_client,
-    ):
-        # Necessitate manual set up to allow external access to endpoint, only in local testing
-        topic_arn, http_subscription_arn, endpoint_url, server = sns_create_http_endpoint(
-            raw_message_delivery
-        )
-
-        dlq_url = sqs_create_queue()
-        dlq_arn = sqs_queue_arn(dlq_url)
-
-        sns_allow_topic_sqs_queue(
-            sqs_queue_url=dlq_url, sqs_queue_arn=dlq_arn, sns_topic_arn=topic_arn
-        )
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=http_subscription_arn,
-            AttributeName="RedrivePolicy",
-            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
-        )
-        assert poll_condition(
-            lambda: len(server.log) >= 1,
-            timeout=5,
-        )
-        sub_request, _ = server.log[0]
-        payload = sub_request.get_json(force=True)
-        assert payload["Type"] == "SubscriptionConfirmation"
-        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
-
-        subscribe_url = payload["SubscribeURL"]
-        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
-
-        confirm_subscribe_request = requests.get(subscribe_url)
-        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
-        assert (
-            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
-                "SubscriptionArn"
-            ]
-            == http_subscription_arn
-        )
-
-        subscription_attributes = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=http_subscription_arn
-        )
-        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
-
-        server.stop()
-        wait_for_port_closed(server.port)
-
-        message = "test_dlq_external_http_endpoint"
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-
-        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=3)
-        assert (
-            len(response["Messages"]) == 1
-        ), f"invalid number of messages in DLQ response {response}"
-
-        if raw_message_delivery:
-            assert response["Messages"][0]["Body"] == message
-        else:
-            received_message = json.loads(response["Messages"][0]["Body"])
-            assert received_message["Type"] == "Notification"
-            assert received_message["Message"] == message
-
-        receipt_handle = response["Messages"][0]["ReceiptHandle"]
-        aws_client.sqs.delete_message(QueueUrl=dlq_url, ReceiptHandle=receipt_handle)
-
-        expected_unsubscribe_url = (
-            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={http_subscription_arn}"
-        )
-
-        unsub_request = requests.get(expected_unsubscribe_url)
-        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
-        assert "UnsubscribeResponse" in unsubscribe_confirmation
-
-        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=2)
-        # AWS doesn't send to the DLQ if the UnsubscribeConfirmation fails to be delivered
-        assert "Messages" not in response
-
-    @markers.aws.validated
-    def test_publish_too_long_message(self, sns_create_topic, snapshot, aws_client):
-        topic_arn = sns_create_topic()["TopicArn"]
-        # simulate payload over 256kb
-        message = "This is a test message" * 12000
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-
-        snapshot.match("error", e.value.response)
-
-        assert e.value.response["Error"]["Code"] == "InvalidParameter"
-        assert e.value.response["Error"]["Message"] == "Invalid parameter: Message too long"
-        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
-
-    @markers.aws.only_localstack  # needs real credentials for GCM/FCM
-    @pytest.mark.xfail(reason="Need to implement credentials validation when creating platform")
-    def test_publish_to_gcm(self, sns_create_platform_application, aws_client):
-        key = "mock_server_key"
-        token = "mock_token"
-
-        response = sns_create_platform_application(
-            Name="firebase", Platform="GCM", Attributes={"PlatformCredential": key}
-        )
-
-        platform_app_arn = response["PlatformApplicationArn"]
-
-        response = aws_client.sns.create_platform_endpoint(
-            PlatformApplicationArn=platform_app_arn,
-            Token=token,
-        )
-        endpoint_arn = response["EndpointArn"]
-
-        message = {
-            "GCM": '{ "notification": {"title": "Title of notification", "body": "It works" } }'
-        }
-
-        with pytest.raises(ClientError) as ex:
-            aws_client.sns.publish(
-                TargetArn=endpoint_arn, MessageStructure="json", Message=json.dumps(message)
-            )
-        assert ex.value.response["Error"]["Code"] == "InvalidParameter"
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_subscription_after_failure_to_deliver(
-        self,
-        sns_create_topic,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sqs_queue_exists,
-        sns_create_sqs_subscription,
-        sns_allow_topic_sqs_queue,
-        sqs_receive_num_messages,
-        snapshot,
-        aws_client,
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_name = f"test-queue-{short_uid()}"
-        queue_url = sqs_create_queue(QueueName=queue_name)
-
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        dlq_url = sqs_create_queue()
-        dlq_arn = sqs_queue_arn(dlq_url)
-
-        sns_allow_topic_sqs_queue(
-            sqs_queue_url=dlq_url,
-            sqs_queue_arn=dlq_arn,
-            sns_topic_arn=topic_arn,
-        )
-
-        sub_attrs = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
-        snapshot.match("subscriptions-attrs", sub_attrs)
-
-        message = "test_dlq_before_sqs_endpoint_deleted"
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=4
-        )
-        snapshot.match("messages-before-delete", response)
-        aws_client.sqs.delete_message(
-            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
-        )
-
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
-
-        # setting up a second queue to be able to poll and know approximately when the message on the deleted queue
-        # have been published
-        queue_test_url = sqs_create_queue()
-        test_subscription = sns_create_sqs_subscription(
-            topic_arn=topic_arn, queue_url=queue_test_url
-        )
-        test_subscription_arn = test_subscription["SubscriptionArn"]
-        # try to send a message before setting a DLQ
-        message = "test_dlq_after_sqs_endpoint_deleted"
-        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-
-        # to avoid race condition, publish is async and the redrive policy can be in effect before the actual publish
-        # we wait until the 2nd subscription received the message
-        poll_condition(
-            lambda: sqs_receive_num_messages(
-                queue_url=queue_test_url, expected_messages=1, max_iterations=2
-            ),
-            timeout=10,
-        )
-        aws_client.sns.unsubscribe(SubscriptionArn=test_subscription_arn)
-        # we still wait a bit to be sure the message is well published
-        time.sleep(1)
-
-        # check the subscription is still there after we deleted the queue
-        subscriptions = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-        snapshot.match("subscriptions", subscriptions)
-
-        # set the RedrivePolicy with a DLQ. Subsequent failing messages to the subscription should go there
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="RedrivePolicy",
-            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
-        )
-
-        sub_attrs = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
-        snapshot.match("subscriptions-attrs-with-redrive", sub_attrs)
-
-        # AWS takes some time to delete the queue, which make the test fails as it delivers the message correctly
-        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
-
-        # test sending and receiving multiple messages
-        for i in range(2):
-            message = f"test_dlq_after_sqs_endpoint_deleted_{i}"
-
-            aws_client.sns.publish(TopicArn=topic_arn, Message=message)
-            response = aws_client.sqs.receive_message(
-                QueueUrl=dlq_url, WaitTimeSeconds=10, MaxNumberOfMessages=4
-            )
-            aws_client.sqs.delete_message(
-                QueueUrl=dlq_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
-            )
-
-            snapshot.match(f"message-{i}-after-delete", response)
-
-    @markers.aws.validated
-    def test_publish_to_firehose_with_s3(
-        self,
-        create_role,
-        s3_create_bucket,
-        firehose_create_delivery_stream,
-        sns_create_topic,
-        sns_subscription,
-        aws_client,
-    ):
-        role_name = f"test-role-{short_uid()}"
-        stream_name = f"test-stream-{short_uid()}"
-        bucket_name = f"test-bucket-{short_uid()}"
-        topic_name = f"test_topic_{short_uid()}"
-
-        trust_policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "s3.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
+        response = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
+        snapshot.match("sub-attrs-raw-true", response)
+        message_group_id = "complexMessageGroupId"
+        publish_batch_request_entries = [
+            {
+                "Id": "1",
+                "MessageGroupId": message_group_id,
+                "Message": "Test Message with two attributes",
+                "Subject": "Subject",
+                "MessageAttributes": {
+                    "attr1": {"DataType": "Number", "StringValue": "99.12"},
+                    "attr2": {"DataType": "Number", "StringValue": "109.12"},
                 },
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "firehose.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                },
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "sns.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                },
-            ],
-        }
-
-        role = create_role(RoleName=role_name, AssumeRolePolicyDocument=json.dumps(trust_policy))
-
-        aws_client.iam.attach_role_policy(
-            RoleName=role_name,
-            PolicyArn="arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess",
-        )
-
-        aws_client.iam.attach_role_policy(
-            RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/AmazonS3FullAccess"
-        )
-        subscription_role_arn = role["Role"]["Arn"]
-
-        if is_aws_cloud():
-            time.sleep(10)
-
-        s3_create_bucket(Bucket=bucket_name)
-
-        stream = firehose_create_delivery_stream(
-            DeliveryStreamName=stream_name,
-            DeliveryStreamType="DirectPut",
-            S3DestinationConfiguration={
-                "RoleARN": subscription_role_arn,
-                "BucketARN": f"arn:aws:s3:::{bucket_name}",
-                "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
             },
-        )
-
-        topic = sns_create_topic(Name=topic_name)
-        sns_subscription(
-            TopicArn=topic["TopicArn"],
-            Protocol="firehose",
-            Endpoint=stream["DeliveryStreamARN"],
-            Attributes={"SubscriptionRoleArn": subscription_role_arn},
-            ReturnSubscriptionArn=True,
-        )
-
-        message = json.dumps({"message": "hello world"})
-        message_attributes = {
-            "testAttribute": {"DataType": "String", "StringValue": "valueOfAttribute"}
-        }
-        aws_client.sns.publish(
-            TopicArn=topic["TopicArn"], Message=message, MessageAttributes=message_attributes
-        )
-
-        def validate_content():
-            files = aws_client.s3.list_objects(Bucket=bucket_name)["Contents"]
-            f = BytesIO()
-            aws_client.s3.download_fileobj(bucket_name, files[0]["Key"], f)
-            content = to_str(f.getvalue())
-
-            sns_message = json.loads(content.split("\n")[0])
-
-            assert "Type" in sns_message
-            assert "MessageId" in sns_message
-            assert "Message" in sns_message
-            assert "Timestamp" in sns_message
-
-            assert message == sns_message["Message"]
-
-        retries = 5
-        sleep = 1
-        sleep_before = 0
-        if is_aws_cloud():
-            retries = 30
-            sleep = 10
-            sleep_before = 10
-
-        retry(validate_content, retries=retries, sleep_before=sleep_before, sleep=sleep)
-
-    @markers.aws.validated
-    def test_empty_or_wrong_message_attributes(
-        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        wrong_message_attributes = {
-            "missing_string_attr": {"attr1": {"DataType": "String", "StringValue": ""}},
-            "missing_binary_attr": {"attr1": {"DataType": "Binary", "BinaryValue": b""}},
-            "str_attr_binary_value": {"attr1": {"DataType": "String", "BinaryValue": b"123"}},
-            "int_attr_binary_value": {"attr1": {"DataType": "Number", "BinaryValue": b"123"}},
-            "binary_attr_string_value": {"attr1": {"DataType": "Binary", "StringValue": "123"}},
-            "invalid_attr_string_value": {
-                "attr1": {"DataType": "InvalidType", "StringValue": "123"}
+            {
+                "Id": "2",
+                "MessageGroupId": message_group_id,
+                "Message": "Test Message with one attribute",
+                "Subject": "Subject",
+                "MessageAttributes": {"attr1": {"DataType": "Number", "StringValue": "19.12"}},
             },
-            "too_long_name": {"a" * 257: {"DataType": "String", "StringValue": "123"}},
-            "invalid_name": {"a^*?": {"DataType": "String", "StringValue": "123"}},
-            "invalid_name_2": {".abc": {"DataType": "String", "StringValue": "123"}},
-            "invalid_name_3": {"abc.": {"DataType": "String", "StringValue": "123"}},
-            "invalid_name_4": {"a..bc": {"DataType": "String", "StringValue": "123"}},
-        }
+            {
+                "Id": "3",
+                "MessageGroupId": message_group_id,
+                "Message": "Test Message without attribute",
+                "Subject": "Subject",
+            },
+        ]
 
-        for error_type, msg_attrs in wrong_message_attributes.items():
-            with pytest.raises(ClientError) as e:
-                aws_client.sns.publish(
-                    TopicArn=topic_arn,
-                    Message="test message",
-                    MessageAttributes=msg_attrs,
+        if not content_based_deduplication:
+            for index, message in enumerate(publish_batch_request_entries):
+                message["MessageDeduplicationId"] = f"MessageDeduplicationId-{index}"
+
+        publish_batch_response = aws_client.sns.publish_batch(
+            TopicArn=topic_arn,
+            PublishBatchRequestEntries=publish_batch_request_entries,
+        )
+
+        snapshot.match("publish-batch-response-fifo", publish_batch_response)
+
+        assert "Successful" in publish_batch_response
+        assert "Failed" in publish_batch_response
+
+        for successful_resp in publish_batch_response["Successful"]:
+            assert "Id" in successful_resp
+            assert "MessageId" in successful_resp
+
+        message_ids_received = set()
+        messages = []
+
+        def get_messages():
+            # due to the random nature of receiving SQS messages, we need to consolidate a single object to match
+            # MaxNumberOfMessages could return less than 3 messages
+            sqs_response = aws_client.sqs.receive_message(
+                QueueUrl=queue_url,
+                MessageAttributeNames=["All"],
+                AttributeNames=["All"],
+                MaxNumberOfMessages=10,
+                WaitTimeSeconds=1,
+                VisibilityTimeout=10,
+            )
+
+            for _message in sqs_response["Messages"]:
+                if _message["MessageId"] in message_ids_received:
+                    continue
+
+                message_ids_received.add(_message["MessageId"])
+                messages.append(_message)
+                aws_client.sqs.delete_message(
+                    QueueUrl=queue_url, ReceiptHandle=_message["ReceiptHandle"]
                 )
 
-            snapshot.match(error_type, e.value.response)
+            assert len(messages) == 3
 
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish_batch(
-                TopicArn=topic_arn,
-                PublishBatchRequestEntries=[
-                    {
-                        "Id": "1",
-                        "Message": "test-batch",
-                        "MessageAttributes": wrong_message_attributes["missing_string_attr"],
-                    },
-                    {
-                        "Id": "2",
-                        "Message": "test-batch",
-                        "MessageAttributes": wrong_message_attributes["str_attr_binary_value"],
-                    },
-                    {
-                        "Id": "3",
-                        "Message": "valid-batch",
-                    },
-                ],
-            )
-        snapshot.match("batch-exception", e.value.response)
+        retry(get_messages, retries=5, sleep=1)
+        snapshot.match("messages", {"Messages": messages})
 
-    @markers.aws.only_localstack
-    def test_publish_to_platform_endpoint_is_dispatched(
-        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        endpoints_arn = {}
-        for platform_type in ["APNS", "GCM"]:
-            application_platform_name = f"app-platform-{platform_type}-{short_uid()}"
-
-            # Create an Apple platform application
-            app_arn = sns_create_platform_application(
-                Name=application_platform_name, Platform=platform_type, Attributes={}
-            )["PlatformApplicationArn"]
-
-            endpoint_arn = aws_client.sns.create_platform_endpoint(
-                PlatformApplicationArn=app_arn, Token=short_uid()
-            )["EndpointArn"]
-
-            # store the endpoint for checking results
-            endpoints_arn[platform_type] = endpoint_arn
-
-            # subscribe this endpoint to a topic
-            sns_subscription(
-                TopicArn=topic_arn,
-                Protocol="application",
-                Endpoint=endpoint_arn,
-            )
-
-        # now we have two platform endpoints subscribed to the same topic
-        message = {
-            "default": "This is the default message which must be present when publishing a message to a topic.",
-            "APNS": '{"aps":{"alert": "Check out these awesome deals!","url":"www.amazon.com"} }',
-            "GCM": '{"data":{"message":"Check out these awesome deals!","url":"www.amazon.com"}}',
-        }
-
-        # publish to the topic
-        aws_client.sns.publish(
+        publish_batch_response = aws_client.sns.publish_batch(
             TopicArn=topic_arn,
-            Message=json.dumps(message),
-            MessageStructure="json",
+            PublishBatchRequestEntries=publish_batch_request_entries,
         )
 
-        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
-        platform_endpoint_msgs = sns_backend.platform_endpoint_messages
-
-        # assert that message has been received
-        def check_message():
-            assert len(platform_endpoint_msgs[endpoint_arn]) > 0
-
-        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-        # each endpoint should only receive the message that was directed to them
-        assert platform_endpoint_msgs[endpoints_arn["GCM"]][0]["Message"] == message["GCM"]
-        assert platform_endpoint_msgs[endpoints_arn["APNS"]][0]["Message"] == message["APNS"]
-
-    @markers.aws.validated
-    def test_message_attributes_prefixes(
-        self, sns_create_sqs_subscription, sns_create_topic, sqs_create_queue, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message="test message",
-                MessageAttributes={"attr1": {"DataType": "String.", "StringValue": "prefixed-1"}},
-            )
-        snapshot.match("publish-error", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message="test message",
-                MessageAttributes={
-                    "attr1": {"DataType": "Stringprefixed", "StringValue": "prefixed-1"}
-                },
-            )
-        snapshot.match("publish-error-2", e.value.response)
-
-        response = aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message="test message",
-            MessageAttributes={
-                "attr1": {"DataType": "String.prefixed", "StringValue": "prefixed-1"}
-            },
+        snapshot.match("republish-batch-response-fifo", publish_batch_response)
+        get_deduplicated_messages = aws_client.sqs.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            AttributeNames=["All"],
+            MaxNumberOfMessages=10,
+            WaitTimeSeconds=3,
+            VisibilityTimeout=0,
         )
-        snapshot.match("publish-ok-1", response)
-
-        response = aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message="test message",
-            MessageAttributes={
-                "attr1": {"DataType": "String.  prefixed.", "StringValue": "prefixed-1"}
-            },
-        )
-        snapshot.match("publish-ok-2", response)
-
-    @markers.aws.validated
-    def test_message_structure_json_exc(self, sns_create_topic, snapshot, aws_client):
-        topic_arn = sns_create_topic()["TopicArn"]
-        # TODO: add batch
-
-        # missing `default` key for the JSON
-        with pytest.raises(ClientError) as e:
-            message = json.dumps({"sqs": "Test message"})
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=message,
-                MessageStructure="json",
-            )
-        snapshot.match("missing-default-key", e.value.response)
-
-        # invalid JSON
-        with pytest.raises(ClientError) as e:
-            message = '{"default": "This is a default message"} }'
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=message,
-                MessageStructure="json",
-            )
-        snapshot.match("invalid-json", e.value.response)
-
-        # duplicate keys: from SNS docs, should fail but does work
-        # https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
-        # `Duplicate keys are not allowed.`
-        message = '{"default": "This is a default message", "default": "Duplicate"}'
-        resp = aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageStructure="json",
-        )
-        snapshot.match("duplicate-json-keys", resp)
-
-        with pytest.raises(ClientError) as e:
-            message = json.dumps({"default": {"object": "test"}})
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=message,
-                MessageStructure="json",
-            )
-        snapshot.match("key-is-not-string", e.value.response)
-
-    @markers.aws.validated
-    def test_message_structure_json_to_sqs(
-        self, aws_client, sns_create_topic, sqs_create_queue, snapshot, sns_create_sqs_subscription
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_name = f"test-queue-{short_uid()}"
-        queue_url = sqs_create_queue(QueueName=queue_name)
-
-        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        message = json.dumps({"default": "default field", "sqs": json.dumps({"field": "value"})})
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageStructure="json",
-        )
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
-        )
-        snapshot.match("get-msg-json-sqs", response)
-        receipt_handle = response["Messages"][0]["ReceiptHandle"]
-        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
-
-        # don't json dumps the SQS field, it will be ignored, and the message received will be the `default`
-        message = json.dumps({"default": "default field", "sqs": {"field": "value"}})
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageStructure="json",
-        )
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, WaitTimeSeconds=10, MaxNumberOfMessages=1
-        )
-        snapshot.match("get-msg-json-default", response)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_set_subscription_filter_policy_scope(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        # we fetch the default subscription attributes
-        # note: the FilterPolicyScope is not present in the response
-        subscription_attrs = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("sub-attrs-default", subscription_attrs)
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicyScope",
-            AttributeValue="MessageBody",
-        )
-
-        # we fetch the subscription attributes after setting the FilterPolicyScope
-        # note: the FilterPolicyScope is still not present in the response
-        subscription_attrs = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("sub-attrs-filter-scope-body", subscription_attrs)
-
-        # we try to set random values to the FilterPolicyScope
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="FilterPolicyScope",
-                AttributeValue="RandomValue",
-            )
-
-        snapshot.match("sub-attrs-filter-scope-error", e.value.response)
-
-        # we try to set a FilterPolicy to see if it will show the FilterPolicyScope in the attributes
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps({"attr": ["match-this"]}),
-        )
-        # the FilterPolicyScope is now present in the attributes
-        subscription_attrs = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("sub-attrs-after-setting-policy", subscription_attrs)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
-    def test_sub_filter_policy_nested_property(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        # see https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/
-        nested_filter_policy = {"object": {"key": [{"prefix": "auto-"}]}}
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="FilterPolicy",
-                AttributeValue=json.dumps(nested_filter_policy),
-            )
-        snapshot.match("sub-filter-policy-nested-error", e.value.response)
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicyScope",
-            AttributeValue="MessageBody",
-        )
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps(nested_filter_policy),
-        )
-
-        # the FilterPolicyScope is now present in the attributes
-        subscription_attrs = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        snapshot.match("sub-attrs-after-setting-nested-policy", subscription_attrs)
-
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$.sub-filter-policy-rule-no-list.Error.Message",  # message contains java trace in AWS, assert instead
-        ]
-    )
-    def test_sub_filter_policy_nested_property_constraints(
-        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
-    ):
-        # https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicyScope",
-            AttributeValue="MessageBody",
-        )
-
-        nested_filter_policy = {
-            "key_a": {
-                "key_b": {"key_c": ["value_one", "value_two", "value_three", "value_four"]},
-            },
-            "key_d": {"key_e": ["value_one", "value_two", "value_three"]},
-            "key_f": ["value_one", "value_two", "value_three"],
-        }
-        # The first array has four values in a three-level nested key, and the second has three values in a two-level
-        # nested key. The total combination is calculated as follows:
-        # 3 x 4 x 2 x 3 x 1 x 3 = 216
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="FilterPolicy",
-                AttributeValue=json.dumps(nested_filter_policy),
-            )
-        snapshot.match("sub-filter-policy-nested-error-too-many-combinations", e.value.response)
-
-        flat_filter_policy = {
-            "key_a": ["value_one"],
-            "key_b": ["value_two"],
-            "key_c": ["value_three"],
-            "key_d": ["value_four"],
-            "key_e": ["value_five"],
-            "key_f": ["value_six"],
-        }
-        # A filter policy can have a maximum of five attribute names. For a nested policy, only parent keys are counted.
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="FilterPolicy",
-                AttributeValue=json.dumps(flat_filter_policy),
-            )
-        snapshot.match("sub-filter-policy-max-attr-keys", e.value.response)
-
-        flat_filter_policy = {"key_a": "value_one"}
-        # Rules should be contained in a list
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="FilterPolicy",
-                AttributeValue=json.dumps(flat_filter_policy),
-            )
-        snapshot.match("sub-filter-policy-rule-no-list", e.value.response)
-        assert (
-            e.value.response["Error"]["Message"]
-            == 'Invalid parameter: FilterPolicy: "key_a" must be an object or an array'
-        )
-
-    @markers.aws.validated
-    @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    def test_filter_policy_on_message_body(
-        self,
-        sqs_create_queue,
-        sns_create_topic,
-        sns_create_sqs_subscription,
-        snapshot,
-        raw_message_delivery,
-        aws_client,
-    ):
-
-        topic_arn = sns_create_topic()["TopicArn"]
-        queue_url = sqs_create_queue()
-        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-        subscription_arn = subscription["SubscriptionArn"]
-        # see https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/
-        nested_filter_policy = {
-            "object": {
-                "key": [{"prefix": "auto-"}, "hardcodedvalue"],
-                "nested_key": [{"exists": False}],
-            },
-            "test": [{"exists": False}],
-        }
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicyScope",
-            AttributeValue="MessageBody",
-        )
-
-        aws_client.sns.set_subscription_attributes(
-            SubscriptionArn=subscription_arn,
-            AttributeName="FilterPolicy",
-            AttributeValue=json.dumps(nested_filter_policy),
-        )
-
-        if raw_message_delivery:
-            aws_client.sns.set_subscription_attributes(
-                SubscriptionArn=subscription_arn,
-                AttributeName="RawMessageDelivery",
-                AttributeValue="true",
-            )
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
-        )
-        snapshot.match("recv-init", response)
-        # assert there are no messages in the queue
-        assert "Messages" not in response
-
-        # publish messages that satisfies the filter policy, assert that messages are received
-        messages = [
-            {"object": {"key": "auto-test"}},
-            {"object": {"key": "hardcodedvalue"}},
-        ]
-        for i, message in enumerate(messages):
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=json.dumps(message),
-            )
-
-            response = aws_client.sqs.receive_message(
-                QueueUrl=queue_url,
-                VisibilityTimeout=0,
-                WaitTimeSeconds=5 if is_aws_cloud() else 2,
-            )
-            snapshot.match(f"recv-passed-msg-{i}", response)
-            receipt_handle = response["Messages"][0]["ReceiptHandle"]
-            aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
-
-        # publish messages that do not satisfy the filter policy, assert those messages are not received
-        messages = [
-            {"object": {"key": "test-auto"}},
-            {"object": {"key": "auto-test"}, "test": "just-exists"},
-            {"object": {"key": "auto-test", "nested_key": "just-exists"}},
-            {"object": {"test": "auto-test"}},
-            {"test": "auto-test"},
-        ]
-        for message in messages:
-            aws_client.sns.publish(
-                TopicArn=topic_arn,
-                Message=json.dumps(message),
-            )
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
-        )
-        # assert there are no messages in the queue
-        assert "Messages" not in response
-
-        # publish message that does not satisfy the filter policy as it's not even JSON, or not a JSON object
-        message = "Regular string message"
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=message,
-        )
-        aws_client.sns.publish(
-            TopicArn=topic_arn,
-            Message=json.dumps(message),  # send it JSON encoded, but not an object
-        )
-
-        response = aws_client.sqs.receive_message(
-            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=2
-        )
-        # assert there are no messages in the queue
-        assert "Messages" not in response
+        # there should not be any messages here, as they are duplicate
+        # see https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
+        snapshot.match("duplicate-messages", get_deduplicated_messages)
 
     @markers.aws.validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
@@ -3442,8 +2338,487 @@ class TestSNSProvider:
         )
         assert "MessageId" in response
 
+
+class TestSNSSubscriptionSES:
+    @markers.aws.only_localstack
+    def test_topic_email_subscription_confirmation(
+        self, sns_create_topic, sns_subscription, aws_client
+    ):
+        # FIXME: we do not send the token to the email endpoint, so they cannot validate it
+        # create AWS validated test for format
+        # for now, access internals
+        topic_arn = sns_create_topic()["TopicArn"]
+        subscription = sns_subscription(
+            TopicArn=topic_arn,
+            Protocol="email",
+            Endpoint="localstack@yopmail.com",
+        )
+        subscription_arn = subscription["SubscriptionArn"]
+        parsed_arn = parse_arn(subscription_arn)
+        store = SnsProvider.get_store(parsed_arn["account"], parsed_arn["region"])
+
+        sub_attr = aws_client.sns.get_subscription_attributes(SubscriptionArn=subscription_arn)
+        assert sub_attr["Attributes"]["PendingConfirmation"] == "true"
+
+        def check_subscription():
+            for token, sub_arn in store.subscription_tokens.items():
+                if sub_arn == subscription_arn:
+                    aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=token)
+
+            sub_attributes = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=subscription_arn
+            )
+            assert sub_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        retry(check_subscription, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+
+class TestSNSFilter:
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
+    def test_filter_policy(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
+        )
+
+        response_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("subscription-attributes", response_attributes)
+
+        response_0 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
+        )
+        snapshot.match("messages-0", response_0)
+        # get number of messages
+        num_msgs_0 = len(response_0.get("Messages", []))
+
+        # publish message that satisfies the filter policy, assert that message is received
+        message = "This is a test message"
+        message_attributes = {"attr1": {"DataType": "Number", "StringValue": "99"}}
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageAttributes=message_attributes,
+        )
+
+        response_1 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-1", response_1)
+
+        num_msgs_1 = len(response_1["Messages"])
+        assert num_msgs_1 == (num_msgs_0 + 1)
+
+        # publish message that does not satisfy the filter policy, assert that message is not received
+        message = "This is another test message"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
+        )
+
+        response_2 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-2", response_2)
+        num_msgs_2 = len(response_2["Messages"])
+        assert num_msgs_2 == num_msgs_1
+
+    @markers.aws.validated
+    def test_exists_filter_policy(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        filter_policy = {"store": [{"exists": True}]}
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
+        )
+
+        response_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("subscription-attributes-policy-1", response_attributes)
+
+        response_0 = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+        snapshot.match("messages-0", response_0)
+        # get number of messages
+        num_msgs_0 = len(response_0.get("Messages", []))
+
+        # publish message that satisfies the filter policy, assert that message is received
+        message_1 = "message-1"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message_1,
+            MessageAttributes={
+                "store": {"DataType": "Number", "StringValue": "99"},
+                "def": {"DataType": "Number", "StringValue": "99"},
+            },
+        )
+        response_1 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-1", response_1)
+        num_msgs_1 = len(response_1["Messages"])
+        assert num_msgs_1 == (num_msgs_0 + 1)
+
+        # publish message that does not satisfy the filter policy, assert that message is not received
+        message_2 = "message-2"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message_2,
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
+        )
+
+        response_2 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-2", response_2)
+        num_msgs_2 = len(response_2["Messages"])
+        assert num_msgs_2 == num_msgs_1
+
+        # delete first message
+        aws_client.sqs.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response_1["Messages"][0]["ReceiptHandle"]
+        )
+
+        # test with exist operator set to false.
+        filter_policy = json.dumps({"store": [{"exists": False}]})
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=filter_policy,
+        )
+
+        def get_filter_policy():
+            subscription_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=subscription_arn
+            )
+            return subscription_attrs["Attributes"]["FilterPolicy"]
+
+        # wait for the new filter policy to be in effect
+        poll_condition(lambda: get_filter_policy() == filter_policy, timeout=4)
+        response_attributes_2 = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("subscription-attributes-policy-2", response_attributes_2)
+
+        # publish message that satisfies the filter policy, assert that message is received
+        message_3 = "message-3"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message_3,
+            MessageAttributes={"def": {"DataType": "Number", "StringValue": "99"}},
+        )
+
+        response_3 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-3", response_3)
+        num_msgs_3 = len(response_3["Messages"])
+        assert num_msgs_3 == num_msgs_1
+
+        # publish message that does not satisfy the filter policy, assert that message is not received
+        message_4 = "message-4"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message_4,
+            MessageAttributes={
+                "store": {"DataType": "Number", "StringValue": "99"},
+                "def": {"DataType": "Number", "StringValue": "99"},
+            },
+        )
+
+        response_4 = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        snapshot.match("messages-4", response_4)
+        num_msgs_4 = len(response_4["Messages"])
+        assert num_msgs_4 == num_msgs_3
+
+    @markers.aws.validated
+    def test_set_subscription_filter_policy_scope(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        # we fetch the default subscription attributes
+        # note: the FilterPolicyScope is not present in the response
+        subscription_attrs = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("sub-attrs-default", subscription_attrs)
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicyScope",
+            AttributeValue="MessageBody",
+        )
+
+        # we fetch the subscription attributes after setting the FilterPolicyScope
+        # note: the FilterPolicyScope is still not present in the response
+        subscription_attrs = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("sub-attrs-filter-scope-body", subscription_attrs)
+
+        # we try to set random values to the FilterPolicyScope
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicyScope",
+                AttributeValue="RandomValue",
+            )
+
+        snapshot.match("sub-attrs-filter-scope-error", e.value.response)
+
+        # we try to set a FilterPolicy to see if it will show the FilterPolicyScope in the attributes
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps({"attr": ["match-this"]}),
+        )
+        # the FilterPolicyScope is now present in the attributes
+        subscription_attrs = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("sub-attrs-after-setting-policy", subscription_attrs)
+
+    @markers.aws.validated
+    def test_sub_filter_policy_nested_property(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        # see https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/
+        nested_filter_policy = {"object": {"key": [{"prefix": "auto-"}]}}
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue=json.dumps(nested_filter_policy),
+            )
+        snapshot.match("sub-filter-policy-nested-error", e.value.response)
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicyScope",
+            AttributeValue="MessageBody",
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(nested_filter_policy),
+        )
+
+        # the FilterPolicyScope is now present in the attributes
+        subscription_attrs = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        snapshot.match("sub-attrs-after-setting-nested-policy", subscription_attrs)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$.sub-filter-policy-rule-no-list.Error.Message",  # message contains java trace in AWS, assert instead
+        ]
+    )
+    def test_sub_filter_policy_nested_property_constraints(
+        self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
+    ):
+        # https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicyScope",
+            AttributeValue="MessageBody",
+        )
+
+        nested_filter_policy = {
+            "key_a": {
+                "key_b": {"key_c": ["value_one", "value_two", "value_three", "value_four"]},
+            },
+            "key_d": {"key_e": ["value_one", "value_two", "value_three"]},
+            "key_f": ["value_one", "value_two", "value_three"],
+        }
+        # The first array has four values in a three-level nested key, and the second has three values in a two-level
+        # nested key. The total combination is calculated as follows:
+        # 3 x 4 x 2 x 3 x 1 x 3 = 216
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue=json.dumps(nested_filter_policy),
+            )
+        snapshot.match("sub-filter-policy-nested-error-too-many-combinations", e.value.response)
+
+        flat_filter_policy = {
+            "key_a": ["value_one"],
+            "key_b": ["value_two"],
+            "key_c": ["value_three"],
+            "key_d": ["value_four"],
+            "key_e": ["value_five"],
+            "key_f": ["value_six"],
+        }
+        # A filter policy can have a maximum of five attribute names. For a nested policy, only parent keys are counted.
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue=json.dumps(flat_filter_policy),
+            )
+        snapshot.match("sub-filter-policy-max-attr-keys", e.value.response)
+
+        flat_filter_policy = {"key_a": "value_one"}
+        # Rules should be contained in a list
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue=json.dumps(flat_filter_policy),
+            )
+        snapshot.match("sub-filter-policy-rule-no-list", e.value.response)
+        assert e.value.response["Error"]["Message"].startswith(
+            'Invalid parameter: FilterPolicy: "key_a" must be an object or an array'
+        )
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    def test_filter_policy_on_message_body(
+        self,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
+        snapshot,
+        raw_message_delivery,
+        aws_client,
+    ):
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+        # see https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/
+        nested_filter_policy = {
+            "object": {
+                "key": [{"prefix": "auto-"}, "hardcodedvalue"],
+                "nested_key": [{"exists": False}],
+            },
+            "test": [{"exists": False}],
+        }
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicyScope",
+            AttributeValue="MessageBody",
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(nested_filter_policy),
+        )
+
+        if raw_message_delivery:
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="RawMessageDelivery",
+                AttributeValue="true",
+            )
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
+        )
+        snapshot.match("recv-init", response)
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
+        # publish messages that satisfies the filter policy, assert that messages are received
+        messages = [
+            {"object": {"key": "auto-test"}},
+            {"object": {"key": "hardcodedvalue"}},
+        ]
+        for i, message in enumerate(messages):
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=json.dumps(message),
+            )
+
+            response = aws_client.sqs.receive_message(
+                QueueUrl=queue_url,
+                VisibilityTimeout=0,
+                WaitTimeSeconds=5 if is_aws_cloud() else 2,
+            )
+            snapshot.match(f"recv-passed-msg-{i}", response)
+            receipt_handle = response["Messages"][0]["ReceiptHandle"]
+            aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+
+        # publish messages that do not satisfy the filter policy, assert those messages are not received
+        messages = [
+            {"object": {"key": "test-auto"}},
+            {"object": {"key": "auto-test"}, "test": "just-exists"},
+            {"object": {"key": "auto-test", "nested_key": "just-exists"}},
+            {"object": {"test": "auto-test"}},
+            {"test": "auto-test"},
+        ]
+        for message in messages:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=json.dumps(message),
+            )
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
+        )
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
+        # publish message that does not satisfy the filter policy as it's not even JSON, or not a JSON object
+        message = "Regular string message"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+        )
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=json.dumps(message),  # send it JSON encoded, but not an object
+        )
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=2
+        )
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
+    @markers.aws.validated
     def test_filter_policy_for_batch(
         self, sqs_create_queue, sns_create_topic, sns_create_sqs_subscription, snapshot, aws_client
     ):
@@ -3547,34 +2922,735 @@ class TestSNSProvider:
         # there should be no messages in this queue
         snapshot.match("messages-with-filter-after-publish-filtered", response_after_publish_filter)
 
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$.invalid-token.Error.Message"]  # validate the token shape
-    )
-    def test_sns_confirm_subscription_wrong_token(self, sns_create_topic, snapshot, aws_client):
+
+class TestSNSPlatformEndpoint:
+    @markers.aws.only_localstack
+    def test_subscribe_platform_endpoint(
+        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
+    ):
+
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
         topic_arn = sns_create_topic()["TopicArn"]
 
-        with pytest.raises(ClientError) as e:
-            wrong_topic = topic_arn[:-1] + "i"
-            aws_client.sns.confirm_subscription(
-                TopicArn=wrong_topic,
-                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+        app_arn = sns_create_platform_application(Name="app1", Platform="p1", Attributes={})[
+            "PlatformApplicationArn"
+        ]
+        platform_arn = aws_client.sns.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token="token_1"
+        )["EndpointArn"]
+
+        # create subscription with filter policy
+        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
+        sns_subscription(
+            TopicArn=topic_arn,
+            Protocol="application",
+            Endpoint=platform_arn,
+            Attributes={"FilterPolicy": json.dumps(filter_policy)},
+        )
+        # publish message that satisfies the filter policy
+        message = "This is a test message"
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=message,
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "99.12"}},
+        )
+
+        # assert that message has been received
+        def check_message():
+            assert len(sns_backend.platform_endpoint_messages[platform_arn]) > 0
+
+        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+    @markers.aws.only_localstack
+    @pytest.mark.skip(
+        reason="Idempotency not supported in Moto backend. See bug https://github.com/spulec/moto/issues/2333"
+    )
+    def test_create_platform_endpoint_check_idempotency(
+        self, sns_create_platform_application, aws_client
+    ):
+        response = sns_create_platform_application(
+            Name=f"test-{short_uid()}",
+            Platform="GCM",
+            Attributes={"PlatformCredential": "123"},
+        )
+        kwargs_list = [
+            {"Token": "test1", "CustomUserData": "test-data"},
+            {"Token": "test1", "CustomUserData": "test-data"},
+            {"Token": "test1"},
+            {"Token": "test1"},
+        ]
+        platform_arn = response["PlatformApplicationArn"]
+        responses = []
+        for kwargs in kwargs_list:
+            responses.append(
+                aws_client.sns.create_platform_endpoint(
+                    PlatformApplicationArn=platform_arn, **kwargs
+                )
             )
+        # Assert endpointarn is returned in every call create platform call
+        for i in range(len(responses)):
+            assert "EndpointArn" in responses[i]
 
-        snapshot.match("topic-not-exists", e.value.response)
+    @markers.aws.only_localstack  # needs real credentials for GCM/FCM
+    @pytest.mark.xfail(reason="Need to implement credentials validation when creating platform")
+    def test_publish_to_gcm(self, sns_create_platform_application, aws_client):
+        key = "mock_server_key"
+        token = "mock_token"
 
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token="randomtoken")
+        response = sns_create_platform_application(
+            Name="firebase", Platform="GCM", Attributes={"PlatformCredential": key}
+        )
 
-        snapshot.match("invalid-token", e.value.response)
+        platform_app_arn = response["PlatformApplicationArn"]
 
-        with pytest.raises(ClientError) as e:
-            aws_client.sns.confirm_subscription(
+        response = aws_client.sns.create_platform_endpoint(
+            PlatformApplicationArn=platform_app_arn,
+            Token=token,
+        )
+        endpoint_arn = response["EndpointArn"]
+
+        message = {
+            "GCM": '{ "notification": {"title": "Title of notification", "body": "It works" } }'
+        }
+
+        with pytest.raises(ClientError) as ex:
+            aws_client.sns.publish(
+                TargetArn=endpoint_arn, MessageStructure="json", Message=json.dumps(message)
+            )
+        assert ex.value.response["Error"]["Code"] == "InvalidParameter"
+
+    @markers.aws.only_localstack
+    def test_publish_to_platform_endpoint_is_dispatched(
+        self, sns_create_topic, sns_subscription, sns_create_platform_application, aws_client
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        endpoints_arn = {}
+        for platform_type in ["APNS", "GCM"]:
+            application_platform_name = f"app-platform-{platform_type}-{short_uid()}"
+
+            # Create an Apple platform application
+            app_arn = sns_create_platform_application(
+                Name=application_platform_name, Platform=platform_type, Attributes={}
+            )["PlatformApplicationArn"]
+
+            endpoint_arn = aws_client.sns.create_platform_endpoint(
+                PlatformApplicationArn=app_arn, Token=short_uid()
+            )["EndpointArn"]
+
+            # store the endpoint for checking results
+            endpoints_arn[platform_type] = endpoint_arn
+
+            # subscribe this endpoint to a topic
+            sns_subscription(
                 TopicArn=topic_arn,
-                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+                Protocol="application",
+                Endpoint=endpoint_arn,
             )
 
-        snapshot.match("token-not-exists", e.value.response)
+        # now we have two platform endpoints subscribed to the same topic
+        message = {
+            "default": "This is the default message which must be present when publishing a message to a topic.",
+            "APNS": '{"aps":{"alert": "Check out these awesome deals!","url":"www.amazon.com"} }',
+            "GCM": '{"data":{"message":"Check out these awesome deals!","url":"www.amazon.com"}}',
+        }
+
+        # publish to the topic
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=json.dumps(message),
+            MessageStructure="json",
+        )
+
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
+        platform_endpoint_msgs = sns_backend.platform_endpoint_messages
+
+        # assert that message has been received
+        def check_message():
+            assert len(platform_endpoint_msgs[endpoint_arn]) > 0
+
+        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+        # each endpoint should only receive the message that was directed to them
+        assert platform_endpoint_msgs[endpoints_arn["GCM"]][0]["Message"] == message["GCM"]
+        assert platform_endpoint_msgs[endpoints_arn["APNS"]][0]["Message"] == message["APNS"]
+
+
+class TestSNSSMS:
+    @markers.aws.only_localstack
+    def test_publish_sms(self, aws_client):
+        phone_number = "+33000000000"
+        response = aws_client.sns.publish(PhoneNumber=phone_number, Message="This is a SMS")
+        assert "MessageId" in response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        sns_backend = SnsProvider.get_store(
+            account_id=TEST_AWS_ACCOUNT_ID,
+            region_name=TEST_AWS_REGION_NAME,
+        )
+
+        def check_messages():
+            sms_was_found = False
+            for message in sns_backend.sms_messages:
+                if message["PhoneNumber"] == phone_number:
+                    sms_was_found = True
+                    break
+
+            assert sms_was_found
+
+        retry(check_messages, sleep=0.5)
+
+    @markers.aws.validated
+    def test_subscribe_sms_endpoint(self, sns_create_topic, sns_subscription, snapshot, aws_client):
+        phone_number = "+123123123"
+        topic_arn = sns_create_topic()["TopicArn"]
+        response = sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint=phone_number)
+        snapshot.match("subscribe-sms-endpoint", response)
+
+        sub_attrs = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=response["SubscriptionArn"]
+        )
+        snapshot.match("subscribe-sms-attrs", sub_attrs)
+
+    @markers.aws.only_localstack
+    def test_publish_sms_endpoint(self, sns_create_topic, sns_subscription, aws_client):
+        list_of_contacts = [
+            f"+{random.randint(100000000, 9999999999)}",
+            f"+{random.randint(100000000, 9999999999)}",
+            f"+{random.randint(100000000, 9999999999)}",
+        ]
+        message = "Good news everyone!"
+        topic_arn = sns_create_topic()["TopicArn"]
+        for number in list_of_contacts:
+            sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint=number)
+
+        aws_client.sns.publish(Message=message, TopicArn=topic_arn)
+
+        sns_backend = SnsProvider.get_store(TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
+
+        def check_messages():
+            sms_messages = sns_backend.sms_messages
+            for contact in list_of_contacts:
+                sms_was_found = False
+                for _message in sms_messages:
+                    if _message["PhoneNumber"] == contact:
+                        sms_was_found = True
+                        break
+
+                assert sms_was_found
+
+        retry(check_messages, sleep=0.5)
+
+    @markers.aws.validated
+    def test_publish_wrong_phone_format(
+        self, sns_create_topic, sns_subscription, snapshot, aws_client
+    ):
+        message = "Good news everyone!"
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, PhoneNumber="+1a234")
+
+        snapshot.match("invalid-number", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, PhoneNumber="NAA+15551234567")
+
+        snapshot.match("wrong-format", e.value.response)
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        with pytest.raises(ClientError) as e:
+            sns_subscription(TopicArn=topic_arn, Protocol="sms", Endpoint="NAA+15551234567")
+        snapshot.match("wrong-endpoint", e.value.response)
+
+
+class TestSNSSubscriptionHttp:
+    @markers.aws.manual_setup_required
+    def test_redrive_policy_http_subscription(
+        self, sns_create_topic, sqs_create_queue, sqs_queue_arn, sns_subscription, aws_client
+    ):
+        dlq_name = f"dlq-{short_uid()}"
+        dlq_url = sqs_create_queue(QueueName=dlq_name)
+        dlq_arn = sqs_queue_arn(dlq_url)
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        # create HTTP endpoint and connect it to SNS topic
+        with HTTPServer() as server:
+            server.expect_request("/subscription").respond_with_data(b"", 200)
+            http_endpoint = server.url_for("/subscription")
+            wait_for_port_open(server.port)
+
+            subscription = sns_subscription(
+                TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint
+            )
+            aws_client.sns.set_subscription_attributes(
+                SubscriptionArn=subscription["SubscriptionArn"],
+                AttributeName="RedrivePolicy",
+                AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+            )
+
+            # wait for subscription notification to arrive at http endpoint
+            poll_condition(lambda: len(server.log) >= 1, timeout=10)
+            request, _ = server.log[0]
+            event = request.get_json(force=True)
+            assert request.path.endswith("/subscription")
+            assert event["Type"] == "SubscriptionConfirmation"
+            assert event["TopicArn"] == topic_arn
+            aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=event["Token"])
+
+        wait_for_port_closed(server.port)
+
+        aws_client.sns.publish(
+            TopicArn=topic_arn,
+            Message=json.dumps({"message": "test_redrive_policy"}),
+        )
+
+        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+        message = json.loads(response["Messages"][0]["Body"])
+        assert message["Type"] == "Notification"
+        assert json.loads(message["Message"])["message"] == "test_redrive_policy"
+
+    @markers.aws.manual_setup_required
+    def test_multiple_subscriptions_http_endpoint(
+        self, sns_create_topic, sns_subscription, aws_client
+    ):
+        # create a topic
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        # build fake http server endpoints
+        _requests = queue.Queue()
+
+        # create HTTP endpoint and connect it to SNS topic
+        def handler(_request):
+            _requests.put(_request)
+            return Response(status=429)
+
+        number_of_endpoints = 4
+
+        servers = []
+        try:
+            for _ in range(number_of_endpoints):
+                server = HTTPServer()
+                server.start()
+                servers.append(server)
+                server.expect_request("/").respond_with_handler(handler)
+                http_endpoint = server.url_for("/")
+                wait_for_port_open(http_endpoint)
+
+                sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
+
+            # fetch subscription information
+            subscription_list = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+            assert subscription_list["ResponseMetadata"]["HTTPStatusCode"] == 200
+            assert (
+                len(subscription_list["Subscriptions"]) == number_of_endpoints
+            ), f"unexpected number of subscriptions {subscription_list}"
+
+            tokens = []
+            for _ in range(number_of_endpoints):
+                request = _requests.get(timeout=2)
+                request_data = request.get_json(True)
+                tokens.append(request_data["Token"])
+                assert request_data["TopicArn"] == topic_arn
+
+            with pytest.raises(queue.Empty):
+                # make sure only four requests are received
+                _requests.get(timeout=1)
+
+            # assert the first subscription is pending confirmation
+            sub_1 = subscription_list["Subscriptions"][0]
+            sub_1_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=sub_1["SubscriptionArn"]
+            )
+            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "true"
+
+            # assert the second subscription is pending confirmation
+            sub_2 = subscription_list["Subscriptions"][1]
+            sub_2_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=sub_2["SubscriptionArn"]
+            )
+            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
+
+            # confirm the first subscription
+            response = aws_client.sns.confirm_subscription(TopicArn=topic_arn, Token=tokens[0])
+            # assert the confirmed subscription is the first one
+            assert response["SubscriptionArn"] == sub_1["SubscriptionArn"]
+
+            # assert the first subscription is confirmed
+            sub_1_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=sub_1["SubscriptionArn"]
+            )
+            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "false"
+
+            # assert the second subscription is NOT confirmed
+            sub_2_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=sub_2["SubscriptionArn"]
+            )
+            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
+
+        finally:
+            subscription_list = aws_client.sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+            for subscription in subscription_list["Subscriptions"]:
+                aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+            for server in servers:
+                server.stop()
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    def test_subscribe_external_http_endpoint(
+        self, sns_create_http_endpoint, raw_message_delivery, aws_client, snapshot
+    ):
+        def _get_snapshot_requests_response(response: requests.Response) -> dict:
+            parsed_xml_body = xmltodict.parse(response.content)
+            for root_tag, fields in parsed_xml_body.items():
+                fields.pop("@xmlns", None)
+                if "ResponseMetadata" in fields:
+                    fields["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
+                    fields["ResponseMetadata"]["HTTPStatusCode"] = response.status_code
+            return parsed_xml_body
+
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("RequestId"),
+                snapshot.transform.key_value("Token"),
+                snapshot.transform.regex(
+                    r"(?i)(?<=SubscribeURL[\"|']:\s[\"|'])(https?.*?)(?=/\?Action=ConfirmSubscription)",
+                    replacement="<subscribe-domain>",
+                ),
+            ]
+        )
+
+        # Necessitate manual set up to allow external access to endpoint, only in local testing
+        topic_arn, subscription_arn, endpoint_url, server = sns_create_http_endpoint(
+            raw_message_delivery
+        )
+        assert poll_condition(
+            lambda: len(server.log) >= 1,
+            timeout=5,
+        )
+        sub_request, _ = server.log[0]
+        payload = sub_request.get_json(force=True)
+        snapshot.match("subscription-confirmation", payload)
+        assert payload["Type"] == "SubscriptionConfirmation"
+        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+        assert "Signature" in payload
+        assert "SigningCertURL" in payload
+
+        token = payload["Token"]
+        subscribe_url = payload["SubscribeURL"]
+        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
+        assert subscribe_url == (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+        )
+
+        test_broken_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn=not-an-arn&Token={token}"
+        )
+        broken_confirm_subscribe_request = requests.get(test_broken_confirm_url)
+        snapshot.match(
+            "broken-topic-arn-confirm",
+            _get_snapshot_requests_response(broken_confirm_subscribe_request),
+        )
+
+        test_broken_token_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token=abc123"
+        )
+        broken_token_confirm_subscribe_request = requests.get(test_broken_token_confirm_url)
+        snapshot.match(
+            "broken-token-confirm",
+            _get_snapshot_requests_response(broken_token_confirm_subscribe_request),
+        )
+
+        # using the right topic name with a different region will fail when confirming the subscription
+        parsed_arn = parse_arn(topic_arn)
+        different_region = "eu-central-1" if parsed_arn["region"] != "eu-central-1" else "us-east-1"
+        different_region_topic = topic_arn.replace(parsed_arn["region"], different_region)
+        different_region_topic_confirm_url = f"{service_url}/?Action=ConfirmSubscription&TopicArn={different_region_topic}&Token={token}"
+        region_topic_confirm_subscribe_request = requests.get(different_region_topic_confirm_url)
+        snapshot.match(
+            "different-region-arn-confirm",
+            _get_snapshot_requests_response(region_topic_confirm_subscribe_request),
+        )
+
+        # but a nonexistent topic in the right region will succeed
+        last_fake_topic_char = "a" if topic_arn[-1] != "a" else "b"
+        nonexistent = topic_arn[:-1] + last_fake_topic_char
+        assert nonexistent != topic_arn
+        test_wrong_topic_confirm_url = (
+            f"{service_url}/?Action=ConfirmSubscription&TopicArn={nonexistent}&Token={token}"
+        )
+        wrong_topic_confirm_subscribe_request = requests.get(test_wrong_topic_confirm_url)
+        snapshot.match(
+            "nonexistent-token-confirm",
+            _get_snapshot_requests_response(wrong_topic_confirm_subscribe_request),
+        )
+
+        # weirdly, even with a wrong topic, SNS will confirm the topic
+        subscription_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        confirm_subscribe_request = requests.get(subscribe_url)
+        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
+        assert (
+            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
+                "SubscriptionArn"
+            ]
+            == subscription_arn
+        )
+        # also confirm that ConfirmSubscription is idempotent
+        snapshot.match(
+            "confirm-subscribe", _get_snapshot_requests_response(confirm_subscribe_request)
+        )
+
+        subscription_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        message = "test_external_http_endpoint"
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+
+        assert poll_condition(
+            lambda: len(server.log) >= 2,
+            timeout=5,
+        )
+        notification_request, _ = server.log[1]
+        assert notification_request.headers["x-amz-sns-message-type"] == "Notification"
+
+        expected_unsubscribe_url = (
+            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={subscription_arn}"
+        )
+        if raw_message_delivery:
+            payload = notification_request.data.decode()
+            assert payload == message
+        else:
+            payload = notification_request.get_json(force=True)
+            assert payload["Type"] == "Notification"
+            assert "Signature" in payload
+            assert "SigningCertURL" in payload
+            assert payload["Message"] == message
+            assert payload["UnsubscribeURL"] == expected_unsubscribe_url
+            snapshot.match("http-message", payload)
+
+        unsub_request = requests.get(expected_unsubscribe_url)
+        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
+        assert "UnsubscribeResponse" in unsubscribe_confirmation
+        snapshot.match("unsubscribe-response", _get_snapshot_requests_response(unsub_request))
+
+        assert poll_condition(
+            lambda: len(server.log) >= 3,
+            timeout=5,
+        )
+        unsub_request, _ = server.log[2]
+
+        payload = unsub_request.get_json(force=True)
+        assert payload["Type"] == "UnsubscribeConfirmation"
+        assert unsub_request.headers["x-amz-sns-message-type"] == "UnsubscribeConfirmation"
+        assert "Signature" in payload
+        assert "SigningCertURL" in payload
+        token = payload["Token"]
+        assert payload["SubscribeURL"] == (
+            f"{service_url}/?" f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+        )
+        snapshot.match("unsubscribe-request", payload)
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    def test_dlq_external_http_endpoint(
+        self,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_subscription,
+        sns_create_http_endpoint,
+        sns_create_sqs_subscription,
+        sns_allow_topic_sqs_queue,
+        raw_message_delivery,
+        aws_client,
+    ):
+        # Necessitate manual set up to allow external access to endpoint, only in local testing
+        topic_arn, http_subscription_arn, endpoint_url, server = sns_create_http_endpoint(
+            raw_message_delivery
+        )
+
+        dlq_url = sqs_create_queue()
+        dlq_arn = sqs_queue_arn(dlq_url)
+
+        sns_allow_topic_sqs_queue(
+            sqs_queue_url=dlq_url, sqs_queue_arn=dlq_arn, sns_topic_arn=topic_arn
+        )
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=http_subscription_arn,
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+        )
+        assert poll_condition(
+            lambda: len(server.log) >= 1,
+            timeout=5,
+        )
+        sub_request, _ = server.log[0]
+        payload = sub_request.get_json(force=True)
+        assert payload["Type"] == "SubscriptionConfirmation"
+        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+
+        subscribe_url = payload["SubscribeURL"]
+        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
+
+        confirm_subscribe_request = requests.get(subscribe_url)
+        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
+        assert (
+            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
+                "SubscriptionArn"
+            ]
+            == http_subscription_arn
+        )
+
+        subscription_attributes = aws_client.sns.get_subscription_attributes(
+            SubscriptionArn=http_subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        server.stop()
+        wait_for_port_closed(server.port)
+
+        message = "test_dlq_external_http_endpoint"
+        aws_client.sns.publish(TopicArn=topic_arn, Message=message)
+
+        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=3)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+
+        if raw_message_delivery:
+            assert response["Messages"][0]["Body"] == message
+        else:
+            received_message = json.loads(response["Messages"][0]["Body"])
+            assert received_message["Type"] == "Notification"
+            assert received_message["Message"] == message
+
+        receipt_handle = response["Messages"][0]["ReceiptHandle"]
+        aws_client.sqs.delete_message(QueueUrl=dlq_url, ReceiptHandle=receipt_handle)
+
+        expected_unsubscribe_url = (
+            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={http_subscription_arn}"
+        )
+
+        unsub_request = requests.get(expected_unsubscribe_url)
+        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
+        assert "UnsubscribeResponse" in unsubscribe_confirmation
+
+        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=2)
+        # AWS doesn't send to the DLQ if the UnsubscribeConfirmation fails to be delivered
+        assert "Messages" not in response
+
+
+class TestSNSSubscriptionFirehose:
+    @markers.aws.validated
+    def test_publish_to_firehose_with_s3(
+        self,
+        create_role,
+        s3_create_bucket,
+        firehose_create_delivery_stream,
+        sns_create_topic,
+        sns_subscription,
+        aws_client,
+    ):
+        role_name = f"test-role-{short_uid()}"
+        stream_name = f"test-stream-{short_uid()}"
+        bucket_name = f"test-bucket-{short_uid()}"
+        topic_name = f"test_topic_{short_uid()}"
+
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "s3.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                },
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "firehose.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                },
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "sns.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                },
+            ],
+        }
+
+        role = create_role(RoleName=role_name, AssumeRolePolicyDocument=json.dumps(trust_policy))
+
+        aws_client.iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess",
+        )
+
+        aws_client.iam.attach_role_policy(
+            RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/AmazonS3FullAccess"
+        )
+        subscription_role_arn = role["Role"]["Arn"]
+
+        if is_aws_cloud():
+            time.sleep(10)
+
+        s3_create_bucket(Bucket=bucket_name)
+
+        stream = firehose_create_delivery_stream(
+            DeliveryStreamName=stream_name,
+            DeliveryStreamType="DirectPut",
+            S3DestinationConfiguration={
+                "RoleARN": subscription_role_arn,
+                "BucketARN": f"arn:aws:s3:::{bucket_name}",
+                "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
+            },
+        )
+
+        topic = sns_create_topic(Name=topic_name)
+        sns_subscription(
+            TopicArn=topic["TopicArn"],
+            Protocol="firehose",
+            Endpoint=stream["DeliveryStreamARN"],
+            Attributes={"SubscriptionRoleArn": subscription_role_arn},
+            ReturnSubscriptionArn=True,
+        )
+
+        message = json.dumps({"message": "hello world"})
+        message_attributes = {
+            "testAttribute": {"DataType": "String", "StringValue": "valueOfAttribute"}
+        }
+        aws_client.sns.publish(
+            TopicArn=topic["TopicArn"], Message=message, MessageAttributes=message_attributes
+        )
+
+        def validate_content():
+            files = aws_client.s3.list_objects(Bucket=bucket_name)["Contents"]
+            f = BytesIO()
+            aws_client.s3.download_fileobj(bucket_name, files[0]["Key"], f)
+            content = to_str(f.getvalue())
+
+            sns_message = json.loads(content.split("\n")[0])
+
+            assert "Type" in sns_message
+            assert "MessageId" in sns_message
+            assert "Message" in sns_message
+            assert "Timestamp" in sns_message
+
+            assert message == sns_message["Message"]
+
+        retries = 5
+        sleep = 1
+        sleep_before = 0
+        if is_aws_cloud():
+            retries = 30
+            sleep = 10
+            sleep_before = 10
+
+        retry(validate_content, retries=retries, sleep_before=sleep_before, sleep=sleep)
 
 
 class TestSNSMultiAccounts:

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -1,6 +1,85 @@
 {
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_tags": {
-    "recorded-date": "09-08-2022, 11:30:16",
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_with_attributes": {
+    "recorded-date": "24-08-2023, 22:30:43",
+    "recorded-content": {
+      "get-topic-attrs": {
+        "Attributes": {
+          "ContentBasedDeduplication": "false",
+          "DisplayName": "TestTopic",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "FifoTopic": "true",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SignatureVersion": "2",
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs-nonexistent-topic": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Topic does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_tags": {
+    "recorded-date": "24-08-2023, 22:30:44",
     "recorded-content": {
       "duplicate-key-error": {
         "Error": {
@@ -14,10 +93,6 @@
         }
       },
       "list-created-tags": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Tags": [
           {
             "Key": "k1",
@@ -27,62 +102,30 @@
             "Key": "k2",
             "Value": "v2"
           }
-        ]
-      },
-      "list-after-delete-tags": {
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
+        }
+      },
+      "list-after-delete-tags": {
         "Tags": [
           {
             "Key": "k2",
             "Value": "v2"
           }
-        ]
-      },
-      "list-after-update-tags": {
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
+        }
+      },
+      "list-after-update-tags": {
         "Tags": [
           {
             "Key": "k2",
             "Value": "v2b"
           }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[True]": {
-    "recorded-date": "10-08-2022, 11:36:11",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": "test_dlq_after_sqs_endpoint_deleted",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "<md5-hash>",
-            "MessageAttributes": {
-              "attr1": {
-                "DataType": "Number",
-                "StringValue": "111"
-              },
-              "attr2": {
-                "BinaryValue": "b'\\x02\\x03\\x04'",
-                "DataType": "Binary"
-              }
-            },
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
         ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -91,44 +134,137 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[False]": {
-    "recorded-date": "10-08-2022, 11:36:14",
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_test_arn": {
+    "recorded-date": "24-08-2023, 22:30:45",
     "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "test_dlq_after_sqs_endpoint_deleted",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>",
-              "MessageAttributes": {
-                "attr2": {
-                  "Type": "Binary",
-                  "Value": "AgME"
+      "create-topic": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-topic-attrs": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
                 },
-                "attr1": {
-                  "Type": "Number",
-                  "Value": "111"
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
                 }
               }
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-topic": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "topic-not-exists": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Topic does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_duplicate_topic_with_more_tags": {
+    "recorded-date": "24-08-2023, 22:30:46",
+    "recorded-content": {
+      "exception-duplicate": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Tags Reason: Topic already exists with different tags",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_duplicate_topic_check_idempotency": {
+    "recorded-date": "24-08-2023, 22:30:47",
+    "recorded-content": {
+      "response-created": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "response-same-arn-0": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "response-same-arn-1": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "response-same-arn-2": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -136,17 +272,47 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_unicode_chars": {
-    "recorded-date": "09-08-2022, 11:30:03",
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_after_delete_with_new_tags": {
+    "recorded-date": "24-08-2023, 22:30:48",
     "recorded-content": {
-      "received-message": {
+      "topic-0": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "topic-1": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_by_path_parameters": {
+    "recorded-date": "24-08-2023, 22:31:40",
+    "recorded-content": {
+      "post-request": {
+        "PublishResponse": {
+          "PublishResult": {
+            "MessageId": "<uuid:1>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "messages": {
         "Messages": [
           {
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
               "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "\u00f6\u00a7a1\"_!?,. \u00a3$-",
+              "Message": "test message direct post request",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
@@ -165,73 +331,24 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSSubscription::test_python_lambda_subscribe_sns_topic": {
-    "recorded-date": "09-08-2022, 11:30:00",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_wrong_arn_format": {
+    "recorded-date": "24-08-2023, 22:31:40",
     "recorded-content": {
-      "notification": {
-        "Message": "Hello world.",
-        "MessageAttributes": {},
-        "MessageId": "<uuid:1>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertUrl": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "Subject": "[Subject] Test subject",
-        "Timestamp": "date",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "Notification",
-        "UnsubscribeUrl": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_attribute_raw_subscribe": {
-    "recorded-date": "09-08-2022, 11:30:06",
-    "recorded-content": {
-      "subscription-attributes": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+      "invalid-topic-arn": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 1",
+          "Type": "Sender"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 400
         }
       },
-      "messages-response": {
-        "Messages": [
-          {
-            "Body": "This is a test message",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "<md5-hash>",
-            "MessageAttributes": {
-              "store": {
-                "BinaryValue": "b'\\x02\\x03\\x04'",
-                "DataType": "Binary"
-              }
-            },
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_with_invalid_protocol": {
-    "recorded-date": "09-08-2022, 11:30:03",
-    "recorded-content": {
-      "exception": {
+      "invalid-topic-arn-1": {
         "Error": {
           "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Amazon SNS does not support this protocol string: test-protocol",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 2",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -241,64 +358,22 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_filter_policy": {
-    "recorded-date": "13-02-2023, 16:48:57",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_message_by_target_arn": {
+    "recorded-date": "24-08-2023, 22:31:42",
     "recorded-content": {
-      "subscription-attributes": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "FilterPolicy": {
-            "attr1": [
-              {
-                "numeric": [
-                  ">",
-                  0,
-                  "<=",
-                  100
-                ]
-              }
-            ]
-          },
-          "FilterPolicyScope": "MessageAttributes",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-0": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-1": {
+      "receive-topic-arn": {
         "Messages": [
           {
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "This is a test message",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "test-msg-1",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "attr1": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",
@@ -310,28 +385,22 @@
           "HTTPStatusCode": 200
         }
       },
-      "messages-2": {
+      "receive-target-arn": {
         "Messages": [
           {
             "Body": {
               "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "This is a test message",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "test-msg-2",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "attr1": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
+            "MessageId": "<uuid:4>",
             "ReceiptHandle": "<receipt-handle:2>"
           }
         ],
@@ -342,250 +411,40 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_exists_filter_policy": {
-    "recorded-date": "13-02-2023, 16:49:47",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_message_before_subscribe_topic": {
+    "recorded-date": "24-08-2023, 22:31:44",
     "recorded-content": {
-      "subscription-attributes-policy-1": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "FilterPolicy": {
-            "store": [
-              {
-                "exists": true
-              }
-            ]
-          },
-          "FilterPolicyScope": "MessageAttributes",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
-        },
+      "publish-before-subscribing": {
+        "MessageId": "<uuid:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "messages-0": {
+      "publish-after-subscribing": {
+        "MessageId": "<uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "messages-1": {
+      "receive-messages": {
         "Messages": [
           {
             "Body": {
               "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "message-1",
+              "MessageId": "<uuid:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Subject": "test-subject-after-sub",
+              "Message": "test_message_after",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "def": {
-                  "Type": "Number",
-                  "Value": "99"
-                },
-                "store": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-2": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "message-1",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "def": {
-                  "Type": "Number",
-                  "Value": "99"
-                },
-                "store": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "subscription-attributes-policy-2": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "FilterPolicy": {
-            "store": [
-              {
-                "exists": false
-              }
-            ]
-          },
-          "FilterPolicyScope": "MessageAttributes",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-3": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "message-3",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "def": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:3>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-4": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "message-3",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "def": {
-                  "Type": "Number",
-                  "Value": "99"
-                }
-              }
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:4>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_sqs_queue": {
-    "recorded-date": "13-02-2023, 16:50:28",
-    "recorded-content": {
-      "subscription-attributes": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "FilterPolicy": {
-            "attr1": [
-              {
-                "numeric": [
-                  ">",
-                  0,
-                  "<=",
-                  100
-                ]
-              }
-            ]
-          },
-          "FilterPolicyScope": "MessageAttributes",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
-              "Message": "This is a test message",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-              "MessageAttributes": {
-                "attr1": {
-                  "Type": "Number",
-                  "Value": "99.12"
-                }
-              }
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
+            "MessageId": "<uuid:3>",
             "ReceiptHandle": "<receipt-handle:1>"
           }
         ],
@@ -596,8 +455,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_unknown_topic_publish": {
-    "recorded-date": "04-03-2023, 21:35:42",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_unknown_topic_publish": {
+    "recorded-date": "24-08-2023, 22:31:45",
     "recorded-content": {
       "success": {
         "MessageId": "<uuid:1>",
@@ -619,23 +478,367 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_sqs_topic_subscription_confirmation": {
-    "recorded-date": "09-08-2022, 11:30:18",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_non_existent_target": {
+    "recorded-date": "24-08-2023, 22:31:46",
     "recorded-content": {
-      "subscription-attrs": {
-        "ConfirmationWasAuthenticated": "true",
-        "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-        "Owner": "111111111111",
-        "PendingConfirmation": "false",
-        "Protocol": "sqs",
-        "RawMessageDelivery": "false",
-        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+      "non-existent-endpoint": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_sns_topic_as_lambda_dead_letter_queue": {
-    "recorded-date": "09-08-2022, 11:34:43",
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_with_empty_subject": {
+    "recorded-date": "24-08-2023, 22:31:46",
+    "recorded-content": {
+      "response-without-subject": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "response-with-empty-subject": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Subject",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_empty_sns_message": {
+    "recorded-date": "24-08-2023, 22:31:48",
+    "recorded-content": {
+      "empty-msg-error": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Empty message",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "queue-attrs": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_too_long_message": {
+    "recorded-date": "24-08-2023, 22:31:49",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message too long",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_message_structure_json_exc": {
+    "recorded-date": "24-08-2023, 22:31:50",
+    "recorded-content": {
+      "missing-default-key": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message Structure - No default entry in JSON message body",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-json": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message Structure - JSON message body failed to parse",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "duplicate-json-keys": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "key-is-not-string": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Message Structure - No default entry in JSON message body",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_with_invalid_protocol": {
+    "recorded-date": "24-08-2023, 23:27:50",
+    "recorded-content": {
+      "exception": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Amazon SNS does not support this protocol string: test-protocol",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_unsubscribe_from_non_existing_subscription": {
+    "recorded-date": "24-08-2023, 23:27:52",
+    "recorded-content": {
+      "empty-unsubscribe": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_create_subscriptions_with_attributes": {
+    "recorded-date": "24-08-2023, 23:27:53",
+    "recorded-content": {
+      "subscribe": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-attrs-nonexistent-sub": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Subscription does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_not_found_error_on_set_subscription_attributes": {
+    "recorded-date": "24-08-2023, 23:27:55",
+    "recorded-content": {
+      "sub": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscriptions-for-topic-before-unsub": {
+        "Subscriptions": [
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-not-found": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Subscription does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "subscriptions-for-topic-after-unsub": {
+        "Subscriptions": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_validate_set_sub_attributes": {
+    "recorded-date": "24-08-2023, 23:27:58",
+    "recorded-content": {
+      "fake-attribute": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: AttributeName",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "fake-arn-redrive-policy": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: RedrivePolicy: deadLetterTargetArn is an invalid arn",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-json-redrive-policy": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: RedrivePolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: java.io.StringReader@5498a819; line: 1, column: 3]",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-json-filter-policy": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: (String)\"{invalidjson}\"; line: 1, column: 3]",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_sns_confirm_subscription_wrong_token": {
+    "recorded-date": "24-08-2023, 23:27:58",
+    "recorded-content": {
+      "topic-not-exists": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-token": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "token-not-exists": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_python_lambda_subscribe_sns_topic": {
+    "recorded-date": "24-08-2023, 23:28:59",
+    "recorded-content": {
+      "notification": {
+        "Message": "Hello world.",
+        "MessageAttributes": {},
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertUrl": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "Subject": "[Subject] Test subject",
+        "Timestamp": "date",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "Notification",
+        "UnsubscribeUrl": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_sns_topic_as_lambda_dead_letter_queue": {
+    "recorded-date": "24-08-2023, 23:32:57",
     "recorded-content": {
       "lambda-response-dlq-config": {
         "TargetArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
@@ -703,8 +906,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_redrive_policy_lambda_subscription": {
-    "recorded-date": "11-08-2022, 14:36:27",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_redrive_policy_lambda_subscription": {
+    "recorded-date": "24-08-2023, 23:33:01",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -717,8 +920,9 @@
           "RedrivePolicy": {
             "deadLetterTargetArn": "arn:aws:sqs:<region>:111111111111:<resource:2>"
           },
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:3>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:5>:<resource:3>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:4>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:5>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -731,13 +935,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:5>",
               "Message": "test_redrive_policy",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:3>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:5>:<resource:3>",
               "MessageAttributes": {
                 "attr1": {
                   "Type": "Number",
@@ -757,273 +961,37 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_with_empty_subject": {
-    "recorded-date": "09-08-2022, 11:34:56",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_subscribe_sqs_queue": {
+    "recorded-date": "24-08-2023, 23:36:00",
     "recorded-content": {
-      "response-without-subject": {
-        "MessageId": "<uuid:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "response-with-empty-subject": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Subject",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_topic_test_arn": {
-    "recorded-date": "14-03-2023, 11:56:54",
-    "recorded-content": {
-      "create-topic": {
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-topic-attrs": {
+      "subscription-attributes": {
         "Attributes": {
-          "DisplayName": "",
-          "EffectiveDeliveryPolicy": {
-            "http": {
-              "defaultHealthyRetryPolicy": {
-                "minDelayTarget": 20,
-                "maxDelayTarget": 20,
-                "numRetries": 3,
-                "numMaxDelayRetries": 0,
-                "numNoDelayRetries": 0,
-                "numMinDelayRetries": 0,
-                "backoffFunction": "linear"
-              },
-              "disableSubscriptionOverrides": false
-            }
-          },
-          "Owner": "111111111111",
-          "Policy": {
-            "Version": "2008-10-17",
-            "Id": "__default_policy_ID",
-            "Statement": [
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "attr1": [
               {
-                "Sid": "__default_statement_ID",
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "*"
-                },
-                "Action": [
-                  "SNS:GetTopicAttributes",
-                  "SNS:SetTopicAttributes",
-                  "SNS:AddPermission",
-                  "SNS:RemovePermission",
-                  "SNS:DeleteTopic",
-                  "SNS:Subscribe",
-                  "SNS:ListSubscriptionsByTopic",
-                  "SNS:Publish"
-                ],
-                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
-                "Condition": {
-                  "StringEquals": {
-                    "AWS:SourceOwner": "111111111111"
-                  }
-                }
+                "numeric": [
+                  ">",
+                  0,
+                  "<=",
+                  100
+                ]
               }
             ]
           },
-          "SubscriptionsConfirmed": "0",
-          "SubscriptionsDeleted": "0",
-          "SubscriptionsPending": "0",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      },
-      "delete-topic": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "topic-not-exists": {
-        "Error": {
-          "Code": "NotFound",
-          "Message": "Topic does not exist",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_message_by_target_arn": {
-    "recorded-date": "09-08-2022, 11:34:59",
-    "recorded-content": {
-      "receive-topic-arn": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "test-msg-1",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "receive-target-arn": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "test-msg-2",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_message_before_subscribe_topic": {
-    "recorded-date": "09-08-2022, 11:35:08",
-    "recorded-content": {
-      "publish-before-subscribing": {
-        "MessageId": "<uuid:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "publish-after-subscribing": {
-        "MessageId": "<uuid:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "receive-messages": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Subject": "test-subject-after-sub",
-              "Message": "test_message_after",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:3>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_duplicate_topic_with_more_tags": {
-    "recorded-date": "09-08-2022, 11:35:08",
-    "recorded-content": {
-      "exception-duplicate": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Tags Reason: Topic already exists with different tags",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_duplicate_topic_check_idempotency": {
-    "recorded-date": "09-08-2022, 11:35:09",
-    "recorded-content": {
-      "response-created": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-      },
-      "response-same-arn-0": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-      },
-      "response-same-arn-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-      },
-      "response-same-arn-2": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_by_path_parameters": {
-    "recorded-date": "09-08-2022, 11:35:12",
-    "recorded-content": {
-      "post-request": {
-        "PublishResponse": {
-          "PublishResult": {
-            "MessageId": "<uuid:1>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
         }
       },
       "messages": {
@@ -1032,8 +1000,43 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "This is a test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "99.12"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_unicode_chars": {
+    "recorded-date": "24-08-2023, 23:36:02",
+    "recorded-content": {
+      "received-message": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
               "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "test message direct post request",
+              "Message": "\u00f6\u00a7a1\"_!?,. \u00a3$-",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
@@ -1052,8 +1055,67 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_sqs_from_sns": {
-    "recorded-date": "09-08-2022, 11:35:22",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_attribute_raw_subscribe": {
+    "recorded-date": "24-08-2023, 23:36:04",
+    "recorded-content": {
+      "subscription-attributes": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-response": {
+        "Messages": [
+          {
+            "Body": "This is a test message",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "<md5-hash>",
+            "MessageAttributes": {
+              "store": {
+                "BinaryValue": "b'\\x02\\x03\\x04'",
+                "DataType": "Binary"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_sqs_topic_subscription_confirmation": {
+    "recorded-date": "24-08-2023, 23:36:06",
+    "recorded-content": {
+      "subscription-attrs": {
+        "ConfirmationWasAuthenticated": "true",
+        "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "Owner": "111111111111",
+        "PendingConfirmation": "false",
+        "Protocol": "sqs",
+        "RawMessageDelivery": "false",
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+        "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_sqs_from_sns": {
+    "recorded-date": "24-08-2023, 23:36:09",
     "recorded-content": {
       "sub-attrs-raw-true": {
         "Attributes": {
@@ -1063,8 +1125,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1100,8 +1163,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1114,13 +1178,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "Test msg",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
               "MessageAttributes": {
                 "attr1": {
                   "Type": "Number",
@@ -1140,8 +1204,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_batch_messages_from_sns_to_sqs": {
-    "recorded-date": "12-06-2023, 18:15:59",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_batch_messages_from_sns_to_sqs": {
+    "recorded-date": "24-08-2023, 23:36:12",
     "recorded-content": {
       "sub-attrs-raw-true": {
         "Attributes": {
@@ -1151,9 +1215,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1273,8 +1337,24 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_batch_exceptions": {
-    "recorded-date": "12-06-2023, 18:22:01",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_batch_messages_without_topic": {
+    "recorded-date": "24-08-2023, 23:36:13",
+    "recorded-content": {
+      "publish-batch-no-topic": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Topic does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_batch_exceptions": {
+    "recorded-date": "24-08-2023, 23:36:14",
     "recorded-content": {
       "no-group-id": {
         "Error": {
@@ -1333,186 +1413,76 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_topic_after_delete_with_new_tags": {
-    "recorded-date": "09-08-2022, 11:35:47",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_subscribe_to_sqs_with_queue_url": {
+    "recorded-date": "24-08-2023, 23:36:15",
     "recorded-content": {
-      "topic-0": {
+      "sub-queue-url": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: SQS endpoint ARN",
+          "Type": "Sender"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-      },
-      "topic-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+          "HTTPStatusCode": 400
+        }
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_not_found_error_on_set_subscription_attributes": {
-    "recorded-date": "09-08-2022, 11:35:51",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_publish_sqs_from_sns_with_xray_propagation": {
+    "recorded-date": "24-08-2023, 23:36:16",
     "recorded-content": {
-      "sub": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>"
-      },
-      "sub-attrs": {
+      "xray-msg": {
         "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
+          "SentTimestamp": "timestamp"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "subscriptions-for-topic-before-unsub": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+        "Body": {
+          "Type": "Notification",
+          "MessageId": "<uuid:1>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+          "Message": "X-Ray propagation test msg",
+          "Timestamp": "date",
+          "SignatureVersion": "1",
+          "Signature": "<signature>",
+          "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+          "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
         },
-        "Subscriptions": [
+        "MD5OfBody": "<md5-hash>",
+        "MessageId": "<uuid:2>",
+        "ReceiptHandle": "<receipt-handle:1>"
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_redrive_policy_sqs_queue_subscription[True]": {
+    "recorded-date": "24-08-2023, 23:36:19",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
           {
-            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-            "Owner": "111111111111",
-            "Protocol": "sqs",
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
-            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "test_dlq_after_sqs_endpoint_deleted",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "<md5-hash>",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "111"
+              },
+              "attr2": {
+                "BinaryValue": "b'\\x02\\x03\\x04'",
+                "DataType": "Binary"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
           }
-        ]
-      },
-      "sub-not-found": {
-        "Error": {
-          "Code": "NotFound",
-          "Message": "Subscription does not exist",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "subscriptions-for-topic-after-unsub": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "Subscriptions": []
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_validations_for_fifo": {
-    "recorded-date": "12-12-2022, 12:01:57",
-    "recorded-content": {
-      "not-fifo-topic": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Invalid parameter: Endpoint Reason: FIFO SQS Queues can not be subscribed to standard SNS topics",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "not-fifo-queue": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Invalid parameter: Endpoint Reason: Please use FIFO SQS queue",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "regular-queue-for-dlq-of-fifo-topic": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: RedrivePolicy: must use a FIFO queue as DLQ for a FIFO topic",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "no-msg-group-id": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: The MessageGroupId parameter is required for FIFO topics",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "no-dedup-policy": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "no-msg-dedup-regular-topic": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "no-msg-group-id-regular-topic": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_empty_sns_message": {
-    "recorded-date": "09-08-2022, 11:35:58",
-    "recorded-content": {
-      "empty-msg-error": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Empty message",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "queue-attrs": {
-        "Attributes": {
-          "ApproximateNumberOfMessages": "0"
-        },
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1520,8 +1490,53 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_attributes_not_missing": {
-    "recorded-date": "09-08-2022, 11:36:07",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_redrive_policy_sqs_queue_subscription[False]": {
+    "recorded-date": "24-08-2023, 23:36:22",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "test_dlq_after_sqs_endpoint_deleted",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>",
+              "MessageAttributes": {
+                "attr2": {
+                  "Type": "Binary",
+                  "Value": "AgME"
+                },
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "111"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_message_attributes_not_missing": {
+    "recorded-date": "24-08-2023, 23:36:25",
     "recorded-content": {
       "publish-msg-raw": {
         "MessageId": "<uuid:1>",
@@ -1610,49 +1625,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_too_long_message": {
-    "recorded-date": "09-08-2022, 11:36:07",
-    "recorded-content": {
-      "error": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Message too long",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_sqs_from_sns_with_xray_propagation": {
-    "recorded-date": "30-11-2022, 18:18:00",
-    "recorded-content": {
-      "xray-msg": {
-        "Attributes": {
-          "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
-          "SentTimestamp": "timestamp"
-        },
-        "Body": {
-          "Type": "Notification",
-          "MessageId": "<uuid:1>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-          "Message": "X-Ray propagation test msg",
-          "Timestamp": "date",
-          "SignatureVersion": "1",
-          "Signature": "<signature>",
-          "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-          "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-        },
-        "MD5OfBody": "<md5-hash>",
-        "MessageId": "<uuid:2>",
-        "ReceiptHandle": "<receipt-handle:1>"
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscription_after_failure_to_deliver": {
-    "recorded-date": "20-12-2022, 20:25:24",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_subscription_after_failure_to_deliver": {
+    "recorded-date": "24-08-2023, 23:36:32",
     "recorded-content": {
       "subscriptions-attrs": {
         "Attributes": {
@@ -1662,9 +1636,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1677,13 +1651,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "test_dlq_before_sqs_endpoint_deleted",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",
@@ -1701,8 +1675,8 @@
             "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
             "Owner": "111111111111",
             "Protocol": "sqs",
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
           }
         ],
         "ResponseMetadata": {
@@ -1719,11 +1693,11 @@
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "RedrivePolicy": {
-            "deadLetterTargetArn": "arn:aws:sqs:<region>:111111111111:<resource:4>"
+            "deadLetterTargetArn": "arn:aws:sqs:<region>:111111111111:<resource:5>"
           },
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1736,13 +1710,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "test_dlq_after_sqs_endpoint_deleted_0",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:4>",
@@ -1760,13 +1734,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:5>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "test_dlq_after_sqs_endpoint_deleted_1",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>"
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:6>",
@@ -1780,518 +1754,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[True]": {
-    "recorded-date": "14-04-2023, 19:17:55",
-    "recorded-content": {
-      "topic-attrs": {
-        "Attributes": {
-          "ContentBasedDeduplication": "true",
-          "DisplayName": "",
-          "EffectiveDeliveryPolicy": {
-            "http": {
-              "defaultHealthyRetryPolicy": {
-                "minDelayTarget": 20,
-                "maxDelayTarget": 20,
-                "numRetries": 3,
-                "numMaxDelayRetries": 0,
-                "numNoDelayRetries": 0,
-                "numMinDelayRetries": 0,
-                "backoffFunction": "linear"
-              },
-              "disableSubscriptionOverrides": false,
-              "defaultRequestPolicy": {
-                "headerContentType": "text/plain; charset=UTF-8"
-              }
-            }
-          },
-          "FifoTopic": "true",
-          "Owner": "111111111111",
-          "Policy": {
-            "Version": "2008-10-17",
-            "Id": "__default_policy_ID",
-            "Statement": [
-              {
-                "Sid": "__default_statement_ID",
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "*"
-                },
-                "Action": [
-                  "SNS:GetTopicAttributes",
-                  "SNS:SetTopicAttributes",
-                  "SNS:AddPermission",
-                  "SNS:RemovePermission",
-                  "SNS:DeleteTopic",
-                  "SNS:Subscribe",
-                  "SNS:ListSubscriptionsByTopic",
-                  "SNS:Publish"
-                ],
-                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
-                "Condition": {
-                  "StringEquals": {
-                    "AWS:SourceOwner": "111111111111"
-                  }
-                }
-              }
-            ]
-          },
-          "SubscriptionsConfirmed": "0",
-          "SubscriptionsDeleted": "0",
-          "SubscriptionsPending": "0",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "sub-attrs-raw-true": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "publish-batch-response-fifo": {
-        "Failed": [],
-        "Successful": [
-          {
-            "Id": "1",
-            "MessageId": "<uuid:1>",
-            "SequenceNumber": "<sequence-number:1>"
-          },
-          {
-            "Id": "2",
-            "MessageId": "<uuid:2>",
-            "SequenceNumber": "<sequence-number:2>"
-          },
-          {
-            "Id": "3",
-            "MessageId": "<uuid:3>",
-            "SequenceNumber": "<sequence-number:3>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "47f6d7e2c477469ad670ae3bfee60ed3e79080bb0105fc01a2805a50f8b21358",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:4>"
-            },
-            "Body": "Test Message with two attributes",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "9b720b3af309c1c4b0d395c53b08c502",
-            "MessageAttributes": {
-              "attr1": {
-                "DataType": "Number",
-                "StringValue": "99.12"
-              },
-              "attr2": {
-                "DataType": "Number",
-                "StringValue": "109.12"
-              }
-            },
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "2186166772ec2fb49b7ba9efbda53c6eabf8e785cb00420db531c8eb9287d8e1",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:5>"
-            },
-            "Body": "Test Message with one attribute",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "1f07082409022a373fa2a2601f82b3cb",
-            "MessageAttributes": {
-              "attr1": {
-                "DataType": "Number",
-                "StringValue": "19.12"
-              }
-            },
-            "MessageId": "<uuid:5>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "a579d4ebff398c5ad4d5037534a1c1bfab36410100c80d8c7c1029b57c7898fe",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:6>"
-            },
-            "Body": "Test Message without attribute",
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:6>",
-            "ReceiptHandle": "<receipt-handle:3>"
-          }
-        ]
-      },
-      "republish-batch-response-fifo": {
-        "Failed": [],
-        "Successful": [
-          {
-            "Id": "1",
-            "MessageId": "<uuid:1>",
-            "SequenceNumber": "<sequence-number:1>"
-          },
-          {
-            "Id": "2",
-            "MessageId": "<uuid:2>",
-            "SequenceNumber": "<sequence-number:2>"
-          },
-          {
-            "Id": "3",
-            "MessageId": "<uuid:3>",
-            "SequenceNumber": "<sequence-number:3>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "duplicate-messages": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[False]": {
-    "recorded-date": "14-04-2023, 19:18:02",
-    "recorded-content": {
-      "topic-attrs": {
-        "Attributes": {
-          "ContentBasedDeduplication": "false",
-          "DisplayName": "",
-          "EffectiveDeliveryPolicy": {
-            "http": {
-              "defaultHealthyRetryPolicy": {
-                "minDelayTarget": 20,
-                "maxDelayTarget": 20,
-                "numRetries": 3,
-                "numMaxDelayRetries": 0,
-                "numNoDelayRetries": 0,
-                "numMinDelayRetries": 0,
-                "backoffFunction": "linear"
-              },
-              "disableSubscriptionOverrides": false,
-              "defaultRequestPolicy": {
-                "headerContentType": "text/plain; charset=UTF-8"
-              }
-            }
-          },
-          "FifoTopic": "true",
-          "Owner": "111111111111",
-          "Policy": {
-            "Version": "2008-10-17",
-            "Id": "__default_policy_ID",
-            "Statement": [
-              {
-                "Sid": "__default_statement_ID",
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "*"
-                },
-                "Action": [
-                  "SNS:GetTopicAttributes",
-                  "SNS:SetTopicAttributes",
-                  "SNS:AddPermission",
-                  "SNS:RemovePermission",
-                  "SNS:DeleteTopic",
-                  "SNS:Subscribe",
-                  "SNS:ListSubscriptionsByTopic",
-                  "SNS:Publish"
-                ],
-                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
-                "Condition": {
-                  "StringEquals": {
-                    "AWS:SourceOwner": "111111111111"
-                  }
-                }
-              }
-            ]
-          },
-          "SubscriptionsConfirmed": "0",
-          "SubscriptionsDeleted": "0",
-          "SubscriptionsPending": "0",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "sub-attrs-raw-true": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "publish-batch-response-fifo": {
-        "Failed": [],
-        "Successful": [
-          {
-            "Id": "1",
-            "MessageId": "<uuid:1>",
-            "SequenceNumber": "<sequence-number:1>"
-          },
-          {
-            "Id": "2",
-            "MessageId": "<uuid:2>",
-            "SequenceNumber": "<sequence-number:2>"
-          },
-          {
-            "Id": "3",
-            "MessageId": "<uuid:3>",
-            "SequenceNumber": "<sequence-number:3>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "MessageDeduplicationId-0",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:4>"
-            },
-            "Body": "Test Message with two attributes",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "9b720b3af309c1c4b0d395c53b08c502",
-            "MessageAttributes": {
-              "attr1": {
-                "DataType": "Number",
-                "StringValue": "99.12"
-              },
-              "attr2": {
-                "DataType": "Number",
-                "StringValue": "109.12"
-              }
-            },
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "MessageDeduplicationId-1",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:5>"
-            },
-            "Body": "Test Message with one attribute",
-            "MD5OfBody": "<md5-hash>",
-            "MD5OfMessageAttributes": "1f07082409022a373fa2a2601f82b3cb",
-            "MessageAttributes": {
-              "attr1": {
-                "DataType": "Number",
-                "StringValue": "19.12"
-              }
-            },
-            "MessageId": "<uuid:5>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "MessageDeduplicationId-2",
-              "MessageGroupId": "complexMessageGroupId",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:6>"
-            },
-            "Body": "Test Message without attribute",
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:6>",
-            "ReceiptHandle": "<receipt-handle:3>"
-          }
-        ]
-      },
-      "republish-batch-response-fifo": {
-        "Failed": [],
-        "Successful": [
-          {
-            "Id": "1",
-            "MessageId": "<uuid:1>",
-            "SequenceNumber": "<sequence-number:1>"
-          },
-          {
-            "Id": "2",
-            "MessageId": "<uuid:2>",
-            "SequenceNumber": "<sequence-number:2>"
-          },
-          {
-            "Id": "3",
-            "MessageId": "<uuid:3>",
-            "SequenceNumber": "<sequence-number:3>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "duplicate-messages": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_to_fifo_sqs[True]": {
-    "recorded-date": "14-04-2023, 19:38:46",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "SequenceNumber": "<sequence-number:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test",
-              "Timestamp": "date",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "dedup-messages": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_to_fifo_sqs[False]": {
-    "recorded-date": "14-04-2023, 19:38:59",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "message-deduplication-id-1",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "SequenceNumber": "<sequence-number:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test",
-              "Timestamp": "date",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "dedup-messages": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_batch_messages_without_topic": {
-    "recorded-date": "01-09-2022, 20:49:54",
-    "recorded-content": {
-      "publish-batch-no-topic": {
-        "Error": {
-          "Code": "NotFound",
-          "Message": "Topic does not exist",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_empty_or_wrong_message_attributes": {
-    "recorded-date": "27-09-2022, 16:22:03",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_empty_or_wrong_message_attributes": {
+    "recorded-date": "24-08-2023, 23:36:35",
     "recorded-content": {
       "missing_string_attr": {
         "Error": {
@@ -2427,8 +1891,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_attributes_prefixes": {
-    "recorded-date": "16-11-2022, 15:34:40",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_message_attributes_prefixes": {
+    "recorded-date": "24-08-2023, 23:36:37",
     "recorded-content": {
       "publish-error": {
         "Error": {
@@ -2468,74 +1932,150 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_structure_json_exc": {
-    "recorded-date": "03-04-2023, 21:23:54",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQS::test_message_structure_json_to_sqs": {
+    "recorded-date": "24-08-2023, 23:36:39",
     "recorded-content": {
-      "missing-default-key": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Message Structure - No default entry in JSON message body",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "invalid-json": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Message Structure - JSON message body failed to parse",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "duplicate-json-keys": {
-        "MessageId": "<uuid:1>",
+      "get-msg-json-sqs": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"field\": \"value\"}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "key-is-not-string": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Message Structure - No default entry in JSON message body",
-          "Type": "Sender"
-        },
+      "get-msg-json-default": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "default field",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_non_existent_target": {
-    "recorded-date": "30-11-2022, 17:03:38",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[True]": {
+    "recorded-date": "24-08-2023, 23:37:43",
     "recorded-content": {
-      "non-existent-endpoint": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified",
-          "Type": "Sender"
-        },
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_wrong_phone_format": {
-    "recorded-date": "30-11-2022, 17:20:37",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[False]": {
+    "recorded-date": "24-08-2023, 23:37:46",
     "recorded-content": {
-      "invalid-number": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "message-deduplication-id-1",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_validations_for_fifo": {
+    "recorded-date": "24-08-2023, 23:55:19",
+    "recorded-content": {
+      "not-fifo-topic": {
         "Error": {
           "Code": "InvalidParameter",
-          "Message": "Invalid parameter: PhoneNumber Reason: +1a234 is not valid to publish to",
+          "Message": "Invalid parameter: Invalid parameter: Endpoint Reason: FIFO SQS Queues can not be subscribed to standard SNS topics",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -2543,10 +2083,21 @@
           "HTTPStatusCode": 400
         }
       },
-      "wrong-format": {
+      "not-fifo-queue": {
+        "ConfirmationWasAuthenticated": "true",
+        "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "Owner": "111111111111",
+        "PendingConfirmation": "false",
+        "Protocol": "sqs",
+        "RawMessageDelivery": "false",
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+        "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+      },
+      "regular-queue-for-dlq-of-fifo-topic": {
         "Error": {
           "Code": "InvalidParameter",
-          "Message": "Invalid parameter: PhoneNumber Reason: NAA+15551234567 is not valid to publish to",
+          "Message": "Invalid parameter: RedrivePolicy: must use a FIFO queue as DLQ for a FIFO Subscription to a FIFO Topic.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -2554,10 +2105,43 @@
           "HTTPStatusCode": 400
         }
       },
-      "wrong-endpoint": {
+      "no-msg-group-id": {
         "Error": {
           "Code": "InvalidParameter",
-          "Message": "Invalid SMS endpoint: NAA+15551234567",
+          "Message": "Invalid parameter: The MessageGroupId parameter is required for FIFO topics",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-dedup-policy": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-msg-dedup-regular-topic": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "no-msg-group-id-regular-topic": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -2567,24 +2151,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_to_sqs_with_queue_url": {
-    "recorded-date": "30-11-2022, 18:09:39",
-    "recorded-content": {
-      "sub-queue-url": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: SQS endpoint ARN",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_fifo_messages_to_dlq[True]": {
-    "recorded-date": "14-04-2023, 18:26:46",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_fifo_messages_to_dlq[True]": {
+    "recorded-date": "24-08-2023, 23:37:54",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -2768,8 +2336,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_fifo_messages_to_dlq[False]": {
-    "recorded-date": "14-04-2023, 18:26:50",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_fifo_messages_to_dlq[False]": {
+    "recorded-date": "24-08-2023, 23:37:59",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -2986,57 +2554,922 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_validate_set_sub_attributes": {
-    "recorded-date": "12-12-2022, 12:33:28",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[True]": {
+    "recorded-date": "24-08-2023, 23:38:05",
     "recorded-content": {
-      "fake-attribute": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: AttributeName",
-          "Type": "Sender"
+      "topic-attrs": {
+        "Attributes": {
+          "ContentBasedDeduplication": "true",
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "FifoTopic": "true",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       },
-      "fake-arn-redrive-policy": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: RedrivePolicy: deadLetterTargetArn is an invalid arn",
-          "Type": "Sender"
+      "sub-attrs-raw-true": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:4>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       },
-      "invalid-json-redrive-policy": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: RedrivePolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: java.io.StringReader@6fb45229; line: 1, column: 3]",
-          "Type": "Sender"
-        },
+      "publish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       },
-      "invalid-json-filter-policy": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: FilterPolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: (String)\"{invalidjson}\"; line: 1, column: 3]",
-          "Type": "Sender"
-        },
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "47f6d7e2c477469ad670ae3bfee60ed3e79080bb0105fc01a2805a50f8b21358",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:4>"
+            },
+            "Body": "Test Message with two attributes",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "9b720b3af309c1c4b0d395c53b08c502",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "99.12"
+              },
+              "attr2": {
+                "DataType": "Number",
+                "StringValue": "109.12"
+              }
+            },
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "2186166772ec2fb49b7ba9efbda53c6eabf8e785cb00420db531c8eb9287d8e1",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:5>"
+            },
+            "Body": "Test Message with one attribute",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "1f07082409022a373fa2a2601f82b3cb",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "19.12"
+              }
+            },
+            "MessageId": "<uuid:5>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "a579d4ebff398c5ad4d5037534a1c1bfab36410100c80d8c7c1029b57c7898fe",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:6>"
+            },
+            "Body": "Test Message without attribute",
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ]
+      },
+      "republish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
+        }
+      },
+      "duplicate-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_set_subscription_filter_policy_scope": {
-    "recorded-date": "30-12-2022, 18:19:59",
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[False]": {
+    "recorded-date": "24-08-2023, 23:38:11",
+    "recorded-content": {
+      "topic-attrs": {
+        "Attributes": {
+          "ContentBasedDeduplication": "false",
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "FifoTopic": "true",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-attrs-raw-true": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:4>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "MessageDeduplicationId-0",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:4>"
+            },
+            "Body": "Test Message with two attributes",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "9b720b3af309c1c4b0d395c53b08c502",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "99.12"
+              },
+              "attr2": {
+                "DataType": "Number",
+                "StringValue": "109.12"
+              }
+            },
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "MessageDeduplicationId-1",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:5>"
+            },
+            "Body": "Test Message with one attribute",
+            "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "1f07082409022a373fa2a2601f82b3cb",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "19.12"
+              }
+            },
+            "MessageId": "<uuid:5>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "MessageDeduplicationId-2",
+              "MessageGroupId": "complexMessageGroupId",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:6>"
+            },
+            "Body": "Test Message without attribute",
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ]
+      },
+      "republish-batch-response-fifo": {
+        "Failed": [],
+        "Successful": [
+          {
+            "Id": "1",
+            "MessageId": "<uuid:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "2",
+            "MessageId": "<uuid:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "3",
+            "MessageId": "<uuid:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "duplicate-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[True]": {
+    "recorded-date": "24-08-2023, 23:38:14",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "Test single",
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:2>"
+            },
+            "Body": "Test batched",
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[False]": {
+    "recorded-date": "24-08-2023, 23:38:17",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test single",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:3>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "SequenceNumber": "<sequence-number:4>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test batched",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_to_fifo_topic_deduplication_on_topic_level": {
+    "recorded-date": "24-08-2023, 23:38:21",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+              "MessageGroupId": "message-group-id-1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[True]": {
+    "recorded-date": "24-08-2023, 23:53:59",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_fifo_topic_to_regular_sqs[False]": {
+    "recorded-date": "24-08-2023, 23:54:05",
+    "recorded-content": {
+      "messages": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "SequenceNumber": "<sequence-number:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "Test",
+              "Timestamp": "date",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
+    "recorded-date": "25-08-2023, 00:15:01",
+    "recorded-content": {
+      "subscription-attributes": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "attr1": [
+              {
+                "numeric": [
+                  ">",
+                  0,
+                  "<=",
+                  100
+                ]
+              }
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-0": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "This is a test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-2": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "This is a test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_exists_filter_policy": {
+    "recorded-date": "25-08-2023, 00:15:09",
+    "recorded-content": {
+      "subscription-attributes-policy-1": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "store": [
+              {
+                "exists": true
+              }
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-0": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-1",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "def": {
+                  "Type": "Number",
+                  "Value": "99"
+                },
+                "store": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-2": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-1",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "def": {
+                  "Type": "Number",
+                  "Value": "99"
+                },
+                "store": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscription-attributes-policy-2": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "store": [
+              {
+                "exists": false
+              }
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-3": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-3",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "def": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-4": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-3",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "def": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_set_subscription_filter_policy_scope": {
+    "recorded-date": "25-08-2023, 00:15:12",
     "recorded-content": {
       "sub-attrs-default": {
         "Attributes": {
@@ -3046,9 +3479,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3063,9 +3496,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3097,9 +3530,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3108,8 +3541,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_sub_filter_policy_nested_property": {
-    "recorded-date": "30-12-2022, 18:38:05",
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_sub_filter_policy_nested_property": {
+    "recorded-date": "25-08-2023, 00:15:14",
     "recorded-content": {
       "sub-filter-policy-nested-error": {
         "Error": {
@@ -3140,9 +3573,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3151,8 +3584,46 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[True]": {
-    "recorded-date": "31-03-2023, 16:57:29",
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_sub_filter_policy_nested_property_constraints": {
+    "recorded-date": "25-08-2023, 00:18:18",
+    "recorded-content": {
+      "sub-filter-policy-nested-error-too-many-combinations": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: Filter policy is too complex",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-filter-policy-max-attr-keys": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: Filter policy can not have more than 5 keys",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-filter-policy-rule-no-list": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: \"key_a\" must be an object or an array\n at [Source: (String)\"{\"key_a\":\"value_one\"}\"; line: 1, column: 11]",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[True]": {
+    "recorded-date": "25-08-2023, 00:15:29",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -3198,8 +3669,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[False]": {
-    "recorded-date": "31-03-2023, 16:57:42",
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[False]": {
+    "recorded-date": "25-08-2023, 00:15:41",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -3257,140 +3728,8 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_sub_filter_policy_nested_property_constraints": {
-    "recorded-date": "04-01-2023, 17:41:42",
-    "recorded-content": {
-      "sub-filter-policy-nested-error-too-many-combinations": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: FilterPolicy: Filter policy is too complex",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "sub-filter-policy-max-attr-keys": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: FilterPolicy: Filter policy can not have more than 5 keys",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "sub-filter-policy-rule-no-list": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: FilterPolicy: \"key_a\" must be an object or an array\n at [Source: (String)\"{\"key_a\":\"value_one\"}\"; line: 1, column: 11]",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[True]": {
-    "recorded-date": "14-04-2023, 19:57:05",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
-            },
-            "Body": "Test single",
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:2>"
-            },
-            "Body": "Test batched",
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup[False]": {
-    "recorded-date": "14-04-2023, 19:57:07",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "2591186cff6c740cb9e0cfce1653a7e6998d57da12e1da13d85344b1c08be4cb",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "SequenceNumber": "<sequence-number:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test single",
-              "Timestamp": "date",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "32a45f72fe3d20fb5d4f1647421d1c5f9d20ef207c8ab713443cc9f9b76c468c",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:3>"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "SequenceNumber": "<sequence-number:4>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test batched",
-              "Timestamp": "date",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_filter_policy_for_batch": {
-    "recorded-date": "13-02-2023, 13:40:06",
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_for_batch": {
+    "recorded-date": "25-08-2023, 00:15:58",
     "recorded-content": {
       "subscription-attributes-with-filter": {
         "Attributes": {
@@ -3413,9 +3752,9 @@
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3425,14 +3764,14 @@
       "subscription-attributes-no-filter": {
         "Attributes": {
           "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:4>",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:5>",
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:6>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3457,13 +3796,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "This is a test message",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:6>",
               "MessageAttributes": {
                 "attr1": {
                   "Type": "Number",
@@ -3487,13 +3826,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "This is a test message",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
               "MessageAttributes": {
                 "attr1": {
                   "Type": "Number",
@@ -3517,13 +3856,13 @@
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:4>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
               "Message": "This is another test message",
               "Timestamp": "date",
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:6>",
               "MessageAttributes": {
                 "attr1": {
                   "Type": "Number",
@@ -3549,8 +3888,75 @@
       }
     }
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_subscribe_sms_endpoint": {
+    "recorded-date": "25-08-2023, 00:20:07",
+    "recorded-content": {
+      "subscribe-sms-endpoint": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscribe-sms-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "+123123123",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sms",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:2>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_publish_wrong_phone_format": {
+    "recorded-date": "25-08-2023, 00:20:12",
+    "recorded-content": {
+      "invalid-number": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: PhoneNumber Reason: +1a234 is not valid to publish to",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-format": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: PhoneNumber Reason: NAA+15551234567 is not valid to publish to",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-endpoint": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid SMS endpoint: NAA+15551234567",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishDelivery::test_delivery_lambda": {
-    "recorded-date": "01-03-2023, 14:56:10",
+    "recorded-date": "25-08-2023, 00:31:30",
     "recorded-content": {
       "get-topic-attrs": {
         "Attributes": {
@@ -3566,7 +3972,10 @@
                 "numMinDelayRetries": 0,
                 "backoffFunction": "linear"
               },
-              "disableSubscriptionOverrides": false
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
             }
           },
           "LambdaSuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/<resource:1>",
@@ -3641,514 +4050,6 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_sns_confirm_subscription_wrong_token": {
-    "recorded-date": "04-03-2023, 21:28:49",
-    "recorded-content": {
-      "topic-not-exists": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Token",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "invalid-token": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid token",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "token-not-exists": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Token",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_sms_endpoint": {
-    "recorded-date": "05-03-2023, 15:29:28",
-    "recorded-content": {
-      "subscribe-sms-endpoint": {
-        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "subscribe-sms-attrs": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "+123123123",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sms",
-          "RawMessageDelivery": "false",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:1>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_unsubscribe_from_non_existing_subscription": {
-    "recorded-date": "17-03-2023, 19:35:30",
-    "recorded-content": {
-      "empty-unsubscribe": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_message_structure_json_to_sqs": {
-    "recorded-date": "03-04-2023, 21:52:04",
-    "recorded-content": {
-      "get-msg-json-sqs": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "{\"field\": \"value\"}",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-msg-json-default": {
-        "Messages": [
-          {
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "default field",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_to_fifo_topic_deduplication_on_topic_level": {
-    "recorded-date": "14-04-2023, 20:03:27",
-    "recorded-content": {
-      "messages": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
-              "MessageGroupId": "message-group-id-1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "SequenceNumber": "<sequence-number:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "Test",
-              "Timestamp": "date",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "dedup-messages": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_external_http_endpoint[True]": {
-    "recorded-date": "13-04-2023, 02:58:36",
-    "recorded-content": {
-      "subscription-confirmation": {
-        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
-        "MessageId": "<uuid:1>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
-        "Timestamp": "date",
-        "Token": "<token:1>",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "SubscriptionConfirmation"
-      },
-      "broken-topic-arn-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Topic",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:1>"
-        }
-      },
-      "broken-token-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Token",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:2>"
-        }
-      },
-      "different-region-arn-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Topic",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:3>"
-        }
-      },
-      "nonexistent-token-confirm": {
-        "ConfirmSubscriptionResponse": {
-          "ConfirmSubscriptionResult": {
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "confirm-subscribe": {
-        "ConfirmSubscriptionResponse": {
-          "ConfirmSubscriptionResult": {
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "unsubscribe-response": {
-        "UnsubscribeResponse": {
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "unsubscribe-request": {
-        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
-        "MessageId": "<uuid:2>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
-        "Timestamp": "date",
-        "Token": "<token:2>",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "UnsubscribeConfirmation"
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_subscribe_external_http_endpoint[False]": {
-    "recorded-date": "13-04-2023, 02:58:52",
-    "recorded-content": {
-      "subscription-confirmation": {
-        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
-        "MessageId": "<uuid:1>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
-        "Timestamp": "date",
-        "Token": "<token:1>",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "SubscriptionConfirmation"
-      },
-      "broken-topic-arn-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Topic",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:1>"
-        }
-      },
-      "broken-token-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Token",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:2>"
-        }
-      },
-      "different-region-arn-confirm": {
-        "ErrorResponse": {
-          "Error": {
-            "Code": "InvalidParameter",
-            "Message": "Invalid parameter: Topic",
-            "Type": "Sender"
-          },
-          "RequestId": "<request-id:3>"
-        }
-      },
-      "nonexistent-token-confirm": {
-        "ConfirmSubscriptionResponse": {
-          "ConfirmSubscriptionResult": {
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "confirm-subscribe": {
-        "ConfirmSubscriptionResponse": {
-          "ConfirmSubscriptionResult": {
-            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-          },
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "http-message": {
-        "Message": "test_external_http_endpoint",
-        "MessageId": "<uuid:2>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "Timestamp": "date",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "Notification",
-        "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-      },
-      "unsubscribe-response": {
-        "UnsubscribeResponse": {
-          "ResponseMetadata": {
-            "HTTPHeaders": {},
-            "HTTPStatusCode": 200
-          }
-        }
-      },
-      "unsubscribe-request": {
-        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
-        "MessageId": "<uuid:3>",
-        "Signature": "<signature>",
-        "SignatureVersion": "1",
-        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
-        "Timestamp": "date",
-        "Token": "<token:2>",
-        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-        "Type": "UnsubscribeConfirmation"
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_publish_wrong_arn_format": {
-    "recorded-date": "01-06-2023, 20:18:02",
-    "recorded-content": {
-      "invalid-topic-arn": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 1",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "invalid-topic-arn-1": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 2",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_subscriptions_with_attributes": {
-    "recorded-date": "07-06-2023, 18:27:05",
-    "recorded-content": {
-      "subscribe": {
-        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-attrs": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:1>",
-          "SubscriptionPrincipal": "<sub-principal>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-attrs-nonexistent-sub": {
-        "Error": {
-          "Code": "NotFound",
-          "Message": "Subscription does not exist",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSProvider::test_create_topic_with_attributes": {
-    "recorded-date": "07-06-2023, 18:34:51",
-    "recorded-content": {
-      "get-topic-attrs": {
-        "Attributes": {
-          "ContentBasedDeduplication": "false",
-          "DisplayName": "TestTopic",
-          "EffectiveDeliveryPolicy": {
-            "http": {
-              "defaultHealthyRetryPolicy": {
-                "minDelayTarget": 20,
-                "maxDelayTarget": 20,
-                "numRetries": 3,
-                "numMaxDelayRetries": 0,
-                "numNoDelayRetries": 0,
-                "numMinDelayRetries": 0,
-                "backoffFunction": "linear"
-              },
-              "disableSubscriptionOverrides": false,
-              "defaultRequestPolicy": {
-                "headerContentType": "text/plain; charset=UTF-8"
-              }
-            }
-          },
-          "FifoTopic": "true",
-          "Owner": "111111111111",
-          "Policy": {
-            "Version": "2008-10-17",
-            "Id": "__default_policy_ID",
-            "Statement": [
-              {
-                "Sid": "__default_statement_ID",
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "*"
-                },
-                "Action": [
-                  "SNS:GetTopicAttributes",
-                  "SNS:SetTopicAttributes",
-                  "SNS:AddPermission",
-                  "SNS:RemovePermission",
-                  "SNS:DeleteTopic",
-                  "SNS:Subscribe",
-                  "SNS:ListSubscriptionsByTopic",
-                  "SNS:Publish"
-                ],
-                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
-                "Condition": {
-                  "StringEquals": {
-                    "AWS:SourceOwner": "111111111111"
-                  }
-                }
-              }
-            ]
-          },
-          "SignatureVersion": "2",
-          "SubscriptionsConfirmed": "0",
-          "SubscriptionsDeleted": "0",
-          "SubscriptionsPending": "0",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-attrs-nonexistent-topic": {
-        "Error": {
-          "Code": "NotFound",
-          "Message": "Topic does not exist",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4053,5 +4053,305 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_list_subscriptions": {
+    "recorded-date": "25-08-2023, 16:23:53",
+    "recorded-content": {
+      "create-topic-1": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-topic-2": {
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-1-0": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-1-1": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:4>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-1-2": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:5>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-2-0": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:6>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-2-1": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:7>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-topic-2-2": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:8>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-subscriptions-aggregated": {
+        "Subscriptions": [
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:9>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+          },
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:10>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:4>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+          },
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:11>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:5>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+          },
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:12>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:6>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+          },
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:13>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:7>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+          },
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:14>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:8>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[True]": {
+    "recorded-date": "25-08-2023, 17:28:02",
+    "recorded-content": {
+      "subscription-confirmation": {
+        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
+        "Timestamp": "date",
+        "Token": "<token:1>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "SubscriptionConfirmation"
+      },
+      "broken-topic-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "broken-token-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Token",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "different-region-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "nonexistent-token-confirm": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "confirm-subscribe": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-response": {
+        "UnsubscribeResponse": {
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-request": {
+        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:2>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
+        "Timestamp": "date",
+        "Token": "<token:2>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "UnsubscribeConfirmation"
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[False]": {
+    "recorded-date": "25-08-2023, 17:28:08",
+    "recorded-content": {
+      "subscription-confirmation": {
+        "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:1>",
+        "Timestamp": "date",
+        "Token": "<token:1>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "SubscriptionConfirmation"
+      },
+      "broken-topic-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "broken-token-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Token",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "different-region-arn-confirm": {
+        "ErrorResponse": {
+          "Error": {
+            "Code": "InvalidParameter",
+            "Message": "Invalid parameter: Topic",
+            "Type": "Sender"
+          },
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "nonexistent-token-confirm": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "confirm-subscribe": {
+        "ConfirmSubscriptionResponse": {
+          "ConfirmSubscriptionResult": {
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+          },
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "http-message": {
+        "Message": "test_external_http_endpoint",
+        "MessageId": "<uuid:2>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "Timestamp": "date",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "Notification",
+        "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+      },
+      "unsubscribe-response": {
+        "UnsubscribeResponse": {
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 200
+          }
+        }
+      },
+      "unsubscribe-request": {
+        "Message": "You have chosen to deactivate subscription arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+        "MessageId": "<uuid:3>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "SubscribeURL": "<subscribe-domain>/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:<region>:111111111111:<resource:1>&Token=<token:2>",
+        "Timestamp": "date",
+        "Token": "<token:2>",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+        "Type": "UnsubscribeConfirmation"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Refreshing SNS snapshots which were for most 1 year old

<!-- What notable changes does this PR make? -->
## Changes
Organised the tests in more classes, to try to separate a little the different cases. It's not very precise, but it allows a bit more fine grained organisation, and it's easier to run/refresh only a certain kind of tests only after a change instead of re-running the whole suite locally. 

Refreshing snapshots put into a light a change regarding FIFO topics: they now accept regular SQS queue as subscribers. Those are not guaranteed to be FIFO, but the deduplication is working (as it's a the topic level, not the subscriber queue level). This is not yet implemented in LocalStack, but there's a TODO to implement it.

Also added a dummy subscription principal to the SNS subscription, as the field was missing. Maybe we could do a call to STS to get the real IAM user doing the call. 


