### PR TITLE
Refresh route53 snapshots

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_route53.py
+++ b/tests/aws/services/cloudformation/resources/test_route53.py
@@ -18,7 +18,7 @@ def test_create_record_set_via_id(route53_hosted_zone, deploy_cfn_template):
     )
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_create_record_set_via_name(deploy_cfn_template, route53_hosted_zone):
     create_zone_response = route53_hosted_zone()
     route53_name = create_zone_response["HostedZone"]["Name"]
@@ -31,7 +31,7 @@ def test_create_record_set_via_name(deploy_cfn_template, route53_hosted_zone):
     )
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_create_record_set_without_resource_record(deploy_cfn_template, route53_hosted_zone):
     create_zone_response = route53_hosted_zone()
     hosted_zone_id = create_zone_response["HostedZone"]["Id"]

--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -1,5 +1,4 @@
 import logging
-import random
 import re
 
 import pytest
@@ -9,8 +8,11 @@ from localstack.aws.api.route53resolver import (
     ListResolverQueryLogConfigsResponse,
     ListResolverRuleAssociationsResponse,
 )
+from localstack.aws.connect import ServiceLevelClientFactory
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
+from localstack.utils.functions import call_safe
 from localstack.utils.sync import poll_condition
 
 LOG = logging.getLogger(__name__)
@@ -21,25 +23,70 @@ def route53resolver_api_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.route53resolver_api())
 
 
-class TestRoute53Resolver:
-    @staticmethod
-    def get_create_resolver_endpoint_ip_address(client, hostId):
-        # getting list of existing (default) subnets
-        subnets = client.describe_subnets()["Subnets"]
-        subnet_ids = [s["SubnetId"] for s in subnets]
-        # construct IPs within CIDR range
-        ips = [re.sub(r"(.*)\.[0-9]+/.+", r"\1." + hostId, s["CidrBlock"]) for s in subnets]
-        return [
-            {"SubnetId": subnet_ids[0], "Ip": ips[0]},
-            {"SubnetId": subnet_ids[1], "Ip": ips[1]},
-        ]
+# TODO: extract this somewhere so that we can reuse it in other places
+def _cleanup_vpc(aws_client: ServiceLevelClientFactory, vpc_id: str):
+    """
+    perform a safe cleanup of a VPC
+    this method assumes that any existing network interfaces have already been detached
+    """
+    # delete security groups
+    sgs = aws_client.ec2.describe_security_groups(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+    for sg in sgs["SecurityGroups"]:
+        if sg["GroupName"] != "default":  # default security group can't be deleted
+            call_safe(lambda: aws_client.ec2.delete_security_group(GroupId=sg["GroupId"]))
 
-    @staticmethod
-    def get_security_group_ids(client):
-        security_groups_ids = []
-        security_groups_response = client.describe_security_groups()["SecurityGroups"]
-        security_groups_ids = [sg["GroupId"] for sg in security_groups_response]
-        return security_groups_ids
+    # delete subnets
+    subnets = aws_client.ec2.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+    for subnet in subnets["Subnets"]:
+        call_safe(lambda: aws_client.ec2.delete_subnet(SubnetId=subnet["SubnetId"]))
+
+    # finally, delete the vpc
+    aws_client.ec2.delete_vpc(VpcId=vpc_id)
+
+
+def delete_route53_resolver_endpoint(route53resolver_client, resolver_endpoint_id: str):
+    """delete a route53resolver resolver endpoint and wait until it is actually deleted"""
+
+    def _delete_resolver_endpoint():
+        # deleting a resolver endpoint is an async operation, but we can't properly observe it since there's no "deleted" terminal state
+        route53resolver_client.delete_resolver_endpoint(ResolverEndpointId=resolver_endpoint_id)
+
+        # retry until we can't get it anymore
+        def _is_endpoint_deleted():
+            try:
+                route53resolver_client.get_resolver_endpoint(
+                    ResolverEndpointId=resolver_endpoint_id
+                )
+            except Exception:
+                return True
+            else:
+                return False
+
+        poll_condition(_is_endpoint_deleted, timeout=180, interval=3 if is_aws_cloud() else 1)
+
+    return _delete_resolver_endpoint
+
+
+class TestRoute53Resolver:
+
+    # TODO: make this class level?
+    @pytest.fixture(scope="function")
+    def setup_resources(self, aws_client, cleanups):
+        vpc = aws_client.ec2.create_vpc(CidrBlock="10.78.0.0/16")
+        vpc_id = vpc["Vpc"]["VpcId"]
+        cleanups.append(lambda: _cleanup_vpc(aws_client, vpc_id))
+
+        subnet1 = aws_client.ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.78.1.0/24")
+        subnet2 = aws_client.ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.78.2.0/24")
+
+        security_group = aws_client.ec2.create_security_group(
+            GroupName=f"test-sg-{short_uid()}", VpcId=vpc_id, Description="test sg"
+        )
+
+        yield vpc, subnet1, subnet2, security_group
+
+    def _construct_ip_for_cidr_and_host(self, cidr_block: str, host_id: str) -> str:
+        return re.sub(r"(.*)\.[0-9]+/.+", r"\1." + host_id, cidr_block)
 
     @staticmethod
     def _wait_associate_or_disassociate_resolver_rule(client, resolver_rule_id, vpc_id, action):
@@ -123,24 +170,32 @@ class TestRoute53Resolver:
             ("OUTBOUND", "10"),
         ],
     )
