### PR TITLE
Screen AWS markers for Lambda

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -26,6 +26,7 @@ LAMBDA_NETWORKS_PYTHON_HANDLER = os.path.join(THIS_FOLDER, "functions/lambda_net
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
+@markers.aws.only_localstack
 class TestHotReloading:
     @pytest.mark.parametrize(
         "runtime,handler_file,handler_filename",
@@ -35,7 +36,6 @@ class TestHotReloading:
         ],
         ids=["nodejs18.x", "python3.9"],
     )
-    @markers.aws.unknown
     def test_hot_reloading(
         self,
         create_lambda_function_aws,
@@ -104,7 +104,6 @@ class TestHotReloading:
         assert response_dict["counter"] == 1
         assert response_dict["constant"] == "value2"
 
-    @markers.aws.unknown
     def test_hot_reloading_publish_version(
         self, create_lambda_function_aws, lambda_su_role, cleanups, aws_client
     ):
@@ -136,8 +135,8 @@ class TestHotReloading:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
+@markers.aws.only_localstack
 class TestDockerFlags:
-    @markers.aws.unknown
     def test_additional_docker_flags(self, create_lambda_function, monkeypatch, aws_client):
         env_value = short_uid()
         monkeypatch.setattr(config, "LAMBDA_DOCKER_FLAGS", f"-e Hello={env_value}")
@@ -154,7 +153,6 @@ class TestDockerFlags:
         result_data = json.loads(to_str(result_data))
         assert {"Hello": env_value} == result_data
 
-    @markers.aws.unknown
     def test_lambda_docker_networks(self, lambda_su_role, monkeypatch, aws_client, cleanups):
         function_name = f"test-network-{short_uid()}"
         container_name = f"server-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -26,7 +26,6 @@ LAMBDA_NETWORKS_PYTHON_HANDLER = os.path.join(THIS_FOLDER, "functions/lambda_net
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
-@markers.aws.only_localstack
 class TestHotReloading:
     @pytest.mark.parametrize(
         "runtime,handler_file,handler_filename",
@@ -36,6 +35,7 @@ class TestHotReloading:
         ],
         ids=["nodejs18.x", "python3.9"],
     )
