### PR TITLE
add service_name attribute to AssetDirectory

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -363,7 +363,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(dynamodb_stores)
         visitor.visit(dynamodbstreams_stores)
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, self.service)))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, self.service)))
 
     def on_before_state_reset(self):
         self.server.stop_dynamodb()

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -62,7 +62,7 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(kinesis_stores)
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "kinesis")))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, "kinesis")))
 
     def on_before_state_load(self):
         # no need to restart servers, since that happens lazily in `server_manager.get_server_for_account`.

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -405,8 +405,8 @@ class OpensearchProvider(OpensearchApi):
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(opensearch_stores)
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "opensearch")))
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "elasticsearch")))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, "opensearch")))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, "elasticsearch")))
 
     def on_after_state_load(self):
         """Starts clusters whose metadata has been restored."""

--- a/localstack/services/redshift/provider.py
+++ b/localstack/services/redshift/provider.py
@@ -37,7 +37,7 @@ def itemize(fn, data, parent_key=None, *args, **kwargs):
 class RedshiftProvider(RedshiftApi):
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(redshift_backends)
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "redshift")))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, "redshift")))
 
     @handler("DescribeClusterSecurityGroups", expand=False)
     def describe_cluster_security_groups(

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -304,7 +304,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(s3_stores)
-        visitor.visit(AssetDirectory(self._storage_backend.root_directory))
+        visitor.visit(AssetDirectory(self.service, self._storage_backend.root_directory))
 
     def on_before_state_save(self):
         self._storage_backend.flush()

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -38,7 +38,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         return f"http://{LOCALHOST}:{config.LOCAL_PORT_STEPFUNCTIONS}"
 
     def accept_state_visitor(self, visitor: StateVisitor):
-        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, self.service)))
+        visitor.visit(AssetDirectory(self.service, os.path.join(config.dirs.data, self.service)))
 
     def on_before_start(self):
         start_stepfunctions()

--- a/localstack/state/core.py
+++ b/localstack/state/core.py
@@ -2,14 +2,17 @@
 import io
 from typing import IO, Any, Protocol, runtime_checkable
 
-StateContainer = Any
-"""While a StateContainer can in principle be anything, localstack currently supports by default the following
-containers:
 
-- BackendDict (moto backend state)
-- AccountRegionBundle (localstack stores)
-- AssetDirectory (folders on disk)
-"""
+class StateContainer(Protocol):
+    """While a StateContainer can in principle be anything, localstack currently supports by default the following
+    containers:
+
+    - BackendDict (moto backend state)
+    - AccountRegionBundle (localstack stores)
+    - AssetDirectory (folders on disk)
+    """
+
+    service_name: str
 
 
 class StateLifecycleHook:
@@ -70,12 +73,17 @@ class AssetDirectory:
     A state container manifested as a directory on the file system.
     """
 
+    service_name: str
     path: str
 
-    def __init__(self, path: str):
+    def __init__(self, service_name: str, path: str):
+        if not service_name:
+            raise ValueError("service name must be set")
+
         if not path:
             raise ValueError("path must be set")
 
+        self.service_name = service_name
         self.path = path
 
     def __str__(self):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In the `StateVisitor` implementations that handle cloud pod state, there is currently no way to know which service the `AssetDirectory` being visited belongs to, unlike `AccountRegionBundle` and `BackendDict` which both have a `service_name` attribute.
Knowing the service name for an `AssetDirectory` is required for technical reasons for s3 v3 persistence.

<!-- What notable changes does this PR make? -->
## Changes

* Make `StateContainer` a protocol and make `service_name` a mandatory attribute
* Refactor all instances of `AssetDirectory` to correctly use the service name

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

