### PR TITLE
Adds internal cache invalidation on DynamoDB table update operations

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -657,7 +657,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 store.REPLICAS[table_name] = replicas
 
             # update response content
-            SchemaExtractor.invalidate_table_schema(table_name)
+            # SchemaExtractor.invalidate_table_schema(table_name)
             SchemaExtractor.invalidate_table_schema(
                 table_name, context.account_id, global_table_region
             )
@@ -667,7 +667,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             )
             return UpdateTableOutput(TableDescription=schema["Table"])
 
-        SchemaExtractor.invalidate_table_schema(table_name)
+        SchemaExtractor.invalidate_table_schema(table_name, context.account_id, global_table_region)
 
         # TODO: DDB streams must also be created for replicas
         if update_table_input.get("StreamSpecification"):

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -657,10 +657,17 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 store.REPLICAS[table_name] = replicas
 
             # update response content
+            SchemaExtractor.invalidate_table_schema(table_name)
+            SchemaExtractor.invalidate_table_schema(
+                table_name, context.account_id, global_table_region
+            )
+
             schema = SchemaExtractor.get_table_schema(
                 table_name, context.account_id, global_table_region
             )
             return UpdateTableOutput(TableDescription=schema["Table"])
+
+        SchemaExtractor.invalidate_table_schema(table_name)
 
         # TODO: DDB streams must also be created for replicas
         if update_table_input.get("StreamSpecification"):

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -657,7 +657,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 store.REPLICAS[table_name] = replicas
 
             # update response content
-            # SchemaExtractor.invalidate_table_schema(table_name)
             SchemaExtractor.invalidate_table_schema(
                 table_name, context.account_id, global_table_region
             )

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -114,6 +114,22 @@ class SchemaExtractor:
                 raise
         return schema
 
+    @classmethod
+    def invalidate_table_schema(
+        cls, table_name: str, account_id: str = None, region_name: str = None
+    ):
+        """
+        Allow cached table schemas to be invalidated without waiting for the TTL to expire
+        """
+        account_id = account_id or get_aws_account_id()
+        region_name = region_name or aws_stack.get_region()
+        key = dynamodb_table_arn(
+            table_name=table_name, account_id=account_id, region_name=region_name
+        )
+        schema = SCHEMA_CACHE.get(key)
+        if schema:
+            SCHEMA_CACHE[key] = None
+
 
 class ItemFinder:
     @staticmethod

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -119,8 +119,6 @@ class SchemaExtractor:
         """
         Allow cached table schemas to be invalidated without waiting for the TTL to expire
         """
-        account_id = account_id or get_aws_account_id()
-        region_name = region_name or aws_stack.get_region()
         key = dynamodb_table_arn(
             table_name=table_name, account_id=account_id, region_name=region_name
         )

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -122,9 +122,7 @@ class SchemaExtractor:
         key = dynamodb_table_arn(
             table_name=table_name, account_id=account_id, region_name=region_name
         )
-        schema = SCHEMA_CACHE.get(key)
-        if schema:
-            SCHEMA_CACHE.pop(key, None)
+        SCHEMA_CACHE.pop(key, None)
 
 
 class ItemFinder:

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -115,9 +115,7 @@ class SchemaExtractor:
         return schema
 
     @classmethod
-    def invalidate_table_schema(
-        cls, table_name: str, account_id: str = None, region_name: str = None
-    ):
+    def invalidate_table_schema(cls, table_name: str, account_id: str, region_name: str):
         """
         Allow cached table schemas to be invalidated without waiting for the TTL to expire
         """
@@ -128,7 +126,7 @@ class SchemaExtractor:
         )
         schema = SCHEMA_CACHE.get(key)
         if schema:
