### PR TITLE
fix proxy Accept-Header handling, combine http clients

### DIFF
--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -14,7 +14,7 @@ from localstack.aws.api.opensearch import (
     EngineType,
     ValidationException,
 )
-from localstack.http.client import SimpleStreamingRequestsClient
+from localstack.http.client import SimpleRequestsClient
 from localstack.http.proxy import ProxyHandler
 from localstack.services.edge import ROUTER
 from localstack.services.infra import DEFAULT_BACKEND_HOST
@@ -229,7 +229,7 @@ def register_cluster(
     forward_url = config.OPENSEARCH_CUSTOM_BACKEND or forward_url
 
     # if the opensearch security plugin is enabled, only TLS connections are allowed, but the cert cannot be verified
-    client = SimpleStreamingRequestsClient()
+    client = SimpleRequestsClient()
     client.session.verify = False
     endpoint = ProxyHandler(forward_url, client)
 
@@ -416,7 +416,6 @@ class OpensearchCluster(Server):
             "http.publish_port": self.port,
             "transport.port": "0",
             "network.host": self.host,
-            # TODO this breaks the cluster check?!
             "http.compression": "true",
             "path.data": f'"{dirs.data}"',
             "path.repo": f'"{dirs.backup}"',

--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -5,7 +5,6 @@ from urllib.parse import urlsplit, urlunsplit
 from localstack import config
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.http import Request, Response
-from localstack.http.client import SimpleStreamingRequestsClient
 from localstack.http.proxy import Proxy
 from localstack.runtime import hooks
 from localstack.services.edge import ROUTER
@@ -62,7 +61,6 @@ class S3VirtualHostProxyHandler:
             forward_base_url=config.get_edge_url(),
             # do not preserve the Host when forwarding (to avoid an endless loop)
             preserve_host=False,
-            client=SimpleStreamingRequestsClient(),
         )
 
     @staticmethod

--- a/tests/unit/http_/test_client.py
+++ b/tests/unit/http_/test_client.py
@@ -40,7 +40,7 @@ def ssl_httpserver(make_ssl_httpserver):
 
 @pytest.mark.parametrize("verify", [True, False])
 @pytest.mark.parametrize("cert_env", [None, "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"])
-def test_http_clients_respect_verify(client_class, verify, cert_env, ssl_httpserver, monkeypatch):
+def test_http_clients_respect_verify(verify, cert_env, ssl_httpserver, monkeypatch):
     # If we want to test that a certain environment variable, setting the CA bundle, is set, we
     # just set the same path as requests uses anyway (the issues is caused just by the variables being set).
     if cert_env:

--- a/tests/unit/http_/test_client.py
+++ b/tests/unit/http_/test_client.py
@@ -7,7 +7,7 @@ from pytest_httpserver import HTTPServer
 from requests.exceptions import SSLError
 
 from localstack.http import Request
-from localstack.http.client import SimpleRequestsClient, SimpleStreamingRequestsClient
+from localstack.http.client import SimpleRequestsClient
 from localstack.utils.ssl import create_ssl_cert
 
 
@@ -38,7 +38,6 @@ def ssl_httpserver(make_ssl_httpserver):
     server.clear()
 
 
-@pytest.mark.parametrize("client_class", [SimpleRequestsClient, SimpleStreamingRequestsClient])
 @pytest.mark.parametrize("verify", [True, False])
 @pytest.mark.parametrize("cert_env", [None, "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"])
 def test_http_clients_respect_verify(client_class, verify, cert_env, ssl_httpserver, monkeypatch):
