### PR TITLE
add label sync, migrate workflows to shared workflows

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -6,44 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  issue-cleanup:
-    runs-on: ubuntu-latest
-    name: Triage Stale Issues
-    steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
-      with:
-        issue-types: issues
-        ancient-issue-message: Hello 👋! It looks like this issue hasn’t been active in longer
-          than five months. We encourage you to check if this is still an issue in the latest release.
-          In the absence of more information, we will be closing this issue soon.
-          If you find that this is still a problem, please feel free to provide a comment or upvote
-          with a reaction on the initial post to prevent automatic closure. If the issue is already closed,
-          please feel free to open a new one.
-        stale-issue-message: Hello 👋! It looks like this issue hasn’t been active in longer than two months.
-          We encourage you to check if this is still an issue in the latest release.
-          In the absence of more information, we will be closing this issue soon.
-          If you find that this is still a problem, please feel free to provide a comment or upvote
-          with a reaction on the initial post to prevent automatic closure. If the issue is already closed,
-          please feel free to open a new one.
-        # These labels are required
-        stale-issue-label: "status: stale"
-        exempt-issue-labels: "status: triage needed,status: confirmed,status: accepted"
-        response-requested-label: "status: response required"
-
-        # Don't set closed-for-staleness label to skip closing very old issues
-        # regardless of label
-        closed-for-staleness-label: "status: resolved/stale"
-
-        # Issue timing
-        days-before-stale: 60
-        days-before-close: 14
-        days-before-ancient: 150
-
-        # If you don't want to mark a issue as being ancient based on a
-        # threshold of "upvotes", you can set this here. An "upvote" is
-        # the total number of +1, heart, hooray, and rocket reactions
-        # on an issue.
-        minimum-upvotes-to-exempt: 2
-
-        repo-token: ${{ secrets.PRO_ACCESS_TOKEN }}
-        loglevel: DEBUG
+  sync-with-project:
+    uses: localstack/meta/.github/workflows/stale-bot.yml@main
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,15 @@
+name: Sync Labels
+
+on:
+  schedule:
+  # once a day at midnight
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync-labels:
+    uses: localstack/meta/.github/workflows/sync-labels.yml@main
+    with:
+        categories: status,aws,semver
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -2,65 +2,13 @@ name: Sync Project Cards
 
 on:
   issues:
-    types: [labeled, unlabeled]
+    types:
+    - labeled
+    - unlabeled
+    - opened
 
 jobs:
-  sync-project-card:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Project status change necessary?
-        uses: actions/github-script@v6
-        id: determine-status
-        with:
-          result-encoding: string
-          script: |
-            // Get the labels on the issue
-            const listLabelsOnIssueResponse = await github.rest.issues.listLabelsOnIssue({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const issueLabels = listLabelsOnIssueResponse.data.map(e => e.name);
-
-            // define the mapping
-            // the order is important, the further down the more important (if multiple status labels are set)
-            const mapping = {
-                "status: triage needed": "status: triage needed ❓",
-                "status: backlog": "status: backlog 🗃",
-                "status: confirmed": "status: backlog 🗃",
-                "status: accepted": "status: backlog 🗃",
-                "status: stale": "status: stale 😴",
-                "status: response required": "status: response required 🗨",
-                "status: in progress": "status: in progress 🧑‍💻",
-                "status: resolved/stale": "status: stale 😴",
-                "status: resolved/fixed": "status: closed ✔",
-                "status: resolved/workaround": "status: closed ✔"
-            };
-
-            // apply the most important mapped project status
-            let result = false;
-            for (const label in mapping) {
-              if (issueLabels.includes(label)) {
-                result = mapping[label];
-              }
-            }
-
-            // if none was found (no known status label is set on the issue), use the fallback (triaging)
-            if (result == false) {
-              result = "status: triage needed ❓";
-            }
-
-            // return the result - usable as "steps.<step-id>.outputs.result" by other steps
-            return result;
-
-      - name: Sync Card Status
-        if: ${{steps.determine-status.outputs.result}}
-        uses: leonsteinhaeuser/project-beta-automations@v2.2.1
-        env:
-          DEBUG_LOG: "true"
-        with:
-          gh_token: ${{ secrets.PRO_ACCESS_TOKEN }}
-          organization: ${{ github.repository_owner }}
-          project_id: 17
-          resource_node_id: ${{ github.event.issue.node_id }}
-          status_value: ${{steps.determine-status.outputs.result}}
+  sync-with-project:
+    uses: localstack/meta/.github/workflows/sync-project.yml@main
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation
We are currently working on unifying processes across multiple repos in the GitHub organization.
For this purpose, we created an internal repo with some shared workflows.
This PR onboards `localstack/localstack` to these shared workflows.

## Changes
- Add the new "Sync Labels" workflow.
  - This means that labels defined in our shared repo are automatically added in this repo.
  - This allows using a specific set of labels for other automations (like the project status sync) in multiple repos.
  - The workflow allows defining multiple "categories", which is a way in defining different sets of labels for different kinds of repos.
- "Sync Project Cards" basically just migrates the existing code to the shared workflow.
  - However, the workflow has been extended a bit such that issues are also automatically added to the projects.
  - This means we do not have to rely on the super-low limit of GitHub project workflow automations (we don't have to have an automation for projects using this workflow).
- "Triage Stale Issues" also just migrates the existing code to the new shared workflow.
  - However, the configuration has been slightly adjusted:
    - The time before an issue becomes marked as "stale" from 60 days to 14 days.
    - The time before a stale issue gets closed from 14 days to 7 days.

## Testing
These workflows have been tested in a separate private repo.