### PR TITLE
Container fixture improvements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,3 +176,7 @@
 /localstack/services/stepfunctions/ @dominikschubert
 /localstack/services/cloudformation/models/stepfunctions.py @dominikschubert
 /tests/aws/test_stepfunctions.py @dominikschubert
+
+# Bootstrap tests
+/tests/bootstrap @simonrw
+/localstack/testing/pytest/container.py @dominikschubert @simonrw

--- a/localstack/testing/pytest/container.py
+++ b/localstack/testing/pytest/container.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import shlex
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 import pytest
 
@@ -28,7 +28,7 @@ class ContainerFactory:
         self,
         # convenience properties
         pro: bool = False,
-        publish: List[int] | None = None,
+        publish: Optional[List[int]] = None,
         # ContainerConfig properties
         **kwargs,
     ) -> Container:
@@ -92,7 +92,7 @@ def container_factory() -> Generator[ContainerFactory, None, None]:
 
 @pytest.fixture
 def wait_for_localstack_ready():
-    def _wait_for(container: RunningContainer, timeout: float | None = None):
+    def _wait_for(container: RunningContainer, timeout: Optional[float] = None):
         container.wait_until_ready(timeout)
 
         poll_condition(

--- a/localstack/testing/pytest/container.py
+++ b/localstack/testing/pytest/container.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import shlex
-from typing import Generator
+from typing import Generator, List
 
 import pytest
 
@@ -22,13 +22,13 @@ LOG = logging.getLogger(__name__)
 
 class ContainerFactory:
     def __init__(self):
-        self._containers: list[Container] = []
+        self._containers: List[Container] = []
 
     def __call__(
         self,
         # convenience properties
         pro: bool = False,
-        publish: list[int] | None = None,
+        publish: List[int] | None = None,
         # ContainerConfig properties
         **kwargs,
     ) -> Container:

--- a/localstack/testing/pytest/container.py
+++ b/localstack/testing/pytest/container.py
@@ -5,7 +5,7 @@ from typing import Generator
 
 import pytest
 
-from localstack import config, constants
+from localstack import constants
 from localstack.utils.bootstrap import Container, RunningContainer, get_docker_image_to_start
 from localstack.utils.container_utils.container_client import (
     ContainerConfiguration,
@@ -39,7 +39,7 @@ class ContainerFactory:
 
         container_configuration = ContainerConfiguration(
             image_name=get_docker_image_to_start(),
-            name=config.MAIN_CONTAINER_NAME,
+            name=None,
             volumes=VolumeMappings(),
             remove=True,
             ports=port_configuration,
@@ -47,9 +47,6 @@ class ContainerFactory:
             command=shlex.split(os.environ.get("CMD", "")) or None,
             env_vars={},
         )
-
-        # allow for randomised container names
-        container_configuration.name = None
 
         # handle the convenience options
         if pro:
@@ -86,7 +83,7 @@ class ContainerFactory:
                 )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def container_factory() -> Generator[ContainerFactory, None, None]:
     factory = ContainerFactory()
     yield factory
@@ -107,15 +104,26 @@ def wait_for_localstack_ready():
 
 
 @pytest.fixture
-def ensure_network(cleanups):
+def ensure_network():
+    networks = []
+
     def _ensure_network(name: str):
         try:
             DOCKER_CLIENT.inspect_network(name)
         except NoSuchNetwork:
             DOCKER_CLIENT.create_network(name)
-            cleanups.append(lambda: DOCKER_CLIENT.delete_network(name))
+            networks.append(name)
 
-    return _ensure_network
+    yield _ensure_network
+
+    for network_name in networks:
+        # detach attached containers
+        details = DOCKER_CLIENT.inspect_network(network_name)
+        for container_id in details["Containers"]:
+            DOCKER_CLIENT.disconnect_container_from_network(
+                network_name=network_name, container_name_or_id=container_id
+            )
+        DOCKER_CLIENT.delete_network(network_name)
 
 
 @pytest.fixture

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -422,7 +422,8 @@ class Container:
             )
             raise
 
-        return RunningContainer(id, container_config=self.config)
+        self.running_container = RunningContainer(id, container_config=self.config)
+        return self.running_container
 
     def _ensure_container_network(self, network: str | None = None):
         """Makes sure the configured container network exists"""

