### PR TITLE
fix python installer when running LS from venv module

### DIFF
--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -8,7 +8,8 @@ from typing import Optional
 
 import requests
 
-from ..config import dirs
+from localstack import config
+
 from ..constants import LOCALSTACK_VENV_FOLDER
 from ..utils.archives import download_and_extract
 from ..utils.files import chmod_r, chown_r, mkdir, rm_rf
@@ -112,7 +113,7 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         download_and_extract(
             download_url,
             retries=3,
-            tmp_archive=os.path.join(dirs.tmp, archive_name),
+            tmp_archive=os.path.join(config.dirs.tmp, archive_name),
             target_dir=target_directory,
         )
         if self.extract_single_directory:

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -8,8 +8,8 @@ from typing import Optional
 
 import requests
 
-from localstack import config, constants
-
+from ..config import dirs
+from ..constants import LOCALSTACK_VENV_FOLDER
 from ..utils.archives import download_and_extract
 from ..utils.files import chmod_r, chown_r, mkdir, rm_rf
 from ..utils.http import download
@@ -112,7 +112,7 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         download_and_extract(
             download_url,
             retries=3,
-            tmp_archive=os.path.join(config.dirs.tmp, archive_name),
+            tmp_archive=os.path.join(dirs.tmp, archive_name),
             target_dir=target_directory,
         )
         if self.extract_single_directory:
@@ -234,7 +234,7 @@ class NodePackageInstaller(ExecutableInstaller):
             chown_r(target_dir, "root")
 
 
-LOCALSTACK_VENV = VirtualEnvironment(os.path.join(constants.LOCALSTACK_ROOT_FOLDER, ".venv"))
+LOCALSTACK_VENV = VirtualEnvironment(LOCALSTACK_VENV_FOLDER)
 
 
 class PythonPackageInstaller(PackageInstaller):


### PR DESCRIPTION
## Motivation
This PR fixes a bug introduced with #8685.
The new `PythonPackageInstaller` detects the `venv` based on `constants.LOCALSTACK_ROOT_FOLDER`.
Unfortunately, this doesn't work if `localstack-core` is installed in the venv, so `LOCALSTACK_ROOT_FOLDER` is within the venv, resulting in a wrong venv dir detection.
This can easily be reproduced with the following `Dockerfile`:
```
FROM localstack/localstack-pro:latest
RUN export DEBUG=1; source .venv/bin/activate && python -m localstack.cli.lpm install vosk
```

It results in the following error:
```
0.623 installing... Vosk
0.624 2023-08-30T10:07:08.063 DEBUG --- [d-1 (worker)] localstack.packages.api    : Starting installation of vosk...
0.624 2023-08-30T10:07:08.064  INFO --- [d-1 (worker)] localstack.packages.core   : creating virtual environment at /usr/lib/localstack/python-packages
3.238 2023-08-30T10:07:10.678  INFO --- [d-1 (worker)] localstack.packages.core   : adding localstack venv path /usr/lib/localstack/python-packages
3.240 error installing Vosk: Installation of vosk failed.
3.243 2023-08-30T10:07:10.681 DEBUG --- [  MainThread] __main__                   : one or more package installations failed.
3.243 Traceback (most recent call last):
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/packages/api.py", line 90, in install
3.243     self._prepare_installation(target)
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/packages/core.py", line 283, in _prepare_installation
3.243     venv.add_pth("localstack-venv", LOCALSTACK_VENV)
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/utils/venv.py", line 92, in add_pth
3.243     path = path.site_dir
3.243   File "/usr/local/lib/python3.10/functools.py", line 981, in __get__
3.243     val = self.func(instance)
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/utils/venv.py", line 61, in site_dir
3.243     raise FileNotFoundError(f"expected venv directory to exist at {venv}")
3.243 FileNotFoundError: expected venv directory to exist at /opt/code/localstack/.venv/lib/python3.10/site-packages/.venv
3.243 
3.243 The above exception was the direct cause of the following exception:
3.243 
3.243 Traceback (most recent call last):
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/cli/lpm.py", line 102, in install
3.243     pool.starmap(
3.243   File "/usr/local/lib/python3.10/multiprocessing/pool.py", line 375, in starmap
3.243     return self._map_async(func, iterable, starmapstar, chunksize).get()
3.243   File "/usr/local/lib/python3.10/multiprocessing/pool.py", line 774, in get
3.243     raise self._value
3.243   File "/usr/local/lib/python3.10/multiprocessing/pool.py", line 125, in worker
3.243     result = (True, func(*args, **kwds))
3.243   File "/usr/local/lib/python3.10/multiprocessing/pool.py", line 51, in starmapstar
3.243     return list(itertools.starmap(args[0], args[1]))
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/cli/lpm.py", line 50, in _do_install_package
3.243     raise e
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/cli/lpm.py", line 46, in _do_install_package
3.243     package.install(version=version, target=target)
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/packages/api.py", line 210, in install
3.243     self.get_installer(version).install(target)
3.243   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/packages/api.py", line 102, in install
3.243     raise PackageException(f"Installation of {self.name} failed.") from e
3.243 localstack.packages.api.PackageException: Installation of vosk failed.
3.243 Error: one or more package installations failed.
```

## Changes
This PR switches to `LOCALSTACK_VENV_FOLDER` to detect the venv.

## Testing
Unfortunately, this issue is somewhat hard to reproduce. This is why I recreated this fix in the aforementioned Dockerfile:
```
FROM localstack/localstack-pro:latest
RUN sed -i "s/LOCALSTACK_VENV =.*/LOCALSTACK_VENV = VirtualEnvironment(constants.LOCALSTACK_VENV_FOLDER)/g" .venv/lib/python3.10/site-packages/localstack/packages/core.py
RUN export DEBUG=1; source .venv/bin/activate && python -m localstack.cli.lpm install vosk
```
Which builds correctly.