### PR TITLE
Fix parameter validation for self-managed Kafka event source mapping

### DIFF
--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1689,10 +1689,15 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         context: RequestContext,
         request: CreateEventSourceMappingRequest,
     ) -> EventSourceMappingConfiguration:
-        if "EventSourceArn" not in request:
-            raise InvalidParameterValueException("Unrecognized event source.", Type="User")
+        service = None
 
-        service = extract_service_from_arn(request["EventSourceArn"])
+        if "SelfManagedEventSource" in request:
+            service = "kafka"
+
+        if service is None and "EventSourceArn" not in request:
+            raise InvalidParameterValueException("Unrecognized event source.", Type="User")
+        if service is None:
+            service = extract_service_from_arn(request["EventSourceArn"])
         if service in ["dynamodb", "kinesis", "kafka"] and "StartingPosition" not in request:
             raise InvalidParameterValueException(
                 "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

(Open for suggestions and discussions)

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When creating an event-source-mapping localstack is validating some not mandatory parameters.

<!-- What notable changes does this PR make? -->
## Changes

Removed check for non mandatory parameter and added check for self-managed-kafka service

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->


---

In our scenario we are trying to create the lambda using `sam` but it fails with the event-source-mapping

```
Resources:
  MyLambda:
    Type: AWS::Serverless::Function
    Properties:
      Handler: handler.lambda_handler
      Events:
        SelfManagedKafkaEvent:
          Type: SelfManagedKafka
          Properties:
            KafkaBootstrapServers:
              - <host:port>
            ConsumerGroupId: MyLambda
            SourceAccessConfigurations:
              - Type: BASIC_AUTH
                URI: arn:aws:secretsmanager:eu-central-1:000000000000:secret:kafka/local-nTMBRS
            Topics:
              - <topic>
```

But it fails, asking for `EventSourceArn` which is not mandatory for self-managed kafka.

Same for the cli:
```
awslocal lambda create-event-source-mapping \
 --topics <topic> \
 --function-name arn:aws:lambda:eu-central-1:000000000000:function:MyLambda \
 --self-managed-event-source '{"Endpoints":{"KAFKA_BOOTSTRAP_SERVERS":["<host:port>"]}}' \
 --source-access-configuration Type=BASIC_AUTH,URI=arn:aws:secretsmanager:eu-central-1:000000000000:secret:kafka/local-nTMBRS \
  --starting-position LATEST
```