### PR TITLE
Add SSM apigateway service test

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1913,6 +1913,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     "Integrations of type 'AWS_PROXY' currently only supports "
                     "Lambda function and Firehose stream invocations."
                 )
+
+        # TODO: if the IntegrationType is AWS, `credentials` is mandatory
         moto_request = copy.copy(request)
         moto_request.setdefault("passthroughBehavior", "WHEN_NO_MATCH")
         moto_request.setdefault("timeoutInMillis", 29000)

--- a/tests/aws/services/apigateway/test_apigateway_ssm.py
+++ b/tests/aws/services/apigateway/test_apigateway_ssm.py
@@ -1,11 +1,11 @@
 from localstack.testing.pytest import markers
+from localstack.utils.http import safe_requests as requests
 from tests.aws.services.apigateway.apigateway_fixtures import (
+    api_invoke_url,
+    create_rest_api_integration,
     create_rest_resource,
     create_rest_resource_method,
-    create_rest_api_integration,
-    api_invoke_url,
 )
-from localstack.utils.http import safe_requests as requests
 
 
 @markers.aws.validated

--- a/tests/aws/services/apigateway/test_apigateway_ssm.py
+++ b/tests/aws/services/apigateway/test_apigateway_ssm.py
@@ -1,49 +1,99 @@
+import json
+
+import pytest
+
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.http import safe_requests as requests
-from tests.aws.services.apigateway.apigateway_fixtures import (
-    api_invoke_url,
-    create_rest_api_integration,
-    create_rest_resource,
-    create_rest_resource_method,
-)
+from localstack.utils.sync import retry
+from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
+from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
 
 
 @markers.aws.validated
-def test_lambda_aws_proxy_integration(create_parameter, aws_client, create_rest_apigw):
+@pytest.mark.skipif(condition=not is_aws_cloud(), reason="Not yet implemented in LocalStack")
+def test_ssm_aws_integration(
+    aws_client,
+    create_parameter,
+    create_rest_apigw,
+    create_role_with_policy,
+    region_name,
+    snapshot,
+):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value(
+                "LastModifiedDate", reference_replacement=False, value_replacement="<timestamp>"
+            )
+        ]
+    )
     param_name = "param-test-123"
-    create_parameter(
+    put_param = create_parameter(
         Name=param_name,
         Description="test",
         Value="123",
         Type="String",
     )
+    snapshot.match("put-param", put_param)
     api_id, _, root = create_rest_apigw(name="aws ssm parameter api")
-    resource_id, _ = create_rest_resource(
-        aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="test"
+
+    # create invocation role
+    _, role_arn = create_role_with_policy(
+        "Allow", "ssm:GetParameter", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
     )
 
+    resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id,
+        parentId=root,
+        pathPart="ssm",
+    )["id"]
+
     # create method and integration
-    create_rest_resource_method(
-        aws_client.apigateway,
+    aws_client.apigateway.put_method(
         restApiId=api_id,
         resourceId=resource_id,
         httpMethod="GET",
         authorizationType="NONE",
     )
-    uri = f"arn:aws:apigateway:{aws_client.apigateway.meta.region_name}:ssm:action/GetParameter"
-    create_rest_api_integration(
-        aws_client.apigateway,
+
+    uri = f"arn:aws:apigateway:{region_name}:ssm:action/GetParameter"
+    aws_client.apigateway.put_integration(
         restApiId=api_id,
         resourceId=resource_id,
         httpMethod="GET",
-        integrationHttpMethod="GET",
+        integrationHttpMethod="POST",
         type="AWS",
+        credentials=role_arn,
         uri=uri,
+        passthroughBehavior="WHEN_NO_TEMPLATES",
+        requestParameters={"integration.request.querystring.Name": f"'{param_name}'"},
     )
 
-    url = api_invoke_url(api_id=api_id, stage="local", path="/test")
-    response = requests.get(url)
-    body = response.json()
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        statusCode="200",
+    )
 
-    assert response.status_code == 400
-    assert f'"{uri}" not yet implemented' in body["message"]
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        statusCode="200",
+        responseModels={"application/json": "Empty"},
+    )
+
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
+
+    url = api_invoke_url(api_id=api_id, stage="test", path="/ssm")
+
+    def invoke_api() -> requests.Response:
+        _response = requests.get(url)
+        assert _response.ok
+        return _response
+
+    response = retry(invoke_api, sleep=2, retries=10)
+    body = response.json()["GetParameterResponse"]
+    body["ResponseMetadata"]["HTTPHeaders"] = response.headers
+    snapshot.match("ssm-aws-integration", body)

--- a/tests/aws/services/apigateway/test_apigateway_ssm.py
+++ b/tests/aws/services/apigateway/test_apigateway_ssm.py
@@ -1,0 +1,49 @@
+from localstack.testing.pytest import markers
+from tests.aws.services.apigateway.apigateway_fixtures import (
+    create_rest_resource,
+    create_rest_resource_method,
+    create_rest_api_integration,
+    api_invoke_url,
+)
+from localstack.utils.http import safe_requests as requests
+
+
+@markers.aws.validated
+def test_lambda_aws_proxy_integration(create_parameter, aws_client, create_rest_apigw):
+    param_name = "param-test-123"
+    create_parameter(
+        Name=param_name,
+        Description="test",
+        Value="123",
+        Type="String",
+    )
+    api_id, _, root = create_rest_apigw(name="aws ssm parameter api")
+    resource_id, _ = create_rest_resource(
+        aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="test"
+    )
+
+    # create method and integration
+    create_rest_resource_method(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+    uri = f"arn:aws:apigateway:{aws_client.apigateway.meta.region_name}:ssm:action/GetParameter"
+    create_rest_api_integration(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        integrationHttpMethod="GET",
+        type="AWS",
+        uri=uri,
+    )
+
+    url = api_invoke_url(api_id=api_id, stage="local", path="/test")
+    response = requests.get(url)
+    body = response.json()
+
+    assert response.status_code == 400
+    assert f'"{uri}" not yet implemented' in body["message"]

--- a/tests/aws/services/apigateway/test_apigateway_ssm.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_ssm.snapshot.json
@@ -1,0 +1,33 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_ssm.py::test_ssm_aws_integration": {
+    "recorded-date": "22-05-2024, 20:07:01",
+    "recorded-content": {
+      "put-param": {
+        "Tier": "Standard",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "ssm-aws-integration": {
+        "GetParameterResult": {
+          "Parameter": {
+            "ARN": "arn:aws:ssm:<region>:111111111111:parameter/param-test-123",
+            "DataType": "text",
+            "LastModifiedDate": "<timestamp>",
+            "Name": "param-test-123",
+            "Selector": null,
+            "SourceResult": null,
+            "Type": "String",
+            "Value": "123",
+            "Version": 1
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_ssm.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_ssm.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_ssm.py::test_ssm_aws_integration": {
+    "last_validated_date": "2024-05-22T20:07:01+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When attempting to use `uri: arn:aws:apigateway:region:ssm:action/GetParameter` the following error is retuned to the user

```{"Type": "User", "message": "Error invoking integration for API Gateway ID '12345678': API Gateway integration type \"AWS\", method \"GET\", URI \"arn:aws:ssm:region:000000000000:action/GetParameter\" not yet implemented", "__type": "InvalidRequest"}```

As there is no documentation regarding this integration, this test will verify this is currently not available. And when it is this test can be update to reflect the GetParameter on SSM.

<!-- What notable changes does this PR make? -->
## Changes

This is a test only PR.

## Testing

This is a test only PR.

## TODO

What's left to do:

- [ ] Complete the integration of SSM and ApiGateway


