### PR TITLE
Fix flake8 E721 type comparison linting errors

### DIFF
--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -78,7 +78,7 @@ def make_hash(o):
 
 
 def config_equality_patch(self, other: object):
-    return type(self) == type(other) and self._user_provided_options == other._user_provided_options
+    return type(self) is type(other) and self._user_provided_options == other._user_provided_options
 
 
 def config_hash_patch(self):

--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -90,7 +90,7 @@ class GenericProxyHandler(Handler):
             headers=request.headers,
         )
 
-        if type(result) == int:
+        if type(result) is int:
             chain.respond(status_code=result)
             return
 

--- a/localstack/aws/handlers/service_plugin.py
+++ b/localstack/aws/handlers/service_plugin.py
@@ -58,7 +58,7 @@ class ServiceLoader(Handler):
             if service_operation in request_router.handlers:
                 return
             if isinstance(service_plugin, Service):
-                if type(service_plugin.listener) == AwsApiListener:
+                if type(service_plugin.listener) is AwsApiListener:
                     request_router.add_skeleton(service_plugin.listener.skeleton)
                 else:
                     request_router.add_handler(service_operation, LegacyPluginHandler())

--- a/localstack/services/lambda_/lambda_api.py
+++ b/localstack/services/lambda_/lambda_api.py
@@ -840,7 +840,7 @@ def do_list_functions():
     store = get_lambda_store_v1()
     this_region = aws_stack.get_region()
     for f_arn, func in store.lambdas.items():
-        if type(func) != LambdaFunction:
+        if type(func) is not LambdaFunction:
             continue
 
         # filter out functions of current region

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -324,7 +324,7 @@ class TestServiceRequestDispatcher:
             ArgTwo: int
 
         def fn(context, arg_one, arg_two):
-            assert type(context) == RequestContext
+            assert type(context) is RequestContext
             assert arg_one == "foo"
             assert arg_two == 69
 
@@ -334,7 +334,7 @@ class TestServiceRequestDispatcher:
     def test_without_context_without_expand(self):
         def fn(*args):
             assert len(args) == 1
-            assert type(args[0]) == dict
+            assert type(args[0]) is dict
 
         dispatcher = ServiceRequestDispatcher(
             fn, "SomeAction", pass_context=False, expand_parameters=False
@@ -344,8 +344,8 @@ class TestServiceRequestDispatcher:
     def test_without_expand(self):
         def fn(*args):
             assert len(args) == 2
-            assert type(args[0]) == RequestContext
-            assert type(args[1]) == dict
+            assert type(args[0]) is RequestContext
+            assert type(args[1]) is dict
 
         dispatcher = ServiceRequestDispatcher(
             fn, "SomeAction", pass_context=True, expand_parameters=False

--- a/tests/unit/services/cloudformation/test_deployment_utils.py
+++ b/tests/unit/services/cloudformation/test_deployment_utils.py
@@ -12,7 +12,7 @@ class TestFixBotoParametersBasedOnReport:
         fixed_params = fix_boto_parameters_based_on_report(params, message)
         value = fixed_params["LaunchTemplate"]["Version"]
         assert value == "1"
-        assert type(value) == str
+        assert type(value) is str
 
     def test_top_level_parameters_are_converted(self):
         params = {"Version": 1}
@@ -21,4 +21,4 @@ class TestFixBotoParametersBasedOnReport:
         fixed_params = fix_boto_parameters_based_on_report(params, message)
         value = fixed_params["Version"]
         assert value == "1"
-        assert type(value) == str
+        assert type(value) is str


### PR DESCRIPTION
## Motivation


Fix linting errors. They do seem sensible, so I've address them in this PR

```
(. .venv/bin/activate; python -m pflake8 --show-source)
./localstack/aws/connect.py:81:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    return type(self) == type(other) and self._user_provided_options == other._user_provided_options
           ^
./localstack/aws/handlers/legacy.py:93:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
        if type(result) == int:
           ^
./localstack/aws/handlers/service_plugin.py:61:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
                if type(service_plugin.listener) == AwsApiListener:
                   ^
./localstack/http/router.py:240:32: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
        if "path" in kwargs or type(args[0]) == str:
                               ^
./localstack/services/lambda_/lambda_api.py:843:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
        if type(func) != LambdaFunction:
           ^
./tests/unit/aws/test_skeleton.py:327:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
            assert type(context) == RequestContext
                   ^
./tests/unit/aws/test_skeleton.py:337:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
            assert type(args[0]) == dict
                   ^
./tests/unit/aws/test_skeleton.py:347:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
            assert type(args[0]) == RequestContext
                   ^
./tests/unit/aws/test_skeleton.py:348:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
            assert type(args[1]) == dict
                   ^
./tests/unit/aws/test_skeleton.py:357:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
            assert type(context) == RequestContext
                   ^
./tests/unit/services/cloudformation/test_deployment_utils.py:15:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
        assert type(value) == str
               ^
./tests/unit/services/cloudformation/test_deployment_utils.py:24:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
        assert type(value) == str
               ^
make: *** [Makefile:206: lint] Error 1
```

## Changes

- Fix new linting errors

