### PR TITLE
wip: rework S3Integration to support path/action

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -553,7 +553,7 @@ class S3Integration(BackendIntegration):
     )
     TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
     # TODO: URI path/ -> basically forward directly to S3
-    # TODO: URI action/ -> map ActionName with client.meta.method_to_api_mapping to get client method then use the body as parameters
+    # TODO: URI action/ -> map ActionName to recreate a request to forward
 
     def _invoke_path(
         self,
@@ -632,7 +632,6 @@ class S3Integration(BackendIntegration):
 
         uri_arn, uri_path = uri_split
         region_name = "us-east-1"  # get region from ARN
-        # TODO: can you pass headers too?
 
         integration_parameters = self.request_params_resolver.resolve(context=invocation_context)
 
@@ -643,8 +642,7 @@ class S3Integration(BackendIntegration):
             source_arn=get_source_arn(invocation_context),
         )
 
-        # TODO: use Accept?
-        accepts = integration_parameters.get("headers", {}).get("Accepts")
+        accepts = integration_parameters.get("headers", {}).get("Accept")
         template = integration.get("requestTemplates", {}).get(accepts, APPLICATION_JSON)
 
         if uri_arn.endswith("path"):
@@ -671,7 +669,7 @@ class S3Integration(BackendIntegration):
             LOG.warning(msg)
             return make_error_response(msg, 400)
 
-        # TODO: add all the Binary Media Type handling, see passthrough...
+        # TODO: add all the Binary Media Type handling, see passthrough:
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html#api-items-in-folder-as-s3-objects-in-bucket
         # apply custom response template
         # max file size is 10MB

