### PR TITLE
fix S3 handling of special character and trailing slash

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -70,6 +70,7 @@ from abc import ABC
 from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 from typing.io import IO
+from urllib.parse import unquote
 from xml.etree import ElementTree as ETree
 
 import cbor2
@@ -1067,14 +1068,14 @@ class S3RequestParser(RestXMLRequestParser):
         Special handling of parsing the shape for s3 object-names (=key):
         trailing '/' are valid and need to be preserved, however, the url-matcher removes it from the key
         we check the request.url to verify the name.
-        We might want to encode the key to take into account the ones with special characters.
+        We decode the key for the comparison with `base_url` in case of special characters.
         """
         if (
             shape is not None
             and uri_params is not None
             and shape.serialization.get("location") == "uri"
             and shape.serialization.get("name") == "Key"
-            and request.base_url.endswith(f"{uri_params['Key']}/")
+            and request.base_url.endswith(f"{unquote(uri_params['Key'])}/")
         ):
             uri_params = dict(uri_params)
             uri_params["Key"] = uri_params["Key"] + "/"

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -30,6 +30,7 @@ from localstack.aws.forwarder import (
 from localstack.aws.skeleton import DispatchTable
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.http import Response
+from localstack.http.request import get_full_raw_path
 
 MotoDispatcher = Callable[[HttpRequest, str, dict], Response]
 
@@ -112,7 +113,8 @@ def dispatch_to_moto(context: RequestContext) -> Response:
     dispatch = get_dispatcher(service.service_name, request.path)
 
     try:
-        response = dispatch(request, request.url, request.headers)
+        # we use the full_raw_path as moto might do some path decoding (in S3 for example)
+        response = dispatch(request, get_full_raw_path(request), request.headers)
         if not response:
             # some operations are only partially implemented by moto
             # e.g. the request will be resolved, but then the request method is not handled

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -30,7 +30,7 @@ from localstack.aws.forwarder import (
 from localstack.aws.skeleton import DispatchTable
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.http import Response
-from localstack.http.request import get_full_raw_path
+from localstack.http.request import get_full_raw_path, get_raw_current_url
 
 MotoDispatcher = Callable[[HttpRequest, str, dict], Response]
 
@@ -111,10 +111,12 @@ def dispatch_to_moto(context: RequestContext) -> Response:
 
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
     dispatch = get_dispatcher(service.service_name, request.path)
-
     try:
-        # we use the full_raw_path as moto might do some path decoding (in S3 for example)
-        response = dispatch(request, get_full_raw_path(request), request.headers)
+        # we use the full_raw_url as moto might do some path decoding (in S3 for example)
+        raw_url = get_raw_current_url(
+            request.scheme, request.host, request.root_path, get_full_raw_path(request)
+        )
+        response = dispatch(request, raw_url, request.headers)
         if not response:
             # some operations are only partially implemented by moto
             # e.g. the request will be resolved, but then the request method is not handled

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1291,7 +1291,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> ListObjectsOutput:
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
-        # TODO: URL encode keys (is it done already in serializer?)
         common_prefixes = set()
         count = 0
         is_truncated = False
@@ -1334,7 +1333,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
             # TODO: add RestoreStatus if present
             object_data = Object(
-                Key=s3_object.key,
+                Key=key,
                 ETag=s3_object.quoted_etag,
                 Owner=s3_bucket.owner,  # TODO: verify reality
                 Size=s3_object.size,
@@ -1393,7 +1392,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if continuation_token and continuation_token == "":
             raise InvalidArgument("The continuation token provided is incorrect")
 
-        # TODO: URL encode keys (is it done already in serializer?)
         common_prefixes = set()
         count = 0
         is_truncated = False
@@ -1447,7 +1445,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
             # TODO: add RestoreStatus if present
             object_data = Object(
-                Key=s3_object.key,
+                Key=key,
                 ETag=s3_object.quoted_etag,
                 Size=s3_object.size,
                 LastModified=s3_object.last_modified,
@@ -1506,7 +1504,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> ListObjectVersionsOutput:
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
-        # TODO: URL encode keys (is it done already in serializer?)
         common_prefixes = set()
         count = 0
         is_truncated = False
@@ -1557,7 +1554,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
             if isinstance(version, S3DeleteMarker):
                 delete_marker = DeleteMarkerEntry(
-                    Key=version.key,
+                    Key=key,
                     Owner=s3_bucket.owner,
                     VersionId=version.version_id,
                     IsLatest=version.is_current,
@@ -1568,7 +1565,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
             # TODO: add RestoreStatus if present
             object_version = ObjectVersion(
-                Key=version.key,
+                Key=key,
                 ETag=version.quoted_etag,
                 Owner=s3_bucket.owner,  # TODO: verify reality
                 Size=version.size,

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -7404,7 +7404,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[file%2Fname]": {
-    "recorded-date": "03-08-2023, 04:13:34",
+    "recorded-date": "13-09-2023, 22:47:29",
     "recorded-content": {
       "put-object-special-char": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -7458,7 +7458,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[test@key/]": {
-    "recorded-date": "03-08-2023, 04:13:37",
+    "recorded-date": "13-09-2023, 22:47:32",
     "recorded-content": {
       "put-object-special-char": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
@@ -7473,6 +7473,114 @@
           {
             "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
             "Key": "test@key/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-special-char": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-object-special-char": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[test%123]": {
+    "recorded-date": "13-09-2023, 22:47:34",
+    "recorded-content": {
+      "put-object-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-special-char": {
+        "Contents": [
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test%123",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-special-char": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-object-special-char": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_get_object_special_character[test%percent]": {
+    "recorded-date": "13-09-2023, 22:47:36",
+    "recorded-content": {
+      "put-object-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-special-char": {
+        "Contents": [
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test%percent",
             "LastModified": "datetime",
             "Size": 4,
             "StorageClass": "STANDARD"
@@ -10309,6 +10417,46 @@
             ]
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_url_encoded_key": {
+    "recorded-date": "14-09-2023, 00:01:41",
+    "recorded-content": {
+      "list-object-encoded-char": {
+        "Contents": [
+          {
+            "ETag": "\"03dc4443b5f395b54d011fdb7d9e0ae1\"",
+            "Key": "test%40key",
+            "LastModified": "datetime",
+            "Size": 24,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"51a6065890415b4b299dec1aa33d712c\"",
+            "Key": "test%40key/",
+            "LastModified": "datetime",
+            "Size": 12,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"b792145c4a8e8d9ac95d3c2f9f0ac42d\"",
+            "Key": "test@key/",
+            "LastModified": "datetime",
+            "Size": 16,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is a follow up from the Werkzeug upgrade, and the moto bump adapting to those changes, following the reported issue #9112

Moto now has a specific handling of special character to maintain compatibility between mocked botocore requests and werkzeuga requests. We've had issues when accessing directly moto's backend to get the key, with the proper key from the request.

I first suspected moto and tried working on a fix there and wrote some tests, but those were passing there, but not in LocalStack.

I've tracked it down to passing the request with `call_moto`, we would use the `request.url`, which is the decoded URL, which moto would then use to create its keys internally. 

Some examples of the issues:
#### Passing decoded request URL to moto:
Raw URL: `http://s3.localhost.localstack.cloud:4566/test-bucket-0ff73618/test%2540key/`
request.url passed to moto: `http://s3.localhost.localstack.cloud:4566/test-bucket-0ff73618/test@key/`
Key name in moto: `test@key/` when it should be `test%40key/`

#### Trailing slashes (once the issue above was done)
Raw path: `/test-bucket-18ba44f6/test%2540key/`
Parsed key in the parser: `test%40key` (missing the trailing slash, but was properly parsed in moto)
base_url: `http://s3.localhost.localstack.cloud:4566/test-bucket-18ba44f6/test@key/`
The check for `base_url.endswith(key)` does not work here, so the trailing slash isn't added.

<!-- What notable changes does this PR make? -->
## Changes

Moto needs the raw URL, so we now use `get_full_raw_path` to get the original request URL, so moto can properly use its logic to decode the URL and create the proper key name out of it. 

I've also thought of another scenario where this could be problematic, with special characters and handling slashes, which was already an issue before (this has been changed often, every time werkzeug changes its handling of URL), but sadly there's isn't a catch-all way to check if the request has a trailing slash that needs to be kept. 

Took the opportunity to fix the key returned by the multiple `List*` in the new provider as well, with some AWS validated tests, and removed some TODOs. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

