### PR TITLE
fix h11 LocalProtocolError on connection close by client

### DIFF
--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -296,6 +296,8 @@ class WsgiStartResponse:
         if not self.started:
             raise ValueError("not started the response yet")
         if getattr(self.send.__self__, "closed", None):
+            # the connection has been closed from the client side, set finalized=True to avoid sending more responses
+            self.finalized = True
             raise BrokenPipeError("Connection closed")
         await self.send({"type": "http.response.body", "body": data, "more_body": True})
         self.sent += len(data)


### PR DESCRIPTION
## Motivation
This PR fixes a cosmetic error when a client unexpectedly closes the connection, because h11 would try to send a response with a predefined content length, even though the connection has been closed and there's no body left to send.
This can be reproduced f.e. if you exploit the initial service catalog cache building (which takes ~1.5 seconds):
- Start a bash which fires health requests to the (not yet running) LocalStack instance:
  ```
  until curl --fail --silent --max-time 1 http://localhost:4566/_localstack/health; do sleep "0.1"; done
  ```
- Remove existing service catalog caches:
  ```
  sudo rm -rf ~/.cache/localstack/volume/cache/
  ```
- Afterwards start LocalStack:
  ```
  localstack start
  ```
- The following error will be logged:
  ```
  2023-09-20T14:01:05.126 DEBUG --- [-functhread6] localstack.http.asgi       : Error while writing responses: Connection closed (client_info: 172.17.0.1:56602)
  2023-09-20T14:01:05.128 ERROR --- [-functhread6] hypercorn.error            : Error in ASGI Framework
  Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/asyncio/task_group.py", line 23, in _handle
  await app(scope, receive, send, sync_spawn, call_soon)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/app_wrappers.py", line 33, in __call__
  await self.app(scope, receive, send)
  File "/opt/code/localstack/localstack/aws/serving/asgi.py", line 70, in __call__
  return await self.adapter(scope, receive, send)
  File "/opt/code/localstack/localstack/http/asgi.py", line 488, in __call__
  return await self.handle_http(scope, receive, send)
  File "/opt/code/localstack/localstack/http/asgi.py", line 559, in handle_http
  await response.close()
  File "/opt/code/localstack/localstack/http/asgi.py", line 311, in close
  await self.send({"type": "http.response.body", "body": b"", "more_body": False})
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/http_stream.py", line 188, in app_send
  await self.send(EndBody(stream_id=self.stream_id))
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/h11.py", line 138, in stream_send
  await self._send_h11_event(h11.EndOfMessage())
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/h11.py", line 240, in _send_h11_event
  data = self.connection.send(event)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_connection.py", line 512, in send
  data_list = self.send_with_data_passthrough(event)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_connection.py", line 545, in send_with_data_passthrough
  writer(event, data_list.append)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_writers.py", line 67, in __call__
  self.send_eom(event.headers, write)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_writers.py", line 96, in send_eom
  raise LocalProtocolError("Too little data for declared Content-Length")
  h11._util.LocalProtocolError: Too little data for declared Content-Length
  2023-09-20T14:01:05.128 ERROR --- [-functhread6] hypercorn.error            : Error in ASGI Framework
  Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/asyncio/task_group.py", line 23, in _handle
  await app(scope, receive, send, sync_spawn, call_soon)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/app_wrappers.py", line 33, in __call__
  await self.app(scope, receive, send)
  File "/opt/code/localstack/localstack/aws/serving/asgi.py", line 70, in __call__
  return await self.adapter(scope, receive, send)
  File "/opt/code/localstack/localstack/http/asgi.py", line 488, in __call__
  return await self.handle_http(scope, receive, send)
  File "/opt/code/localstack/localstack/http/asgi.py", line 559, in handle_http
  await response.close()
  File "/opt/code/localstack/localstack/http/asgi.py", line 311, in close
  await self.send({"type": "http.response.body", "body": b"", "more_body": False})
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/http_stream.py", line 188, in app_send
  await self.send(EndBody(stream_id=self.stream_id))
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/h11.py", line 138, in stream_send
  await self._send_h11_event(h11.EndOfMessage())
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/protocol/h11.py", line 240, in _send_h11_event
  data = self.connection.send(event)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_connection.py", line 512, in send
  data_list = self.send_with_data_passthrough(event)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_connection.py", line 545, in send_with_data_passthrough
  writer(event, data_list.append)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_writers.py", line 67, in __call__
  self.send_eom(event.headers, write)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/h11/_writers.py", line 96, in send_eom
  raise LocalProtocolError("Too little data for declared Content-Length")
  h11._util.LocalProtocolError: Too little data for declared Content-Length
  ```

This issue was introduced with #8582 (because since then the shutdown of generators is properly handled).
/cc @whummer 

## Changes
- Before raising a `BrokenPipeError`, set `WsgiStartResponse.finalized = True` to avoid sending the connection close response.

## Testing
Unfortunately, I was having a hard time coming up with a test.
I verified the fix locally, however, I'm happy for any feedback for a unit test.