+    @markers.aws.only_localstack
     def test_hot_reloading(
         self,
         create_lambda_function_aws,
@@ -104,6 +104,7 @@ class TestHotReloading:
         assert response_dict["counter"] == 1
         assert response_dict["constant"] == "value2"
 
+    @markers.aws.only_localstack
     def test_hot_reloading_publish_version(
         self, create_lambda_function_aws, lambda_su_role, cleanups, aws_client
     ):
@@ -135,8 +136,8 @@ class TestHotReloading:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
-@markers.aws.only_localstack
 class TestDockerFlags:
+    @markers.aws.only_localstack
     def test_additional_docker_flags(self, create_lambda_function, monkeypatch, aws_client):
         env_value = short_uid()
         monkeypatch.setattr(config, "LAMBDA_DOCKER_FLAGS", f"-e Hello={env_value}")
@@ -153,6 +154,7 @@ class TestDockerFlags:
         result_data = json.loads(to_str(result_data))
         assert {"Hello": env_value} == result_data
 
+    @markers.aws.only_localstack
     def test_lambda_docker_networks(self, lambda_su_role, monkeypatch, aws_client, cleanups):
         function_name = f"test-network-{short_uid()}"
         container_name = f"server-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_legacy.py
+++ b/tests/aws/services/lambda_/test_lambda_legacy.py
@@ -89,8 +89,8 @@ def test_logging_in_local_executor(create_lambda_function, handler_path, aws_cli
 
 
 @pytest.mark.skipif(not is_old_provider(), reason="test does not make valid assertions against AWS")
-@markers.aws.unknown
 class TestLambdaLegacyProvider:
+    @markers.aws.unknown
     def test_add_lambda_multiple_permission(self, create_lambda_function, aws_client):
         """Test adding multiple permissions"""
         function_name = f"lambda_func-{short_uid()}"
@@ -147,6 +147,7 @@ class TestLambdaLegacyProvider:
         )
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
+    @markers.aws.unknown
     def test_add_lambda_permission(self, create_lambda_function, aws_client):
         function_name = f"lambda_func-{short_uid()}"
         lambda_create_response = create_lambda_function(
@@ -198,6 +199,7 @@ class TestLambdaLegacyProvider:
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
     # remove? be aware of partition check
+    @markers.aws.unknown
     def test_create_lambda_function(self, aws_client):
         """Basic test that creates and deletes a Lambda function"""
         func_name = f"lambda_func-{short_uid()}"
@@ -245,6 +247,7 @@ class TestLambdaLegacyProvider:
         assert "ResourceNotFoundException" in str(exc)
 
     @skip_if_pro_enabled
+    @markers.aws.unknown
     def test_update_lambda_with_layers(self, create_lambda_function, aws_client):
         func_name = f"lambda-{short_uid()}"
         create_lambda_function(

--- a/tests/aws/services/lambda_/test_lambda_legacy.py
+++ b/tests/aws/services/lambda_/test_lambda_legacy.py
@@ -29,6 +29,8 @@ from tests.aws.services.lambda_.test_lambda import (
     read_streams,
 )
 
+# TODO: remove these tests with 3.0 because they are only for the legacy provider and not aws-validated.
+#   not worth fixing the unknown markers.
 pytestmark = pytest.mark.skipif(
     condition=is_new_provider(), reason="only relevant for old provider"
 )
@@ -87,8 +89,8 @@ def test_logging_in_local_executor(create_lambda_function, handler_path, aws_cli
 
 
 @pytest.mark.skipif(not is_old_provider(), reason="test does not make valid assertions against AWS")
+@markers.aws.unknown
 class TestLambdaLegacyProvider:
-    @markers.aws.unknown
     def test_add_lambda_multiple_permission(self, create_lambda_function, aws_client):
         """Test adding multiple permissions"""
         function_name = f"lambda_func-{short_uid()}"
@@ -145,7 +147,6 @@ class TestLambdaLegacyProvider:
         )
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
-    @markers.aws.unknown
     def test_add_lambda_permission(self, create_lambda_function, aws_client):
         function_name = f"lambda_func-{short_uid()}"
         lambda_create_response = create_lambda_function(
@@ -197,7 +198,6 @@ class TestLambdaLegacyProvider:
         assert 200 == resp["ResponseMetadata"]["HTTPStatusCode"]
 
     # remove? be aware of partition check
-    @markers.aws.unknown
     def test_create_lambda_function(self, aws_client):
         """Basic test that creates and deletes a Lambda function"""
         func_name = f"lambda_func-{short_uid()}"
@@ -245,7 +245,6 @@ class TestLambdaLegacyProvider:
         assert "ResourceNotFoundException" in str(exc)
 
     @skip_if_pro_enabled
-    @markers.aws.unknown
     def test_update_lambda_with_layers(self, create_lambda_function, aws_client):
         func_name = f"lambda-{short_uid()}"
         create_lambda_function(

--- a/tests/aws/services/lambda_/test_lambda_performance.py
+++ b/tests/aws/services/lambda_/test_lambda_performance.py
@@ -30,7 +30,7 @@ if not is_env_true("TEST_PERFORMANCE"):
 LOG = logging.getLogger(__name__)
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_invoke_warm_start(create_lambda_function, aws_client):
     function_name = f"echo-func-{short_uid()}"
     create_lambda_function(
@@ -53,7 +53,7 @@ def test_invoke_warm_start(create_lambda_function, aws_client):
     export_csv(timings, "test_invoke_warm_start")
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_invoke_cold_start(create_lambda_function, aws_client, monkeypatch):
     monkeypatch.setattr(config, "LAMBDA_KEEPALIVE_MS", 0)
     function_name = f"echo-func-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_runtimes.py
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.py
@@ -134,8 +134,7 @@ class TestNodeJSRuntimes:
 
 class TestJavaRuntimes:
     @pytest.fixture(scope="class")
-    @markers.aws.unknown
-    def test_java_jar(self) -> bytes:
+    def java_jar(self) -> bytes:
         lambda_java_testlibs_package.install()
         java_file = load_file(
             lambda_java_testlibs_package.get_installer().get_executable_path(), mode="rb"
@@ -143,8 +142,7 @@ class TestJavaRuntimes:
         return java_file
 
     @pytest.fixture(scope="class")
-    @markers.aws.unknown
-    def test_java_zip(self, tmpdir_factory, test_java_jar) -> bytes:
+    def java_zip(self, tmpdir_factory, java_jar) -> bytes:
         tmpdir = tmpdir_factory.mktemp("tmp-java-zip")
         zip_lib_dir = os.path.join(tmpdir, "lib")
         zip_jar_path = os.path.join(zip_lib_dir, "test.lambda.jar")
@@ -156,7 +154,7 @@ class TestJavaRuntimes:
             java_lib_dir,
             os.path.join(zip_lib_dir, "executor.lambda.jar"),
         )
-        save_file(zip_jar_path, test_java_jar)
+        save_file(zip_jar_path, java_jar)
         return testutil.create_zip_file(tmpdir, get_content=True)
 
     @markers.snapshot.skip_snapshot_verify(
@@ -210,13 +208,11 @@ class TestJavaRuntimes:
 
     @parametrize_java_runtimes
     @markers.aws.validated
-    def test_stream_handler(
-        self, create_lambda_function, test_java_jar, runtime, snapshot, aws_client
-    ):
+    def test_stream_handler(self, create_lambda_function, java_jar, runtime, snapshot, aws_client):
         function_name = f"test-lambda-{short_uid()}"
         create_lambda_function(
             func_name=function_name,
-            zip_file=test_java_jar,
+            zip_file=java_jar,
             runtime=runtime,
             handler="cloud.localstack.awssdkv1.sample.LambdaStreamHandler",
         )
@@ -229,13 +225,13 @@ class TestJavaRuntimes:
     @parametrize_java_runtimes
     @markers.aws.validated
     def test_serializable_input_object(
-        self, create_lambda_function, test_java_zip, runtime, snapshot, aws_client
+        self, create_lambda_function, java_zip, runtime, snapshot, aws_client
     ):
         # deploy lambda - Java with serializable input object
         function_name = f"test-lambda-{short_uid()}"
         create_result = create_lambda_function(
             func_name=function_name,
-            zip_file=test_java_zip,
+            zip_file=java_zip,
             runtime=runtime,
             handler="cloud.localstack.awssdkv1.sample.SerializedInputLambdaHandler",
         )
@@ -328,7 +324,7 @@ class TestJavaRuntimes:
         sns_create_topic,
         snapshot,
         create_lambda_function,
-        test_java_zip,
+        java_zip,
         aws_client,
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())
@@ -338,7 +334,7 @@ class TestJavaRuntimes:
         key = f"key-{short_uid()}"
         create_lambda_function(
             func_name=function_name,
-            zip_file=test_java_zip,
+            zip_file=java_zip,
             runtime=Runtime.java11,
             handler="cloud.localstack.sample.LambdaHandler",
         )


### PR DESCRIPTION
Companion PR: https://github.com/localstack/localstack-ext/pull/2159

## Motivation

Fix AWS markers for Lambda according to marker report https://github.com/localstack/localstack/issues/9147

Grepped for some extra occurrences not covered in the marker report.

## Changes

* Set markers to `localstack_only` where applicable
* Remove false positives and rename fixtures or inner asserts to clarify their intent
* Leave some to `unknown` scheduled to be removed at 3.0 (not worth fixing/testing)