@@ -47,7 +46,7 @@ def test_http_clients_respect_verify(client_class, verify, cert_env, ssl_httpser
     if cert_env:
         monkeypatch.setenv(cert_env, certifi.where())
 
-    client = client_class()
+    client = SimpleRequestsClient()
     client.session.verify = verify
 
     # Configure the SSL http server fixture

--- a/tests/unit/http_/test_proxy.py
+++ b/tests/unit/http_/test_proxy.py
@@ -7,7 +7,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request as WerkzeugRequest
 
 from localstack.http import Request, Response, Router
-from localstack.http.client import SimpleRequestsClient, SimpleStreamingRequestsClient
+from localstack.http.client import SimpleRequestsClient
 from localstack.http.dispatcher import handler_dispatcher
 from localstack.http.hypercorn import HypercornServer
 from localstack.http.proxy import Proxy, ProxyHandler, forward
@@ -213,19 +213,18 @@ class TestProxy:
 
         httpserver.expect_request("").respond_with_handler(_handler)
 
-        with SimpleStreamingRequestsClient() as client:
-            proxy = Proxy(httpserver.url_for("/").lstrip("/"), client)
+        proxy = Proxy(httpserver.url_for("/").lstrip("/"))
 
-            request = Request(path="/", method="GET", headers={"Host": "127.0.0.1:80"})
+        request = Request(path="/", method="GET", headers={"Host": "127.0.0.1:80"})
 
-            response = proxy.request(request)
+        response = proxy.request(request)
 
-            if chunked:
-                assert response.headers["Transfer-Encoding"] == "chunked"
-                assert "Content-Length" not in response.headers
-            else:
-                assert response.headers["Content-Length"] == str(len(body))
-                assert "Transfer-Encoding" not in response.headers
+        if chunked:
+            assert response.headers["Transfer-Encoding"] == "chunked"
+            assert "Content-Length" not in response.headers
+        else:
+            assert response.headers["Content-Length"] == str(len(body))
+            assert "Transfer-Encoding" not in response.headers
 
 
 @pytest.mark.parametrize("consume_data", [True, False])


### PR DESCRIPTION
## Motivation
This PR addresses #8793, which describes an issue with the handling of the `Accept-Encoding` header when communicating with OpenSearch clusters with enabled http compression (as enabled statically with #8628).
This bug is actually caused by our HTTP client used in the Proxy infrastructure used to proxy requests from the client via LocalStack to the started OpenSearch server. This HTTP client _always_ adds `Accept-Encoding: gzip, deflate` to the proxied HTTP request if no `Accept-Encoding` is set in the originating request.

With enabling the compression support for OpenSearch (i.e. OpenSearch will compress the responses using GZIP `Content-Encoding` in responses if the client sends `gzip` in the `Accept-Encoding` request header), this issue surfaced since every request to OpenSearch via LocalStack (which is the default) without the `Accept-Encoding` header (which is the default f.e. for a plain `curl` request).

It turns out that sending HTTP requests without any `Accept-Encoding` header is not possible with `requests` because it uses `urllib3` under the hood, which in turn uses Python's `http.client` standard lib:
- `urllib3` automatically adds `` if the `Accept-Encoding` header is not set at all. See [`urllib3.util.request.ACCEPT_ENCODING`](https://github.com/urllib3/urllib3/blob/23799f263998ac138d569ed92635df8b09278ed0/src/urllib3/util/request.py#L21).
  - This could be circumvented by setting `Accept-Encoding` explicitly to `None`
- BUT: One layer below - Python's `http.client` - sets the `Accept-Encoding: identity` in case it's not set or `None`.
  - However, as discussed in https://github.com/psf/requests/issues/2234, this behavior should be compliant to the specs / RFCs.

This means it's not really possible to identically relay a request which does not contain the `Accept-Encoding` header at all.

## Changes
- This PR explicitly sets the `Accept-Encoding` header to `identity` in case it's not set or `None`.
  - An alternative would have been just to circumvent the behavior of `urllib3` by setting the `Accept-Encoding` header to `None`, but I wanted to make this behavior as explicit as possible (because it was quite a pain to get to the root of this weird behavior).
- This PR also merges the `SimpleHttpClient` with the `SimpleStreamingHttpClient`. The latter was introduced with #8148 in addition to the `SimpleHttpClient` where it should actually just have been an extension of the default (but that was understandable at the time in order to prevent too wide-ranging changes).
  - This is why I classified this change as "minor".

## Testing
Testing this in Python is actually quite hard (since the test explicitly has to send a request without any `Accept-Encoding` header whatsoever). I actually had to directly use the `HTTPConnection` class of Python's std lib.

Fixes #8793.