### PR TITLE
add ddb ttl resource-exceptions for inexistent tables

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -82,6 +82,15 @@ class TestDynamoDB:
 
     @markers.aws.only_localstack
     def test_time_to_live(self, aws_client, ddb_test_table):
+        # check response for inexistent table
+        response = testutil.send_describe_dynamodb_ttl_request("test")
+        assert json.loads(response._content)["__type"] == "ResourceNotFoundException"
+        assert response.status_code == 400
+
+        response = testutil.send_update_dynamodb_ttl_request("test", True)
+        assert json.loads(response._content)["__type"] == "ResourceNotFoundException"
+        assert response.status_code == 400
+
         # Insert some items to the table
         items = {
             "id1": {PARTITION_KEY: {"S": "id1"}, "data": {"S": "IT IS"}},


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR addresses that the DDB operations [DescribeTimeToLive](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/describe-time-to-live.html) and [UpdateTimeToLive](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/update-time-to-live.html) both had no checks in regards to the existence of the table, as highlighted in #9030. 

The `ResourceNotFoundException` message might look peculiar, but this is due to parity:
```
$ aws dynamodb describe-time-to-live --table-name test

An error occurred (ResourceNotFoundException) when calling the DescribeTimeToLive operation: Requested resource not found: Table: test not found

$ aws dynamodb update-time-to-live --table-name test --time-to-live-specification Enabled=true,AttributeName=ttl

An error occurred (ResourceNotFoundException) when calling the UpdateTimeToLive operation: Requested resource not found: Table: test not found
```
I would've liked to prove this via a snapshot test, but the refactoring was out of scope for this simple patch.

fixes: #9030 

<!-- What notable changes does this PR make? -->
## Changes
- add resource checks for both operations
- add a simple check to the test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

