### PR TITLE
fix gateway shutdown procedure

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -27,6 +27,8 @@ class LocalstackAwsGateway(Gateway):
         self.request_handlers.extend(
             [
                 handlers.push_request_context,
+                handlers.add_internal_request_params,
+                handlers.handle_runtime_shutdown,
                 metric_collector.create_metric_handler_item,
                 handlers.preprocess_request,
                 handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
@@ -40,7 +42,6 @@ class LocalstackAwsGateway(Gateway):
                 handlers.inject_auth_header_if_missing,
                 handlers.add_region_from_header,
                 handlers.add_account_id,
-                handlers.add_internal_request_params,
                 handlers.parse_service_request,
                 metric_collector.record_parsed_request,
                 handlers.serve_custom_service_request_handlers,

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -16,6 +16,7 @@ from . import (
     service,
 )
 
+handle_runtime_shutdown = internal.RuntimeShutdownHandler()
 enforce_cors = cors.CorsEnforcer()
 preprocess_request = chain.CompositeHandler()
 add_cors_response_headers = cors.CorsResponseEnricher()

--- a/localstack/aws/handlers/internal.py
+++ b/localstack/aws/handlers/internal.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import NotFound
 
 from localstack import constants
 from localstack.http import Response
+from localstack.runtime import events
 from localstack.services.internal import LocalstackResources
 
 from ..api import RequestContext
@@ -36,3 +37,13 @@ class LocalstackResourceHandler(Handler):
                 # only return 404 if we're accessing an internal resource, otherwise fall back to the other handlers
                 LOG.warning("Unable to find resource handler for path: %s", path)
                 chain.respond(404)
+
+
+class RuntimeShutdownHandler(Handler):
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        if events.infra_stopped.is_set():
+            chain.respond(503)
+        elif events.infra_stopping.is_set():
+            # if we're in the process of shutting down the infrastructure, only accept internal calls
+            if not context.is_internal_call:
+                chain.respond(503)

--- a/localstack/runtime/shutdown.py
+++ b/localstack/runtime/shutdown.py
@@ -1,7 +1,13 @@
+import logging
 from typing import Any, Callable
 
 from localstack.runtime import hooks
 from localstack.utils.functions import call_safe
+
+LOG = logging.getLogger(__name__)
+
+SERVICE_SHUTDOWN_PRIORITY = -10
+"""Shutdown hook priority for shutting down service plugins."""
 
 
 class ShutdownHandlers:
@@ -42,8 +48,26 @@ class ShutdownHandlers:
 
 
 SHUTDOWN_HANDLERS = ShutdownHandlers()
+"""Shutdown handlers run with default priority in an on_infra_shutdown hook."""
+
+ON_AFTER_SERVICE_SHUTDOWN_HANDLERS = ShutdownHandlers()
+"""Shutdown handlers that are executed after all services have been shut down."""
 
 
 @hooks.on_infra_shutdown()
 def run_shutdown_handlers():
     SHUTDOWN_HANDLERS.run()
+
+
+@hooks.on_infra_shutdown(priority=SERVICE_SHUTDOWN_PRIORITY)
+def shutdown_services():
+    # TODO: this belongs into the shutdown procedure of a `Platform` or `RuntimeContainer` class.
+    from localstack.services.plugins import SERVICE_PLUGINS
+
+    LOG.info("[shutdown] Stopping all services")
+    SERVICE_PLUGINS.stop_all_services()
+
+
+@hooks.on_infra_shutdown(priority=SERVICE_SHUTDOWN_PRIORITY - 10)
+def run_on_after_service_shutdown_handlers():
+    ON_AFTER_SERVICE_SHUTDOWN_HANDLERS.run()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -17,7 +17,7 @@ from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import ENV_DEV, LOCALSTACK_INFRA_PROCESS, LOCALSTACK_VENV_FOLDER
 from localstack.runtime import events, hooks
 from localstack.runtime.exceptions import LocalstackExit
-from localstack.services import generic_proxy, motoserver
+from localstack.services import motoserver
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceDisabled, wait_for_infra_shutdown
 from localstack.utils import config_listener, files, objects
@@ -278,13 +278,11 @@ def stop_infra():
     # also used to signal shutdown for edge proxy so that any further requests will be rejected
     events.infra_stopping.set()
 
-    # run plugin hooks for infra shutdown
-    hooks.on_infra_shutdown.run()
-
     try:
-        generic_proxy.QUIET = True  # TODO: this doesn't seem to be doing anything
-        LOG.debug("[shutdown] Cleaning up services ...")
-        SERVICE_PLUGINS.stop_all_services()
+        LOG.debug("[shutdown] Running shutdown hooks ...")
+        # run plugin hooks for infra shutdown
+        hooks.on_infra_shutdown.run()
+
         LOG.debug("[shutdown] Cleaning up resources ...")
         cleanup_resources()
 

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -194,6 +194,7 @@ class PluginsResource:
             hooks.prepare_host.manager,
             hooks.on_infra_ready.manager,
             hooks.on_infra_start.manager,
+            hooks.on_infra_shutdown.manager,
         ]
 
         def get_plugin_details(_manager: PluginManager, _name: str):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With providers now depending on other services for their internal functionality, it becomes important that we allow services to continue to use other services during the infra shutdown procedure so they can properly shut down themselves. This means we need to shutdown services *before* the gateway so services can still make internal requests to properly shut down This was previously not possible because of how shutdown handlers were implemented.

This PR adds a band-aid for this issue applied until we complete re-write the `start_infra` procedure.

Moreover, if we shut down the gateway last, then we should be rejecting incoming requests while we're shutting down the infra. This PR adds a handler that implements this logic. It accepts internal requests so internal components can continue working during the shutdown procedure.


<!-- What notable changes does this PR make? -->
## Changes

* Move service plugin shutdown into a `infra_shutdown` hook with a well-known priority of `-10`
* Add a new `ShutdownHandler` instance that is executed with a lower priority so we have a way to execute shutdown handlers after services were shut down
* Add new handler into the handler chain to return 503 while the system is shutting down
* Move `handlers.add_internal_request_params` almost to the top of the handler chain, since knowing whether it's an internal request is needed in the handler
* Add shutdown handlers to list of plugin managers that can be queried via `/_localstack/plugins`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

