### PR TITLE
Add S3 deprecation warnings

### DIFF
--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -242,7 +242,11 @@ def s3_legacy():
     from localstack.services.s3.legacy import s3_listener, s3_starter
 
     return Service(
-        "s3", listener=s3_listener.UPDATE_S3, start=s3_starter.start_s3, check=s3_starter.check_s3
+        "s3",
+        listener=s3_listener.UPDATE_S3,
+        start=s3_starter.start_s3,
+        check=s3_starter.check_s3,
+        lifecycle_hook=s3_starter.S3LifecycleHook(),
     )
 
 
@@ -251,7 +255,11 @@ def s3_v1():
     from localstack.services.s3.legacy import s3_listener, s3_starter
 
     return Service(
-        "s3", listener=s3_listener.UPDATE_S3, start=s3_starter.start_s3, check=s3_starter.check_s3
+        "s3",
+        listener=s3_listener.UPDATE_S3,
+        start=s3_starter.start_s3,
+        check=s3_starter.check_s3,
+        lifecycle_hook=s3_starter.S3LifecycleHook(),
     )
 
 

--- a/localstack/services/s3/legacy/s3_starter.py
+++ b/localstack/services/s3/legacy/s3_starter.py
@@ -11,6 +11,7 @@ from moto.s3.responses import S3_ALL_MULTIPARTS, MalformedXML, minidom
 from localstack import config
 from localstack.aws.connect import connect_to
 from localstack.services.infra import start_moto_server
+from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3 import constants as s3_constants
 from localstack.services.s3.legacy import s3_listener, s3_utils
 from localstack.utils.collections import get_safe
@@ -29,6 +30,15 @@ TMP_TAG = {}
 
 # Key for tracking patch applience
 PATCHES_APPLIED = "S3_PATCHED"
+
+
+class S3LifecycleHook(ServiceLifecycleHook):
+    def on_after_init(self):
+        LOG.warning(
+            "The deprecated 'v1'/'legacy' S3 provider will be removed with the next major release (3.0). "
+            "Remove 'PROVIDER_OVERRIDE_S3' to use the S3 'v2' provider (current default). "
+            "or set 'PROVIDER_OVERRIDE_S3=v3' to opt-in to the new 'v3' S3 provider."
+        )
 
 
 def check_s3(expect_shutdown=False, print_error=False):


### PR DESCRIPTION
## Motivation

* With 1.?, the new S3 `v2` provider became available as opt-in.
* With 1.4, the legacy `v1` provider was deprecated and we encouraged users to opt-in to our new S3 `v2` provider.
* With 2.0, the current S3 provider `v2` became the default implementation https://github.com/localstack/localstack/pull/6724.
* With 2.3, we add removal warnings in the old `v1` provider (this PR) and the new native S3 provider `v3` becomes available https://github.com/localstack/localstack/pull/8785.
* With 3.0 the old (v1) provider will be removed completely and the new native S3 provider `v3` becomes the default.
* With 3.1/3.2? (TBD), the current S3 provider `v2` provider will be deprecated
* With 4.0 the current S3 provider `v2` will be removed completely.

## Changes

Add a log warning when the legacy S3 v1 provider is used. Only logged during initialization (`on_after_init`) for people using the legacy S3 service.

⚠️ This PR needs to be merged before the ext PR: https://github.com/localstack/localstack-ext/pull/2115

## Discussion

Consistency: Trying to align the language for the deprecations and removals of s3, lambda, stepfunctions /cc
* @dominikschubert StepFunctions: https://github.com/localstack/localstack/pull/9198
* @joe4dev Lambda: https://github.com/localstack/localstack/pull/9203
