### PR TITLE
add container port and volume flags to localstack start

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -396,9 +396,30 @@ def _print_service_table(services: Dict[str, str]) -> None:
     multiple=True,
     required=False,
 )
+@click.option(
+    "--publish",
+    "-p",
+    help="Additional port mappings that are passed to the LocalStack container",
+    multiple=True,
+    required=False,
+)
+@click.option(
+    "--volume",
+    "-v",
+    help="Additional volume mounts that are passed to the LocalStack container",
+    multiple=True,
+    required=False,
+)
 @publish_invocation
 def cmd_start(
-    docker: bool, host: bool, no_banner: bool, detached: bool, network: str = None, env: Tuple = ()
+    docker: bool,
+    host: bool,
+    no_banner: bool,
+    detached: bool,
+    network: str = None,
+    env: Tuple = (),
+    publish: Tuple = (),
+    volume: Tuple = (),
 ) -> None:
     """
     Start the LocalStack runtime.

--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -23,12 +23,9 @@ from .configurators import (
     CoverageRunScriptConfigurator,
     DependencyMountConfigurator,
     EntryPointMountConfigurator,
-    EnvironmentVariablesFromParameters,
     ImageConfigurator,
     PortConfigurator,
-    PortsFromParameters,
     SourceVolumeMountConfigurator,
-    VolumeFromParameters,
 )
 from .paths import HostPaths
 
@@ -266,9 +263,9 @@ def run(
     # make sure anything coming from CLI arguments has priority
     configurators.extend(
         [
-            VolumeFromParameters(list(volume)),
-            PortsFromParameters(publish),
-            EnvironmentVariablesFromParameters(env),
+            ContainerConfigurators.volume_cli_params(volume),
+            ContainerConfigurators.port_cli_params(publish),
+            ContainerConfigurators.env_cli_params(env),
         ]
     )
 

--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -5,7 +5,6 @@ import gzip
 import os
 from pathlib import Path, PurePosixPath
 from tempfile import gettempdir
-from typing import Iterable, List
 
 from localstack import config, constants
 from localstack.utils.bootstrap import ContainerConfigurators
@@ -21,68 +20,6 @@ from localstack.utils.run import run
 from localstack.utils.strings import md5
 
 from .paths import CommunityContainerPaths, ContainerPaths, HostPaths, ProContainerPaths
-
-
-class VolumeFromParameters:
-    """
-    Configures volumes from additional CLI input through the ``-v`` options.
-    """
-
-    def __init__(self, params: List[str]):
-        self.params = params
-
-    def __call__(self, cfg: ContainerConfiguration):
-        for param in self.params:
-            cfg.volumes.append(VolumeBind.parse(param))
-
-
-class PortsFromParameters:
-    """
-    Configures ports from additional CLI input through the ``-p`` options.
-
-    TODO: reconcile with Utils.parse_additional_flags.
-    """
-
-    def __init__(self, ports: Iterable[str]):
-        self.ports = ports or ()
-
-    def __call__(self, cfg: ContainerConfiguration):
-        for port_mapping in self.ports:
-            port_split = port_mapping.split(":")
-            protocol = "tcp"
-            if len(port_split) == 1:
-                host_port = container_port = port_split[0]
-            elif len(port_split) == 2:
-                host_port, container_port = port_split
-            elif len(port_split) == 3:
-                _, host_port, container_port = port_split
-            else:
-                raise ValueError(f"Invalid port string provided: {port_mapping}")
-            host_port_split = host_port.split("-")
-            if len(host_port_split) == 2:
-                host_port = [int(host_port_split[0]), int(host_port_split[1])]
-            elif len(host_port_split) == 1:
-                host_port = int(host_port)
-            else:
-                raise ValueError(f"Invalid port string provided: {port_mapping}")
-            if "/" in container_port:
-                container_port, protocol = container_port.split("/")
-            cfg.ports.add(host_port, int(container_port), protocol)
-
-
-class EnvironmentVariablesFromParameters:
-    """Configures the environment variables from additional CLI input through the ``-e`` options."""
-
-    def __init__(self, env_args: Iterable[str]):
-        self.env_args = env_args or ()
-
-    def __call__(self, cfg: ContainerConfiguration):
-        for kv in self.env_args:
-            kv = kv.split("=", maxsplit=1)
-            k = kv[0]
-            v = kv[1] if len(kv) == 2 else os.environ.get(k)
-            if v is not None:
-                cfg.env_vars[k] = v
 
 
 class ConfigEnvironmentConfigurator:

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -371,7 +371,7 @@ class VolumeBind:
 
         volume = cls(parts[0], parts[1])
         if len(parts) == 3:
-            if "ro" in parts[3].split(","):
+            if "ro" in parts[2].split(","):
                 volume.read_only = True
         return volume
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We want to make it easier to add customizations when running `localstack start`. For instance, to generalize something like `DNS_ADDRESS`, we could just provide a port mapping for `localstack start`, that allows people to map, say, `127.0.0.1:1053:53/udp`. Similarly, there's now easy way to mount custom volumes into the localstack container other than using `DOCKER_FLAGS`.

This PR adds a `-p` and `-v` flag to `localstack start`, which are the same as the flags used in `docker run`. This is a continuation of #8772

<!-- What notable changes does this PR make? -->
## Changes

* Add `-p/--publish` and `-v/--volume` flags to `localstack start`
* Re-use and refactor the necessary code from dev configurators (was already there) into the bootstrap `ContainerConfigurators`
* Fixed an issue where volume parsing wasn't working correctly if `:ro` suffix was provided
* Fixed an issue in ports parsing that would prevent a `/<protocol>` suffix or port range `<start>-<end>` to be parsed correctly
* Added a unit test for the configurator

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

