### PR TITLE
Remove internal developer configuration from CONFIG_ENV_VARS

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1093,8 +1093,9 @@ DISABLE_BOTO_RETRIES = is_env_true("DISABLE_BOTO_RETRIES")
 
 # HINT: Please add deprecated environment variables to deprecations.py
 
-# list of environment variable names used for configuration.
+# List of environment variable names used for configuration that are passed from the host into the LocalStack container.
 # Make sure to keep this in sync with the above!
+# Do *not* include any internal developer configurations that apply to host-mode only in this list.
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = [
     "ALLOW_NONSTANDARD_REGIONS",
@@ -1173,7 +1174,6 @@ CONFIG_ENV_VARS = [
     "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_REMOVE_CONTAINERS",
-    "LAMBDA_DEV_PORT_EXPOSE",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
     "LAMBDA_STAY_OPEN_MODE",


### PR DESCRIPTION
## Motivation

Using `LAMBDA_DEV_PORT_EXPOSE` within Docker breaks Lambda leading to a connection error because the LocalStack container cannot reach the Lambda container:

```
Failed invocation MyHTTPConnectionPool(host='127.0.0.1', port=58301): Max retries exceeded with url: /invoke (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff40fa18a0>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

/cc @whummer 

## Changes

* Remove the internal developer configuration `LAMBDA_DEV_PORT_EXPOSE` from `CONFIG_ENV_VARS`
* Add a code comment to clarify the intent of `CONFIG_ENV_VARS`
