### PR TITLE
add utility to find contiguous port range

### DIFF
--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import re
 import socket
 import threading
@@ -20,6 +21,13 @@ LOG = logging.getLogger(__name__)
 IP_REGEX = (
     r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
 )
+
+# many linux kernels use 32768-60999, RFC 6335 is 49152-65535, so we use a mix here
+DYNAMIC_PORT_RANGE_START = 32768
+DYNAMIC_PORT_RANGE_END = 65536
+
+DEFAULT_PORT_RESERVED_SECONDS = 6
+"""Default nuber of seconds a port is reserved in a PortRange."""
 
 
 class Port(NamedTuple):
@@ -193,15 +201,72 @@ def get_free_udp_port(blocklist: List[int] = None) -> int:
 
 
 def get_free_tcp_port(blocklist: List[int] = None) -> int:
+    """
+    Tries to bind a socket to port 0 and returns the port that was assigned by the system. If the port is
+    in the given ``blocklist``, or the port is marked as reserved in ``dynamic_port_range``, the procedure
+    is repeated for up to 50 times.
+
+    :param blocklist: an optional list of ports that are not allowed as random ports
+    :return: a free TCP port
+    """
     blocklist = blocklist or []
-    for i in range(10):
+    for i in range(50):
         tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tcp.bind(("", 0))
         addr, port = tcp.getsockname()
         tcp.close()
-        if port not in blocklist:
+        if port not in blocklist and not dynamic_port_range.is_port_reserved(port):
+            try:
+                dynamic_port_range.mark_reserved(port)
+            except ValueError:
+                # depending on the ephemeral port range of the system, the allocated port may be outside what
+                # we defined as dynamic port range
+                pass
             return port
     raise Exception(f"Unable to determine free TCP port with blocklist {blocklist}")
+
+
+def get_free_tcp_port_range(num_ports: int, max_attempts: int = 50) -> "PortRange":
+    """
+    Attempts to get a contiguous range of free ports from the dynamic port range. For instance,
+    ``get_free_tcp_port_range(4)`` may return the following result: ``PortRange(44000:44004)``.
+
+    :param num_ports: the number of ports in the range
+    :param max_attempts: the number of times to retry if a contiguous range was not found
+    :return: a port range of free TCP ports
+    :raises PortNotAvailableException: if max_attempts was reached to re-try
+    """
+    if num_ports < 2:
+        raise ValueError(f"invalid number of ports {num_ports}")
+
+    def _is_port_range_free(_range: PortRange):
+        for _port in _range:
+            if dynamic_port_range.is_port_reserved(_port) or not port_can_be_bound(_port):
+                return False
+        return True
+
+    attempts = 0
+    while attempts <= max_attempts:
+        attempts += 1
+
+        # try to find a suitable starting point (leave enough space at the end)
+        port_range_start = random.randint(
+            dynamic_port_range.start, dynamic_port_range.end - num_ports - 1
+        )
+        port_range = PortRange(port_range_start, port_range_start + num_ports - 1)
+
+        # check that each port in the range is available (has not been reserved and can be bound)
+        # we don't use dynamic_port_range.reserve_port because in case the port range check fails at some port
+        # all ports up until then would be reserved
+        if not _is_port_range_free(port_range):
+            continue
+
+        # port range found! mark them as reserved in the dynamic port range and return
+        for port in port_range:
+            dynamic_port_range.mark_reserved(port)
+        return port_range
+
+    raise PortNotAvailableException("reached max_attempts when trying to find port range")
 
 
 def resolve_hostname(hostname: str) -> Optional[str]:
@@ -230,7 +295,7 @@ def is_ipv4_address(address: str) -> bool:
 
 
 class PortNotAvailableException(Exception):
-    """Exception which indicates that the PortPool could not reserve a port."""
+    """Exception which indicates that the PortRange could not reserve a port."""
 
     pass
 
@@ -239,23 +304,32 @@ class PortRange:
     """Manages a range of ports that can be reserved and requested."""
 
     def __init__(self, start: int, end: int):
-        # cache for locally available ports (ports are reserved for a short period of a few seconds)
-        self._ports_cache: MutableMapping[Port, Any] = CustomExpiryTTLCache(maxsize=100, ttl=6)
-        self._ports_lock = threading.RLock()
         self.start = start
         self.end = end
+
+        # cache for locally available ports (ports are reserved for a short period of a few seconds)
+        self._ports_cache: MutableMapping[Port, Any] = CustomExpiryTTLCache(
+            maxsize=len(self),
+            ttl=DEFAULT_PORT_RESERVED_SECONDS,
+        )
+        self._ports_lock = threading.RLock()
+
+    def as_range(self) -> range:
+        return range(self.start, self.end + 1)
 
     def reserve_port(self, port: Optional[IntOrPort] = None, duration: Optional[int] = None) -> int:
         """
         Reserves the given port (if it is still free). If the given port is None, it reserves a free port from the
         configured port range for external services. If a port is given, it has to be within the configured
         range of external services (i.e., in the range [self.start, self.end)).
+
         :param port: explicit port to check or None if a random port from the configured range should be selected
+        :param duration: the time in seconds the port is reserved for (defaults to a few seconds)
         :return: reserved, free port number (int)
-        :raises: PortNotAvailableException if the given port is outside the configured range, it is already bound or
+        :raises PortNotAvailableException: if the given port is outside the configured range, it is already bound or
                     reserved, or if the given port is none and there is no free port in the configured service range.
         """
