### PR TITLE
Add account ID and region to AWS trace log output

### DIFF
--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -98,6 +98,9 @@ class ResponseLogger:
                     response.status_code,
                     context.service_exception.code,
                     extra={
+                        # context
+                        "account_id": context.account_id,
+                        "region": context.region,
                         # request
                         "input_type": context.operation.input_shape.name
                         if context.operation.input_shape
@@ -117,6 +120,9 @@ class ResponseLogger:
                     context.operation.name,
                     response.status_code,
                     extra={
+                        # context
+                        "account_id": context.account_id,
+                        "region": context.region,
                         # request
                         "input_type": context.operation.input_shape.name
                         if context.operation.input_shape

--- a/localstack/logging/format.py
+++ b/localstack/logging/format.py
@@ -107,8 +107,9 @@ def compress_logger_name(name: str, length: int) -> str:
 
 class TraceLoggingFormatter(logging.Formatter):
     aws_trace_log_format = (
-        LOG_FORMAT
-        + "; %(input_type)s(%(input)s, headers=%(request_headers)s); %(output_type)s(%(output)s, headers=%(response_headers)s)"
+        LOG_FORMAT + "; %(account_id)s/%(region)s - "
+        "%(input_type)s(%(input)s, headers=%(request_headers)s); "
+        "%(output_type)s(%(output)s, headers=%(response_headers)s)"
     )
 
     def __init__(self):


### PR DESCRIPTION
## Motivation

There've been some support cases and issue reports where the root cause was a mismatch in account ID or region specified in the client requests. With multi-account being more widely adopted by our users, the account ID a request is made against is becoming an important part of the trace debug information.

## Changes

This PR adds the AWS account ID / region name to the trace log outputs.

Format before:
```
2023-09-07T10:20:45.044  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200; CreateBucketRequest({'ACL': None, ...
```

Format after:
```
2023-09-07T10:21:39.171  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200; 000000000000/us-east-1 - CreateBucketRequest({'ACL': None, ...
```

Happy for any suggestions regarding the message format. Also, we could consider hiding this behind a feature flag, or dumping the account ID only if it is different from the default account ID (`000000000000`), if we think that the output is becoming too spammy otherwise. No strong opinion from my side, we just need a mechanism to enable this output when debugging a user issue.