### PR TITLE
fix CreatePlatformEndpoint idempotency and Publish to mobile endpoint when disabled

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -478,11 +478,11 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             store = self.get_store(account_id=parsed_arn["account"], region_name=context.region)
             moto_sns_backend = self.get_moto_backend(parsed_arn["account"], context.region)
             if is_endpoint_publish:
-                if target_arn not in moto_sns_backend.platform_endpoints:
+                if not (platform_endpoint := moto_sns_backend.platform_endpoints.get(target_arn)):
                     raise InvalidParameterException(
                         "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified"
                     )
-                elif moto_sns_backend.platform_endpoints.get("Enabled") != "true":
+                elif not platform_endpoint.enabled:
                     raise EndpointDisabledException("Endpoint is disabled")
             else:
                 if topic_or_target_arn not in store.topic_subscriptions:

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -341,9 +341,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 for e in moto_sns_backend.platform_endpoints.values():
                     if e.token == token:
                         if custom_user_data and custom_user_data != e.custom_user_data:
-                            raise CommonServiceException(
-                                code="DuplicateEndpoint",
-                                message=f"Endpoint already exist for token: {token} with different attributes",
+                            raise InvalidParameterException(
+                                f"Endpoint {e.arn} already exists with the same Token, but different attributes."
                             )
                         else:
                             return CreateEndpointResponse(EndpointArn=e.arn)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -16,6 +16,7 @@ from localstack.aws.api.sns import (
     CreateEndpointResponse,
     CreatePlatformApplicationResponse,
     CreateTopicResponse,
+    EndpointDisabledException,
     GetSubscriptionAttributesResponse,
     GetTopicAttributesResponse,
     InvalidParameterException,
@@ -335,17 +336,17 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         try:
             result: CreateEndpointResponse = call_moto(context)
         except CommonServiceException as e:
-            # TODO: this was unclear in the old provider, check against aws and moto
             if "DuplicateEndpoint" in e.code:
                 moto_sns_backend = self.get_moto_backend(context.account_id, context.region)
                 for e in moto_sns_backend.platform_endpoints.values():
                     if e.token == token:
                         if custom_user_data and custom_user_data != e.custom_user_data:
-                            # TODO: check error against aws
                             raise CommonServiceException(
                                 code="DuplicateEndpoint",
                                 message=f"Endpoint already exist for token: {token} with different attributes",
                             )
+                        else:
+                            return CreateEndpointResponse(EndpointArn=e.arn)
             raise
         return result
 
@@ -482,6 +483,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     raise InvalidParameterException(
                         "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified"
                     )
+                elif moto_sns_backend.platform_endpoints.get("Enabled") != "true":
+                    raise EndpointDisabledException("Endpoint is disabled")
             else:
                 if topic_or_target_arn not in store.topic_subscriptions:
                     raise NotFoundException(

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3122,9 +3122,9 @@ class TestSNSPlatformEndpoint:
                     PlatformApplicationArn=platform_arn, **kwargs
                 )
             )
-        # Assert endpointarn is returned in every call create platform call
-        for i in range(len(responses)):
-            assert "EndpointArn" in responses[i]
+        # Assert EndpointArn is returned in every call create platform call
+        assert all("EndpointArn" in response for response in responses)
+        endpoint_arn = responses[0]["EndpointArn"]
 
         with pytest.raises(ClientError) as e:
             aws_client.sns.create_platform_endpoint(
@@ -3132,10 +3132,10 @@ class TestSNSPlatformEndpoint:
                 Token=token,
                 CustomUserData="different-user-data",
             )
-        assert e.value.response["Error"]["Code"] == "DuplicateEndpoint"
+        assert e.value.response["Error"]["Code"] == "InvalidParameter"
         assert (
             e.value.response["Error"]["Message"]
-            == f"Endpoint already exist for token: {token} with different attributes"
+            == f"Endpoint {endpoint_arn} already exists with the same Token, but different attributes."
         )
 
     @markers.aws.needs_fixing


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
These issues were reported in our community slack channel and converted into an issue: #9173 

We wouldn't check the endpoint status when publishing, and we had an incomplete fix for the `CreatePlatformEndpoint` idempotency, which led to an `skip` SNS test. 

<!-- What notable changes does this PR make? -->
## Changes
- Properly return the `EndpointArn` when calling `CreatePlatformEndpoint` multiple times with the same `CustomUserData` or no user data, and return the proper exception when the `CustomUserData` is different ("InvalidParameter") 
- Properly validate the endpoint status before publishing and raise an exception if the endpoint is disabled. 

As always, we cannot AWS validate those because we need real credentials to a register mobile app in GCM (Firebase) or Apple for example to set up a test case. This is always in the backlog, and would be awesome to have at some point, but we'll trust user reports and AWS documentation. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