-            SCHEMA_CACHE[key] = None
+            SCHEMA_CACHE.pop(key, None)
 
 
 class ItemFinder:

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from localstack.aws.accounts import get_aws_account_id
+from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.dynamodb.provider import DynamoDBProvider, get_store
 from localstack.services.dynamodb.utils import (
     SCHEMA_CACHE,
@@ -102,12 +103,14 @@ def test_invalidate_table_schema():
     # to look up the table later on
     SCHEMA_CACHE[key] = table_schema
 
-    schema = schema_extractor.get_table_schema(table_name)
+    schema = schema_extractor.get_table_schema(
+        table_name, account_id=TEST_AWS_ACCOUNT_ID, region_name=TEST_AWS_REGION_NAME
+    )
 
     # Assert output is expected from the get_table_schema (fallback)
     assert schema == table_schema
     # Invalidate the cache now for the table
-    schema_extractor.invalidate_table_schema(table_name)
+    schema_extractor.invalidate_table_schema(table_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
     # Assert that the key is now set to None
     assert SCHEMA_CACHE[key] is None
 

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -4,8 +4,14 @@ import pytest
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.dynamodb.provider import DynamoDBProvider, get_store
-from localstack.services.dynamodb.utils import ItemSet, SchemaExtractor, dynamize_value
+from localstack.services.dynamodb.utils import (
+    SCHEMA_CACHE,
+    ItemSet,
+    SchemaExtractor,
+    dynamize_value,
+)
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import dynamodb_table_arn
 
 
 def test_fix_region_in_headers():
@@ -77,6 +83,33 @@ def test_get_key_schema_without_table_definition(mock_get_table_schema):
     assert (
         dynamodb_store.table_definitions[table_name] == mock_get_table_schema.return_value["Table"]
     )
+
+
+def test_invalidate_table_schema():
+    schema_extractor = SchemaExtractor()
+
+    key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
+    attr_definitions = [
+        {"AttributeName": "Artist", "AttributeType": "S"},
+        {"AttributeName": "SongTitle", "AttributeType": "S"},
+    ]
+    table_name = "nonexistent_table"
+
+    key = dynamodb_table_arn(table_name=table_name, account_id=None, region_name=None)
+
+    table_schema = {"Table": {"KeySchema": key_schema, "AttributeDefinitions": attr_definitions}}
+    # This isn't great but we need to inject into the cache here so that we're not trying to hit dynamodb
+    # to look up the table later on
+    SCHEMA_CACHE[key] = table_schema
+
+    schema = schema_extractor.get_table_schema(table_name)
+
+    # Assert output is expected from the get_table_schema (fallback)
+    assert schema == table_schema
+    # Invalidate the cache now for the table
+    schema_extractor.invalidate_table_schema(table_name)
+    # Assert that the key is now set to None
+    assert SCHEMA_CACHE[key] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -96,7 +96,9 @@ def test_invalidate_table_schema():
     ]
     table_name = "nonexistent_table"
 
-    key = dynamodb_table_arn(table_name=table_name, account_id=None, region_name=None)
+    key = dynamodb_table_arn(
+        table_name=table_name, account_id=TEST_AWS_ACCOUNT_ID, region_name=TEST_AWS_REGION_NAME
+    )
 
     table_schema = {"Table": {"KeySchema": key_schema, "AttributeDefinitions": attr_definitions}}
     # This isn't great but we need to inject into the cache here so that we're not trying to hit dynamodb
@@ -112,7 +114,7 @@ def test_invalidate_table_schema():
     # Invalidate the cache now for the table
     schema_extractor.invalidate_table_schema(table_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
     # Assert that the key is now set to None
-    assert SCHEMA_CACHE[key] is None
+    assert SCHEMA_CACHE.get(key) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes #9243 

<!-- What notable changes does this PR make? -->
## Changes

* Adds a new method for internal cache invalidation to remove cached DynamoDB table schemas
* Adds cache invalidation calls when running update table calls against DynamoDB

<!-- The following sections are optional, but can be useful! 

## Testing

A test was added to check the invalidation method. It currently isn't in a great state because it is required to modify the global cache used by DynamoDB. I'm open to suggestions on how to make this better if available.

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

