### PR TITLE
fix APIGW UpdateStage with /tracingEnabled

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -549,6 +549,7 @@ class TestStages:
                 {"op": "replace", "path": "/variables/var2", "value": "test2"},
                 {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "123"},
                 {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
+                {"op": "replace", "path": "/tracingEnabled", "value": "true"},
             ],
         )
         snapshot.match("update-stage", response)

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -371,7 +371,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
-    "recorded-date": "09-08-2023, 15:09:29",
+    "recorded-date": "01-09-2023, 00:33:13",
     "recorded-content": {
       "create-stage": {
         "cacheClusterEnabled": false,
@@ -433,7 +433,7 @@
           }
         },
         "stageName": "s1",
-        "tracingEnabled": false,
+        "tracingEnabled": true,
         "variables": {
           "var1": "test",
           "var2": "test2"
@@ -465,7 +465,7 @@
           }
         },
         "stageName": "s1",
-        "tracingEnabled": false,
+        "tracingEnabled": true,
         "variables": {
           "var1": "test",
           "var2": "test2"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A user reported a stuck Terraform deployment with an API GW REST API: Terraform would loop and never finish while trying to update a stage when `xray_tracing_enabled` is set. 

When setting `TF_LOG=trace`, we see there's an issue when unmarshalling the response, because we were returning a string `"true"` instead of a boolean `True`.
```
DEBUG: Unmarshal Response apigateway/UpdateStage failed, attempt 9/25, error SerializationError: failed decoding JSON RPC response
```

Add a case to a snapshot test to validate this behaviour as well. 

<!-- What notable changes does this PR make? -->
## Changes

Added a check if the path is `/tracingEnabled` to cast the value into a boolean.
Also used `copy.deepcopy` to the input, because we were modifying it in place, and the logging would show the modified input instead of what we really received. 



## Testing

I could reproduce the issue with the following stage resource:
```hcl
resource "aws_api_gateway_rest_api" "api" {
  name           = "rest"
  api_key_source = "HEADER"
}

resource "aws_api_gateway_deployment" "deployment" {
  rest_api_id = aws_api_gateway_rest_api.api.id

  lifecycle {
    create_before_destroy = true
  }
}

resource "aws_api_gateway_stage" "stage" {
  stage_name    = "dev"
  rest_api_id   = aws_api_gateway_rest_api.api.id
  deployment_id = aws_api_gateway_deployment.deployment.id
  depends_on    = [aws_cloudwatch_log_group.test]
  variables = {
    "TEST_ENV" = "local"
  }
  xray_tracing_enabled = "true"

  access_log_settings {
    destination_arn = aws_cloudwatch_log_group.test.arn
    format = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
  }
}

resource "aws_cloudwatch_log_group" "test" {
  name = "Yada"

  tags = {
    Environment = "production"
    Application = "serviceA"
  }
}

```

<!-- The following sections are optional, but can be useful! 
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

