### PR TITLE
fix apigw import root and extend OpenAPIExporter

### DIFF
--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -1,0 +1,262 @@
+import abc
+import json
+from typing import Literal, Type
+
+from apispec import APISpec
+
+from localstack.aws.api.apigateway import ListOfModel
+from localstack.aws.connect import connect_to
+from localstack.utils.time import TIMESTAMP_FORMAT_TZ, timestamp
+
+# TODO:
+# - handle extensions
+#
+
+
+class _BaseOpenApiExporter(abc.ABC):
+    VERSION = None
+
+    def __init__(self):
+        self.export_formats = {"application/json": "to_dict", "application/yaml": "to_yaml"}
+
+    def _add_models(self, spec: APISpec, models: ListOfModel, base_path: str):
+        for model in models:
+            model_def = json.loads(model["schema"])
+            self._resolve_refs(model_def, base_path)
+            spec.components.schema(
+                component_id=model["name"],
+                component=model_def,
+            )
+
+    def _resolve_refs(self, schema: dict, base_path: str):
+        if "$ref" in schema:
+            schema["$ref"] = f'{base_path}/{schema["$ref"].rsplit("/", maxsplit=1)[-1]}'
+        for value in schema.values():
+            if isinstance(value, dict):
+                self._resolve_refs(value, base_path)
+
+    @abc.abstractmethod
+    def export(self, api_id: str, stage: str, export_format: str) -> str:
+        ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def _add_paths(spec, resources):
+        ...
+
+
+class _OpenApiSwaggerExporter(_BaseOpenApiExporter):
+    VERSION = "2.0"
+
+    @staticmethod
+    def _add_paths(spec, resources):
+        for item in resources.get("items"):
+            path = item.get("path")
+            for method, method_config in item.get("resourceMethods", {}).items():
+                print(f"{path=}, {method_config=}")
+                method = method.lower()
+
+                # TODO: this is extension, integration is extensions
+                method_integration = method_config.get("methodIntegration", {})
+                integration_responses = method_integration.get("integrationResponses", {})
+                method_responses = method_config.get("methodResponses")
+                responses = {}
+                produces = set()
+                for status_code, values in method_responses.items():
+                    response = {"description": f"{status_code} response"}
+                    if response_parameters := values.get("responseParameters"):
+                        headers = {}
+                        for parameter in response_parameters:
+                            in_, name = parameter.removeprefix("method.response.").split(".")
+                            # TODO: other type?
+                            if in_ == "header":
+                                headers[name] = {"type": "string"}
+
+                        if headers:
+                            response["headers"] = headers
+                    if response_models := values.get("responseModels"):
+                        for content_type, model_name in response_models.items():
+                            produces.add(content_type)
+                            response["schema"] = model_name
+                    if integration_response := integration_responses.get(status_code, {}):
+                        produces.update(integration_response.get("responseTemplates", {}).keys())
+
+                    responses[status_code] = response
+
+                request_parameters = method_config.get("requestParameters", {})
+                parameters = []
+                for parameter, required in request_parameters.items():
+                    in_, name = parameter.removeprefix("method.request.").split(".")
+                    in_ = in_ if in_ != "querystring" else "query"
+                    parameters.append(
+                        {"name": name, "in": in_, "required": required, "type": "string"}
+                    )
+
+                request_models = method_config.get("requestModels", {})
+                for model_name in request_models.values():
+                    parameter = {
+                        "in": "body",
+                        "name": model_name,
+                        "required": True,
+                        "schema": {"$ref": f"#/definitions/{model_name}"},
+                    }
+                    parameters.append(parameter)
+
+                content_types = request_models | method_integration.get("requestTemplates", {})
+
+                method_operations = {"responses": responses}
+                if parameters:
+                    method_operations["parameters"] = parameters
+                if produces:
+                    method_operations["produces"] = list(produces)
+                if content_types:
+                    method_operations["consumes"] = list(content_types.keys())
+                if operation_name := method_config.get("operationName"):
+                    method_operations["operationId"] = operation_name
+
+                spec.path(path=path, operations={method: method_operations})
+
+    def export(self, api_id: str, stage: str, export_format: str) -> str:
+        """
+        https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
+        """
+        apigateway_client = connect_to().apigateway
+
+        rest_api = apigateway_client.get_rest_api(restApiId=api_id)
+        resources = apigateway_client.get_resources(restApiId=api_id)
+        models = apigateway_client.get_models(restApiId=api_id)
+
+        info = {}
+        if (description := rest_api.get("description")) is not None:
+            info["description"] = description
+
+        spec = APISpec(
+            title=rest_api.get("name"),
+            version=rest_api.get("version")
+            or timestamp(rest_api.get("createdDate"), format=TIMESTAMP_FORMAT_TZ),
+            info=info,
+            openapi_version=self.VERSION,
+            basePath=f"/{stage}",
+            schemes=["https"],
+        )
+
+        self._add_paths(spec, resources)
+        self._add_models(spec, models["items"], "#/definitions")
+
+        return getattr(spec, self.export_formats.get(export_format))()
+
+
+class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
+    VERSION = "3.0.1"
+
+    @staticmethod
+    def _add_paths(spec, resources):
+        for item in resources.get("items"):
+            path = item.get("path")
+            for method, method_config in item.get("resourceMethods", {}).items():
+                print(f"{path=}, {method_config=}")
+                method = method.lower()
+
+                # TODO: this is extension, integration is extensions
+                method_integration = method_config.get("methodIntegration", {})
+                integration_responses = method_integration.get("integrationResponses", {})
+                method_responses = method_config.get("methodResponses")
+                responses = {}
+                produces = set()
+                for status_code, values in method_responses.items():
+                    response = {"description": f"{status_code} response"}
+                    content = {}
+                    if response_parameters := values.get("responseParameters"):
+                        headers = {}
+                        for parameter in response_parameters:
+                            in_, name = parameter.removeprefix("method.response.").split(".")
+                            # TODO: other type?
+                            if in_ == "header":
+                                headers[name] = {"schema": {"type": "string"}}
+
+                        if headers:
+                            response["headers"] = headers
+                    if response_models := values.get("responseModels"):
+                        for content_type, model_name in response_models.items():
+                            content[content_type] = {
+                                "schema": {"$ref": f"#/components/schemas/{model_name}"}
+                            }
+                    if integration_response := integration_responses.get(status_code, {}):
+                        produces.update(integration_response.get("responseTemplates", {}).keys())
+
+                    response["content"] = content
+                    responses[status_code] = response
+
+                request_parameters = method_config.get("requestParameters", {})
+                parameters = []
+                for parameter, required in request_parameters.items():
+                    in_, name = parameter.removeprefix("method.request.").split(".")
+                    in_ = in_ if in_ != "querystring" else "query"
+                    parameters.append({"name": name, "in": in_, "schema": {"type": "string"}})
+
+                request_body = {"content": {}}
+                request_models = method_config.get("requestModels", {})
+                for content_type, model_name in request_models.items():
+                    request_body["content"][content_type] = {
+                        "schema": {"$ref": f"#/components/schemas/{model_name}"},
+                    }
+                    request_body["required"] = True
+
+                method_operations = {"responses": responses}
+                if parameters:
+                    method_operations["parameters"] = parameters
+                if request_body["content"]:
+                    method_operations["requestBody"] = request_body
+                if operation_name := method_config.get("operationName"):
+                    method_operations["operationId"] = operation_name
+
+                spec.path(path=path, operations={method: method_operations})
+
+    def export(self, api_id: str, stage: str, export_format: str) -> str:
+        """
+        https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
+        """
+        apigateway_client = connect_to().apigateway
+
+        rest_api = apigateway_client.get_rest_api(restApiId=api_id)
+        resources = apigateway_client.get_resources(restApiId=api_id)
+        models = apigateway_client.get_models(restApiId=api_id)
+
+        info = {}
+
+        if (description := rest_api.get("description")) is not None:
+            info["description"] = description
+
+        spec = APISpec(
+            title=rest_api.get("name"),
+            version=rest_api.get("version")
+            or timestamp(rest_api.get("createdDate"), format=TIMESTAMP_FORMAT_TZ),
+            info=info,
+            openapi_version=self.VERSION,
+            servers=[{"variables": {"basePath": {"default": stage}}}],
+        )
+
+        self._add_paths(spec, resources)
+        self._add_models(spec, models["items"], "#/components/schemas")
+
+        response = getattr(spec, self.export_formats.get(export_format))()
+        if isinstance(response, dict) and "components" not in response:
+            response["components"] = {}
+        return response
+
+
+class OpenApiExporter:
+    exporters: dict[str, Type[_BaseOpenApiExporter]]
+
+    def __init__(self):
+        self.exporters = {"swagger": _OpenApiSwaggerExporter, "oas30": _OpenApiOAS30Exporter}
+
+    def export_api(
+        self,
+        api_id: str,
+        stage: str,
+        export_type: Literal["swagger", "oas30"],
+        export_format: str = "application/json",
+    ) -> str:
+        exporter = self.exporters.get(export_type)()
+        return exporter.export(api_id, stage, export_format)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -7,10 +7,9 @@ import re
 import time
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, Union
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 from urllib import parse as urlparse
 
