### PR TITLE
Fix lambda invoke exception with invalid payload

### DIFF
--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Optional
 from localstack import config
 from localstack.aws.api.lambda_ import (
     InvalidParameterValueException,
+    InvalidRequestContentException,
     InvocationType,
     LastUpdateStatus,
     ResourceConflictException,
@@ -291,6 +292,16 @@ class LambdaService:
         # empty payloads have to work as well
         if payload is None:
             payload = b"{}"
+        else:
+            # detect invalid payloads early before creating an execution environment
+            try:
+                to_str(payload)
+            except Exception as e:
+                # MAYBE: improve parity of detailed exception message (quite cumbersome)
+                raise InvalidRequestContentException(
+                    f"Could not parse request body into json: Could not parse payload into json: {e}",
+                    Type="User",
+                )
         if invocation_type is None:
             invocation_type = InvocationType.RequestResponse
         if invocation_type == InvocationType.DryRun:

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3425,5 +3425,39 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaErrors::test_lambda_invoke_payload_encoding_error[body-n\\x87r\\x9e\\xe9\\xb5\\xd7I\\xee\\x9bmt]": {
+    "recorded-date": "15-09-2023, 22:16:36",
+    "recorded-content": {
+      "invoke_function_invalid_payload_body": {
+        "Error": {
+          "Code": "InvalidRequestContentException",
+          "Message": "Could not parse request body into json: Could not parse payload into json: Invalid UTF-8 start byte 0x87\n at [Source: (byte[])\"n\ufffdr\ufffd\ufffd\ufffdI\ufffdmt\"; line: 1, column: 3]"
+        },
+        "Type": "User",
+        "message": "Could not parse request body into json: Could not parse payload into json: Invalid UTF-8 start byte 0x87\n at [Source: (byte[])\"n\ufffdr\ufffd\ufffd\ufffdI\ufffdmt\"; line: 1, column: 3]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaErrors::test_lambda_invoke_payload_encoding_error[message-\\x99\\xeb,j\\x07\\xa1zYh]": {
+    "recorded-date": "15-09-2023, 22:16:40",
+    "recorded-content": {
+      "invoke_function_invalid_payload_message": {
+        "Error": {
+          "Code": "InvalidRequestContentException",
+          "Message": "Could not parse request body into json: Could not parse payload into json: Unexpected character ((CTRL-CHAR, code 153)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: (byte[])\"\ufffd\ufffd,j\u0007\ufffdzYh\"; line: 1, column: 2]"
+        },
+        "Type": "User",
+        "message": "Could not parse request body into json: Could not parse payload into json: Unexpected character ((CTRL-CHAR, code 153)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: (byte[])\"\ufffd\ufffd,j\u0007\ufffdzYh\"; line: 1, column: 2]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Addresses https://github.com/localstack/docs/issues/785
Related to https://github.com/localstack/localstack-pro-samples/issues/224

## Motivation

The AWS CLI v1 and v2 differ in their Lambda payload encoding and using the wrong command or CLI version causes LocalStack to return a confusing `Internal error while executing lambda` rather than raising an `InvalidRequestContentException`.

## Changes

This PR fixes the exception type and improves AWS parity of the error message. The detailed parsing message still differs at AWS but that's cumbersome to fix (probably not worth it).

Add an AWS-validated test with two different encoding errors.
