### PR TITLE
feat: CLIError exception

### DIFF
--- a/localstack/cli/exceptions.py
+++ b/localstack/cli/exceptions.py
@@ -1,0 +1,19 @@
+import typing as t
+from gettext import gettext
+
+import click
+from click import ClickException, echo
+from click._compat import get_text_stderr
+
+
+class CLIError(ClickException):
+    """A ClickException with a red error message"""
+
+    def format_message(self) -> str:
+        return click.style(f"❌ Error: {self.message}", fg="red")
+
+    def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
+        if file is None:
+            file = get_text_stderr()
+
+        echo(gettext(self.format_message()), file=file)

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -6,6 +6,7 @@ import traceback
 from typing import Dict, List, Optional, Tuple
 
 from localstack import config
+from localstack.cli.exceptions import CLIError
 from localstack.utils.analytics.cli import publish_invocation
 from localstack.utils.bootstrap import get_container_default_logfile_location
 from localstack.utils.json import CustomEncoder
@@ -51,15 +52,15 @@ class ExceptionCmdHandler(click.Group):
             )
 
             if isinstance(e, DockerNotAvailable):
-                raise click.ClickException(
+                raise CLIError(
                     "Docker could not be found on the system.\n"
                     "Please make sure that you have a working docker environment on your machine."
                 )
             elif isinstance(e, ContainerException):
-                raise click.ClickException(e.message)
+                raise CLIError(e.message)
             else:
                 # If we have a generic exception, we wrap it in a ClickException
-                raise click.ClickException(str(e)) from e
+                raise CLIError(str(e)) from e
 
 
 def create_with_plugins() -> LocalstackCli:
@@ -346,7 +347,7 @@ def cmd_status_services(format_: str) -> None:
     except requests.ConnectionError:
         if config.DEBUG:
             console.print_exception()
-        raise click.ClickException(f"could not connect to LocalStack health endpoint at {url}")
+        raise CLIError(f"could not connect to LocalStack health endpoint at {url}")
 
 
 def _print_service_table(services: Dict[str, str]) -> None:
@@ -407,9 +408,9 @@ def cmd_start(
     with best-practice volume mounts and port mappings.
     """
     if docker and host:
-        raise click.ClickException("Please specify either --docker or --host")
+        raise CLIError("Please specify either --docker or --host")
     if host and detached:
-        raise click.ClickException("Cannot start detached in host mode")
+        raise CLIError("Cannot start detached in host mode")
 
     if not no_banner:
         print_banner()
@@ -439,7 +440,7 @@ def cmd_start(
         except ImportError:
             if config.DEBUG:
                 console.print_exception()
-            raise click.ClickException(
+            raise CLIError(
                 "It appears you have a light install of localstack which only supports running in docker.\n"
                 "If you would like to use --host, please install localstack with Python using "
                 "`pip install localstack[runtime]` instead."
@@ -462,7 +463,7 @@ def cmd_start(
             # `--network` is set.
             if config.MAIN_DOCKER_NETWORK:
                 if config.MAIN_DOCKER_NETWORK != network:
-                    raise click.ClickException(
+                    raise CLIError(
                         f"Values of MAIN_DOCKER_NETWORK={config.MAIN_DOCKER_NETWORK} and --network={network} "
                         f"do not match"
                     )
@@ -498,7 +499,7 @@ def cmd_stop() -> None:
         DOCKER_CLIENT.stop_container(container_name)
         console.print("container stopped: %s" % container_name)
     except NoSuchContainer:
-        raise click.ClickException(
+        raise CLIError(
             f'Expected a running LocalStack container named "{container_name}", but found none'
         )
 
@@ -586,7 +587,7 @@ def cmd_wait(timeout: Optional[float] = None) -> None:
     from localstack.utils.bootstrap import wait_container_is_ready
 
     if not wait_container_is_ready(timeout=timeout):
-        raise click.ClickException("timeout")
+        raise CLIError("timeout")
 
 
 @localstack.command(name="ssh", short_help="Obtain a shell in LocalStack")
@@ -605,7 +606,7 @@ def cmd_ssh() -> None:
     from localstack.utils.run import run
 
     if not DOCKER_CLIENT.is_container_running(config.MAIN_CONTAINER_NAME):
-        raise click.ClickException(
+        raise CLIError(
             f'Expected a running LocalStack container named "{config.MAIN_CONTAINER_NAME}", but found none'
         )
     try:
@@ -652,7 +653,7 @@ def cmd_update_localstack_cli() -> None:
     """
     if is_frozen_bundle():
         # "update" can only be performed if running from source / in a non-frozen interpreter
-        raise click.ClickException(
+        raise CLIError(
             "The LocalStack CLI can only update itself if installed via PIP. "
             "Please follow the instructions on https://docs.localstack.cloud/ to update your CLI."
         )
@@ -783,7 +784,7 @@ def localstack_completion(ctx: click.Context, shell: str) -> None:
 
     comp_cls = click.shell_completion.get_completion_class(shell)
     if comp_cls is None:
-        raise click.ClickException("Completion for given shell could not be found.")
+        raise CLIError("Completion for given shell could not be found.")
 
     # Click's program name is the base path of sys.argv[0]
     path = sys.argv[0]

--- a/localstack/cli/lpm.py
+++ b/localstack/cli/lpm.py
@@ -4,10 +4,10 @@ from multiprocessing.pool import ThreadPool
 from typing import List, Optional
 
 import click
-from click import ClickException
 from rich.console import Console
 
 from localstack import config
+from localstack.cli.exceptions import CLIError
 from localstack.packages import InstallTarget, Package
 from localstack.packages.api import NoSuchPackageException, PackagesPluginManager
 from localstack.utils.bootstrap import setup_logging
@@ -105,10 +105,10 @@ def install(
             )
     except NoSuchPackageException as e:
         LOG.debug(str(e), exc_info=e)
-        raise ClickException(str(e))
+        raise CLIError(str(e))
     except Exception as e:
         LOG.debug("one or more package installations failed.", exc_info=e)
-        raise ClickException("one or more package installations failed.")
+        raise CLIError("one or more package installations failed.")
 
 
 @cli.command(name="list")

--- a/localstack/cli/plugins.py
+++ b/localstack/cli/plugins.py
@@ -9,6 +9,8 @@ from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
+from localstack.cli.exceptions import CLIError
+
 console = Console()
 
 
@@ -53,7 +55,7 @@ def find(where, exclude, include, output):
     elif output == "dict":
         rprint(dict(plugins))
     else:
-        raise click.ClickException("unknown output format %s" % output)
+        raise CLIError("unknown output format %s" % output)
 
 
 @cli.command("list")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We want to make errors from the CLI a bit more fancy and easily recognizable.


<!-- What notable changes does this PR make? -->
## Changes

Introducing `CLIError`, extending `ClickException` with the following additions:
- the text is red-colored;
- a ❌ is prepended to the error message.

This PR also replaces all the old usage of `ClickException` with this new implementation.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