-from apispec import APISpec
 from botocore.utils import InvalidArnException
 from jsonpatch import apply_patch
 from jsonpointer import JsonPointerException
@@ -27,7 +26,6 @@ from localstack.aws.api.apigateway import (
     DocumentationPart,
     DocumentationPartLocation,
     IntegrationType,
-    ListOfModel,
     Model,
     RequestValidator,
 )
@@ -52,7 +50,6 @@ from localstack.utils.aws.aws_responses import requests_error_response_json, req
 from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
 from localstack.utils.json import try_json
 from localstack.utils.strings import long_uid, short_uid, to_bytes, to_str
-from localstack.utils.time import TIMESTAMP_FORMAT_TZ, timestamp
 from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
@@ -1496,165 +1493,6 @@ def create_invocation_headers(invocation_context: ApiInvocationContext) -> Dict[
             ):
                 headers.update({header_name: req_parameter_value})
     return headers
-
-
-# TODO:
-# - handle extensions
-#
-
-TypeExporter = Callable[[str, str, str], str]
-
-
-class OpenApiExporter:
-    SWAGGER_VERSION = "2.0"
-    OPENAPI_VERSION = "3.0.1"
-
-    exporters: Dict[str, TypeExporter]
-
-    def __init__(self):
-        self.exporters = {"swagger": self._swagger_export, "oas30": self._oas30_export}
-        self.export_formats = {"application/json": "to_dict", "application/yaml": "to_yaml"}
-
-    def export_api(
-        self, api_id: str, stage: str, export_type: str, export_format: str = "application/json"
-    ) -> str:
-        return self.exporters.get(export_type)(api_id, stage, export_format)
-
-    @staticmethod
-    def _add_paths(spec, resources):
-        for item in resources.get("items"):
-            path = item.get("path")
-            for method, method_config in item.get("resourceMethods", {}).items():
-                print(f"{path=}, {method_config=}")
-                method = method.lower()
-
-                # TODO: this is extension, integration is extensions
-                method_integration = method_config.get("methodIntegration", {})
-                integration_responses = method_integration.get("integrationResponses", {})
-                method_responses = method_config.get("methodResponses")
-                responses = {}
-                produces = set()
-                for status_code, values in method_responses.items():
-                    response = {"description": f"{status_code} response"}
-                    if response_parameters := values.get("responseParameters"):
-                        headers = {}
-                        for parameter in response_parameters:
-                            in_, name = parameter.removeprefix("method.response.").split(".")
-                            # TODO: other type?
-                            if in_ == "header":
-                                headers[name] = {"type": "string"}
-
-                        if headers:
-                            response["headers"] = headers
-                    if response_models := values.get("responseModels"):
-                        for content_type, model_name in response_models.items():
-                            produces.add(content_type)
-                            response["schema"] = model_name
-                    if integration_response := integration_responses.get(status_code, {}):
-                        produces.update(integration_response.get("responseTemplates", {}).keys())
-
-                    responses[status_code] = response
-
-                request_parameters = method_config.get("requestParameters", {})
-                parameters = []
-                for parameter, required in request_parameters.items():
-                    in_, name = parameter.removeprefix("method.request.").split(".")
-                    in_ = in_ if in_ != "querystring" else "query"
-                    parameters.append(
-                        {"name": name, "in": in_, "required": required, "type": "string"}
-                    )
-
-                request_models = method_config.get("requestModels", {})
-                for model_name in request_models.values():
-                    parameter = {
-                        "in": "body",
-                        "name": model_name,
-                        "required": True,
-                        "schema": {"$ref": f"#/definitions/{model_name}"},
-                    }
-                    parameters.append(parameter)
-
-                content_types = request_models | method_integration.get("requestTemplates", {})
-
-                method_operations = {"responses": responses}
-                if parameters:
-                    method_operations["parameters"] = parameters
-                if produces:
-                    method_operations["produces"] = list(produces)
-                if content_types:
-                    method_operations["consumes"] = list(content_types.keys())
-                if operation_name := method_config.get("operationName"):
-                    method_operations["operationId"] = operation_name
-
-                spec.path(path=path, operations={method: method_operations})
-
-    def _get_definitions(self, models: ListOfModel):
-        definitions = {}
-        for model in models:
-            model_def = json.loads(model["schema"])
-            self._resolve_refs(model_def)
-            definitions[model["name"]] = model_def
-        return definitions
-
-    def _resolve_refs(self, schema: dict):
-        if "$ref" in schema:
-            schema["$ref"] = f'#/definitions/{schema["$ref"].rsplit("/", maxsplit=1)[-1]}'
-        for value in schema.values():
-            if isinstance(value, dict):
-                self._resolve_refs(value)
-
-    def _swagger_export(self, api_id: str, stage: str, export_format: str) -> str:
-        """
-        https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
-        """
-        apigateway_client = connect_to().apigateway
-
-        rest_api = apigateway_client.get_rest_api(restApiId=api_id)
-        resources = apigateway_client.get_resources(restApiId=api_id)
-        models = apigateway_client.get_models(restApiId=api_id)
-        definitions = self._get_definitions(models["items"])
-
-        info = {}
-        kwargs = {}
-        if (description := rest_api.get("description")) is not None:
-            info["description"] = description
-        if definitions:
-            kwargs["definitions"] = definitions
-
-        spec = APISpec(
-            title=rest_api.get("name"),
-            version=rest_api.get("version")
-            or timestamp(rest_api.get("createdDate"), format=TIMESTAMP_FORMAT_TZ),
-            info=info,
-            openapi_version=self.SWAGGER_VERSION,
-            basePath=f"/{stage}",
-            schemes=["https"],
-            **kwargs,
-        )
-
-        self._add_paths(spec, resources)
-
-        return getattr(spec, self.export_formats.get(export_format))()
-
-    def _oas30_export(self, api_id: str, stage: str, export_format: str) -> str:
-        """
-        https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
-        """
-        apigateway_client = connect_to().apigateway
-
-        rest_api = apigateway_client.get_rest_api(restApiId=api_id)
-        resources = apigateway_client.get_resources(restApiId=api_id)
-
-        spec = APISpec(
-            title=rest_api.get("name"),
-            version=timestamp(rest_api.get("createdDate"), format=TIMESTAMP_FORMAT_TZ),
-            info=dict(description=rest_api.get("description")),
-            openapi_version=self.OPENAPI_VERSION,
-        )
-
-        self._add_paths(spec, resources)
-
-        return getattr(spec, self.export_formats.get(export_format))()
 
 
 def is_greedy_path(path_part: str) -> bool:

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1521,7 +1521,7 @@ class OpenApiExporter:
     def _add_paths(cls, spec, resources):
         for item in resources.get("items"):
             path = item.get("path")
