### PR TITLE
fix S3 s3_empty_bucket fixture and add parity

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -901,6 +901,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not (s3_bucket := store.buckets.get(bucket)):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
 
+        if bypass_governance_retention is not None and not s3_bucket.object_lock_enabled:
+            raise InvalidArgument(
+                "x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets.",
+                ArgumentName="x-amz-bypass-governance-retention",
+            )
+
         if s3_bucket.versioning_status is None:
             if version_id and version_id != "null":
                 raise InvalidArgument(
@@ -969,6 +975,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store = self.get_store(context.account_id, context.region)
         if not (s3_bucket := store.buckets.get(bucket)):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+
+        if bypass_governance_retention is not None and not s3_bucket.object_lock_enabled:
+            raise InvalidArgument(
+                "x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets.",
+                ArgumentName="x-amz-bypass-governance-retention",
+            )
 
         objects: list[ObjectIdentifier] = delete.get("Objects")
         if not objects:

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -228,7 +228,7 @@ def s3_empty_bucket(aws_client):
     def factory(bucket_name: str):
         kwargs = {}
         try:
-            aws_client.s3.get_object_lock_configuration(Bucket=s3_bucket)
+            aws_client.s3.get_object_lock_configuration(Bucket=bucket_name)
             kwargs["BypassGovernanceRetention"] = True
         except ClientError:
             pass

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -5498,6 +5498,20 @@ class TestS3:
         lowercase_headers = {k.lower(): v for k, v in response.headers.items()}
         snapshot.match("get-obj-content-len-headers", lowercase_headers)
 
+    @markers.aws.validated
+    def test_empty_bucket_fixture(self, s3_bucket, s3_empty_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        for i in range(3):
+            aws_client.s3.put_object(Bucket=s3_bucket, Key=f"key{i}", Body="123")
+
+        response = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-obj", response)
+
+        s3_empty_bucket(s3_bucket)
+
+        response = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-obj-after-empty", response)
+
 
 class TestS3MultiAccounts:
     @pytest.fixture

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10213,5 +10213,57 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_empty_bucket_fixture": {
+    "recorded-date": "08-09-2023, 18:52:15",
+    "recorded-content": {
+      "list-obj": {
+        "Contents": [
+          {
+            "ETag": "\"202cb962ac59075b964b07152d234b70\"",
+            "Key": "key0",
+            "LastModified": "datetime",
+            "Size": 3,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"202cb962ac59075b964b07152d234b70\"",
+            "Key": "key1",
+            "LastModified": "datetime",
+            "Size": 3,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"202cb962ac59075b964b07152d234b70\"",
+            "Key": "key2",
+            "LastModified": "datetime",
+            "Size": 3,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-obj-after-empty": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 0,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1452,6 +1452,25 @@ class TestS3ObjectLock:
             )
         snapshot.match("disable-versioning-on-locked-bucket", e.value.response)
 
+    @markers.aws.validated
+    def test_delete_object_with_no_locking(self, s3_bucket, aws_client, snapshot):
+        key = "test-delete-no-lock"
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=key, Body=b"test")
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_object(Bucket=s3_bucket, Key=key, BypassGovernanceRetention=True)
+        snapshot.match("delete-object-bypass-no-lock", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_object(Bucket=s3_bucket, Key=key, BypassGovernanceRetention=False)
+        snapshot.match("delete-object-bypass-no-lock-false", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.delete_objects(
+                Bucket=s3_bucket, Delete={"Objects": [{"Key": key}]}, BypassGovernanceRetention=True
+            )
+        snapshot.match("delete-objects-bypass-no-lock", e.value.response)
+
 
 class TestS3BucketOwnershipControls:
     @markers.aws.validated

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -3150,5 +3150,43 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_delete_object_with_no_locking": {
+    "recorded-date": "08-09-2023, 18:29:03",
+    "recorded-content": {
+      "delete-object-bypass-no-lock": {
+        "Error": {
+          "ArgumentName": "x-amz-bypass-governance-retention",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-object-bypass-no-lock-false": {
+        "Error": {
+          "ArgumentName": "x-amz-bypass-governance-retention",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "delete-objects-bypass-no-lock": {
+        "Error": {
+          "ArgumentName": "x-amz-bypass-governance-retention",
+          "Code": "InvalidArgument",
+          "Message": "x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It seems I introduced an issue when fixing the `s3_empty_bucket` fixture to force deleting locked objects.
```python
2023-09-08T17:33:09.910 DEBUG --- [  MainThread] localstack.testing.pytest.fixtures : error cleaning up bucket test-bucket-5c896954: An error occurred (InvalidArgument) when calling the DeleteObjects operation: x-amz-bypass-governance-retention is only applicable to Object Lock enabled buckets.
```
It also showed that LocalStack didn't have parity when checking this, and allowed the parameter to be passed if the bucket doesn't have it enabled. Added the fix in LocalStack as well, but this was an issue only when running against AWS (lots of clean up to do 😭)

<!-- What notable changes does this PR make? -->
## Changes
- added a check in the fixture to check if the bucket can be locked.
- added a test for the fixture, so we're sure it's working.
- added parity in LocalStack to also raise the error if the parameter is used.

