### PR TITLE
upgrade to actions/checkout@v4, add actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alexrashed"
+    labels:
+      - "area: dependencies"
+      - "semver: patch"

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Open Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -13,7 +13,7 @@ jobs:
     name: Sync DockerHub Description
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Docker Hub Description
       uses: peter-evans/dockerhub-description@v3

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -61,7 +61,7 @@ jobs:
       CI_JOB_ID: ${{ github.job }}-${{ matrix.python-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v4

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -42,7 +42,7 @@ jobs:
       CI_JOB_ID: ${{ github.job }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -69,7 +69,7 @@ jobs:
       CI_JOB_ID: ${{ github.job }}
     steps:
       - name: Checkout Community
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: localstack
 
@@ -131,7 +131,7 @@ jobs:
             return DEFAULT_REF
 
       - name: Checkout Pro
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: localstack/localstack-ext
           ref: ${{steps.determine-companion-ref.outputs.result}}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are still seeing build issues related to https://github.com/actions/checkout/issues/1448, even though the incident should already be fixed (according to https://www.githubstatus.com/).
Some comments in this issue imply that an upgrade to the just newly released version 4 of [actions/checkout](https://github.com/actions/checkout) might fix the issue.
I used this opportunity toi also 

<!-- What notable changes does this PR make? -->
## Changes
- Upgrades all usages of [actions/checkout](https://github.com/actions/checkout) to version 4.
- Add GitHub actions to the dependabot config to file these upgrade PRs automatically in the future.