### PR TITLE
make config.dirs.tmp be inside the container filesystem, add mounted_tmp

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -173,7 +173,7 @@ class Directories:
             var_libs=None,
             cache=str(cache_dir),  # used by analytics metadata
             tmp=tmp_dir,
-            mounted_tmp=None,
+            mounted_tmp=tmp_dir,
             functions=None,
             data=os.path.join(tmp_dir, "state"),  # used by localstack_ext config TODO: remove
             logs=os.path.join(tmp_dir, "logs"),  # used for container logs

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -40,7 +40,8 @@ class Directories:
         static_libs: container only; binaries and libraries statically packaged with the image
         var_libs:    shared; binaries and libraries+data computed at runtime: lazy-loaded binaries, ssl cert, ...
         cache:       shared; ephemeral data that has to persist across localstack runs and reboots
-        tmp:         shared; ephemeral data that has to persist across localstack runs but not reboots
+        tmp:         container only; ephemeral data that has to persist across localstack runs but not reboots
+        mounted_tmp: shared; same as above, but shared for persistence across different containers, tests, ...
         functions:   shared; volume to communicate between host<->lambda containers
         data:        shared; holds localstack state, pods, ...
         config:      host only; pre-defined configuration values, cached credentials, machine id, ...
@@ -52,6 +53,7 @@ class Directories:
     var_libs: str
     cache: str
     tmp: str
+    mounted_tmp: str
     functions: str
     data: str
     config: str
@@ -64,6 +66,7 @@ class Directories:
         var_libs: str,
         cache: str,
         tmp: str,
+        mounted_tmp: str,
         functions: str,
         data: str,
         config: str,
@@ -75,6 +78,7 @@ class Directories:
         self.var_libs = var_libs
         self.cache = cache
         self.tmp = tmp
+        self.mounted_tmp = mounted_tmp
         self.functions = functions
         self.data = data
         self.config = config
@@ -88,7 +92,8 @@ class Directories:
             static_libs="/usr/lib/localstack",
             var_libs=f"{DEFAULT_VOLUME_DIR}/lib",
             cache=f"{DEFAULT_VOLUME_DIR}/cache",
-            tmp=f"{DEFAULT_VOLUME_DIR}/tmp",
+            tmp=os.path.join(tempfile.gettempdir(), "localstack"),
+            mounted_tmp=f"{DEFAULT_VOLUME_DIR}/tmp",
             functions=f"{DEFAULT_VOLUME_DIR}/tmp",  # FIXME: remove - this was misconceived
             data=f"{DEFAULT_VOLUME_DIR}/state",
             logs=f"{DEFAULT_VOLUME_DIR}/logs",
@@ -112,6 +117,7 @@ class Directories:
             var_libs=defaults.var_libs,
             cache=defaults.cache,
             tmp=tmp_dir,
+            mounted_tmp=defaults.mounted_tmp,
             functions=defaults.functions,
             data=defaults.data if PERSISTENCE else os.path.join(tmp_dir, "state"),
             config=defaults.config,
@@ -138,6 +144,7 @@ class Directories:
             var_libs=os.path.join(root, defaults.var_libs.lstrip("/")),
             cache=os.path.join(root, defaults.cache.lstrip("/")),
             tmp=tmp,
+            mounted_tmp=os.path.join(root, defaults.mounted_tmp.lstrip("/")),
             functions=os.path.join(root, defaults.functions.lstrip("/")),
             data=data if PERSISTENCE else os.path.join(tmp, "state"),
             config=os.path.join(root, defaults.config.lstrip("/")),
@@ -166,6 +173,7 @@ class Directories:
             var_libs=None,
             cache=str(cache_dir),  # used by analytics metadata
             tmp=tmp_dir,
+            mounted_tmp=None,
             functions=None,
             data=os.path.join(tmp_dir, "state"),  # used by localstack_ext config TODO: remove
             logs=os.path.join(tmp_dir, "logs"),  # used for container logs
@@ -179,6 +187,7 @@ class Directories:
             self.var_libs,
             self.cache,
             self.tmp,
+            self.mounted_tmp,
             self.functions,
             self.data,
             self.config,

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -100,19 +100,20 @@ class Directories:
     def for_container() -> "Directories":
         """
         Returns Localstack directory paths as they are defined within the container. Everything shared and writable
-        lives in /var/lib/localstack or /tmp/localstack.
+        lives in /var/lib/localstack or {tempfile.gettempdir()}/localstack.
 
         :returns: Directories object
         """
         defaults = Directories.defaults()
