### PR TITLE
drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     timeout-minutes: 10
     env:
       # Set job-specific environment variables for pytest-tinybird

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can directly install the LocalStack CLI in your Python environment using `pi
 
 #### Prerequisites
 
-* `python` (Python 3.7 up to 3.11 supported)
+* `python` (Python 3.8 up to 3.11 supported)
 
 #### Installation
 ```

--- a/localstack/aws/api/acm/__init__.py
+++ b/localstack/aws/api/acm/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/apigateway/__init__.py
+++ b/localstack/aws/api/apigateway/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import IO, Dict, Iterable, List, Optional, Union
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import IO, Dict, Iterable, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/cloudcontrol/__init__.py
+++ b/localstack/aws/api/cloudcontrol/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/cloudformation/__init__.py
+++ b/localstack/aws/api/cloudformation/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack/aws/api/cloudwatch/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/config/__init__.py
+++ b/localstack/aws/api/config/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -1,18 +1,11 @@
 import functools
-import sys
-from typing import Any, NamedTuple, Optional, Type, Union
-
-from localstack.aws.connect import InternalRequestParameters
-from localstack.utils.strings import long_uid
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, TypedDict
-else:
-    from typing_extensions import Protocol, TypedDict
+from typing import Any, NamedTuple, Optional, Protocol, Type, TypedDict, Union
 
 from botocore.model import OperationModel, ServiceModel
 
+from localstack.aws.connect import InternalRequestParameters
 from localstack.http import Request, Response
+from localstack.utils.strings import long_uid
 
 # FIXME: deprecated, use localstack.http.Request and localstack.http.Response instead
 HttpRequest = Request

--- a/localstack/aws/api/dynamodb/__init__.py
+++ b/localstack/aws/api/dynamodb/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/dynamodbstreams/__init__.py
+++ b/localstack/aws/api/dynamodbstreams/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceRequest, handler
 

--- a/localstack/aws/api/es/__init__.py
+++ b/localstack/aws/api/es/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/events/__init__.py
+++ b/localstack/aws/api/events/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/firehose/__init__.py
+++ b/localstack/aws/api/firehose/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/iam/__init__.py
+++ b/localstack/aws/api/iam/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/kinesis/__init__.py
+++ b/localstack/aws/api/kinesis/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, Iterator, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, Iterator, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/kms/__init__.py
+++ b/localstack/aws/api/kms/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import IO, Dict, Iterable, Iterator, List, Optional, Union
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import IO, Dict, Iterable, Iterator, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/logs/__init__.py
+++ b/localstack/aws/api/logs/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/opensearch/__init__.py
+++ b/localstack/aws/api/opensearch/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/redshift/__init__.py
+++ b/localstack/aws/api/redshift/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/resource_groups/__init__.py
+++ b/localstack/aws/api/resource_groups/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/resourcegroupstaggingapi/__init__.py
+++ b/localstack/aws/api/resourcegroupstaggingapi/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/route53/__init__.py
+++ b/localstack/aws/api/route53/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/route53resolver/__init__.py
+++ b/localstack/aws/api/route53resolver/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import IO, Dict, Iterable, Iterator, List, Optional, Union
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import IO, Dict, Iterable, Iterator, List, Optional, TypedDict, Union
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/s3control/__init__.py
+++ b/localstack/aws/api/s3control/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/scheduler/__init__.py
+++ b/localstack/aws/api/scheduler/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/secretsmanager/__init__.py
+++ b/localstack/aws/api/secretsmanager/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/ses/__init__.py
+++ b/localstack/aws/api/ses/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/sns/__init__.py
+++ b/localstack/aws/api/sns/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/sqs/__init__.py
+++ b/localstack/aws/api/sqs/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/ssm/__init__.py
+++ b/localstack/aws/api/ssm/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/stepfunctions/__init__.py
+++ b/localstack/aws/api/stepfunctions/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/sts/__init__.py
+++ b/localstack/aws/api/sts/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/support/__init__.py
+++ b/localstack/aws/api/support/__init__.py
@@ -1,10 +1,4 @@
-import sys
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/swf/__init__.py
+++ b/localstack/aws/api/swf/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/api/transcribe/__init__.py
+++ b/localstack/aws/api/transcribe/__init__.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from typing import Dict, List, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -312,13 +312,10 @@ class ShapeNode:
 
 
 def generate_service_types(output, service: ServiceModel, doc=True):
-    output.write("import sys\n")
-    output.write("from typing import Dict, List, Optional, Iterator, Iterable, IO, Union\n")
+    output.write(
+        "from typing import Dict, List, Optional, Iterator, Iterable, IO, Union, TypedDict\n"
+    )
     output.write("from datetime import datetime\n")
