### PR TITLE
Bump moto-ext to 4.2.3.post1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ runtime =
     # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
     localstack-client>=2.0
-    moto-ext[all]==4.2.2.post2
+    moto-ext[all]==4.2.3.post1
     opensearch-py==2.1.1
     pproxy>=2.7.0
     pymongo>=4.2.0


### PR DESCRIPTION
Ext integration passing :heavy_check_mark:  See Ext Integration Tests # 2467 

Closes: https://github.com/localstack/localstack/issues/8550