### PR TITLE
Set up acceptance test marker & CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - run:
           name: Acceptance tests (EXPERIMENTAL)
           environment:
-            TEST_PATH: "tests/aws/services/stepfunctions/v2/"
+            TEST_PATH: "tests/"
             COVERAGE_ARGS: "-p"
           command: |
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" make test-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,31 @@ jobs:
       - store_test_results:
           path: target/reports/
 
+  acceptance-tests:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-pytest-tinybird
+      - run:
+          name: Acceptance tests (EXPERIMENTAL)
+          environment:
+            TEST_PATH: "tests/aws/services/stepfunctions/v2/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance.xml -o junit_suite_name='sfn_v2'" make test-coverage
+      - run:
+          name: Store coverage results
+          command: mv .coverage.* target/coverage/
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
   itest-s3-stream-provider:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -438,6 +463,9 @@ workflows:
       - preflight:
           requires:
             - install
+      - acceptance-tests:
+          requires:
+            - preflight
       - itest-lambda-legacy-local:
           requires:
             - preflight
@@ -491,6 +519,7 @@ workflows:
           requires:
             - itest-lambda-legacy-local
             - itest-sfn-v2-provider
+            - acceptance-tests
             - docker-test-amd64
             - docker-test-arm64
             - collect-not-implemented
@@ -502,6 +531,7 @@ workflows:
           requires:
             - itest-lambda-legacy-local
             - itest-sfn-v2-provider
+            - acceptance-tests
             - docker-test-amd64
             - docker-test-arm64
             - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             TEST_PATH: "tests/aws/services/stepfunctions/v2/"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance.xml -o junit_suite_name='sfn_v2'" make test-coverage
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - run:
           name: Acceptance tests (EXPERIMENTAL)
           environment:
-            TEST_PATH: "tests/"
+            TEST_PATH: "tests/aws/ tests/integration/"
             COVERAGE_ARGS: "-p"
           command: |
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" make test-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,6 @@ jobs:
             make test-coverage
       - store_test_results:
           path: target/reports/
-      - run:
-          name: Store coverage results
-          command: mv .coverage.* target/coverage/
       - persist_to_workspace:
           root:
             /tmp/workspace
@@ -120,9 +117,6 @@ jobs:
             COVERAGE_FILE="target/coverage/.coverage.lambdav1.${CIRCLE_NODE_INDEX}" \
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='legacy-lambda-local'" \
             make test-coverage
-      - run:
-          name: Store coverage results
-          command: mv .coverage.* target/coverage/
       - persist_to_workspace:
           root:
             /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ jobs:
             TEST_PATH: "tests/unit"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests" make test-coverage
+            COVERAGE_FILE="target/coverage/.coverage.unit.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests" \
+            make test-coverage
       - store_test_results:
           path: target/reports/
       - run:
@@ -115,7 +117,9 @@ jobs:
             TEST_PATH: "tests/aws/services/lambda_/ tests/aws/test_integration.py tests/aws/services/apigateway/test_apigateway_basic.py tests/aws/services/cloudformation/resources/test_lambda.py"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='legacy-lambda-local'" make test-coverage
+            COVERAGE_FILE="target/coverage/.coverage.lambdav1.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='legacy-lambda-local'" \
+            make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/
@@ -141,10 +145,9 @@ jobs:
             TEST_PATH: "tests/aws/services/stepfunctions/v2/"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_v2.xml -o junit_suite_name='sfn_v2'" make test-coverage
-      - run:
-          name: Store coverage results
-          command: mv .coverage.* target/coverage/
+            COVERAGE_FILE="target/coverage/.coverage.sfnv2.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/sfn_v2.xml -o junit_suite_name='sfn_v2'" \
+            make test-coverage
       - persist_to_workspace:
           root:
             /tmp/workspace
@@ -166,10 +169,9 @@ jobs:
             TEST_PATH: "tests/aws/"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" make test-coverage
-      - run:
-          name: Store coverage results
-          command: mv .coverage.* target/coverage/
+            COVERAGE_FILE="target/coverage/.coverage.acceptance.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" \
+            make test-coverage
       - persist_to_workspace:
           root:
             /tmp/workspace
@@ -192,10 +194,9 @@ jobs:
             TEST_PATH: "tests/aws/services/s3/"
             COVERAGE_ARGS: "-p"
           command: |
-            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/s3_stream.xml -o junit_suite_name='s3_stream'" make test-coverage
-      - run:
-          name: Store coverage results
-          command: mv .coverage.* target/coverage/
+            COVERAGE_FILE="target/coverage/.coverage.s3stream.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/s3_stream.xml -o junit_suite_name='s3_stream'" \
+            make test-coverage
       - persist_to_workspace:
           root:
             /tmp/workspace
@@ -405,6 +406,13 @@ jobs:
           destination: community/implementation_coverage_full.csv
       - store_artifacts:
           path: .coverage
+      # store (uncombined) coverage from acceptance tests
+      - run:
+          name: fetch isolated acceptance coverage
+          command: |
+            cp target/coverage/coverage.acceptance.* .coverage.acceptance
+      - store_artifacts:
+          path: .coverage.acceptance
 
   push:
     executor: ubuntu-machine-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             /tmp/workspace
           paths:
             - repo/target/reports/
-            - repo/target/metric_reports
+            - repo/target/metric_reports/
             - repo/target/coverage/
       - store_test_results:
           path: target/reports/
@@ -402,6 +402,13 @@ jobs:
             python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
       - store_artifacts:
           path: parity_metrics/
