### PR TITLE
fix global analytics bus to correctly disable tracking

### DIFF
--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -257,6 +257,12 @@ class GlobalAnalyticsBus(PublisherBuffer):
             response = self._client.start_session(get_client_metadata())
             if config.DEBUG_ANALYTICS:
                 LOG.debug("session endpoint returned: %s", response)
+
+            if not response.track_events():
+                if config.DEBUG_ANALYTICS:
+                    LOG.debug("gracefully disabling analytics tracking")
+                self.tracking_disabled = True
+
         except Exception:
             self.tracking_disabled = True
             if config.DEBUG_ANALYTICS:

--- a/tests/unit/utils/analytics/test_publisher.py
+++ b/tests/unit/utils/analytics/test_publisher.py
@@ -3,6 +3,8 @@ import threading
 from queue import Queue
 from typing import List
 
+import pytest
+
 from localstack.utils.analytics import GlobalAnalyticsBus
 from localstack.utils.analytics.client import AnalyticsClient
 from localstack.utils.analytics.events import Event, EventMetadata
@@ -106,9 +108,44 @@ class TestGlobalAnalyticsBus:
         request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
         assert request.path == "/v0/session"
         assert response.json["track_events"]
-
+        assert not bus.tracking_disabled
         bus.handle(new_event())  # should flush here because of flush_size 2
 
         request, _ = retry(httpserver.log.pop, sleep=0.2, retries=10)
         assert request.path == "/v0/events"
         assert len(request.json["events"]) == 2
+
+    @pytest.mark.parametrize("status_code", [200, 403])
+    def test_with_track_events_disabled(self, httpserver, status_code):
+        httpserver.expect_request("/v1/session").respond_with_json(
+            {"track_events": False},
+            status=status_code,
+        )
+        httpserver.expect_request("/v1/events").respond_with_data(b"")
+
+        client = AnalyticsClient(httpserver.url_for("/v1"))
+        bus = GlobalAnalyticsBus(client=client, flush_size=2)
+        bus.force_tracking = True
+
+        bus.handle(new_event())
+
+        # first event should trigger registration
+        request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
+        assert request.path == "/v1/session"
+        assert not response.json["track_events"]
+        assert bus.tracking_disabled
+
+    def test_with_session_error_response(self, httpserver):
+        httpserver.expect_request("/v1/session").respond_with_data(b"oh noes", status=418)
+        httpserver.expect_request("/v1/events").respond_with_data(b"")
+
+        client = AnalyticsClient(httpserver.url_for("/v1"))
+        bus = GlobalAnalyticsBus(client=client, flush_size=2)
+        bus.force_tracking = True
+
+        bus.handle(new_event())
+
+        # first event should trigger registration
+        request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
+        assert request.path == "/v1/session"
+        assert bus.tracking_disabled


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While working on the analytics backend, we noticed that the client actually isn't reacting to `track_events=False` responses from the server. Good catch @ackdav.

<!-- What notable changes does this PR make? -->
## Changes

* Properly disable the global analytics bus if the backend responds with `track_events=False`
* Add a gate for 403 errors, which we will introduce in the analytics backend to properly terminate older clients. In the older clients a 403 would trigger an exception in the `AnalyticsClient.start_session` method, also leading to disabling of tracking, albeit less gracefully.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

