### PR TITLE
fix apigw pathParameters context resolving before authorizer run

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1347,7 +1347,16 @@ def get_target_resource_details(
         if not extracted_path:
             return None, None
         invocation_context.resource = resource
+        invocation_context.resource_path = extracted_path
+        try:
+            invocation_context.path_params = extract_path_params(
+                path=relative_path, extracted_path=extracted_path
+            )
+        except Exception:
+            invocation_context.path_params = {}
+
         return extracted_path, resource
+
     except Exception:
         return None, None
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -12,8 +12,6 @@ from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import (
     EMPTY_MODEL,
     ModelResolver,
-    extract_path_params,
-    extract_query_string_params,
     get_apigateway_store_for_invocation,
     get_cors_response,
     make_error_response,
@@ -286,24 +284,17 @@ def invoke_rest_api_integration(invocation_context: ApiInvocationContext):
 # in Pro (potentially to be replaced with a runtime hook in the future).
 def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext):
     # define local aliases from invocation context
-    invocation_path = invocation_context.path_with_query_string
+    # invocation_path = invocation_context.path_with_query_string
     method = invocation_context.method
     headers = invocation_context.headers
-    resource_path = invocation_context.resource_path
+    # resource_path = invocation_context.resource_path
     integration = invocation_context.integration
     # extract integration type and path parameters
-    relative_path, query_string_params = extract_query_string_params(path=invocation_path)
+    # relative_path, query_string_params = extract_query_string_params(path=invocation_path)
     integration_type_orig = integration.get("type") or integration.get("integrationType") or ""
     integration_type = integration_type_orig.upper()
     integration_method = integration.get("httpMethod")
     uri = integration.get("uri") or integration.get("integrationUri") or ""
-
-    try:
-        invocation_context.path_params = extract_path_params(
-            path=relative_path, extracted_path=resource_path
-        )
-    except Exception:
-        invocation_context.path_params = {}
 
     if (uri.startswith("arn:aws:apigateway:") and ":lambda:path" in uri) or uri.startswith(
         "arn:aws:lambda"

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -284,13 +284,9 @@ def invoke_rest_api_integration(invocation_context: ApiInvocationContext):
 # in Pro (potentially to be replaced with a runtime hook in the future).
 def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext):
     # define local aliases from invocation context
-    # invocation_path = invocation_context.path_with_query_string
     method = invocation_context.method
     headers = invocation_context.headers
-    # resource_path = invocation_context.resource_path
     integration = invocation_context.integration
-    # extract integration type and path parameters
-    # relative_path, query_string_params = extract_query_string_params(path=invocation_path)
     integration_type_orig = integration.get("type") or integration.get("integrationType") or ""
     integration_type = integration_type_orig.upper()
     integration_method = integration.get("httpMethod")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This issue was reported in a support case, the `pathParams` field was not available in the authorizer context. After checking, it seems we only resolved and added to the invocation context at the invocation step, which is executed after the authorizer.

~Beware, this PR is on top of #9208 because the new tests are using this routing to test different scenarios with the path.~

<!-- What notable changes does this PR make? -->
## Changes
Updated a util to set the context as soon as we have the resource details (so that we're able to resolve the path parameters), and removed the resolving in the integration step. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