-            for method, method_config in item.get("resourceMethods").items():
+            for method, method_config in item.get("resourceMethods", {}).items():
                 method = method.lower()
                 integration_responses = (
                     method_config.get("methodIntegration", {})

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1824,8 +1824,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     ) -> ExportResponse:
         moto_rest_api = get_moto_rest_api(context, rest_api_id)
         openapi_exporter = OpenApiExporter()
+        # FIXME: look into parser why `parameters` is always None
+        has_extension = context.request.values.get("extensions") == "apigateway"
         result = openapi_exporter.export_api(
-            api_id=rest_api_id, stage=stage_name, export_type=export_type, export_format=accepts
+            api_id=rest_api_id,
+            stage=stage_name,
+            export_type=export_type,
+            export_format=accepts,
+            with_extension=has_extension,
         )
 
         accepts = accepts or APPLICATION_JSON

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -91,10 +91,10 @@ from localstack.aws.api.apigateway import (
 from localstack.aws.connect import connect_to
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError, create_aws_request_context
 from localstack.constants import APPLICATION_JSON
+from localstack.services.apigateway.exporter import OpenApiExporter
 from localstack.services.apigateway.helpers import (
     EMPTY_MODEL,
     ERROR_MODEL,
-    OpenApiExporter,
     OpenAPIExt,
     apply_json_patch_safe,
     get_apigateway_store,

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -40,10 +40,13 @@ def test_export_swagger_openapi(aws_client, snapshot, import_file):
     )
     snapshot.match("get-export", response)
 
-    # response = aws_client.apigateway.get_export(
-    #     restApiId=api_id, stageName="local", exportType="swagger", parameters={"extensions": "apigateway"}
-    # )
-    # snapshot.match("get-export-with-extensions", response)
+    response = aws_client.apigateway.get_export(
+        restApiId=api_id,
+        stageName="local",
+        exportType="swagger",
+        parameters={"extensions": "apigateway"},
+    )
+    snapshot.match("get-export-with-extensions", response)
 
 
 @markers.aws.validated
@@ -64,7 +67,7 @@ def test_export_oas30_openapi(aws_client, snapshot, import_file):
 
     spec_file = load_file(import_file)
     response = aws_client.apigateway.import_rest_api(failOnWarnings=True, body=spec_file)
-    # snapshot.match("import-api", response)
+    snapshot.match("import-api", response)
     api_id = response["id"]
 
     aws_client.apigateway.create_deployment(restApiId=api_id, stageName="local")
@@ -74,13 +77,16 @@ def test_export_oas30_openapi(aws_client, snapshot, import_file):
     )
     snapshot.match("get-export", response)
 
