### PR TITLE
Type conversion for AWS::OpenSearch::Domain

### DIFF
--- a/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
+++ b/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
@@ -1,6 +1,7 @@
 # LocalStack Resource Provider Scaffolding v2
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional, Type, TypedDict
 
@@ -222,6 +223,19 @@ class OpenSearchServiceDomainProvider(ResourceProvider[OpenSearchServiceDomainPr
                 # set defaults required for boto3 calls
                 cluster_config.setdefault("DedicatedMasterType", "m3.medium.search")
                 cluster_config.setdefault("WarmType", "ultrawarm1.medium.search")
+
+                for key in ["DedicatedMasterCount", "InstanceCount", "WarmCount"]:
+                    if key in cluster_config and isinstance(cluster_config[key], str):
+                        cluster_config[key] = int(cluster_config[key])
+
+            if properties.get("AccessPolicies") and isinstance(properties["AccessPolicies"], dict):
+                properties["AccessPolicies"] = json.dumps(properties["AccessPolicies"])
+
+            ebs_options = properties.get("EBSOptions")
+            if isinstance(ebs_options, dict):
+                for key in ["Iops", "Throughput", "VolumeSize"]:
+                    if key in ebs_options and isinstance(ebs_options[key], str):
+                        ebs_options[key] = int(ebs_options[key])
 
             create_kwargs = {**util.deselect_attributes(properties, ["Tags"])}
             if tags := properties.get("Tags"):

--- a/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
+++ b/localstack/services/opensearch/resource_providers/aws_opensearchservice_domain.py
@@ -228,11 +228,10 @@ class OpenSearchServiceDomainProvider(ResourceProvider[OpenSearchServiceDomainPr
                     if key in cluster_config and isinstance(cluster_config[key], str):
                         cluster_config[key] = int(cluster_config[key])
 
-            if properties.get("AccessPolicies") and isinstance(properties["AccessPolicies"], dict):
+            if properties.get("AccessPolicies"):
                 properties["AccessPolicies"] = json.dumps(properties["AccessPolicies"])
 
-            ebs_options = properties.get("EBSOptions")
-            if isinstance(ebs_options, dict):
+            if ebs_options := properties.get("EBSOptions"):
                 for key in ["Iops", "Throughput", "VolumeSize"]:
                     if key in ebs_options and isinstance(ebs_options[key], str):
                         ebs_options[key] = int(ebs_options[key])

--- a/tests/aws/services/cloudformation/resources/test_opensearch.py
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.py
@@ -51,7 +51,27 @@ def test_domain(deploy_cfn_template, aws_client, snapshot):
 
 
 @markers.aws.validated
-def test_domain_with_alternative_types(deploy_cfn_template, aws_client):
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..DomainStatus.AccessPolicies",
+        "$..DomainStatus.AdvancedOptions.override_main_response_version",
+        "$..DomainStatus.AdvancedSecurityOptions.AnonymousAuthEnabled",
+        "$..DomainStatus.AutoTuneOptions.State",
+        "$..DomainStatus.AutoTuneOptions.UseOffPeakWindow",
+        "$..DomainStatus.ChangeProgressDetails",
+        "$..DomainStatus.ClusterConfig.DedicatedMasterCount",
+        "$..DomainStatus.ClusterConfig.InstanceCount",
+        "$..DomainStatus.ClusterConfig.MultiAZWithStandbyEnabled",
+        "$..DomainStatus.ClusterConfig.ZoneAwarenessConfig",
+        "$..DomainStatus.ClusterConfig.ZoneAwarenessEnabled",
+        "$..DomainStatus.EBSOptions.VolumeSize",
+        "$..DomainStatus.Endpoint",
+        "$..DomainStatus.OffPeakWindowOptions",
+        "$..DomainStatus.ServiceSoftwareOptions.CurrentVersion",
+        "$..DomainStatus.SoftwareUpdateOptions",
+    ]
+)
+def test_domain_with_alternative_types(deploy_cfn_template, aws_client, snapshot):
     """
     Test that the alternative types for the OpenSearch domain are accepted using the resource documentation example
     """
@@ -62,4 +82,4 @@ def test_domain_with_alternative_types(deploy_cfn_template, aws_client):
     )
     domain_name = stack.outputs["SearchDomain"]
     domain = aws_client.opensearch.describe_domain(DomainName=domain_name)
-    assert domain["DomainStatus"]["DomainName"] == domain_name
+    snapshot.match("describe_domain", domain)

--- a/tests/aws/services/cloudformation/resources/test_opensearch.py
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.py
@@ -48,3 +48,18 @@ def test_domain(deploy_cfn_template, aws_client, snapshot):
     tags_result = aws_client.opensearch.list_tags(ARN=domain_arn)
     tags_result["TagList"].sort(key=itemgetter("Key"))
     snapshot.match("list_tags", tags_result)
+
+
+@markers.aws.validated
+def test_domain_with_alternative_types(deploy_cfn_template, aws_client):
+    """
+    Test that the alternative types for the OpenSearch domain are accepted using the resource documentation example
+    """
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/opensearch_domain_alternative_types.yml"
+        )
+    )
+    domain_name = stack.outputs["SearchDomain"]
+    domain = aws_client.opensearch.describe_domain(DomainName=domain_name)
+    assert domain["DomainStatus"]["DomainName"] == domain_name

