### PR TITLE
Enable sqs sse by default

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -236,7 +236,7 @@ class SqsQueue:
             QueueAttributeName.QueueArn: self.arn,
             QueueAttributeName.ReceiveMessageWaitTimeSeconds: "0",
             QueueAttributeName.VisibilityTimeout: "30",
-            QueueAttributeName.SqsManagedSseEnabled: "false",
+            QueueAttributeName.SqsManagedSseEnabled: "true",
         }
 
     def update_delay_seconds(self, value: int):

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -257,6 +257,12 @@ class GlobalAnalyticsBus(PublisherBuffer):
             response = self._client.start_session(get_client_metadata())
             if config.DEBUG_ANALYTICS:
                 LOG.debug("session endpoint returned: %s", response)
+
+            if not response.track_events():
+                if config.DEBUG_ANALYTICS:
+                    LOG.debug("gracefully disabling analytics tracking")
+                self.tracking_disabled = True
+
         except Exception:
             self.tracking_disabled = True
             if config.DEBUG_ANALYTICS:

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -124,12 +124,6 @@ def create_lambda_archive(
         return result
 
 
-# TODO: remove all occurrences
-def delete_lambda_function(name, region_name: str = None):
-    client = connect_externally_to(region_name=region_name).lambda_
-    client.delete_function(FunctionName=name)
-
-
 def create_zip_file(
     file_path: str,
     zip_file: str = None,

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1694,8 +1694,8 @@ def test_rest_api_multi_region(
 
     delete_rest_api(apigateway_client_eu, restApiId=api_eu_id)
     delete_rest_api(apigateway_client_us, restApiId=api_us_id)
-    testutil.delete_lambda_function(name=lambda_name, region_name="eu-west-1")
-    testutil.delete_lambda_function(name=lambda_name, region_name="us-west-1")
+    aws_client_factory(region_name="eu-west-1").lambda_.delete_function(FunctionName=lambda_name)
+    aws_client_factory(region_name="us-west-1").lambda_.delete_function(FunctionName=lambda_name)
 
 
 class TestIntegrations:

--- a/tests/aws/services/lambda_/test_lambda_whitebox.py
+++ b/tests/aws/services/lambda_/test_lambda_whitebox.py
@@ -307,7 +307,7 @@ class TestDockerExecutors:
         assert 0 == len(executor.get_all_container_names())
 
         # clean up
-        testutil.delete_lambda_function(func_name)
+        aws_client.lambda_.delete_function(FunctionName=func_name)
 
     @pytest.mark.skipif(
         condition=not isinstance(
@@ -356,7 +356,7 @@ class TestDockerExecutors:
         retry(assert_container_destroyed, retries=3)
 
         # clean up
-        testutil.delete_lambda_function(func_name)
+        aws_client.lambda_.delete_function(FunctionName=func_name)
 
     @pytest.mark.skipif(
         condition=not isinstance(
@@ -384,7 +384,7 @@ class TestDockerExecutors:
         assert "FunctionError" not in result
 
         # clean up
-        testutil.delete_lambda_function(func_name)
+        aws_client.lambda_.delete_function(FunctionName=func_name)
 
 
 class TestLocalExecutors:
@@ -432,8 +432,8 @@ class TestLocalExecutors:
             assert "setting2" in to_str(result_data2)
 
             # clean up
-            testutil.delete_lambda_function(lambda_name1)
-            testutil.delete_lambda_function(lambda_name2)
+            lambda_client.delete_function(FunctionName=lambda_name1)
+            lambda_client.delete_function(FunctionName=lambda_name2)
         finally:
             lambda_api.DO_USE_DOCKER = original_do_use_docker
 

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -457,7 +457,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail": {
-    "recorded-date": "22-08-2022, 21:28:31",
+    "recorded-date": "29-08-2023, 11:03:34",
     "recorded-content": {
       "purge_queue_error": {
         "Error": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -597,7 +597,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_too_many_entries_in_batch_request": {
-    "recorded-date": "27-10-2022, 20:25:28",
+    "recorded-date": "29-08-2023, 11:02:09",
     "recorded-content": {
       "test_too_many_entries_in_batch_request": {
         "Error": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -336,12 +336,12 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes": {
-    "recorded-date": "01-08-2022, 21:14:43",
+    "recorded-date": "29-08-2023, 11:04:58",
     "recorded-content": {
       "sse_kms_attributes": {
         "Attributes": {
-          "KmsMasterKeyId": "testKeyId",
           "KmsDataKeyReusePeriodSeconds": "6000",
+          "KmsMasterKeyId": "testKeyId",
           "SqsManagedSseEnabled": "false"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -180,109 +180,84 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters": {
-    "recorded-date": "31-05-2022, 12:18:44",
+    "recorded-date": "29-08-2023, 11:15:01",
     "recorded-content": {
       "all_attributes": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>",
-            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
-            "Body": "msg",
             "Attributes": {
-              "SenderId": "<sender-id:1>",
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id:1>",
               "SentTimestamp": "timestamp"
-            }
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "all_system_and_message_attributes": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:2>",
-            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
-            "Body": "msg",
             "Attributes": {
-              "SenderId": "<sender-id:1>",
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "2",
+              "SenderId": "<sender-id:1>",
               "SentTimestamp": "timestamp"
             },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
             "MD5OfMessageAttributes": "ae7155c6026991b6d54b11589678bf9c",
             "MessageAttributes": {
               "Foo": {
-                "StringValue": "Bar",
-                "DataType": "String"
+                "DataType": "String",
+                "StringValue": "Bar"
               }
-            }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "single_attribute": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:3>",
-            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
-            "Body": "msg",
             "Attributes": {
               "SenderId": "<sender-id:1>"
-            }
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:3>"
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "multiple_attributes": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:4>",
-            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
-            "Body": "msg",
             "Attributes": {
               "SenderId": "<sender-id:1>"
-            }
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:4>"
           }
         ],
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_attributes": {
-    "recorded-date": "01-08-2022, 20:33:31",
-    "recorded-content": {
-      "get_queue_attributes": {
-        "Attributes": {
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
-          "ApproximateNumberOfMessagesDelayed": "0",
-          "CreatedTimestamp": "timestamp",
-          "LastModifiedTimestamp": "timestamp",
-          "VisibilityTimeout": "20",
-          "MaximumMessageSize": "262144",
-          "MessageRetentionPeriod": "604800",
-          "DelaySeconds": "0",
-          "ReceiveMessageWaitTimeSeconds": "10",
-          "SqsManagedSseEnabled": "false"
-        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -291,22 +266,22 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_and_update_queue_attributes": {
-    "recorded-date": "01-08-2022, 20:51:00",
+    "recorded-date": "29-08-2023, 11:14:51",
     "recorded-content": {
       "get_queue_attributes": {
         "Attributes": {
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
           "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
           "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
           "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "0",
           "LastModifiedTimestamp": "timestamp",
-          "VisibilityTimeout": "20",
           "MaximumMessageSize": "262144",
           "MessageRetentionPeriod": "604800",
-          "DelaySeconds": "0",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
           "ReceiveMessageWaitTimeSeconds": "10",
-          "SqsManagedSseEnabled": "false"
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "20"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -315,18 +290,18 @@
       },
       "get_updated_queue_attributes": {
         "Attributes": {
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
           "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
           "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
           "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "420",
           "LastModifiedTimestamp": "timestamp",
-          "VisibilityTimeout": "69",
           "MaximumMessageSize": "2048",
           "MessageRetentionPeriod": "604800",
-          "DelaySeconds": "420",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
           "ReceiveMessageWaitTimeSeconds": "10",
-          "SqsManagedSseEnabled": "false"
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "69"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -367,29 +342,29 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails": {
-    "recorded-date": "03-08-2022, 18:36:23",
+    "recorded-date": "29-08-2023, 11:14:59",
     "recorded-content": {
       "send_message": "An error occurred (InvalidParameterValue) when calling the SendMessage operation: Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type."
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception": {
-    "recorded-date": "04-08-2022, 17:27:47",
+    "recorded-date": "29-08-2023, 11:14:54",
     "recorded-content": {
       "create_queue_01": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds",
       "create_queue_02": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds"
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes": {
-    "recorded-date": "21-08-2022, 00:35:54",
+    "recorded-date": "29-08-2023, 11:14:58",
     "recorded-content": {
       "send_message": {
         "MD5OfMessageBody": "19c9e282d65f9733bc6b35d50062c7ee",
         "MessageId": "<uuid:1>",
+        "SequenceNumber": "<sequence-number:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "SequenceNumber": "<sequence-number:1>"
+        }
       },
       "receive_message_0": {
         "Messages": [
@@ -440,7 +415,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_dead_letter_arn_rejected_before_lookup": {
-    "recorded-date": "21-08-2022, 00:54:10",
+    "recorded-date": "29-08-2023, 11:14:59",
     "recorded-content": {
       "error_response": {
         "Error": {
@@ -491,7 +466,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_updated_maximum_message_size": {
-    "recorded-date": "12-11-2022, 15:19:10",
+    "recorded-date": "29-08-2023, 11:15:06",
     "recorded-content": {
       "send_oversized_message": {
         "Error": {
@@ -508,7 +483,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents": {
-    "recorded-date": "13-11-2022, 13:33:00",
+    "recorded-date": "29-08-2023, 11:15:03",
     "recorded-content": {
       "send_oversized_message_batch": {
         "Error": {
@@ -525,7 +500,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size": {
-    "recorded-date": "13-11-2022, 13:39:28",
+    "recorded-date": "29-08-2023, 11:15:05",
     "recorded-content": {
       "send_oversized_message_batch": {
         "Successful": [
@@ -549,7 +524,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[]": {
-    "recorded-date": "13-10-2022, 19:19:31",
+    "recorded-date": "29-08-2023, 11:14:55",
     "recorded-content": {
       "error_response": {
         "Error": {
@@ -565,7 +540,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[testLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongId]": {
-    "recorded-date": "13-10-2022, 19:19:31",
+    "recorded-date": "29-08-2023, 11:14:56",
     "recorded-content": {
       "error_response": {
         "Error": {
@@ -581,7 +556,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[invalid:id]": {
-    "recorded-date": "13-10-2022, 19:19:32",
+    "recorded-date": "29-08-2023, 11:14:57",
     "recorded-content": {
       "error_response": {
         "Error": {

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -474,7 +474,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_oversized_message": {
-    "recorded-date": "12-11-2022, 15:12:26",
+    "recorded-date": "29-08-2023, 11:09:40",
     "recorded-content": {
       "send_oversized_message": {
         "Error": {

--- a/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -218,11 +218,11 @@ def setup_and_tear_down(aws_client):
 
     yield
 
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_1)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_2)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_3)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_4)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_5)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_1)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_2)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_3)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_4)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_5)
 
 
 @pytest.fixture

--- a/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
+++ b/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
@@ -227,11 +227,11 @@ def setup_and_tear_down(aws_client):
 
     yield
 
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_1)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_2)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_3)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_4)
-    testutil.delete_lambda_function(name=TEST_LAMBDA_NAME_5)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_1)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_2)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_3)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_4)
+    aws_client.lambda_.delete_function(FunctionName=TEST_LAMBDA_NAME_5)
 
 
 def _assert_machine_instances(expected_instances, sfn_client):

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -74,7 +74,7 @@ def scheduled_test_lambda(aws_client):
 
     aws_client.events.remove_targets(Rule=rule_name, Ids=[target_id])
     aws_client.events.delete_rule(Name=rule_name)
-    testutil.delete_lambda_function(scheduled_lambda_name)
+    aws_client.lambda_.delete_function(FunctionName=scheduled_lambda_name)
 
 
 @pytest.mark.usefixtures("scheduled_test_lambda")

--- a/tests/unit/utils/analytics/test_publisher.py
+++ b/tests/unit/utils/analytics/test_publisher.py
@@ -3,6 +3,8 @@ import threading
 from queue import Queue
 from typing import List
 
+import pytest
+
 from localstack.utils.analytics import GlobalAnalyticsBus
 from localstack.utils.analytics.client import AnalyticsClient
 from localstack.utils.analytics.events import Event, EventMetadata
@@ -106,9 +108,44 @@ class TestGlobalAnalyticsBus:
         request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
         assert request.path == "/v0/session"
         assert response.json["track_events"]
-
+        assert not bus.tracking_disabled
         bus.handle(new_event())  # should flush here because of flush_size 2
 
         request, _ = retry(httpserver.log.pop, sleep=0.2, retries=10)
         assert request.path == "/v0/events"
         assert len(request.json["events"]) == 2
+
+    @pytest.mark.parametrize("status_code", [200, 403])
+    def test_with_track_events_disabled(self, httpserver, status_code):
+        httpserver.expect_request("/v1/session").respond_with_json(
+            {"track_events": False},
+            status=status_code,
+        )
+        httpserver.expect_request("/v1/events").respond_with_data(b"")
+
+        client = AnalyticsClient(httpserver.url_for("/v1"))
+        bus = GlobalAnalyticsBus(client=client, flush_size=2)
+        bus.force_tracking = True
+
+        bus.handle(new_event())
+
+        # first event should trigger registration
+        request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
+        assert request.path == "/v1/session"
+        assert not response.json["track_events"]
+        assert bus.tracking_disabled
+
+    def test_with_session_error_response(self, httpserver):
+        httpserver.expect_request("/v1/session").respond_with_data(b"oh noes", status=418)
+        httpserver.expect_request("/v1/events").respond_with_data(b"")
+
+        client = AnalyticsClient(httpserver.url_for("/v1"))
+        bus = GlobalAnalyticsBus(client=client, flush_size=2)
+        bus.force_tracking = True
+
+        bus.handle(new_event())
+
+        # first event should trigger registration
+        request, response = retry(httpserver.log.pop, sleep=0.2, retries=10)
+        assert request.path == "/v1/session"
+        assert bus.tracking_disabled


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While updating the outdated snapshots, it became apparent that AWS is enabling SQS server side encryption by default [since 17/8/22
](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/step-create-queue.html). This PR addresses this in a mock fashion.
<!-- What notable changes does this PR make? -->
## Changes
- set `SqsManagedSseEnabled` to true by default whenever a new queue is created 

## TODO
- [ ] Clarify if a mock is enough
  - [ ] if not, implement encryption


