### PR TITLE
extend lambda alias model

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -1030,6 +1030,7 @@ class TestCfnLambdaDestinations:
 
 
 @markers.aws.validated
+@pytest.mark.skipif(condition=is_old_provider())
 def test_python_lambda_code_deployed_via_s3(deploy_cfn_template, aws_client, s3_bucket):
     bucket_key = "handler.zip"
     zip_file = create_lambda_archive(

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -66,7 +66,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_lambda_alias": {
-    "recorded-date": "27-02-2023, 17:28:29",
+    "recorded-date": "07-09-2023, 11:28:45",
     "recorded-content": {
       "stack_resource_descriptions": {
         "StackResources": [

--- a/tests/aws/templates/cfn_lambda_alias.yml
+++ b/tests/aws/templates/cfn_lambda_alias.yml
@@ -29,13 +29,19 @@ Resources:
     Properties:
       FunctionName: !Ref FunctionName
       Code:
-        ZipFile: exports.handler = function(event) =>  { console.log(event); };
+        ZipFile: |
+          exports.handler = function(event) {
+            return {
+              statusCode: 200,
+              body: "Hello, World!" 
+            };
+          };
       Role:
         Fn::GetAtt:
           - MyFnServiceRole
           - Arn
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
     DependsOn:
       - MyFnServiceRole
 
@@ -51,6 +57,8 @@ Resources:
       FunctionName: !Ref FunctionName
       FunctionVersion: !GetAtt Version.Version
       Name: !Ref AliasName
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 5
 
     DependsOn:
       - LambdaFunction


### PR DESCRIPTION
## Motivation
This PR fixes the CFn crash that happens when deploying a AWS::Lambda::Alias resource that has a `ProvisionedConcurrencyConfig` 

## Changes
Model limits the correct parameters for the creation and then it check if the attribute exists.

## Testing
The testing just extends a previous tests and corrects the code of the lambda function so it can be deployed on AWS