### PR TITLE
allow single container port to auto-assigned host port mapping

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -365,7 +365,7 @@ def get_docker_image_to_start():
 
 
 def extract_port_flags(user_flags, port_mappings: PortMappings):
-    regex = r"-p\s+([0-9]+)(\-([0-9]+))?:([0-9]+)(\-([0-9]+))?"
+    regex = r"-p\s+([0-9]+)(\-([0-9]+))?:?([0-9]+)?(\-([0-9]+))?"
     matches = re.match(".*%s" % regex, user_flags)
     if matches:
         for match in re.findall(regex, user_flags):

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -1209,6 +1209,9 @@ class Util:
                         "Host part of port mappings are ignored currently in additional flags"
                     )
                     _, host_port, container_port = port_split
+                elif len(port_split) == 1:
+                    _, _, container_port = port_split
+                    host_port = ""
                 else:
                     raise ValueError(f"Invalid port string provided: {port_mapping}")
                 host_port_split = host_port.split("-")

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -1222,7 +1222,6 @@ class Util:
                 args.privileged,
             )
             privileged = args.privileged
-
         if args.publish_ports:
             for port_mapping in args.publish_ports:
                 port_split = port_mapping.split(":")
@@ -1235,7 +1234,7 @@ class Util:
                     )
                     _, host_port, container_port = port_split
                 elif len(port_split) == 1:
-                    container_port = port_split
+                    container_port = port_split[0]
                     host_port = ""
                 else:
                     raise ValueError(f"Invalid port string provided: {port_mapping}")

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -231,7 +231,10 @@ class PortMappings:
             protocol_suffix = f"/{protocol}" if protocol != "tcp" else ""
             return f"-p {port}{protocol_suffix}"
 
-        return " ".join([entry(k, v) for k, v in self.mappings.items()] + [entry_random(k, v) for k, v in self.exposed_to_random.items()])
+        return " ".join(
+            [entry(k, v) for k, v in self.mappings.items()]
+            + [entry_random(k, v) for k, v in self.exposed_to_random.items()]
+        )
 
     def to_list(self) -> List[str]:  # TODO test
         bind_address = f"{self.bind_host}:" if self.bind_host else ""
@@ -249,12 +252,11 @@ class PortMappings:
 
         def entry_random(port, protocol):
             protocol_suffix = f"/{protocol}" if protocol != "tcp" else ""
-            return [
-                "-p",
-                f"-p {port}{protocol_suffix}"
-            ]
+            return ["-p", f"{port}{protocol_suffix}"]
 
-        return [item for k, v in self.mappings.items() for item in entry(k, v)] + [item for k, v in self.exposed_to_random.items() for item in entry_random(k, v)]
+        return [item for k, v in self.mappings.items() for item in entry(k, v)] + [
+            item for k, v in self.exposed_to_random.items() for item in entry_random(k, v)
+        ]
 
     def to_dict(self) -> Dict[str, Union[Tuple[str, Union[int, List[int]]], int]]:
         bind_address = self.bind_host or ""
@@ -284,13 +286,11 @@ class PortMappings:
 
         def entry_random(port, protocol):
             protocol_suffix = f"/{protocol}" if protocol != "tcp" else ""
-            return [
-                (
-                    f"{port}{protocol_suffix}", ()
-                )
-            ]
+            return [(f"{port}{protocol_suffix}", ())]
 
-        items = [item for k, v in self.mappings.items() for item in entry(k, v)] + [item for k, v in self.exposed_to_random.items() for item in entry_random(k, v)]
+        items = [item for k, v in self.mappings.items() for item in entry(k, v)] + [
+            item for k, v in self.exposed_to_random.items() for item in entry_random(k, v)
+        ]
         return dict(items)
 
     def contains(self, port: int, protocol: PortProtocol = "tcp") -> bool:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -256,6 +256,15 @@ class TestPortMappings:
         assert "-p 1234:1234" in mapping_str
         assert "-p 80-90:81-91" in mapping_str
 
