### PR TITLE
Fix cache misses for Boto Client

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,9 @@
 /localstack/services/stores.py @viren-nadkarni
 /tests/unit/test_stores.py @viren-nadkarni
 
+# Internal Boto client lib
+/localstack/aws/connect.py @viren-nadkarni @dfangl
+
 # Dockerfile
 /Dockerfile @alexrashed
 
@@ -223,4 +226,3 @@
 /localstack/aws/api/transcribe/ @sannya-singal @ackdav
 /localstack/services/transcribe/ @sannya-singal @ackdav
 /tests/aws/services/transcribe/ @sannya-singal @ackdav
-


### PR DESCRIPTION
## Motivation

The caching mechanism of `ClientFactory._get_client()` relies on the hash value of all its args. This includes a Boto `Config` object.

The use of `Config.merge()` which returned a new `Config` object everytime, causing cache misses in all invocations of `ClientFactory._get_client()`.

## Implementation

This PR introduces a dedicated merge method for `Config` objects that must be used for all Boto `Config` merges outside of `ClientFactory._get_client()`.

@dfangl: Feel free to change this if you think of a better way :)

## Related

https://github.com/localstack/localstack/issues/9126