### PR TITLE
Let hypercorn listen directly to privileged ports if run as root

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -539,8 +539,18 @@ class HostAndPort:
 
         return cls(host=host, port=port)
 
+    def _get_unprivileged_port_range_start(self) -> int:
+        try:
+            with open(
+                "/proc/sys/net/ipv4/ip_unprivileged_port_start", "rt"
+            ) as unprivileged_port_start:
+                port = unprivileged_port_start.read()
+                return int(port.strip())
+        except Exception:
+            return 1024
+
     def is_unprivileged(self) -> bool:
-        return self.port >= 1024
+        return self.port >= self._get_unprivileged_port_range_start()
 
     def __hash__(self) -> int:
         return hash((self.host, self.port))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This is basically a continuation of #8948 and #9012.

We basically reintroduce hypercorn binding directly to the privileged ports, if run as root.

Additionally, we check the `sys.net.ipv4.ip_unprivileged_port_start` kernel parameter, to check the port start of unprivileged ports.

We will need to provide proper paths of error handling, to avoid #9012 again.

<!-- What notable changes does this PR make? -->
## Changes
* Bind hypercorn to privileged ports if root
* Check the actual unprivileged port start instead of assuming 1024.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