+      - run:
+          name: store acceptance parity metrics
+          command: |
+            mkdir acceptance_parity_metrics
+            mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/
+      - store_artifacts:
+          path: acceptance_parity_metrics/
       - store_artifacts:
           path: scripts/implementation_coverage_aggregated.csv
           destination: community/implementation_coverage_aggregated.csv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,6 +366,13 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      # store (uncombined) coverage from acceptance tests
+      - run:
+          name: fetch isolated acceptance coverage
+          command: |
+            cp target/coverage/.coverage.acceptance.* .coverage.acceptance
+      - store_artifacts:
+          path: .coverage.acceptance
       - run:
           name: Collect coverage
           command: |
@@ -400,13 +407,7 @@ jobs:
           destination: community/implementation_coverage_full.csv
       - store_artifacts:
           path: .coverage
-      # store (uncombined) coverage from acceptance tests
-      - run:
-          name: fetch isolated acceptance coverage
-          command: |
-            cp target/coverage/.coverage.acceptance.* .coverage.acceptance
-      - store_artifacts:
-          path: .coverage.acceptance
+
 
   push:
     executor: ubuntu-machine-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
           environment:
             TEST_PATH: "tests/aws/"
             COVERAGE_ARGS: "-p"
+            LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC: 1
           command: |
             COVERAGE_FILE="target/coverage/.coverage.acceptance.${CIRCLE_NODE_INDEX}" \
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" \
@@ -170,6 +171,8 @@ jobs:
           root:
             /tmp/workspace
           paths:
+            - repo/target/reports/
+            - repo/target/metric_reports
             - repo/target/coverage/
       - store_test_results:
           path: target/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
       - run:
           name: fetch isolated acceptance coverage
           command: |
-            cp target/coverage/coverage.acceptance.* .coverage.acceptance
+            cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - run:
           name: Acceptance tests (EXPERIMENTAL)
           environment:
-            TEST_PATH: "tests/aws/ tests/integration/"
+            TEST_PATH: "tests/aws/"
             COVERAGE_ARGS: "-p"
           command: |
             PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}--reruns 3 -m acceptance_test --junitxml=target/reports/acceptance_test.xml -o junit_suite_name='acceptance_test'" make test-coverage

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -55,6 +55,9 @@ class Markers:
     multiruntime: MultiRuntimeMarker = pytest.mark.multiruntime
 
     # test selection
+    acceptance_test_beta = (
+        pytest.mark.acceptance_test
+    )  # for now with a _beta suffix to make clear they are not really used as acceptance tests yet
     skip_offline = pytest.mark.skip_offline
     only_on_amd64 = pytest.mark.only_on_amd64
     resource_heavy = pytest.mark.resource_heavy

--- a/tests/aws/scenario/test_apigateway_scenario.py
+++ b/tests/aws/scenario/test_apigateway_scenario.py
@@ -18,6 +18,7 @@ def handler(event, context):
 """
 
 
+@markers.acceptance_test_beta
 class TestApigatewayLambdaIntegrationScenario:
     @pytest.fixture(scope="class", autouse=True)
     def infrastructure(self, aws_client):

--- a/tests/aws/scenario/test_bookstore.py
+++ b/tests/aws/scenario/test_bookstore.py
@@ -93,6 +93,7 @@ def setup_lambda(s3_client: "S3Client", bucket_name: str, key_name: str, code_pa
             os.remove(tmp_zip_path)
 
 
+@markers.acceptance_test_beta
 class TestBookstoreApplication:
     @pytest.fixture(scope="class")
     def patch_opensearch_strategy(self):

--- a/tests/aws/scenario/test_ecs_scenario.py
+++ b/tests/aws/scenario/test_ecs_scenario.py
@@ -10,6 +10,7 @@ from localstack.testing.scenario.provisioning import InfraProvisioner
 @pytest.mark.skip(
     reason="requires pro",
 )
+@markers.acceptance_test_beta
 class TestEcsScenario:
     @pytest.fixture(scope="class", autouse=True)
     def infrastructure(self, aws_client):

--- a/tests/aws/scenario/test_ecs_scenario.py
+++ b/tests/aws/scenario/test_ecs_scenario.py
@@ -10,7 +10,6 @@ from localstack.testing.scenario.provisioning import InfraProvisioner
 @pytest.mark.skip(
     reason="requires pro",
 )
-@markers.acceptance_test_beta
 class TestEcsScenario:
     @pytest.fixture(scope="class", autouse=True)
     def infrastructure(self, aws_client):


### PR DESCRIPTION
## Motivation
In the future we want to experiment more with using only a subset of our integration tests as a sort of acceptance test suite.
Since we want to start early to get a feeling for how well this will work and what we need to look for in potential acceptance test candidates, we're now already starting with a very small subset of tests that are only executed in parallel to the current CI test jobs.


## Changes

- introduce a new pytest marker `acceptance_test`
  - initially this is exposed via our markers as `@markers.acceptance_tests_beta` to communicate more clearly that these tests aren't yet used as the only acceptance tests. (to avoid confusion)
- creates a job in CircleCI to execute all tests 
  - tests are currently only executed on the default architecture (amd64) 
  - as discussed previously, the tests form part of the gate for pushing the built images
  - the selected tests marked by `acceptance_test` are now being executed more than once during the total CI run since we don't deselect the marker yet in our "normal" test suite.
- mark one test as an acceptance test, so we have at least something already in there :sweat_smile: 
  - in the following week we'll constantly add more of these markers where we deem them to be appropriate
- currently only executes tests in `tests/aws/`


