### PR TITLE
Adopt lambda dns setting, fix dns in host mode

### DIFF
--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -835,6 +835,7 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
         dns_server.shutdown()
         return
     DNS_SERVER = dns_server
+    LOG.debug("DNS server startup finished!")
 
 
 def stop_servers():
@@ -858,6 +859,7 @@ def start_dns_server_as_sudo(port: int):
         return
 
     DNS_SERVER = dns_server
+    LOG.debug("DNS server startup finished (as sudo)!")
 
 
 def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = False):

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -698,7 +698,7 @@ class DnsServer(Server, DnsServerProtocol):
 class SeparateProcessDNSServer(Server, DnsServerProtocol):
     def __init__(
         self,
-        port: int,
+        port: int = 53,
         host: str = "0.0.0.0",
     ) -> None:
         super().__init__(port, host)
@@ -835,7 +835,7 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
         dns_server.shutdown()
         return
     DNS_SERVER = dns_server
-    LOG.debug("DNS server startup finished!")
+    LOG.debug("DNS server startup finished.")
 
 
 def stop_servers():
@@ -859,7 +859,7 @@ def start_dns_server_as_sudo(port: int):
         return
 
     DNS_SERVER = dns_server
-    LOG.debug("DNS server startup finished (as sudo)!")
+    LOG.debug("DNS server startup finished (as sudo).")
 
 
 def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = False):
@@ -883,7 +883,7 @@ def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = F
     if in_docker():
         host = "0.0.0.0"
 
-    if port_can_be_bound(Port(port, "udp")):
+    if port_can_be_bound(Port(port, "udp"), address=host):
         start_server(port=port, host=host, upstream_dns=upstream_dns)
         if not asynchronous:
             sleep_forever()

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -695,6 +695,48 @@ class DnsServer(Server, DnsServerProtocol):
         self.resolver.clear()
 
 
+class SeparateProcessDNSServer(Server, DnsServerProtocol):
+    def __init__(
+        self,
+        port: int,
+        host: str = "0.0.0.0",
+    ) -> None:
+        super().__init__(port, host)
+
+    @property
+    def protocol(self):
+        return "udp"
+
+    def health(self):
+        """
+        Runs a health check on the server. The default implementation performs is_port_open on the server URL.
+        """
+        try:
+            request = dns.message.make_query("localhost.localstack.cloud", "A")
+            answers = dns.query.udp(request, "127.0.0.1", port=self.port, timeout=0.5).answer
+            return len(answers) > 0
+        except Exception:
+            return False
+
+    def do_start_thread(self):
+        # For host mode
+        env_vars = {}
+        for env_var in config.CONFIG_ENV_VARS:
+            if env_var.startswith("DNS_"):
+                value = os.environ.get(env_var, None)
+                if value is not None:
+                    env_vars[env_var] = value
+
+        # note: running in a separate process breaks integration with Route53 (to be fixed for local dev mode!)
+        thread = run_module_as_sudo(
+            "localstack.dns.server",
+            asynchronous=True,
+            env_vars=env_vars,
+            arguments=["-p", str(self.port)],
+        )
+        return thread
+
+
 def get_fallback_dns_server():
     return config.DNS_SERVER or get_available_dns_server()
 
@@ -800,6 +842,24 @@ def stop_servers():
         DNS_SERVER.shutdown()
 
 
+def start_dns_server_as_sudo(port: int):
+    global DNS_SERVER
+    LOG.debug(
+        "Starting the DNS on its privileged port (%s) needs root permissions. Trying to start DNS with sudo.",
+        config.DNS_PORT,
+    )
+
+    dns_server = SeparateProcessDNSServer(port)
+    dns_server.start()
+
+    if not dns_server.wait_is_up(timeout=5):
+        LOG.warning("DNS server did not come up within 5 seconds.")
+        dns_server.shutdown()
+        return
+
+    DNS_SERVER = dns_server
+
+
 def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = False):
     # start local DNS server, if present
     if not config.use_custom_dns():
@@ -826,25 +886,7 @@ def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = F
         LOG.debug("Already in standalone mode and port binding still fails.")
         return
 
