### PR TITLE
Update deployment stage_name when creating API Gateway stages to fix parity issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VENV_DIR ?= .venv
 PIP_CMD ?= pip3
 TEST_PATH ?= .
 PYTEST_LOGLEVEL ?=
+DISABLE_BOTO_RETRIES ?= 1
 MAIN_CONTAINER_NAME ?= localstack_main
 
 MAJOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f1)
@@ -176,12 +177,12 @@ docker-cp-coverage:
 		docker rm -v $$id
 
 test:              		  ## Run automated tests
-	($(VENV_RUN); DEBUG=$(DEBUG) DISABLE_BOTO_RETRIES=1 pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
+	($(VENV_RUN); DEBUG=$(DEBUG) DISABLE_BOTO_RETRIES=$(DISABLE_BOTO_RETRIES) pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
 
 test-coverage:     		  ## Run automated tests and create coverage report
 	($(VENV_RUN); python -m coverage --version; \
 		DEBUG=$(DEBUG) \
-		DISABLE_BOTO_RETRIES=1 \
+		DISABLE_BOTO_RETRIES=$(DISABLE_BOTO_RETRIES) \
 		LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC=1 \
 		python -m coverage run $(COVERAGE_ARGS) -m \
 		pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -869,7 +869,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response = call_moto(context)
         for stage in response["item"]:
             self._patch_stage_response(stage)
-            stage.pop("description", None)
+            if not stage.get("description"):
+                stage.pop("description", None)
         return Stages(**response)
 
     @handler("UpdateStage")

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -76,6 +76,7 @@ from localstack.aws.api.apigateway import (
     RestApis,
     SecurityPolicy,
     Stage,
+    Stages,
     StatusCode,
     String,
     Tags,
@@ -849,6 +850,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if not hasattr(stage, "documentation_version"):
             stage.documentation_version = request.get("documentationVersion")
 
+        # make sure we update the stage_name on the deployment entity in moto
+        deployment = moto_api.deployments.get(request["deploymentId"])
+        deployment.stage_name = stage.name
+
         response = stage.to_json()
         self._patch_stage_response(response)
         return response
@@ -857,6 +862,15 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response = call_moto(context)
         self._patch_stage_response(response)
         return response
+
+    def get_stages(
+        self, context: RequestContext, rest_api_id: String, deployment_id: String = None
+    ) -> Stages:
+        response = call_moto(context)
+        for stage in response["item"]:
+            self._patch_stage_response(stage)
+            stage.pop("description", None)
+        return Stages(**response)
 
     @handler("UpdateStage")
     def update_stage(

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -588,7 +588,7 @@ class TestDeployments:
         response = client.get_deployment(restApiId=api_id, deploymentId=deployment_id)
         snapshot.match("get-deployment", response)
         response = client.get_stages(restApiId=api_id)
-        snapshot.match(f"get-stages", response)
+        snapshot.match("get-stages", response)
 
         for i in range(3):
             # asset that deleting the deployment fails if stage exists

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -556,3 +556,58 @@ class TestStages:
 
         response = client.get_stage(restApiId=api_id, stageName="s1")
         snapshot.match("get-stage", response)
+
+
+class TestDeployments:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
+    @pytest.mark.parametrize("create_stage_manually", [True, False])
+    def test_create_delete_deployments(
+        self, create_stage_manually, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
+    ):
+        snapshot.add_transformer(snapshot.transform.apigateway_api())
+        client = aws_client.apigateway
+
+        # create API, method, integration, deployment
+        api_id, _, root_id = create_rest_apigw()
+        client.put_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+        )
+        client.put_integration(restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK")
+
+        # create deployment - stage can be passed as parameter, or created separately below
+        kwargs = {} if create_stage_manually else {"stageName": "s1"}
+        response = client.create_deployment(restApiId=api_id, **kwargs)
+        deployment_id = response["id"]
+
+        # create stage
+        if create_stage_manually:
+            client.create_stage(restApiId=api_id, stageName="s1", deploymentId=deployment_id)
+
+        # get deployment and stages
+        response = client.get_deployment(restApiId=api_id, deploymentId=deployment_id)
+        snapshot.match("get-deployment", response)
+        response = client.get_stages(restApiId=api_id)
+        snapshot.match(f"get-stages", response)
+
+        for i in range(3):
+            # asset that deleting the deployment fails if stage exists
+            with pytest.raises(ClientError) as ctx:
+                client.delete_deployment(restApiId=api_id, deploymentId=deployment_id)
+            snapshot.match(f"delete-deployment-error-{i}", ctx.value.response)
+
+            # delete stage and deployment
+            client.delete_stage(restApiId=api_id, stageName="s1")
+            client.delete_deployment(restApiId=api_id, deploymentId=deployment_id)
+
+            # re-create stage and deployment
+            response = client.create_deployment(restApiId=api_id, **kwargs)
+            deployment_id = response["id"]
+            if create_stage_manually:
+                client.create_stage(restApiId=api_id, stageName="s1", deploymentId=deployment_id)
+
+            # list deployments and stages again
+            response = client.get_deployments(restApiId=api_id)
+            snapshot.match(f"get-deployments-{i}", response)
+            response = client.get_stages(restApiId=api_id)
+            snapshot.match(f"get-stages-{i}", response)

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -537,5 +537,313 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_delete_deployments[True]": {
+    "recorded-date": "07-09-2023, 19:27:48",
+    "recorded-content": {
+      "get-deployment": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<deployment-id:1>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-0": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-0": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-0": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-1": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-1": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-1": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-2": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-2": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-2": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:3>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_delete_deployments[False]": {
+    "recorded-date": "07-09-2023, 19:20:47",
+    "recorded-content": {
+      "get-deployment": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<deployment-id:1>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-0": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-0": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-0": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:1>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-1": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-1": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-1": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:2>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error-2": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployments-2": {
+        "items": [
+          {
+            "createdDate": "datetime",
+            "id": "<id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-2": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<id:3>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation

Addresses a user issue reported in Slack. We are currently seeing parity issues in the linkage between API Gateway stages and deployments. In a nutshell, we need to establish a bidirectional link `stage<>deployment` for the `create_stage(..)` API. Moto was currently only adding the `stage->deployment`, but the reverse direction was still missing, leading to deployment errors, e.g., with Terraform.

## Changes

* update `create_stage(..)` to update the `stage_name` on the Deployment on creation of a Stage
* add small fix in `get_stages(..)` to transform the result entries
* add Makefile parametrization for `DISABLE_BOTO_RETRIES` (API Gateway snapshot tests require retries, due to high frequency of `TooManyRequestsException`)
* add a snapshot test to cover a sequence of different creations/deletions of stages&deployments