### PR TITLE
remove extensions venv link from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,10 +164,6 @@ RUN --mount=type=cache,target=/root/.cache \
     chown -R localstack:localstack /usr/lib/localstack && \
     chmod -R 777 /usr/lib/localstack
 
-# link the extensions virtual environment into the localstack venv
-RUN echo /var/lib/localstack/lib/extensions/python_venv/lib/python3.10/site-packages > localstack-extensions-venv.pth && \
-    mv localstack-extensions-venv.pth .venv/lib/python*/site-packages/
-
 # link the python package installer virtual environments into the localstack venv
 RUN echo /var/lib/localstack/lib/python-packages/lib/python3.10/site-packages > localstack-var-python-packages-venv.pth && \
     mv localstack-var-python-packages-venv.pth .venv/lib/python*/site-packages/


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

@simonrw noticed that when you first install an extensions using localstack pro, and then go back to using localstack community, there will be wonkyness because the extensions/python_venv contains a copy of localstack-ext.

We don't want to do this linking of venvs in community in the first place, so removing it here. This should be safe since we have this explicitly in the ext Dockerfile.

<!-- What notable changes does this PR make? -->
## Changes

* remove the extensions venv linking from the community Dockerfile

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

