### PR TITLE
fix flaky get_metric_data cloudwatch test

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -148,10 +148,14 @@ class TestCloudwatch:
             assert 2 == len(response["MetricDataResults"])
 
             for data_metric in response["MetricDataResults"]:
+                # TODO: there's an issue in the implementation of the service here.
+                #  The returned timestamps should have the seconds set to 0
                 if data_metric["Id"] == "some":
-                    assert 41.0 == data_metric["Values"][0]
+                    assert 41.0 == sum(
+                        data_metric["Values"]
+                    )  # might fall under different 60s "buckets"
                 if data_metric["Id"] == "part":
-                    assert 23.0 == data_metric["Values"][0]
+                    assert 23.0 == sum(data_metric["Values"])
 
         # need to retry because the might most likely not be ingested immediately (it's fairly quick though)
         retry(_get_metric_data_sum, retries=10, sleep_before=2)


### PR DESCRIPTION

## Motivation
The  `tests.aws.services.cloudwatch.test_cloudwatch.TestCloudwatch.test_get_metric_data` test has been flaky in the past. This PR aims to fix the test to remove this flakiness.

Example flake: https://app.circleci.com/pipelines/github/localstack/localstack/18675/workflows/963c77f7-1832-4350-9fac-4cc9837e58c0/jobs/144301

## Changes

- Check the sum of all values instead of only the first value, since the two `put_metric_data` entries might end up in two different 60s metric statistics "buckets"


## Testing

To trigger the case where multiple "buckets" exist, i.e. where the array would be [18,23] instead of [41], simply add a time.sleep(60) like this:

```python
        aws_client.cloudwatch.put_metric_data(
            Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
        )
        time.sleep(60)
        aws_client.cloudwatch.put_metric_data(
            Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=18)]
        )
        aws_client.cloudwatch.put_metric_data(
            Namespace=namespace2, MetricData=[dict(MetricName="ug", Value=23)]
        )
```

this will cause them to be 60s apart and thus fall on different data points for the metrics
