### PR TITLE
Ensure unique addresses for GATEWAY_LISTEN

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -571,7 +571,7 @@ class HostAndPort:
         return f"HostAndPort(host={self.host}, port={self.port})"
 
 
-class UniqueHostAndPortList(list[HostAndPort]):
+class UniqueHostAndPortList(List[HostAndPort]):
     """
     Container type that ensures that ports added to the list are unique based
     on these rules:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -582,6 +582,11 @@ class UniquePortList(list[HostAndPort]):
           create [`0.0.0.0:4566`]
     """
 
+    def __init__(self, iterable=None):
+        super().__init__()
+        for item in iterable or []:
+            self.append(item)
+
     def append(self, value: HostAndPort):
         # no exact duplicates
         if value in self:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -571,7 +571,7 @@ class HostAndPort:
         return f"HostAndPort(host={self.host}, port={self.port})"
 
 
-class UniquePortList(list[HostAndPort]):
+class UniqueHostAndPortList(list[HostAndPort]):
     """
     Container type that ensures that ports added to the list are unique based
     on these rules:
@@ -613,7 +613,7 @@ class UniquePortList(list[HostAndPort]):
 
 def populate_legacy_edge_configuration(
     environment: Mapping[str, str]
-) -> Tuple[HostAndPort, UniquePortList, str, int, int]:
+) -> Tuple[HostAndPort, UniqueHostAndPortList, str, int, int]:
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
     gateway_listen_raw = environment.get("GATEWAY_LISTEN")
 
@@ -670,7 +670,7 @@ def populate_legacy_edge_configuration(
 
     return (
         localstack_host,
-        UniquePortList(gateway_listen),
+        UniqueHostAndPortList(gateway_listen),
         edge_bind_host,
         edge_port,
         edge_port_http,

--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -234,6 +234,15 @@ def run(
         network=network,
     )
 
+    # replicate pro startup
+    if pro:
+        try:
+            from localstack_ext.plugins import modify_edge_port_config
+
+            modify_edge_port_config(config)
+        except ImportError:
+            pass
+
     # setup configurators
     configurators = [
         ImageConfigurator(pro, image),

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -64,6 +64,9 @@ def get_localstack_config() -> Dict:
             continue
         if "typing." in str(type(v)):
             continue
+        if k == "GATEWAY_LISTEN":
+            result[k] = config.GATEWAY_LISTEN
+            continue
 
         if hasattr(v, "__dict__"):
             result[k] = v.__dict__

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -12,7 +12,7 @@ def pytest_configure(config: Config):
     #  run in the same CI test step, but only one localstack instance is started for both.
     config.option.start_localstack = True
     localstack_config.FORCE_SHUTDOWN = False
-    localstack_config.GATEWAY_LISTEN = localstack_config.UniquePortList(
+    localstack_config.GATEWAY_LISTEN = localstack_config.UniqueHostAndPortList(
         [localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
     )
 

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -12,9 +12,9 @@ def pytest_configure(config: Config):
     #  run in the same CI test step, but only one localstack instance is started for both.
     config.option.start_localstack = True
     localstack_config.FORCE_SHUTDOWN = False
-    localstack_config.GATEWAY_LISTEN = [
-        localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)
-    ]
+    localstack_config.GATEWAY_LISTEN = localstack_config.UniquePortList(
+        [localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
+    )
 
 
 def pytest_runtestloop(session):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,6 @@ def pytest_configure(config: Config):
     #  the same CI test step, but only one localstack instance is started for both.
     config.option.start_localstack = True
     localstack_config.FORCE_SHUTDOWN = False
-    localstack_config.GATEWAY_LISTEN = localstack_config.UniquePortList(
+    localstack_config.GATEWAY_LISTEN = localstack_config.UniqueHostAndPortList(
         [localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,6 @@ def pytest_configure(config: Config):
     #  the same CI test step, but only one localstack instance is started for both.
     config.option.start_localstack = True
     localstack_config.FORCE_SHUTDOWN = False
-    localstack_config.GATEWAY_LISTEN = [
-        localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)
-    ]
+    localstack_config.GATEWAY_LISTEN = localstack_config.UniquePortList(
+        [localstack_config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
+    )

--- a/tests/integration/utils/test_diagnose.py
+++ b/tests/integration/utils/test_diagnose.py
@@ -12,5 +12,6 @@ def test_diagnose_resource():
     assert "/var/lib/localstack" in result["file-tree"]
     assert result["config"]["EDGE_PORT"] == config.EDGE_PORT
     assert result["config"]["DATA_DIR"] == config.DATA_DIR
+    assert result["config"]["GATEWAY_LISTEN"] == [config.HostAndPort("0.0.0.0", 4566)]
     assert result["important-endpoints"]["localhost.localstack.cloud"].startswith("127.0.")
     assert result["logs"]["docker"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -220,6 +220,17 @@ class TestEdgeVariablesDerivedCorrectly:
 
 
 class TestUniquePortList:
+    def test_construction(self):
+        ports = config.UniquePortList(
+            [
+                HostAndPort("127.0.0.1", 53),
+                HostAndPort("127.0.0.1", 53),
+            ]
+        )
+        assert ports == [
+            HostAndPort("127.0.0.1", 53),
+        ]
+
     def test_add_separate_values(self):
         ports = config.UniquePortList()
         ports.append(HostAndPort("127.0.0.1", 42))
@@ -253,6 +264,30 @@ class TestUniquePortList:
         assert ports == [
             HostAndPort("0.0.0.0", 42),
         ]
+
+    def test_index_access(self):
+        ports = config.UniquePortList(
+            [
+                HostAndPort("0.0.0.0", 42),
+            ]
+        )
+
+        assert ports[0] == HostAndPort("0.0.0.0", 42)
+        with pytest.raises(IndexError):
+            _ = ports[10]
+
+    def test_iteration(self):
+        ports = config.UniquePortList(
+            [
+                HostAndPort("127.0.0.1", 42),
+                HostAndPort("127.0.0.1", 43),
+            ]
+        )
+        n = 0
+        for _ in ports:
+            n += 1
+
+        assert n == len(ports) == 2
 
 
 class TestHostAndPort:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -219,6 +219,42 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_port_http == 20202
 
 
+class TestUniquePortList:
+    def test_add_separate_values(self):
+        ports = config.UniquePortList()
+        ports.append(HostAndPort("127.0.0.1", 42))
+        ports.append(HostAndPort("127.0.0.1", 43))
+
+        assert ports == [HostAndPort("127.0.0.1", 42), HostAndPort("127.0.0.1", 43)]
+
+    def test_add_same_value(self):
+        ports = config.UniquePortList()
+        ports.append(HostAndPort("127.0.0.1", 42))
+        ports.append(HostAndPort("127.0.0.1", 42))
+
+        assert ports == [
+            HostAndPort("127.0.0.1", 42),
+        ]
+
+    def test_add_all_interfaces_value(self):
+        ports = config.UniquePortList()
+        ports.append(HostAndPort("0.0.0.0", 42))
+        ports.append(HostAndPort("127.0.0.1", 42))
+
+        assert ports == [
+            HostAndPort("0.0.0.0", 42),
+        ]
+
+    def test_add_all_interfaces_value_after(self):
+        ports = config.UniquePortList()
+        ports.append(HostAndPort("127.0.0.1", 42))
+        ports.append(HostAndPort("0.0.0.0", 42))
+
+        assert ports == [
+            HostAndPort("0.0.0.0", 42),
+        ]
+
+
 class TestHostAndPort:
     def test_parsing_hostname_and_ip(self):
         h = config.HostAndPort.parse("0.0.0.0:1000", default_host="", default_port=0)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -221,7 +221,7 @@ class TestEdgeVariablesDerivedCorrectly:
 
 class TestUniquePortList:
     def test_construction(self):
-        ports = config.UniquePortList(
+        ports = config.UniqueHostAndPortList(
             [
                 HostAndPort("127.0.0.1", 53),
                 HostAndPort("127.0.0.1", 53),
@@ -232,14 +232,14 @@ class TestUniquePortList:
         ]
 
     def test_add_separate_values(self):
-        ports = config.UniquePortList()
+        ports = config.UniqueHostAndPortList()
         ports.append(HostAndPort("127.0.0.1", 42))
         ports.append(HostAndPort("127.0.0.1", 43))
 
         assert ports == [HostAndPort("127.0.0.1", 42), HostAndPort("127.0.0.1", 43)]
 
     def test_add_same_value(self):
-        ports = config.UniquePortList()
+        ports = config.UniqueHostAndPortList()
         ports.append(HostAndPort("127.0.0.1", 42))
         ports.append(HostAndPort("127.0.0.1", 42))
 
@@ -248,7 +248,7 @@ class TestUniquePortList:
         ]
 
     def test_add_all_interfaces_value(self):
-        ports = config.UniquePortList()
+        ports = config.UniqueHostAndPortList()
         ports.append(HostAndPort("0.0.0.0", 42))
         ports.append(HostAndPort("127.0.0.1", 42))
 
@@ -257,7 +257,7 @@ class TestUniquePortList:
         ]
 
     def test_add_all_interfaces_value_after(self):
-        ports = config.UniquePortList()
+        ports = config.UniqueHostAndPortList()
         ports.append(HostAndPort("127.0.0.1", 42))
         ports.append(HostAndPort("0.0.0.0", 42))
 
@@ -266,7 +266,7 @@ class TestUniquePortList:
         ]
 
     def test_index_access(self):
-        ports = config.UniquePortList(
+        ports = config.UniqueHostAndPortList(
             [
                 HostAndPort("0.0.0.0", 42),
             ]
@@ -277,7 +277,7 @@ class TestUniquePortList:
             _ = ports[10]
 
     def test_iteration(self):
-        ports = config.UniquePortList(
+        ports = config.UniqueHostAndPortList(
             [
                 HostAndPort("127.0.0.1", 42),
                 HostAndPort("127.0.0.1", 43),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

If `LOCALSTACK_HOST` is set to include port 443, and `GATEWAY_LISTEN` is not set, in -ext we by default add port 443 to the list, so `GATEWAY_LISTEN` becomes:

```
GATEWAY_HOST = [
    HostAndPort("0.0.0.0", 443),
    HostAndPort("0.0.0.0", 443),
]
```

Hypercorn then tries to bind to the port twice and crashes.


<!-- What notable changes does this PR make? -->
## Changes

* Introduce the concept of a `UniqueHostAndPortList` - see the docstring for guarantees
* Configure the dev container to modify the edge port config

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