-    # For host mode
-    env_vars = {}
-    for env_var in config.CONFIG_ENV_VARS:
-        if env_var.startswith("DNS_"):
-            value = os.environ.get(env_var, None)
-            if value is not None:
-                env_vars[env_var] = value
-
-    LOG.debug(
-        "Starting the DNS on its privileged port (%s) needs root permissions. Trying to start DNS with sudo.",
-        config.DNS_PORT,
-    )
-    # note: running in a separate process breaks integration with Route53 (to be fixed for local dev mode!)
-    run_module_as_sudo(
-        "localstack.services.dns_server",
-        asynchronous=asynchronous,
-        env_vars=env_vars,
-        arguments=["-p", str(port)],
-    )
+    start_dns_server_as_sudo(port)
 
 
 def get_dns_server() -> DnsServerProtocol:

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -861,7 +861,12 @@ def start_dns_server_as_sudo(port: int):
 
 
 def start_dns_server(port: int, asynchronous: bool = False, standalone: bool = False):
-    # start local DNS server, if present
+    if DNS_SERVER:
+        # already started - bail
+        LOG.error("DNS servers are already started. Avoid starting again.")
+        return
+
+    # check if DNS server is disabled
     if not config.use_custom_dns():
         LOG.debug("Not starting DNS. DNS_ADDRESS=%s", config.DNS_ADDRESS)
         return

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -224,7 +224,7 @@ class TestLambdaDNS:
             FunctionName=function_name,
             Payload=json.dumps(
                 {
-                    "url": f"http://localhost.localstack.cloud:{config.LOCALSTACK_HOST.port}/_localstack/health"
+                    "url": f"http://localhost.localstack.cloud:{config.GATEWAY_LISTEN[0].port}/_localstack/health"
                 }
             ),
         )

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -203,3 +203,31 @@ class TestDockerFlags:
         result_data = json.loads(to_str(result_data))
         assert result_data["status"] == 200
         assert "nginx" in result_data["response"]
+
+
+class TestLambdaDNS:
+    @markers.aws.only_localstack
+    @pytest.mark.skipif(
+        not config.use_custom_dns(), reason="Test invalid if DNS server is disabled"
+    )
+    def test_lambda_localhost_localstack_cloud_connectivity(
+        self, create_lambda_function, aws_client
+    ):
+        function_name = f"test-network-{short_uid()}"
+        create_lambda_function(
+            handler_file=LAMBDA_NETWORKS_PYTHON_HANDLER,
+            func_name=function_name,
+            runtime=Runtime.python3_11,
+        )
+
+        result = aws_client.lambda_.invoke(
+            FunctionName=function_name,
+            Payload=json.dumps(
+                {"url": f"http://localhost.localstack.cloud:{config.EDGE_PORT}/_localstack/health"}
+            ),
+        )
+        assert "FunctionError" not in result
+        result_data = result["Payload"].read()
+        result_data = json.loads(to_str(result_data))
+        assert result_data["status"] == 200
+        assert "services" in result_data["response"]

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -223,7 +223,9 @@ class TestLambdaDNS:
         result = aws_client.lambda_.invoke(
             FunctionName=function_name,
             Payload=json.dumps(
-                {"url": f"http://localhost.localstack.cloud:{config.EDGE_PORT}/_localstack/health"}
+                {
+                    "url": f"http://localhost.localstack.cloud:{config.LOCALSTACK_HOST.port}/_localstack/health"
+                }
             ),
         )
         assert "FunctionError" not in result


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We want to enable our DNS integration for all lambda images. In community we only forward all subdomains of `localhost.localstack.cloud` to LS, which is already helpful when using lambdas to connect to returned endpoints (e.g. apigateway endpoints).

Also, the host mode version is currently broken, so this has to be fixed.

<!-- What notable changes does this PR make? -->
## Changes
* Fix host mode DNS by creating a new server class for dns servers running in a separate (sudo) process. It is not possible to interact with it programatically yet, but it now it does not raise errors when calling DNSServerProtocol methods
* Set the DNS in lambda, if no other LAMBDA_DOCKER_DNS is set.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

