### PR TITLE
Fix AWS::IAM::InstanceProfile creation

### DIFF
--- a/localstack/services/iam/resource_providers/aws_iam_instanceprofile.py
+++ b/localstack/services/iam/resource_providers/aws_iam_instanceprofile.py
@@ -66,8 +66,13 @@ class IAMInstanceProfileProvider(ResourceProvider[IAMInstanceProfileProperties])
             model["InstanceProfileName"] = role_name
 
         response = iam.create_instance_profile(
-            InstanceProfileName=model["InstanceProfileName"],
-            Path=model["Path"],
+            **util.select_attributes(
+                model,
+                [
+                    "InstanceProfileName",
+                    "Path",
+                ],
+            ),
         )
         for role_name in model.get("Roles", []):
             iam.add_role_to_instance_profile(
@@ -75,7 +80,7 @@ class IAMInstanceProfileProvider(ResourceProvider[IAMInstanceProfileProperties])
             )
         model["Arn"] = response["InstanceProfile"]["Arn"]
         return ProgressEvent(
-            status=OperationStatus.IN_PROGRESS,
+            status=OperationStatus.SUCCESS,
             resource_model=model,
         )
 


### PR DESCRIPTION
## Motivation
A recent PR (https://github.com/localstack/localstack/pull/9011) introduced a regression for the `AWS::IAM::InstanceProfile` resource type.

## Changes

- fixes the `create` handler for `AWS::IAM::InstanceProfile` to return a success state and to consider the path as optional
