### PR TITLE
Triage aws_unknown markers across AWS test suite

### DIFF
--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -173,7 +173,7 @@ class TestStacksApi:
         resources = aws_client.cloudformation.describe_stack_resources(StackName=stack_name)
         snapshot.match("stack_resources", resources)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_list_stack_resources_for_removed_resource(self, deploy_cfn_template, aws_client):
         template_path = os.path.join(
             os.path.dirname(__file__), "../../../templates/eventbridge_policy.yaml"
@@ -212,7 +212,7 @@ class TestStacksApi:
         statuses = set([res["ResourceStatus"] for res in resources])
         assert statuses == {"UPDATE_COMPLETE"}
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_update_stack_with_same_template_withoutchange(self, deploy_cfn_template, aws_client):
         template = load_file(
             os.path.join(os.path.dirname(__file__), "../../../templates/fifo_queue.json")

--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -10,7 +10,7 @@ from localstack.utils.sync import wait_until
 LOG = logging.getLogger(__name__)
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_eventbus_policies(deploy_cfn_template, aws_client):
     event_bus_name = f"event-bus-{short_uid()}"
 
@@ -51,7 +51,7 @@ def test_eventbus_policies(deploy_cfn_template, aws_client):
     assert len(policy["Statement"]) == 1
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_eventbus_policy_statement(deploy_cfn_template, aws_client):
     event_bus_name = f"event-bus-{short_uid()}"
     statement_id = f"statement-{short_uid()}"
@@ -75,7 +75,7 @@ def test_eventbus_policy_statement(deploy_cfn_template, aws_client):
     assert event_bus_name in statement["Resource"]
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_event_rule_to_logs(deploy_cfn_template, aws_client):
     event_rule_name = f"event-rule-{short_uid()}"
     log_group_name = f"log-group-{short_uid()}"
@@ -126,7 +126,8 @@ def test_event_rule_to_logs(deploy_cfn_template, aws_client):
     assert message_token in log_events["events"][0]["message"]
 
 
-@markers.aws.unknown
+# {"LogicalResourceId": "TestRule99A50909", "ResourceType": "AWS::Events::Rule", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Parameter ScheduleExpression is not valid."}
+@markers.aws.needs_fixing
 def test_event_rule_creation_without_target(deploy_cfn_template, aws_client):
     event_rule_name = f"event-rule-{short_uid()}"
     deploy_cfn_template(
@@ -142,7 +143,7 @@ def test_event_rule_creation_without_target(deploy_cfn_template, aws_client):
     assert response
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_cfn_event_bus_resource(deploy_cfn_template, aws_client):
     def _assert(expected_len):
         rs = aws_client.events.list_event_buses()
@@ -211,7 +212,8 @@ Resources:
 """
 
 
-@markers.aws.unknown
+# {"LogicalResourceId": "ScheduledRule", "ResourceType": "AWS::Events::Rule", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "s3 is not a supported service for a target."}
+@markers.aws.needs_fixing
 def test_cfn_handle_events_rule(deploy_cfn_template, aws_client):
     bucket_name = f"target-{short_uid()}"
     rule_prefix = f"s3-rule-{short_uid()}"
@@ -234,7 +236,8 @@ def test_cfn_handle_events_rule(deploy_cfn_template, aws_client):
     assert rule_name not in [rule["Name"] for rule in rs["Rules"]]
 
 
-@markers.aws.unknown
+# {"LogicalResourceId": "TestStateMachine", "ResourceType": "AWS::StepFunctions::StateMachine", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Resource handler returned message: \"Cross-account pass role is not allowed."}
+@markers.aws.needs_fixing
 def test_cfn_handle_events_rule_without_name(deploy_cfn_template, aws_client):
     rs = aws_client.events.list_rules()
     rule_names = [rule["Name"] for rule in rs["Rules"]]

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.py
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.py
@@ -10,7 +10,7 @@ from localstack.utils.sync import wait_until
 from tests.aws.services.stepfunctions.utils import await_execution_terminated
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_statemachine_definitionsubstitution(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(
@@ -44,7 +44,7 @@ def test_statemachine_definitionsubstitution(deploy_cfn_template, aws_client):
     assert "hello from statemachine" in execution_desc["output"]
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_nested_statemachine_with_sync2(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(
@@ -76,7 +76,7 @@ def test_nested_statemachine_with_sync2(deploy_cfn_template, aws_client):
     assert output["Value"] == 3
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_apigateway_invoke(deploy_cfn_template, aws_client):
     deploy_result = deploy_cfn_template(
         template_path=os.path.join(
@@ -102,7 +102,7 @@ def test_apigateway_invoke(deploy_cfn_template, aws_client):
     assert "hello from stepfunctions" in execution_result["output"]
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_apigateway_invoke_with_path(deploy_cfn_template, aws_client):
     deploy_result = deploy_cfn_template(
         template_path=os.path.join(
@@ -128,7 +128,7 @@ def test_apigateway_invoke_with_path(deploy_cfn_template, aws_client):
     assert "hello_with_path from stepfunctions" in execution_result["output"]
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_apigateway_invoke_localhost(deploy_cfn_template, aws_client):
     """tests the same as above but with the "generic" localhost version of invoking the apigateway"""
     deploy_result = deploy_cfn_template(
@@ -174,7 +174,7 @@ def test_apigateway_invoke_localhost(deploy_cfn_template, aws_client):
     assert "hello from stepfunctions" in execution_result["output"]
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_apigateway_invoke_localhost_with_path(deploy_cfn_template, aws_client):
     """tests the same as above but with the "generic" localhost version of invoking the apigateway"""
     deploy_result = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -117,7 +117,7 @@ class TestIntrinsicFunctions:
             ("Fn::Or", "1", "1", True),
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_and_or_functions(
         self,
         intrinsic_fn,
@@ -329,7 +329,7 @@ class TestSsmParameters:
         tags = aws_client.sns.list_tags_for_resource(ResourceArn=matching[0])
         snapshot.match("topic-tags", tags)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_resolve_ssm(self, create_parameter, deploy_cfn_template):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"
@@ -345,7 +345,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value_v0 = f"param-value-{short_uid()}"
@@ -371,7 +371,7 @@ class TestSsmParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value_v1
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_resolve_ssm_secure(self, create_parameter, deploy_cfn_template):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"
@@ -398,7 +398,7 @@ class TestSecretsManagerParameters:
             "resolve_secretsmanager.yaml",
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_resolve_secretsmanager(self, create_secret, deploy_cfn_template, template_name):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -250,7 +250,6 @@ class TestLambdaRuntimesCommon:
 
 
 # TODO: Split this and move to PRO
-@pytest.mark.whitebox
 @pytest.mark.skipif(
     condition=is_old_provider(),
     reason="Local executor does not support the majority of the runtimes",
@@ -271,7 +270,7 @@ class TestLambdaCallingLocalstack:
             "dotnet6",  # TODO: does not yet support transparent endpoint injection
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_calling_localstack_from_lambda(self, multiruntime_lambda, tmp_path, aws_client):
         create_function_result = multiruntime_lambda.create_function(
             MemorySize=1024,

--- a/tests/aws/services/lambda_/test_lambda_whitebox.py
+++ b/tests/aws/services/lambda_/test_lambda_whitebox.py
@@ -76,7 +76,7 @@ class TestLambdaFallbackUrl:
             else:
                 config.LAMBDA_FORWARD_URL = ""
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_forward_to_fallback_url_dynamodb(self, aws_client):
         db_table = f"lambda-records-{short_uid()}"
         ddb_client = aws_client.dynamodb
@@ -89,7 +89,7 @@ class TestLambdaFallbackUrl:
         items_after = num_items()
         assert items_before + 3 == items_after
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_forward_to_fallback_url_http(self, aws_client):
         lambda_client = aws_client.lambda_
         lambda_result = {"result": "test123"}
@@ -153,7 +153,7 @@ class TestLambdaFallbackUrl:
                 # clean up / shutdown
                 lambda_client.delete_function(FunctionName=lambda_name)
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_adding_fallback_function_name_in_headers(self, aws_client):
         lambda_client = aws_client.lambda_
         ddb_client = aws_client.dynamodb
@@ -176,7 +176,7 @@ class TestLambdaFallbackUrl:
 
 class TestDockerExecutors:
     @pytest.mark.skipif(not use_docker(), reason="Only applicable with docker executor")
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_additional_docker_flags(self, aws_client):
         flags_before = config.LAMBDA_DOCKER_FLAGS
         env_value = short_uid()
@@ -203,7 +203,7 @@ class TestDockerExecutors:
         # clean up
         lambda_client.delete_function(FunctionName=function_name)
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_code_updated_on_redeployment(self, aws_client):
         lambda_api.LAMBDA_EXECUTOR.cleanup()
 
@@ -244,7 +244,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_prime_and_destroy_containers(self, aws_client):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = f"test_prime_and_destroy_containers_{short_uid()}"
@@ -315,7 +315,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_destroy_idle_containers(self, aws_client):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = "test_destroy_idle_containers"
@@ -364,7 +364,7 @@ class TestDockerExecutors:
         ),
         reason="Test only applicable if docker-reuse executor is selected",
     )
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_logresult_more_than_4k_characters(self, aws_client):
         lambda_api.LAMBDA_EXECUTOR.cleanup()
 
@@ -388,7 +388,7 @@ class TestDockerExecutors:
 
 
 class TestLocalExecutors:
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_python3_runtime_multiple_create_with_conflicting_module(self, aws_client):
         lambda_client = aws_client.lambda_
         original_do_use_docker = lambda_api.DO_USE_DOCKER
@@ -439,7 +439,7 @@ class TestLocalExecutors:
 
 
 class TestFunctionStates:
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_invoke_failure_when_state_pending(self, lambda_su_role, monkeypatch, aws_client):
         """Tests if a lambda invocation fails if state is pending"""
         function_name = f"test-function-{short_uid()}"

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -968,7 +968,7 @@ class TestSqsProvider:
         response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert len(response["Messages"]) == 1
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_delete_message_batch_from_lambda(
         self, sqs_create_queue, create_lambda_function, aws_client
     ):
@@ -2087,7 +2087,7 @@ class TestSqsProvider:
         e.match("InvalidParameterValue")
 
     @pytest.mark.xfail
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_redrive_policy_attribute_validity(self, sqs_create_queue, sqs_queue_arn, aws_client):
         dl_queue_name = f"dl-queue-{short_uid()}"
         dl_queue_url = sqs_create_queue(QueueName=dl_queue_name)
@@ -2502,7 +2502,7 @@ class TestSqsProvider:
             == result_send["MessageId"]
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_dead_letter_queue_chain(self, sqs_create_queue, aws_client):
         # test a chain of 3 queues, with DLQ flow q1 -> q2 -> q3
 
@@ -2835,7 +2835,7 @@ class TestSqsProvider:
             == "5ae4d5d7636402d80f4eb6d213245a88"
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_inflight_message_requeue(self, sqs_create_queue, aws_client):
         visibility_timeout = 3
         queue_name = f"queue-{short_uid()}"
@@ -3980,7 +3980,7 @@ class TestSqsQueryApi:
         assert response.ok
         assert "foobar" in response.text
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_queue_url_format_path_strategy(self, sqs_create_queue, monkeypatch):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "path")
         queue_name = f"path_queue_{short_uid()}"

--- a/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -6,6 +6,7 @@ import pytest
 
 from localstack.services.events.provider import TEST_EVENTS_CACHE
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
 from localstack.utils.aws import arns
@@ -93,7 +94,7 @@ STATE_MACHINE_CATCH = {
                 {
                     "ErrorEquals": [
                         "Exception",
-                        "Lambda.Unknown",
+                        "Lambda.needs_fixing",
                         "ValueError",
                     ],
                     "ResultPath": "$.error",
@@ -273,13 +274,14 @@ def get_machine_arn(sm_name, sfn_client):
 
 
 pytestmark = pytest.mark.skipif(
-    condition=is_new_provider(), reason="Test suite only for legacy provider."
+    condition=not is_aws_cloud() and is_new_provider(),
+    reason="Test suite only for legacy provider.",
 )
 
 
 @pytest.mark.usefixtures("setup_and_tear_down")
 class TestStateMachine:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_choice_state_machine(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
         role_arn = arns.role_arn("sfn_role")
@@ -317,7 +319,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, sfn_client=aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_run_map_state_machine(self, aws_client):
         names = ["Bob", "Meg", "Joe"]
         test_input = [{"map": name} for name in names]
@@ -357,7 +359,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_run_state_machine(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
@@ -393,7 +395,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_try_catch_state_machine(self, aws_client):
         if os.environ.get("AWS_DEFAULT_REGION") != "us-east-1":
             pytest.skip("skipping non us-east-1 temporarily")
@@ -431,7 +433,7 @@ class TestStateMachine:
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
     # TODO: validate against AWS
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_intrinsic_functions(self, aws_client):
         if os.environ.get("AWS_DEFAULT_REGION") != "us-east-1":
             pytest.skip("skipping non us-east-1 temporarily")
@@ -473,7 +475,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_events_state_machine(self, aws_client):
         events = aws_client.events
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
@@ -514,7 +516,7 @@ class TestStateMachine:
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
         events.delete_event_bus(Name=bus_name)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_state_machines_in_parallel(self, cleanups, aws_client):
         """
         Perform a test that creates a series of state machines in parallel. Without concurrency control, using
@@ -604,7 +606,7 @@ STS_ROLE_POLICY_DOC = {
 
 @pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1", "eu-central-1"))
 @pytest.mark.parametrize("statemachine_definition", (TEST_STATE_MACHINE_3,))  # TODO: add sync2 test
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_multiregion_nested(aws_client_factory, region_name, statemachine_definition):
     client1 = aws_client_factory(region_name=region_name).stepfunctions
     # create state machine
@@ -682,7 +684,7 @@ def test_default_logging_configuration(create_state_machine, aws_client):
 
 
 @pytest.mark.skip("Does not work against Pro in new pipeline.")
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_aws_sdk_task(sfn_execution_role, aws_client):
     statemachine_definition = {
         "StartAt": "CreateTopicTask",
@@ -764,7 +766,7 @@ def test_aws_sdk_task(sfn_execution_role, aws_client):
 
 
 @pytest.mark.skip("Does not work against Pro in new pipeline.")
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_aws_sdk_task_delete_s3_object(s3_bucket, sfn_execution_role, aws_client):
     s3_key = "test-key"
     statemachine_definition = {

--- a/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -94,7 +94,7 @@ STATE_MACHINE_CATCH = {
                 {
                     "ErrorEquals": [
                         "Exception",
-                        "Lambda.needs_fixing",
+                        "Lambda.Unknown",
                         "ValueError",
                     ],
                     "ResultPath": "$.error",

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -133,7 +133,7 @@ class TestSnfBase:
         )
 
     @pytest.mark.skip(reason="flaky")  # FIXME
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_event_bridge_events_failure(
         self,
         create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.py
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.skipif(
 )
 class TestCallback:
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_sqs_wait_for_task_token(
         self,
         aws_client,
@@ -75,7 +75,7 @@ class TestCallback:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_sqs_wait_for_task_token_timeout(
         self,
         aws_client,
@@ -114,7 +114,7 @@ class TestCallback:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_sqs_failure_in_wait_for_task_token(
         self,
         aws_client,
@@ -155,7 +155,7 @@ class TestCallback:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_sqs_wait_for_task_tok_with_heartbeat(
         self,
         aws_client,
@@ -196,7 +196,7 @@ class TestCallback:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_sync(
         self,
         aws_client,
@@ -243,7 +243,7 @@ class TestCallback:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_sync2(
         self,
         aws_client,
@@ -290,7 +290,7 @@ class TestCallback:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_sync_delegate_failure(
         self,
         aws_client,
@@ -344,7 +344,7 @@ class TestCallback:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_sync_delegate_timeout(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/choice_operators/test_boolean_equals.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/test_boolean_equals.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestBooleanEquals:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_boolean_equals(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -32,7 +32,7 @@ class TestBooleanEquals:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_boolean_equals_path(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/choice_operators/test_is_operators.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/test_is_operators.py
@@ -1,5 +1,6 @@
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from tests.aws.services.stepfunctions.utils import is_old_provider
 from tests.aws.services.stepfunctions.v2.choice_operators.utils import (
@@ -19,7 +20,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestIsOperators:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_is_boolean(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -32,7 +33,7 @@ class TestIsOperators:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_is_null(self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client):
         create_and_test_comparison_function(
             aws_client.stepfunctions,
@@ -43,7 +44,7 @@ class TestIsOperators:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_is_numeric(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -56,7 +57,7 @@ class TestIsOperators:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_is_present(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -69,7 +70,7 @@ class TestIsOperators:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_is_string(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -82,8 +83,10 @@ class TestIsOperators:
             comparisons=TYPE_COMPARISONS,
         )
 
-    @pytest.mark.skip(reason="TODO: investigate IsTimestamp behaviour.")
-    @markers.aws.unknown
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="TODO: investigate IsTimestamp behaviour."
+    )
+    @markers.aws.needs_fixing
     def test_is_timestamp(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/choice_operators/test_numeric.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/test_numeric.py
@@ -36,7 +36,7 @@ TYPE_COMPARISONS_VARS: Final[list[Any]] = [
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestNumerics:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_equals(
         self,
         aws_client,
@@ -60,7 +60,7 @@ class TestNumerics:
             comparisons=[*type_equals, (-0, 0), (0.0, 0), (2.22, 2.22)],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_equals_path(
         self,
         aws_client,
@@ -85,7 +85,7 @@ class TestNumerics:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_greater_than(
         self,
         aws_client,
@@ -102,7 +102,7 @@ class TestNumerics:
             comparisons=[(-0, 0), (0.0, 0), (0, 1), (1, 1), (1, 0), (0, 1)],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_greater_than_path(
         self,
         aws_client,
@@ -120,7 +120,7 @@ class TestNumerics:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_greater_than_equals(
         self,
         aws_client,
@@ -137,7 +137,7 @@ class TestNumerics:
             comparisons=[(-0, 0), (0.0, 0), (0, 1), (1, 1), (1, 0), (0, 1)],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_greater_than_equals_path(
         self,
         aws_client,
@@ -155,7 +155,7 @@ class TestNumerics:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_less_than(
         self,
         aws_client,
@@ -172,7 +172,7 @@ class TestNumerics:
             comparisons=[(-0, 0), (0.0, 0), (0, 1), (1, 1), (1, 0), (0, 1)],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_less_than_path(
         self,
         aws_client,
@@ -190,7 +190,7 @@ class TestNumerics:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_less_than_equals(
         self,
         aws_client,
@@ -207,7 +207,7 @@ class TestNumerics:
             comparisons=[(-0, 0), (0.0, 0), (0, 1), (1, 1), (1, 0), (0, 1)],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_numeric_less_than_equals_path(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/choice_operators/test_string_operators.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/test_string_operators.py
@@ -36,7 +36,7 @@ TYPE_COMPARISONS_VARS: Final[list[Any]] = [
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestStrings:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_equals(
         self,
         aws_client,
@@ -57,7 +57,7 @@ class TestStrings:
             comparisons=[*type_equals, (" ", "     "), ("\t\n", "\t\r\n"), ("Hello", "Hello")],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_equals_path(
         self,
         aws_client,
@@ -82,7 +82,7 @@ class TestStrings:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_greater_than(
         self,
         aws_client,
@@ -99,7 +99,7 @@ class TestStrings:
             comparisons=[("", ""), ("A", "A "), ("A", "A\t\n\r"), ("AB", "ABC")],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_greater_than_path(
         self,
         aws_client,
@@ -117,7 +117,7 @@ class TestStrings:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_greater_than_equals(
         self,
         aws_client,
@@ -134,7 +134,7 @@ class TestStrings:
             comparisons=[("", ""), ("A", "AB"), ("AB", "A")],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_greater_than_equals_path(
         self,
         aws_client,
@@ -152,7 +152,7 @@ class TestStrings:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_less_than(
         self,
         aws_client,
@@ -169,7 +169,7 @@ class TestStrings:
             comparisons=[("", ""), ("A", "AB"), ("AB", "A")],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_less_than_path(
         self,
         aws_client,
@@ -187,7 +187,7 @@ class TestStrings:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_less_than_equals(
         self,
         aws_client,
@@ -204,7 +204,7 @@ class TestStrings:
             comparisons=[("", ""), ("A", "AB"), ("AB", "A")],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_less_than_equals_path(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/choice_operators/test_timestamp_operators.py
+++ b/tests/aws/services/stepfunctions/v2/choice_operators/test_timestamp_operators.py
@@ -41,7 +41,7 @@ BASE_COMPARISONS: Final[list[tuple[str, str]]] = [(T0, T0), (T0, T1), (T1, T0)]
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestTimestamps:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_equals(
         self,
         aws_client,
@@ -62,7 +62,7 @@ class TestTimestamps:
             comparisons=[*type_equals, *BASE_COMPARISONS],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_equals_path(
         self,
         aws_client,
@@ -80,7 +80,7 @@ class TestTimestamps:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_greater_than(
         self,
         aws_client,
@@ -97,7 +97,7 @@ class TestTimestamps:
             comparisons=BASE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_greater_than_path(
         self,
         aws_client,
@@ -115,7 +115,7 @@ class TestTimestamps:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_greater_than_equals(
         self,
         aws_client,
@@ -132,7 +132,7 @@ class TestTimestamps:
             comparisons=BASE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_greater_than_equals_path(
         self,
         aws_client,
@@ -150,7 +150,7 @@ class TestTimestamps:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_less_than(
         self,
         aws_client,
@@ -167,7 +167,7 @@ class TestTimestamps:
             comparisons=BASE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_less_than_path(
         self,
         aws_client,
@@ -185,7 +185,7 @@ class TestTimestamps:
             add_literal_value=False,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_less_than_equals(
         self,
         aws_client,
@@ -202,7 +202,7 @@ class TestTimestamps:
             comparisons=BASE_COMPARISONS,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_timestamp_less_than_equals_path(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_aws_sdk.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.utils.strings import short_uid
@@ -19,7 +20,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestAwsSdk:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invalid_secret_name(
         self, aws_client, create_iam_role_for_sfn, create_state_machine, sfn_snapshot
     ):
@@ -35,7 +36,7 @@ class TestAwsSdk:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_no_such_bucket(
         self, aws_client, create_iam_role_for_sfn, create_state_machine, sfn_snapshot
     ):
@@ -53,9 +54,12 @@ class TestAwsSdk:
             exec_input,
         )
 
-    @pytest.mark.skip(reason="No parameters validation for dynamodb api calls being returned.")
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(),
+        reason="No parameters validation for dynamodb api calls being returned.",
+    )
     @markers.snapshot.skip_snapshot_verify(paths=["$..cause"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_dynamodb_invalid_param(
         self,
         aws_client,
@@ -82,7 +86,7 @@ class TestAwsSdk:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..cause"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_dynamodb_put_item_no_such_table(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_lambda.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskLambda:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_raise_exception(
         self,
         aws_client,
@@ -58,7 +58,7 @@ class TestTaskLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_raise_exception_catch(
         self,
         aws_client,
@@ -91,7 +91,7 @@ class TestTaskLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_no_such_function(
         self,
         aws_client,
@@ -124,7 +124,7 @@ class TestTaskLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_no_such_function_catch(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestTaskServiceLambda:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_raise_exception(
         self,
         aws_client,
@@ -52,7 +52,7 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_raise_exception_catch(
         self,
         aws_client,
@@ -82,7 +82,7 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_no_such_function(
         self,
         aws_client,
@@ -112,7 +112,7 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_no_such_function_catch(
         self,
         aws_client,
@@ -142,7 +142,7 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_timeout(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_sfn.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_sfn.py
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceSfn:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_no_such_arn(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_sqs.py
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_sqs.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import JsonpathTransformer, RegexTransformer
 from localstack.utils.strings import short_uid
@@ -32,7 +33,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceSqs:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_send_message_no_such_queue(
         self,
         aws_client,
@@ -61,7 +62,7 @@ class TestTaskServiceSqs:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_send_message_no_such_queue_no_catch(
         self,
         aws_client,
@@ -90,8 +91,10 @@ class TestTaskServiceSqs:
             exec_input,
         )
 
-    @pytest.mark.skip("SQS does not raise error on empty body.")
-    @markers.aws.unknown
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="SQS does not raise error on empty body."
+    )
+    @markers.aws.validated
     def test_send_message_empty_body(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_array.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_array.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestArray:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_0(self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client):
         create_and_test_on_inputs(
             aws_client.stepfunctions,
@@ -32,7 +32,7 @@ class TestArray:
             ["HelloWorld"],
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_2(self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client):
         values = [
             "",
@@ -56,7 +56,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_partition(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -74,7 +74,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_contains(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -101,7 +101,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_range(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -123,7 +123,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_get_item(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -137,7 +137,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_length(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -151,7 +151,7 @@ class TestArray:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_array_unique(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_encode_decode.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_encode_decode.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestEncodeDecode:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_base_64_encode(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -33,7 +33,7 @@ class TestEncodeDecode:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_base_64_decode(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_generic.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_generic.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestGeneric:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_format_1(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -35,7 +35,7 @@ class TestGeneric:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_format_2(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_hash_calculations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_hash_calculations.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestHashCalculations:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_hash(self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client):
         hash_bindings = [
             ("input data", "MD5"),

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_json_manipulation.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestJsonManipulation:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_to_json(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -46,7 +46,7 @@ class TestJsonManipulation:
             input_values,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_json_to_string(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -70,7 +70,7 @@ class TestJsonManipulation:
             input_values_jsons,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_json_merge(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestMathOperations:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_math_random(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -76,7 +76,7 @@ class TestMathOperations:
             )
             sfn_snapshot.match(f"exec_hist_resp_{i}", exec_hist_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_math_random_seeded(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -124,7 +124,7 @@ class TestMathOperations:
         exec_hist_resp = aws_client.stepfunctions.get_execution_history(executionArn=execution_arn)
         sfn_snapshot.match("exec_hist_resp", exec_hist_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_math_add(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import JsonpathTransformer, RegexTransformer
 from localstack.utils.strings import short_uid
@@ -12,7 +13,7 @@ from tests.aws.services.stepfunctions.utils import await_execution_success, is_o
 from tests.aws.services.stepfunctions.v2.intrinsic_functions.utils import create_and_test_on_inputs
 
 pytestmark = pytest.mark.skipif(
-    condition=is_old_provider(), reason="Test suite for v2 provider only."
+    condition=is_old_provider() and not is_aws_cloud(), reason="Test suite for v2 provider only."
 )
 
 
@@ -128,7 +129,31 @@ class TestMathOperations:
     def test_math_add(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
-        add_tuples = [(-9, 3), (1.49, 1.50), (1.50, 1.51), (-1.49, -1.50), (-1.50, -1.51)]
+        add_tuples = [
+            (-9, 3),
+            (1.49, 1.50),
+            (1.50, 1.51),
+            (-1.49, -1.50),
+            (-1.50, -1.51),
+            (1.49, 0),
+            (1.49, -1.49),
+            (1.50, 0),
+            (1.51, 0),
+            (-1.49, 0),
+            (-1.50, 0),
+            (-1.51, 0),
+            # below are cases specifically to verify java vs. python rounding
+            # python by default would round to even
+            (0.5, 0),  # python: 0, # java: 1
+            (1.5, 0),  # python: 2, # java: 2
+            (2.5, 0),  # python: 2, # java: 3
+            (3.5, 0),  # python: 4, # java: 4
+            (-0.5, 0.5),  # python: 0, # java: 1
+            (-0.5, 0),  # python: 0, # java: -1
+            (-1.5, 0),  # python: -2, # java: -2
+            (-2.5, 0),  # python: -2, # java: -3
+            (-3.5, 0),  # python: -4, # java: -4
+        ]
         input_values = list()
         for fst, snd in add_tuples:
             input_values.append({"fst": fst, "snd": snd})

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.snapshot.json
@@ -304,7 +304,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py::TestMathOperations::test_math_add": {
-    "recorded-date": "13-02-2023, 14:51:11",
+    "recorded-date": "13-09-2023, 16:01:59",
     "recorded-content": {
       "exec_hist_resp_0": {
         "events": [
@@ -423,7 +423,7 @@
             "stateExitedEventDetails": {
               "name": "State_0",
               "output": {
-                "FunctionResult": 2
+                "FunctionResult": 3
               },
               "outputDetails": {
                 "truncated": false
@@ -435,7 +435,7 @@
           {
             "executionSucceededEventDetails": {
               "output": {
-                "FunctionResult": 2
+                "FunctionResult": 3
               },
               "outputDetails": {
                 "truncated": false
@@ -496,7 +496,7 @@
             "stateExitedEventDetails": {
               "name": "State_0",
               "output": {
-                "FunctionResult": 2
+                "FunctionResult": 4
               },
               "outputDetails": {
                 "truncated": false
@@ -508,7 +508,7 @@
           {
             "executionSucceededEventDetails": {
               "output": {
-                "FunctionResult": 2
+                "FunctionResult": 4
               },
               "outputDetails": {
                 "truncated": false
@@ -642,7 +642,7 @@
             "stateExitedEventDetails": {
               "name": "State_0",
               "output": {
-                "FunctionResult": -2
+                "FunctionResult": -3
               },
               "outputDetails": {
                 "truncated": false
@@ -654,7 +654,7 @@
           {
             "executionSucceededEventDetails": {
               "output": {
-                "FunctionResult": -2
+                "FunctionResult": -3
               },
               "outputDetails": {
                 "truncated": false

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.snapshot.json
@@ -304,7 +304,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_math_operations.py::TestMathOperations::test_math_add": {
-    "recorded-date": "13-09-2023, 16:01:59",
+    "recorded-date": "13-09-2023, 23:07:34",
     "recorded-content": {
       "exec_hist_resp_0": {
         "events": [
@@ -626,6 +626,1174 @@
                 "FunctionInput": {
                   "fst": -1.5,
                   "snd": -1.51
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_5": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.49,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.49,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_6": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.49,
+                  "snd": -1.49
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.49,
+                  "snd": -1.49
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 0
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 0
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_7": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_8": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.51,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.51,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_9": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.49,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.49,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_10": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_11": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.51,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.51,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_12": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 0.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 0.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_13": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_14": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 2.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 2.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_15": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 3.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": 3.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 4
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 4
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_16": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -0.5,
+                  "snd": 0.5
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -0.5,
+                  "snd": 0.5
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_17": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -0.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -0.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": 0
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": 0
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_18": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -1.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -1
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_19": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -2.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -2.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": -2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": -2
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_20": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -3.5,
+                  "snd": 0
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": -3.5,
+                  "snd": 0
                 }
               },
               "inputDetails": {

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestStringOperations:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_string_split(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_unique_id_generation.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_unique_id_generation.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestUniqueIdGeneration:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_uuid(self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client):
         snf_role_arn = create_iam_role_for_sfn()
         sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestBaseScenarios:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_parallel_state(
         self,
         aws_client,
@@ -40,7 +40,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state(
         self,
         aws_client,
@@ -61,7 +61,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_legacy(
         self,
         aws_client,
@@ -82,7 +82,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_item_selector(
         self,
         aws_client,
@@ -103,7 +103,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_parameters_legacy(
         self,
         aws_client,
@@ -124,7 +124,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_item_selector_singleton(
         self,
         aws_client,
@@ -145,7 +145,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_parameters_singleton_legacy(
         self,
         aws_client,
@@ -166,7 +166,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_catch(
         self,
         aws_client,
@@ -208,7 +208,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_catch_legacy(
         self,
         aws_client,
@@ -229,7 +229,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_retry(
         self,
         aws_client,
@@ -250,7 +250,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_retry_multiple_retriers(
         self,
         aws_client,
@@ -271,7 +271,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_retry_legacy(
         self,
         aws_client,
@@ -292,7 +292,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_map_state_break_condition(
         self,
         aws_client,
@@ -313,7 +313,7 @@ class TestBaseScenarios:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_map_state_break_condition_legacy(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
@@ -186,7 +186,7 @@ class TestTaskApiGateway:
             invocation_url = f"{config.service_url('apigateway')}/restapis/{api_id}"
         return invocation_url, stage_name
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_base(
         self,
         aws_client,
@@ -236,7 +236,7 @@ class TestTaskApiGateway:
             {"message": "HelloWorld!"},
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_with_body_post(
         self,
         aws_client,
@@ -291,7 +291,7 @@ class TestTaskApiGateway:
             "$..output.ResponseBody"
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_with_query_parameters(
         self,
         aws_client,
@@ -349,7 +349,7 @@ class TestTaskApiGateway:
             "$..cause",
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_error(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(
 )
 class TestTaskServiceAwsSdk:
     @markers.snapshot.skip_snapshot_verify(paths=["$..SecretList"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_list_secrets(
         self, aws_client, create_iam_role_for_sfn, create_state_machine, sfn_snapshot
     ):

--- a/tests/aws/services/stepfunctions/v2/services/test_dynamodb_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_dynamodb_task_service.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceDynamoDB:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_put_get_item(
         self,
         aws_client,
@@ -58,7 +58,7 @@ class TestTaskServiceDynamoDB:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_put_delete_item(
         self,
         aws_client,
@@ -91,7 +91,7 @@ class TestTaskServiceDynamoDB:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_put_update_get_item(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_lambda_task.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_lambda_task.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestTaskLambda:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_bytes_payload(
         self,
         aws_client,
@@ -65,7 +65,7 @@ class TestTaskLambda:
             [],
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_json_values(
         self,
         aws_client,
@@ -99,7 +99,7 @@ class TestTaskLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_pipe(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_lambda_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_lambda_task_service.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from localstack.aws.api.lambda_ import LogType
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import JsonpathTransformer, RegexTransformer
 from localstack.utils.strings import short_uid
@@ -27,7 +28,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceLambda:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke(
         self,
         aws_client,
@@ -57,7 +58,7 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_bytes_payload(
         self,
         aws_client,
@@ -90,7 +91,7 @@ class TestTaskServiceLambda:
         )
 
     # AWS's stepfuctions documentation seems to incorrectly classify LogType parameters as unsupported.
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_unsupported_param(
         self,
         aws_client,
@@ -137,7 +138,7 @@ class TestTaskServiceLambda:
             [],
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invoke_json_values(
         self,
         aws_client,
@@ -171,8 +172,11 @@ class TestTaskServiceLambda:
             exec_input,
         )
 
-    @pytest.mark.skip(reason="Add support for Invalid State Machine Definition errors")
-    @markers.aws.unknown
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(),
+        reason="Add support for Invalid State Machine Definition errors",
+    )
+    @markers.aws.needs_fixing
     def test_list_functions(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_sfn_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_sfn_task_service.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceSfn:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_start_execution(
         self,
         aws_client,
@@ -70,7 +70,7 @@ class TestTaskServiceSfn:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_execution_input_json(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_sqs_task_service.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.skipif(
     ]
 )
 class TestTaskServiceSqs:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_send_message(
         self,
         aws_client,
@@ -64,7 +64,7 @@ class TestTaskServiceSqs:
         assert len(receive_message_res["Messages"]) == 1
         assert receive_message_res["Messages"][0]["Body"] == message_body
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_send_message_unsupported_parameters(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestSnfApi:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_delete_valid_sm(
         self,
         create_iam_role_for_sfn,
@@ -73,7 +73,7 @@ class TestSnfApi:
             "$..message",
         ]
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_delete_invalid_sm(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot
     ):
@@ -89,7 +89,7 @@ class TestSnfApi:
             create_state_machine(name=sm_name, definition=definition_str, roleArn=snf_role_arn)
         sfn_snapshot.match("invalid_definition_1", resource_not_found.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_delete_nonexistent_sm(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -113,7 +113,7 @@ class TestSnfApi:
         )
         sfn_snapshot.match("deletion_resp_1", deletion_resp_1)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_exact_duplicate_sm(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -153,7 +153,7 @@ class TestSnfApi:
         )
         sfn_snapshot.match("describe_resp_1_2", describe_resp_1_2)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_duplicate_definition_format_sm(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -181,7 +181,7 @@ class TestSnfApi:
             create_state_machine(name=sm_name, definition=definition_str_2, roleArn=snf_role_arn)
         sfn_snapshot.match("already_exists_1", resource_not_found.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_duplicate_sm_name(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -212,7 +212,7 @@ class TestSnfApi:
             create_state_machine(name=sm_name, definition=definition_str_2, roleArn=snf_role_arn)
         sfn_snapshot.match("already_exists_1", resource_not_found.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_list_sms(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -268,7 +268,7 @@ class TestSnfApi:
         lst_resp = aws_client.stepfunctions.list_state_machines()
         sfn_snapshot.match("lst_resp_del_end", lst_resp)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_start_execution(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -301,7 +301,7 @@ class TestSnfApi:
         exec_hist_resp = aws_client.stepfunctions.get_execution_history(executionArn=execution_arn)
         sfn_snapshot.match("exec_hist_resp", exec_hist_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invalid_start_execution_arn(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -329,7 +329,7 @@ class TestSnfApi:
         sfn_snapshot.match("start_exec_of_deleted", resource_not_found.value.response)
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Message", "$..message"])
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_invalid_start_execution_input(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
@@ -381,7 +381,7 @@ class TestSnfApi:
         sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(start_res_null, 2))
         sfn_snapshot.match("start_res_null", start_res_null)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_stop_execution(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_versioning.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.skipif(
     paths=["$..loggingConfiguration", "$..tracingConfiguration", "$..previousEventId"]
 )
 class TestSnfApiVersioning:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_with_publish(
         self,
         create_iam_role_for_sfn,
@@ -44,7 +44,7 @@ class TestSnfApiVersioning:
         sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp_1, 0))
         sfn_snapshot.match("creation_resp_1", creation_resp_1)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_with_version_description_no_publish(
         self,
         create_iam_role_for_sfn,
@@ -68,7 +68,7 @@ class TestSnfApiVersioning:
             )
         sfn_snapshot.match("validation_exception", validation_exception.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_publish_describe_no_version_description(
         self,
         create_iam_role_for_sfn,
@@ -101,7 +101,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("describe_resp", describe_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_publish_describe_with_version_description(
         self,
         create_iam_role_for_sfn,
@@ -138,7 +138,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("describe_resp", describe_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_list_delete_version(
         self,
         create_iam_role_for_sfn,
@@ -194,7 +194,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("delete_version_resp_after_del", delete_version_resp_after_del)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_update_state_machine(
         self,
         create_iam_role_for_sfn,
@@ -271,7 +271,7 @@ class TestSnfApiVersioning:
             )
         sfn_snapshot.match("invalid_arn_2", invalid_arn_2.value.response)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_publish_state_machine_version(
         self,
         create_iam_role_for_sfn,
@@ -367,7 +367,7 @@ class TestSnfApiVersioning:
             )
         sfn_snapshot.match("conflict_exception", conflict_exception.value)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_start_version_execution(
         self,
         create_iam_role_for_sfn,
@@ -432,7 +432,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("exec_version_list_resp", exec_version_list_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_version_ids_between_deletions(
         self,
         create_iam_role_for_sfn,
@@ -481,7 +481,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("publish_res_v2_2", publish_res_v2_2)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_idempotent_publish(
         self,
         create_iam_role_for_sfn,
@@ -521,7 +521,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("list_versions_resp", list_versions_resp)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_empty_revision_with_publish_and_publish_on_creation(
         self,
         create_iam_role_for_sfn,
@@ -553,7 +553,7 @@ class TestSnfApiVersioning:
         )
         sfn_snapshot.match("update_resp_2", update_resp_2)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_empty_revision_with_publish_and_no_publish_on_creation(
         self,
         create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
+++ b/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
@@ -9,6 +9,7 @@ from localstack.constants import (
     SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
 )
 from localstack.services.events.provider import TEST_EVENTS_CACHE
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
 from localstack.utils.aws import arns
@@ -278,7 +279,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.usefixtures("setup_and_tear_down")
 class TestStateMachine:
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_choice_state_machine(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
         role_arn = arns.role_arn("sfn_role")
@@ -316,7 +317,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, sfn_client=aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_run_map_state_machine(self, aws_client):
         names = ["Bob", "Meg", "Joe"]
         test_input = [{"map": name} for name in names]
@@ -356,7 +357,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_run_state_machine(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
@@ -392,7 +393,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_try_catch_state_machine(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
@@ -426,7 +427,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_intrinsic_functions(self, aws_client):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
@@ -465,8 +466,10 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
 
-    @pytest.mark.skip("Accurate events reporting not yet supported.")
-    @markers.aws.unknown
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Accurate events reporting not yet supported."
+    )
+    @markers.aws.needs_fixing
     def test_events_state_machine(self, aws_client):
         events = aws_client.events
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
@@ -507,7 +510,7 @@ class TestStateMachine:
         cleanup(sm_arn, state_machines_before, aws_client.stepfunctions)
         events.delete_event_bus(Name=bus_name)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_create_state_machines_in_parallel(self, cleanups, aws_client):
         """
         Perform a test that creates a series of state machines in parallel. Without concurrency control, using
@@ -596,10 +599,12 @@ STS_ROLE_POLICY_DOC = {
 }
 
 
-@pytest.mark.skip("Investigate error around states:startExecution.sync")
+@pytest.mark.skipif(
+    condition=not is_aws_cloud(), reason="Investigate error around states:startExecution.sync"
+)
 @pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1", "eu-central-1"))
 @pytest.mark.parametrize("statemachine_definition", (TEST_STATE_MACHINE_3,))  # TODO: add sync2 test
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_multiregion_nested(aws_client_factory, region_name, statemachine_definition):
     client1 = aws_client_factory(
         region_name=region_name,
@@ -682,7 +687,7 @@ def test_default_logging_configuration(create_state_machine, aws_client):
         aws_client.iam.delete_role(RoleName=role_name)
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_aws_sdk_task(aws_client):
     statemachine_definition = {
         "StartAt": "CreateTopicTask",
@@ -773,7 +778,7 @@ def test_aws_sdk_task(aws_client):
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=machine_arn)
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_run_aws_sdk_secrets_manager(aws_client):
     state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(
 )
 class TestHeartbeats:
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_heartbeat_timeout(
         self,
         aws_client,
@@ -65,7 +65,7 @@ class TestHeartbeats:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_heartbeat_path_timeout(
         self,
         aws_client,
@@ -108,7 +108,7 @@ class TestHeartbeats:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_heartbeat_no_timeout(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.utils.strings import short_uid
@@ -59,7 +60,7 @@ class TestTimeouts:
         describe_execution = aws_client.stepfunctions.describe_execution(executionArn=execution_arn)
         sfn_snapshot.match("describe_execution", describe_execution)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_fixed_timeout_service_lambda(
         self,
         aws_client,
@@ -89,7 +90,7 @@ class TestTimeouts:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_fixed_timeout_service_lambda_with_path(
         self,
         aws_client,
@@ -123,7 +124,7 @@ class TestTimeouts:
             exec_input,
         )
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_fixed_timeout_lambda(
         self,
         aws_client,
@@ -155,8 +156,10 @@ class TestTimeouts:
             exec_input,
         )
 
-    @pytest.mark.skip(reason="Add support for State Map event history first.")
-    @markers.aws.unknown
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Add support for State Map event history first."
+    )
+    @markers.aws.needs_fixing
     def test_service_lambda_map_timeout(
         self,
         aws_client,

--- a/tests/aws/templates/stepfunctions_statemachine_substitutions.yaml
+++ b/tests/aws/templates/stepfunctions_statemachine_substitutions.yaml
@@ -60,7 +60,7 @@ Resources:
           - startFnServiceRoleB86C6980
           - Arn
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
     DependsOn:
       - startFnServiceRoleB86C6980
   stm:

--- a/tests/aws/test_moto.py
+++ b/tests/aws/test_moto.py
@@ -14,7 +14,7 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_sqs_creates_state_correctly():
     qname = f"queue-{short_uid()}"
 
@@ -37,7 +37,7 @@ def test_call_with_sqs_creates_state_correctly():
     assert url not in response.get("QueueUrls", [])
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_sqs_invalid_call_raises_http_exception():
     with pytest.raises(ServiceException) as e:
         moto.call_moto(
@@ -52,7 +52,7 @@ def test_call_sqs_invalid_call_raises_http_exception():
     e.match("The specified queue does not exist")
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_non_implemented_operation():
     with pytest.raises(NotImplementedError):
         # we'll need to keep finding methods that moto doesn't implement ;-)
@@ -61,7 +61,7 @@ def test_call_non_implemented_operation():
         )
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_sqs_modifies_state_in_moto_backend():
     """Whitebox test to check that moto backends are populated correctly"""
     from moto.sqs.models import sqs_backends
@@ -80,7 +80,7 @@ def test_call_with_sqs_modifies_state_in_moto_backend():
 @pytest.mark.parametrize(
     "payload", ["foobar", b"foobar", BytesIO(b"foobar")], ids=["str", "bytes", "IO[bytes]"]
 )
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_s3_with_streaming_trait(payload, monkeypatch):
     monkeypatch.setenv("MOTO_S3_CUSTOM_ENDPOINTS", "s3.localhost.localstack.cloud:4566")
 
@@ -118,7 +118,7 @@ def test_call_s3_with_streaming_trait(payload, monkeypatch):
     moto.call_moto(moto.create_aws_request_context("s3", "DeleteBucket", {"Bucket": bucket_name}))
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_include_response_metadata():
     ctx = moto.create_aws_request_context("sqs", "ListQueues")
 
@@ -129,7 +129,7 @@ def test_call_include_response_metadata():
     assert "ResponseMetadata" in response
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_modified_request():
     from moto.sqs.models import sqs_backends
 
@@ -146,7 +146,7 @@ def test_call_with_modified_request():
     moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_es_creates_state_correctly():
     domain_name = f"domain-{short_uid()}"
     response = moto.call_moto(
@@ -175,7 +175,7 @@ def test_call_with_es_creates_state_correctly():
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_multi_region_backends():
     from moto.sqs.models import sqs_backends
 
@@ -203,7 +203,7 @@ def test_call_multi_region_backends():
     del sqs_backends[DEFAULT_MOTO_ACCOUNT_ID]["eu-central-1"].queues[qname_eu]
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_sqs_invalid_call_raises_exception():
     with pytest.raises(ServiceException):
         moto.call_moto(
@@ -217,7 +217,7 @@ def test_call_with_sqs_invalid_call_raises_exception():
         )
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_call_with_sqs_returns_service_response():
     qname = f"queue-{short_uid()}"
 
@@ -250,7 +250,7 @@ class FakeSqsProvider(FakeSqsApi):
         return moto.call_moto(context)
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_moto_fallback_dispatcher():
     provider = FakeSqsProvider()
     dispatcher = MotoFallbackDispatcher(provider)
@@ -307,7 +307,7 @@ class FakeS3Provider:
         raise NotImplementedAvoidFallbackError
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_moto_fallback_dispatcher_error_handling(monkeypatch):
     """
     This test checks if the error handling (marshalling / unmarshalling) works correctly on all levels, including
@@ -343,7 +343,7 @@ def test_moto_fallback_dispatcher_error_handling(monkeypatch):
         _dispatch("PutObject", {"Bucket": bucket_name, "Key": "key"})
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_request_with_response_header_location_fields():
     # CreateHostedZoneResponse has a member "Location" that's located in the headers
     zone_name = f"zone-{short_uid()}.com"

--- a/tests/aws/test_multi_accounts.py
+++ b/tests/aws/test_multi_accounts.py
@@ -18,7 +18,7 @@ def client_factory(aws_client_factory):
 
 
 class TestMultiAccounts:
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_account_id_namespacing_for_moto_backends(self, client_factory):
         #
         # ACM
@@ -70,7 +70,7 @@ class TestMultiAccounts:
         vpcs = ec2_client1.describe_vpcs()["Vpcs"]
         assert all([vpc["OwnerId"] == account_id1 for vpc in vpcs])
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_account_id_namespacing_for_localstack_backends(self, client_factory):
         # Ensure resources are isolated by account ID namespaces
         account_id1 = "420420420420"
@@ -104,7 +104,7 @@ class TestMultiAccounts:
         assert len(sns_client2.list_tags_for_resource(ResourceArn=arn2)["Tags"]) == 2
         assert len(sns_client2.list_tags_for_resource(ResourceArn=arn3)["Tags"]) == 1
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_multi_accounts_dynamodb(self, client_factory, cleanups):
         """DynamoDB depends on an external service - DynamoDB Local"""
         account_id1 = "420420420420"
@@ -175,7 +175,7 @@ class TestMultiAccounts:
         response = ddb_client3.describe_table(TableName=tab1)
         assert response["Table"]["ItemCount"] == 3
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_multi_accounts_kinesis(self, client_factory):
         """Test that multi-accounts work with external dependency, Kinesis Mock."""
         account_id1 = "420420420420"

--- a/tests/aws/test_terraform.py
+++ b/tests/aws/test_terraform.py
@@ -96,7 +96,7 @@ class TestTerraform:
         start_worker_thread(_run)
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_bucket_exists(self, aws_client):
         response = aws_client.s3.head_bucket(Bucket=BUCKET_NAME)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -116,7 +116,7 @@ class TestTerraform:
         assert response["Status"] == "Enabled"
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_sqs(self, aws_client):
         queue_url = aws_client.sqs.get_queue_url(QueueName=QUEUE_NAME)["QueueUrl"]
         response = aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
@@ -127,7 +127,7 @@ class TestTerraform:
         assert response["Attributes"]["ReceiveMessageWaitTimeSeconds"] == "10"
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_lambda(self, aws_client):
         account_id = get_aws_account_id()
         response = aws_client.lambda_.get_function(FunctionName=LAMBDA_NAME)
@@ -137,7 +137,7 @@ class TestTerraform:
         assert response["Configuration"]["Role"] == LAMBDA_ROLE.format(account_id=account_id)
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_event_source_mapping(self, aws_client):
         queue_arn = QUEUE_ARN.format(account_id=get_aws_account_id())
         lambda_arn = LAMBDA_ARN.format(account_id=get_aws_account_id(), lambda_name=LAMBDA_NAME)
@@ -150,7 +150,7 @@ class TestTerraform:
 
     @markers.skip_offline
     @pytest.mark.xfail(reason="flaky")
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_apigateway(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()
 
@@ -180,7 +180,7 @@ class TestTerraform:
         assert res2[0]["resourceMethods"]["GET"]["methodIntegration"]["uri"]
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_route53(self, aws_client):
         response = aws_client.route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
@@ -190,7 +190,7 @@ class TestTerraform:
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_acm(self, aws_client):
         certs = aws_client.acm.list_certificates()["CertificateSummaryList"]
         certs = [c for c in certs if c.get("DomainName") == "example.com"]
@@ -198,7 +198,7 @@ class TestTerraform:
 
     @markers.skip_offline
     @pytest.mark.xfail(reason="flaky")
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_apigateway_escaped_policy(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()
 
@@ -211,7 +211,7 @@ class TestTerraform:
         assert len(service_apis) == 1
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_dynamodb(self, aws_client):
         def _table_exists(tablename, dynamotables):
             return any(name for name in dynamotables["TableNames"] if name == tablename)
@@ -222,7 +222,7 @@ class TestTerraform:
         assert _table_exists("tf_dynamotable3", tables)
 
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_security_groups(self, aws_client):
         rules = aws_client.ec2.describe_security_groups(MaxResults=100)["SecurityGroups"]
         matching = [r for r in rules if r["Description"] == "TF SG with ingress / egress rules"]


### PR DESCRIPTION
## Motivation

To unblock another task (opening a GH issue for all aws_unknown/aws_needs_fixing markers, I need to reduce them first, otherwise we're running into issues with the maximum character limit for GH issues.

## Changes

- Validate a lot of `@markers.aws.unknown`-marked integration tests against AWS and assigned `@markers.aws.validated`/`@markers.aws.needs_fixing`/`@markers.aws.only_localstack` where applicable.

