### PR TITLE
exclude werkzeug 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ runtime =
     Quart>=0.18
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
-    Werkzeug>=2.3.4
+    Werkzeug>=2.3.4,<3.0
     xmltodict>=0.13.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

PR builds started failing yesterday. Example: https://app.circleci.com/pipelines/github/localstack/localstack/18636/workflows/bf96fc58-330d-4526-8720-fac54a29c45e

I had a hunch it may be Werkzeug again, since they released 3.0 the other day: https://github.com/pallets/werkzeug/releases/tag/3.0.0. I haven't had time to investigate yet, but assume it has something to do with deprecated code they removed.

<!-- What notable changes does this PR make? -->
## Changes

* Constrain werkzeug version to <3.0

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

