### PR TITLE
add warning about future deprecation of stepfunctions v1 provider

### DIFF
--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -35,7 +35,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
 
     def on_after_init(self):
         LOG.warning(
-            "The 'v1' (current default) stepfunctions provider will be deprecated with the next major release (3.0). Set 'PROVIDER_OVERRIDE_STEPFUNCTIONS=v2' to opt-in to the new StepFunctions provider."
+            "The 'v1' (current default) StepFunctions provider will be deprecated with the next major release (3.0). Set 'PROVIDER_OVERRIDE_STEPFUNCTIONS=v2' to opt-in to the new StepFunctions provider."
         )
 
     def get_forward_url(self) -> str:

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -33,6 +33,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     def __init__(self):
         self.forward_request = get_request_forwarder_http(self.get_forward_url)
 
+    def on_after_init(self):
+        LOG.warning(
+            "The 'v1' (current default) stepfunctions provider will be deprecated with the next major release (3.0). Set 'PROVIDER_OVERRIDE_STEPFUNCTIONS=v2' to opt-in to the new StepFunctions provider."
+        )
+
     def get_forward_url(self) -> str:
         """Return the URL of the backend StepFunctions server to forward requests to"""
         return f"http://{LOCALHOST}:{config.LOCAL_PORT_STEPFUNCTIONS}"

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -35,7 +35,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
 
     def on_after_init(self):
         LOG.warning(
-            "The 'v1' (current default) StepFunctions provider will be deprecated with the next major release (3.0). Set 'PROVIDER_OVERRIDE_STEPFUNCTIONS=v2' to opt-in to the new StepFunctions provider."
+            "The 'v1' StepFunctions provider (current default) will be deprecated with the next major release (3.0). "
+            "Set 'PROVIDER_OVERRIDE_STEPFUNCTIONS=v2' to opt-in to the new StepFunctions 'v2' provider."
         )
 
     def get_forward_url(self) -> str:


### PR DESCRIPTION
## Motivation

* With **2.3** we want to start advertising the new `v2` stepfunctions provider more broadly and also let users know that with the next major release, the defaults will change. Ideally anyone using stepfunctions should start to at least opt-in at some point and make sure their current applications are still working with `v2`.
* With **3.0** the old (`v1`) provider will become deprecated and `v2` will become the new default. Users can still opt-in to the old `v1` provider.
* With **4.0** the old (`v1`) provider will be removed completely.

## Changes

- Log a warning when the stepfunctions `v1` provider is used. Only logged during initialization since a lot of people might not be affected at this point if they're not using the stepfunctions service at all.

## Discussion

We should also make sure our language is somewhat similar between all the upcoming provider deprecations (s3, lambda, stepfunctions).  /cc @bentsku @joe4dev 
