### PR TITLE
bump version of airspeed to 0.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ localstack =
 [options.extras_require]
 # required to actually run localstack on the host
 runtime =
-    airspeed-ext==0.6.0
+    airspeed-ext>=0.6.1
     amazon_kclpy>=2.0.6,!=2.1.0
     antlr4-python3-runtime==4.12.0
     apispec>=5.1.1


### PR DESCRIPTION
## Motivation

Bump version of airspeed to 0.6.1 - there have recently been some enhancements for handling of multi-line dict expressions: https://github.com/localstack/airspeed/pull/11

## Changes

The PR updates `airspeed-ext` to `>= 0.6.1` - I'd argue we can use an open version range (instead of exact pin), as we're now in full control of our airspeed fork, and the functionality is covered by shapshot tests, so breaking changes should be unlikely. Using a version range will allow us to move a bit more quickly, not having to bump the version across different repos each time.