### PR TITLE
use run_interactive for localstack ssh to fix tty issues

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -12,7 +12,6 @@ from localstack.cli.exceptions import CLIError
 from localstack.utils.analytics.cli import publish_invocation
 from localstack.utils.bootstrap import get_container_default_logfile_location
 from localstack.utils.json import CustomEncoder
-from localstack.utils.run import run_interactive
 
 from .console import BANNER, console
 from .plugin import LocalstackCli, load_cli_plugins
@@ -623,10 +622,7 @@ def cmd_ssh() -> None:
         raise CLIError(
             f'Expected a running LocalStack container named "{config.MAIN_CONTAINER_NAME}", but found none'
         )
-    try:
-        run_interactive(["docker", "exec", "-it", config.MAIN_CONTAINER_NAME, "bash"])
-    except KeyboardInterrupt:
-        pass
+    os.execlp("docker", "docker", "exec", "-it", config.MAIN_CONTAINER_NAME, "bash")
 
 
 @localstack.group(name="update", short_help="Update LocalStack")

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -12,6 +12,7 @@ from localstack.cli.exceptions import CLIError
 from localstack.utils.analytics.cli import publish_invocation
 from localstack.utils.bootstrap import get_container_default_logfile_location
 from localstack.utils.json import CustomEncoder
+from localstack.utils.run import run_interactive
 
 from .console import BANNER, console
 from .plugin import LocalstackCli, load_cli_plugins
@@ -617,15 +618,13 @@ def cmd_ssh() -> None:
     `MAIN_CONTAINER_NAME`.
     """
     from localstack.utils.docker_utils import DOCKER_CLIENT
-    from localstack.utils.run import run
 
     if not DOCKER_CLIENT.is_container_running(config.MAIN_CONTAINER_NAME):
         raise CLIError(
             f'Expected a running LocalStack container named "{config.MAIN_CONTAINER_NAME}", but found none'
         )
     try:
-        process = run("docker exec -it %s bash" % config.MAIN_CONTAINER_NAME, tty=True)
-        process.wait()
+        run_interactive(["docker", "exec", "-it", config.MAIN_CONTAINER_NAME, "bash"])
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While working on #9210, I noticed that `localstack ssh` had some wonky terminal behavior.
I couldn't use CTRL+A, CTRL+E, CTRL+R and other control sequences correctly. New lines were also added twice.

![Peek 2023-09-22 18-03](https://github.com/localstack/localstack/assets/3996682/4f292b8b-01ee-4bd1-b2e2-7ce55148eb9d)

It looks like the `tty=True` option of `run` doesn't really work correctly. <strike>For #8994 I added a `run_interactive` method that is a much simpler implementation of running an interactive command in a subprocess.</strike> Using `os.execlp` (based on @dfangl's suggestion), is much simpler. This works much better now:

![Peek 2023-09-22 18-03-update](https://github.com/localstack/localstack/assets/3996682/bc2e7b2c-f4fd-464c-8d74-67859b24852b)


<!-- What notable changes does this PR make? -->
## Changes

* Use `run_interactive` for `localstack ssh`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