-    # response = aws_client.apigateway.get_export(
-    #   restApiId=api_id, stageName="local", exportType="oas30", parameters={"extensions": "apigateway"}
-    # )
-    # snapshot.match("get-export-with-extensions", response)
+    response = aws_client.apigateway.get_export(
+        restApiId=api_id,
+        stageName="local",
+        exportType="oas30",
+        parameters={"extensions": "apigateway"},
+    )
+    snapshot.match("get-export-with-extensions", response)
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_create_domain_names(aws_client):
     domain_name = f"{short_uid()}-testDomain"
     test_certificate_name = "test.certificate"
@@ -101,7 +107,7 @@ def test_create_domain_names(aws_client):
     assert ex.value.response["Error"]["Code"] == "BadRequestException"
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_get_domain_names(aws_client):
     # create domain name
     domain_name = f"domain-{short_uid()}"
@@ -122,7 +128,7 @@ def test_get_domain_names(aws_client):
     assert added[0]["domainNameStatus"] == "AVAILABLE"
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_get_domain_name(aws_client):
     domain_name = f"{short_uid()}-testDomain"
     # adding a domain name

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -347,5 +347,354 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
+    "recorded-date": "15-09-2023, 03:09:35",
+    "recorded-content": {
+      "get-export": {
+        "body": {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "PetStore",
+            "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+            "version": "date"
+          },
+          "servers": [
+            {
+              "url": "https://ew246l06b4.execute-api.<region>.amazonaws.com/{basePath}",
+              "variables": {
+                "basePath": {
+                  "default": "local"
+                }
+              }
+            }
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "type",
+                    "in": "query",
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "page",
+                    "in": "query",
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Pets"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "post": {
+                "operationId": "CreatePet",
+                "requestBody": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/NewPet"
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/NewPetResponse"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "options": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Empty"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "operationId": "GetPet",
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Pet"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "options": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Empty"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "/": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Content-Type": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {}
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "Pets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "Empty": {
+                "type": "object"
+              },
+              "NewPetResponse": {
+                "type": "object",
+                "properties": {
+                  "pet": {
+                    "$ref": "#/components/schemas/Pet"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              },
+              "Pet": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "price": {
+                    "type": "number"
+                  }
+                }
+              },
+              "NewPet": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/PetType"
+                  },
+                  "price": {
+                    "type": "number"
+                  }
+                }
+              },
+              "PetType": {
+                "type": "string",
+                "enum": [
+                  "dog",
+                  "cat",
+                  "fish",
+                  "bird",
+                  "gecko"
+                ]
+              }
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"oas30_date.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
+    "recorded-date": "15-09-2023, 03:09:44",
+    "recorded-content": {
+      "get-export": {
+        "body": {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "Simple PetStore (Swagger)",
+            "version": "1.0.0"
+          },
+          "servers": [
+            {
+              "url": "https://rtsuhzffy8.execute-api.<region>.amazonaws.com/{basePath}",
+              "variables": {
+                "basePath": {
+                  "default": "local"
+                }
+              }
+            }
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "content": {}
+                  }
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "content": {}
+                  }
+                }
+              }
+            }
+          },
+          "components": {}
+        },
+        "contentDisposition": "attachment; filename=\"oas30_1.0.0.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-09-2023, 01:01:10",
+    "recorded-date": "15-09-2023, 04:27:47",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -27,7 +27,7 @@
             "version": "date",
             "title": "PetStore"
           },
