### PR TITLE
upgrade debian to bookworm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "alexrashed"
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "eclipse-temurin"
+        update-types: ["version-update:semver-major"]
     labels:
       - "area: dependencies"
       - "semver: patch"
@@ -19,3 +23,7 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -85,6 +85,6 @@ jobs:
           author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
           committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
           commit-message: "update generated ASF APIs to latest version"
-          labels: "area: asf, area: dependencies"
+          labels: "area: asf, area: dependencies, semver: patch"
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           reviewers: alexrashed

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java,...)
-FROM python:3.11.5-slim-buster@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf as base
+FROM python:3.11.5-slim-bookworm@sha256:edaf703dce209d774af3ff768fc92b1e3b60261e7602126276f9ceb0e3a96874 as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
-# builder: Stage to build a custom JRE (with jlink)
-FROM python:3.11.5-slim-buster@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf as java-builder
-ARG TARGETARCH
-
-# install OpenJDK 11
-RUN apt-get update && \
-        apt-get install -y openjdk-11-jdk-headless && \
-        apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
+# java-builder: Stage to build a custom JRE (with jlink)
+FROM eclipse-temurin:11@sha256:271c1393da8cac27d58b64779bd65563737c00297bba9d0ac49e328d4ea87d32 as java-builder
 
 # create a custom, minimized JRE via jlink
 RUN jlink --add-modules \
@@ -100,11 +92,9 @@ RUN { \
         echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
     } > /usr/local/bin/docker-java-home \
     && chmod +x /usr/local/bin/docker-java-home
-COPY --from=java-builder /usr/lib/jvm/java-11 /usr/lib/jvm/java-11
-COPY --from=java-builder /etc/ssl/certs/java /etc/ssl/certs/java
-COPY --from=java-builder /etc/java-11-openjdk/security /etc/java-11-openjdk/security
-RUN ln -s /usr/lib/jvm/java-11/bin/java /usr/bin/java
 ENV JAVA_HOME /usr/lib/jvm/java-11
+COPY --from=java-builder /usr/lib/jvm/java-11 $JAVA_HOME
+RUN ln -s /usr/lib/jvm/java-11/bin/java /usr/bin/java
 ENV PATH "${PATH}:${JAVA_HOME}/bin"
 
 # set workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN { \
     && chmod +x /usr/local/bin/docker-java-home
 ENV JAVA_HOME /usr/lib/jvm/java-11
 COPY --from=java-builder /usr/lib/jvm/java-11 $JAVA_HOME
-RUN ln -s /usr/lib/jvm/java-11/bin/java /usr/bin/java
+RUN ln -s $JAVA_HOME/bin/java /usr/bin/java
 ENV PATH "${PATH}:${JAVA_HOME}/bin"
 
 # set workdir
@@ -127,7 +127,7 @@ ADD bin/hosts /etc/hosts
 # expose default environment
 # Set edge bind host so localstack can be reached by other containers
 # set library path and default LocalStack hostname
-ENV LD_LIBRARY_PATH=/usr/lib/jvm/java-11/lib:/usr/lib/jvm/java-11/lib/server
+ENV LD_LIBRARY_PATH=$JAVA_HOME/lib:$JAVA_HOME/lib/server
 ENV USER=localstack
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Motivation
This PR upgrades the OS version of the Docker image from Debian Bullseye to Debian Bookworm.
The last upgrade was done with the release of version `2.1.0` in https://github.com/localstack/localstack/pull/8344 / https://github.com/localstack/localstack/pull/7876.
Since the Debian repositories for bookworm do not contain `openjdk-11` anymore, I also switched the java-builder to use the `eclipse-temurin:11` image.

## Changes
- The base image's OS has been upgraded from Debian Bullseye (oldstable) to Debian Bookworm (stable).
- The `java-builder` stage has been replaced to use [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin) image (because Debian Bookworm does not have OpenJDK in the repos anymore).
  - We are already using Eclipse Temurin in the Java installer if we need other Java versions (for BigData services).

## Testing
- Tested by building the image locally.
- If all tests are green, we can be quite confident that everything works correctly.

## Merge?
This PR contains some important changes:
- Updates the base image from Debian Bullseye to Debian Bookworm.
  - This could have an implication for users which install any kind of packages in the Docker image.
- Change the Java JDK from OpenJDK in the package repo to the Temurin build.
  - I think this should actually be a safe change.
  - Eclipse Temurin is based OpenJDK.

We should decide on when to merge this change. The last time (with the Debian upgrade from Buster to Bullseye), we didn't really see any issues among our user-base.