### PR TITLE
CirecleCI: add report for acceptance and diff coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,8 +372,8 @@ jobs:
       # store (uncombined) coverage from acceptance tests
       - run:
           name: fetch isolated acceptance coverage
-          command: |
           # might need to combine coverage files in future
+          command: |
             cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
@@ -393,16 +393,31 @@ jobs:
             coverage html || true
             coveralls || true
       - run:
-          name: Create Coverage Diff
+          name: Create Coverage Diff (Code Coverage)
+          # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
+          # but we still want cirecleci to continue with the tasks, so we return 0 always
           command: |
             source .venv/bin/activate
             pip install pycobertura
             coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack/services/*/**" --omit="*/**/__init__.py"
             coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack/services/*/**"  --omit="*/**/__init__.py"
             pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
-          # pycobertura will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
-          # but we still want cirecleci to continue with the tasks, so we return 0 always
             bash -c "pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
+      - run:
+          name: store acceptance parity metrics
+          command: |
+            mkdir acceptance_parity_metrics
+            mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/
+      - run:
+          name: Create Metric Coverage Diff (API Coverage)
+          environment:
+            COVERAGE_DIR_ALL: "parity_metrics"
+            COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
+            OUTPUT_DIR: "./api-coverage"
+          command: |
+            source .venv/bin/activate
+            mkdir api-coverage
+            python -m scripts.metrics_coverage.diff_metrics_coverage
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
@@ -413,16 +428,13 @@ jobs:
             SOURCE_TYPE=community \
             python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
       - store_artifacts:
+          path: api-coverage
+      - store_artifacts:
           path: coverage-acceptance.html
       - store_artifacts:
           path: coverage-diff.html
       - store_artifacts:
           path: parity_metrics/
-      - run:
-          name: store acceptance parity metrics
-          command: |
-            mkdir acceptance_parity_metrics
-            mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/
       - store_artifacts:
           path: acceptance_parity_metrics/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,12 +399,11 @@ jobs:
             pip install pycobertura
             coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack/services/*/**" --omit="*/**/__init__.py"
             coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack/services/*/**"  --omit="*/**/__init__.py"
+            pycobertura --help
             pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
+            echo "'show' successfully executed"
             pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html
-      - store_artifacts:
-          path: coverage-acceptance.html
-      - store_artifacts:
-          path: coverage-diff.html
+            echo "finished script"
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
@@ -414,6 +413,10 @@ jobs:
             IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv \
             SOURCE_TYPE=community \
             python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
+      - store_artifacts:
+          path: coverage-acceptance.html
+      - store_artifacts:
+          path: coverage-diff.html
       - store_artifacts:
           path: parity_metrics/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,6 +373,7 @@ jobs:
       - run:
           name: fetch isolated acceptance coverage
           command: |
+            # might need to combine coverage files in future
             cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
@@ -391,6 +392,19 @@ jobs:
             coverage report || true
             coverage html || true
             coveralls || true
+      - run:
+          name: Create Coverage Diff
+          command: |
+            source .venv/bin/activate
+            pip install pycobertura
+            coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack/services/*/**" --omit="*/**/__init__.py"
+            coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack/services/*/**"  --omit="*/**/__init__.py"
+            pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
+            pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html
+      - store_artifacts:
+          path: coverage-acceptance.html
+      - store_artifacts:
+          path: coverage-diff.html
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,6 +393,20 @@ jobs:
             coverage html || true
             coveralls || true
       - run:
+          name: store acceptance parity metrics
+          command: |
+            mkdir acceptance_parity_metrics
+            mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/
+      - run:
+          name: Upload test metrics and implemented coverage data to tinybird
+          command: |
+            source .venv/bin/activate
+            mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
+            METRIC_REPORT_DIR_PATH=parity_metrics \
+            IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv \
+            SOURCE_TYPE=community \
+            python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
+      - run:
           name: Create Coverage Diff (Code Coverage)
           # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
           # but we still want cirecleci to continue with the tasks, so we return 0 always
@@ -404,31 +418,17 @@ jobs:
             pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
             bash -c "pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
       - run:
-          name: store acceptance parity metrics
-          command: |
-            mkdir acceptance_parity_metrics
-            mv target/metric_reports/metric-report*acceptance* acceptance_parity_metrics/
-      - run:
           name: Create Metric Coverage Diff (API Coverage)
           environment:
             COVERAGE_DIR_ALL: "parity_metrics"
             COVERAGE_DIR_ACCEPTANCE: "acceptance_parity_metrics"
-            OUTPUT_DIR: "./api-coverage"
+            OUTPUT_DIR: "api-coverage"
           command: |
             source .venv/bin/activate
             mkdir api-coverage
             python -m scripts.metrics_coverage.diff_metrics_coverage
