### PR TITLE
avoid setting LOCALSTACK_CLI in the container

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1271,7 +1271,10 @@ def populate_config_env_var_names():
     CONFIG_ENV_VARS += [
         key
         for key in [key.upper() for key in os.environ]
-        if key.startswith("LOCALSTACK_") or key.startswith("PROVIDER_OVERRIDE_")
+        if (key.startswith("LOCALSTACK_") or key.startswith("PROVIDER_OVERRIDE_"))
+        # explicitly exclude LOCALSTACK_CLI (it's prefixed with "LOCALSTACK_",
+        # but is only used in the CLI (should not be forwarded to the container)
+        and key != "LOCALSTACK_CLI"
     ]
 
     # create variable aliases prefixed with LOCALSTACK_ (except LOCALSTACK_HOSTNAME)


### PR DESCRIPTION
## Motivation
#7906 introduced the `LOCALSTACK_CLI` env variable, which is only used as a workaround to indicate that we are currently in a CLI environment (other than an actual runtime environment).

With #8307, we removed the install-dependency on `localstack_client`.
We added a global env prefix `LOCALSTACK_`. All environment variables with this prefix will be added to the container (no matter if they are listed in the `CONFIG_ENV_VARS` global variable). The intention for that is that we have a simple way of adding new variables which should be forwarded to a container without maintaining this global list.

Unfortunately, since #8307 is merged, we set the `LOCALSTACK_CLI` also in LocalStack containers started by the CLI, which shouldn't be set.

This PR fixes this.

## Changes
- Explicitly exclude `LOCALSTACK_CLI` from the `CONFIG_ENV_VARS` when populating it from the current environment.

## Testing
Unfortunately, this is really hard to test, since it's a change in `config.py`. The `LOCALSTACK_CLI` env var is only set later for our tests in the `conftest.py`, which is why this change isn't even considered in our tests (the tests never even adds the `LOCALSTACK_CLI`, since it's set after the `CONFIG_ENV_VARS` are populated).
I'm happy for any suggestions on how to properly test this...