-          "host": "l98ejsmxvl.execute-api.<region>.amazonaws.com",
+          "host": "<api-id:1>.execute-api.<region>.amazonaws.com",
           "basePath": "/local",
           "schemes": [
             "https"
@@ -275,11 +275,369 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-export-with-extensions": {
+        "body": {
+          "swagger": "2.0",
+          "info": {
+            "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+            "version": "date",
+            "title": "PetStore"
+          },
+          "host": "<api-id:1>.execute-api.<region>.amazonaws.com",
+          "basePath": "/local",
+          "schemes": [
+            "https"
+          ],
+          "paths": {
+            "/": {
+              "get": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "text/html"
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Content-Type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Content-Type": "'text/html'"
+                      },
+                      "responseTemplates": {
+                        "text/html": "<html>\n    <head>\n        <style>\n        body {\n            color: #333;\n            font-family: Sans-serif;\n            max-width: 800px;\n            margin: auto;\n        }\n        </style>\n    </head>\n    <body>\n        <h1>Welcome to your Pet Store API</h1>\n        <p>\n            You have successfully deployed your first API. You are seeing this HTML page because the <code>GET</code> method to the root resource of your API returns this content as a Mock integration.\n        </p>\n        <p>\n            The Pet Store API contains the <code>/pets</code> and <code>/pets/{petId}</code> resources. By making a <a href=\"/$context.stage/pets/\" target=\"_blank\"><code>GET</code> request</a> to <code>/pets</code> you can retrieve a list of Pets in your API. If you are looking for a specific pet, for example the pet with ID 1, you can make a <a href=\"/$context.stage/pets/1\" target=\"_blank\"><code>GET</code> request</a> to <code>/pets/1</code>.\n        </p>\n        <p>\n            You can use a REST client such as <a href=\"https://www.getpostman.com/\" target=\"_blank\">Postman</a> to test the <code>POST</code> methods in your API to create a new pet. Use the sample body below to send the <code>POST</code> request:\n        </p>\n        <pre>\n{\n    \"type\" : \"cat\",\n    \"price\" : 123.11\n}\n        </pre>\n    </body>\n</html>"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            },
+            "/pets": {
+              "get": {
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "type",
+                    "in": "query",
+                    "required": false,
+                    "type": "string"
+                  },
+                  {
+                    "name": "page",
+                    "in": "query",
+                    "required": false,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Pets"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.querystring.page": "method.request.querystring.page",
+                    "integration.request.querystring.type": "method.request.querystring.type"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "post": {
+                "operationId": "CreatePet",
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "in": "body",
+                    "name": "NewPet",
+                    "required": true,
+                    "schema": {
+                      "$ref": "#/definitions/NewPet"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/NewPetResponse"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "options": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Methods": "'POST,GET,OPTIONS'",
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "operationId": "GetPet",
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Pet"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.path.petId": "method.request.path.petId"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "options": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'",
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            }
+          },
+          "definitions": {
+            "Pets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            },
+            "Empty": {
+              "type": "object"
+            },
+            "NewPetResponse": {
+              "type": "object",
+              "properties": {
+                "pet": {
+                  "$ref": "#/definitions/Pet"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            },
+            "Pet": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "price": {
+                  "type": "number"
+                }
+              }
+            },
+            "NewPet": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "$ref": "#/definitions/PetType"
+                },
+                "price": {
+                  "type": "number"
+                }
+              }
+            },
+            "PetType": {
+              "type": "string",
+              "enum": [
+                "dog",
+                "cat",
+                "fish",
+                "bird",
+                "gecko"
+              ]
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"swagger_date.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-09-2023, 01:01:20",
+    "recorded-date": "15-09-2023, 04:27:55",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -305,7 +663,7 @@
             "version": "1.0.0",
             "title": "Simple PetStore (Swagger)"
           },
-          "host": "9zn31zyvmh.execute-api.<region>.amazonaws.com",
+          "host": "<api-id:1>.execute-api.<region>.amazonaws.com",
           "basePath": "/local",
           "schemes": [
             "https"
@@ -345,12 +703,102 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-export-with-extensions": {
+        "body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0.0",
+            "title": "Simple PetStore (Swagger)"
+          },
+          "host": "<api-id:1>.execute-api.<region>.amazonaws.com",
+          "basePath": "/local",
+          "schemes": [
+            "https"
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200"
+                    }
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200"
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.path.id": "method.request.path.petId"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              }
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"swagger_1.0.0.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-09-2023, 03:09:35",
+    "recorded-date": "15-09-2023, 04:55:14",
     "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<api-id:1>",
+        "name": "PetStore",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
       "get-export": {
         "body": {
           "openapi": "3.0.1",
@@ -361,7 +809,7 @@
           },
           "servers": [
             {
-              "url": "https://ew246l06b4.execute-api.<region>.amazonaws.com/{basePath}",
+              "url": "https://<api-id:1>.execute-api.<region>.amazonaws.com/{basePath}",
               "variables": {
                 "basePath": {
                   "default": "local"
@@ -631,12 +1079,411 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-export-with-extensions": {
+        "body": {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "PetStore",
+            "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+            "version": "date"
+          },
+          "servers": [
+            {
+              "url": "https://<api-id:1>.execute-api.<region>.amazonaws.com/{basePath}",
+              "variables": {
+                "basePath": {
+                  "default": "local"
+                }
+              }
+            }
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "type",
+                    "in": "query",
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "page",
+                    "in": "query",
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Pets"
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.querystring.page": "method.request.querystring.page",
+                    "integration.request.querystring.type": "method.request.querystring.type"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "post": {
+                "operationId": "CreatePet",
+                "requestBody": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/NewPet"
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/NewPetResponse"
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "options": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Empty"
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Methods": "'POST,GET,OPTIONS'",
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "operationId": "GetPet",
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Pet"
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.path.petId": "method.request.path.petId"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              },
+              "options": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/Empty"
+                        }
+                      }
+                    }
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'",
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
+                        "method.response.header.Access-Control-Allow-Origin": "'*'"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            },
+            "/": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Content-Type": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content": {}
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseParameters": {
+                        "method.response.header.Content-Type": "'text/html'"
+                      },
+                      "responseTemplates": {
+                        "text/html": "<html>\n    <head>\n        <style>\n        body {\n            color: #333;\n            font-family: Sans-serif;\n            max-width: 800px;\n            margin: auto;\n        }\n        </style>\n    </head>\n    <body>\n        <h1>Welcome to your Pet Store API</h1>\n        <p>\n            You have successfully deployed your first API. You are seeing this HTML page because the <code>GET</code> method to the root resource of your API returns this content as a Mock integration.\n        </p>\n        <p>\n            The Pet Store API contains the <code>/pets</code> and <code>/pets/{petId}</code> resources. By making a <a href=\"/$context.stage/pets/\" target=\"_blank\"><code>GET</code> request</a> to <code>/pets</code> you can retrieve a list of Pets in your API. If you are looking for a specific pet, for example the pet with ID 1, you can make a <a href=\"/$context.stage/pets/1\" target=\"_blank\"><code>GET</code> request</a> to <code>/pets/1</code>.\n        </p>\n        <p>\n            You can use a REST client such as <a href=\"https://www.getpostman.com/\" target=\"_blank\">Postman</a> to test the <code>POST</code> methods in your API to create a new pet. Use the sample body below to send the <code>POST</code> request:\n        </p>\n        <pre>\n{\n    \"type\" : \"cat\",\n    \"price\" : 123.11\n}\n        </pre>\n    </body>\n</html>"
+                      }
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "Pets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "Empty": {
+                "type": "object"
+              },
+              "NewPetResponse": {
+                "type": "object",
+                "properties": {
+                  "pet": {
+                    "$ref": "#/components/schemas/Pet"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              },
+              "Pet": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "price": {
+                    "type": "number"
+                  }
+                }
+              },
+              "NewPet": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/PetType"
+                  },
+                  "price": {
+                    "type": "number"
+                  }
+                }
+              },
+              "PetType": {
+                "type": "string",
+                "enum": [
+                  "dog",
+                  "cat",
+                  "fish",
+                  "bird",
+                  "gecko"
+                ]
+              }
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"oas30_date.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-09-2023, 03:09:44",
+    "recorded-date": "15-09-2023, 04:55:22",
     "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<api-id:1>",
+        "name": "Simple PetStore (Swagger)",
+        "version": "1.0.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
       "get-export": {
         "body": {
           "openapi": "3.0.1",
@@ -646,7 +1493,7 @@
           },
           "servers": [
             {
-              "url": "https://rtsuhzffy8.execute-api.<region>.amazonaws.com/{basePath}",
+              "url": "https://<api-id:1>.execute-api.<region>.amazonaws.com/{basePath}",
               "variables": {
                 "basePath": {
                   "default": "local"
@@ -682,6 +1529,89 @@
                     "description": "200 response",
                     "content": {}
                   }
+                }
+              }
+            }
+          },
+          "components": {}
+        },
+        "contentDisposition": "attachment; filename=\"oas30_1.0.0.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-export-with-extensions": {
+        "body": {
+          "openapi": "3.0.1",
+          "info": {
+            "title": "Simple PetStore (Swagger)",
+            "version": "1.0.0"
+          },
+          "servers": [
+            {
+              "url": "https://<api-id:1>.execute-api.<region>.amazonaws.com/{basePath}",
+              "variables": {
+                "basePath": {
+                  "default": "local"
+                }
+              }
+            }
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "content": {}
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200"
+                    }
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "content": {}
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "GET",
+                  "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
+                  "responses": {
+                    "default": {
+                      "statusCode": "200"
+                    }
+                  },
+                  "requestParameters": {
+                    "integration.request.path.id": "method.request.path.petId"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               }
             }

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,0 +1,351 @@
+{
+  "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
+    "recorded-date": "15-09-2023, 01:01:10",
+    "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<api-id:1>",
+        "name": "PetStore",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-export": {
+        "body": {
+          "swagger": "2.0",
+          "info": {
+            "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
+            "version": "date",
+            "title": "PetStore"
+          },
+          "host": "l98ejsmxvl.execute-api.<region>.amazonaws.com",
+          "basePath": "/local",
+          "schemes": [
+            "https"
+          ],
+          "paths": {
+            "/": {
+              "get": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "text/html"
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "headers": {
+                      "Content-Type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "/pets": {
+              "get": {
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "type",
+                    "in": "query",
+                    "required": false,
+                    "type": "string"
+                  },
+                  {
+                    "name": "page",
+                    "in": "query",
+                    "required": false,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Pets"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "post": {
+                "operationId": "CreatePet",
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "in": "body",
+                    "name": "NewPet",
+                    "required": true,
+                    "schema": {
+                      "$ref": "#/definitions/NewPet"
+                    }
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/NewPetResponse"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "options": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "operationId": "GetPet",
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Pet"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "options": {
+                "consumes": [
+                  "application/json"
+                ],
+                "produces": [
+                  "application/json"
+                ],
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response",
+                    "schema": {
+                      "$ref": "#/definitions/Empty"
+                    },
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "definitions": {
+            "Pets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            },
+            "Empty": {
+              "type": "object"
+            },
+            "NewPetResponse": {
+              "type": "object",
+              "properties": {
+                "pet": {
+                  "$ref": "#/definitions/Pet"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            },
+            "Pet": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "price": {
+                  "type": "number"
+                }
+              }
+            },
+            "NewPet": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "$ref": "#/definitions/PetType"
+                },
+                "price": {
+                  "type": "number"
+                }
+              }
+            },
+            "PetType": {
+              "type": "string",
+              "enum": [
+                "dog",
+                "cat",
+                "fish",
+                "bird",
+                "gecko"
+              ]
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"swagger_date.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
+    "recorded-date": "15-09-2023, 01:01:20",
+    "recorded-content": {
+      "import-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<api-id:1>",
+        "name": "Simple PetStore (Swagger)",
+        "version": "1.0.0",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-export": {
+        "body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0.0",
+            "title": "Simple PetStore (Swagger)"
+          },
+          "host": "9zn31zyvmh.execute-api.<region>.amazonaws.com",
+          "basePath": "/local",
+          "schemes": [
+            "https"
+          ],
+          "paths": {
+            "/pets": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "200 response"
+                  }
+                }
+              }
+            },
+            "/pets/{petId}": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "200 response"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "contentDisposition": "attachment; filename=\"swagger_1.0.0.json\"",
+        "contentType": "application/octet-stream",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
What started as a quick fix for #9145 got a bit out of hand with the introduction of snapshot test.

This PR fixes the bug mentioned, and extend the behaviour of the OpenAPI Exporter. It introduces more parity and separate clearly both types of exporter (I'm not exactly sure of the split yet and if I like it, but this could be a good intro for the Importer). 

Also introduces one apigateway extension, but this will need to be extended to support almost all of them, same way as the importer. 

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-export-api.html

<!-- What notable changes does this PR make? -->
## Changes
Fix the bug above by adding safety around getting attributes.

Refactored the importer for better separation of the two types of Exporter, those are pretty close but still quite different in their format, and it's hard to merge some behaviour. 

Added 2 snapshot validated tests around exporting, which helped a lot! 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