--- a/tests/aws/files/swagger-s3-proxy.json
+++ b/tests/aws/files/swagger-s3-proxy.json
@@ -1,0 +1,546 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "MyS3Proxy",
+    "description": "Amazon S3 proxy in API Gateway"
+  },
+  "basePath": "/S3",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Timestamp": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "security": [
+          {
+            "sigv4": []
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Length": "integration.response.header.Content-Length",
+                "method.response.header.Timestamp": "integration.response.header.Date"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path//",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "aws"
+        }
+      }
+    },
+    "/{folder}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Date": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Date": "integration.response.header.Date",
+                "method.response.header.Content-Length": "integration.response.header.content-length"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.bucket": "method.request.path.folder"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "aws"
+        }
+      },
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Length": "integration.response.header.Content-Length"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.bucket": "method.request.path.folder",
+            "integration.request.header.Content-Type": "method.request.header.Content-Type"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "PUT",
+          "type": "aws"
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Date": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Date": "integration.response.header.Date"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.bucket": "method.request.path.folder"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "DELETE",
+          "type": "aws"
+        }
+      }
+    },
+    "/{folder}/{item}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "item",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "content-type": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.content-type": "integration.response.header.content-type",
+                "method.response.header.Content-Type": "integration.response.header.Content-Type"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.object": "method.request.path.item",
+            "integration.request.path.bucket": "method.request.path.folder"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}/{object}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "GET",
+          "type": "aws"
+        }
+      },
+      "head": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "item",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Length": "integration.response.header.Content-Length"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.object": "method.request.path.item",
+            "integration.request.path.bucket": "method.request.path.folder"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}/{object}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "HEAD",
+          "type": "aws"
+        }
+      },
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "item",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Length": "integration.response.header.Content-Length"
+              }
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.object": "method.request.path.item",
+            "integration.request.path.bucket": "method.request.path.folder",
+            "integration.request.header.Content-Type": "method.request.header.Content-Type"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}/{object}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "PUT",
+          "type": "aws"
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "item",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "folder",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Content-Length": {
+                "type": "string"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "500": {
+            "description": "500 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "credentials": "{{credentials}}",
+          "responses": {
+            "4\\d{2}": {
+              "statusCode": "400"
+            },
+            "default": {
+              "statusCode": "200"
+            },
+            "5\\d{2}": {
+              "statusCode": "500"
+            }
+          },
+          "requestParameters": {
+            "integration.request.path.object": "method.request.path.item",
+            "integration.request.path.bucket": "method.request.path.folder"
+          },
+          "uri": "arn:aws:apigateway:us-west-2:s3:path/{bucket}/{object}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "DELETE",
+          "type": "aws"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Empty": {
+      "type": "object",
+      "title": "Empty Schema"
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1784,41 +1784,6 @@ def test_rest_api_multi_region(
 
 
 class TestIntegrations:
-    @markers.aws.unknown
-    def test_api_gateway_s3_get_integration(self, create_rest_apigw, aws_client):
-        s3_client = aws_client.s3
-
-        bucket_name = f"test-bucket-{short_uid()}"
-        apigateway_name = f"test-api-{short_uid()}"
-        object_name = "test.json"
-        object_content = '{ "success": "true" }'
-        object_content_type = "application/json"
-
-        api_id, _, _ = create_rest_apigw(name=apigateway_name)
-
-        try:
-            resource_util.get_or_create_bucket(bucket_name)
-            s3_client.put_object(
-                Bucket=bucket_name,
-                Key=object_name,
-                Body=object_content,
-                ContentType=object_content_type,
-            )
-
-            self.connect_api_gateway_to_s3(
-                aws_client.apigateway, bucket_name, object_name, api_id, "GET"
-            )
-
-            aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
-            url = path_based_url(api_id, "test", f"/{object_name}")
-            result = requests.get(url)
-            assert 200 == result.status_code
-            assert object_content == result.text
-            assert object_content_type == result.headers["content-type"]
-        finally:
-            s3_client.delete_object(Bucket=bucket_name, Key=object_name)
-            s3_client.delete_bucket(Bucket=bucket_name)
-
     @pytest.mark.parametrize("method", ["GET", "POST"])
     @pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
     @pytest.mark.parametrize(
@@ -2017,39 +1982,6 @@ class TestIntegrations:
     # Helper methods
     # TODO: replace with fixtures, to allow passing aws_client and enable snapshot testing
     # ==================
-
-    def connect_api_gateway_to_s3(self, apigw_client, bucket_name, file_name, api_id, method):
-        """Connects the root resource of an api gateway to the given object of an s3 bucket."""
-        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
-            TEST_AWS_REGION_NAME, bucket_name
-        )
-
-        test_role = "test-s3-role"
-        role_arn = arns.role_arn(role_name=test_role)
-        resources = apigw_client.get_resources(restApiId=api_id)
-        # using the root resource '/' directly for this test
-        root_resource_id = resources["items"][0]["id"]
-        proxy_resource = apigw_client.create_resource(
-            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
-        )
-        apigw_client.put_method(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            authorizationType="NONE",
-            apiKeyRequired=False,
-            requestParameters={},
-        )
-        apigw_client.put_integration(
-            restApiId=api_id,
-            resourceId=proxy_resource["id"],
-            httpMethod=method,
-            type="AWS",
-            integrationHttpMethod=method,
-            uri=s3_uri,
-            credentials=role_arn,
-            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
-        )
 
     def connect_api_gateway_to_kinesis(self, aws_client, gateway_name: str, kinesis_stream: str):
         template = APIGATEWAY_DATA_INBOUND_TEMPLATE % kinesis_stream

--- a/tests/aws/services/apigateway/test_apigateway_s3.py
+++ b/tests/aws/services/apigateway/test_apigateway_s3.py
@@ -1,0 +1,67 @@
+import requests
+
+from localstack.constants import TEST_AWS_REGION_NAME
+from localstack.testing.pytest import markers
+from localstack.utils.aws import arns
+from localstack.utils.strings import short_uid
+from tests.aws.services.apigateway.apigateway_fixtures import api_invoke_url
+
+
+class TestS3Integration:
+    @markers.aws.unknown
+    def test_api_gateway_s3_get_integration(self, s3_bucket, create_rest_apigw, aws_client):
+        apigateway_name = f"test-api-{short_uid()}"
+        object_name = "test.json"
+        object_content = '{ "success": "true" }'
+        object_content_type = "application/json"
+
+        api_id, _, _ = create_rest_apigw(name=apigateway_name)
+
+        aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_name,
+            Body=object_content,
+            ContentType=object_content_type,
+        )
+
+        self.connect_api_gateway_to_s3(aws_client.apigateway, s3_bucket, object_name, api_id, "GET")
+
+        aws_client.apigateway.create_deployment(restApiId=api_id, stageName="test")
+        url = api_invoke_url(api_id, stage="test", path=f"/{object_name}")
+        result = requests.get(url)
+        assert 200 == result.status_code
+        assert object_content == result.text
+        assert object_content_type == result.headers["content-type"]
+
+    def connect_api_gateway_to_s3(self, apigw_client, bucket_name, file_name, api_id, method):
+        """Connects the root resource of an api gateway to the given object of an s3 bucket."""
+        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
+            TEST_AWS_REGION_NAME, bucket_name
+        )
+
+        test_role = "test-s3-role"
+        role_arn = arns.role_arn(role_name=test_role)
+        resources = apigw_client.get_resources(restApiId=api_id)
+        # using the root resource '/' directly for this test
+        root_resource_id = resources["items"][0]["id"]
+        proxy_resource = apigw_client.create_resource(
+            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
+        )
+        apigw_client.put_method(
+            restApiId=api_id,
+            resourceId=proxy_resource["id"],
+            httpMethod=method,
+            authorizationType="NONE",
+            apiKeyRequired=False,
+            requestParameters={},
+        )
+        apigw_client.put_integration(
+            restApiId=api_id,
+            resourceId=proxy_resource["id"],
+            httpMethod=method,
+            type="AWS",
+            integrationHttpMethod=method,
+            uri=s3_uri,
+            credentials=role_arn,
+            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
+        )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We're currently only supporting 2 cases of the APIGW AWS S3 integration, `GetObject` for `path` and `action` URI.

Following this scenario should be successful against LocalStack: https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html
https://github.com/aws-samples/serverless-patterns/blob/main/apigw-s3-cdk/cdk/lib/apigw-s3-cdk-stack.ts

<!-- What notable changes does this PR make? -->
## Changes
Rework the whole S3 integration to support both `path` and `action` with different strategies to forward the request to S3. TBD


## TODO

What's left to do:

- [ ] AWS validate the existing test (seems weird with the proxy+ integration)
- [ ] Import the swagger file and run all operations tests on it (`path` based URI)
- [ ] try to find some sample/write tests for `action` based URI. 
- [x] add support for `requestOverride.path` from VTL template
- [ ] add test for `requestOverride.path` 


