### PR TITLE
fix value of for CidrBlockAssociations in AWS::EC2::VPC

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -471,7 +471,7 @@ class EC2VPC(GenericBaseModel):
             resource["Properties"]["VpcId"] = vpc_id
             resource["Properties"]["CidrBlock"] = result["Vpc"]["CidrBlock"]
             resource["Properties"]["CidrBlockAssociations"] = [
-                cba["CidrBlock"] for cba in result["Vpc"]["CidrBlockAssociationSet"]
+                cba["AssociationId"] for cba in result["Vpc"]["CidrBlockAssociationSet"]
             ]
             # resource["Properties"]["Ipv6CidrBlocks"] = ?
             resource["Properties"]["DefaultNetworkAcl"] = _get_default_acl_for_vpc(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While adding the resource for AWS::EC2::VPCCidrBlock as mentioned in https://github.com/localstack/localstack/issues/8511 in cloud formation template, there were parity issues found in resource `AWS::EC2::VPC`. 

<!-- What notable changes does this PR make? -->
## Changes
This PR fixes value for param `CidrBlockAssociations`. 

## Testing
Related test added in [#2018](https://github.com/localstack/localstack-ext/pull/2018)

<!-- The following sections are optional, but can be useful! 

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