-      - run:
-          name: Upload test metrics and implemented coverage data to tinybird
-          command: |
-            source .venv/bin/activate
-            mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
-            METRIC_REPORT_DIR_PATH=parity_metrics \
-            IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv \
-            SOURCE_TYPE=community \
-            python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
       - store_artifacts:
-          path: api-coverage
+          path: api-coverage/
       - store_artifacts:
           path: coverage-acceptance.html
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,14 +409,20 @@ jobs:
       - run:
           name: Create Coverage Diff (Code Coverage)
           # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
-          # but we still want cirecleci to continue with the tasks, so we return 0 always
+          # but we still want cirecleci to continue with the tasks, so we return 0.
+          # From the docs:
+          # Upon exit, the diff command may return various exit codes:
+          #    0: all changes are covered, no new uncovered statements have been introduced
+          #    1: some exception occurred (likely due to inappropriate usage or a bug in pycobertura)
+          #    2: the changes worsened the overall coverage
+          #    3: the changes introduced uncovered statements but the overall coverage is still better than before
           command: |
             source .venv/bin/activate
             pip install pycobertura
             coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack/services/*/**" --omit="*/**/__init__.py"
             coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack/services/*/**"  --omit="*/**/__init__.py"
             pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
-            bash -c "pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
+            bash -c "pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 1 ]] ; then exit 1 ; else exit 0 ; fi"
       - run:
           name: Create Metric Coverage Diff (API Coverage)
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
       - run:
           name: fetch isolated acceptance coverage
           command: |
-            # might need to combine coverage files in future
+          # might need to combine coverage files in future
             cp target/coverage/.coverage.acceptance.* .coverage.acceptance
       - store_artifacts:
           path: .coverage.acceptance
@@ -399,11 +399,10 @@ jobs:
             pip install pycobertura
             coverage xml --data-file=.coverage -o all.coverage.report.xml --include="localstack/services/*/**" --omit="*/**/__init__.py"
             coverage xml --data-file=.coverage.acceptance -o acceptance.coverage.report.xml --include="localstack/services/*/**"  --omit="*/**/__init__.py"
-            pycobertura --help
             pycobertura show --format html -s localstack/ acceptance.coverage.report.xml -o coverage-acceptance.html
-            echo "'show' successfully executed"
-            pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html
-            echo "finished script"
+          # pycobertura will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),
+          # but we still want cirecleci to continue with the tasks, so we return 0 always
+            bash -c "pycobertura diff --format html -s1 localstack/ -s2 localstack/ all.coverage.report.xml acceptance.coverage.report.xml -o coverage-diff.html; if [[ \$? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |

