### PR TITLE
fix APIGW matching with {proxy+} and methods

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -718,12 +718,10 @@ def get_resource_for_path(
         for match in matches:
             match_methods = list(match[1].get("resourceMethods", {}).keys())
             # only look for path matches if the request method is in the resource
-            if method in match_methods or "ANY" in match_methods:
+            if method.upper() in match_methods or "ANY" in match_methods:
                 # check if we have an exact match (exact matches take precedence) if the method is the same
-                if match[0] == path:
-                    return match
-                elif path_matches_pattern(path, match[0]):
-                    # not an exact match but parameters can fit in
+                if match[0] == path or path_matches_pattern(path, match[0]):
+                    # either an exact match or not an exact match but parameters can fit in
                     return match
 
                 filtered_matches.append(match)
@@ -1360,12 +1358,7 @@ def get_target_resource_method(invocation_context: ApiInvocationContext) -> Opti
     if not resource:
         return None
     methods = resource.get("resourceMethods") or {}
-    method_name = invocation_context.method.upper()
-    return (
-        methods.get(method_name)
-        or methods.get("ANY")
-        or methods.get("X-AMAZON-APIGATEWAY-ANY-METHOD")
-    )
+    return methods.get(invocation_context.method.upper()) or methods.get("ANY")
 
 
 def get_event_request_context(invocation_context: ApiInvocationContext):

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -461,7 +461,7 @@ class TestAPIGateway:
         path_map = get_rest_api_paths(
             account_id=TEST_AWS_ACCOUNT_ID, region_name=TEST_AWS_REGION_NAME, rest_api_id=api_id
         )
-        _, resource = get_resource_for_path(path, path_map)
+        _, resource = get_resource_for_path(path, method="POST", path_map=path_map)
 
         # make test request to gateway and check response
         path_with_replace = path.replace("{test_param1}", "foo1")

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -24,12 +24,12 @@ TEST_IMPORT_PETS = os.path.join(THIS_FOLDER, "../../files/pets.json")
         "$..body.host",
     ]
 )
-def test_export_swagger_openapi(aws_client, snapshot, import_file):
+def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file):
     snapshot.add_transformer(
         snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
     )
     spec_file = load_file(import_file)
-    response = aws_client.apigateway.import_rest_api(failOnWarnings=True, body=spec_file)
+    response, _ = import_apigw(body=spec_file, failOnWarnings=True)
     snapshot.match("import-api", response)
     api_id = response["id"]
 
@@ -60,13 +60,13 @@ def test_export_swagger_openapi(aws_client, snapshot, import_file):
         "$..body.servers..url",
     ]
 )
-def test_export_oas30_openapi(aws_client, snapshot, import_file):
+def test_export_oas30_openapi(aws_client, snapshot, import_apigw, import_file):
     snapshot.add_transformer(
         snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
     )
 
     spec_file = load_file(import_file)
-    response = aws_client.apigateway.import_rest_api(failOnWarnings=True, body=spec_file)
+    response, _ = import_apigw(body=spec_file, failOnWarnings=True)
     snapshot.match("import-api", response)
     api_id = response["id"]
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -35,73 +35,83 @@ from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import clone
 
 
-class ApiGatewayPathsTest(unittest.TestCase):
+class TestApiGatewayPaths:
     def test_extract_query_params(self):
         path, query_params = extract_query_string_params("/foo/bar?foo=foo&bar=bar&bar=baz")
-        self.assertEqual("/foo/bar", path)
-        self.assertEqual({"foo": "foo", "bar": ["bar", "baz"]}, query_params)
+        assert path == "/foo/bar"
+        assert query_params == {"foo": "foo", "bar": ["bar", "baz"]}
 
-    def test_extract_path_params(self):
-        params = extract_path_params("/foo/bar", "/foo/{param1}")
-        self.assertEqual({"param1": "bar"}, params)
+    @pytest.mark.parametrize(
+        "path,path_part,expected",
+        [
+            ("/foo/bar", "/foo/{param1}", {"param1": "bar"}),
+            ("/foo/bar1/bar2", "/foo/{param1}/{param2}", {"param1": "bar1", "param2": "bar2"}),
+            ("/foo/bar", "/foo/bar", {}),
+            ("/foo/bar/baz", "/foo/{proxy+}", {"proxy": "bar/baz"}),
+        ],
+    )
+    def test_extract_path_params(self, path, path_part, expected):
+        assert extract_path_params(path, path_part) == expected
 