-    def test_create_resolver_endpoint(self, direction, hostId, cleanups, snapshot, aws_client):
+    def test_create_resolver_endpoint(
+        self, direction, hostId, cleanups, snapshot, aws_client, setup_resources
+    ):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], hostId)
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], hostId)
 
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
-        result = aws_client.route53resolver.create_resolver_endpoint(
+        create_resolver_endpoint_res = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction=direction,
             Name=resolver_endpoint_name,
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, hostId),
+            IpAddresses=[
+                {"SubnetId": subnet1_id, "Ip": ip1},
+                {"SubnetId": subnet2_id, "Ip": ip2},
+            ],
         )
-
-        create_resolver_endpoint_res = result.get("ResolverEndpoint")
-        # clean up
+        resolver_endpoint = create_resolver_endpoint_res["ResolverEndpoint"]
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=create_resolver_endpoint_res["Id"]
-            )
+            delete_route53_resolver_endpoint(aws_client.route53resolver, resolver_endpoint["Id"])
         )
 
         self._wait_created_endpoint_is_listed_with_status(
@@ -149,7 +204,15 @@ class TestRoute53Resolver:
         snapshot.match("create_resolver_endpoint_res", create_resolver_endpoint_res)
 
     @markers.aws.validated
-    def test_route53resolver_bad_create_endpoint_security_groups(self, snapshot, aws_client):
+    def test_route53resolver_bad_create_endpoint_security_groups(
+        self, snapshot, aws_client, setup_resources
+    ):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "43")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "43")
+
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
         with pytest.raises(
@@ -160,32 +223,38 @@ class TestRoute53Resolver:
                 SecurityGroupIds=["test-invalid-sg-123"],
                 Direction="INBOUND",
                 Name=resolver_endpoint_name,
-                IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "43"),
+                IpAddresses=[
+                    {"SubnetId": subnet1_id, "Ip": ip1},
+                    {"SubnetId": subnet2_id, "Ip": ip2},
+                ],
             )
         snapshot.match("inavlid_param_request_res", inavlid_param_request_res.value.response)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds"])
     def test_multiple_create_resolver_endpoint_with_same_req_id(
-        self, cleanups, snapshot, aws_client
+        self, cleanups, snapshot, aws_client, setup_resources
     ):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "41")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "41")
+
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
-        ip_addresses = self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "41")
-        security_groups_ids = self.get_security_group_ids(aws_client.ec2)
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=security_groups_ids,
+            SecurityGroupIds=[security_group_id],
             Direction="INBOUND",
             Name=resolver_endpoint_name,
