### PR TITLE
Resolve LOCALSTACK_HOST to the LocalStack container

### DIFF
--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -247,6 +247,7 @@ class NonLoggingHandler(DNSHandler):
 
 NAME_PATTERNS_POINTING_TO_LOCALSTACK = [
     f".*{LOCALHOST_HOSTNAME}",
+    f".*{config.LOCALSTACK_HOST.host}",
 ]
 
 

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -247,7 +247,6 @@ class NonLoggingHandler(DNSHandler):
 
 NAME_PATTERNS_POINTING_TO_LOCALSTACK = [
     f".*{LOCALHOST_HOSTNAME}",
-    f".*{config.LOCALSTACK_HOST.host}",
 ]
 
 
@@ -825,11 +824,16 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
 
     LOG.debug("Starting DNS servers (tcp/udp port %s on %s)..." % (port, host))
     dns_server = DnsServer(port, protocols=["tcp", "udp"], host=host, upstream_dns=upstream_dns)
+
     for name in NAME_PATTERNS_POINTING_TO_LOCALSTACK:
         dns_server.add_host_pointing_to_localstack(name)
+    if config.LOCALSTACK_HOST.host != LOCALHOST_HOSTNAME:
+        dns_server.add_host_pointing_to_localstack(f".*{config.LOCALSTACK_HOST.host}")
+
     if config.DNS_LOCAL_NAME_PATTERNS:
         for skip_pattern in re.split(r"[,;\s]+", config.DNS_LOCAL_NAME_PATTERNS):
             dns_server.add_skip(skip_pattern)
+
     dns_server.start()
     if not dns_server.wait_is_up(timeout=5):
         LOG.warning("DNS server did not come up within 5 seconds.")

--- a/tests/bootstrap/test_container_listen_configuration.py
+++ b/tests/bootstrap/test_container_listen_configuration.py
@@ -3,6 +3,7 @@ import requests
 
 from localstack.config import in_docker
 from localstack.testing.pytest.container import ContainerFactory
