### PR TITLE
[SFN] ApiGW url implicit endpoint conversion

### DIFF
--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
@@ -14,7 +14,11 @@ from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
 from tests.aws.services.stepfunctions.templates.services.services_templates import (
     ServicesTemplates as ST,
 )
-from tests.aws.services.stepfunctions.utils import create_and_record_execution
+from tests.aws.services.stepfunctions.utils import create_and_record_execution, is_old_provider
+
+pytestmark = pytest.mark.skipif(
+    condition=is_old_provider(), reason="Test suite for v2 provider only."
+)
 
 
 @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
@@ -14,11 +14,7 @@ from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
 from tests.aws.services.stepfunctions.templates.services.services_templates import (
     ServicesTemplates as ST,
 )
-from tests.aws.services.stepfunctions.utils import create_and_record_execution, is_old_provider
-
-pytestmark = pytest.mark.skipif(
-    condition=is_old_provider(), reason="Test suite for v2 provider only."
-)
+from tests.aws.services.stepfunctions.utils import create_and_record_execution
 
 
 @markers.snapshot.skip_snapshot_verify(
@@ -233,10 +229,7 @@ class TestTaskApiGateway:
             None,
             "",
             "HelloWorld",
-            json.dumps("HelloWorld"),
-            json.dumps(0),
-            json.dumps(True),
-            json.dumps({"message": "HelloWorld!"}),
+            {"message": "HelloWorld!"},
         ],
     )
     @markers.aws.unknown

--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.snapshot.json
@@ -449,7 +449,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py::TestTaskApiGateway::test_invoke_with_body_post[None]": {
-    "recorded-date": "20-08-2023, 15:22:22",
+    "recorded-date": "25-08-2023, 12:40:49",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -642,7 +642,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py::TestTaskApiGateway::test_invoke_with_body_post[]": {
-    "recorded-date": "20-08-2023, 15:22:44",
+    "recorded-date": "25-08-2023, 12:41:13",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -835,7 +835,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py::TestTaskApiGateway::test_invoke_with_body_post[HelloWorld]": {
-    "recorded-date": "20-08-2023, 15:23:11",
+    "recorded-date": "25-08-2023, 12:41:49",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1895,6 +1895,211 @@
             "previousEventId": 5,
             "timestamp": "timestamp",
             "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py::TestTaskApiGateway::test_invoke_with_body_post[request_body3]": {
+    "recorded-date": "25-08-2023, 12:42:12",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "ApiEndpoint": "<api-endpoint>",
+                "Method": "POST",
+                "Path": "id_func",
+                "Stage": "sfn-apigw-api",
+                "RequestBody": {
+                  "message": "HelloWorld!"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "ApiEndpoint": "<api-endpoint>",
+                "Method": "POST",
+                "Path": "id_func",
+                "Stage": "sfn-apigw-api",
+                "RequestBody": {
+                  "message": "HelloWorld!"
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ApiGatewayInvoke"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Path": "id_func",
+                "Stage": "sfn-apigw-api",
+                "ApiEndpoint": "<api-endpoint>",
+                "Method": "POST",
+                "RequestBody": {
+                  "message": "HelloWorld!"
+                }
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "apigateway"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "apigateway"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "26"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "<headers-date>",
+                  "Via": "<headers-Via>",
+                  "x-amz-apigw-id": "<headers-x-amz-apigw-id>",
+                  "X-Amz-Cf-Id": "<headers-X-Amz-Cf-Id>",
+                  "X-Amz-Cf-Pop": "<headers-X-Amz-Cf-Pop>",
+                  "x-amzn-RequestId": "<headers-x-amzn-RequestId>",
+                  "X-Amzn-Trace-Id": "<headers-X-Amzn-Trace-Id>",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "message": "HelloWorld!"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "invoke",
+              "resourceType": "apigateway"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "ApiGatewayInvoke",
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "26"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "<headers-date>",
+                  "Via": "<headers-Via>",
+                  "x-amz-apigw-id": "<headers-x-amz-apigw-id>",
+                  "X-Amz-Cf-Id": "<headers-X-Amz-Cf-Id>",
+                  "X-Amz-Cf-Pop": "<headers-X-Amz-Cf-Pop>",
+                  "x-amzn-RequestId": "<headers-x-amzn-RequestId>",
+                  "X-Amzn-Trace-Id": "<headers-X-Amzn-Trace-Id>",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "message": "HelloWorld!"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "26"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "<headers-date>",
+                  "Via": "<headers-Via>",
+                  "x-amz-apigw-id": "<headers-x-amz-apigw-id>",
+                  "X-Amz-Cf-Id": "<headers-X-Amz-Cf-Id>",
+                  "X-Amz-Cf-Pop": "<headers-X-Amz-Cf-Pop>",
+                  "x-amzn-RequestId": "<headers-x-amzn-RequestId>",
+                  "X-Amzn-Trace-Id": "<headers-X-Amzn-Trace-Id>",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "message": "HelloWorld!"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When evaluating `StepFunction`'s `ApiGateway` tasks, the provided `ApiEndpoint` is converted to a path style LocalStack endpoint, if a url one is provided.
Improves loading of json `ResponseBody` and removes out of scope test inputs.

<!-- What notable changes does this PR make? -->
## Changes
Added url transformation logic to the `ApiGateway`'s task resolver, as well as json request body parsing attempt.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