-            IpAddresses=ip_addresses,
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
-
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
-
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=create_resolver_endpoint_res["Id"]
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -199,10 +268,13 @@ class TestRoute53Resolver:
         ) as res_exists_ex:
             aws_client.route53resolver.create_resolver_endpoint(
                 CreatorRequestId=request_id,
-                SecurityGroupIds=security_groups_ids,
+                SecurityGroupIds=[security_group_id],
                 Direction="INBOUND",
                 Name=resolver_endpoint_name,
-                IpAddresses=ip_addresses,
+                IpAddresses=[
+                    {"SubnetId": subnet1_id, "Ip": ip1},
+                    {"SubnetId": subnet2_id, "Ip": ip2},
+                ],
             )
 
         snapshot.match(
@@ -215,20 +287,25 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds"])
-    def test_update_resolver_endpoint(self, cleanups, snapshot, aws_client):
+    def test_update_resolver_endpoint(self, cleanups, snapshot, aws_client, setup_resources):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "58")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "58")
+
         request_id = short_uid()
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="INBOUND",
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "58"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
-
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
-
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=create_resolver_endpoint_res["Id"]
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -250,16 +327,27 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds"])
-    def test_delete_resolver_endpoint(self, cleanups, snapshot, aws_client):
+    def test_delete_resolver_endpoint(self, cleanups, snapshot, aws_client, setup_resources):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "48")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "48")
+
         request_id = short_uid()
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="INBOUND",
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "48"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
-
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
+        cleanups.append(
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
+            )
+        )
 
         self._wait_created_endpoint_is_listed_with_status(
             aws_client.route53resolver, request_id, "OPERATIONAL"
@@ -291,23 +379,27 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds", "$..ShareStatus"])
-    def test_create_resolver_rule(self, cleanups, snapshot, aws_client):
+    def test_create_resolver_rule(self, cleanups, snapshot, aws_client, setup_resources):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "38")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "38")
+
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="OUTBOUND",
             Name=resolver_endpoint_name,
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "38"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
-
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
-
-        # clean up
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=create_resolver_endpoint_res["Id"]
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -325,10 +417,8 @@ class TestRoute53Resolver:
                 {"Ip": "10.0.1.200", "Port": 123},
             ],
         )
-
         create_resolver_rule_res = create_resolver_rule_res.get("ResolverRule")
         snapshot.match("create_resolver_rule_res", create_resolver_rule_res)
-
         delete_resolver_rule_res = aws_client.route53resolver.delete_resolver_rule(
             ResolverRuleId=create_resolver_rule_res["Id"]
         )
@@ -336,22 +426,30 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds"])
-    def test_create_resolver_rule_with_invalid_direction(self, cleanups, snapshot, aws_client):
+    def test_create_resolver_rule_with_invalid_direction(
+        self, cleanups, snapshot, aws_client, setup_resources
+    ):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "28")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "28")
+
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="INBOUND",
             Name=resolver_endpoint_name,
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "28"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
 
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
-        # clean up
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=create_resolver_endpoint_res["Id"]
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -377,24 +475,28 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecurityGroupIds", "$..ShareStatus"])
-    def test_multipe_create_resolver_rule(self, cleanups, snapshot, aws_client):
+    def test_multipe_create_resolver_rule(self, cleanups, snapshot, aws_client, setup_resources):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "18")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "18")
+
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="OUTBOUND",
             Name=resolver_endpoint_name,
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "18"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
-
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
         resolver_endpoint_id = create_resolver_endpoint_res["Id"]
-
-        # clean up
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=resolver_endpoint_id
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -447,13 +549,26 @@ class TestRoute53Resolver:
     def test_create_resolver_query_log_config(self, cleanups, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("Name"))
         request_id = short_uid()
+
+        log_group_name = f"test-r53resolver-lg-{short_uid()}"
+        aws_client.logs.create_log_group(logGroupName=log_group_name)
+        cleanups.append(lambda: aws_client.logs.delete_log_group(logGroupName=log_group_name))
+        log_group_arn = aws_client.logs.describe_log_groups(logGroupNamePrefix=log_group_name)[
+            "logGroups"
+        ][0]["arn"]
+
         result = aws_client.route53resolver.create_resolver_query_log_config(
             Name=f"test-{short_uid()}",
-            DestinationArn="arn:aws:logs:us-east-1:123456789012:log-group:sampletest123",
+            DestinationArn=log_group_arn,
             CreatorRequestId=request_id,
         )
         create_rqlc = result.get("ResolverQueryLogConfig")
         resolver_config_id = create_rqlc["Id"]
