### PR TITLE
pin deepdiff to version 6.3.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,7 @@ full =
 test =
     # coverage version should be synced with bin/Dockerfile.base
     coverage[toml]>=5.5
-    deepdiff>=5.5.0
+    deepdiff==6.3.1
     jsonpath-ng>=1.5.3
     pytest==6.2.4
     pytest-split>=0.8.0


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
deepdiff released 6.4 overnight, which has an issue: https://github.com/seperman/deepdiff/issues/415. This PR pins the version to unblock the pipeline.

<!-- What notable changes does this PR make? -->
## Changes
- pin deepdiff to 6.3.1

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