-        params = extract_path_params("/foo/bar1/bar2", "/foo/{param1}/{param2}")
-        self.assertEqual({"param1": "bar1", "param2": "bar2"}, params)
+    @pytest.mark.parametrize(
+        "path,path_parts,expected",
+        [
+            ("/foo/bar", ["/foo/{param1}"], "/foo/{param1}"),
+            ("/foo/bar", ["/foo/bar", "/foo/{param1}"], "/foo/bar"),
+            ("/foo/bar/baz", ["/foo/bar", "/foo/{proxy+}"], "/foo/{proxy+}"),
+            ("/foo/bar/baz", ["/{proxy+}", "/foo/{proxy+}"], "/foo/{proxy+}"),
+            ("/foo/bar", ["/foo/bar1", "/foo/bar2"], None),
+            ("/foo/bar", ["/{param1}/bar1", "/foo/bar2"], None),
+            ("/foo/bar", ["/{param1}/{param2}/foo/{param3}", "/{param}/bar"], "/{param}/bar"),
+            ("/foo/bar", ["/{param1}/{param2}", "/{param}/bar"], "/{param}/bar"),
+            (
+                "/foo/bar/baz",
+                ["/{param1}/{param2}/baz", "/{param1}/bar/{param2}"],
+                "/{param1}/{param2}/baz",
+            ),
+            ("/foo/bar/baz", ["/foo123/{param1}/baz"], None),
+            ("/foo/bar/baz", ["/foo/{param1}/baz", "/foo/{param1}/{param2}"], None),
+        ],
+    )
+    def test_path_matches(self, path, path_parts, expected):
+        default_resource = {"resourceMethods": {"GET": {}}}
 
-        params = extract_path_params("/foo/bar", "/foo/bar")
-        self.assertEqual({}, params)
+        path_map = {path_part: default_resource for path_part in path_parts}
+        path, _ = get_resource_for_path(path, "GET", path_map)
+        assert path == expected
 
-        params = extract_path_params("/foo/bar/baz", "/foo/{proxy+}")
-        self.assertEqual({"proxy": "bar/baz"}, params)
+    def test_path_routing_with_method(self):
+        """Not using parametrization as testing a simple scenario, AWS validated"""
+        paths_map = {
+            "/{proxy+}": {"resourceMethods": {"OPTIONS": {}}},
+            "/foo": {"resourceMethods": {"POST": {}}},
+            "/foo/bar": {"resourceMethods": {"ANY": {}}},
+        }
+        # If there is an exact match on the path but the resource on that path does not match on the method, try
+        # greedy path then
 
-    def test_path_matches(self):
-        path, details = get_resource_for_path("/foo/bar", {"/foo/{param1}": {}})
-        self.assertEqual("/foo/{param1}", path)
+        path, _ = get_resource_for_path("/foo", "GET", paths_map)
+        # we can see that /foo would match 1:1, but it does not have a "GET" method, so it will try to match {proxy+},
+        # but proxy does not have a GET either, so it will not match anything
+        assert path is None
 
-        path, details = get_resource_for_path("/foo/bar", {"/foo/bar": {}, "/foo/{param1}": {}})
-        self.assertEqual("/foo/bar", path)
+        path, _ = get_resource_for_path("/foo", "OPTIONS", paths_map)
+        # now OPTIONS matches proxy
+        assert path == "/{proxy+}"
 
-        path, details = get_resource_for_path("/foo/bar/baz", {"/foo/bar": {}, "/foo/{proxy+}": {}})
-        self.assertEqual("/foo/{proxy+}", path)
+        path, _ = get_resource_for_path("/foo", "POST", paths_map)
+        # now POST directly matches /foo
+        assert path == "/foo"
 
-        path, details = get_resource_for_path(
-            "/foo/bar/baz", {"/{proxy+}": {}, "/foo/{proxy+}": {}}
-        )
-        self.assertEqual("/foo/{proxy+}", path)
+        path, _ = get_resource_for_path("/foo/bar", "GET", paths_map)
+        # with this nested path, it will try to match the exact 1:1, and this one contains ANY, which will properly
+        # match before trying {proxy+}
+        assert path == "/foo/bar"
 
