### PR TITLE
Fix subscribe idempotency when no attributes are given

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -579,7 +579,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             sub = store.subscriptions.get(existing_topic_subscription, {})
             if sub.get("Endpoint") == endpoint:
                 for attr in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
-                    if attributes is not None and sub.get(attr) != attributes.get(attr):
+                    if attributes and sub.get(attr) != attributes.get(attr):
                         raise InvalidParameterException(
                             "Invalid parameter: Attributes Reason: Subscription already exists with different attributes"
                         )

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -768,7 +768,7 @@ class TestSNSSubscriptionCrud:
         )
         snapshot.match("subscribe-idempotent", subscribe_resp)
 
-        # no attributes are working as well
+        # no attributes and empty attributes are working as well
         subscribe_resp = aws_client.sns.subscribe(
             TopicArn=topic_arn,
             Protocol="sqs",
@@ -777,10 +777,14 @@ class TestSNSSubscriptionCrud:
         )
         snapshot.match("subscribe-idempotent-no-attributes", subscribe_resp)
 
-        get_attrs_resp = aws_client.sns.get_subscription_attributes(
-            SubscriptionArn=subscribe_resp["SubscriptionArn"]
+        subscribe_resp = aws_client.sns.subscribe(
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            ReturnSubscriptionArn=True,
+            Attributes={},
         )
-        snapshot.match("get-sub-attrs-2", get_attrs_resp)
+        snapshot.match("subscribe-idempotent-empty-attributes", subscribe_resp)
 
         with pytest.raises(ClientError) as e:
             aws_client.sns.subscribe(

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4166,7 +4166,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_idempotency": {
-    "recorded-date": "04-09-2023, 09:33:37",
+    "recorded-date": "04-09-2023, 09:45:33",
     "recorded-content": {
       "subscribe": {
         "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
@@ -4206,18 +4206,8 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-sub-attrs-2": {
-        "Attributes": {
-          "ConfirmationWasAuthenticated": "true",
-          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:2>",
-          "Owner": "111111111111",
-          "PendingConfirmation": "false",
-          "Protocol": "sqs",
-          "RawMessageDelivery": "true",
-          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
-          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
-        },
+      "subscribe-idempotent-empty-attributes": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
## Motivation
Addresses https://github.com/localstack/localstack/issues/9054

Specifying no attributes lead to the following exception 
```
E               if sub.get(attr) != attributes.get(attr):
E           AttributeError: 'NoneType' object has no attribute 'get'
```


## Changes

- Safety-check on the attributes before accessing keys.
- Adds a test case verifying this behavior