+        tmp_dir = os.path.join(tempfile.gettempdir(), "localstack")
 
         return Directories(
             static_libs=defaults.static_libs,
             var_libs=defaults.var_libs,
             cache=defaults.cache,
-            tmp=defaults.tmp,
+            tmp=tmp_dir,
             functions=defaults.functions,
-            data=defaults.data if PERSISTENCE else os.path.join(defaults.tmp, "state"),
+            data=defaults.data if PERSISTENCE else os.path.join(tmp_dir, "state"),
             config=defaults.config,
             logs=defaults.logs,
             init=defaults.init,

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -110,16 +110,15 @@ class Directories:
         :returns: Directories object
         """
         defaults = Directories.defaults()
-        tmp_dir = os.path.join(tempfile.gettempdir(), "localstack")
 
         return Directories(
             static_libs=defaults.static_libs,
             var_libs=defaults.var_libs,
             cache=defaults.cache,
-            tmp=tmp_dir,
+            tmp=defaults.tmp,
             mounted_tmp=defaults.mounted_tmp,
             functions=defaults.functions,
-            data=defaults.data if PERSISTENCE else os.path.join(tmp_dir, "state"),
+            data=defaults.data if PERSISTENCE else os.path.join(defaults.tmp, "state"),
             config=defaults.config,
             logs=defaults.logs,
             init=defaults.init,

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -315,6 +315,14 @@ def cleanup_resources():
                 config.dirs.tmp,
                 e,
             )
+        try:
+            files.rm_rf(config.dirs.mounted_tmp)
+        except PermissionError as e:
+            LOG.error(
+                "unable to delete mounted temp folder %s: %s, please delete manually or you will keep seeing these errors",
+                config.dirs.mounted_tmp,
+                e,
+            )
 
 
 def log_startup_message(service):

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -116,7 +116,7 @@ def get_image_environment_variable(env_name: str) -> Optional[str]:
 
 
 def get_container_default_logfile_location(container_name: str) -> str:
-    return os.path.join(config.dirs.tmp, f"{container_name}_container.log")
+    return os.path.join(config.dirs.mounted_tmp, f"{container_name}_container.log")
 
 
 def get_server_version_from_running_container() -> str:

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -1017,7 +1017,7 @@ class Util:
 
     @staticmethod
     def mountable_tmp_file():
-        f = os.path.join(config.dirs.tmp, short_uid())
+        f = os.path.join(config.dirs.mounted_tmp, short_uid())
         TMP_FILES.append(f)
         return f
 

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -49,7 +49,7 @@ class TestHotReloading:
         """Test hot reloading of lambda code"""
         function_name = f"test-hot-reloading-{short_uid()}"
         hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
-        tmp_path = config.dirs.tmp
+        tmp_path = config.dirs.mounted_tmp
         hot_reloading_dir_path = os.path.join(tmp_path, f"hot-reload-{short_uid()}")
         mkdir(hot_reloading_dir_path)
         cleanups.append(lambda: rm_rf(hot_reloading_dir_path))
@@ -116,7 +116,7 @@ class TestHotReloading:
 
         function_name = f"test-hot-reloading-{short_uid()}"
         hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
-        tmp_path = config.dirs.tmp
+        tmp_path = config.dirs.mounted_tmp
         hot_reloading_dir_path = os.path.join(tmp_path, f"hot-reload-{short_uid()}")
         mkdir(hot_reloading_dir_path)
         cleanups.append(lambda: rm_rf(hot_reloading_dir_path))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When working on S3 performance, it was shown that using mounted volumes on macOS induces a drop in filesystem operation performance from between 25 to 50%. This can be acceptable if using persistence, as there wouldn't be any other way to do it. However, when not using persistence, for many services, we are using the `config.dirs.data` folder (which points to tmp), which is inside the mounted volume, to create assets. This creates a drop in performance that might not be needed, if we can use the container own filesystem where it wouldn't be mounted.

<!-- What notable changes does this PR make? -->
## Changes
Use the `tempfile.gettempdir` method to create a temp dir which wouldn't clash inside the container for the `config.dirs.tmp`, which has the advantage of already having the logic for when persistence is disabled, data would direct to `config.dirs.tmp / "state"`. 

Create a new directory for the services that expected a temporary mounted directory, be it for tests or actual service implementation like RDS using it for sharing data between containers. 

### Solved PR discussions
Edit: seems like some Lambda tests are failing because they expect `tmp` to be a mounted dir. I guess we could change that? @joe4dev not sure if we need to change the directory used for the test, or if this is a real problem.
- tests/aws/services/lambda_/test_lambda.py::TestLayerHotReloading::test_layer_only_hot_reloading
- tests/aws/services/lambda_/test_lambda.py::TestLayerHotReloading::test_layer_and_function_hot_reloading

The issue is also in other services:
-  tests/aws/services/batch/test_batch.py::TestBatch::test_create_with_additional_config
- tests/aws/services/ec2/test_ec2.py::TestEC2::test_create_instance_with_ebs_create_fs
- tests/aws/services/ecs/test_ecs.py::TestTaskExecution::test_task_mount_host_volume
- tests/aws/services/eks/test_eks.py::TestK3SCluster::test_volume_mount

Basically, it seems we're using this mounted tmp as the directory to test mounted volume things. Should we just mount an arbitrary volume, something only for tests? That we could define? Or define another directory in `Directories` just for this? As this seems overkill to define a mounted `tmp` in the image we distribute just for testing purposes. 

Basically linked to this code snippet and this method `get_host_path_for_path_in_docker`:
```python
# note: directory must be mountable from the host, cannot use "tmpdir" fixture from pytest here...
local_tmpdir = DockerUtil.mountable_tmp_file()
host_tmpdir = get_host_path_for_path_in_docker(local_tmpdir)
```
@dfangl any insights into `DockerUtil.mountable_tmp_file`, does it really need to be mountable or can it be a regular file? Do we need another directory just for this, something like the cache one?

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

