### PR TITLE
fix secretsmanager PutSecretValue on empty secret

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -496,7 +496,7 @@ def backend_update_secret_version_stage(
 @patch(FakeSecret.reset_default_version)
 def fake_secret_reset_default_version(fn, self, secret_version, version_id):
     # fn(self, secret_version, version_id)
-
+    # FIXME: remove for the next moto bump (above 4.2.post1) and uncomment line above
     # remove all old AWSPREVIOUS stages
     for old_version in self.versions.values():
         if "AWSPREVIOUS" in old_version["version_stages"]:
@@ -509,6 +509,7 @@ def fake_secret_reset_default_version(fn, self, secret_version, version_id):
 
     self.versions[version_id] = secret_version
     self.default_version_id = version_id
+    # Remove until here ^
 
     # Remove versions with no version stages.
     versions_no_stages = [

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -445,8 +445,8 @@ def backend_update_secret(
     return json.dumps(resp)
 
 
-@patch(SecretsManagerResponse.update_secret)
-def response_update_secret(_, self):
+@patch(SecretsManagerResponse.update_secret, pass_target=False)
+def response_update_secret(self):
     secret_id = self._get_param("SecretId")
     description = self._get_param("Description")
     secret_string = self._get_param("SecretString")
@@ -495,7 +495,21 @@ def backend_update_secret_version_stage(
 
 @patch(FakeSecret.reset_default_version)
 def fake_secret_reset_default_version(fn, self, secret_version, version_id):
-    fn(self, secret_version, version_id)
+    # fn(self, secret_version, version_id)
+
+    # remove all old AWSPREVIOUS stages
+    for old_version in self.versions.values():
+        if "AWSPREVIOUS" in old_version["version_stages"]:
+            old_version["version_stages"].remove("AWSPREVIOUS")
+
+    # set old AWSCURRENT secret to AWSPREVIOUS
+    if self.default_version_id in self.versions:
+        previous_current_version_id = self.default_version_id
+        self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]  # type: ignore
+
+    self.versions[version_id] = secret_version
+    self.default_version_id = version_id
+
     # Remove versions with no version stages.
     versions_no_stages = [
         version_id for version_id, version in self.versions.items() if not version["version_stages"]

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3650,5 +3650,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_version_from_empty_secret": {
+    "recorded-date": "05-09-2023, 22:19:06",
+    "recorded-content": {
+      "create-empty-secret": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-version:1>",
+        "Name": "<name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-secret": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-version:1>",
+        "CreatedDate": "datetime",
+        "LastChangedDate": "datetime",
+        "Name": "<name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-secret-value": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-version:1>",
+        "Name": "<name:1>",
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A regression was introduced in moto and part of localstack after #9044 when calling `PutSecretValue` on a secret with no value.

<!-- What notable changes does this PR make? -->
## Changes
This adds a test for the fix in https://github.com/getmoto/moto/pull/6775
Edit: well, apparently this has been fixed with https://github.com/getmoto/moto/pull/6771
I don't know if we already want to do a moto bump, or we keep this fix inside LocalStack for now, this might be faster still. 

I've also put the fix in the patch for the moment until the next moto bump where we can remove it and use the one from upstream. This fix is kinda urgent, as the customer is downgrading moto in their LocalStack container in the meantime and it introduces incompatibilities, especially with `logs`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

