### PR TITLE
Pin jsonpath_ng to 1.5.3 to unblock CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ runtime =
     hypercorn>=0.14.4
     json5==0.9.11
     jsonpatch>=1.24,<2.0
-    jsonpath-ng>=1.5.3
+    jsonpath-ng==1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-client>=2.0
     moto-ext[all]==4.2.2.post1


### PR DESCRIPTION

## Motivation

CI started experiencing a failing unit test for snapshots with the recent `1.6.0` update of `jsonpath_ng`
## Changes

- pins `jsonpath_ng` to version `1.5.3`


