### PR TITLE
add domain-name for opensearch domain in cfn

### DIFF
--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -4,7 +4,10 @@ from localstack.aws.api.opensearch import (
     OpenSearchWarmPartitionInstanceType,
 )
 from localstack.aws.connect import connect_to
-from localstack.services.cloudformation.deployment_utils import remove_none_values
+from localstack.services.cloudformation.deployment_utils import (
+    generate_default_name,
+    remove_none_values,
+)
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import arns
 from localstack.utils.collections import convert_to_typed_dict
@@ -39,6 +42,16 @@ class OpenSearchDomain(GenericBaseModel):
 
     def _domain_name(self):
         return self.props.get("DomainName") or self.logical_resource_id
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        domain_name = resource.get("Properties", {}).get("DomainName")
+        if not domain_name:
+            # name must have a minimum length of 3 and a maximum length of 28
+            # only lower case is valid for domain name, pattern: [a-z][a-z0-9\-]+
+            resource["Properties"]["DomainName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            ).lower()[0:28]
 
     @staticmethod
     def get_deploy_templates():

--- a/tests/aws/services/cloudformation/resources/test_opensearch.py
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.py
@@ -1,20 +1,39 @@
 import os
 
 from localstack.testing.pytest import markers
-from localstack.utils.strings import short_uid
 
 
-@markers.aws.unknown
-def test_domain(deploy_cfn_template, aws_client):
-    name = f"domain-{short_uid()}"
-
+@markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..ClusterConfig.DedicatedMasterCount",  # added in LS
+        "$..ClusterConfig.DedicatedMasterEnabled",  # added in LS
+        "$..ClusterConfig.DedicatedMasterType",  # added in LS
+        "$..SoftwareUpdateOptions",  # missing
+        "$..OffPeakWindowOptions",  # missing
+        "$..ChangeProgressDetails",  # missing
+        "$..AutoTuneOptions.UseOffPeakWindow",  # missing
+        "$..ClusterConfig.MultiAZWithStandbyEnabled",  # missing
+        "$..AdvancedSecurityOptions.AnonymousAuthEnabled",  # missing
+        # TODO different values:
+        "$..Processing",
+        "$..ServiceSoftwareOptions.CurrentVersion",
+        "$..ClusterConfig.DedicatedMasterEnabled",
+        "$..ClusterConfig.InstanceType",  # TODO the type was set in cfn
+        "$..AutoTuneOptions.State",
+        '$..AdvancedOptions."rest.action.multi.allow_explicit_index"',  # TODO this was set to false in cfn
+    ]
+)
+def test_domain(deploy_cfn_template, aws_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.key_value("DomainId"))
+    snapshot.add_transformer(snapshot.transform.key_value("DomainName"))
+    snapshot.add_transformer(snapshot.transform.key_value("ChangeId"))
+    snapshot.add_transformer(snapshot.transform.key_value("Endpoint"), priority=-1)
     template_path = os.path.join(
         os.path.dirname(__file__), "../../../templates/opensearch_domain.yml"
     )
-    deploy_cfn_template(
-        template_path=template_path,
-        parameters={"domainName": name},
-    )
-
-    domain = aws_client.opensearch.describe_domain(DomainName=name)
+    result = deploy_cfn_template(template_path=template_path)
+    domain_name = result.outputs["SearchDomain"]
+    domain = aws_client.opensearch.describe_domain(DomainName=domain_name)
     assert domain["DomainStatus"]
+    snapshot.match("describe_domain", domain)

