### PR TITLE
Fix service health endpoint with custom GATEWAY_LISTEN

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -8,7 +8,6 @@ import traceback
 from typing import Dict, List, Union
 
 import boto3
-from localstack_client.config import get_service_port
 from moto.core import BaseModel
 from moto.core.base_backend import InstanceTrackerMeta
 
@@ -243,7 +242,8 @@ def start_moto_server_separate(key, port, name=None, backend_port=None, asynchro
 
 
 def add_service_proxy_listener(api: str, listener: ProxyListener, port=None):
-    PROXY_LISTENERS[api] = (api, port or get_service_port(api), listener)
+    port = port or config.GATEWAY_LISTEN[0].port
+    PROXY_LISTENERS[api] = (api, port, listener)
 
 
 def start_local_api(name, port, api, method, asynchronous=False, listener=None):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When using `GATEWAY_LISTEN` to override the hypercorn port(s) the internal service health checks are not configured to use this gateway port. This means that the internal health checks will fail.


<!-- What notable changes does this PR make? -->
## Changes

- Add tests that creates a service and checks the internal health check log line, configuring `GATEWAY_LISTEN` and `LOCALSTACK_HOST` (based on existing behaviour).
- Proxy listeners adhere to `GATEWAY_LISTEN`



<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