+        cleanups.append(
+            lambda: aws_client.route53resolver.delete_resolver_query_log_config(
+                ResolverQueryLogConfigId=resolver_config_id
+            )
+        )
         if self._wait_created_log_config_is_listed_with_status(
             aws_client.route53resolver, resolver_config_id, "CREATED"
         ):
@@ -468,44 +583,54 @@ class TestRoute53Resolver:
 
     @markers.aws.validated
     def test_delete_non_existent_resolver_query_log_config(self, snapshot, aws_client):
-        resolver_rqlc_id = "test_123"
+        resolver_rqlc_id = "test_123_doesntexist"
         with pytest.raises(
             aws_client.route53resolver.exceptions.ResourceNotFoundException
         ) as resource_not_found:
             aws_client.route53resolver.delete_resolver_query_log_config(
-                ResolverQueryLogConfigId=resolver_rqlc_id
+                ResolverQueryLogConfigId=resolver_rqlc_id,
             )
+        error_msg = resource_not_found.value.response["Error"]["Message"]
+        match = re.search('Trace Id: "(.+)"', error_msg)
+        trace_id = match.groups()[0]
+        snapshot.add_transformer(snapshot.transform.regex(trace_id, "<trace-id>"))
+
         snapshot.match(
-            "resource_not_found_ex_error_code",
-            resource_not_found.value.response.get("Error", {}).get("Code"),
-        )
-        snapshot.match(
-            "resource_not_found_ex_http_status_code",
-            resource_not_found.value.response.get("ResponseMetadata", {}).get("HTTPStatusCode"),
+            "resource_not_found_ex",
+            resource_not_found.value.response,
         )
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..SecurityGroupIds", "$..ShareStatus", "$..StatusMessage"]
     )