--- a/tests/bootstrap/conftest.py
+++ b/tests/bootstrap/conftest.py
@@ -1,4 +1,3 @@
 pytest_plugins = [
-    "localstack.testing.pytest.container",
     "localstack.testing.pytest.bootstrap",
 ]

--- a/tests/bootstrap/test_container_listen_configuration.py
+++ b/tests/bootstrap/test_container_listen_configuration.py
@@ -2,25 +2,28 @@ import pytest
 import requests
 
 from localstack.config import in_docker
+from localstack.testing.pytest.container import ContainerFactory
 from localstack.utils.net import get_free_tcp_port
 
 
 @pytest.mark.skipif(condition=in_docker(), reason="cannot run bootstrap tests in docker")
 class TestContainerConfiguration:
-    def test_defaults(self, container_factory, wait_for_localstack_ready):
+    def test_defaults(self, container_factory: ContainerFactory, wait_for_localstack_ready):
         """
         The default configuration is to listen on 0.0.0.0:4566
         """
         port = get_free_tcp_port()
         container = container_factory()
         container.config.ports.add(port, 4566)
-        with container.start(attach=False) as running_container:
-            wait_for_localstack_ready(running_container)
+        running_container = container.start(attach=False)
+        wait_for_localstack_ready(running_container)
 
-            r = requests.get(f"http://127.0.0.1:{port}/_localstack/health")
-            assert r.status_code == 200
+        r = requests.get(f"http://127.0.0.1:{port}/_localstack/health")
+        assert r.status_code == 200
 
-    def test_gateway_listen_single_value(self, container_factory, wait_for_localstack_ready):
+    def test_gateway_listen_single_value(
+        self, container_factory: ContainerFactory, wait_for_localstack_ready
+    ):
         """
         Test using GATEWAY_LISTEN to change the hypercorn port
         """
@@ -32,15 +35,15 @@ class TestContainerConfiguration:
             },
         )
         container.config.ports.add(port1, 5000)
-        with container.start(attach=False) as running_container:
-            wait_for_localstack_ready(running_container)
+        running_container = container.start(attach=False)
+        wait_for_localstack_ready(running_container)
 
-            # check the ports listening on 0.0.0.0
-            r = requests.get(f"http://127.0.0.1:{port1}/_localstack/health")
-            assert r.status_code == 200
+        # check the ports listening on 0.0.0.0
+        r = requests.get(f"http://127.0.0.1:{port1}/_localstack/health")
+        assert r.status_code == 200
 
     def test_gateway_listen_multiple_values(
-        self, container_factory, docker_network, wait_for_localstack_ready
+        self, container_factory: ContainerFactory, docker_network, wait_for_localstack_ready
     ):
         """
         Test multiple container ports
@@ -61,12 +64,12 @@ class TestContainerConfiguration:
         )
         container.config.ports.add(port1, 5000)
         container.config.ports.add(port2, 2000)
-        with container.start(attach=False) as running_container:
-            wait_for_localstack_ready(running_container)
+        running_container = container.start(attach=False)
+        wait_for_localstack_ready(running_container)
 
-            # check the ports listening on 0.0.0.0
-            r = requests.get(f"http://127.0.0.1:{port1}/_localstack/health")
-            assert r.ok
+        # check the ports listening on 0.0.0.0
+        r = requests.get(f"http://127.0.0.1:{port1}/_localstack/health")
+        assert r.ok
 
-            r = requests.get(f"http://127.0.0.1:{port2}/_localstack/health")
-            assert r.ok
+        r = requests.get(f"http://127.0.0.1:{port2}/_localstack/health")
+        assert r.ok

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ os.environ["LOCALSTACK_INTERNAL_TEST_RUN"] = "1"
 pytest_plugins = [
     "localstack.testing.pytest.cloudtrail_tracking",
     "localstack.testing.pytest.fixtures",
+    "localstack.testing.pytest.container",
     "localstack.testing.pytest.snapshot",
     "localstack.testing.pytest.filters",
     "localstack.testing.pytest.fixture_conflicts",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The container fixtures created in ... were:

* only usable in the `bootstrap` subdir, but we need them in the `cli` subdir (amongst others)
* are too widely scoped (session scoped `ContainerFactory`)
* uses a confusing fixture order (cleanups)
* did not store the running container, so automatic cleanup was not possible


<!-- What notable changes does this PR make? -->
## Changes

Fix the items above

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

