### PR TITLE
enable DomainEndpoint cfn output for Opensearch

### DIFF
--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -84,6 +84,7 @@ class OpenSearchDomain(GenericBaseModel):
             resource: dict,
         ):
             resource["PhysicalResourceId"] = result["DomainStatus"]["DomainName"]
+            resource["Properties"]["DomainEndpoint"] = result["DomainStatus"]["Endpoint"]
 
         return {
             "create": [

--- a/tests/aws/services/cloudformation/resources/test_opensearch.py
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.py
@@ -33,6 +33,8 @@ def test_domain(deploy_cfn_template, aws_client, snapshot):
         os.path.dirname(__file__), "../../../templates/opensearch_domain.yml"
     )
     result = deploy_cfn_template(template_path=template_path)
+    domain_endpoint = result.outputs["SearchDomainEndpoint"]
+    assert domain_endpoint
     domain_name = result.outputs["SearchDomain"]
     domain = aws_client.opensearch.describe_domain(DomainName=domain_name)
     assert domain["DomainStatus"]

--- a/tests/aws/templates/opensearch_domain.yml
+++ b/tests/aws/templates/opensearch_domain.yml
@@ -28,3 +28,5 @@ Resources:
 Outputs:
   SearchDomain:
     Value: !Ref "Domain66AC69E0"
+  SearchDomainEndpoint:
+    Value: !GetAtt Domain66AC69E0.DomainEndpoint


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow-up for https://github.com/localstack/localstack/pull/9027. 
The `DomainEndpoint` seems to be a commonly used [return value for Opensearch Domain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html#aws-resource-opensearchservice-domain-return-values).

<!-- What notable changes does this PR make? -->
## Changes
Added support for output of `DomainEndpoint`.



