### PR TITLE
Add test for s3 bucket concurrency

### DIFF
--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -95,7 +95,7 @@ class BucketCorsIndex:
     @staticmethod
     def _build_bucket_index() -> set[BucketName]:
         result = set()
-        for account_id, regions in moto_s3_backends.items():
+        for account_id, regions in list(moto_s3_backends.items()):
             result.update(regions["global"].buckets.keys())
         return result
 

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -1,0 +1,40 @@
+import logging
+import threading
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+LOG = logging.getLogger(__name__)
+
+
+class TestParallelBucketCreation:
+    @markers.aws.unknown
+    def test_parallel_bucket_creation(self, aws_client_factory):
+        num_threads = 10
+        create_barrier = threading.Barrier(num_threads)
+        errored = False
+
+        def _create_bucket(runner: int):
+            nonlocal errored
+            bucket_name = f"bucket-{short_uid()}"
+            s3_client = aws_client_factory(
+                region_name="us-east-1", aws_access_key_id=f"{runner:012d}"
+            ).s3
+            create_barrier.wait()
+            try:
+                s3_client.create_bucket(Bucket=bucket_name)
+                s3_client.create_bucket(Bucket=bucket_name)
+            except Exception:
+                LOG.exception("Create bucket failed")
+                errored = True
+
+        thread_list = []
+        for i in range(1, num_threads + 1):
+            thread = threading.Thread(target=_create_bucket, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        assert not errored

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -8,7 +8,7 @@ LOG = logging.getLogger(__name__)
 
 
 class TestParallelBucketCreation:
-    @markers.aws.validated
+    @markers.aws.only_localstack
     def test_parallel_bucket_creation(self, aws_client_factory, cleanups):
         num_threads = 10
         create_barrier = threading.Barrier(num_threads)

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -8,8 +8,8 @@ LOG = logging.getLogger(__name__)
 
 
 class TestParallelBucketCreation:
-    @markers.aws.unknown
-    def test_parallel_bucket_creation(self, aws_client_factory):
+    @markers.aws.validated
+    def test_parallel_bucket_creation(self, aws_client_factory, cleanups):
         num_threads = 10
         create_barrier = threading.Barrier(num_threads)
         errored = False
@@ -20,6 +20,7 @@ class TestParallelBucketCreation:
             s3_client = aws_client_factory(
                 region_name="us-east-1", aws_access_key_id=f"{runner:012d}"
             ).s3
+            cleanups.append(lambda: s3_client.delete_bucket(Bucket=bucket_name))
             create_barrier.wait()
             try:
                 s3_client.create_bucket(Bucket=bucket_name)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had some problem with simultaneous bucket operations. This PR adds a test for it. It should be fixed with #9044

<!-- What notable changes does this PR make? -->
## Changes
* Add list wrapper to avoid issue with concurrent modification of a dict while iterating
* Add test for 10 simultaneous bucket creations with the requirement of us-east-1 bucket creation idempotency.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