-    def test_associate_and_disassociate_resolver_rule(self, cleanups, snapshot, aws_client):
+    def test_associate_and_disassociate_resolver_rule(
+        self, cleanups, snapshot, aws_client, setup_resources
+    ):
+        vpc, subnet1, subnet2, security_group = setup_resources
+        subnet1_id = subnet1["Subnet"]["SubnetId"]
+        subnet2_id = subnet2["Subnet"]["SubnetId"]
+        security_group_id = security_group["GroupId"]
+        ip1 = self._construct_ip_for_cidr_and_host(subnet1["Subnet"]["CidrBlock"], "68")
+        ip2 = self._construct_ip_for_cidr_and_host(subnet2["Subnet"]["CidrBlock"], "68")
+
         snapshot.add_transformer(snapshot.transform.key_value("ResolverRuleId", "rslvr-rr-id"))
         snapshot.add_transformer(snapshot.transform.key_value("VPCId", "vpc-id"))
         request_id = short_uid()
         resolver_endpoint_name = f"rs-{request_id}"
         result = aws_client.route53resolver.create_resolver_endpoint(
             CreatorRequestId=request_id,
-            SecurityGroupIds=self.get_security_group_ids(aws_client.ec2),
+            SecurityGroupIds=[security_group_id],
             Direction="OUTBOUND",
             Name=resolver_endpoint_name,
-            IpAddresses=self.get_create_resolver_endpoint_ip_address(aws_client.ec2, "68"),
+            IpAddresses=[{"SubnetId": subnet1_id, "Ip": ip1}, {"SubnetId": subnet2_id, "Ip": ip2}],
         )
 
         create_resolver_endpoint_res = result.get("ResolverEndpoint")
         resolver_endpoint_id = create_resolver_endpoint_res["Id"]
         cleanups.append(
-            lambda: aws_client.route53resolver.delete_resolver_endpoint(
-                ResolverEndpointId=resolver_endpoint_id
+            delete_route53_resolver_endpoint(
+                aws_client.route53resolver, create_resolver_endpoint_res["Id"]
             )
         )
 
@@ -533,27 +658,28 @@ class TestRoute53Resolver:
 
         snapshot.match("create_resolver_rule_res", create_resolver_rule_res)
 
-        vpcs = aws_client.ec2.describe_vpcs()["Vpcs"]
-        vpcId = random.choice(vpcs)["VpcId"]
+        vpc_id = vpc["Vpc"]["VpcId"]
 
         associated_resolver_rule_res = aws_client.route53resolver.associate_resolver_rule(
             ResolverRuleId=resolver_rule_id,
             Name="test-associate-resolver-rule",
-            VPCId=random.choice(vpcs)["VpcId"],
+            VPCId=vpc_id,
         )["ResolverRuleAssociation"]
 
-        if self._wait_associate_or_disassociate_resolver_rule(
-            aws_client.route53resolver, resolver_rule_id, vpcId, "associate"
-        ):
-            associated_resolver_rule_res["Status"] = "COMPLETE"
-        snapshot.match("associated_resolver_rule_res", associated_resolver_rule_res)
+        assert self._wait_associate_or_disassociate_resolver_rule(
+            aws_client.route53resolver, resolver_rule_id, vpc_id, "associate"
+        )
+        rule_association = aws_client.route53resolver.get_resolver_rule_association(
+            ResolverRuleAssociationId=associated_resolver_rule_res["Id"]
+        )
+        snapshot.match("rule_association", rule_association)
 
         disassociate_resolver_rule_res = aws_client.route53resolver.disassociate_resolver_rule(
-            ResolverRuleId=resolver_rule_id, VPCId=vpcId
+            ResolverRuleId=resolver_rule_id, VPCId=vpc_id
         )
         # wait till resolver rule is disassociated
         self._wait_associate_or_disassociate_resolver_rule(
-            aws_client.route53resolver, resolver_rule_id, vpcId, "disassociate"
+            aws_client.route53resolver, resolver_rule_id, vpc_id, "disassociate"
         )
         snapshot.match("disassociate_resolver_rule_res", disassociate_resolver_rule_res)
 

--- a/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
+++ b/tests/aws/services/route53resolver/test_route53resolver.snapshot.json
@@ -1,44 +1,58 @@
 {
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_endpoint[INBOUND-5]": {
-    "recorded-date": "02-11-2022, 20:20:24",
+    "recorded-date": "08-09-2023, 08:22:31",
     "recorded-content": {
       "create_resolver_endpoint_res": {
-        "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
-        "CreationTime": "date",
-        "CreatorRequestId": "<creator-request-id:1>",
-        "Direction": "INBOUND",
-        "HostVPCId": "<host-vpc-id:1>",
-        "Id": "<id:1>",
-        "IpAddressCount": 2,
-        "ModificationTime": "date",
-        "Name": "rs-<creator-request-id:1>",
-        "SecurityGroupIds": "sg-ids",
-        "Status": "CREATING",
-        "StatusMessage": "status-message"
+        "ResolverEndpoint": {
+          "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:1>",
+          "Direction": "INBOUND",
+          "HostVPCId": "<host-vpc-id:1>",
+          "Id": "<id:1>",
+          "IpAddressCount": 2,
+          "ModificationTime": "date",
+          "Name": "rs-<creator-request-id:1>",
+          "ResolverEndpointType": "IPV4",
+          "SecurityGroupIds": "sg-ids",
+          "Status": "CREATING",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_endpoint[OUTBOUND-10]": {
-    "recorded-date": "02-11-2022, 20:22:15",
+    "recorded-date": "08-09-2023, 08:25:18",
     "recorded-content": {
       "create_resolver_endpoint_res": {
-        "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
-        "CreationTime": "date",
-        "CreatorRequestId": "<creator-request-id:1>",
-        "Direction": "OUTBOUND",
-        "HostVPCId": "<host-vpc-id:1>",
-        "Id": "<id:1>",
-        "IpAddressCount": 2,
-        "ModificationTime": "date",
-        "Name": "rs-<creator-request-id:1>",
-        "SecurityGroupIds": "sg-ids",
-        "Status": "CREATING",
-        "StatusMessage": "status-message"
+        "ResolverEndpoint": {
+          "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:1>",
+          "Direction": "OUTBOUND",
+          "HostVPCId": "<host-vpc-id:1>",
+          "Id": "<id:1>",
+          "IpAddressCount": 2,
+          "ModificationTime": "date",
+          "Name": "rs-<creator-request-id:1>",
+          "ResolverEndpointType": "IPV4",
+          "SecurityGroupIds": "sg-ids",
+          "Status": "CREATING",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_route53resolver_bad_create_endpoint_security_groups": {
-    "recorded-date": "02-11-2022, 20:22:18",
+    "recorded-date": "08-09-2023, 08:35:45",
     "recorded-content": {
       "inavlid_param_request_res": {
         "Error": {
@@ -54,7 +68,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_multiple_create_resolver_endpoint_with_same_req_id": {
-    "recorded-date": "02-11-2022, 20:22:51",
+    "recorded-date": "08-09-2023, 08:37:11",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -66,6 +80,7 @@
         "IpAddressCount": 2,
         "ModificationTime": "date",
         "Name": "rs-<creator-request-id:1>",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -75,7 +90,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_update_resolver_endpoint": {
-    "recorded-date": "02-11-2022, 20:23:25",
+    "recorded-date": "08-09-2023, 08:39:43",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -86,6 +101,7 @@
         "Id": "<id:1>",
         "IpAddressCount": 2,
         "ModificationTime": "date",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -101,6 +117,7 @@
           "IpAddressCount": 2,
           "ModificationTime": "date",
           "Name": "resolver_endpoint_name",
+          "ResolverEndpointType": "IPV4",
           "SecurityGroupIds": "sg-ids",
           "Status": "OPERATIONAL",
           "StatusMessage": "status-message"
@@ -114,7 +131,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_delete_resolver_endpoint": {
-    "recorded-date": "02-11-2022, 20:24:01",
+    "recorded-date": "08-09-2023, 08:42:35",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -125,6 +142,7 @@
         "Id": "<id:1>",
         "IpAddressCount": 2,
         "ModificationTime": "date",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -139,6 +157,7 @@
           "Id": "<id:1>",
           "IpAddressCount": 2,
           "ModificationTime": "date",
+          "ResolverEndpointType": "IPV4",
           "SecurityGroupIds": "sg-ids",
           "Status": "DELETING",
           "StatusMessage": "status-message"
@@ -151,14 +170,14 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_delete_non_existent_resolver_endpoint": {
-    "recorded-date": "02-11-2022, 20:24:01",
+    "recorded-date": "08-09-2023, 08:43:29",
     "recorded-content": {
       "resource_not_found_ex_error_code": "ResourceNotFoundException",
       "resource_not_found_ex_http_status_code": 400
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_rule": {
-    "recorded-date": "02-11-2022, 20:26:38",
+    "recorded-date": "08-09-2023, 08:47:16",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -170,6 +189,7 @@
         "IpAddressCount": 2,
         "ModificationTime": "date",
         "Name": "rs-<creator-request-id:1>",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -223,7 +243,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_rule_with_invalid_direction": {
-    "recorded-date": "02-11-2022, 20:27:08",
+    "recorded-date": "08-09-2023, 08:52:13",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -235,6 +255,7 @@
         "IpAddressCount": 2,
         "ModificationTime": "date",
         "Name": "rs-<creator-request-id:1>",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -253,7 +274,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_multipe_create_resolver_rule": {
-    "recorded-date": "02-11-2022, 20:29:29",
+    "recorded-date": "08-09-2023, 10:10:19",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -265,6 +286,7 @@
         "IpAddressCount": 2,
         "ModificationTime": "date",
         "Name": "rs-<creator-request-id:1>",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -410,7 +432,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_delete_non_existent_resolver_rule": {
-    "recorded-date": "02-11-2022, 20:29:29",
+    "recorded-date": "08-09-2023, 10:10:29",
     "recorded-content": {
       "resource_not_found_res": {
         "Error": {
@@ -426,7 +448,7 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_associate_and_disassociate_resolver_rule": {
-    "recorded-date": "02-11-2022, 20:34:56",
+    "recorded-date": "08-09-2023, 10:43:50",
     "recorded-content": {
       "create_resolver_endpoint_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-endpoint/<id:1>",
@@ -438,6 +460,7 @@
         "IpAddressCount": 2,
         "ModificationTime": "date",
         "Name": "rs-<creator-request-id:1>",
+        "ResolverEndpointType": "IPV4",
         "SecurityGroupIds": "sg-ids",
         "Status": "CREATING",
         "StatusMessage": "status-message"
@@ -462,13 +485,19 @@
           }
         ]
       },
-      "associated_resolver_rule_res": {
-        "Id": "<id:3>",
-        "Name": "test-associate-resolver-rule",
-        "ResolverRuleId": "<id:2>",
-        "Status": "COMPLETE",
-        "StatusMessage": "status-message",
-        "VPCId": "<host-vpc-id:1>"
+      "rule_association": {
+        "ResolverRuleAssociation": {
+          "Id": "<id:3>",
+          "Name": "test-associate-resolver-rule",
+          "ResolverRuleId": "<id:2>",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message",
+          "VPCId": "<host-vpc-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "disassociate_resolver_rule_res": {
         "ResolverRuleAssociation": {
@@ -487,20 +516,20 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_disassociate_non_existent_association": {
-    "recorded-date": "02-11-2022, 20:29:30",
+    "recorded-date": "08-09-2023, 10:22:56",
     "recorded-content": {
       "resource_not_found_res": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DisassociateResolverRule operation: [RSLVR-00703] Resolver rule with ID \"rslvr-123\" does not exist.') tblen=3>"
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_create_resolver_query_log_config": {
-    "recorded-date": "02-11-2022, 20:29:31",
+    "recorded-date": "08-09-2023, 10:27:08",
     "recorded-content": {
       "create_resolver_query_log_config_res": {
         "Arn": "arn:aws:route53resolver:<region>:111111111111:resolver-query-log-config/<id:1>",
         "AssociationCount": 0,
         "CreationTime": "date",
         "CreatorRequestId": "<creator-request-id:1>",
-        "DestinationArn": "arn:aws:logs:<region>:123456789012:log-group:<Arn:1>",
+        "DestinationArn": "arn:aws:logs:<region>:111111111111:log-group:<Arn:1>",
         "Id": "<id:1>",
         "Name": "<name:1>",
         "OwnerId": "111111111111",
@@ -513,7 +542,7 @@
           "AssociationCount": 0,
           "CreationTime": "date",
           "CreatorRequestId": "<creator-request-id:1>",
-          "DestinationArn": "arn:aws:logs:<region>:123456789012:log-group:<Arn:1>",
+          "DestinationArn": "arn:aws:logs:<region>:111111111111:log-group:<Arn:1>",
           "Id": "<id:1>",
           "Name": "<name:1>",
           "OwnerId": "111111111111",
@@ -528,14 +557,23 @@
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_delete_non_existent_resolver_query_log_config": {
-    "recorded-date": "02-11-2022, 20:29:32",
+    "recorded-date": "08-09-2023, 10:37:52",
     "recorded-content": {
-      "resource_not_found_ex_error_code": "ResourceNotFoundException",
-      "resource_not_found_ex_http_status_code": 400
+      "resource_not_found_ex": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: \"<trace-id>\""
+        },
+        "Message": "[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: \"<trace-id>\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
     }
   },
   "tests/aws/services/route53resolver/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_domain_lists": {
-    "recorded-date": "13-01-2023, 18:47:03",
+    "recorded-date": "01-09-2023, 10:05:46",
     "recorded-content": {
       "create-firewall-domain-list": {
         "FirewallDomainList": {

--- a/tests/aws/templates/route53_recordset_without_resource_records.yaml
+++ b/tests/aws/templates/route53_recordset_without_resource_records.yaml
@@ -10,5 +10,7 @@ Resources:
     Properties:
       HostedZoneId: !Ref HostedZoneId
       Name: !Ref Name
+      ResourceRecords:
+        - 192.0.2.99
       TTL: 900
       Type: A


### PR DESCRIPTION
## Motivation

As part of our snapshot age project, the goal here is to simply re-validate the route53 integration tests and regenerate the collected snapshots.

## Changes

- fixed tests where they were failing against AWS and made cleanup of resources more robust.
- updated all snapshots for route53resolver



