### PR TITLE
Fix flaky lambda concurrency test

### DIFF
--- a/localstack/services/lambda_/invocation/counting_service.py
+++ b/localstack/services/lambda_/invocation/counting_service.py
@@ -157,6 +157,15 @@ class CountingService:
                         on_demand_tracker.increment(unqualified_function_arn)
                         lease_type = "on-demand"
                     else:
+                        extras = {
+                            "available_reserved_concurrency": available_reserved_concurrency,
+                            "reserved_concurrent_executions": function.reserved_concurrent_executions,
+                            "provisioned_concurrency_sum": calculate_provisioned_concurrency_sum(
+                                function
+                            ),
+                            "on_demand_running_invocation_count": on_demand_running_invocation_count,
+                        }
+                        LOG.debug("Insufficient reserved concurrency available: %s", extras)
                         raise TooManyRequestsException(
                             "Rate Exceeded.",
                             Reason="ReservedFunctionConcurrentInvocationLimitExceeded",
@@ -196,6 +205,12 @@ class CountingService:
                                 unqualified_function_arn,
                                 available_unreserved_concurrency,
                             )
+                        extras = {
+                            "available_unreserved_concurrency": available_unreserved_concurrency,
+                            "lambda_limits_concurrent_executions": config.LAMBDA_LIMITS_CONCURRENT_EXECUTIONS,
+                            "total_used_concurrency": total_used_concurrency,
+                        }
+                        LOG.debug("Insufficient unreserved concurrency available: %s", extras)
                         raise TooManyRequestsException(
                             "Rate Exceeded.",
                             Reason="ReservedFunctionConcurrentInvocationLimitExceeded",


### PR DESCRIPTION
## Motivation

A flaky Lambda test occasionally blocks the pipeline. 

Thank you @bentsku for raising this https://localstack-cloud.slack.com/archives/C02U7DN1B4M/p1695076802171769

## Changes

* Increase reserved concurrency in test case
* Document race condition
* Add extra debug logging for concurrency exceptions

## Discussion

a) The safest fix is to increase ReservedConcurrentExecutions=3 but then we only occasionally test the border case.
b) We could slow down the test and use sleeps to have a high likelyhood of succeeding
c) We separate the mixed async/sync invoke into a separate test case (or after asserting the logs).
