### PR TITLE
fix service router test by excluding bedrock

### DIFF
--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -23,6 +23,8 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
             # FIXME try to support more and more services, get these exclusions down!
             # Exclude all operations for the following, currently _not_ supported services
             if service.service_name in [
+                "bedrock",
+                "bedrock-runtime",
                 "chime",
                 "chime-sdk-identity",
                 "chime-sdk-media-pipelines",


### PR DESCRIPTION
## Motivation
This PR fixes the service router unit tests by excluding a newly added AWS Bedrock (which was added to `botocore` with https://github.com/boto/botocore/commit/730bfe40b1431f229d68f0d525756aaf67742a80)

## Changes
Exclude bedrock for now from the service router testing.