### PR TITLE
fix lambda layer version compatibility with Python 3.11

### DIFF
--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -90,6 +90,7 @@ URL_CHAR_SET = string.ascii_lowercase + string.digits
 # Date format as returned by the lambda service
 LAMBDA_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f+0000"
 
+# An unordered list of all Lambda runtimes supported by LocalStack.
 RUNTIMES = [
     Runtime.nodejs12_x,
     Runtime.nodejs14_x,
@@ -99,6 +100,7 @@ RUNTIMES = [
     Runtime.python3_8,
     Runtime.python3_9,
     Runtime.python3_10,
+    Runtime.python3_11,
     Runtime.ruby2_7,
     Runtime.ruby3_2,
     Runtime.java8,
@@ -112,6 +114,7 @@ RUNTIMES = [
     Runtime.provided_al2,
 ]
 
+# An unordered list of all Lambda CPU architectures supported by LocalStack.
 ARCHITECTURES = [Architecture.arm64, Architecture.x86_64]
 
 

--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -91,6 +91,7 @@ URL_CHAR_SET = string.ascii_lowercase + string.digits
 LAMBDA_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f+0000"
 
 # An unordered list of all Lambda runtimes supported by LocalStack.
+# Has to contain all elements of lambda_mapping.IMAGE_MAPPING.
 RUNTIMES = [
     Runtime.nodejs12_x,
     Runtime.nodejs14_x,

--- a/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack/services/lambda_/invocation/lambda_models.py
@@ -39,7 +39,7 @@ from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
 
-# To add support for a new runtime, just add it here with the accompanying image postfix
+# To add support for a new runtime, just add it here with the accompanying image postfix and to api_utils.RUNTIMES
 IMAGE_MAPPING = {
     "python3.7": "python:3.7",
     "python3.8": "python:3.8",

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -139,7 +139,7 @@ from localstack.aws.connect import connect_to
 from localstack.services.edge import ROUTER
 from localstack.services.lambda_ import api_utils
 from localstack.services.lambda_ import hooks as lambda_hooks
-from localstack.services.lambda_.api_utils import STATEMENT_ID_REGEX
+from localstack.services.lambda_.api_utils import ARCHITECTURES, STATEMENT_ID_REGEX
 from localstack.services.lambda_.event_source_listeners.event_source_listener import (
     EventSourceListener,
 )
@@ -671,7 +671,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
                     f"satisfy constraint: Member must have length less than or equal to 1",
                 )
-            if architectures[0] not in [Architecture.x86_64, Architecture.arm64]:
+            if architectures[0] not in ARCHITECTURES:
                 raise ValidationException(
                     f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
                     f"satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: "

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13041,5 +13041,120 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities": {
+    "recorded-date": "30-08-2023, 09:57:12",
+    "recorded-content": {
+      "publish_result": {
+        "CompatibleArchitectures": [
+          "arm64",
+          "x86_64"
+        ],
+        "CompatibleRuntimes": [
+          "nodejs12.x",
+          "nodejs14.x",
+          "nodejs16.x",
+          "nodejs18.x",
+          "python3.7",
+          "python3.8",
+          "python3.9",
+          "python3.10",
+          "python3.11",
+          "ruby2.7",
+          "ruby3.2",
+          "java8",
+          "java8.al2",
+          "java11"
+        ],
+        "Content": {
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Location": "<layer-location>"
+        },
+        "CreatedDate": "date",
+        "Description": "",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>:1",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
+    "recorded-date": "30-08-2023, 09:59:24",
+    "recorded-content": {
+      "publish_result": {
+        "CompatibleArchitectures": [
+          "arm64",
+          "x86_64"
+        ],
+        "CompatibleRuntimes": [
+          "nodejs12.x",
+          "nodejs14.x",
+          "nodejs16.x",
+          "nodejs18.x",
+          "python3.7",
+          "python3.8",
+          "python3.9",
+          "python3.10",
+          "python3.11",
+          "ruby2.7",
+          "ruby3.2",
+          "java8",
+          "java8.al2",
+          "java11"
+        ],
+        "Content": {
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Location": "<layer-location>"
+        },
+        "CreatedDate": "date",
+        "Description": "",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>:1",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
+    "recorded-date": "30-08-2023, 09:59:27",
+    "recorded-content": {
+      "publish_result": {
+        "CompatibleArchitectures": [
+          "arm64",
+          "x86_64"
+        ],
+        "CompatibleRuntimes": [
+          "java17",
+          "dotnetcore3.1",
+          "dotnet6",
+          "go1.x",
+          "provided",
+          "provided.al2"
+        ],
+        "Content": {
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Location": "<layer-location>"
+        },
+        "CreatedDate": "date",
+        "Description": "",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>:1",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -9,6 +9,8 @@ from unittest import mock
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.lambda_ import lambda_api, lambda_executors, lambda_utils
+from localstack.services.lambda_.api_utils import RUNTIMES
+from localstack.services.lambda_.invocation.lambda_models import IMAGE_MAPPING
 from localstack.services.lambda_.lambda_api import get_lambda_policy_name
 from localstack.services.lambda_.lambda_executors import OutputLog
 from localstack.services.lambda_.lambda_utils import (
@@ -1173,3 +1175,11 @@ class TestLambdaUtils:
         policy_name2 = get_lambda_policy_name(lambda_api.func_arn(func_name))
         assert func_name in policy_name1
         assert policy_name1 == policy_name2
+
+    def test_check_runtime(self):
+        """
+        Make sure that the list of runtimes to test at least contains all mapped runtime images.
+        This is a test which ensures that runtimes considered for validation do not diverge from the supported runtimes.
+        See #9020 for more details.
+        """
+        assert set(RUNTIMES) == set(IMAGE_MAPPING.keys())


### PR DESCRIPTION
## Motivation
This PR fixes an issue where Lambda layer compatibility check failed for the `python3.11` runtime:
```
$ awslocal lambda publish-layer-version --layer-name layer1 --zip-file fileb://.serverless/MyLayer.zip --compatible-runtimes python3.11

An error occurred (ValidationException) when calling the PublishLayerVersion operation: 1 validation error detected: Value '[python3.11]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [java17, provided, nodejs16.x, nodejs14.x, ruby2.7, python3.10, java11, python3.11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, ruby3.2, python3.7, python3.8, python3.9]
```

## Changes
This PR adds `python3.11` to the list of supported runtimes for Lambda layer validation.

## Testing
A snapshot verified test creating a Lambda layer with all possible validations.
However, this test does not save us from the same mistake happening again, because it uses the list of `RUNTIMES` which is used by the validation.
Initially, I wanted to use the keys of the `IMAGE_MAPPING` dict (which is described as the dict where newly supported runtimes should be added), but this mapping is contained in `lambda_models` (even though I think it's not a model).
We could move this mapping from there and directly use it for the runtime validation, then this issue could not happen in the future again. Happy for any feedback!