### PR TITLE
fix S3 v3 Range handling

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -194,13 +194,16 @@ class ObjectRange(NamedTuple):
 def parse_range_header(range_header: str, object_size: int) -> ObjectRange | None:
     """
     Takes a Range header, and returns a dataclass containing the necessary information to return only a slice of an
-    S3 object
+    S3 object. If the range header is invalid, we return None so that the request is treated as a regular request.
     :param range_header: a Range header
     :param object_size: the requested S3 object total size
-    :return: ObjectRange
+    :return: ObjectRange or None if the Range header is invalid
     """
     last = object_size - 1
-    _, rspec = range_header.split("=")
+    try:
+        _, rspec = range_header.split("=")
+    except ValueError:
+        return None
     if "," in rspec:
         return None
 
@@ -229,6 +232,68 @@ def parse_range_header(range_header: str, object_size: int) -> ObjectRange | Non
     if begin > min(end, last):
         # Treat as non-range request if after the logic is applied
         return None
+
+    return ObjectRange(
+        content_range=f"bytes {begin}-{end}/{object_size}",
+        content_length=end - begin + 1,
+        begin=begin,
+        end=end,
+    )
+
+
+def parse_copy_source_range_header(copy_source_range: str, object_size: int) -> ObjectRange:
+    """
+    Takes a CopySourceRange parameter, and returns a dataclass containing the necessary information to return only a slice of an
+    S3 object. The validation is much stricter than `parse_range_header`
+    :param copy_source_range: a CopySourceRange parameter for UploadCopyPart
+    :param object_size: the requested S3 object total size
+    :raises InvalidArgument if the CopySourceRanger parameter does not follow validation
+    :return: ObjectRange
+    """
+    last = object_size - 1
+    try:
+        _, rspec = copy_source_range.split("=")
+    except ValueError:
+        raise InvalidArgument(
+            "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+            ArgumentName="x-amz-copy-source-range",
+            ArgumentValue=copy_source_range,
+        )
+    if "," in rspec:
+        raise InvalidArgument(
+            "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+            ArgumentName="x-amz-copy-source-range",
+            ArgumentValue=copy_source_range,
+        )
+
+    try:
+        begin, end = [int(i) if i else None for i in rspec.split("-")]
+    except ValueError:
+        # if we can't parse the Range header, S3 just treat the request as a non-range request
+        raise InvalidArgument(
+            "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+            ArgumentName="x-amz-copy-source-range",
+            ArgumentValue=copy_source_range,
+        )
+
+    if begin is None or end is None or begin > end:
+        raise InvalidArgument(
+            "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+            ArgumentName="x-amz-copy-source-range",
+            ArgumentValue=copy_source_range,
+        )
+
+    if begin > last:
+        # Treat as non-range request if after the logic is applied
+        raise InvalidRequest(
+            "The specified copy range is invalid for the source object size",
+        )
+    elif end > last:
+        raise InvalidArgument(
+            f"Range specified is not valid for source object of size: {object_size}",
+            ArgumentName="x-amz-copy-source-range",
+            ArgumentValue=copy_source_range,
+        )
 
     return ObjectRange(
         content_range=f"bytes {begin}-{end}/{object_size}",

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -235,6 +235,7 @@ from localstack.services.s3.utils import (
     get_system_metadata_from_request,
     get_unique_key_id,
     is_bucket_name_valid,
+    parse_copy_source_range_header,
     parse_post_object_tagging_xml,
     parse_range_header,
     parse_tagging_header,
@@ -1910,7 +1911,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         source_range = request.get("CopySourceRange")
         # TODO implement copy source IF (done in ASF provider)
-        range_data = parse_range_header(source_range, src_s3_object.size)
+        range_data = parse_copy_source_range_header(source_range, src_s3_object.size)
 
         s3_part = S3Part(part_number=part_number)
 

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2679,7 +2679,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_get_object_range": {
-    "recorded-date": "06-09-2023, 20:34:22",
+    "recorded-date": "07-09-2023, 17:40:46",
     "recorded-content": {
       "get-0-8": {
         "AcceptRanges": "bytes",
@@ -2857,6 +2857,20 @@
           "HTTPStatusCode": 200
         }
       },
+      "get-wrong-format": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get--": {
         "AcceptRanges": "bytes",
         "Body": "0123456789",
@@ -2893,6 +2907,246 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 416
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_range": {
+    "recorded-date": "07-09-2023, 17:51:48",
+    "recorded-content": {
+      "put-src-object": {
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "test-upload-part-copy",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-1": {
+        "CopyPartResult": {
+          "ETag": "\"22975d8a5ed1b91445f6c55ac121505b\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-2": {
+        "CopyPartResult": {
+          "ETag": "\"c4ca4238a0b923820dcc509a6f75849b\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-3": {
+        "CopyPartResult": {
+          "ETag": "\"cfcd208495d565ef66e7dff9f98764da\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-upload-part-copy",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 3,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"22975d8a5ed1b91445f6c55ac121505b\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 9
+          },
+          {
+            "ETag": "\"c4ca4238a0b923820dcc509a6f75849b\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 1
+          },
+          {
+            "ETag": "\"cfcd208495d565ef66e7dff9f98764da\"",
+            "LastModified": "datetime",
+            "PartNumber": 3,
+            "Size": 1
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-wrong-format": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "0-8",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-1-0": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=1-0",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc--1-": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=-1-",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-0--1": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=0--1",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-0-1,3-4,7-9": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=0-1,3-4,7-9",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc--": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=-",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc--0": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=-0",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-0-100": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=0-100",
+          "Code": "InvalidArgument",
+          "Message": "Range specified is not valid for source object of size: 10"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-100-200": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The specified copy range is invalid for the source object size"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc-1-": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=1-",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc--2": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=-2",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-copy-range-exc--15": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source-range",
+          "ArgumentValue": "bytes=-15",
+          "Code": "InvalidArgument",
+          "Message": "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2677,5 +2677,224 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_get_object_range": {
+    "recorded-date": "06-09-2023, 20:34:22",
+    "recorded-content": {
+      "get-0-8": {
+        "AcceptRanges": "bytes",
+        "Body": "012345678",
+        "ContentLength": 9,
+        "ContentRange": "bytes 0-8/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-1-1": {
+        "AcceptRanges": "bytes",
+        "Body": "1",
+        "ContentLength": 1,
+        "ContentRange": "bytes 1-1/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-1-0": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-1-": {
+        "AcceptRanges": "bytes",
+        "Body": "123456789",
+        "ContentLength": 9,
+        "ContentRange": "bytes 1-9/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get--1-": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get--2": {
+        "AcceptRanges": "bytes",
+        "Body": "89",
+        "ContentLength": 2,
+        "ContentRange": "bytes 8-9/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get--9": {
+        "AcceptRanges": "bytes",
+        "Body": "123456789",
+        "ContentLength": 9,
+        "ContentRange": "bytes 1-9/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get--15": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentRange": "bytes 0-9/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-0-100": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentRange": "bytes 0-9/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-0-0": {
+        "AcceptRanges": "bytes",
+        "Body": "0",
+        "ContentLength": 1,
+        "ContentRange": "bytes 0-0/10",
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 206
+        }
+      },
+      "get-0--1": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-multiple-ranges": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get--": {
+        "AcceptRanges": "bytes",
+        "Body": "0123456789",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get--0": {
+        "Error": {
+          "ActualObjectSize": "10",
+          "Code": "InvalidRange",
+          "Message": "The requested range is not satisfiable",
+          "RangeRequested": "bytes=-0"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 416
+        }
+      },
+      "get-100-200": {
+        "Error": {
+          "ActualObjectSize": "10",
+          "Code": "InvalidRange",
+          "Message": "The requested range is not satisfiable",
+          "RangeRequested": "bytes=100-200"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 416
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9076, there is an issue in the way Moto and LocalStack handles HTTP Range requests for S3. AWS is apparently not following the RFC for range requests and is very, very forgiving, as shown by the added test.
> An [int-range](https://www.rfc-editor.org/rfc/rfc9110.html#rule.int-range) is invalid if the [last-pos](https://www.rfc-editor.org/rfc/rfc9110.html#rule.int-range) value is present and less than the [first-pos](https://www.rfc-editor.org/rfc/rfc9110.html#rule.int-range).

As pointed out by @sjperkins who went through the RFC, the server can ignore the range header for some conditions:
> A server that supports range requests MAY ignore or reject a [Range](https://www.rfc-editor.org/rfc/rfc9110.html#field.range) header field that contains an invalid [ranges-specifier](https://www.rfc-editor.org/rfc/rfc9110.html#rule.ranges-specifier) ([Section 14.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#range.specifiers)), a [ranges-specifier](https://www.rfc-editor.org/rfc/rfc9110.html#rule.ranges-specifier) with more than two overlapping ranges, or a set of many small ranges that are not listed in ascending order,

Basically, if the range request is badly formatted or invalid, S3 will just treat the request as a non-range request and will return the entire object with a `200` status code.
Only certain conditions will trigger an exception and `416`, mainly if the beginning of the request is above the end of the object and the request is a valid `Range` request (meaning it can be parsed), or if the request is a "suffix" request and it ends with 0.

<!-- What notable changes does this PR make? -->
## Changes
This fixes the behaviour only for the v3 provider for now, I'll need to open a PR upstream in moto to fix the behaviour there to fix the default current provider. Edit: the PR upstream is already merged, so I'd like to have the v3 behaviour in line.

I might remove all the `skip` for the new provider tests and selectively xfail the tests for the default provider in a follow up PR, to see the extent of the issue with the current provider, and try to have some tests such as this one valid for both.

I've launched a run with this fix in the forced v3 S3 branch here, and it's green: https://app.circleci.com/pipelines/github/localstack/localstack/17924/workflows/3026ab82-afaa-4b31-9b45-fbd7afbab1bd

This also fix the behaviour for `UploadPartCopy` which has a very strict handling of the `CopySourceRange` parameter. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