-    output.write("if sys.version_info >= (3, 8):\n")
-    output.write("    from typing import TypedDict\n")
-    output.write("else:\n")
-    output.write("    from typing_extensions import TypedDict\n")
     output.write("\n")
     output.write(
         "from localstack.aws.api import handler, RequestContext, ServiceException, ServiceRequest"

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -3,22 +3,15 @@ import logging
 import os
 import sys
 import traceback
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TypedDict
 
-from localstack import config
+import click
+
+from localstack import __version__, config
 from localstack.cli.exceptions import CLIError
 from localstack.utils.analytics.cli import publish_invocation
 from localstack.utils.bootstrap import get_container_default_logfile_location
 from localstack.utils.json import CustomEncoder
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
-import click
-
-from localstack import __version__
 
 from .console import BANNER, console
 from .plugin import LocalstackCli, load_cli_plugins

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -5,7 +5,6 @@ and manipulate python collection (dicts, list, sets).
 
 import logging
 import re
-import sys
 from collections.abc import Mapping
 from typing import (
     Any,
@@ -18,18 +17,15 @@ from typing import (
     Sized,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 
 import cachetools
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict, get_args, get_origin
-else:
-    from typing_extensions import TypedDict, get_args, get_origin
-
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -11,18 +11,12 @@ import tempfile
 from abc import ABCMeta, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
-
-from localstack.utils.no_exit_argument_parser import NoExitArgumentParser
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, get_args
-else:
-    from typing_extensions import Literal, Protocol, get_args
+from typing import Dict, List, Literal, NamedTuple, Optional, Protocol, Tuple, Union, get_args
 
 from localstack import config
 from localstack.utils.collections import HashableList, ensure_list
 from localstack.utils.files import TMP_FILES, rm_rf, save_file
+from localstack.utils.no_exit_argument_parser import NoExitArgumentParser
 from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)

--- a/localstack/utils/sync.py
+++ b/localstack/utils/sync.py
@@ -1,15 +1,9 @@
 """Concurrency synchronization utilities"""
 import functools
-import sys
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, TypeVar
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Callable, Literal, TypeVar
 
 
 class ShortCircuitWaitException(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Topic :: System :: Emulators
 
 [options]
+python_requires = >=3.8
 zip_safe = False
 test_suite = tests
 scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,10 +38,6 @@ install_requires =
     requests>=2.20.0
     semver>=2.10
     stevedore>=3.4.0
-    # needed for python3.7 compat of stevedore
-    importlib-metadata<5.0; python_version < '3.8'
-    # needed for python3.7 compat (TypedDict, Literal, type hints)
-    typing-extensions; python_version < '3.8'
     tailer>=0.4.1
 
 [options.packages.find]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -291,13 +291,6 @@ class TestImports:
     """Simple tests to assert that certain code paths can be imported from the CLI"""
 
     def test_import_venv(self):
-        try:
-            from functools import cached_property  # noqa
-        except Exception:
-            pytest.skip(
-                "Skip test in Python <= 3.7 (cached_property is required for VirtualEnvironment)"
-            )
-
         from localstack.utils.venv import VirtualEnvironment
 
         assert VirtualEnvironment

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -1,15 +1,6 @@
-import sys
-from typing import Dict, List
+from typing import Dict, List, TypedDict
 
 import pytest
-
-from localstack.aws.api.sqs import SendMessageRequest
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 from botocore.parsers import create_parser
 
 from localstack.aws.api import (
@@ -20,6 +11,7 @@ from localstack.aws.api import (
     ServiceRequest,
     handler,
 )
+from localstack.aws.api.sqs import SendMessageRequest
 from localstack.aws.skeleton import DispatchTable, ServiceRequestDispatcher, Skeleton
 from localstack.aws.spec import load_service
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -430,8 +430,6 @@ class TestCommonFileOperations:
         assert not fp.exists()
 
     def test_cp_r(self, tmp_path):
-        pytest.skip("this test does not work on python3.7 due to an issue shutil used by cp_r")
-
         source = tmp_path / "source"
         target = tmp_path / "target"
 


### PR DESCRIPTION
## Motivation
As announced in https://github.com/localstack/localstack/issues/8827, we are going to drop Python 3.7 support with the next minor release `2.3`.
This PR drops the tests and updates a bit of the code.

## Changes
- Updates the README to define the minimum python version to be `3.8`.
- Drops the CLI tests for `3.7`.
- Drops some dependency restrictions for Python < 3.8
  - This is debatable, it will most likely break 3.7 compatibility right away.
- Removes some `3.7`-specific checks in the tests.