### PR TITLE
add support for xml to json responses

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -5,7 +5,6 @@ import json
 import logging
 import re
 import time
-import xml.etree.ElementTree as ET
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, Union
@@ -550,15 +549,6 @@ def get_stage_variables(context: ApiInvocationContext) -> Optional[Dict[str, str
 # ---------------
 # UTIL FUNCTIONS
 # ---------------
-
-
-def is_valid_xml(xml_string):
-    try:
-        # Attempt to parse the XML string
-        ET.fromstring(xml_string.encode("utf-8"))
-        return True
-    except ET.ParseError:
-        return False
 
 
 def path_based_url(api_id: str, stage_name: str, path: str) -> str:

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -74,26 +74,6 @@ def apply_patches():
 
         return result
 
-    @patch(APIGatewayResponse.integration_responses)
-    def apigateway_response_integration_responses(fn, self, request, *args, **kwargs):
-        result = fn(self, request, *args, **kwargs)
-        if self.method not in ["PATCH"]:
-            return result
-
-        url_path_parts = self.path.split("/")
-        function_id = url_path_parts[2]
-        resource_id = url_path_parts[4]
-        method_type = url_path_parts[6]
-
-        integration = self.backend.get_integration(function_id, resource_id, method_type)
-        if not integration:
-            return result
-
-        if self.method == "PATCH":
-            patch_operations = self._get_param("patchOperations")
-            apply_json_patch_safe(integration.to_json(), patch_operations, in_place=True)
-            return 200, {}, json.dumps(integration.to_json())
-
     @patch(APIGatewayResponse.usage_plan_individual)
     def apigateway_response_usage_plan_individual(
         fn, self, request, full_url, headers, *args, **kwargs

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -515,6 +515,46 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         parent_id = moto_resource.parent_id
         api_resources[parent_id].remove(resource_id)
 
+    def update_integration_response(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        status_code: StatusCode,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> IntegrationResponse:
+        # XXX: THIS IS NOT A COMPLETE IMPLEMENTATION, just the minimum required to get tests going
+        # TODO: validate patch operations
+
+        moto_rest_api = get_moto_rest_api(context, rest_api_id)
+        moto_resource = moto_rest_api.resources.get(resource_id)
+        if not moto_resource:
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        moto_method = moto_resource.resource_methods.get(http_method)
+        if not moto_method:
+            raise NotFoundException("Invalid Method identifier specified")
+
+        integration_response = moto_method.method_integration.integration_responses.get(status_code)
+        if not integration_response:
+            raise NotFoundException("Invalid Integration Response identifier specified")
+
+        for patch_operation in patch_operations:
+            op = patch_operation.get("op")
+            path = patch_operation.get("path")
+
+            # for path "/responseTemplates/application~1json"
+            if "/responseTemplates" in path:
+                value = patch_operation.get("value")
+                if not isinstance(value, str):
+                    raise BadRequestException(
+                        f"Invalid patch value  '{value}' specified for op '{op}'. Must be a string"
+                    )
+                param = path.removeprefix("/responseTemplates/")
+                param = param.replace("~1", "/")
+                integration_response.response_templates.pop(param)
+
     def update_resource(
         self,
         context: RequestContext,

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -187,6 +187,7 @@ class Templates:
             "path": {},
             "querystring": {},
         }
+
         return {
             "context": ctx,
             "stage_variables": api_context.stage_variables or {},

--- a/localstack/utils/xml.py
+++ b/localstack/utils/xml.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree as ET
 from typing import Any
 
 
@@ -26,3 +27,15 @@ def strip_xmlns(obj: Any) -> Any:
             return obj["#text"]
         return {k: strip_xmlns(v) for k, v in obj.items()}
     return obj
+
+
+def is_valid_xml(xml_string: str) -> bool:
+    """
+    Check if the given string is a valid XML document.
+    """
+    try:
+        # Attempt to parse the XML string
+        ET.fromstring(xml_string.encode("utf-8"))
+        return True
+    except ET.ParseError:
+        return False

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ runtime =
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
     Werkzeug>=2.3.4
-    xmltodict>=0.11.0
+    xmltodict>=0.13.0
 
 # @deprecated - use extra 'runtime' instead.
 full =

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1919,7 +1919,7 @@ class TestIntegrations:
         result = requests.post(url, data=json.dumps(test_data))
         assert 200 == result.status_code
 
-        parsed_json = xmltodict.parse(result.content)
+        parsed_json = json.loads(result.content)
         result = parsed_json["SendMessageResponse"]["SendMessageResult"]
 
         body_md5 = result["MD5OfMessageBody"]

--- a/tests/aws/services/apigateway/test_apigateway_sqs.py
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.py
@@ -6,7 +6,6 @@ import requests
 
 from localstack.services.apigateway.helpers import (
     connect_api_gateway_to_sqs,
-    is_valid_xml,
     path_based_url,
 )
 from localstack.testing.pytest import markers
@@ -14,6 +13,7 @@ from localstack.utils.aws import queries
 from localstack.utils.aws import resources as resource_util
 from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
+from localstack.utils.xml import is_valid_xml
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
 from tests.aws.services.apigateway.test_apigateway_basic import TEST_STAGE_NAME

--- a/tests/aws/services/apigateway/test_apigateway_sqs.py
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.py
@@ -1,13 +1,18 @@
 import base64
 import json
+import re
 
 import requests
 
-from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs, path_based_url
+from localstack.services.apigateway.helpers import (
+    connect_api_gateway_to_sqs,
+    is_valid_xml,
+    path_based_url,
+)
 from localstack.testing.pytest import markers
 from localstack.utils.aws import queries
 from localstack.utils.aws import resources as resource_util
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
 from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
 from tests.aws.services.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
@@ -132,3 +137,151 @@ def test_sqs_aws_integration(
 
     response_data = retry(invoke_api, sleep=2, retries=10, url=invocation_url)
     snapshot.match("sqs-aws-integration", response_data)
+
+
+@markers.aws.validated
+def test_sqs_request_and_response_xml_templates_integration(
+    create_rest_apigw,
+    sqs_create_queue,
+    aws_client,
+    create_role_with_policy,
+    region,
+    account_id,
+    snapshot,
+):
+    queue_name = f"queue-{short_uid()}"
+    sqs_create_queue(QueueName=queue_name)
+
+    # create invocation role
+    _, role_arn = create_role_with_policy(
+        "Allow", "sqs:SendMessage", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+
+    api_id, _, root = create_rest_apigw(
+        name=f"test-api-${short_uid()}",
+    )
+
+    resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id,
+        parentId=root,
+        pathPart="sqs",
+    )["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        authorizationType="NONE",
+    )
+
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        type="AWS",
+        integrationHttpMethod="POST",
+        uri=f"arn:aws:apigateway:{region}:sqs:path/{account_id}/{queue_name}",
+        credentials=role_arn,
+        requestParameters={
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
+        },
+        requestTemplates={"application/json": "Action=SendMessage&MessageBody=$input.body"},
+        passthroughBehavior="NEVER",
+    )
+
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        statusCode="200",
+        responseModels={"application/json": "Empty"},
+    )
+
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        statusCode="200",
+        responseTemplates={
+            "application/json": """
+            #set($responseBody = $input.path('$.SendMessageResponse'))
+            #set($requestId = $input.path('$.SendMessageResponse.ResponseMetadata.RequestId'))
+            #set($messageId = $responseBody.SendMessageResult.MessageId)
+            {
+            "requestId": "$requestId",
+            "messageId": "$messageId"
+            }
+            """
+        },
+    )
+
+    response = aws_client.apigateway.create_deployment(
+        restApiId=api_id,
+    )
+    deployment_id = response["id"]
+
+    aws_client.apigateway.create_stage(
+        restApiId=api_id, stageName=TEST_STAGE_NAME, deploymentId=deployment_id
+    )
+
+    invocation_url = api_invoke_url(api_id=api_id, stage=TEST_STAGE_NAME, path="/sqs")
+
+    def invoke_api(url, is_valid_xml=None):
+        _response = requests.post(url, data="<xml>Hello World</xml>", verify=False)
+        if is_valid_xml:
+            assert is_valid_xml(_response.content.decode("utf-8"))
+            return _response
+
+        assert _response.ok
+        return _response
+
+    response_data = retry(invoke_api, sleep=2, retries=10, url=invocation_url)
+    snapshot.match("sqs-json-response", response_data.json())
+
+    # patch integration request parameters to use Accept header with "application/xml"
+    # and remove response templates
+    aws_client.apigateway.update_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        patchOperations=[
+            {
+                "op": "add",
+                "path": "/requestParameters/integration.request.header.Accept",
+                "value": "'application/xml'",
+            }
+        ],
+    )
+
+    aws_client.apigateway.update_integration_response(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        statusCode="200",
+        patchOperations=[
+            {
+                "op": "remove",
+                "path": "/responseTemplates/application~1json",
+                "value": "application/json",
+            }
+        ],
+    )
+
+    # create deployment and update stage for re-deployment
+    deployment = aws_client.apigateway.create_deployment(
+        restApiId=api_id,
+    )
+
+    aws_client.apigateway.update_stage(
+        restApiId=api_id,
+        stageName=TEST_STAGE_NAME,
+        patchOperations=[{"op": "replace", "path": "/deploymentId", "value": deployment["id"]}],
+    )
+
+    response = retry(invoke_api, sleep=2, retries=10, url=invocation_url, is_valid_xml=is_valid_xml)
+
+    xml_body = to_str(response.content)
+    # snapshotting would be great, but the response differs from AWS on the XML on the element order
+    assert re.search("<MessageId>.*</MessageId>", xml_body)
+    assert re.search("<MD5OfMessageBody>.*</MD5OfMessageBody>", xml_body)
+    assert re.search("<RequestId>.*</RequestId>", xml_body)

--- a/tests/aws/services/apigateway/test_apigateway_sqs.py
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.py
@@ -4,10 +4,7 @@ import re
 
 import requests
 
-from localstack.services.apigateway.helpers import (
-    connect_api_gateway_to_sqs,
-    path_based_url,
-)
+from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs, path_based_url
 from localstack.testing.pytest import markers
 from localstack.utils.aws import queries
 from localstack.utils.aws import resources as resource_util

--- a/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
@@ -6,5 +6,14 @@
         "message": "great success!"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_request_and_response_xml_templates_integration": {
+    "recorded-date": "10-09-2023, 10:13:06",
+    "recorded-content": {
+      "sqs-json-response": {
+        "messageId": "<uuid:1>",
+        "requestId": "<uuid:2>"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Rework this PR to instead of forcing xml to json format exchange, it adds parity to AWS by defaulting SQS responses to JSON. It also works if the request parameter is set to `application/xml`, in that case, the response from the integration is not JSON but XML.

<!-- What notable changes does this PR make? -->
## Changes

- Applies the same defaults as AWS, the default response being JSON.
- It also adds a basic implementation of `update_integration` and `update_integration_response` just to comply with the tests. A follow-up PR will improve the implementation.
- Snapshot tests and exercise multiple response formats



<!-- The following sections are optional, but can be useful! 

## Testing

Adds a snapshot that tackles the customer issue

