### PR TITLE
Add get_docker_host_from_container(..) util to remove DNS operations from config.py

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -729,28 +729,10 @@ if not DOCKER_BRIDGE_IP:
     if is_in_docker:
         candidates = (DOCKER_BRIDGE_IP, "172.18.0.1")
         for ip in candidates:
+            # TODO: remove from here - should not perform I/O operations in top-level config.py
             if ping(ip):
                 DOCKER_BRIDGE_IP = ip
                 break
-
-# determine route to Docker host from container
-try:
-    DOCKER_HOST_FROM_CONTAINER = DOCKER_BRIDGE_IP
-    if not is_in_docker and not is_in_linux:
-        # If we're running outside docker, and would like the Lambda containers to be able
-        # to access services running on the local machine, set DOCKER_HOST_FROM_CONTAINER accordingly
-        if LOCALSTACK_HOSTNAME == LOCALHOST:
-            DOCKER_HOST_FROM_CONTAINER = "host.docker.internal"
-    # update LOCALSTACK_HOSTNAME if host.docker.internal is available
-    if is_in_docker:
-        try:
-            DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.docker.internal")
-        except socket.error:
-            DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.containers.internal")
-        if LOCALSTACK_HOSTNAME == DOCKER_BRIDGE_IP:
-            LOCALSTACK_HOSTNAME = DOCKER_HOST_FROM_CONTAINER
-except socket.error:
-    pass
 
 # -----
 # SERVICE-SPECIFIC CONFIGS BELOW

--- a/localstack/utils/container_networking.py
+++ b/localstack/utils/container_networking.py
@@ -7,6 +7,7 @@ from typing import Optional
 from localstack import config, constants
 from localstack.utils.container_utils.container_client import ContainerException
 from localstack.utils.docker_utils import DOCKER_CLIENT
+from localstack.utils.net import get_docker_host_from_container
 
 LOG = logging.getLogger(__name__)
 
@@ -94,7 +95,11 @@ def get_endpoint_for_network(network: Optional[str] = None) -> str:
     except Exception as e:
         LOG.info("Unable to get main container IP address: %s", e)
 
-    return main_container_ip or config.DOCKER_HOST_FROM_CONTAINER
+    if not main_container_ip:
+        # fall back to returning the hostname/IP of the Docker host, if we cannot determine the main container IP
+        return get_docker_host_from_container()
+
+    return main_container_ip
 
 
 def get_main_container_ip():

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -2,10 +2,17 @@ import socket
 
 import pytest as pytest
 
-from localstack.constants import LOCALHOST
+from localstack import config
+from localstack.constants import LOCALHOST, LOCALHOST_HOSTNAME, LOCALHOST_IP
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
-from localstack.utils.net import Port, get_free_udp_port, port_can_be_bound, resolve_hostname
+from localstack.utils.net import (
+    Port,
+    get_addressable_container_host,
+    get_free_udp_port,
+    port_can_be_bound,
+    resolve_hostname,
+)
 
 
 @markers.skip_offline
@@ -39,3 +46,14 @@ def test_port_open(protocol):
 def test_get_free_udp_port():
     port = get_free_udp_port()
     assert port_can_be_bound(Port(port, "udp"))
+
+
+def test_get_addressable_container_host(monkeypatch):
+    if not config.is_in_docker:
+        monkeypatch.setattr(config, "is_in_docker", True)
+        monkeypatch.setattr(config, "in_docker", lambda: True)
+        assert get_addressable_container_host() == LOCALHOST_IP
+
+    monkeypatch.setattr(config, "is_in_docker", False)
+    monkeypatch.setattr(config, "in_docker", lambda: False)
+    assert get_addressable_container_host(default_local_hostname="test.abc") == "test.abc"

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -3,13 +3,14 @@ import socket
 import pytest as pytest
 
 from localstack import config
-from localstack.constants import LOCALHOST, LOCALHOST_IP
+from localstack.constants import LOCALHOST
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 from localstack.utils.net import (
     Port,
     get_addressable_container_host,
     get_free_udp_port,
+    is_ip_address,
     port_can_be_bound,
     resolve_hostname,
 )
@@ -52,7 +53,7 @@ def test_get_addressable_container_host(monkeypatch):
     if not config.is_in_docker:
         monkeypatch.setattr(config, "is_in_docker", True)
         monkeypatch.setattr(config, "in_docker", lambda: True)
-        assert get_addressable_container_host() == LOCALHOST_IP
+        assert is_ip_address(get_addressable_container_host())
 
     monkeypatch.setattr(config, "is_in_docker", False)
     monkeypatch.setattr(config, "in_docker", lambda: False)

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -3,7 +3,7 @@ import socket
 import pytest as pytest
 
 from localstack import config
-from localstack.constants import LOCALHOST, LOCALHOST_HOSTNAME, LOCALHOST_IP
+from localstack.constants import LOCALHOST, LOCALHOST_IP
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 from localstack.utils.net import (


### PR DESCRIPTION
## Motivation

We should ideally not be performing I/O operations in the top-level import path, including `config.py`, but rather defer such operations until they are actually required. This has recently surfaced as a reproducible issue in the Testcontainers Go module (https://github.com/testcontainers/testcontainers-go/issues/1495), causing very slow startups under Linux in certain circumstances.

## Changes

* add a `get_docker_host_from_container(..)` utility function to remove DNS operations from `config.py`
* remove top-level constant `DOCKER_HOST_FROM_CONTAINER` from `config.py`
* use the new `get_docker_host_from_container(..)` function from `get_endpoint_for_network(..)` in `container_networking.py`
* add `get_addressable_container_host(..)` utility, which covers a fairly common use case to get the addressable endpoint for a service running inside a container (depending on execution context, running either inside or outside of Docker)
