### PR TITLE
implement S3 cross account across all operations

### DIFF
--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -13,6 +13,7 @@ from localstack.aws.api import RequestContext
 from localstack.aws.api.events import PutEventsRequestEntry
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.aws.api.s3 import (
+    AccountId,
     BucketName,
     BucketRegion,
     Event,
@@ -97,6 +98,8 @@ class S3EventNotificationContext:
     key_name: ObjectKey
     xray: str
     bucket_location: BucketRegion
+    bucket_account_id: AccountId
+    caller: AccountId
     key_size: int
     key_etag: str
     key_version_id: str
@@ -154,8 +157,10 @@ class S3EventNotificationContext:
             event_type=EVENT_OPERATION_MAP.get(request_context.operation.wire_name, ""),
             event_time=datetime.datetime.now(),
             region=request_context.region,
+            caller=request_context.account_id,  # TODO: use it for `userIdentity`
             bucket_name=bucket_name,
             bucket_location=bucket.location,
+            bucket_account_id=bucket.account_id,  # TODO: use it for bucket owner identity
             key_name=quote(key.name),
             key_etag=etag,
             key_size=key_size,
@@ -201,8 +206,10 @@ class S3EventNotificationContext:
             event_type=EVENT_OPERATION_MAP.get(request_context.operation.wire_name, ""),
             event_time=datetime.datetime.now(),
             region=request_context.region,
+            caller=request_context.account_id,  # TODO: use it for `userIdentity`
             bucket_name=bucket_name,
             bucket_location=s3_bucket.bucket_region,
+            bucket_account_id=s3_bucket.bucket_account_id,  # TODO: use it for bucket owner identity
             key_name=quote(s3_object.key),
             key_etag=etag,
             key_size=key_size,
@@ -375,7 +382,7 @@ class BaseNotifier:
             awsRegion=ctx.region,
             eventTime=timestamp_millis(ctx.event_time),
             eventName=ctx.event_type.removeprefix("s3:"),
-            userIdentity={"principalId": "AIDAJDPLRKLG7UEXAMPLE"},
+            userIdentity={"principalId": "AIDAJDPLRKLG7UEXAMPLE"},  # TODO: use the real one?
             requestParameters={
                 "sourceIPAddress": "127.0.0.1"
             },  # TODO sourceIPAddress was previously extracted from headers ("X-Forwarded-For")

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -258,9 +258,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             s3_notif_ctx = S3EventNotificationContext.from_request_context(
                 context, key_name=key_name
             )
-        if notification_config := self.get_store(
-            context.account_id, context.region
-        ).bucket_notification_configs.get(s3_notif_ctx.bucket_name):
+        store = self.get_store(s3_notif_ctx.bucket_account_id, s3_notif_ctx.bucket_location)
+        if notification_config := store.bucket_notification_configs.get(s3_notif_ctx.bucket_name):
             self._notification_dispatcher.send_notifications(s3_notif_ctx, notification_config)
 
     def _verify_notification_configuration(

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -11,7 +11,6 @@ from zoneinfo import ZoneInfo
 import moto.s3.responses as moto_s3_responses
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, ServiceException, handler
 from localstack.aws.api.s3 import (
     MFA,
@@ -138,6 +137,7 @@ from localstack.aws.api.s3 import (
 )
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
 from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
+from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
@@ -180,7 +180,7 @@ from localstack.services.s3.validation import (
     validate_website_configuration,
 )
 from localstack.services.s3.website_hosting import register_website_hosting_routes
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns
 from localstack.utils.aws.arns import s3_bucket_name
 from localstack.utils.collections import get_safe
 from localstack.utils.patch import patch
@@ -212,14 +212,11 @@ def get_full_default_bucket_location(bucket_name):
 
 class S3Provider(S3Api, ServiceLifecycleHook):
     @staticmethod
-    def get_store(context: Optional[RequestContext] = None) -> S3Store:
-        if not context:
-            return s3_stores[get_aws_account_id()][aws_stack.get_region()]
+    def get_store(account_id: Optional[str] = None, region: Optional[str] = None) -> S3Store:
+        return s3_stores[account_id or DEFAULT_AWS_ACCOUNT_ID][region or AWS_REGION_US_EAST_1]
 
-        return s3_stores[context.account_id][context.region]
-
-    def _clear_bucket_from_store(self, bucket: BucketName):
-        store = self.get_store()
+    def _clear_bucket_from_store(self, context: RequestContext, bucket: BucketName):
+        store = self.get_store(context.account_id, context.region)
         store.bucket_lifecycle_configuration.pop(bucket, None)
         store.bucket_versioning_status.pop(bucket, None)
         store.bucket_cors.pop(bucket, None)
@@ -261,9 +258,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             s3_notif_ctx = S3EventNotificationContext.from_request_context(
                 context, key_name=key_name
             )
-        if notification_config := self.get_store(context).bucket_notification_configs.get(
-            s3_notif_ctx.bucket_name
-        ):
+        if notification_config := self.get_store(
+            context.account_id, context.region
+        ).bucket_notification_configs.get(s3_notif_ctx.bucket_name):
             self._notification_dispatcher.send_notifications(s3_notif_ctx, notification_config)
 
     def _verify_notification_configuration(
@@ -335,7 +332,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
         call_moto(context)
-        self._clear_bucket_from_store(bucket)
+        self._clear_bucket_from_store(context, bucket)
         self._cors_handler.invalidate_cache()
 
     def get_bucket_location(
@@ -440,7 +437,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response[f"Checksum{checksum_algorithm.upper()}"] = key_object.checksum_value  # noqa
 
         if not request.get("VersionId"):
-            store = self.get_store(context)
+            store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
             if (
                 bucket_lifecycle_config := store.bucket_lifecycle_configuration.get(
                     request["Bucket"]
@@ -459,14 +456,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         key = request["Key"]
         bucket = request["Bucket"]
         version_id = request.get("VersionId")
-        if is_object_expired(context, bucket=bucket, key=key, version_id=version_id):
+        moto_backend = get_moto_s3_backend(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
+
+        if is_object_expired(moto_bucket=moto_bucket, key=key, version_id=version_id):
             # TODO: old behaviour was deleting key instantly if expired. AWS cleans up only once a day generally
             # see if we need to implement a feature flag
             # but you can still HeadObject on it and you get the expiry time
             raise NoSuchKey("The specified key does not exist.", Key=key)
 
         response: GetObjectOutput = call_moto(context)
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         # check for the presence in the response, was fixed by moto but incompletely
         if bucket in store.bucket_versioning_status and "VersionId" not in response:
             response["VersionId"] = "null"
@@ -475,8 +475,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             if request_param_value := request.get(request_param):  # noqa
                 response[response_param] = request_param_value  # noqa
 
-        moto_backend = get_moto_s3_backend(context)
-        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
         key_object = get_key_from_moto_bucket(moto_bucket, key=key, version_id=version_id)
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and key_object.kms_key_id:
@@ -561,7 +559,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 key_object.value,
             )
 
-        bucket_lifecycle_configurations = self.get_store(context).bucket_lifecycle_configuration
+        bucket_lifecycle_configurations = self.get_store(
+            context.account_id, context.region
+        ).bucket_lifecycle_configuration
         if (bucket_lifecycle_config := bucket_lifecycle_configurations.get(request["Bucket"])) and (
             rules := bucket_lifecycle_config.get("Rules")
         ):
@@ -656,7 +656,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     ArgumentName="x-amz-bypass-governance-retention",
                 )
 
-        if request["Bucket"] not in self.get_store(context).bucket_notification_configs:
+        if (
+            request["Bucket"]
+            not in self.get_store(context.account_id, context.region).bucket_notification_configs
+        ):
             return call_moto(context)
 
         # TODO: we do not differentiate between deleting a key and creating a DeleteMarker in a versioned bucket
@@ -881,7 +884,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # we can't add the VersionId for now
         if (
             "VersionId" in response
-            and request["Bucket"] not in self.get_store(context).bucket_versioning_status
+            and request["Bucket"]
+            not in self.get_store(context.account_id, context.region).bucket_versioning_status
         ):
             response.pop("VersionId")
         return response
@@ -964,7 +968,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 raise InvalidRequest("Destination bucket must have versioning enabled.")
 
         # TODO more validation on input
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         store.bucket_replication[bucket] = replication_configuration
 
     def get_bucket_replication(
@@ -972,9 +976,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> GetBucketReplicationOutput:
         # test if bucket exists in moto
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket=bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         replication = store.bucket_replication.get(bucket, None)
         if not replication:
             ex = ReplicationConfigurationNotFoundError(
@@ -997,9 +1001,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> GetBucketLifecycleConfigurationOutput:
         # test if bucket exists in moto
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket=bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
 
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         bucket_lifecycle = store.bucket_lifecycle_configuration.get(bucket)
         if not bucket_lifecycle:
             ex = NoSuchLifecycleConfiguration("The lifecycle configuration does not exist")
@@ -1039,7 +1043,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #  everytime we get/head an object
         # for now, we keep a cache and get it everytime we fetch an object, as it's easier to invalidate than
         # iterating over every single key to set the Expiration header to None
-        store = self.get_store(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         store.bucket_lifecycle_configuration[bucket] = lifecycle_conf
         self._expiration_cache[bucket].clear()
 
@@ -1048,9 +1053,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> None:
         # test if bucket exists in moto
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket=bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
 
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         store.bucket_lifecycle_configuration.pop(bucket, None)
         self._expiration_cache[bucket].clear()
 
@@ -1064,15 +1069,23 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         response = call_moto(context)
-        self.get_store(context).bucket_cors[bucket] = cors_configuration
+        moto_backend = get_moto_s3_backend(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
+
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
+        store.bucket_cors[bucket] = cors_configuration
         self._cors_handler.invalidate_cache()
         return response
 
     def get_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketCorsOutput:
+        moto_backend = get_moto_s3_backend(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
         call_moto(context)
-        cors_rules = self.get_store(context).bucket_cors.get(bucket)
+
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
+        cors_rules = store.bucket_cors.get(bucket)
         if not cors_rules:
             raise NoSuchCORSConfiguration(
                 "The CORS configuration does not exist",
@@ -1084,7 +1097,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
         response = call_moto(context)
-        if self.get_store(context).bucket_cors.pop(bucket, None):
+        moto_backend = get_moto_s3_backend(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
+        if store.bucket_cors.pop(bucket, None):
             self._cors_handler.invalidate_cache()
         return response
 
@@ -1156,6 +1172,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         retention_date = retention.get("RetainUntilDate")
         retention_date = retention_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         moto_key.lock_until = retention_date
+        return PutObjectRetentionOutput()
 
     @handler("PutBucketAcl", expand=False)
     def put_bucket_acl(
@@ -1275,7 +1292,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # set it in the store, so we can keep the state if it was ever enabled
         if versioning_status := request.get("VersioningConfiguration", {}).get("Status"):
             bucket_name = request["Bucket"]
-            store = self.get_store(context)
+            moto_backend = get_moto_s3_backend(context)
+            moto_bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
+            store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
             store.bucket_versioning_status[bucket_name] = versioning_status == "Enabled"
 
     def put_bucket_notification_configuration(
@@ -1294,7 +1313,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self._verify_notification_configuration(
             notification_configuration, skip_destination_validation, context, bucket
         )
-        self.get_store(context).bucket_notification_configs[bucket] = notification_configuration
+        self.get_store(context.account_id, context.region).bucket_notification_configs[
+            bucket
+        ] = notification_configuration
 
     def get_bucket_notification_configuration(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
@@ -1302,7 +1323,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO how to verify expected_bucket_owner
         # check if the bucket exists
         get_bucket_from_moto(get_moto_s3_backend(context), bucket=bucket)
-        return self.get_store(context).bucket_notification_configs.get(
+        return self.get_store(context.account_id, context.region).bucket_notification_configs.get(
             bucket, NotificationConfiguration()
         )
 
@@ -1312,13 +1333,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # to check if the bucket exists
         # TODO: simplify this when we don't use moto
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
-
-        if not (
-            website_configuration := self.get_store(context).bucket_website_configuration.get(
-                bucket
-            )
-        ):
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
+        if not (website_configuration := store.bucket_website_configuration.get(bucket)):
             ex = NoSuchWebsiteConfiguration(
                 "The specified bucket does not have a website configuration"
             )
@@ -1339,10 +1356,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # to check if the bucket exists
         # TODO: simplify this when we don't use moto
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
 
         validate_website_configuration(website_configuration)
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         store.bucket_website_configuration[bucket] = website_configuration
 
     def delete_bucket_website(
@@ -1353,7 +1370,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         moto_backend = get_moto_s3_backend(context)
         get_bucket_from_moto(moto_backend, bucket)
         # does not raise error if the bucket did not have a config, will simply return
-        self.get_store(context).bucket_website_configuration.pop(bucket, None)
+        self.get_store(context.account_id, context.region).bucket_website_configuration.pop(
+            bucket, None
+        )
 
     def post_object(
         self, context: RequestContext, bucket: BucketName, body: IO[Body] = None
@@ -1405,7 +1424,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             "LocationHeader", f"{get_full_default_bucket_location(bucket)}{key_name}"
         )
 
-        if bucket in self.get_store(context).bucket_versioning_status:
+        if bucket in self.get_store(context.account_id, context.region).bucket_versioning_status:
             response["VersionId"] = key.version_id
 
         self._notify(context, key_name=key_name)
@@ -1452,7 +1471,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         response["LastModified"] = key.last_modified
 
-        if bucket_name in self.get_store(context).bucket_versioning_status:
+        if (
+            bucket_name
+            in self.get_store(context.account_id, context.region).bucket_versioning_status
+        ):
             response["VersionId"] = key.version_id
 
         if key.multipart:
@@ -1471,9 +1493,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
-
-        store = self.get_store(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
         validate_bucket_analytics_configuration(
             id=id, analytics_configuration=analytics_configuration
@@ -1492,9 +1513,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> GetBucketAnalyticsConfigurationOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
-
-        store = self.get_store(context)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
         analytics_configuration: AnalyticsConfiguration = store.bucket_analytics_configuration.get(
             bucket, {}
@@ -1511,9 +1531,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> ListBucketAnalyticsConfigurationsOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         analytics_configurations: Dict[
             AnalyticsId, AnalyticsConfiguration
         ] = store.bucket_analytics_configuration.get(bucket, {})
@@ -1532,9 +1552,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         analytics_configurations = store.bucket_analytics_configuration.get(bucket, {})
         if not analytics_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -1547,11 +1567,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         intelligent_tiering_configuration: IntelligentTieringConfiguration,
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
 
         validate_bucket_intelligent_tiering_configuration(id, intelligent_tiering_configuration)
-
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         bucket_intelligent_tiering_configurations = (
             store.bucket_intelligent_tiering_configuration.setdefault(bucket, {})
         )
@@ -1561,9 +1580,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
     ) -> GetBucketIntelligentTieringConfigurationOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         intelligent_tiering_configuration: IntelligentTieringConfiguration = (
             store.bucket_intelligent_tiering_configuration.get(bucket, {}).get(id)
         )
@@ -1577,9 +1596,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         bucket_intelligent_tiering_configurations = (
             store.bucket_intelligent_tiering_configuration.get(bucket, {})
         )
@@ -1590,9 +1609,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, continuation_token: Token = None
     ) -> ListBucketIntelligentTieringConfigurationsOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         bucket_intelligent_tiering_configurations: Dict[
             IntelligentTieringId, IntelligentTieringConfiguration
         ] = store.bucket_intelligent_tiering_configuration.get(bucket, {})
@@ -1704,13 +1723,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
 
         validate_inventory_configuration(
             config_id=id, inventory_configuration=inventory_configuration
         )
 
-        store = self.get_store(context)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
         inventory_configurations = store.bucket_inventory_configurations.setdefault(bucket, {})
         inventory_configurations[id] = inventory_configuration
 
@@ -1722,9 +1741,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> GetBucketInventoryConfigurationOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         inventory_configuration = store.bucket_inventory_configurations.get(bucket, {}).get(id)
         if not inventory_configuration:
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -1738,9 +1757,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> ListBucketInventoryConfigurationsOutput:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         bucket_inventory_configurations = store.bucket_inventory_configurations.get(bucket, {})
 
         return ListBucketInventoryConfigurationsOutput(
@@ -1758,19 +1777,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         moto_backend = get_moto_s3_backend(context)
-        get_bucket_from_moto(moto_backend, bucket)
+        moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+        store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        store = self.get_store(context)
         bucket_inventory_configurations = store.bucket_inventory_configurations.get(bucket, {})
         if not bucket_inventory_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
 
 
-def is_object_expired(
-    context: RequestContext, bucket: BucketName, key: ObjectKey, version_id: str = None
-) -> bool:
-    moto_backend = get_moto_s3_backend(context)
-    moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+def is_object_expired(moto_bucket, key: ObjectKey, version_id: str = None) -> bool:
     key_object = get_key_from_moto_bucket(moto_bucket, key, version_id=version_id)
     return is_key_expired(key_object=key_object)
 

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -169,7 +169,9 @@ class S3ProviderStream(S3Provider):
         if key_object.checksum_algorithm:
             response[f"Checksum{key_object.checksum_algorithm.upper()}"] = key_object.checksum_value
 
-        bucket_lifecycle_configurations = self.get_store(context).bucket_lifecycle_configuration
+        bucket_lifecycle_configurations = self.get_store(
+            context.account_id, context.region
+        ).bucket_lifecycle_configuration
         if (bucket_lifecycle_config := bucket_lifecycle_configurations.get(request["Bucket"])) and (
             rules := bucket_lifecycle_config.get("Rules")
         ):

--- a/localstack/services/s3/provider_stream.py
+++ b/localstack/services/s3/provider_stream.py
@@ -170,7 +170,8 @@ class S3ProviderStream(S3Provider):
             response[f"Checksum{key_object.checksum_algorithm.upper()}"] = key_object.checksum_value
 
         bucket_lifecycle_configurations = self.get_store(
-            context.account_id, context.region
+            moto_bucket.account_id,
+            moto_bucket.region_name,
         ).bucket_lifecycle_configuration
         if (bucket_lifecycle_config := bucket_lifecycle_configurations.get(request["Bucket"])) and (
             rules := bucket_lifecycle_config.get("Rules")

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -477,9 +477,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         # the bucket still contains objects
         if not s3_bucket.objects.is_empty():
@@ -515,8 +513,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> HeadBucketOutput:
         store = self.get_store(context.account_id, context.region)
         if not (s3_bucket := store.buckets.get(bucket)):
-            # just to return the 404 error message
-            raise NoSuchBucket()
+            if not (account_id := store.global_bucket_map.get(bucket)):
+                # just to return the 404 error message
+                raise NoSuchBucket()
+
+            store = self.get_store(account_id, context.region)
+            if not (s3_bucket := store.buckets.get(bucket)):
+                # just to return the 404 error message
+                raise NoSuchBucket()
 
         # TODO: this call is also used to check if the user has access/authorization for the bucket
         #  it can return 403
@@ -535,9 +539,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
           the payload, which is why we need to manually do this here by manipulating the string.
         Botocore implements this hack for parsing the response in `botocore.handlers.py#parse_get_bucket_location`
         """
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         location_constraint = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -801,12 +803,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: HeadObjectRequest,
     ) -> HeadObjectOutput:
-        store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
         object_key = request["Key"]
         version_id = request.get("VersionId")
-        if not (s3_bucket := store.buckets.get(bucket_name)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket_name)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
         # TODO implement PartNumber, don't know about part number + version id?
         s3_object = s3_bucket.get_object(
@@ -897,9 +897,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> DeleteObjectOutput:
         # TODO: implement bypass_governance_retention, it is done in moto
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if bypass_governance_retention is not None and not s3_bucket.object_lock_enabled:
             raise InvalidArgument(
@@ -972,9 +970,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
     ) -> DeleteObjectsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if bypass_governance_retention is not None and not s3_bucket.object_lock_enabled:
             raise InvalidArgument(
@@ -1105,16 +1101,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
         # TODO: handle those parameters next:
-        # acl: ObjectCannedACL = None,
-        # grant_full_control: GrantFullControl = None,
-        # grant_read: GrantRead = None,
-        # grant_read_acp: GrantReadACP = None,
-        # grant_write_acp: GrantWriteACP = None,
-        #
         # request_payer: RequestPayer = None,
         dest_bucket = request["Bucket"]
         dest_key = request["Key"]
         store = self.get_store(context.account_id, context.region)
+        # TODO: verify cross account CopyObject
         if not (dest_s3_bucket := store.buckets.get(dest_bucket)):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=dest_bucket)
 
@@ -1614,11 +1605,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: GetObjectAttributesRequest,
     ) -> GetObjectAttributesOutput:
-        store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
         object_key = request["Key"]
-        if not (s3_bucket := store.buckets.get(bucket_name)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket_name)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
         s3_object = s3_bucket.get_object(
             key=object_key,
@@ -1661,9 +1650,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> RestoreObjectOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_object = s3_bucket.get_object(
             key=key,
@@ -1715,10 +1702,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> CreateMultipartUploadOutput:
         # TODO: handle missing parameters:
         #  request_payer: RequestPayer = None,
-        store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
-        if not (s3_bucket := store.buckets.get(bucket_name)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket_name)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
         if (storage_class := request.get("StorageClass")) is not None and (
             storage_class not in STORAGE_CLASSES or storage_class == StorageClass.OUTPOSTS
@@ -1801,10 +1786,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #  content_length: ContentLength = None, ->validate?
         #  content_md5: ContentMD5 = None, -> validate?
         #  request_payer: RequestPayer = None,
-        store = self.get_store(context.account_id, context.region)
         bucket_name = request["Bucket"]
-        if not (s3_bucket := store.buckets.get(bucket_name)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket_name)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
         upload_id = request.get("UploadId")
         if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
@@ -1882,6 +1865,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         dest_bucket = request["Bucket"]
         dest_key = request["Bucket"]
         store = self.get_store(context.account_id, context.region)
+        # TODO: validate cross-account UploadPartCopy
         if not (dest_s3_bucket := store.buckets.get(dest_bucket)):
             raise NoSuchBucket("The specified bucket does not exist", BucketName=dest_bucket)
 
@@ -1972,10 +1956,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         sse_customer_key: SSECustomerKey = None,
         sse_customer_key_md5: SSECustomerKeyMD5 = None,
     ) -> CompleteMultipartUploadOutput:
-
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
             raise NoSuchUpload(
@@ -2065,9 +2046,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> AbortMultipartUploadOutput:
         # TODO: write tests around this
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (s3_multipart := s3_bucket.multiparts.pop(upload_id, None)):
             raise NoSuchUpload(
@@ -2095,9 +2074,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         sse_customer_key: SSECustomerKey = None,
         sse_customer_key_md5: SSECustomerKeyMD5 = None,
     ) -> ListPartsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
             raise NoSuchUpload(
@@ -2156,9 +2133,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
     ) -> ListMultipartUploadsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_multiparts = s3_bucket.multiparts
         # https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
@@ -2205,9 +2180,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         mfa: MFA = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not (versioning_status := versioning_configuration.get("Status")):
             raise CommonServiceException(
                 code="IllegalVersioningConfigurationException",
@@ -2230,9 +2203,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_versioning(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketVersioningOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.versioning_status:
             return GetBucketVersioningOutput()
@@ -2244,9 +2215,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> GetBucketEncryptionOutput:
         # AWS now encrypts bucket by default with AES256, see:
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.encryption_rule:
             return GetBucketEncryptionOutput()
@@ -2264,9 +2233,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (rules := server_side_encryption_configuration.get("Rules")):
             raise MalformedXML()
@@ -2299,9 +2266,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_encryption(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.encryption_rule = None
 
@@ -2313,9 +2278,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         skip_destination_validation: SkipValidation = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         self._verify_notification_configuration(
             notification_configuration, skip_destination_validation, context, bucket
@@ -2325,9 +2288,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_notification_configuration(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> NotificationConfiguration:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return s3_bucket.notification_configuration or NotificationConfiguration()
 
@@ -2340,9 +2301,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if "TagSet" not in tagging:
             raise MalformedXML()
@@ -2356,9 +2315,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_tagging(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketTaggingOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         tag_set = store.TAGS.list_tags_for_resource(s3_bucket.bucket_arn, root_name="Tags")["Tags"]
         if not tag_set:
             raise NoSuchTagSet(
@@ -2371,9 +2328,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_tagging(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         store.TAGS.tags.pop(s3_bucket.bucket_arn, None)
 
@@ -2389,9 +2344,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
     ) -> PutObjectTaggingOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_object = s3_bucket.get_object(
             key=key,
@@ -2425,9 +2378,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
     ) -> GetObjectTaggingOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         try:
             s3_object = s3_bucket.get_object(
@@ -2458,9 +2409,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         version_id: ObjectVersionId = None,
         expected_bucket_owner: AccountId = None,
     ) -> DeleteObjectTaggingOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_object = s3_bucket.get_object(
             key=key,
@@ -2486,9 +2435,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         validate_cors_configuration(cors_configuration)
         s3_bucket.cors_rules = cors_configuration
         self._cors_handler.invalidate_cache()
@@ -2496,9 +2443,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketCorsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.cors_rules:
             raise NoSuchCORSConfiguration(
@@ -2510,9 +2455,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if s3_bucket.cors_rules:
             self._cors_handler.invalidate_cache()
@@ -2521,9 +2464,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_lifecycle_configuration(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketLifecycleConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.lifecycle_rules:
             raise NoSuchLifecycleConfiguration(
@@ -2541,9 +2482,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         lifecycle_configuration: BucketLifecycleConfiguration = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         validate_lifecycle_configuration(lifecycle_configuration)
         # TODO: we either apply the lifecycle to existing objects when we set the new rules, or we need to apply them
@@ -2555,9 +2494,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_lifecycle(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.lifecycle_rules = None
         self._expiration_cache[bucket].clear()
@@ -2570,9 +2507,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         analytics_configuration: AnalyticsConfiguration,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         validate_bucket_analytics_configuration(
             id=id, analytics_configuration=analytics_configuration
@@ -2587,9 +2522,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         id: AnalyticsId,
         expected_bucket_owner: AccountId = None,
     ) -> GetBucketAnalyticsConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (analytic_config := s3_bucket.analytics_configurations.get(id)):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2603,9 +2536,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         continuation_token: Token = None,
         expected_bucket_owner: AccountId = None,
     ) -> ListBucketAnalyticsConfigurationsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return ListBucketAnalyticsConfigurationsOutput(
             IsTruncated=False,
@@ -2622,9 +2553,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         id: AnalyticsId,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.analytics_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2636,9 +2565,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         id: IntelligentTieringId,
         intelligent_tiering_configuration: IntelligentTieringConfiguration,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         validate_bucket_intelligent_tiering_configuration(id, intelligent_tiering_configuration)
 
@@ -2647,9 +2574,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_intelligent_tiering_configuration(
         self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
     ) -> GetBucketIntelligentTieringConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (itier_config := s3_bucket.intelligent_tiering_configurations.get(id)):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2661,9 +2586,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_intelligent_tiering_configuration(
         self, context: RequestContext, bucket: BucketName, id: IntelligentTieringId
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.intelligent_tiering_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2671,9 +2594,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def list_bucket_intelligent_tiering_configurations(
         self, context: RequestContext, bucket: BucketName, continuation_token: Token = None
     ) -> ListBucketIntelligentTieringConfigurationsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return ListBucketIntelligentTieringConfigurationsOutput(
             IsTruncated=False,
@@ -2691,9 +2612,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         inventory_configuration: InventoryConfiguration,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         validate_inventory_configuration(
             config_id=id, inventory_configuration=inventory_configuration
@@ -2707,9 +2626,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         id: InventoryId,
         expected_bucket_owner: AccountId = None,
     ) -> GetBucketInventoryConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (inv_config := s3_bucket.inventory_configurations.get(id)):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2722,9 +2639,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         continuation_token: Token = None,
         expected_bucket_owner: AccountId = None,
     ) -> ListBucketInventoryConfigurationsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return ListBucketInventoryConfigurationsOutput(
             IsTruncated=False,
@@ -2740,9 +2655,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         id: InventoryId,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.inventory_configurations.pop(id, None):
             raise NoSuchConfiguration("The specified configuration does not exist.")
@@ -2750,9 +2663,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_website(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketWebsiteOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.website_configuration:
             raise NoSuchWebsiteConfiguration(
@@ -2770,9 +2681,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         validate_website_configuration(website_configuration)
         s3_bucket.website_configuration = website_configuration
@@ -2780,18 +2689,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_website(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         # does not raise error if the bucket did not have a config, will simply return
         s3_bucket.website_configuration = None
 
     def get_object_lock_configuration(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetObjectLockConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.object_lock_enabled:
             raise ObjectLockConfigurationNotFoundError(
                 "Object Lock configuration does not exist for this bucket",
@@ -2821,9 +2726,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> PutObjectLockConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.object_lock_enabled:
             raise InvalidBucketState(
                 "Object Lock configuration cannot be enabled on existing buckets"
@@ -2862,9 +2765,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
     ) -> GetObjectLegalHoldOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.object_lock_enabled:
             raise InvalidRequest("Bucket is missing Object Lock Configuration")
 
@@ -2894,9 +2795,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> PutObjectLegalHoldOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not legal_hold:
             raise MalformedXML()
@@ -2927,9 +2826,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
     ) -> GetObjectRetentionOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.object_lock_enabled:
             raise InvalidRequest("Bucket is missing Object Lock Configuration")
 
@@ -2963,9 +2860,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> PutObjectRetentionOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.object_lock_enabled:
             raise InvalidRequest("Bucket is missing Object Lock Configuration")
 
@@ -3004,9 +2899,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         # TODO: this currently only mock the operation, but its actual effect is not emulated
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         payer = request_payment_configuration.get("Payer")
         if payer not in ["Requester", "BucketOwner"]:
@@ -3018,18 +2911,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketRequestPaymentOutput:
         # TODO: this currently only mock the operation, but its actual effect is not emulated
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return GetBucketRequestPaymentOutput(Payer=s3_bucket.payer)
 
     def get_bucket_ownership_controls(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketOwnershipControlsOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.object_ownership:
             raise OwnershipControlsNotFoundError(
@@ -3051,9 +2940,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> None:
         # TODO: this currently only mock the operation, but its actual effect is not emulated
         #  it for example almost forbid ACL usage when set to BucketOwnerEnforced
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (rules := ownership_controls.get("Rules")) or len(rules) > 1:
             raise MalformedXML()
@@ -3067,18 +2954,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_ownership_controls(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.object_ownership = None
 
     def get_public_access_block(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetPublicAccessBlockOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.public_access_block:
             raise NoSuchPublicAccessBlockConfiguration(
@@ -3101,9 +2984,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO: this currently only mock the operation, but its actual effect is not emulated
         #  as we do not enforce ACL directly. Also, this should take the most restrictive between S3Control and the
         #  bucket configuration. See s3control
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         public_access_block_fields = {
             "BlockPublicAcls",
@@ -3127,18 +3008,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_public_access_block(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.public_access_block = None
 
     def get_bucket_policy(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketPolicyOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.policy:
             raise NoSuchBucketPolicy(
                 "The bucket policy does not exist",
@@ -3158,9 +3035,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> None:
         # TODO: there is not validation of the policy at the moment, as there was none in moto
         #  we store the JSON policy as is, as we do not need to decode it
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not policy or policy[0] != "{":
             raise MalformedPolicy("Policies must be valid JSON and the first byte must be '{'")
@@ -3177,9 +3052,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_policy(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.policy = None
 
@@ -3190,9 +3063,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
     ) -> GetBucketAccelerateConfigurationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         response = GetBucketAccelerateConfigurationOutput()
         if s3_bucket.accelerate_status:
@@ -3208,9 +3079,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if "." in bucket:
             raise InvalidRequest(
@@ -3234,9 +3103,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         checksum_algorithm: ChecksumAlgorithm = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (logging_config := bucket_logging_status.get("LoggingEnabled")):
             s3_bucket.logging = {}
@@ -3268,9 +3135,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_logging(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketLoggingOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.logging:
             return GetBucketLoggingOutput()
@@ -3287,9 +3152,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         token: ObjectLockToken = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         if not s3_bucket.versioning_status == BucketVersioningStatus.Enabled:
             raise InvalidRequest(
                 "Versioning must be 'Enabled' on the bucket to apply a replication configuration"
@@ -3318,9 +3181,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_replication(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketReplicationOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not s3_bucket.replication:
             raise ReplicationConfigurationNotFoundError(
@@ -3333,9 +3194,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def delete_bucket_replication(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> None:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_bucket.replication = None
 
@@ -3346,9 +3205,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: PutBucketAclRequest,
     ) -> None:
         bucket = request["Bucket"]
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
         acp = get_access_control_policy_from_acl_request(
             request=request, owner=s3_bucket.owner, request_body=context.request.data
         )
@@ -3357,9 +3214,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_acl(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketAclOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         return GetBucketAclOutput(Owner=s3_bucket.acl["Owner"], Grants=s3_bucket.acl["Grants"])
 
@@ -3370,9 +3225,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: PutObjectAclRequest,
     ) -> PutObjectAclOutput:
         bucket = request["Bucket"]
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_object = s3_bucket.get_object(
             key=request["Key"],
@@ -3400,9 +3253,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
     ) -> GetObjectAclOutput:
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         s3_object = s3_bucket.get_object(
             key=key,
@@ -3434,9 +3285,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # policy validation is not implemented either, except expiration and mandatory fields
         # This operation is the only one using form for storing the request data. We will have to do some manual
         # parsing here, as no specs are present for this, as no client directly implements this operation.
-        store = self.get_store(context.account_id, context.region)
-        if not (s3_bucket := store.buckets.get(bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=bucket)
+        store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         form = context.request.form
         validate_post_policy(form)

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10265,5 +10265,47 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_operation_between_regions": {
+    "recorded-date": "12-09-2023, 14:35:39",
+    "recorded-content": {
+      "put-website-config-region-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-cors-config-region-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-website-config-region-2": {
+        "IndexDocument": {
+          "Suffix": "index.html"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-cors-config-region-2": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Issues with S3 Website were found from #9017, which showed a deeper issue in our S3 cross/multi account implementation.
`GetBucketWebsite` would return `NoSuchBucket` if a request from account A was done to a bucket in account B, even though you could get an object from account B.

We need to implement proper cross-account access for S3.

<!-- What notable changes does this PR make? -->
## Changes
### Make all S3 access cross-account

#### For the current provider:
Before, if we tried to access a bucket existing in account A from account B, we would get some weird issue, as we got the bucket from moto but we would then access the store from account B, which wouldn't have the bucket properties. We now use the found moto bucket account id and region to fetch the store.

#### For the v3 provider:
We now use the cross account access for every S3 operation, which will allow us to have some implementation of ACL if not using bucket policies, instead of returning `NoSuchBucket` if the bucket didn't exist in the caller account. This will need multi account setup in our test suite at some point? 

#### Misc
Added a quick cross region test to verify it, and we didn't have one earlier for bucket operations. 

~Also sneaked in a little change for the request, I would get a big logging error that the account_id and region were not passed to the logging format string, following #9084 @whummer. This might just return `None/None`, not sure if that would still be helping or if we should refactor the format string?~ deleted as it's now part of another PR.
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

