### PR TITLE
Improve caching for Community Integration Tests against Pro

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -38,6 +38,20 @@ on:
       - master
       - 'v[0-9]+'
       - release/*
+  push:
+    paths:
+      - ".github/workflows/tests-pro-integration.yml"
+      - "localstack/**"
+      - "tests/**"
+      - "setup.py"
+      - "pyproject.toml"
+      - "setup.cfg"
+      - "Dockerfile"
+      - "Dockerfile.rh"
+      - "docker-compose.yml"
+      - "bin/**"
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -173,7 +187,7 @@ jobs:
             localstack-ext/.venv
             localstack/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml', 'localstack/setup.cfg', '**/packages.py', '**/packages/*') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml', 'localstack/setup.cfg', '**/packages.py', 'localstack/packages/*.py', 'localstack-ext/packages/*.py') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
 
       - name: Restore Lambda common runtime packages
         id: cached-lambda-common-restore

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -187,7 +187,7 @@ jobs:
             localstack-ext/.venv
             localstack/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml', 'localstack/setup.cfg', '**/packages.py', 'localstack/packages/*.py', 'localstack-ext/packages/*.py') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml', 'localstack/setup.cfg', 'localstack/**/packages.py', 'localstack-ext/**/packages.py', 'localstack/packages/*.py', 'localstack-ext/packages/*.py') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
 
       - name: Restore Lambda common runtime packages
         id: cached-lambda-common-restore
@@ -249,6 +249,7 @@ jobs:
           # add the GitHub API token to avoid rate limit issues
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: 1
+          DISABLE_BOTO_RETRIES: 1
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "local"
           LOCALSTACK_API_KEY: "test"

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -41,8 +41,8 @@ on:
   push:
     paths:
       - ".github/workflows/tests-pro-integration.yml"
-      - "localstack/**"
-      - "tests/**"
+      - "localstack/**/packages.py"
+      - "localstack/packages/*.py"
       - "setup.py"
       - "pyproject.toml"
       - "setup.cfg"

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -183,11 +183,15 @@ jobs:
         if: inputs.disableCaching != true
         uses: actions/cache@v3
         with:
+          # TODO: maybe we should split these into two steps with different keys?
           path: |
             localstack-ext/.venv
             localstack/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
           key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml', 'localstack/setup.cfg', 'localstack/**/packages.py', 'localstack-ext/**/packages.py', 'localstack/packages/*.py', 'localstack-ext/packages/*.py') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
+          restore-keys: |
+            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/setup.cfg', 'localstack-ext/pyproject.toml','localstack-ext/**/packages.py','localstack-ext/packages/*.py' 'localstack/setup.cfg', 'localstack/**/packages.py',  'localstack/packages/*.py', ) }}-
+
 
       - name: Restore Lambda common runtime packages
         id: cached-lambda-common-restore


### PR DESCRIPTION
## Motivation

Currently the `Community Integration Tests against Pro` are the slowest part of our community test suite on PRs.
In this PR we attempt to reduce the runtime of these tests to get them to a point where we don't have to wait an additional 20+ minutes until the pro tests against community are done for a green pipeline.

The initial commit will currently never find a cache hit since we don't execute the action on master. Additionally the cache key seems to be calculated incorrectly by considering too many files for caching and never actually restored the venv/lib cache, even in a single PR with multiple runs.

Successful caching of the built lambda common packages should already save ~8 minutes.

## Changes

- stricter matching/hash calculation
- Add a restore key for the venv/lib caching to match cache from master
- execute action on master again to populate cache for PRs to use
- set `DISABLE_BOTO_RETRIES` for test execution

What's left to do:

- [ ] run scheduled on master instead of push-based
- [ ] we could actually even skip the tests on master again and just run the installers manually
