### PR TITLE
fix S3 PUT operations returning HTTP Body by default

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -166,20 +166,6 @@ def create_signature_does_not_match_sig_v4(
     return ex
 
 
-def s3_presigned_url_response_handler(_: HandlerChain, context: RequestContext, response: Response):
-    """
-    Pre-signed URL with PUT method (typically object upload) should return an empty body
-    """
-    if (
-        not context.request.method == "PUT"
-        or not is_presigned_url_request(context)
-        or response.status_code >= 400
-    ):
-        return
-    else:
-        response.data = b""
-
-
 class S3PreSignedURLRequestHandler:
     @cached_property
     def _service(self) -> ServiceModel:

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -137,11 +137,7 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
 )
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
-from localstack.aws.handlers import (
-    modify_service_response,
-    preprocess_request,
-    serve_custom_service_request_handlers,
-)
+from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
@@ -156,10 +152,7 @@ from localstack.services.s3.exceptions import (
 )
 from localstack.services.s3.models import BucketCorsIndex, S3Store, get_moto_s3_backend, s3_stores
 from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
-from localstack.services.s3.presigned_url import (
-    s3_presigned_url_response_handler,
-    validate_post_policy,
-)
+from localstack.services.s3.presigned_url import validate_post_policy
 from localstack.services.s3.utils import (
     capitalize_header_name_from_snake_case,
     create_redirect_for_post_request,
@@ -241,7 +234,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         apply_moto_patches()
         preprocess_request.append(self._cors_handler)
         register_website_hosting_routes(router=ROUTER)
-        register_custom_handlers()
+        serve_custom_service_request_handlers.append(s3_cors_request_handler)
         # registering of virtual host routes happens with the hook on_infra_ready in virtual_host.py
         # create a AWS managed KMS key at start and save it in the store for persistence?
 
@@ -1916,9 +1909,3 @@ def apply_moto_patches():
         return False
 
     setattr(moto_s3_models.FakeKey, "is_locked", property(key_is_locked))
-
-
-def register_custom_handlers():
-    serve_custom_service_request_handlers.append(s3_cors_request_handler)
-    # serve_custom_service_request_handlers.append(s3_presigned_url_request_handler)
-    modify_service_response.append(S3Provider.service, s3_presigned_url_response_handler)

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -195,11 +195,7 @@ from localstack.aws.api.s3 import (
     VersioningConfiguration,
     WebsiteConfiguration,
 )
-from localstack.aws.handlers import (
-    modify_service_response,
-    preprocess_request,
-    serve_custom_service_request_handlers,
-)
+from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.codec import AwsChunkedDecoder
@@ -220,10 +216,7 @@ from localstack.services.s3.exceptions import (
     UnexpectedContent,
 )
 from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
-from localstack.services.s3.presigned_url import (
-    s3_presigned_url_response_handler,
-    validate_post_policy,
-)
+from localstack.services.s3.presigned_url import validate_post_policy
 from localstack.services.s3.utils import (
     ObjectRange,
     add_expiration_days_to_datetime,
@@ -306,7 +299,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def on_after_init(self):
         preprocess_request.append(self._cors_handler)
         serve_custom_service_request_handlers.append(s3_cors_request_handler)
-        modify_service_response.append(S3Provider.service, s3_presigned_url_response_handler)
         register_website_hosting_routes(router=ROUTER)
 
     def accept_state_visitor(self, visitor: StateVisitor):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2816,8 +2816,7 @@ class TestS3:
         response = requests.put(url, data, headers=headers, verify=False)
         assert response.ok
         part_etag = response.headers.get("ETag")
-        xml_response = xmltodict.parse(response.content)
-        assert "UploadPartOutput" in xml_response
+        assert not response.content
 
         # validate that the object etag is the same as the pre-calculated one
         assert part_etag.strip('"') == precalculated_etag

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -57,7 +57,10 @@ def match_headers(snapshot, snapshot_headers):
             "StatusCode": response.status_code,
             "Headers": headers,
         }
-        if response.headers.get("Content-Type") in ("application/xml", "text/xml"):
+        if (
+            response.headers.get("Content-Type") in ("application/xml", "text/xml")
+            and response.content
+        ):
             match_object["Body"] = xmltodict.parse(response.content)
         else:
             match_object["Body"] = response.text


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9032, some S3 operations (the one using the `PUT` http method) would return an empty XML body when the S3 docs specifies that the body should be empty. After looking at the specs, only `CopyObject` and `CopyObjectPart` would return a body. Luckily, those operations implement a field specifying that they return a body, the `payload` one.

<!-- What notable changes does this PR make? -->
## Changes
Removed the pre-signed handler deleting the response body, since this behaviour should have been for every `PUT` request except some, and it was actually fixing a symptom instead of the cause.

Implemented a check in the serializer for not serializing a body if the conditions were not set (if it's a PUT request without the `payload` field). 

Added 2 cases in a test checking the raw returned body without boto parsing, one for a known PUT operation which should return a body (`CopyObject`) and one for `UploadPart`, which should not return a body. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

