### PR TITLE
fix escaping backslash in comments

### DIFF
--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -60,6 +60,7 @@ def html_to_rst(html: str):
     doc = doc.replace("\_", "_")  # noqa: W605
     doc = doc.replace("\|", "|")  # noqa: W605
     doc = doc.replace("\ ", " ")  # noqa: W605
+    doc = doc.replace("\\", "\\\\")  # noqa: W605
     rst = doc.strip()
     return rst
 
@@ -511,8 +512,10 @@ def generate_code(service_name: str, doc: bool = False) -> str:
 
         # try to sort imports
         code = isort.code(code, config=isort.Config(profile="black", line_length=100))
-    except Exception:
-        pass
+    except ImportError:
+        click.echo(
+            "Skip code cleaning / formatting due to missing tools (autoflake, isort, black)..."
+        )
 
     return code
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The latest version of `botocore` contains a change in the spec (namely https://github.com/boto/botocore/commit/29dbcb9e1408c63ce9a3215447116789d6b4f528) which contains a backslash in the documentation of an operation of SESv2.
API code generated based on this botocore version fail the linting check, because the generated docstring contains the <code>\`\\`</code> (which violates [flake8's W605](https://www.flake8rules.com/rules/W605.html)).

<!-- What notable changes does this PR make? -->
## Changes
This PR just adds the backslash to the list of characters which need to be escaped in the docstring to fix the linting errors.

## Testing
The SESv2 API has been generated based on the change and it passes the linting.
