### PR TITLE
Revert hypercorn binding to privileged ports

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -488,11 +488,6 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
 
     # separate privileged and unprivileged addresses
     unprivileged, privileged = split_list_by(listen, lambda addr: addr.is_unprivileged() or False)
-    if is_root():
-        # we don't need to split since we are already root, so move all
-        # privileged ports to unprivileged and serve via hypercorn
-        unprivileged = unprivileged + privileged
-        privileged = []
 
     # check that we are actually started the gateway server
     if not unprivileged:


### PR DESCRIPTION


<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When binding hypercorn on privileged ports, if one of the ports is not available the entire hypercorn server will fail to bind, leaving LocalStack in a terminal failure state. This state is not caught in a user friendly way (the background thread dies leaving a traceback).



<!-- What notable changes does this PR make? -->
## Changes

* This reverts commit 8246af9a3e3a8e1d17ead01932018c985c27aba2.
    * allow hypercorn to only bind on unprivileged ports, and revert to using TCP proxies for unprivileged ports, meaning that at least hypercorn should be able to bind to _something_ even if the proxies fail


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

