### PR TITLE
add Cfn ResourceProvider for AWS::OpenSearchService::Domain

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -53,6 +53,7 @@ PROVIDER_DEFAULTS = {
     "AWS::IAM::Policy": "ResourceProvider",
     "AWS::IAM::InstanceProfile": "ResourceProvider",
     "AWS::IAM::ServiceLinkedRole": "ResourceProvider",
+    "AWS::OpenSearchService::Domain": "ResourceProvider",
     # "AWS::SSM::Parameter": "GenericBaseModel",
     # "AWS::OpenSearchService::Domain": "GenericBaseModel",
 }

--- a/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
+++ b/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
@@ -223,10 +223,9 @@ class OpenSearchServiceDomainProvider(ResourceProvider[OpenSearchServiceDomainPr
                 cluster_config.setdefault("DedicatedMasterType", "m3.medium.search")
                 cluster_config.setdefault("WarmType", "ultrawarm1.medium.search")
 
-            create_kwargs = {
-                **util.deselect_attributes(properties, ["Tags"]),
-                "TagList": properties.get("Tags"),
-            }
+            create_kwargs = {**util.deselect_attributes(properties, ["Tags"])}
+            if tags := properties.get("Tags"):
+                create_kwargs["TagList"] = tags
             opensearch_client.create_domain(**create_kwargs)
             return ProgressEvent(
                 status=OperationStatus.IN_PROGRESS,
@@ -279,6 +278,8 @@ class OpenSearchServiceDomainProvider(ResourceProvider[OpenSearchServiceDomainPr
           - es:DescribeDomain
         """
         opensearch_client = request.aws_client_factory.opensearch
+        # TODO the delete is currently synchronous;
+        #   if this changes, we should also reflect the OperationStatus here
         opensearch_client.delete_domain(DomainName=request.previous_state["DomainName"])
         return ProgressEvent(status=OperationStatus.SUCCESS, resource_model={})
 

--- a/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/resources/test_opensearch.py::test_domain": {
-    "recorded-date": "30-08-2023, 14:46:54",
+    "recorded-date": "31-08-2023, 17:42:29",
     "recorded-content": {
       "describe_domain": {
         "DomainStatus": {
@@ -87,6 +87,22 @@
           },
           "UpgradeProcessing": false
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags": {
+        "TagList": [
+          {
+            "Key": "anotherkey",
+            "Value": "hello"
+          },
+          {
+            "Key": "foo",
+            "Value": "bar"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/templates/opensearch_domain.yml
+++ b/tests/aws/templates/opensearch_domain.yml
@@ -23,6 +23,11 @@ Resources:
       LogPublishingOptions: {}
       NodeToNodeEncryptionOptions:
         Enabled: false
+      Tags:
+        - Key: foo
+          Value: bar
+        - Key: anotherkey
+          Value: hello
     UpdateReplacePolicy: "Retain"
     DeletionPolicy: "Delete"
 Outputs:
@@ -30,3 +35,5 @@ Outputs:
     Value: !Ref "Domain66AC69E0"
   SearchDomainEndpoint:
     Value: !GetAtt Domain66AC69E0.DomainEndpoint
+  SearchDomainArn:
+    Value: !GetAtt Domain66AC69E0.DomainArn


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Working with the Cfn and `opensearch` revealed a few shortcomings the past days. Already fixed some issues in the old provider, but it might be time to move the new `ResourceProvider` now 🙂 

<!-- What notable changes does this PR make? -->
## Changes
* set the `opensearch` ResourceProvider as default for Cfn
* added logic to the `ResourceProvider` in a pairing session with @dominikschubert 
* enhanced test case a little (include `Tags`)

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

