### PR TITLE
Fix running LS for tests in the new in_memory_localstack plugin

### DIFF
--- a/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack/testing/pytest/in_memory_localstack.py
@@ -25,6 +25,7 @@ from localstack.config import is_env_true
 from localstack.constants import ENV_INTERNAL_TEST_RUN
 
 LOG = logging.getLogger(__name__)
+LOG.info("Pytest plugin for in-memory-localstack session loaded.")
 
 if localstack_config.is_collect_metrics_mode():
     pytest_plugins = "localstack.testing.pytest.metric_collection"
@@ -44,7 +45,6 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtestloop(session: Session):
     if not session.config.option.start_localstack:
-        LOG.info("Configuration option to start LocalStack not set.")
         return
 
     from localstack.testing.aws.util import is_aws_cloud

--- a/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack/testing/pytest/in_memory_localstack.py
@@ -42,8 +42,9 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_sessionstart(session: Session):
+def pytest_runtestloop(session: Session):
     if not session.config.option.start_localstack:
+        LOG.info("Configuration option to start LocalStack not set.")
         return
 
     from localstack.testing.aws.util import is_aws_cloud


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #9139, we introduced a new way to start LS in tests, via a pytest plugin.

However, the hook chosen to start LS, and to check the configuration option, might be executed before the configuration option is set.

The configuration options are set in the `pytest_configure` hook, with the following definition:

```
pytest_configure(config)
Allow plugins and conftest files to perform initial configuration.

This hook is called for every plugin and initial conftest file after command line options have been parsed.

After that, the hook is called for other conftest files as they are imported.
```

In community, this works, as the hook is specified in the initial conftest file, before the pytest_sessionstart hook is executed.

This, however, does not work if the test directory specified is a parent folder of the conftest file, as those will then only be imported during test collection, `pytest_sessionstart` takes place before test collection though.

<!-- What notable changes does this PR make? -->
## Changes
* Add log entry if the config option is not set, to be able to see the cause easier (in comparison to the plugin not being loaded, for example).
* Start LocalStack with the pytest_runtestloop hook. This will take place after test collection, so after the conftest.py files in subdirectories are imported, and therefore the configuration option to start LocalStack should be present in these cases.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

