### PR TITLE
fix SNS subscribe idempotency

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -578,11 +578,14 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         for existing_topic_subscription in store.topic_subscriptions.get(topic_arn, []):
             sub = store.subscriptions.get(existing_topic_subscription, {})
             if sub.get("Endpoint") == endpoint:
-                for attr in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
-                    if attributes and sub.get(attr) != attributes.get(attr):
-                        raise InvalidParameterException(
-                            "Invalid parameter: Attributes Reason: Subscription already exists with different attributes"
-                        )
+                if attributes:
+                    # validate the subscription attributes aren't different
+                    for attr in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
+                        # if a new attribute is present and different from an existent one, raise
+                        if (new_attr := attributes.get(attr)) and sub.get(attr) != new_attr:
+                            raise InvalidParameterException(
+                                "Invalid parameter: Attributes Reason: Subscription already exists with different attributes"
+                            )
 
                 return SubscribeResponse(SubscriptionArn=sub["SubscriptionArn"])
 

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4166,7 +4166,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_subscribe_idempotency": {
-    "recorded-date": "04-09-2023, 09:45:33",
+    "recorded-date": "15-09-2023, 17:29:11",
     "recorded-content": {
       "subscribe": {
         "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
@@ -4187,6 +4187,13 @@
           "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscribe-exact-same-raw": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4213,18 +4220,14 @@
           "HTTPStatusCode": 200
         }
       },
-      "subscribe-diff-attributes": {
-        "Error": {
-          "Code": "InvalidParameter",
-          "Message": "Invalid parameter: Attributes Reason: Subscription already exists with different attributes",
-          "Type": "Sender"
-        },
+      "subscribe-missing-attributes": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       },
-      "subscribe-missing-attributes": {
+      "subscribe-diff-attributes": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: Attributes Reason: Subscription already exists with different attributes",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is finally fixing SNS Subscribe idempotency and Subscription Attributes validation, reported again with #9154, which was introduced in #8976 and already fixed with #9055. 

This time, I think I've got the logic right, basically SNS will only validate present attributes in the `Subscribe` request. If an attribute is not provided, it won't be replaced by its default value but simply ignored.

This kinda shows that validation is good, but sometimes can be a bit tricky to write tests for, my bad 😬 

<!-- What notable changes does this PR make? -->
## Changes
This PR introduces the above logic and should fix all subsequent issues. We now check if the attributes is provided, then check if individual validated attributes are present in the request before validating equality with the subscription's. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

