### PR TITLE
introduce request finalizers into handler chain

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -69,21 +69,26 @@ class LocalstackAwsGateway(Gateway):
                 handlers.add_cors_response_headers,
                 handlers.log_response,
                 handlers.count_service_request,
-                handlers.pop_request_context,
                 metric_collector.update_metric_collection,
             ]
         )
 
+        # request chain finalization
         self.finalizers.extend(
             [
                 handlers.set_close_connection_header,
+                handlers.run_custom_finalizers,
+                handlers.pop_request_context,
             ]
         )
 
     def new_chain(self) -> HandlerChain:
         if config.DEBUG_HANDLER_CHAIN:
             return TracingHandlerChain(
-                self.request_handlers, self.response_handlers, self.exception_handlers
+                self.request_handlers,
+                self.response_handlers,
+                self.finalizers,
+                self.exception_handlers,
             )
         return super().new_chain()
 

--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -65,13 +65,18 @@ class LocalstackAwsGateway(Gateway):
             [
                 handlers.modify_service_response,
                 handlers.parse_service_response,
-                handlers.set_close_connection_header,
                 handlers.run_custom_response_handlers,
                 handlers.add_cors_response_headers,
                 handlers.log_response,
                 handlers.count_service_request,
                 handlers.pop_request_context,
                 metric_collector.update_metric_collection,
+            ]
+        )
+
+        self.finalizers.extend(
+            [
+                handlers.set_close_connection_header,
             ]
         )
 

--- a/localstack/aws/gateway.py
+++ b/localstack/aws/gateway.py
@@ -24,6 +24,7 @@ class Gateway:
         super().__init__()
         self.request_handlers = list()
         self.response_handlers = list()
+        self.finalizers = list()
         self.exception_handlers = list()
 
     def new_chain(self) -> HandlerChain:

--- a/localstack/aws/gateway.py
+++ b/localstack/aws/gateway.py
@@ -17,6 +17,7 @@ class Gateway:
 
     request_handlers: List[Handler]
     response_handlers: List[Handler]
+    finalizers: List[Handler]
     exception_handlers: List[ExceptionHandler]
 
     def __init__(self) -> None:
@@ -26,7 +27,12 @@ class Gateway:
         self.exception_handlers = list()
 
     def new_chain(self) -> HandlerChain:
-        return HandlerChain(self.request_handlers, self.response_handlers, self.exception_handlers)
+        return HandlerChain(
+            self.request_handlers,
+            self.response_handlers,
+            self.finalizers,
+            self.exception_handlers,
+        )
 
     def process(self, request: Request, response: Response):
         chain = self.new_chain()

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -38,6 +38,7 @@ run_custom_response_handlers = chain.CompositeResponseHandler()
 modify_service_response = service.ServiceResponseHandlers()
 parse_service_response = service.ServiceResponseParser()
 parse_pre_signed_url_request = presigned_url.ParsePreSignedUrlRequest()
+run_custom_finalizers = chain.CompositeFinalizer()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()
 set_close_connection_header = legacy.set_close_connection_header

--- a/tests/unit/aws/test_chain.py
+++ b/tests/unit/aws/test_chain.py
@@ -14,6 +14,7 @@ class TestCompositeHandler:
         outer1 = mock.MagicMock()
         outer2 = mock.MagicMock()
         response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
 
         chain = HandlerChain()
 
@@ -25,12 +26,14 @@ class TestCompositeHandler:
         chain.request_handlers.append(composite)
         chain.request_handlers.append(outer2)
         chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
 
         chain.handle(RequestContext(), Response())
         outer1.assert_called_once()
         outer2.assert_not_called()
         inner2.assert_not_called()
         response1.assert_called_once()
+        finalizer.assert_called_once()
 
     def test_composite_handler_terminates_handler_chain(self):
         def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
@@ -40,6 +43,7 @@ class TestCompositeHandler:
         outer1 = mock.MagicMock()
         outer2 = mock.MagicMock()
         response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
 
         chain = HandlerChain()
 
@@ -51,12 +55,14 @@ class TestCompositeHandler:
         chain.request_handlers.append(composite)
         chain.request_handlers.append(outer2)
         chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
 
         chain.handle(RequestContext(), Response())
         outer1.assert_called_once()
         outer2.assert_not_called()
         inner2.assert_not_called()
         response1.assert_not_called()
+        finalizer.assert_called_once()
 
     def test_composite_handler_with_not_return_on_stop(self):
         def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
@@ -66,6 +72,7 @@ class TestCompositeHandler:
         outer1 = mock.MagicMock()
         outer2 = mock.MagicMock()
         response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
 
         chain = HandlerChain()
 
@@ -77,12 +84,14 @@ class TestCompositeHandler:
         chain.request_handlers.append(composite)
         chain.request_handlers.append(outer2)
         chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
 
         chain.handle(RequestContext(), Response())
         outer1.assert_called_once()
         outer2.assert_not_called()
         inner2.assert_called_once()
         response1.assert_called_once()
+        finalizer.assert_called_once()
 
     def test_composite_handler_continues_handler_chain(self):
         inner1 = mock.MagicMock()
@@ -90,6 +99,7 @@ class TestCompositeHandler:
         outer1 = mock.MagicMock()
         outer2 = mock.MagicMock()
         response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
 
         chain = HandlerChain()
 
@@ -101,6 +111,7 @@ class TestCompositeHandler:
         chain.request_handlers.append(composite)
         chain.request_handlers.append(outer2)
         chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
 
         chain.handle(RequestContext(), Response())
         outer1.assert_called_once()
@@ -108,6 +119,7 @@ class TestCompositeHandler:
         inner1.assert_called_once()
         inner2.assert_called_once()
         response1.assert_called_once()
+        finalizer.assert_called_once()
 
     def test_composite_handler_exception_calls_outer_exception_handlers(self):
         def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
@@ -118,6 +130,7 @@ class TestCompositeHandler:
         outer2 = mock.MagicMock()
         exception_handler = mock.MagicMock()
         response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
 
         chain = HandlerChain()
 
@@ -130,6 +143,7 @@ class TestCompositeHandler:
         chain.request_handlers.append(outer2)
         chain.exception_handlers.append(exception_handler)
         chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
 
         chain.handle(RequestContext(), Response())
         outer1.assert_called_once()
@@ -137,3 +151,4 @@ class TestCompositeHandler:
         inner2.assert_not_called()
         exception_handler.assert_called_once()
         response1.assert_called_once()
+        finalizer.assert_called_once()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In the persistence plugin (and perhaps elsewhere), we are using a pattern where we are acquiring locks in request handlers, and freeing them in response handlers, to lock certain things across a request invocation. This can lead to locks never being freed, when handlers (like the CORS enforcer) call `chain.terminate()`, which prevents response handlers from being called.

This PR introduces the concept of finalizers into the handler chain, which are *always* called, even if the chain is terminated. Obviously these should be used sparsely, and only run essential finalization code.

<!-- What notable changes does this PR make? -->
## Changes

* Introduce the `finalizer: List[Handler]` attribute
* Re-formatted a bunch of docs to match the column limit of our black config

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

