### PR TITLE
fix opensearch-knn plugin by setting LD_LIBRARY_PATH

### DIFF
--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -461,10 +461,18 @@ class OpensearchCluster(Server):
         return cmd
 
     def _create_env_vars(self, directories: Directories) -> Dict:
-        return {
+        env_vars = {
             "OPENSEARCH_JAVA_OPTS": os.environ.get("OPENSEARCH_JAVA_OPTS", "-Xms200m -Xmx600m"),
             "OPENSEARCH_TMPDIR": directories.tmp,
         }
+
+        # if the "opensearch-knn" plugin exists and has a "lib" directory, add it to the LD_LIBRARY_PATH
+        # see https://forum.opensearch.org/t/issue-with-opensearch-knn/12633
+        knn_lib_dir = os.path.join(directories.install, "plugins", "opensearch-knn", "lib")
+        if os.path.isdir(knn_lib_dir):
+            env_vars["LD_LIBRARY_PATH"] = f"{knn_lib_dir}:{os.environ.get('LD_LIBRARY_PATH', '')}"
+
+        return env_vars
 
     def _log_listener(self, line, **_kwargs):
         # logging the port before each line to be able to connect logs to specific instances

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -563,6 +563,33 @@ class TestOpensearchProvider:
             assert req_result[0]["health"] in ["green", "yellow"]
             assert req_result[0]["index"] in indices
 
+        # create a knn index to make sure the knn plugin works
+        index_path = f"{opensearch_endpoint}/knn"
+        body = {
+            "settings": {"index": {"knn": True}},
+            "mappings": {
+                "properties": {
+                    "embedding": {
+                        "type": "knn_vector",
+                        "dimension": 2,
+                    }
+                }
+            },
+        }
+        put = requests.put(index_path, headers=COMMON_HEADERS, json=body)
+        assert put.status_code == 200
+        get = requests.get(f"{opensearch_endpoint}/_cat/indices/knn?format=json&pretty")
+        assert get.status_code == 200
+
+        # add a document
+        document_path = f"{opensearch_endpoint}/knn/_doc/test_document"
+        body = {"embedding": [1, 2]}
+        put = requests.put(document_path, headers=COMMON_HEADERS, json=body)
+        assert put.status_code == 201
+
+        get = requests.get(document_path)
+        assert get.status_code == 200
+
     @markers.aws.unknown
     def test_get_document(self, opensearch_document_path):
         response = requests.get(opensearch_document_path)


### PR DESCRIPTION
## Motivation
The OpenSearch KNN plugin is currently not working in LocalStack, because we do not properly add the KNN libraries to the `LD_LIBRARY_PATH` when starting OpenSearch.
See the awesome bug report by @theahura in https://github.com/localstack/localstack/issues/9193 for more details.

## Changes
- When starting OpenSearch, we check if the specific installation contains a directory at `./plugins/opensearch-knn/lib`.
- If so, we add this path to an existing `LD_LIBRARY_PATH`.

## Testing
- An existing test was extended (to not waste additional resources in the CI run) which creates - in addition to some plain indices - an index where the KNN plugin is enabled.
- Afterwards a document is added and retrieved.
- The actual error (return status code 500), in case the plugin is not working properly, actually only occurs when retrieving the document!

Fixes #9193 