### PR TITLE
Allow --mount-dependencies for python modules which are not in a separate directory

### DIFF
--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -294,8 +294,8 @@ class DependencyMountConfigurator:
 
         # find dependencies from the host
         for dep_path in self.host_paths.venv_dir.glob("lib/python3.*/site-packages/*"):
-            # filter out everything that heuristically cannot be a source directory
-            if not dep_path.is_dir():
+            # filter out everything that heuristically cannot be a source path
+            if not self._can_be_source_path(dep_path):
                 continue
             if dep_path.name.endswith(".dist-info"):
                 continue
@@ -315,6 +315,9 @@ class DependencyMountConfigurator:
                 continue
 
             cfg.volumes.append(VolumeBind(str(dep_path), target_path))
+
+    def _can_be_source_path(self, path: Path) -> bool:
+        return path.is_dir() or (path.name.endswith(".py") and not path.name.startswith("__"))
 
     def _has_mount(self, volumes: VolumeMappings, target_path: str) -> bool:
         return True if volumes.find_target_mapping(target_path) else False


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, in the dev script, we only mount python modules which are in there own subfolder.
However, the assumption that all dependencies are located in a subfolder does not hold:
For example, `nest-asyncio` is only one file, and is not located in a separate folder in `site-packages`. (This is a dependency for serverless tests in -ext, and without it, test collection fails).

We should therefore also mount python files in `site-packages`, unless they start with `__` (sometimes linked editable installs have a python finder file like this: `__editable___localstack_core_2_2_1_dev0_finder.py`).

<!-- What notable changes does this PR make? -->
## Changes
* Mount files from `site-packages` as dependency as well, unless they start with a dunder

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

