### PR TITLE
Fix build failures by pinning jsonschema<=4.19.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-ng==1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
+    # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
     localstack-client>=2.0
     moto-ext[all]==4.2.2.post2

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-ng==1.5.3
     jsonpath-rw>=1.4.0,<2.0.0
+    jsonschema<=4.19.0
     localstack-client>=2.0
     moto-ext[all]==4.2.2.post2
     opensearch-py==2.1.1


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Recent release `4.19.1` of `jsonschema` broke our pipeline due to our dependency on `openapi-schema-validator` (via moto).

Upstream issue: python-openapi/openapi-schema-validator#131 .

<!-- What notable changes does this PR make? -->
## Changes
* Pin `jsonschema` to 4.19.0 or lower

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

