### PR TITLE
fix APIGW DeleteDeployment to verify if stage is assigned to it

### DIFF
--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -3,8 +3,10 @@ import logging
 
 from moto.apigateway import models as apigateway_models
 from moto.apigateway.exceptions import (
+    DeploymentNotFoundException,
     NoIntegrationDefined,
     RestAPINotFound,
+    StageStillActive,
     UsagePlanNotFoundException,
 )
 from moto.apigateway.responses import APIGatewayResponse
@@ -219,3 +221,17 @@ def apply_patches():
             if key.lower() == function_id.lower():
                 return self.apis[key]
         raise RestAPINotFound()
+
+    @patch(apigateway_models.RestAPI.delete_deployment, pass_target=False)
+    def patch_delete_deployment(self, deployment_id: str) -> apigateway_models.Deployment:
+        if deployment_id not in self.deployments:
+            raise DeploymentNotFoundException()
+        deployment = self.deployments[deployment_id]
+        if deployment.stage_name and (
+            (stage := self.stages.get(deployment.stage_name))
+            and stage.deployment_id == deployment.id
+        ):
+            # Stage is still active
+            raise StageStillActive()
+
+        return self.deployments.pop(deployment_id)

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -845,5 +845,98 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_update_deployments": {
+    "recorded-date": "11-09-2023, 12:12:50",
+    "recorded-content": {
+      "get-deployment-1": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<deployment-id:1>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-error": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-deployment-1-after-update": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-deployment-2": {
+        "createdDate": "datetime",
+        "id": "<deployment-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stages-after-update": {
+        "item": [
+          {
+            "cacheClusterEnabled": false,
+            "cacheClusterStatus": "NOT_AVAILABLE",
+            "createdDate": "datetime",
+            "deploymentId": "<deployment-id:2>",
+            "lastUpdatedDate": "datetime",
+            "methodSettings": {},
+            "stageName": "s1",
+            "tracingEnabled": false
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-deployment-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "delete-deployment-2-error": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Active stages pointing to this deployment must be moved or deleted"
+        },
+        "message": "Active stages pointing to this deployment must be moved or deleted",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #9095

The scenario described by the user was the following:
1. Create api gateway
2. Create api gateway stage
3. Create api gateway stage deployment
4. Create another api gateway stage deployment (which updates the stage itself)

<!-- What notable changes does this PR make? -->
## Changes
The issue was in the moto implementation: 
```python
        if deployment.stage_name and deployment.stage_name in self.stages:
            # Stage is still active
            raise StageStillActive()
```
But it didn't check if the actual stage which had the same name was attached to the deployment we were deleting. 
I've created a patch as we don't have any `deployment` operation in our provider at the moment and this is a quick fix, the issue was long running and hindering their Terraform deployments.
Added an AWS test which was reproducing the issue. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