-        ports_range = range(self.start, self.end)
+        ports_range = self.as_range()
         port = Port.wrap(port) if port is not None else port
         if port is not None and port.port not in ports_range:
             raise PortNotAvailableException(
@@ -272,25 +346,63 @@ class PortRange:
                         # We ignore the fact that this single port is reserved, we just check the next one
                         pass
         raise PortNotAvailableException(
-            "No free network ports available in the port range (currently reserved: %s)",
+            f"No free network ports available in {self!r} (currently reserved: %s)",
             list(self._ports_cache.keys()),
         )
 
     def is_port_reserved(self, port: IntOrPort) -> bool:
+        """
+        Checks whether the port has been reserved in this PortRange. Does not check whether the port can be
+        bound or not, and does not check whether the port is in range.
+
+        :param port: the port to check
+        :return: true if the port is reserved within the range
+        """
         port = Port.wrap(port)
         return self._ports_cache.get(port) is not None
 
-    def _try_reserve_port(self, port: IntOrPort, duration: int) -> int:
-        """Checks if the given port is currently not reserved and can be bound."""
+    def mark_reserved(self, port: IntOrPort, duration: int = None):
+        """
+        Marks the given port as reserved for the given duration, regardless of whether it is free for not.
+
+        :param port: the port to reserve
+        :param duration: the duration
+        :raises ValueError: if the port is not in this port range
+        """
         port = Port.wrap(port)
-        if not self.is_port_reserved(port) and port_can_be_bound(port):
+
+        if port.port not in self.as_range():
+            raise ValueError(f"port {port} not in {self!r}")
+
+        with self._ports_lock:
             # reserve the port for a short period of time
             self._ports_cache[port] = "__reserved__"
             if duration:
                 self._ports_cache.set_expiry(port, duration)
-            return port.port
-        else:
+
+    def _try_reserve_port(self, port: IntOrPort, duration: int) -> int:
+        """Checks if the given port is currently not reserved and can be bound."""
+        port = Port.wrap(port)
+
+        if self.is_port_reserved(port):
             raise PortNotAvailableException(f"The given port ({port}) is already reserved.")
+        if not self._port_can_be_bound(port):
+            raise PortNotAvailableException(f"The given port ({port}) is already in use.")
+
+        self.mark_reserved(port, duration)
+        return port.port
+
+    def _port_can_be_bound(self, port: IntOrPort) -> bool:
+        return port_can_be_bound(port)
+
+    def __len__(self):
+        return self.end - self.start + 1
+
+    def __iter__(self):
+        return self.as_range().__iter__()
+
+    def __repr__(self):
+        return f"PortRange({self.start}:{self.end})"
 
 
 @singleton_factory
@@ -336,3 +448,7 @@ def get_addressable_container_host(default_local_hostname: str = None) -> str:
     """
     default_local_hostname = default_local_hostname or constants.LOCALHOST_HOSTNAME
     return get_docker_host_from_container() if config.is_in_docker else default_local_hostname
+
+
+dynamic_port_range = PortRange(DYNAMIC_PORT_RANGE_START, DYNAMIC_PORT_RANGE_END)
+"""The dynamic port range."""

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -8,7 +8,12 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 from localstack.utils.net import (
     Port,
+    PortNotAvailableException,
+    PortRange,
+    dynamic_port_range,
     get_addressable_container_host,
+    get_free_tcp_port,
+    get_free_tcp_port_range,
     get_free_udp_port,
     is_ip_address,
     port_can_be_bound,
@@ -47,6 +52,59 @@ def test_port_open(protocol):
 def test_get_free_udp_port():
     port = get_free_udp_port()
     assert port_can_be_bound(Port(port, "udp"))
+
+
+def test_free_tcp_port_blocklist_raises_exception():
+    blocklist = range(0, 70000)  # blocklist all existing ports
+    with pytest.raises(Exception) as ctx:
+        get_free_tcp_port(blocklist)
+
+    assert "Unable to determine free TCP" in str(ctx.value)
+
+
+def test_port_can_be_bound():
+    port = get_free_tcp_port()
+    assert port_can_be_bound(port)
+
+
+def test_port_can_be_bound_illegal_port():
+    assert not port_can_be_bound(9999999999)
+
+
+def test_port_can_be_bound_already_bound():
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        tcp.bind(("", 0))
+        addr, port = tcp.getsockname()
+        assert not port_can_be_bound(port)
+    finally:
+        tcp.close()
+
+    assert port_can_be_bound(port)
+
+
+def test_get_free_tcp_port_range():
+    port_range = get_free_tcp_port_range(20)
+
+    assert len(port_range) == 20
+
+    for port in port_range:
+        assert dynamic_port_range.is_port_reserved(port)
+
+    for port in port_range:
+        assert port_can_be_bound(port)
+
+
+def test_get_free_tcp_port_range_fails_if_reserved(monkeypatch):
+    monkeypatch.setattr(dynamic_port_range, "is_port_reserved", lambda *args, **kwargs: True)
+
+    with pytest.raises(PortNotAvailableException):
+        get_free_tcp_port_range(20)
+
+
+def test_port_range_iter():
+    ports = PortRange(10, 13)
+    assert list(ports) == [10, 11, 12, 13]
 
 
 def test_get_addressable_container_host(monkeypatch):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When creating multiple instances of localstack within tests, we need to randomize container ports. This includes the gateway port `4566`, but also the service port range. Specifically I need this in #9050 to make the `random_service_port_range` configurator work.

Until now, there was no good way of finding a random port range that is contiguous that could be mapped to the external service port range, this PR adds such a method to the `net` utils.

<!-- What notable changes does this PR make? -->
## Changes

* add `get_free_tcp_port_range` that finds a random contiguous port range of `num_ports`
* made `PortRange` inclusive, i.e., it now correctly considers the port `5002` in range if the range is `PortRange(5000,5002)`
* add global `dynamic_port_range` that marks the default dynamic port range 49152 to 65535. this is now used in `get_free_tcp_port` to also check+mark ports as reserved, making it a bit more robust
* did some refactoring along the way

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

