### PR TITLE
Fix handling of exceptions without arguments in legacy provider with local executor

### DIFF
--- a/localstack/services/lambda_/lambda_executors.py
+++ b/localstack/services/lambda_/lambda_executors.py
@@ -1434,7 +1434,7 @@ class LambdaExecutorLocal(LambdaExecutor):
                     # need to translate to dict here, as custom errors from handlers cannot be pickled
                     execute_error = {
                         "errorType": e.__class__.__name__,
-                        "errorMessage": e.args[0],
+                        "errorMessage": e.args[0] if e.args else execute_result,
                         "stackTrace": traceback.format_tb(e.__traceback__),
                     }
                     sys.stderr.write("%s %s" % (e, traceback.format_exc()))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I am fixing the issue in Step Functions when a Lambda function raise an exception without arguments, like: `raise ValueError()`.
Currently, the code fails in this case trying to get the error message to propagate and make controller upstream time out.

Address #9169

<!-- What notable changes does this PR make? -->
## Changes
Patch the behavior of retrieving the error message from the exception during errors in the lambda invoked.

<!-- The following sections are optional, but can be useful! 

## Testing

Just create a step function which lambda perform `raise ValueError()`
Now the SFN execution wont time out.

## TODO

What's left to do: Nothing