### PR TITLE
Fix deletion of AWS::IAM::Policy 

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -640,6 +640,9 @@ class ResourceProviderExecutor:
 
                 event = self.execute_action(resource_provider, payload)
 
+                if event.status == OperationStatus.FAILED:
+                    return event
+
                 if event.status == OperationStatus.SUCCESS:
 
                     if not isinstance(resource_provider, LegacyResourceProvider):

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -57,7 +57,7 @@ class TransformerUtility:
         :return: KeyValueBasedTransformer
         """
         return KeyValueBasedTransformer(
-            lambda k, v: v if k == key else None,
+            lambda k, v: v if k == key and (v is not None and v != "") else None,
             replacement=value_replacement or _replace_camel_string_with_hyphen(key),
             replace_reference=reference_replacement,
         )

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -4,8 +4,11 @@ import os
 import botocore.exceptions
 import pytest
 import yaml
+from botocore.exceptions import WaiterError
 
+from localstack.aws.api.cloudformation import Capability
 from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.files import load_file
@@ -633,7 +636,7 @@ def test_events_resource_types(deploy_cfn_template, snapshot, aws_client):
 
 
 @markers.aws.validated
-def test_list_parameter_type(aws_client, deploy_cfn_template, cleanups, lambda_su_role):
+def test_list_parameter_type(aws_client, deploy_cfn_template, cleanups):
     stack_name = f"test-stack-{short_uid()}"
     cleanups.append(lambda: aws_client.cloudformation.delete_stack(StackName=stack_name))
     stack = deploy_cfn_template(
@@ -646,3 +649,56 @@ def test_list_parameter_type(aws_client, deploy_cfn_template, cleanups, lambda_s
     )
 
     assert stack.outputs["ParamValue"] == "foo|bar"
+
+
+@markers.aws.validated
+@pytest.mark.skipif(condition=not is_aws_cloud(), reason="rollback not implemented")
+def test_blocked_stack_deletion(aws_client, cleanups, snapshot):
+    """
+    uses AWS::IAM::Policy for demonstrating this behavior
+
+    1. create fails
+    2. rollback fails even though create didn't even provision anything
+    3. trying to delete the stack afterwards also doesn't work
+    4. deleting the stack with retain resources works
+    """
+    cfn = aws_client.cloudformation
+    stack_name = f"test-stacks-blocked-{short_uid()}"
+    policy_name = f"test-broken-policy-{short_uid()}"
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
+    template_body = load_file(
+        os.path.join(os.path.dirname(__file__), "../../../templates/iam_policy_invalid.yaml")
+    )
+    waiter_config = {"Delay": 1, "MaxAttempts": 20}
+
+    snapshot.add_transformer(snapshot.transform.key_value("PhysicalResourceId"))
+    snapshot.add_transformer(
+        snapshot.transform.key_value("ResourceStatusReason", reference_replacement=False)
+    )
+
+    stack = cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_body,
+        Parameters=[{"ParameterKey": "Name", "ParameterValue": policy_name}],
+        Capabilities=[Capability.CAPABILITY_NAMED_IAM],
+    )
+    stack_id = stack["StackId"]
+    cleanups.append(lambda: cfn.delete_stack(StackName=stack_id, RetainResources=["BrokenPolicy"]))
+    with pytest.raises(WaiterError):
+        cfn.get_waiter("stack_create_complete").wait(StackName=stack_id, WaiterConfig=waiter_config)
+    stack_post_create = cfn.describe_stacks(StackName=stack_id)
+    snapshot.match("stack_post_create", stack_post_create)
+
+    cfn.delete_stack(StackName=stack_id)
+    with pytest.raises(WaiterError):
+        cfn.get_waiter("stack_delete_complete").wait(StackName=stack_id, WaiterConfig=waiter_config)
+    stack_post_fail_delete = cfn.describe_stacks(StackName=stack_id)
+    snapshot.match("stack_post_fail_delete", stack_post_fail_delete)
+
+    cfn.delete_stack(StackName=stack_id, RetainResources=["BrokenPolicy"])
+    cfn.get_waiter("stack_delete_complete").wait(StackName=stack_id, WaiterConfig=waiter_config)
+    stack_post_success_delete = cfn.describe_stacks(StackName=stack_id)
+    snapshot.match("stack_post_success_delete", stack_post_success_delete)
+    stack_events = cfn.describe_stack_events(StackName=stack_id)
+    snapshot.match("stack_events", stack_events)

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -591,5 +591,379 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_blocked_stack_deletion": {
+    "recorded-date": "06-09-2023, 11:01:18",
+    "recorded-content": {
+      "stack_post_create": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "Name",
+                "ParameterValue": "<policy-name>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "ROLLBACK_FAILED",
+            "StackStatusReason": "The following resource(s) failed to delete: [BrokenPolicy]. ",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_post_fail_delete": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "Name",
+                "ParameterValue": "<policy-name>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_FAILED",
+            "StackStatusReason": "The following resource(s) failed to delete: [BrokenPolicy]. ",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_post_success_delete": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "Name",
+                "ParameterValue": "<policy-name>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_events": {
+        "StackEvents": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-DELETE_SKIPPED-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "DELETE_SKIPPED",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "DELETE_FAILED",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-DELETE_FAILED-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "DELETE_FAILED",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-DELETE_IN_PROGRESS-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "ROLLBACK_FAILED",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-DELETE_FAILED-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "DELETE_FAILED",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-DELETE_IN_PROGRESS-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "ROLLBACK_IN_PROGRESS",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-CREATE_FAILED-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "CREATE_FAILED",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "BrokenPolicy-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "BrokenPolicy",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "PolicyName": "<policy-name>",
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Action": "*",
+                    "Resource": "*",
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::IAM::Policy",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:7>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "resource-status-reason",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_update_stack.py
+++ b/tests/aws/services/cloudformation/api/test_update_stack.py
@@ -59,7 +59,7 @@ def test_update_using_template_url(deploy_cfn_template, s3_create_bucket, aws_cl
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="Not supported")
+@pytest.mark.skip(reason="Not supported")
 def test_update_with_previous_template(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(
@@ -77,8 +77,8 @@ def test_update_with_previous_template(deploy_cfn_template, aws_client):
     aws_client.cloudformation.get_waiter("stack_update_complete").wait(StackName=stack.stack_name)
 
 
-@markers.aws.validated
-@pytest.mark.xfail(reason="Not raising the correct error")
+@markers.aws.needs_fixing
+@pytest.mark.skip(reason="templates are not partially not valid => re-evaluate")
 @pytest.mark.parametrize(
     "capability",
     [
@@ -123,7 +123,7 @@ def test_update_with_capabilities(capability, deploy_cfn_template, snapshot, aws
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="Not raising the correct error")
+@pytest.mark.skip(reason="Not raising the correct error")
 def test_update_with_resource_types(deploy_cfn_template, snapshot, aws_client):
     template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../templates/sns_topic_parameter.yml")
@@ -166,7 +166,7 @@ def test_update_with_resource_types(deploy_cfn_template, snapshot, aws_client):
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="Update value not being applied")
+@pytest.mark.skip(reason="Update value not being applied")
 def test_set_notification_arn_with_update(deploy_cfn_template, sns_create_topic, aws_client):
     template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../templates/sns_topic_parameter.yml")
@@ -191,7 +191,7 @@ def test_set_notification_arn_with_update(deploy_cfn_template, sns_create_topic,
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="Update value not being applied")
+@pytest.mark.skip(reason="Update value not being applied")
 def test_update_tags(deploy_cfn_template, aws_client):
     template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../templates/sns_topic_parameter.yml")
@@ -220,7 +220,7 @@ def test_update_tags(deploy_cfn_template, aws_client):
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="The correct error is not being raised")
+@pytest.mark.skip(reason="The correct error is not being raised")
 def test_no_template_error(deploy_cfn_template, snapshot, aws_client):
     template = load_file(
         os.path.join(os.path.dirname(__file__), "../../../templates/sns_topic_parameter.yml")
@@ -276,7 +276,7 @@ def test_update_with_previous_parameter_value(deploy_cfn_template, snapshot, aws
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="The correct error is not being raised")
+@pytest.mark.skip(reason="The correct error is not being raised")
 def test_update_with_role_without_permissions(
     deploy_cfn_template, snapshot, create_role, aws_client
 ):
@@ -315,7 +315,7 @@ def test_update_with_role_without_permissions(
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="The correct error is not being raised")
+@pytest.mark.skip(reason="The correct error is not being raised")
 def test_update_with_invalid_rollback_configuration_errors(
     deploy_cfn_template, snapshot, aws_client
 ):
@@ -358,7 +358,7 @@ def test_update_with_invalid_rollback_configuration_errors(
 
 
 @markers.aws.validated
-@pytest.mark.xfail(reason="The update value is not being applied")
+@pytest.mark.skip(reason="The update value is not being applied")
 def test_update_with_rollback_configuration(deploy_cfn_template, aws_client):
 
     aws_client.cloudwatch.put_metric_alarm(

--- a/tests/aws/templates/iam_policy_invalid.yaml
+++ b/tests/aws/templates/iam_policy_invalid.yaml
@@ -1,0 +1,15 @@
+Parameters:
+  Name:
+    Type: String
+Resources:
+  BrokenPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName:
+        Ref: Name
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource: '*'

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -3,7 +3,10 @@ import pytest
 from localstack.testing.snapshots import SnapshotSession
 from localstack.testing.snapshots.report import _format_json_path
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer, SortingTransformer
-from localstack.testing.snapshots.transformer_utility import _resource_name_transformer
+from localstack.testing.snapshots.transformer_utility import (
+    TransformerUtility,
+    _resource_name_transformer,
+)
 
 
 class TestSnapshotManager:
@@ -36,6 +39,13 @@ class TestSnapshotManager:
         )
         sm.recorded_state = {"key_a": {"aaa": "<A:1>", "bbb": "<A:1> hello"}}
         sm.match("key_a", {"aaa": "something", "bbb": "something hello"})
+        sm._assert_all()
+
+    def test_context_replacement_no_change(self):
+        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm.add_transformer(TransformerUtility.key_value("name"))
+        sm.recorded_state = {"key_a": {"name": ""}}
+        sm.match("key_a", {"name": ""})
         sm._assert_all()
 
     def test_match_order_reference_replacement(self):


### PR DESCRIPTION
## Motivation

When working on other tasks, I noticed the AWS::IAM::Policy usually fails to clean up leading to a lot of cleanup issues since other resources usually depend on this resource. It seems this was also implemented wrong in the original `GenericBaseModel` version.

## Changes

- Add proper delete for `AWS::IAM::Policy`
- Add test for a broken delete where resources need to be orphaned to "unblock" the delete.
- Fix transformers, so that it won't try to do a reference replacement with `""` values

