### PR TITLE
Slim down marker report issue template rendering

### DIFF
--- a/.github/bot_templates/MARKER_REPORT_ISSUE.md.j2
+++ b/.github/bot_templates/MARKER_REPORT_ISSUE.md.j2
@@ -26,11 +26,11 @@ _Note_: The individual assignments here are based on the entries in the [CODEOWN
 ## unknown ({{ data.aggregated['aws_unknown'] }})
 
 {% for item in data.owners_aws_unknown -%}
-- [ ] `{{ item.pytest_node_id }}` ([file]({{ item.file_url }})) {{ " ".join(item.owners) }}
+- [ ] `{{ item.pytest_node_id }}` {{ " ".join(item.owners) }}
 {% endfor %}
 
 ## needs_fixing ({{ data.aggregated['aws_needs_fixing'] }})
 
 {% for item in data.owners_aws_needs_fixing -%}
-- [ ] `{{ item.pytest_node_id }}` ([file]({{ item.file_url }})) {{ " ".join(item.owners) }}
+- [ ] `{{ item.pytest_node_id }}` {{ " ".join(item.owners) }}
 {% endfor %}

--- a/.github/workflows/marker-report-issue.yml
+++ b/.github/workflows/marker-report-issue.yml
@@ -3,6 +3,11 @@ on:
   # only manual for now
   workflow_dispatch:
     inputs:
+      dryRun:
+        description: 'Execute a Dry-Run? A Dry-Run will not create any issues and only print the issue content in the logs instead'
+        required: false
+        type: boolean
+        default: false
       updateExistingIssue:
         description: 'Select the empty string "" to open duplicate issues, "true" to update duplicate issues and "false" to skip duplicate issues'
         required: false
@@ -68,6 +73,7 @@ jobs:
           path: ./target/MARKER_REPORT_ISSUE.md
 
       - name: Create GH issue from template
+        if: inputs.dryRun != true
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/scripts/render_marker_report.py
+++ b/scripts/render_marker_report.py
@@ -69,7 +69,7 @@ def create_test_entry(entry, *, code_owners: CodeOwners, commit_sha: str, github
     return TestEntry(
         pytest_node_id=entry["node_id"],
         file_path=rel_path,
-        owners=[o[1] for o in code_owners.of(rel_path)] or ["CODEOWNER_MISSING"],
+        owners=[o[1] for o in code_owners.of(rel_path)] or ["?"],
         file_url=f"https://github.com/{github_repo}/blob/{commit_sha}/{rel_path}",
     )
 


### PR DESCRIPTION
## Motivation

When trying to open the [issue for the marker report](https://github.com/localstack/localstack/actions/runs/6172856621), we noticed that we're running into the maximum character limit of GitHub issues:
`Validation Failed: {"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}`

In a previous PR (https://github.com/localstack/localstack/pull/9141) we've reduced the number of marked tests in the report. We're still a bit off our target, but with this PR it should finally fall under the the `65536` character limit and allow us to open the first GH issue for the marker report.

## Changes

- remove links to files
- shorten `CODEOWNER_MISSING` => `?`

