### PR TITLE
fix SNS FilterPolicy with null value

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -1019,7 +1019,7 @@ class SubscriptionFilter:
 
     def _evaluate_condition(self, value, condition, field_exists: bool):
         if not isinstance(condition, dict):
-            return value == condition
+            return field_exists and value == condition
         elif (must_exist := condition.get("exists")) is not None:
             # if must_exists is True then field_exists must be True
             # if must_exists is False then fields_exists must be False

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -3179,7 +3179,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
-    "recorded-date": "25-08-2023, 00:15:01",
+    "recorded-date": "29-09-2023, 15:32:02",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -3272,6 +3272,38 @@
             "ReceiptHandle": "<receipt-handle:2>"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscription-attributes-2": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "attr1": [
+              null,
+              {
+                "anything-but": "whatever"
+              }
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-3": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #9261, we would not properly filter for the `null` value in a FilterPolicy. This is because we set the value to `None` if it didn't exist. We luckily have a field to indicated the presence of the field or not `field_exists`. 

<!-- What notable changes does this PR make? -->
## Changes
Add the check for the `field_exists` before comparing the value with the condition.
Added a snapshot tests for validating this use-case. 

_closes #9261_

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