--- a/scripts/metrics_coverage/diff_metrics_coverage.py
+++ b/scripts/metrics_coverage/diff_metrics_coverage.py
@@ -1,0 +1,197 @@
+import csv
+import os
+from pathlib import Path
+
+
+def print_usage():
+    return """
+    Helper script to an output report for the metrics coverage diff.
+
+    Set the env `COVERAGE_DIR_ALL` which points to a folder containing metrics-raw-data reports for the initial tests.
+    The env `COVERAGE_DIR_ACCEPTANCE` should point to the folder containing metrics-raw-data reports for the acceptance
+    test suite (usually a subset of the initial tests).
+
+    Use `OUTPUT_DIR` env to set the path where the report will be stored
+    """
+
+
+def sort_dict_helper(d):
+    if isinstance(d, dict):
+        return {k: sort_dict_helper(v) for k, v in sorted(d.items())}
+    else:
+        return d
+
+
+def create_initial_coverage(path_to_initial_metrics: str) -> dict:
+    pathlist = Path(path_to_initial_metrics).rglob("*.csv")
+    coverage = {}
+    for path in pathlist:
+        with open(path, "r") as csv_obj:
+            csv_dict_reader = csv.DictReader(csv_obj)
+            for metric in csv_dict_reader:
+                service = metric.get("service")
+                operation = metric.get("operation")
+                response_code = metric.get("response_code")
+
+                service_details = coverage.setdefault(service, {})
+                operation_details = service_details.setdefault(operation, {})
+                if response_code not in operation_details:
+                    operation_details[response_code] = False
+    return coverage
+
+
+def mark_coverage_acceptance_test(
+    path_to_acceptance_metrics: str, coverage_collection: dict
+) -> dict:
+    pathlist = Path(path_to_acceptance_metrics).rglob("*.csv")
+    additional_tested = {}
+    add_to_additional = False
+    for path in pathlist:
+        with open(path, "r") as csv_obj:
+            csv_dict_reader = csv.DictReader(csv_obj)
+            for metric in csv_dict_reader:
+                service = metric.get("service")
+                operation = metric.get("operation")
+                response_code = metric.get("response_code")
+
+                if service not in coverage_collection:
+                    add_to_additional = True
+                else:
+                    service_details = coverage_collection[service]
+                    if operation not in service_details:
+                        add_to_additional = True
+                    else:
+                        operation_details = service_details.setdefault(operation, {})
+                        if response_code not in operation_details:
+                            add_to_additional = True
+                        else:
+                            operation_details[response_code] = True
+
+                if add_to_additional:
+                    service_details = additional_tested.setdefault(service, {})
+                    operation_details = service_details.setdefault(operation, {})
+                    if response_code not in operation_details:
+                        operation_details[response_code] = True
+                    add_to_additional = False
+
+    return additional_tested
+
+
+def create_readable_report(
+    coverage_collection: dict, additional_tested_collection: dict, output_dir: str
+):
+    service_overview_coverage = """
+    <table>
+      <tr>
+        <th style="text-align: left">Service</th>
+        <th style="text-align: right">Coverage of Acceptance Tests Suite</th>
+      </tr>
+    """
+    coverage_details = """
+    <table>
+      <tr>
+        <th style="text-align: left">Service</th>
+        <th style="text-align: left">Operation</th>
+        <th>Return Code</th>
+        <th>Covered By Acceptance Test</th>
+      </tr>"""
+    additional_test_details = ""
+    coverage_collection = sort_dict_helper(coverage_collection)
+    additional_tested_collection = sort_dict_helper(additional_tested_collection)
+    for service, operations in coverage_collection.items():
+        # count tested operations vs operations that are somehow covered with acceptance
+        amount_ops = len(operations)
+        covered_ops = len([op for op, details in operations.items() if any(details.values())])
+        percentage_covered = 100 * covered_ops / amount_ops
+        service_overview_coverage += "    <tr>\n"
+        service_overview_coverage += f"    <td>{service}</td>\n"
+        service_overview_coverage += (
+            f"""    <td style="text-align: right">{percentage_covered:.2f}%</td>\n"""
+        )
+        service_overview_coverage += "    </tr>\n"
+
+        for op_name, details in operations.items():
+            for response_code, covered in details.items():
+                coverage_details += "    <tr>\n"
+                coverage_details += f"    <td>{service}</td>\n"
+                coverage_details += f"    <td>{op_name}</td>\n"
+                coverage_details += f"""    <td style="text-align: center">{response_code}</td>\n"""
+                coverage_details += (
+                    f"""    <td style="text-align: center">{'✅' if covered else '❌'}</td>\n"""
+                )
+                coverage_details += "    </tr>\n"
+    if additional_tested_collection:
+        additional_test_details = """<table>
+      <tr>
+        <th>Service</th>
+        <th>Operation</th>
+        <th>Return Code</th>
+        <th>Covered By Acceptance Test</th>
+      </tr>"""
+        for service, operations in coverage_collection.items():
+            for op_name, details in operations.items():
+                for response_code, covered in details.items():
+                    additional_test_details += "    <tr>\n"
+                    additional_test_details += f"    <td>{service}</td>\n"
+                    additional_test_details += f"    <td>{op_name}</td>\n"
+                    additional_test_details += f"    <td>{response_code}</td>\n"
+                    additional_test_details += f"    <td>{'✅' if covered else '❌'}</td>\n"
+                    additional_test_details += "    </tr>\n"
+        additional_test_details += "</table><br/>\n"
+    service_overview_coverage += "</table><br/>\n"
+    coverage_details += "</table><br/>\n"
+    path = Path(output_dir)
+    file_name = path.joinpath("report_metric_coverage.html")
+    with open(file_name, "w") as fd:
+        fd.write(
+            """<!doctype html>
+<html>
+  <style>
+    h1 {text-align: center;}
+    h2 {text-align: center;}
+    table {text-align: left;margin-left:auto;margin-right:auto;}
+    p {text-align: center;}
+    div {text-align: center;}
+ </style>
+<body>"""
+        )
+        fd.write("  <h1>Diff Report Metrics Coverage</h1>\n")
+        fd.write("   <h2>Service Coverage</h2>\n")
+        fd.write(
+            "       <div><p>Assumption: the initial test suite is considered to have 100% coverage.</p>\n"
+        )
+        fd.write(f"<p>{service_overview_coverage}</p></div>\n")
+        fd.write("   <h2>Coverage Details</h2>\n")
+        fd.write(f"<div>{coverage_details}</div>")
+        if additional_test_details:
+            fd.write("    <h2>Additional Test Coverage</h2>\n")
+            fd.write(
+                "<div>     Note: this is probalby wrong usage of the script. It includes operations that have been covered with the acceptance tests only"
+            )
+            fd.write(f"<p>{additional_test_details}</p></div>\n")
+        fd.write("</body></html")
+
+
+def main():
+    coverage_path_all = os.environ.get("COVERAGE_DIR_ALL", "")
+    coverage_path_acceptance = os.environ.get("COVERAGE_DIR_ACCEPTANCE", "")
+    output_dir = os.environ.get("OUTPUT_DIR", "")
+    if not coverage_path_all or not coverage_path_acceptance:
+        print_usage()
+    print(
+        f"COVERAGE_DIR_ALL={coverage_path_all}, COVERAGE_DIR_ACCEPTANCE={coverage_path_acceptance}, OUTPUTDIR={output_dir}"
+    )
+
+    coverage_collection = create_initial_coverage(coverage_path_all)
+    additional_tested = mark_coverage_acceptance_test(coverage_path_acceptance, coverage_collection)
+
+    if additional_tested:
+        print(
+            "WARN: Found tests that are covered by acceptance tests, but haven't been covered by the initial tests"
+        )
+
+    create_readable_report(coverage_collection, additional_tested, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/metrics_coverage/diff_metrics_coverage.py
+++ b/scripts/metrics_coverage/diff_metrics_coverage.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 
 def print_usage():
-    return """
+    print(
+        """
     Helper script to an output report for the metrics coverage diff.
 
     Set the env `COVERAGE_DIR_ALL` which points to a folder containing metrics-raw-data reports for the initial tests.
@@ -13,6 +14,7 @@ def print_usage():
 
     Use `OUTPUT_DIR` env to set the path where the report will be stored
     """
+    )
 
 
 def sort_dict_helper(d):
@@ -173,15 +175,17 @@ def create_readable_report(
 
 
 def main():
-    coverage_path_all = os.environ.get("COVERAGE_DIR_ALL", "")
-    coverage_path_acceptance = os.environ.get("COVERAGE_DIR_ACCEPTANCE", "")
-    output_dir = os.environ.get("OUTPUT_DIR", "")
-    if not coverage_path_all or not coverage_path_acceptance:
+    coverage_path_all = os.environ.get("COVERAGE_DIR_ALL")
+    coverage_path_acceptance = os.environ.get("COVERAGE_DIR_ACCEPTANCE")
+    output_dir = os.environ.get("OUTPUT_DIR")
+
+    if not coverage_path_all or not coverage_path_acceptance or not output_dir:
         print_usage()
+        return
+
     print(
         f"COVERAGE_DIR_ALL={coverage_path_all}, COVERAGE_DIR_ACCEPTANCE={coverage_path_acceptance}, OUTPUTDIR={output_dir}"
     )
-
     coverage_collection = create_initial_coverage(coverage_path_all)
     additional_tested = mark_coverage_acceptance_test(coverage_path_acceptance, coverage_collection)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With the introduction of the acceptance test suite in #9045 we started collecting metrics as well. 
This PR aims to provide the first prototype to quickly glance through the collected metrics.

Currently we have two kind of metrics:
- code coverage
- api coverage

In the future those metrics are intended to help service owners to choose tests that should be part of the acceptance test suite. 

### Code Coverage
The code coverage is collected using the pytest plugin `coverage`, and results in a sqlite database added as artifact in the `report` job. 
Code coverage for the "normal" integration test is already reported to coveralls.

In order to get an overview about the acceptance coverage and the diff, we create two html reports, using [pycobertura](https://github.com/aconrad/pycobertura):
* **coverage-acceptance.html**
  * shows the acceptance code coverage
  * currently it only considers the files in `localstack/services` (which IMO are only relevant ones for the acceptance test suite, but we can discuss this)
  * it also excludes all `__init__.py` files to prevent blowing up the report with (probably) irrelevant information. 
* **coverage-diff.html**
  * same restrictions as above, e.g. only considering `localstack/services` and ignoring `__init__.py`
  * gives an overview about code lines that are missed by the acceptance test suite

### API Coverage
The metric collection for our test suite include data about each API call. 
To keep things simple, the first prototype considers only service-operation-responsecode combinations. 
We could further enhance this to include specific exceptions, or parameters used. 
The report **api-coverage/report_metric_coverage.html** is added as an artifact to the `report` job as well.

#### Details
The PR adds a small script that can be used to create simple HTML report outlining some basic metrics:
* It will show a very naive calculation of service coverage, by counting the amount of operations for each service that have been called for the full integration test suite (which is then treated as 100%); vs the operation called by the acceptance test suite (not considering the specific response codes)
![Screenshot 2023-09-21 at 17 47 34](https://github.com/localstack/localstack/assets/5726672/0f574603-9b33-4abe-bc4b-867e49c634f4)


* Additionally, the report contains a list of all service-operation-responsecode combinations and a hint if those have been covered by the acceptance tests.
![Screenshot 2023-09-21 at 17 47 48](https://github.com/localstack/localstack/assets/5726672/1b21094a-a899-448a-85ce-c13bc723b07f)
 


<!-- What notable changes does this PR make? -->
## Changes
* added two steps to the `report` job to create the html reports



<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

