### PR TITLE
replace deprecated command with environment file

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -128,10 +128,10 @@ function explain_release_steps() {
 }
 
 function print_github_outputs() {
-    echo "::set-output name=current::${CURRENT_VER}"
-    echo "::set-output name=release::${RELEASE_VER}"
-    echo "::set-output name=develop::${DEVELOP_VER}"
-    echo "::set-output name=boundary::${BOUNDARY_VER}"
+    echo "current=${CURRENT_VER}" >> $GITHUB_OUTPUT
+    echo "release=${RELEASE_VER}" >> $GITHUB_OUTPUT
+    echo "develop=${DEVELOP_VER}" >> $GITHUB_OUTPUT
+    echo "boundary=${BOUNDARY_VER}" >> $GITHUB_OUTPUT
 }
 
 # commands


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Closes #9196 

Update `bin/release-helper.sh` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

<!-- What notable changes does this PR make? -->
## Changes

Replace deprecated command with environment file.

**AS-IS**

```shell
function print_github_outputs() {
    echo "::set-output name=current::${CURRENT_VER}"
    echo "::set-output name=release::${RELEASE_VER}"
    echo "::set-output name=develop::${DEVELOP_VER}"
    echo "::set-output name=boundary::${BOUNDARY_VER}"
}
```

**TO-BE**

```shell
function print_github_outputs() {
    echo "current=${CURRENT_VER}" >> $GITHUB_OUTPUT
    echo "release=${RELEASE_VER}" >> $GITHUB_OUTPUT
    echo "develop=${DEVELOP_VER}" >> $GITHUB_OUTPUT
    echo "boundary=${BOUNDARY_VER}" >> $GITHUB_OUTPUT
}
```
