### PR TITLE
Add develop mode to dev script

### DIFF
--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -51,6 +51,12 @@ from .paths import HostPaths
     help="Whether to start localstack pro or community. If not set, it will guess from the current directory",
 )
 @click.option(
+    "--develop/--no-develop",
+    is_flag=True,
+    default=False,
+    help="Install debugpy and expose port 5678",
+)
+@click.option(
     "--randomize",
     is_flag=True,
     default=False,
@@ -113,6 +119,7 @@ def run(
     image: str = None,
     volume_dir: str = None,
     pro: bool = None,
+    develop: bool = False,
     randomize: bool = False,
     mount_source: bool = True,
     mount_dependencies: bool = False,
@@ -162,6 +169,10 @@ def run(
     Or use custom entrypoints:
 
         python -m localstack.dev.run --entrypoint /bin/bash -- echo "hello"
+
+    You can import and expose debugpy:
+
+        python -m localstack.dev.run --develop
 
     You can also mount local dependencies (e.g., pytest and other test dependencies, and then use that
     in the container)::
@@ -268,6 +279,8 @@ def run(
         configurators.append(EntryPointMountConfigurator(host_paths=host_paths, pro=pro))
     if mount_dependencies:
         configurators.append(DependencyMountConfigurator(host_paths=host_paths))
+    if develop:
+        configurators.append(ContainerConfigurators.develop)
 
     # make sure anything coming from CLI arguments has priority
     configurators.extend(

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -521,6 +521,15 @@ class ContainerConfigurators:
     def debug(cfg: ContainerConfiguration):
         cfg.env_vars["DEBUG"] = "1"
 
+    @classmethod
+    def develop(cls, cfg: ContainerConfiguration):
+        cls.env_vars(
+            {
+                "DEVELOP": "1",
+            }
+        )(cfg)
+        cls.port(5678)(cfg)
+
     @staticmethod
     def network(network: str):
         def _cfg(cfg: ContainerConfiguration):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

It is sometimes nice to attach a remote debugger to a running container. For this we can use the `DEVELOP=1` flag with the CLI, which
* installs `debugpy` into the container before infrastructure startup, and
* publishes port 5678 (the default [DAP](https://microsoft.github.io/debug-adapter-protocol/) port) to the host.

These two commands _can_ be added to the debug script, however it is marginally annoying. And of course we know that developers hate to be _mildy_ annoyed... 😂


<!-- What notable changes does this PR make? -->
## Changes

* Add a `--develop/--no-develop` flag to the CLI which performs the two above steps


## Testing

```
python -m localstack.dev.run --develop`
```

should allow for remote debugging via the DAP protocol. Specifically it should:
* install debugpy into the container, and
* publish port 5678

<!-- The following sections are optional, but can be useful! 
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

