### PR TITLE
fix S3 PutObject with MD5 and enabled ARN Partition Rewriting

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import logging
 import re
 from re import Match
@@ -108,6 +110,12 @@ class ArnPartitionRewriteHandler(Handler):
         forward_rewritten_headers = self._adjust_partition(
             dict(request.headers), self.DEFAULT_INBOUND_PARTITION
         )
+
+        # if a Content-MD5 was given, we need to update it after a potential modification
+        if "Content-MD5" in forward_rewritten_headers:
+            md = hashlib.md5(forward_rewritten_body).digest()
+            content_md5 = base64.b64encode(md).decode("utf-8")
+            forward_rewritten_headers["Content-MD5"] = content_md5
 
         # add header to signal request has already been rewritten
         forward_rewritten_headers["LS-INTERNAL-REWRITE-HANDLER"] = "1"


### PR DESCRIPTION
## Motivation
#9064 introduced the MD5 checks for S3's PutObject operation.
Until now, the ARN Partition Rewriting did not update the MD5 hashes in requests.
This now causes issues with the MD5 check in S3, since the checksum is verified, but the content is maybe modified due to the rewriting.

## Changes
- Replaces the `Content-MD5` header with a new value in case it is set.
