### PR TITLE
Fix #8985 'describe-security-group-rules' to return rules description

### DIFF
--- a/localstack/services/ec2/exceptions.py
+++ b/localstack/services/ec2/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from localstack.aws.api import CommonServiceException
 
 
@@ -53,4 +55,22 @@ class InvalidLaunchTemplateIdError(CommonServiceException):
         super().__init__(
             code="InvalidLaunchTemplateId.VersionNotFound",
             message="Could not find launch template version",
+        )
+
+
+class InvalidSecurityGroupNotFound(CommonServiceException):
+    def __init__(self, name: Any):
+        super().__init__(
+            "InvalidGroup.NotFound",
+            f"The security group '{name}' does not exist",
+        )
+
+
+class InvalidGroupIdMalformed(CommonServiceException):
+    def __init__(
+        self,
+    ):
+        super().__init__(
+            "InvalidGroupId.Malformed",
+            "The security group ID '' is malformed",
         )

--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -179,8 +179,6 @@ class Ec2Provider(Ec2Api, ABC):
                                 SecurityGroupRule(
                                     CidrIpv4=ip_range.get("CidrIp", None),
                                     CidrIpv6=ip_range.get("CidrIpv6", None),
-                                    PrefixListId=None,
-                                    ReferencedGroupInfo=None,
                                     Description=ip_range.get("Description", None),
                                     **common_fields,
                                 )
@@ -197,9 +195,6 @@ class Ec2Provider(Ec2Api, ABC):
                                         UserId=source_group.get("OwnerId", None),
                                     ),
                                     Description=source_group.get("Description", None),
-                                    CidrIpv4=None,
-                                    CidrIpv6=None,
-                                    PrefixListId=None,
                                     **common_fields,
                                 )
                                 for source_group in rule.source_groups
@@ -212,9 +207,6 @@ class Ec2Provider(Ec2Api, ABC):
                                 SecurityGroupRule(
                                     PrefixListId=prefix_list_id.get("PrefixListId"),
                                     Description=prefix_list_id.get("Description", None),
-                                    ReferencedGroupInfo=None,
-                                    CidrIpv4=None,
-                                    CidrIpv6=None,
                                     **common_fields,
                                 )
                                 for prefix_list_id in rule.prefix_list_ids

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -535,7 +535,7 @@ class TestDescribeSecurityGroupRules:
         for rule in result["SecurityGroupRules"]:
             if not rule["IsEgress"]:
                 assert rule["Description"] == "UserGroupID Test Description"
-                assert rule["ReferencedGroupInfo"]["UserId"] == DEFAULT_AWS_ACCOUNT_ID
+                assert rule["ReferencedGroupInfo"]["UserId"] == TEST_AWS_ACCOUNT_ID
 
     @markers.aws.validated
     def test_describe_security_group_rules_with_invalid_group_id(self, aws_client):


### PR DESCRIPTION
Fixes #8985 

Label : https://github.com/localstack/localstack/labels/semver%3A%20patch

# Motivation.

As reported in #8985 ,  ```describe-security-group-rules``` command does not return rules description.

The Moto backend was returning an object of SecurityGroupRule that contained various attributes, including PrefixListId, GroupId, and CidrIp, as illustrated in the examples below:

```BASH
[{'PrefixListId': 'pl-78a54011', 'Description': 'pl-78a54011-description'}]
[{'GroupId': 'sg-f7da0aeb67db76223', 'Description': 'Allow traffic from another security group', 'OwnerId': '000000000000'}]
[{'CidrIp': '127.0.0.1/32', 'Description': 'test-description1'}, {'CidrIpv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334/128', 'Description': 'IPv6 test description'}]
```

According to my analysis, the ```moto.ec2.responses.DESCRIBE_SECURITY_GROUP_RULES_RESPONSE``` does not currently provide support for parsing responses when a SecurityGroupRule object contains fields such as PrefixListId, GroupId, and CidrIpv6.

# Changes

Implemented modifications in the pull request to align the response with AWS standards and return ```Description```

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Before
```BASH
security_group_id=$(awslocal ec2 create-security-group --group-name example --description "Test Security Group" | jq -r .GroupId)
```
```BASH
awslocal ec2 authorize-security-group-ingress --group-id "${security_group_id}" --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=127.0.0.1/32,Description=test-description1}],PrefixListIds=[{PrefixListId=pl-78a54011,Description=pl-78a54011-description}],Ipv6Ranges=[{CidrIpv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334/128,Description=IPv6 test description}],UserIdGroupPairs=[{GroupId='${security_group_id}',Description=Allow traffic from another security group}]'
```
```BASH
awslocal ec2 describe-security-group-rules --filters "Name=group-id,Values=${security_group_id}" 
{
    "SecurityGroupRules": [
        {
            "SecurityGroupRuleId": "sgr-c67a52ca18e6cdac2",
            "GroupId": "sg-cdc859e438b01a8e9",
            "GroupOwnerId": "000000000000",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "CidrIpv4": "127.0.0.1/32"
        },
        {
            "SecurityGroupRuleId": "sgr-e7cbce7cd2fa11415",
            "GroupId": "sg-cdc859e438b01a8e9",
            "GroupOwnerId": "000000000000",
            "IsEgress": true,
            "IpProtocol": "-1",
            "CidrIpv4": "0.0.0.0/0"
        }
    ]
}
```
## After
```BASH
awslocal ec2 authorize-security-group-ingress --group-id "${security_group_id}" --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=127.0.0.1/32,Description=test-description1}],PrefixListIds=[{PrefixListId=pl-78a54011,Description=pl-78a54011-description}],Ipv6Ranges=[{CidrIpv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334/128,Description=IPv6 test description}],UserIdGroupPairs=[{GroupId='${security_group_id}',Description=Allow traffic from another security group}]'
{
    "Return": true,
    "SecurityGroupRules": [
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "GroupOwnerId": "000000000000",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "CidrIpv4": "127.0.0.1/32",
            "Description": "test-description1"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "GroupOwnerId": "000000000000",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "CidrIpv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128",
            "Description": "IPv6 test description"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "GroupOwnerId": "000000000000",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "PrefixListId": "pl-78a54011",
            "Description": "pl-78a54011-description"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "GroupOwnerId": "000000000000",
            "IsEgress": true,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "ReferencedGroupInfo": {
                "GroupId": "sg-c8a89d730e37ac39e",
                "UserId": "000000000000"
            },
            "Description": "Allow traffic from another security group"
        }
    ]
}
```
```BASH
awslocal ec2 describe-security-group-rules --filters "Name=group-id,Values=${security_group_id}"
{
    "SecurityGroupRules": [
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "CidrIpv4": "127.0.0.1/32",
            "Description": "test-description1"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "CidrIpv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128",
            "Description": "IPv6 test description"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "ReferencedGroupInfo": {
                "GroupId": "sg-c8a89d730e37ac39e",
                "UserId": "000000000000"
            },
            "Description": "Allow traffic from another security group"
        },
        {
            "SecurityGroupRuleId": "sgr-e714ef9d4dab5e113",
            "GroupId": "sg-c8a89d730e37ac39e",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 3389,
            "ToPort": 3389,
            "PrefixListId": "pl-78a54011",
            "Description": "pl-78a54011-description"
        },
        {
            "SecurityGroupRuleId": "sgr-bb0c717b7d5657733",
            "GroupId": "sg-c8a89d730e37ac39e",
            "IsEgress": true,
            "IpProtocol": "-1",
            "CidrIpv4": "0.0.0.0/0"
        }
    ]
}
```

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ]  

Patch this change in response schema for describe-security-group-rules command

-->

