### PR TITLE
upgrade werkzeug to version 3

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -221,7 +221,7 @@ def create_http_request(aws_request: AWSPreparedRequest) -> Request:
     # prepare the RequestContext
     headers = Headers()
     for k, v in aws_request.headers.items():
-        headers[k] = v
+        headers[k] = to_str(v, "latin-1")
 
     return Request(
         method=aws_request.method,

--- a/localstack/aws/serving/wsgi.py
+++ b/localstack/aws/serving/wsgi.py
@@ -4,10 +4,11 @@ from typing import TYPE_CHECKING, Iterable
 if TYPE_CHECKING:
     from _typeshed.wsgi import WSGIEnvironment, StartResponse
 
-from werkzeug.datastructures import Headers
+from werkzeug.datastructures import Headers, MultiDict
 from werkzeug.wrappers import Request
 
 from localstack.http import Response
+from localstack.utils import strings
 
 from ..gateway import Gateway
 
@@ -39,7 +40,14 @@ class WsgiGateway:
         if "asgi.headers" in environ:
             # restores raw headers from ASGI scope, which allows dashes in header keys
             # see https://github.com/pallets/werkzeug/issues/940
-            request.headers = Headers(environ["asgi.headers"])
+            request.headers = Headers(
+                MultiDict(
+                    [
+                        (strings.to_str(k, "latin-1"), strings.to_str(v, "latin-1"))
+                        for (k, v) in environ["asgi.headers"]
+                    ]
+                )
+            )
         else:
             # by default, werkzeug requests from environ are immutable
             request.headers = Headers(request.headers)

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -135,9 +135,6 @@ def call_endpoint(
 
 def _clone_map_without_rules(old: Map) -> Map:
     return Map(
-        # TODO charset and encoding_errors are deprecated, remove with upgrade to Werkzeug 2.4.0
-        charset=old.charset,
-        encoding_errors=old.encoding_errors,
         default_subdomain=old.default_subdomain,
         strict_slashes=old.strict_slashes,
         merge_slashes=old.merge_slashes,

--- a/localstack/services/lambda_/lambda_api.py
+++ b/localstack/services/lambda_/lambda_api.py
@@ -1809,7 +1809,7 @@ def invoke_function(function):
             details["Headers"]["X-Amz-Function-Error"] = str(details["FunctionError"])
         # LogResult contains the last 4KB (~4k characters) of log outputs
         logs = log_output[-4000:] if log_type == "Tail" else ""
-        details["Headers"]["X-Amz-Log-Result"] = base64.b64encode(to_bytes(logs))
+        details["Headers"]["X-Amz-Log-Result"] = to_str(base64.b64encode(to_bytes(logs)))
         details["Headers"]["X-Amz-Executed-Version"] = str(qualifier or VERSION_LATEST)
         # Construct response object
         response_obj = details["Payload"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,9 +73,8 @@ runtime =
     crontab>=0.22.6
     dnspython>=1.16.0
     docker==6.0.1
-    flask>=2.3.2
-    flask-cors>=3.0.3,<3.1.0
-    flask_swagger==0.2.12
+    flask>=3.0.0
+    flask-cors>=4.0.0
     hypercorn>=0.14.4
     json5==0.9.11
     jsonpatch>=1.24,<2.0
@@ -88,10 +87,10 @@ runtime =
     opensearch-py==2.1.1
     pymongo>=4.2.0
     pyopenssl>=23.0.0
-    Quart>=0.18
+    Quart>=0.19.2
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
-    Werkzeug>=2.3.4,<3.0
+    Werkzeug>=3.0.0
     xmltodict>=0.13.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
## Motivation
This PR upgrades Werkzeug to version 3 and fixes some issues caused by the removal of deprecations (or other breaking changes with version 3).
This PR removes the pin (avoiding the upgrade) added with https://github.com/localstack/localstack/pull/9272.

## Changes
- Updates minimum version in `setup.cfg`.
- Fixes some issues which came up with the new major release:
  - Decode headers when populating the WSGI request headers from the ASGI requests and when forwarding requests.
    - Werkzeug's `Headers` object raises a `BadRequestKeyError` if a key is not of type `str`.
    - See https://github.com/pallets/werkzeug/commit/5ff0a573f4b78d9724f1f063fb058fd6bc76b24d.
  - Removes the usage of `charset` and `encoding_errors` on the `Map` (they have been removed).
    - Also see https://github.com/pallets/werkzeug/commit/5ff0a573f4b78d9724f1f063fb058fd6bc76b24d (even though it's not mentioned in the commit message).

## Testing
As soon as the pipeline is green again (and the upgrade is tested with LocalStack Pro), this upgrade is safe to be merged.

## TODO
- [x] Make sure all tests in the pipeline are 💚 
  - I executed a full run (amd64, arm64, community tests) of our Pro pipeline. All 💚.