### PR TITLE
add error handling for Events.PutRule

### DIFF
--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -667,10 +667,10 @@ class TestEvents:
         self.assert_valid_event(actual_event)
         assert actual_event["detail"] == EVENT_DETAIL
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_rule_disable(self, aws_client, clean_up):
-        rule_name = "rule-{}".format(short_uid())
-        aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minutes)")
+        rule_name = f"rule-{short_uid()}"
+        aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)")
 
         response = aws_client.events.list_rules()
         assert response["Rules"][0]["State"] == "ENABLED"
@@ -750,7 +750,7 @@ class TestEvents:
         event = {"env": "testing"}
         event_json = json.dumps(event)
 
-        aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minutes)")
+        aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)")
 
         aws_client.events.put_targets(
             Rule=rule_name,
@@ -1503,18 +1503,6 @@ class TestEvents:
             aws_client.events.put_rule(Name=rule_name, ScheduleExpression=schedule_expression)
         finally:
             clean_up(rule_name=rule_name)
-
-    @pytest.mark.parametrize(
-        "schedule_expression", ["rate(1 minutes)", "rate(1 days)", "rate(1 hours)"]
-    )
-    @markers.aws.validated
-    @pytest.mark.xfail
-    def test_create_rule_with_one_unit_in_plural_should_fail(self, schedule_expression, aws_client):
-        rule_name = f"rule-{short_uid()}"
-
-        # rule should not be creatable with given expression
-        with pytest.raises(ClientError):
-            aws_client.events.put_rule(Name=rule_name, ScheduleExpression=schedule_expression)
 
     @markers.aws.validated
     @pytest.mark.xfail

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -171,6 +171,18 @@ class TestEvents:
         # clean up
         clean_up(rule_name=rule_name)
 
+    @markers.aws.validated
+    def test_put_rule_invalid_schedule_expression(self, aws_client, snapshot):
+        with pytest.raises(ClientError) as e:
+            aws_client.events.put_rule(
+                Name=f"rule-{short_uid()}", ScheduleExpression="rate(10 seconds)"
+            )
+        snapshot.match("error-response-1", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.events.put_rule(Name=f"rule-{short_uid()}", ScheduleExpression="rate()")
+        snapshot.match("error-response-2", e.value.response)
+
     @markers.aws.unknown
     def test_events_written_to_disk_are_timestamp_prefixed_for_chronological_ordering(
         self, aws_client

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -208,5 +208,30 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_rule_invalid_schedule_expression": {
+    "recorded-date": "29-09-2023, 19:18:52",
+    "recorded-content": {
+      "error-response-1": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter ScheduleExpression is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-response-2": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Parameter ScheduleExpression is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -233,5 +233,44 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_rule": {
+    "recorded-date": "29-09-2023, 19:26:53",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules": {
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "<rule-name>",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -209,31 +209,6 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_rule_invalid_schedule_expression": {
-    "recorded-date": "29-09-2023, 19:18:52",
-    "recorded-content": {
-      "error-response-1": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "Parameter ScheduleExpression is not valid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "error-response-2": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "Parameter ScheduleExpression is not valid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_rule": {
     "recorded-date": "29-09-2023, 19:26:53",
     "recorded-content": {

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -68,7 +68,7 @@ def scheduled_test_lambda(aws_client):
     # create scheduled Lambda function
     rule_name = f"rule-{short_uid()}"
     target_id = f"target-{short_uid()}"
-    aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minutes)")
+    aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)")
     aws_client.events.put_targets(Rule=rule_name, Targets=[{"Id": target_id, "Arn": func_arn}])
 
     yield scheduled_lambda_name


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While using event bus, I noticed that specifying invalid rule expressions did not create the correct error response.

There was also a TODO related to us allowing `rate(1 minutes)` (value 1 with plural unit) which is for some reason not allowed in AWS. This may have some implications on user code.

<!-- What notable changes does this PR make? -->
## Changes

* Added proper handling and an AWS validated test
* Added [weird plural/singular handling of rate units](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rate-expressions.html)
  * Fixed all occurrences of invalid rates
* drive-by validated a few other tests

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