--- a/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_opensearch.snapshot.json
@@ -109,5 +109,117 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_opensearch.py::test_domain_with_alternative_types": {
+    "recorded-date": "05-10-2023, 11:07:39",
+    "recorded-content": {
+      "describe_domain": {
+        "DomainStatus": {
+          "ARN": "arn:aws:es:<region>:111111111111:domain/test-opensearch-domain",
+          "AccessPolicies": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:root"
+                },
+                "Action": "es:*",
+                "Resource": "arn:aws:es:<region>:111111111111:domain/test-opensearch-domain/*"
+              }
+            ]
+          },
+          "AdvancedOptions": {
+            "override_main_response_version": "true",
+            "rest.action.multi.allow_explicit_index": "true"
+          },
+          "AdvancedSecurityOptions": {
+            "AnonymousAuthEnabled": false,
+            "Enabled": false,
+            "InternalUserDatabaseEnabled": false
+          },
+          "AutoTuneOptions": {
+            "State": "ENABLED",
+            "UseOffPeakWindow": false
+          },
+          "ChangeProgressDetails": {
+            "ChangeId": "<uuid:1>"
+          },
+          "ClusterConfig": {
+            "ColdStorageOptions": {
+              "Enabled": false
+            },
+            "DedicatedMasterCount": 3,
+            "DedicatedMasterEnabled": true,
+            "DedicatedMasterType": "m3.medium.search",
+            "InstanceCount": 2,
+            "InstanceType": "m3.medium.search",
+            "MultiAZWithStandbyEnabled": false,
+            "WarmEnabled": false,
+            "ZoneAwarenessConfig": {
+              "AvailabilityZoneCount": 2
+            },
+            "ZoneAwarenessEnabled": true
+          },
+          "CognitoOptions": {
+            "Enabled": false
+          },
+          "Created": true,
+          "Deleted": false,
+          "DomainEndpointOptions": {
+            "CustomEndpointEnabled": false,
+            "EnforceHTTPS": false,
+            "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
+          },
+          "DomainId": "111111111111/test-opensearch-domain",
+          "DomainName": "test-opensearch-domain",
+          "EBSOptions": {
+            "EBSEnabled": true,
+            "Iops": 0,
+            "VolumeSize": 20,
+            "VolumeType": "gp2"
+          },
+          "EncryptionAtRestOptions": {
+            "Enabled": false
+          },
+          "Endpoint": "search-test-opensearch-domain-lwnlbu3h4beauepbhlq5emyh3m.<region>.es.amazonaws.com",
+          "EngineVersion": "OpenSearch_1.0",
+          "NodeToNodeEncryptionOptions": {
+            "Enabled": false
+          },
+          "OffPeakWindowOptions": {
+            "Enabled": true,
+            "OffPeakWindow": {
+              "WindowStartTime": {
+                "Hours": 2,
+                "Minutes": 0
+              }
+            }
+          },
+          "Processing": false,
+          "ServiceSoftwareOptions": {
+            "AutomatedUpdateDate": "datetime",
+            "Cancellable": false,
+            "CurrentVersion": "OpenSearch_1_0_R20230928",
+            "Description": "There is no software update available for this domain.",
+            "NewVersion": "",
+            "OptionalDeployment": true,
+            "UpdateAvailable": false,
+            "UpdateStatus": "COMPLETED"
+          },
+          "SnapshotOptions": {
+            "AutomatedSnapshotStartHour": 0
+          },
+          "SoftwareUpdateOptions": {
+            "AutoSoftwareUpdateEnabled": false
+          },
+          "UpgradeProcessing": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/templates/opensearch_domain_alternative_types.yml
+++ b/tests/aws/templates/opensearch_domain_alternative_types.yml
@@ -1,0 +1,36 @@
+Resources:
+  OpenSearchServiceDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: 'test-opensearch-domain'
+      EngineVersion: 'OpenSearch_1.0'
+      ClusterConfig:
+        DedicatedMasterEnabled: true
+        InstanceCount: '2'
+        ZoneAwarenessEnabled: true
+        InstanceType: 'm3.medium.search'
+        DedicatedMasterType: 'm3.medium.search'
+        DedicatedMasterCount: '3'
+      EBSOptions:
+        EBSEnabled: true
+        Iops: '0'
+        VolumeSize: '20'
+        VolumeType: 'gp2'
+      AccessPolicies:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: 'Allow'
+            Principal:
+              AWS:
+                Fn::Sub: 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'es:*'
+            Resource:
+              Fn::Sub: 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/test-opensearch-domain/*'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+        override_main_response_version: 'true'
+Outputs:
+  SearchDomain:
+    Value:
+        Ref: OpenSearchServiceDomain

--- a/tests/aws/templates/opensearch_domain_alternative_types.yml
+++ b/tests/aws/templates/opensearch_domain_alternative_types.yml
@@ -1,3 +1,4 @@
+# sample from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
 Resources:
   OpenSearchServiceDomain:
     Type: AWS::OpenSearchService::Domain


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The example from the resource type cdocumentation cannot be deployed in LocalStack due to the lack of some extra type conversions for some parameters.

<!-- What notable changes does this PR make? -->
## Changes
Extra type validations and transformations in the resource provider

## Testing
The added test uses the template from the documentation 
