### PR TITLE
disable health check for default service providers

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -174,6 +174,7 @@ class Service:
             name=provider.service,
             listener=AwsApiListener(provider.service, delegate=delegate),
             lifecycle_hook=service_lifecycle_hook,
+            check=None,
         )
         service._provider = provider
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

For legacy reasons, we used the `local_api_checker` as default health check. This made sense when we had backends running on different ports, but now almost all providers run in memory and not as backends, and those that require backends (like dynamodb), aren't considered anymore through the default `local_api_checker` health check (since we basically just call `:4566`).
Basically, doing health checks in this way makes no sense any more, and we can evaluate whether the concept as such makes sense and if so what we need to do to perform meaningful health checks.

I've seen errors related to these health checks in logs recently, and I think this is a good opportunity to get rid of them.


<!-- What notable changes does this PR make? -->
## Changes

* When using `Service.for_provider` (which is done in most cases), disable the health check

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

