### PR TITLE
Implement APIGW UpdateGatewayResponse

### DIFF
--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -8,6 +8,7 @@ from localstack.aws.api.apigateway import (
     DocumentationVersion,
     DomainName,
     GatewayResponse,
+    GatewayResponseType,
     Model,
     RequestValidator,
     RestApi,
@@ -33,7 +34,7 @@ class RestApiContainer:
     # map doc version name -> DocumentationVersion
     documentation_versions: Dict[str, DocumentationVersion]
     # not used yet, still in moto
-    gateway_responses: Dict[str, GatewayResponse]
+    gateway_responses: Dict[GatewayResponseType, GatewayResponse]
     # maps Model name -> Model
     models: Dict[str, Model]
     # maps Model name -> resolved dict Model, so we don't need to load the JSON everytime

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -43,6 +43,9 @@ from localstack.aws.api.apigateway import (
     DomainNameStatus,
     EndpointConfiguration,
     ExportResponse,
+    GatewayResponse,
+    GatewayResponses,
+    GatewayResponseType,
     GetDocumentationPartsRequest,
     Integration,
     IntegrationResponse,
@@ -2034,6 +2037,120 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         return usage_plans
 
+    def put_gateway_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        response_type: GatewayResponseType,
+        status_code: StatusCode = None,
+        response_parameters: MapOfStringToString = None,
+        response_templates: MapOfStringToString = None,
+    ) -> GatewayResponse:
+        # There were no validation in moto, so implementing as is
+        # TODO: add validation
+        store = get_apigateway_store(context=context)
+        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
+
+        if response_type not in DEFAULT_GATEWAY_RESPONSES:
+            raise CommonServiceException(
+                code="ValidationException",
+                message=f"1 validation error detected: Value '{response_type}' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [{', '.join(DEFAULT_GATEWAY_RESPONSES)}]",
+            )
+
+        gateway_response = GatewayResponse(
+            statusCode=status_code,
+            responseParameters=response_parameters,
+            responseTemplates=response_templates,
+            responseType=response_type,
+            defaultResponse=False,
+        )
+        rest_api_container.gateway_responses[response_type] = gateway_response
+        return gateway_response
+
+    def get_gateway_response(
+        self, context: RequestContext, rest_api_id: String, response_type: GatewayResponseType
+    ) -> GatewayResponse:
+        store = get_apigateway_store(context=context)
+        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
+
+        if response_type not in DEFAULT_GATEWAY_RESPONSES:
+            raise CommonServiceException(
+                code="ValidationException",
+                message=f"1 validation error detected: Value '{response_type}' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [{', '.join(DEFAULT_GATEWAY_RESPONSES)}]",
+            )
+
+        gateway_response = rest_api_container.gateway_responses.get(
+            response_type, DEFAULT_GATEWAY_RESPONSES[response_type]
+        )
+        # TODO: add validation with the parameters? seems like it validated client side? how to try?
+        return gateway_response
+
+    def get_gateway_responses(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        position: String = None,
+        limit: NullableInteger = None,
+    ) -> GatewayResponses:
+        store = get_apigateway_store(context=context)
+        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
+
+        user_gateway_resp = rest_api_container.gateway_responses
+        gateway_responses = [
+            user_gateway_resp.get(key) or value for key, value in DEFAULT_GATEWAY_RESPONSES.items()
+        ]
+        return GatewayResponses(items=gateway_responses)
+
+    def delete_gateway_response(
+        self, context: RequestContext, rest_api_id: String, response_type: GatewayResponseType
+    ) -> None:
+        store = get_apigateway_store(context=context)
+        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
+
+        if response_type not in DEFAULT_GATEWAY_RESPONSES:
+            raise CommonServiceException(
+                code="ValidationException",
+                message=f"1 validation error detected: Value '{response_type}' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [{', '.join(DEFAULT_GATEWAY_RESPONSES)}]",
+            )
+
+        if not rest_api_container.gateway_responses.pop(response_type, None):
+            raise NotFoundException("Gateway response type not defined on api")
+
+    def update_gateway_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        response_type: GatewayResponseType,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> GatewayResponse:
+        store = get_apigateway_store(context=context)
+        if not (rest_api_container := store.rest_apis.get(rest_api_id)):
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
+
+        if response_type not in DEFAULT_GATEWAY_RESPONSES:
+            raise CommonServiceException(
+                code="ValidationException",
+                message=f"1 validation error detected: Value '{response_type}' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [{', '.join(DEFAULT_GATEWAY_RESPONSES)}]",
+            )
+
+        print(rest_api_container)
+
+    # TODO
+
 
 # ---------------
 # UTIL FUNCTIONS
@@ -2303,4 +2420,152 @@ UPDATE_METHOD_PATCH_PATHS = {
         "/requestModels/",
         "/requestValidatorId",
     ],
+}
+
+DEFAULT_GATEWAY_RESPONSES: dict[GatewayResponseType, GatewayResponse] = {
+    GatewayResponseType.REQUEST_TOO_LARGE: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "REQUEST_TOO_LARGE",
+        "statusCode": "413",
+    },
+    GatewayResponseType.RESOURCE_NOT_FOUND: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "RESOURCE_NOT_FOUND",
+        "statusCode": "404",
+    },
+    GatewayResponseType.AUTHORIZER_CONFIGURATION_ERROR: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "AUTHORIZER_CONFIGURATION_ERROR",
+        "statusCode": "500",
+    },
+    GatewayResponseType.MISSING_AUTHENTICATION_TOKEN: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "MISSING_AUTHENTICATION_TOKEN",
+        "statusCode": "403",
+    },
+    GatewayResponseType.BAD_REQUEST_BODY: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "BAD_REQUEST_BODY",
+        "statusCode": "400",
+    },
+    GatewayResponseType.INVALID_SIGNATURE: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "INVALID_SIGNATURE",
+        "statusCode": "403",
+    },
+    GatewayResponseType.INVALID_API_KEY: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "INVALID_API_KEY",
+        "statusCode": "403",
+    },
+    GatewayResponseType.BAD_REQUEST_PARAMETERS: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "BAD_REQUEST_PARAMETERS",
+        "statusCode": "400",
+    },
+    GatewayResponseType.AUTHORIZER_FAILURE: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "AUTHORIZER_FAILURE",
+        "statusCode": "500",
+    },
+    GatewayResponseType.UNAUTHORIZED: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "UNAUTHORIZED",
+        "statusCode": "401",
+    },
+    GatewayResponseType.INTEGRATION_TIMEOUT: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "INTEGRATION_TIMEOUT",
+        "statusCode": "504",
+    },
+    GatewayResponseType.ACCESS_DENIED: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "ACCESS_DENIED",
+        "statusCode": "403",
+    },
+    GatewayResponseType.DEFAULT_4XX: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "DEFAULT_4XX",
+    },
+    GatewayResponseType.DEFAULT_5XX: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "DEFAULT_5XX",
+    },
+    GatewayResponseType.WAF_FILTERED: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "WAF_FILTERED",
+        "statusCode": "403",
+    },
+    GatewayResponseType.QUOTA_EXCEEDED: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "QUOTA_EXCEEDED",
+        "statusCode": "429",
+    },
+    GatewayResponseType.THROTTLED: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "THROTTLED",
+        "statusCode": "429",
+    },
+    GatewayResponseType.API_CONFIGURATION_ERROR: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "API_CONFIGURATION_ERROR",
+        "statusCode": "500",
+    },
+    GatewayResponseType.UNSUPPORTED_MEDIA_TYPE: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "UNSUPPORTED_MEDIA_TYPE",
+        "statusCode": "415",
+    },
+    GatewayResponseType.INTEGRATION_FAILURE: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "INTEGRATION_FAILURE",
+        "statusCode": "504",
+    },
+    GatewayResponseType.EXPIRED_TOKEN: {
+        "defaultResponse": True,
+        "responseParameters": {},
+        "responseTemplates": {"application/json": '{"message":$context.error.messageString}'},
+        "responseType": "EXPIRED_TOKEN",
+        "statusCode": "403",
+    },
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -2976,5 +2976,185 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
+    "recorded-date": "05-09-2023, 01:58:33",
+    "recorded-content": {
+      "update-gateway-response-not-set": {
+        "defaultResponse": false,
+        "responseParameters": {},
+        "responseTemplates": {
+          "application/json": "{\"message\":$context.error.messageString}"
+        },
+        "responseType": "DEFAULT_4XX",
+        "statusCode": "444",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default-get-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {},
+        "responseTemplates": {
+          "application/json": "{\"message\":$context.error.messageString}"
+        },
+        "responseType": "DEFAULT_4XX",
+        "statusCode": "444",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'a.b.c'",
+          "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+          "gatewayresponse.header.x-request-path": "method.request.path.petId",
+          "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+        },
+        "responseTemplates": {
+          "application/json": {
+            "application/json": "{\"message\":$context.error.messageString}"
+          }
+        },
+        "responseType": "DEFAULT_4XX",
+        "statusCode": "404",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'example.com'",
+          "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+          "gatewayresponse.header.x-request-path": "method.request.path.petId",
+          "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+        },
+        "responseTemplates": {
+          "application/json": {
+            "application/json": "{\"message\":$context.error.messageString}"
+          },
+          "application/xml": "<gatewayResponse><message>$context.error.messageString</message><type>$context.error.responseType</type></gatewayResponse>"
+        },
+        "responseType": "DEFAULT_4XX",
+        "statusCode": "444",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'example.com'",
+          "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+          "gatewayresponse.header.x-request-path": "method.request.path.petId",
+          "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+        },
+        "responseTemplates": {
+          "application/json": {
+            "application/json": "{\"message\":$context.error.messageString}"
+          },
+          "application/xml": "<gatewayResponse><message>$context.error.messageString</message><type>$context.error.responseType</type></gatewayResponse>"
+        },
+        "responseType": "DEFAULT_4XX",
+        "statusCode": "444",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-gateway-add-status-code": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /statusCode"
+        },
+        "message": "Invalid patch path /statusCode",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-remove-status-code": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /statusCode"
+        },
+        "message": "Invalid patch path /statusCode",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-replace-invalid-parameter": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid parameter name specified"
+        },
+        "message": "Invalid parameter name specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "update-gateway-no-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path null"
+        },
+        "message": "Invalid patch path null",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-wrong-op": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'wrong-op' at 'updateGatewayResponseInput.patchOperations.1.member.op' failed to satisfy constraint: Member must satisfy enum value set: [add, remove, move, test, replace, copy]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-wrong-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /wrongPath"
+        },
+        "message": "Invalid patch path /wrongPath",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-replace-invalid-parameter-0-none": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid null or empty value in responseTemplates"
+        },
+        "message": "Invalid null or empty value in responseTemplates",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-replace-invalid-parameter-1-none": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid null or empty value in responseParameters"
+        },
+        "message": "Invalid null or empty value in responseParameters",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -2603,5 +2603,378 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_crud": {
+    "recorded-date": "04-09-2023, 20:13:20",
+    "recorded-content": {
+      "get-gateway-response-default": {
+        "defaultResponse": true,
+        "responseParameters": {},
+        "responseTemplates": {
+          "application/json": "{\"message\":$context.error.messageString}"
+        },
+        "responseType": "MISSING_AUTHENTICATION_TOKEN",
+        "statusCode": "403",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'a.b.c'",
+          "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+          "gatewayresponse.header.x-request-path": "method.request.path.petId",
+          "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+        },
+        "responseTemplates": {
+          "application/json": "{\n     \"message\": $context.error.messageString,\n     \"type\":  \"$context.error.responseType\",\n     \"stage\":  \"$context.stage\",\n     \"resourcePath\":  \"$context.resourcePath\",\n     \"stageVariables.a\":  \"$stageVariables.a\",\n     \"statusCode\": \"'404'\"\n}"
+        },
+        "responseType": "MISSING_AUTHENTICATION_TOKEN",
+        "statusCode": "404",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-gateway-responses": {
+        "items": [
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "ACCESS_DENIED",
+            "statusCode": "403"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "API_CONFIGURATION_ERROR",
+            "statusCode": "500"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "AUTHORIZER_CONFIGURATION_ERROR",
+            "statusCode": "500"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "AUTHORIZER_FAILURE",
+            "statusCode": "500"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "BAD_REQUEST_BODY",
+            "statusCode": "400"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "BAD_REQUEST_PARAMETERS",
+            "statusCode": "400"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "DEFAULT_4XX"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "DEFAULT_5XX"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "EXPIRED_TOKEN",
+            "statusCode": "403"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "INTEGRATION_FAILURE",
+            "statusCode": "504"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "INTEGRATION_TIMEOUT",
+            "statusCode": "504"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "INVALID_API_KEY",
+            "statusCode": "403"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "INVALID_SIGNATURE",
+            "statusCode": "403"
+          },
+          {
+            "defaultResponse": false,
+            "responseParameters": {
+              "gatewayresponse.header.Access-Control-Allow-Origin": "'a.b.c'",
+              "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+              "gatewayresponse.header.x-request-path": "method.request.path.petId",
+              "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+            },
+            "responseTemplates": {
+              "application/json": "{\n     \"message\": $context.error.messageString,\n     \"type\":  \"$context.error.responseType\",\n     \"stage\":  \"$context.stage\",\n     \"resourcePath\":  \"$context.resourcePath\",\n     \"stageVariables.a\":  \"$stageVariables.a\",\n     \"statusCode\": \"'404'\"\n}"
+            },
+            "responseType": "MISSING_AUTHENTICATION_TOKEN",
+            "statusCode": "404"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "QUOTA_EXCEEDED",
+            "statusCode": "429"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "REQUEST_TOO_LARGE",
+            "statusCode": "413"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "RESOURCE_NOT_FOUND",
+            "statusCode": "404"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "THROTTLED",
+            "statusCode": "429"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "UNAUTHORIZED",
+            "statusCode": "401"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "UNSUPPORTED_MEDIA_TYPE",
+            "statusCode": "415"
+          },
+          {
+            "defaultResponse": true,
+            "responseParameters": {},
+            "responseTemplates": {
+              "application/json": "{\"message\":$context.error.messageString}"
+            },
+            "responseType": "WAF_FILTERED",
+            "statusCode": "403"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-gateway-response": {
+        "defaultResponse": false,
+        "responseParameters": {
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'a.b.c'",
+          "gatewayresponse.header.x-request-header": "method.request.header.Accept",
+          "gatewayresponse.header.x-request-path": "method.request.path.petId",
+          "gatewayresponse.header.x-request-query": "method.request.querystring.q"
+        },
+        "responseTemplates": {
+          "application/json": "{\n     \"message\": $context.error.messageString,\n     \"type\":  \"$context.error.responseType\",\n     \"stage\":  \"$context.stage\",\n     \"resourcePath\":  \"$context.resourcePath\",\n     \"stageVariables.a\":  \"$stageVariables.a\",\n     \"statusCode\": \"'404'\"\n}"
+        },
+        "responseType": "MISSING_AUTHENTICATION_TOKEN",
+        "statusCode": "404",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-gateway-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get-deleted-gw-response": {
+        "defaultResponse": true,
+        "responseParameters": {},
+        "responseTemplates": {
+          "application/json": "{\"message\":$context.error.messageString}"
+        },
+        "responseType": "MISSING_AUTHENTICATION_TOKEN",
+        "statusCode": "403",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_validation": {
+    "recorded-date": "04-09-2023, 20:32:34",
+    "recorded-content": {
+      "get-gateway-responses-no-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:fake-api-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:fake-api-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-gateway-response-no-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:fake-api-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:fake-api-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-gateway-response-no-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:fake-api-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:fake-api-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "update-gateway-response-no-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:fake-api-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:fake-api-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-gateway-response-not-set": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Gateway response type not defined on api"
+        },
+        "message": "Gateway response type not defined on api",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-gateway-response-wrong-response-type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'FAKE_RESPONSE_TYPE' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [REQUEST_TOO_LARGE, RESOURCE_NOT_FOUND, AUTHORIZER_CONFIGURATION_ERROR, MISSING_AUTHENTICATION_TOKEN, BAD_REQUEST_BODY, INVALID_SIGNATURE, INVALID_API_KEY, BAD_REQUEST_PARAMETERS, AUTHORIZER_FAILURE, UNAUTHORIZED, INTEGRATION_TIMEOUT, ACCESS_DENIED, DEFAULT_4XX, DEFAULT_5XX, WAF_FILTERED, QUOTA_EXCEEDED, THROTTLED, API_CONFIGURATION_ERROR, UNSUPPORTED_MEDIA_TYPE, INTEGRATION_FAILURE, EXPIRED_TOKEN]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-gateway-response-wrong-response-type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'FAKE_RESPONSE_TYPE' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [REQUEST_TOO_LARGE, RESOURCE_NOT_FOUND, AUTHORIZER_CONFIGURATION_ERROR, MISSING_AUTHENTICATION_TOKEN, BAD_REQUEST_BODY, INVALID_SIGNATURE, INVALID_API_KEY, BAD_REQUEST_PARAMETERS, AUTHORIZER_FAILURE, UNAUTHORIZED, INTEGRATION_TIMEOUT, ACCESS_DENIED, DEFAULT_4XX, DEFAULT_5XX, WAF_FILTERED, QUOTA_EXCEEDED, THROTTLED, API_CONFIGURATION_ERROR, UNSUPPORTED_MEDIA_TYPE, INTEGRATION_FAILURE, EXPIRED_TOKEN]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-gateway-response-wrong-response-type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'FAKE_RESPONSE_TYPE' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [REQUEST_TOO_LARGE, RESOURCE_NOT_FOUND, AUTHORIZER_CONFIGURATION_ERROR, MISSING_AUTHENTICATION_TOKEN, BAD_REQUEST_BODY, INVALID_SIGNATURE, INVALID_API_KEY, BAD_REQUEST_PARAMETERS, AUTHORIZER_FAILURE, UNAUTHORIZED, INTEGRATION_TIMEOUT, ACCESS_DENIED, DEFAULT_4XX, DEFAULT_5XX, WAF_FILTERED, QUOTA_EXCEEDED, THROTTLED, API_CONFIGURATION_ERROR, UNSUPPORTED_MEDIA_TYPE, INTEGRATION_FAILURE, EXPIRED_TOKEN]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-gateway-response-wrong-response-type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'FAKE_RESPONSE_TYPE' at 'responseType' failed to satisfy constraint: Member must satisfy enum value set: [REQUEST_TOO_LARGE, RESOURCE_NOT_FOUND, AUTHORIZER_CONFIGURATION_ERROR, MISSING_AUTHENTICATION_TOKEN, BAD_REQUEST_BODY, INVALID_SIGNATURE, INVALID_API_KEY, BAD_REQUEST_PARAMETERS, AUTHORIZER_FAILURE, UNAUTHORIZED, INTEGRATION_TIMEOUT, ACCESS_DENIED, DEFAULT_4XX, DEFAULT_5XX, WAF_FILTERED, QUOTA_EXCEEDED, THROTTLED, API_CONFIGURATION_ERROR, UNSUPPORTED_MEDIA_TYPE, INTEGRATION_FAILURE, EXPIRED_TOKEN]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've had a feature request to implement UpdateGatewayResponse, which was missing from the moto implementation.
After a quick check to the moto implementation and some AWS validated tests, it showed that the current implementation was lacking all the default `GatewayResponse` from AWS. It was then quicker to implement it in our provider than to patch the whole moto implementation just to add an operation, especially since the moto implementation did not implement any validation. 

To note: even though this is implemented, we don't currently use `GatewayResponse` in our actual invocation part of the code. It also shows that there are different kinds of exception raised internally, and this could help us restructure the code around those exceptions (looking at the response type documentation page).

Documentation about `GatewayResponse`:
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html
https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateGatewayResponse.html

<!-- What notable changes does this PR make? -->
## Changes
Migrated the following operations from moto:
- `PutGatewayResponse`
- `GetGatewayResponse`
- `GetGatewayResponses`
- `DeleteGatewayResponse`

Implemented the following:
- `UpdateGatewayResponse`

Created 3 new AWS validated tests validating the behaviour of our operations. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

