### PR TITLE
deactivate PR and push trigger for podman tests

### DIFF
--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -2,24 +2,6 @@ name: Podman Docker Client Tests
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/tests-podman.yml"
-      - "localstack/utils/container_utils/"
-      - "localstack/utils/docker_utils.py"
-      - "tests/integration/docker_utils/"
-    branches:
-      - master
-      - release/*
-  push:
-    paths:
-      - ".github/workflows/tests-podman.yml"
-      - "localstack/utils/container_utils/"
-      - "localstack/utils/docker_utils.py"
-      - "tests/integration/docker_utils/"
-    branches:
-      - master
-      - release/*
 
 env:
   # Set non-job-specific environment variables for pytest-tinybird


### PR DESCRIPTION
## Motivation
This PR deactivates the PR and the push trigger for the podman tests (`.github/workflows/tests-podman.yml`).
These tests have been introduced with #8349, but were never green.
The podman support is currently baked into the `CmdDockerClient` which makes it hard to skip the right tests based on a skip marker.
This is why I would like to deactivate the PR and push trigger for now, until we:
- Refactor the Docker client such that the Podman Docker client is in a separate class.
- The tests which are not working yet (because the support has not been enhanced wide enough), are skipped for the podman tests such that they can actually become green.

However, the workflow will not be disabled and can be triggered whenever you would like to execute them manually.

## Changes
Delete the `pull_request` and `push` triggers in `.github/workflows/tests-podman.yml`.