+from localstack.utils.bootstrap import ContainerConfigurators
 from localstack.utils.net import get_free_tcp_port
 
 pytestmarks = pytest.mark.skipif(
@@ -11,34 +12,48 @@ pytestmarks = pytest.mark.skipif(
 
 
 class TestContainerConfiguration:
-    def test_defaults(self, container_factory: ContainerFactory, wait_for_localstack_ready):
+    def test_defaults(
+        self, container_factory: ContainerFactory, stream_container_logs, wait_for_localstack_ready
+    ):
         """
         The default configuration is to listen on 0.0.0.0:4566
         """
         port = get_free_tcp_port()
-        container = container_factory()
-        container.config.ports.add(port, 4566)
+        container = container_factory(
+            configurators=[
+                ContainerConfigurators.debug,
+                ContainerConfigurators.mount_docker_socket,
+                ContainerConfigurators.port(port, 4566),
+            ]
+        )
         running_container = container.start(attach=False)
+        stream_container_logs(container)
         wait_for_localstack_ready(running_container)
 
         r = requests.get(f"http://127.0.0.1:{port}/_localstack/health")
         assert r.status_code == 200
 
     def test_gateway_listen_single_value(
-        self, container_factory: ContainerFactory, wait_for_localstack_ready
+        self, container_factory: ContainerFactory, stream_container_logs, wait_for_localstack_ready
     ):
         """
         Test using GATEWAY_LISTEN to change the hypercorn port
         """
         port1 = get_free_tcp_port()
-
         container = container_factory(
-            env_vars={
-                "GATEWAY_LISTEN": "0.0.0.0:5000",
-            },
+            configurators=[
+                ContainerConfigurators.debug,
+                ContainerConfigurators.mount_docker_socket,
+                ContainerConfigurators.port(port1, 5000),
+                ContainerConfigurators.env_vars(
+                    {
+                        "GATEWAY_LISTEN": "0.0.0.0:5000",
+                    }
+                ),
+            ]
         )
-        container.config.ports.add(port1, 5000)
         running_container = container.start(attach=False)
+        stream_container_logs(container)
         wait_for_localstack_ready(running_container)
 
         # check the ports listening on 0.0.0.0
@@ -46,7 +61,11 @@ class TestContainerConfiguration:
         assert r.status_code == 200
 
     def test_gateway_listen_multiple_values(
-        self, container_factory: ContainerFactory, docker_network, wait_for_localstack_ready
+        self,
+        container_factory: ContainerFactory,
+        docker_network,
+        stream_container_logs,
+        wait_for_localstack_ready,
     ):
         """
         Test multiple container ports
@@ -55,19 +74,26 @@ class TestContainerConfiguration:
         port2 = get_free_tcp_port()
 
         container = container_factory(
-            env_vars={
-                "GATEWAY_LISTEN": ",".join(
-                    [
-                        "0.0.0.0:5000",
-                        "0.0.0.0:2000",
-                    ]
-                )
-            },
-            network=docker_network,
+            configurators=[
+                ContainerConfigurators.debug,
+                ContainerConfigurators.mount_docker_socket,
+                ContainerConfigurators.network(docker_network),
+                ContainerConfigurators.port(port1, 5000),
+                ContainerConfigurators.port(port2, 2000),
+                ContainerConfigurators.env_vars(
+                    {
+                        "GATEWAY_LISTEN": ",".join(
+                            [
+                                "0.0.0.0:5000",
+                                "0.0.0.0:2000",
+                            ]
+                        ),
+                    }
+                ),
+            ]
         )
-        container.config.ports.add(port1, 5000)
-        container.config.ports.add(port2, 2000)
         running_container = container.start(attach=False)
+        stream_container_logs(container)
         wait_for_localstack_ready(running_container)
 
         # check the ports listening on 0.0.0.0

--- a/tests/bootstrap/test_container_listen_configuration.py
+++ b/tests/bootstrap/test_container_listen_configuration.py
@@ -5,8 +5,11 @@ from localstack.config import in_docker
 from localstack.testing.pytest.container import ContainerFactory
 from localstack.utils.net import get_free_tcp_port
 
+pytestmarks = pytest.mark.skipif(
+    condition=in_docker(), reason="cannot run bootstrap tests in docker"
+)
 
-@pytest.mark.skipif(condition=in_docker(), reason="cannot run bootstrap tests in docker")
+
 class TestContainerConfiguration:
     def test_defaults(self, container_factory: ContainerFactory, wait_for_localstack_ready):
         """

--- a/tests/bootstrap/test_dns_server.py
+++ b/tests/bootstrap/test_dns_server.py
@@ -6,6 +6,7 @@ from localstack.config import in_docker
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.testing.pytest.container import ContainerFactory
 from localstack.utils.bootstrap import ContainerConfigurators
+from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)
 
@@ -59,4 +60,35 @@ def test_user_defined_network(
         name=LOCALHOST_HOSTNAME, ip_address=container_ip, network=docker_network
     )
 
+    assert container_ip in stdout.decode().splitlines()
+
+
+def test_resolve_localstack_host(
+    container_factory: ContainerFactory,
+    stream_container_logs,
+    wait_for_localstack_ready,
+    dns_query_from_container,
+):
+    localstack_host = f"host-{short_uid()}"
+    ls_container = container_factory(
+        configurators=[
+            ContainerConfigurators.debug,
+            ContainerConfigurators.mount_docker_socket,
+            ContainerConfigurators.env_vars(
+                {
+                    "LOCALSTACK_HOST": localstack_host,
+                },
+            ),
+        ],
+    )
+    running_container = ls_container.start()
+    stream_container_logs(ls_container)
+    wait_for_localstack_ready(running_container)
+
+    container_ip = running_container.ip_address()
+
+    stdout, _ = dns_query_from_container(name=LOCALHOST_HOSTNAME, ip_address=container_ip)
+    assert container_ip in stdout.decode().splitlines()
+
+    stdout, _ = dns_query_from_container(name=localstack_host, ip_address=container_ip)
     assert container_ip in stdout.decode().splitlines()

--- a/tests/bootstrap/test_dns_server.py
+++ b/tests/bootstrap/test_dns_server.py
@@ -32,8 +32,11 @@ def test_default_network(
     wait_for_localstack_ready(running_container)
 
     container_ip = running_container.ip_address()
-    stdout, _ = dns_query_from_container(name=LOCALHOST_HOSTNAME, ip_address=container_ip)
 
+    stdout, _ = dns_query_from_container(name=LOCALHOST_HOSTNAME, ip_address=container_ip)
+    assert container_ip in stdout.decode().splitlines()
+
+    stdout, _ = dns_query_from_container(name=f"foo.{LOCALHOST_HOSTNAME}", ip_address=container_ip)
     assert container_ip in stdout.decode().splitlines()
 
 
@@ -59,7 +62,11 @@ def test_user_defined_network(
     stdout, _ = dns_query_from_container(
         name=LOCALHOST_HOSTNAME, ip_address=container_ip, network=docker_network
     )
+    assert container_ip in stdout.decode().splitlines()
 
+    stdout, _ = dns_query_from_container(
+        name=f"foo.{LOCALHOST_HOSTNAME}", ip_address=container_ip, network=docker_network
+    )
     assert container_ip in stdout.decode().splitlines()
 
 
@@ -90,5 +97,11 @@ def test_resolve_localstack_host(
     stdout, _ = dns_query_from_container(name=LOCALHOST_HOSTNAME, ip_address=container_ip)
     assert container_ip in stdout.decode().splitlines()
 
+    stdout, _ = dns_query_from_container(name=f"foo.{LOCALHOST_HOSTNAME}", ip_address=container_ip)
+    assert container_ip in stdout.decode().splitlines()
+
     stdout, _ = dns_query_from_container(name=localstack_host, ip_address=container_ip)
+    assert container_ip in stdout.decode().splitlines()
+
+    stdout, _ = dns_query_from_container(name=f"foo.{localstack_host}", ip_address=container_ip)
     assert container_ip in stdout.decode().splitlines()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The user may specify a custom value of `LOCALSTACK_HOST` which is the domain name of the LocalStack container from the outside. This will not work however in created compute environments, or external docker containers since we only resolve `localhost.localstack.cloud` to the LocalStack container.


<!-- What notable changes does this PR make? -->
## Changes

- Bind LOCALSTACK_HOST to LocalStack IP address
- Update bootstrap tests to use `stream_container_logs` and `ContainerConfigurators`


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

