### PR TITLE
update several SQS test markers

### DIFF
--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -3030,10 +3030,7 @@ class TestSqsProvider:
         result_recv = aws_client.sqs.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0)
         assert result_recv["Messages"][0]["MessageId"] == result_send["MessageId"]
 
-    # verification of community posted issue
-    # FIXME: \r gets lost
-    @pytest.mark.skip
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_message_with_carriage_return(self, sqs_create_queue, aws_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -4071,7 +4068,7 @@ class TestSqsQueryApi:
 
 class TestSQSMultiAccounts:
     @pytest.mark.parametrize("strategy", ["domain", "path"])
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_cross_account_access(
         self, monkeypatch, sqs_create_queue, secondary_aws_client, strategy
     ):
@@ -4105,7 +4102,7 @@ class TestSQSMultiAccounts:
         # - UntagQueue
 
     @pytest.mark.parametrize("strategy", ["domain", "path"])
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_cross_account_get_queue_url(
         self, monkeypatch, sqs_create_queue, secondary_aws_client, strategy
     ):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes some of the markers noted in #9147 that were obvious/worked out of the box

<!-- What notable changes does this PR make? -->
## Changes

* Marked the two multi-account tests as only-localstack, since they require a secondary account/test endpoint strategies
* `test_message_with_carriage_return` seems to work now :-)


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