-        result = get_resource_for_path("/foo/bar", {"/foo/bar1": {}, "/foo/bar2": {}})
-        self.assertEqual(None, result)
-
-        result = get_resource_for_path("/foo/bar", {"/{param1}/bar1": {}, "/foo/bar2": {}})
-        self.assertEqual(None, result)
-
-        path_args = {"/{param1}/{param2}/foo/{param3}": {}, "/{param}/bar": {}}
-        path, details = get_resource_for_path("/foo/bar", path_args)
-        self.assertEqual("/{param}/bar", path)
-
-        path_args = {"/{param1}/{param2}": {}, "/{param}/bar": {}}
-        path, details = get_resource_for_path("/foo/bar", path_args)
-        self.assertEqual("/{param}/bar", path)
-
-        path_args = {"/{param1}/{param2}": {}, "/{param1}/bar": {}}
-        path, details = get_resource_for_path("/foo/baz", path_args)
-        self.assertEqual("/{param1}/{param2}", path)
-
-        path_args = {"/{param1}/{param2}/baz": {}, "/{param1}/bar/{param2}": {}}
-        path, details = get_resource_for_path("/foo/bar/baz", path_args)
-        self.assertEqual("/{param1}/{param2}/baz", path)
-
-        path_args = {"/{param1}/{param2}/baz": {}, "/{param1}/{param2}/{param2}": {}}
-        path, details = get_resource_for_path("/foo/bar/baz", path_args)
-        self.assertEqual("/{param1}/{param2}/baz", path)
-
-        path_args = {"/foo123/{param1}/baz": {}}
-        result = get_resource_for_path("/foo/bar/baz", path_args)
-        self.assertEqual(None, result)
-
-        path_args = {"/foo/{param1}/baz": {}, "/foo/{param1}/{param2}": {}}
-        path, result = get_resource_for_path("/foo/bar/baz", path_args)
-        self.assertEqual("/foo/{param1}/baz", path)
+        path, _ = get_resource_for_path("/foo/bar", "OPTIONS", paths_map)
+        # with this nested path, it will try to match the exact 1:1, and this one contains ANY, which will properly
+        # match before trying {proxy+} even if it has the right OPTIONS method
+        assert path == "/foo/bar"
 
     def test_apply_request_parameters(self):
         integration = {
@@ -121,8 +131,10 @@ class ApiGatewayPathsTest(unittest.TestCase):
             path_params={"proxy": "foo/bar/baz"},
             query_params={"param": "foobar"},
         )
-        self.assertEqual("https://httpbin.org/anything/foo/bar/baz?param=foobar", uri)
+        assert uri == "https://httpbin.org/anything/foo/bar/baz?param=foobar"
 
+
+class TestApiGatewayRequestValidator(unittest.TestCase):
     def test_if_request_is_valid_with_no_resource_methods(self):
         ctx = ApiInvocationContext(
             method="POST",

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -70,15 +70,15 @@ class TestApiGatewayPaths:
                 "/{param1}/{param2}/baz",
             ),
             ("/foo/bar/baz", ["/foo123/{param1}/baz"], None),
-            ("/foo/bar/baz", ["/foo/{param1}/baz", "/foo/{param1}/{param2}"], None),
+            ("/foo/bar/baz", ["/foo/{param1}/baz", "/foo/{param1}/{param2}"], "/foo/{param1}/baz"),
         ],
     )
     def test_path_matches(self, path, path_parts, expected):
         default_resource = {"resourceMethods": {"GET": {}}}
 
         path_map = {path_part: default_resource for path_part in path_parts}
-        path, _ = get_resource_for_path(path, "GET", path_map)
-        assert path == expected
+        matched_path, _ = get_resource_for_path(path, "GET", path_map)
+        assert matched_path == expected
 
     def test_path_routing_with_method(self):
         """Not using parametrization as testing a simple scenario, AWS validated"""


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9207, we did not properly take into account the request method to retrieve the associated APIGW resource. We would take into account the path only, and then retrieve the method. 

<!-- What notable changes does this PR make? -->
## Changes
We now take the method into account, and don't match a path if it doesn't contain the request method or `ANY`. Added tests validating this behaviour against AWS, and adapted the unit tests too.
I suppose a bigger refactor would be nice around this, but this seemed like a rather urgent thing to fix. I'll take this into the APIGW backlog together with the more global refactor around the invocation. 

Sneaked a quick fix regarding fixture usage and cleanup for some export tests importing API.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

