### PR TITLE
enable new s3 v3 tests for current provider

### DIFF
--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -475,6 +475,10 @@ class TestS3ObjectCRUD:
         snapshot.match("list-object-versions", list_object_versions)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=config.STREAM_S3_PROVIDER,
+        reason="Range fix not applied in S3 Stream provider due to removal in the near future",
+    )
     def test_get_object_range(self, aws_client, s3_bucket, snapshot):
         content = "0123456789"
         key = "test-key-range"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When writing the new S3 v3 provider, a lot of new tests have been written to either verify missing cases or tests things that were implemented in moto only.
This PR aims to enable those tests for the current provider, and xfail the ones that are not passing.

<!-- What notable changes does this PR make? -->
## Changes
Remove all the `skip` pytest markers and go individually over each test to verify if they pass. 


## TODO

What's left to do:

- [x] merge #9082 because this PR is based on it, as it added a new test that was the point to have those tests run for both providers


