### PR TITLE
added support for overriding the log level of Kinesis Mock Server

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -774,6 +774,9 @@ KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
 # Delay between data persistence (in seconds)
 KINESIS_MOCK_PERSIST_INTERVAL = os.environ.get("KINESIS_MOCK_PERSIST_INTERVAL", "").strip() or "5s"
 
+# Kinesis mock log level override when inconsistent with LS_LOG (e.g., when LS_LOG=debug)
+KINESIS_MOCK_LOG_LEVEL = os.environ.get("KINESIS_MOCK_LOG_LEVEL", "").strip()
+
 # DEPRECATED: 1 (default) only applies to old lambda provider
 # Whether to handle Kinesis Lambda event sources as synchronous invocations.
 SYNCHRONOUS_KINESIS_EVENTS = is_env_not_false("SYNCHRONOUS_KINESIS_EVENTS")  # DEPRECATED
@@ -1152,6 +1155,7 @@ CONFIG_ENV_VARS = [
     "KINESIS_ERROR_PROBABILITY",
     "KINESIS_INITIALIZE_STREAMS",
     "KINESIS_MOCK_PERSIST_INTERVAL",
+    "KINESIS_MOCK_LOG_LEVEL",
     "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT",
     "LAMBDA_CODE_EXTRACT_TIME",
     "LAMBDA_CONTAINER_REGISTRY",

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -150,7 +150,9 @@ class KinesisServerManager:
         # kinesis-mock stores state in json files <account_id>.json, so we can dump everything into `kinesis/`
         persist_path = os.path.join(config.dirs.data, "kinesis")
         mkdir(persist_path)
-        if config.LS_LOG:
+        if config.KINESIS_MOCK_LOG_LEVEL:
+            log_level = config.KINESIS_MOCK_LOG_LEVEL.upper()
+        elif config.LS_LOG:
             if config.LS_LOG == "warning":
                 log_level = "WARN"
             else:


### PR DESCRIPTION
...when it is not the same as the desired log level set in LS_LOG

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Kinesis Mock Server Log-Level Logs when consistent with the other logs show when LS_LOG is set to debug is too verbose and so we would like a way to control those logs separately.


<!-- What notable changes does this PR make? -->
## Changes
Added additional log level control to Kinesis Mock Server.

<!-- The following sections are optional, but can be useful! 

## Testing
Tested Locally using the docker image built from source as the base image in our localstack project.

Description of how to test the changes
Enable a Localstack DynamoDB service that utilizes the KINESIS_MOCK_LOG_LEVEL env var and LS_LOG. Set them to be separate values (e.g LS_LOG=debug and KINESIS_MOCK_LOG_LEVEL=error).

