### PR TITLE
Support checking a specific host for port bindability

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -133,7 +133,7 @@ def get_host_path_for_path_in_docker(path):
 
 
 def container_ports_can_be_bound(
-    ports: Union[IntOrPort, List[IntOrPort]], bind_host: str | None = None
+    ports: Union[IntOrPort, List[IntOrPort]], bind_host: Union[str, None] = None
 ) -> bool:
     """Determine whether a given list of ports can be bound by Docker containers
 

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -132,13 +132,16 @@ def get_host_path_for_path_in_docker(path):
     return path
 
 
-def container_ports_can_be_bound(ports: Union[IntOrPort, List[IntOrPort]]) -> bool:
+def container_ports_can_be_bound(
+    ports: Union[IntOrPort, List[IntOrPort]], bind_host: str | None = None
+) -> bool:
     """Determine whether a given list of ports can be bound by Docker containers
 
     :param ports: single port or list of ports to check
+    :param bind_host: optional ip address to bind to for the test
     :return: True iff all ports can be bound
     """
-    port_mappings = PortMappings()
+    port_mappings = PortMappings(bind_host)
     ports = ensure_list(ports)
     for port in ports:
         port = Port.wrap(port)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When starting the DNS server, we check if we can publish 0.0.0.0:53, but on systems running systemd-resolved, 127.0.0.1:53 is bindable but 127.0.0.53 is not and the check returns falsy.


<!-- What notable changes does this PR make? -->
## Changes

We allow a custom host to be tested for whether a port can be bound or not.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

