### PR TITLE
fix welcome action by upgrading to github-script v6

### DIFF
--- a/.github/workflows/pr-welcome-first-time-contributors.yml
+++ b/.github/workflows/pr-welcome-first-time-contributors.yml
@@ -62,7 +62,7 @@ jobs:
           const message = isIssue ? issueMessage : prMessage;
           if (isIssue) {
               const issueNumber = context.payload.issue.number;
-              await github.issues.createComment({
+              await github.rest.issues.createComment({
                   owner: context.payload.repository.owner.login,
                   repo: context.payload.repository.name,
                   issue_number: issueNumber,
@@ -71,7 +71,7 @@ jobs:
           }
           else {
             const pullNumber = context.payload.pull_request.number;
-              await github.pulls.createReview({
+              await github.rest.pulls.createReview({
                   owner: context.payload.repository.owner.login,
                   repo: context.payload.repository.name,
                   pull_number: pullNumber,


### PR DESCRIPTION
## Motivation
Unfortunately, #9068 broke the "Welcome First Time Contributors" GitHub action.
This PR upgraded the action from GitHub Script v2 to v6.
With GitHub Script v5, there were some breaking changes related to the REST operations on the `github` object.
More details can be found here: https://github.com/actions/github-script#breaking-changes-in-v5

## Changes
- Use `github.rest.<rest-action>` instead of `github.<rest-action>`.

/cc @HarshCasper 