+        port_mappings = PortMappings()
+        flags = extract_port_flags(
+            "foo -p 1234 bar -p 80-90:81-91 baz", port_mappings=port_mappings
+        )
+        assert flags == "foo  bar  baz"
+        mapping_str = port_mappings.to_str()
+        assert "-p 1234" in mapping_str
+        assert "-p 80-90:81-91" in mapping_str
+
     def test_overlapping_port_ranges(self):
         port_mappings = PortMappings()
         port_mappings.add(4590)
@@ -286,14 +295,14 @@ class TestPortMappings:
         port_mappings.add(5001, 7000)
         port_mappings.add(5003, 8000)
         port_mappings.add([5004, 5006], 9000)
-        port_mappings.add(9229)
+        port_mappings.add_random(9229)
         result = port_mappings.to_dict()
         expected_result = {
             "6000/tcp": ("0.0.0.0", 5000),
             "7000/tcp": ("0.0.0.0", 5001),
             "8000/tcp": ("0.0.0.0", 5003),
             "9000/tcp": ("0.0.0.0", [5004, 5005, 5006]),
-            "9229/tcp": (),
+            "9229": (),
         }
         assert result == expected_result
 

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -293,7 +293,7 @@ class TestPortMappings:
             "7000/tcp": ("0.0.0.0", 5001),
             "8000/tcp": ("0.0.0.0", 5003),
             "9000/tcp": ("0.0.0.0", [5004, 5005, 5006]),
-            "9000/tcp": (),
+            "9229/tcp": (),
         }
         assert result == expected_result
 

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -286,12 +286,14 @@ class TestPortMappings:
         port_mappings.add(5001, 7000)
         port_mappings.add(5003, 8000)
         port_mappings.add([5004, 5006], 9000)
+        port_mappings.add(9229)
         result = port_mappings.to_dict()
         expected_result = {
             "6000/tcp": ("0.0.0.0", 5000),
             "7000/tcp": ("0.0.0.0", 5001),
             "8000/tcp": ("0.0.0.0", 5003),
             "9000/tcp": ("0.0.0.0", [5004, 5005, 5006]),
+            "9000/tcp": (),
         }
         assert result == expected_result
 

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -119,7 +119,7 @@ class TestArgumentParsing:
         assert flags.network == "bridge"
         assert flags.platform == "linux/arm64"
         assert flags.privileged
-        assert ports.to_str() == "-p 80:8080/udp -p 6000:7000 -p 9230-9231:9230"
+        assert ports.to_str() == "-p 80:8080/udp -p 6000:7000 -p 9230-9231:9230 -p 9229"
         assert flags.ulimits == [
             Ulimit(name="nproc", soft_limit=3, hard_limit=3),
             Ulimit(name="nofile", soft_limit=768, hard_limit=1024),

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -75,6 +75,7 @@ class TestArgumentParsing:
         test_port_string = "-p 80:8080/udp"
         test_port_string_with_host = "-p 127.0.0.1:6000:7000/tcp"
         test_port_string_many_to_one = "-p 9230-9231:9230"
+        test_port_string_one_to_random = "-p 9229"
         test_ulimit_string = "--ulimit nofile=768:1024 --ulimit nproc=3"
         test_user_string = "-u sbx_user1051"
         test_dns_string = "--dns 1.2.3.4 --dns 5.6.7.8"
@@ -86,6 +87,7 @@ class TestArgumentParsing:
                 test_port_string,
                 test_port_string_with_host,
                 test_port_string_many_to_one,
+                test_port_string_one_to_random,
                 test_platform_string,
                 test_privileged_string,
                 test_ulimit_string,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

## Motivation
#8533

<!-- What notable changes does this PR make? -->
## Changes
Will allow adding 
`LAMBDA_DOCKER_FLAGS=-e NODE_OPTIONS=--inspect-brk=127.0.0.1:9229 -p 9229`
as environmental variable to Localstack in docker-compose. This will allow new containers to be started for lambda functions with an auto-assigned host port mapped to the container port.