--- a/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
@@ -1,0 +1,97 @@
+{
+  "tests/aws/services/cloudformation/resources/test_opensearch.py::test_domain": {
+    "recorded-date": "30-08-2023, 14:46:54",
+    "recorded-content": {
+      "describe_domain": {
+        "DomainStatus": {
+          "ARN": "arn:aws:es:<region>:111111111111:domain/<domain-name:1>",
+          "AccessPolicies": "",
+          "AdvancedOptions": {
+            "override_main_response_version": "false",
+            "rest.action.multi.allow_explicit_index": "false"
+          },
+          "AdvancedSecurityOptions": {
+            "AnonymousAuthEnabled": false,
+            "Enabled": false,
+            "InternalUserDatabaseEnabled": false
+          },
+          "AutoTuneOptions": {
+            "State": "ENABLED",
+            "UseOffPeakWindow": false
+          },
+          "ChangeProgressDetails": {
+            "ChangeId": "<change-id:1>"
+          },
+          "ClusterConfig": {
+            "ColdStorageOptions": {
+              "Enabled": false
+            },
+            "DedicatedMasterEnabled": false,
+            "InstanceCount": 1,
+            "InstanceType": "r5.large.search",
+            "MultiAZWithStandbyEnabled": false,
+            "WarmEnabled": false,
+            "ZoneAwarenessEnabled": false
+          },
+          "CognitoOptions": {
+            "Enabled": false
+          },
+          "Created": true,
+          "Deleted": false,
+          "DomainEndpointOptions": {
+            "CustomEndpointEnabled": false,
+            "EnforceHTTPS": false,
+            "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
+          },
+          "DomainId": "<domain-id:1>",
+          "DomainName": "<domain-name:1>",
+          "EBSOptions": {
+            "EBSEnabled": true,
+            "Iops": 0,
+            "VolumeSize": 10,
+            "VolumeType": "gp2"
+          },
+          "EncryptionAtRestOptions": {
+            "Enabled": false
+          },
+          "Endpoint": "<endpoint:1>",
+          "EngineVersion": "OpenSearch_2.5",
+          "NodeToNodeEncryptionOptions": {
+            "Enabled": false
+          },
+          "OffPeakWindowOptions": {
+            "Enabled": true,
+            "OffPeakWindow": {
+              "WindowStartTime": {
+                "Hours": 2,
+                "Minutes": 0
+              }
+            }
+          },
+          "Processing": false,
+          "ServiceSoftwareOptions": {
+            "AutomatedUpdateDate": "datetime",
+            "Cancellable": false,
+            "CurrentVersion": "OpenSearch_2_5_R20230308-P4",
+            "Description": "There is no software update available for this domain.",
+            "NewVersion": "",
+            "OptionalDeployment": true,
+            "UpdateAvailable": false,
+            "UpdateStatus": "COMPLETED"
+          },
+          "SnapshotOptions": {
+            "AutomatedSnapshotStartHour": 0
+          },
+          "SoftwareUpdateOptions": {
+            "AutoSoftwareUpdateEnabled": false
+          },
+          "UpgradeProcessing": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/templates/opensearch_domain.yml
+++ b/tests/aws/templates/opensearch_domain.yml
@@ -1,15 +1,30 @@
-Parameters:
-  domainName:
-    Type: String
-    Default: DomainName
 Resources:
-  Domain:
-    Type: AWS::OpenSearchService::Domain
+  Domain66AC69E0:
+    Type: "AWS::OpenSearchService::Domain"
     Properties:
-      DomainName:
-        Ref: domainName
-      EngineVersion: OpenSearch_1.0
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "false"
       ClusterConfig:
-        InstanceType: 'm3.medium.search'
-        # test using string types instead of int
-        InstanceCount: "2"
+        DedicatedMasterEnabled: false
+        InstanceCount: 1
+        InstanceType: "r5.large.search"
+        ZoneAwarenessEnabled: false
+      DomainEndpointOptions:
+        EnforceHTTPS: false
+        TLSSecurityPolicy: "Policy-Min-TLS-1-0-2019-07"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: 0
+        VolumeSize: 10
+        VolumeType: "gp2"
+      EncryptionAtRestOptions:
+        Enabled: false
+      EngineVersion: "OpenSearch_2.5"
+      LogPublishingOptions: {}
+      NodeToNodeEncryptionOptions:
+        Enabled: false
+    UpdateReplacePolicy: "Retain"
+    DeletionPolicy: "Delete"
+Outputs:
+  SearchDomain:
+    Value: !Ref "Domain66AC69E0"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Working on scenario tests revealed that opensearch currently requires the `DomainName` attribute, which shouldn't necessarily be the case. 
The [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html) suggest that the parameter is "conditional" required and state:

> The name must have a minimum length of 3 and a maximum length of 28. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the domain name. 

<!-- What notable changes does this PR make? -->
## Changes
* adapted CFN model and genenerate a `DomainName` if none is set
* aws-validated test


