### PR TITLE
implement Content-MD5 check for PutObject

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -232,8 +232,6 @@ class BucketLocationConstraint(str):
     us_gov_west_1 = "us-gov-west-1"
     us_west_1 = "us-west-1"
     us_west_2 = "us-west-2"
-    ap_south_2 = "ap-south-2"
-    eu_south_2 = "eu-south-2"
 
 
 class BucketLogsPermission(str):
@@ -370,8 +368,6 @@ class InventoryOptionalField(str):
     IntelligentTieringAccessTier = "IntelligentTieringAccessTier"
     BucketKeyStatus = "BucketKeyStatus"
     ChecksumAlgorithm = "ChecksumAlgorithm"
-    ObjectAccessControlList = "ObjectAccessControlList"
-    ObjectOwner = "ObjectOwner"
 
 
 class JSONType(str):
@@ -880,6 +876,13 @@ class NoSuchBucketPolicy(ServiceException):
     sender_fault: bool = False
     status_code: int = 404
     BucketName: Optional[BucketName]
+
+
+class InvalidDigest(ServiceException):
+    code: str = "InvalidDigest"
+    sender_fault: bool = False
+    status_code: int = 400
+    Content_MD5: Optional[ContentMD5]
 
 
 AbortDate = datetime

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1134,6 +1134,21 @@
       "value": {
         "httpStatusCode": 403
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidDigest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Content_MD5": {
+            "shape": "ContentMD5",
+            "locationName":"Content-MD5"
+          }
+        },
+        "documentation": "<p>The Content-MD5 you specified was invalid.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -30,6 +30,7 @@ from localstack.aws.api.s3 import (
     CopyObjectOutput,
     CopyObjectRequest,
     InvalidArgument,
+    InvalidDigest,
     InvalidStorageClass,
     NoSuchUpload,
     PreconditionFailed,
@@ -44,6 +45,7 @@ from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.provider import S3Provider
 from localstack.services.s3.utils import (
     InvalidRequest,
+    etag_to_base_64_content_md5,
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
     get_key_from_moto_bucket,
@@ -150,6 +152,21 @@ class S3ProviderStream(S3Provider):
 
         # the etag is recalculated
         response["ETag"] = key_object.etag
+
+        # verify content_md5
+        if content_md5 := request.get("ContentMD5"):
+            calculated_md5 = etag_to_base_64_content_md5(key_object.etag.strip('"'))
+            if calculated_md5 != content_md5:
+                moto_backend.delete_object(
+                    bucket_name=request["Bucket"],
+                    key_name=request["Key"],
+                    version_id=key_object.version_id,
+                    bypass=True,
+                )
+                raise InvalidDigest(
+                    "The Content-MD5 you specified was invalid.",
+                    Content_MD5=content_md5,
+                )
 
         if expires := request.get("Expires"):
             key_object.set_expiry(expires)

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -1,3 +1,5 @@
+import base64
+import codecs
 import datetime
 import hashlib
 import logging
@@ -64,7 +66,14 @@ from localstack.services.s3.constants import (
 from localstack.services.s3.exceptions import InvalidRequest, MalformedXML
 from localstack.utils.aws import arns
 from localstack.utils.aws.arns import parse_arn
-from localstack.utils.strings import checksum_crc32, checksum_crc32c, hash_sha1, hash_sha256
+from localstack.utils.strings import (
+    checksum_crc32,
+    checksum_crc32c,
+    hash_sha1,
+    hash_sha256,
+    to_bytes,
+    to_str,
+)
 from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
@@ -272,6 +281,17 @@ def verify_checksum(checksum_algorithm: str, data: bytes, request: Dict):
         raise InvalidRequest(
             f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
         )
+
+
+def etag_to_base_64_content_md5(etag: ETag) -> str:
+    """
+    Convert an ETag, representing an md5 hexdigest (might be quoted), to its base64 encoded representation
+    :param etag: an ETag, might be quoted
+    :return: the base64 value
+    """
+    # get the bytes digest from the hexdigest
+    byte_digest = codecs.decode(to_bytes(etag.strip('"')), "hex")
+    return to_str(base64.b64encode(byte_digest))
 
 
 def decode_aws_chunked_object(

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -99,6 +99,7 @@ from localstack.aws.api.s3 import (
     IntelligentTieringId,
     InvalidArgument,
     InvalidBucketName,
+    InvalidDigest,
     InvalidObjectState,
     InvalidPartNumber,
     InvalidPartOrder,
@@ -222,6 +223,7 @@ from localstack.services.s3.utils import (
     add_expiration_days_to_datetime,
     create_redirect_for_post_request,
     create_s3_kms_managed_key_for_region,
+    etag_to_base_64_content_md5,
     extract_bucket_key_version_id_from_copy_source,
     get_canned_acl,
     get_class_attrs_from_spec_class,
@@ -633,6 +635,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             raise InvalidRequest(
                 f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
             )
+
+        # TODO: handle ContentMD5 and ChecksumAlgorithm in a handler for all requests except requests with a streaming
+        #  body. We can use the specs to verify which operations needs to have the checksum validated
+        if content_md5 := request.get("ContentMD5"):
+            calculated_md5 = etag_to_base_64_content_md5(s3_stored_object.etag)
+            if calculated_md5 != content_md5:
+                self._storage_backend.remove(bucket_name, s3_object)
+                raise InvalidDigest(
+                    "The Content-MD5 you specified was invalid.",
+                    Content_MD5=content_md5,
+                )
 
         s3_bucket.objects.set(key, s3_object)
 

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1613,7 +1613,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_invalid_content_md5": {
-    "recorded-date": "03-08-2023, 04:17:53",
+    "recorded-date": "05-09-2023, 02:58:55",
     "recorded-content": {
       "md5-error-0": {
         "Error": {
@@ -1657,6 +1657,14 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "success-put-object-md5": {
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As requested and reported in #8929, we were missing `Content-MD5` validation for `PutObject`, which was implemented in the `legacy` provider.

`ChecksumAlgorithm` or `Content-MD5` allows to verify that the payload sent is properly received in the right shape.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#checking-object-integrity-md5

This will only concern `PutObject` for now, but many operation have this parameter (I think around 21, some like `PutBucketAcl` for example). 

As we had a look with @alexrashed a long, long time ago, the specs implement some kind of way to know which operations have to have some kind of required checksum.

The end goal would be to have a handler to manage the checksum verification for all operations, except the ones with a streaming body like `PutObject`, as those require special handling (reading the body only once). This is in the backlog and will be tackled in the future.

<!-- What notable changes does this PR make? -->
## Changes
Implemented different strategies depending on the provider.
For the default and streaming providers, I've done the same kind of logic as the checksum for the streaming provider, but using the `ETag` of the object, which represents the `hexdigest` of the md5 hash. The `Content-MD5` header is the base64 encoded digest of the hash, so it needs a bit of encoding/decoding to be able to compare them.
I did not do the same logic as the regular checksum in the default provider, because if the request is encoded using `aws-chunk`, the request data is not equal to the object body, and should be decoded twice (once in LocalStack and once in moto), so I'm doing after moto already calculated the ETag.

Same logic for the v3 provider, we first set the object to read the body only once, and we then verify the b64 encoded etag vs the provided `Content-MD5` value. 

Removed the xfail for the related test and improved it a bit. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

