### PR TITLE
Add removal warning for legacy lambda provider

### DIFF
--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -303,6 +303,22 @@ def log_deprecation_warnings(deprecations: Optional[List[EnvVarDeprecation]] = N
     affected_deprecations = collect_affected_deprecations(deprecations)
     log_env_warning(affected_deprecations)
 
+    provider_override_lambda = os.environ.get("PROVIDER_OVERRIDE_LAMBDA")
+    if provider_override_lambda and provider_override_lambda in ["v1", "legacy"]:
+        env_var_value = f"PROVIDER_OVERRIDE_LAMBDA={provider_override_lambda}"
+        deprecation_version = "2.0.0"
+        deprecation_path = (
+            f"Remove {env_var_value} to use the new Lambda 'v2' provider (current default). "
+            "For more details, refer to our Lambda migration guide "
+            "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2"
+        )
+        LOG.warning(
+            "%s is deprecated (since %s) and will be removed in upcoming releases of LocalStack! %s",
+            env_var_value,
+            deprecation_version,
+            deprecation_path,
+        )
+
 
 def deprecated_endpoint(
     endpoint: Callable, previous_path: str, deprecation_version: str, new_path: str

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -1,7 +1,7 @@
 # A simple module to track deprecations over time / versions, and some simple functions guiding affected users.
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, List, Optional
 
 from localstack.utils.analytics import log
@@ -27,28 +27,6 @@ class EnvVarDeprecation:
         :return: true if the environment is affected / is using a deprecated config
         """
         return os.environ.get(self.env_var) is not None
-
-
-@dataclass
-class EnvVarValueDeprecation(EnvVarDeprecation):
-    """
-    Extension of EnvVarDeprecation to define a deprecation for a specific value of an environment variable config.
-    """
-
-    # The value or list of values considered to be deprecated
-    deprecation_value: str | list[str] = field(default_factory=list)
-
-    @property
-    def is_affected(self) -> bool:
-        """Checks whether an environment is affected.
-        :return: true if the value of the environment is affected
-        """
-        value = os.environ.get(self.env_var)
-        if value is None:
-            return False
-        if isinstance(self.deprecation_value, str):
-            return value == self.deprecation_value
-        return value in self.deprecation_value
 
 
 #
@@ -277,14 +255,6 @@ DEPRECATIONS = [
         "ES_ENDPOINT_STRATEGY",
         "0.14.0",
         "This option is marked for removal. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
-    ),
-    EnvVarValueDeprecation(
-        "PROVIDER_OVERRIDE_LAMBDA",
-        "2.3.0",
-        "PROVIDER_OVERRIDE_LAMBDA=v1/legacy is deprecated and will be removed with the next major release (3.0). "
-        "For more details, refer to our Lambda migration guide "
-        "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2",
-        ["v1", "legacy"],
     ),
 ]
 

--- a/localstack/services/lambda_/lambda_starter.py
+++ b/localstack/services/lambda_/lambda_starter.py
@@ -23,6 +23,12 @@ PATCHES_APPLIED = "LAMBDA_PATCHED"
 
 class LambdaLifecycleHook(ServiceLifecycleHook):
     def on_after_init(self):
+        LOG.warning(
+            "The deprecated 'v1'/'legacy' Lambda provider will be removed with the next major release (3.0). "
+            "Remove 'PROVIDER_OVERRIDE_LAMBDA' to use the new Lambda 'v2' provider (current default). "
+            "For more details, refer to our Lambda migration guide "
+            "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2"
+        )
         ROUTER.add(
             "/",
             host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",


### PR DESCRIPTION
## Motivation

* With 1.3, the new Lambda `v2` provider became available as opt-in.
* With 1.4 (ish), the legacy `v1` provider was deprecated and we encouraged users to opt-in to our new Lambda `v2` provider.
* With 2.0, the new lambda provider `v2` became the default implementation https://github.com/localstack/localstack/pull/6724.
* With 2.3, we add removal warnings in the old `v1` provider (this PR). We also ship the Lambda invocation loop rework https://github.com/localstack/localstack/pull/8970 (re-write of data plane).
* With 3.0 the old (v1) provider will be removed completely.

## Changes

Add a log warning when the legacy Lambda v1 provider is used. Only logged during initialization (`on_after_init`) for people using the legacy Lambda service.

## Discussion

Pro-active warnings at LocalStack startup:
* Do we want to prominently warn about deprecated environment values such as `PROVIDER_OVERRIDE_LAMBDA=v1` at the startup of LocalStack? We currently do not support this with `EnvVarDeprecation`. I drafted an `EnvVarValueDeprecation` in `a26c77375` but reverted it because it needs further updates in the logging message and telemetry if we even need this.
* I guess we would mainly use it for (important) provider deprecation warnings (e.g., S3, Lambda).
* It would help customers to see the warning right at the startup rather than potentially miss it somewhere in the logs when the provider gets loaded lazily.

Consistency: Trying to align the language for the deprecations and removals of s3, lambda, stepfunctions /cc
* @dominikschubert StepFunctions: https://github.com/localstack/localstack/pull/9198
* @bentsku S3: https://github.com/localstack/localstack/pull/9204
