### PR TITLE
Bump moto-ext to 4.2.4.post1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ runtime =
     # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
     localstack-client>=2.0
-    moto-ext[all]==4.2.3.post1
+    moto-ext[all]==4.2.4.post1
     opensearch-py==2.1.1
     pproxy>=2.7.0
     pymongo>=4.2.0


### PR DESCRIPTION
Final bump ahead of v2.3 release

Ext Integration Tests # 2494 (seems to be a flake)

```
2023-09-25T10:01:44.2398121Z =========================== short test summary info ============================
2023-09-25T10:01:44.2398381Z FAILED tests/aws/services/rds/test_rds.py::TestRdsMysql::test_data_api[True]
2023-09-25T10:01:44.3346634Z [31m= [31m[1m1 failed[0m, [32m463 passed[0m, [33m80 skipped[0m, [33m595 deselected[0m, [33m45 xfailed[0m, [33m6 xpassed[0m, [33m336857 warnings[0m, 
```

cc: @giograno @sannya-singal 

Closes https://github.com/localstack/localstack/issues/8984

