### PR TITLE
add option to disable retries & disable boto retries for CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,11 +176,12 @@ docker-cp-coverage:
 		docker rm -v $$id
 
 test:              		  ## Run automated tests
-	($(VENV_RUN); DEBUG=$(DEBUG) pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
+	($(VENV_RUN); DEBUG=$(DEBUG) DISABLE_BOTO_RETRIES=1 pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
 
 test-coverage:     		  ## Run automated tests and create coverage report
 	($(VENV_RUN); python -m coverage --version; \
 		DEBUG=$(DEBUG) \
+		DISABLE_BOTO_RETRIES=1 \
 		LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC=1 \
 		python -m coverage run $(COVERAGE_ARGS) -m \
 		pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))

--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -324,6 +324,12 @@ class ClientFactory(ABC):
         :return: Boto3 client.
         """
         with self._create_client_lock:
+            default_config = (
+                Config(retries={"max_attempts": 0})
+                if localstack_config.DISABLE_BOTO_RETRIES
+                else Config()
+            )
+
             client = self._session.client(
                 service_name=service_name,
                 region_name=region_name,
@@ -333,7 +339,7 @@ class ClientFactory(ABC):
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,
-                config=config.merge(Config(retries={"max_attempts": 0})),
+                config=config.merge(default_config),
             )
 
         return self._get_client_post_hook(client)

--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -333,7 +333,7 @@ class ClientFactory(ABC):
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,
-                config=config,
+                config=config.merge(Config(retries={"max_attempts": 0})),
             )
 
         return self._get_client_post_hook(client)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1051,6 +1051,9 @@ CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES = is_env_not_false("CFN_IGNORE_UNSUPPORTED
 # e.g. CFN_RESOURCE_PROVIDER_OVERRIDES='{"AWS::Lambda::Version": "GenericBaseModel","AWS::Lambda::Function": "ResourceProvider"}'
 CFN_RESOURCE_PROVIDER_OVERRIDES = os.environ.get("CFN_RESOURCE_PROVIDER_OVERRIDES", "{}")
 
+# defaults to true, i.e. by default boto clients created with our client factories won't perform retries unless explicitly configured to do so.
+DISABLE_BOTO_RETRIES = is_env_not_false("DISABLE_BOTO_RETRIES")
+
 # HINT: Please add deprecated environment variables to deprecations.py
 
 # list of environment variable names used for configuration.
@@ -1069,6 +1072,7 @@ CONFIG_ENV_VARS = [
     "DEFAULT_REGION",
     "DEVELOP",
     "DEVELOP_PORT",
+    "DISABLE_BOTO_RETRIES",
     "DISABLE_CORS_CHECKS",
     "DISABLE_CORS_HEADERS",
     "DISABLE_CUSTOM_CORS_APIGATEWAY",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1052,7 +1052,7 @@ CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES = is_env_not_false("CFN_IGNORE_UNSUPPORTED
 CFN_RESOURCE_PROVIDER_OVERRIDES = os.environ.get("CFN_RESOURCE_PROVIDER_OVERRIDES", "{}")
 
 # defaults to true, i.e. by default boto clients created with our client factories won't perform retries unless explicitly configured to do so.
-DISABLE_BOTO_RETRIES = is_env_not_false("DISABLE_BOTO_RETRIES")
+DISABLE_BOTO_RETRIES = is_env_true("DISABLE_BOTO_RETRIES")
 
 # HINT: Please add deprecated environment variables to deprecations.py
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1051,7 +1051,8 @@ CFN_IGNORE_UNSUPPORTED_RESOURCE_TYPES = is_env_not_false("CFN_IGNORE_UNSUPPORTED
 # e.g. CFN_RESOURCE_PROVIDER_OVERRIDES='{"AWS::Lambda::Version": "GenericBaseModel","AWS::Lambda::Function": "ResourceProvider"}'
 CFN_RESOURCE_PROVIDER_OVERRIDES = os.environ.get("CFN_RESOURCE_PROVIDER_OVERRIDES", "{}")
 
-# defaults to true, i.e. by default boto clients created with our client factories won't perform retries unless explicitly configured to do so.
+# defaults to false
+# if `DISABLE_BOTO_RETRIES=1` is set, all our created boto clients will have retries disabled
 DISABLE_BOTO_RETRIES = is_env_true("DISABLE_BOTO_RETRIES")
 
 # HINT: Please add deprecated environment variables to deprecations.py


### PR DESCRIPTION
## Motivation

These uncontrolled boto-client level retries are an inherent source of unpredictable behavior, so let's see if disabling them causes any unexpected issues.

Retries also cause unnecessary time waiting when we actually want to test a failure case.

## Changes

- disables retries for all clients created via our client factories in our test suite (CI)
- adds config variable `DISABLE_BOTO_RETRIES`. Set `DISABLE_BOTO_RETRIES=1` to opt-tin of the new behavior.

## Discussion

Might also want to go through cases where we use SDKs in lambda functions etc. to disable any retries.