### PR TITLE
add /_localstack/info endpoint for basic infos about the instance

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -127,27 +127,24 @@ class InfoResource:
     """
 
     def on_get(self, request):
-        try:
+        return self.get_info_data()
 
-            client_metadata = get_client_metadata()
-            uptime = int(time.time() - config.load_start_time)
+    @staticmethod
+    def get_info_data() -> dict:
+        client_metadata = get_client_metadata()
+        uptime = int(time.time() - config.load_start_time)
 
-            response = {
-                "version": client_metadata.version,
-                "edition": get_localstack_edition() or "unknown",
-                "is_license_activated": is_license_activated(),
-                "session_id": client_metadata.session_id,
-                "machine_id": client_metadata.machine_id,
-                "system": client_metadata.system,
-                "is_docker": client_metadata.is_docker,
-                "server_time_utc": datetime.utcnow().isoformat(timespec="seconds"),
-                "uptime": uptime,
-            }
-        except Exception:
-            LOG.exception("Error")
-            return
-
-        return response
+        return {
+            "version": client_metadata.version,
+            "edition": get_localstack_edition() or "unknown",
+            "is_license_activated": is_license_activated(),
+            "session_id": client_metadata.session_id,
+            "machine_id": client_metadata.machine_id,
+            "system": client_metadata.system,
+            "is_docker": client_metadata.is_docker,
+            "server_time_utc": datetime.utcnow().isoformat(timespec="seconds"),
+            "uptime": uptime,
+        }
 
 
 class CloudFormationUi:
@@ -204,6 +201,7 @@ class DiagnoseResource:
                     "kernel": call_safe(diagnose.get_host_kernel_version),
                 },
             },
+            "info": call_safe(InfoResource.get_info_data),
             "services": call_safe(diagnose.get_service_stats),
             "config": call_safe(diagnose.get_localstack_config),
             "docker-inspect": call_safe(diagnose.inspect_main_container),

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -118,10 +118,16 @@ def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community
 
 def is_license_activated() -> bool:
     try:
+        from localstack_ext import config  # noqa
+    except ImportError:
+        return False
+
+    try:
         from localstack_ext.bootstrap import licensingv2
 
         return licensingv2.get_licensed_environment().activated
-    except ImportError:
+    except Exception:
+        LOG.exception("Could not determine license activation status")
         return False
 
 

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -2,11 +2,12 @@ import dataclasses
 import logging
 import os
 import platform
-from typing import Optional
+from typing import Literal, Optional
 
 from localstack import config, constants
 from localstack.runtime import hooks
 from localstack.utils.bootstrap import Container
+from localstack.utils.files import rm_rf
 from localstack.utils.functions import call_safe
 from localstack.utils.json import FileMappedDocument
 from localstack.utils.objects import singleton_factory
@@ -83,7 +84,17 @@ def get_client_metadata() -> ClientMetadata:
 @singleton_factory
 def get_machine_id() -> str:
     cache_path = os.path.join(config.dirs.cache, "machine.json")
-    doc = FileMappedDocument(cache_path)
+    try:
+        doc = FileMappedDocument(cache_path)
+    except Exception:
+        # it's possible that the file is somehow messed up, so we try to delete the file first and try again.
+        # if that fails, we return a generated ID.
+        call_safe(rm_rf, args=(cache_path,))
+
+        try:
+            doc = FileMappedDocument(cache_path)
+        except Exception:
+            return _generate_machine_id()
 
     if "machine_id" not in doc:
         # generate a machine id
@@ -92,6 +103,26 @@ def get_machine_id() -> str:
         call_safe(doc.save)
 
     return doc["machine_id"]
+
+
+def get_localstack_edition() -> Optional[Literal["enterprise", "pro", "community"]]:
+    if os.path.exists("/usr/lib/localstack/.enterprise-version"):
+        return "enterprise"
+    elif os.path.exists("/usr/lib/localstack/.pro-version"):
+        return "pro"
+    elif os.path.exists("/usr/lib/localstack/.community-version"):
+        return "community"
+
+    return None
+
+
+def is_license_activated() -> bool:
+    try:
+        from localstack_ext.bootstrap import licensingv2
+
+        return licensingv2.get_licensed_environment().activated
+    except ImportError:
+        return False
 
 
 def _generate_session_id() -> str:

--- a/tests/integration/services/test_internal.py
+++ b/tests/integration/services/test_internal.py
@@ -36,8 +36,25 @@ class TestHealthResource:
         response = requests.get(get_edge_url() + "/_localstack/health")
         assert response.ok
         assert "services" in response.json()
+        assert "edition" in response.json()
 
     def test_head(self):
         response = requests.head(get_edge_url() + "/_localstack/health")
         assert response.ok
         assert not response.text
+
+
+class TestInfoEndpoint:
+    def test_get(self):
+        response = requests.get(get_edge_url() + "/_localstack/info")
+        assert response.ok
+        doc = response.json()
+
+        from localstack import __version__ as version
+
+        # we're being specifically vague here since we want this test to be robust against pro or community
+        assert doc["version"].startswith(str(version))
+        assert doc["session_id"]
+        assert doc["machine_id"]
+        assert doc["system"]
+        assert type(doc["is_license_activated"]) == bool

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -26,6 +26,8 @@ class TestHealthResource:
         )
 
         state = resource.on_get(Request("GET", "/", body=b"None"))
+        # edition may return a different value depending on how the tests are run
+        state.pop("edition", None)
 
         assert state == {
             "features": {
@@ -55,6 +57,7 @@ class TestHealthResource:
         resource.on_put(Request("PUT", "/", body=b'{"features:initScripts": "initialized"}'))
 
         state = resource.on_get(Request("GET", "/", body=b"None"))
+        state.pop("edition", None)
 
         assert state == {
             "features": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Several other localstack systems need access to basic information about the running instance beyond the health status. Much like `docker info`, this new endpoint aims to provide this information.

Example:

```json
{
  "version": "2.3.3.dev:c77b830",
  "edition": "pro",
  "is_license_activated": true,
  "session_id": "1830110c-6e4d-4256-9bc0-9008b8c5b6b9",
  "machine_id": "4256a311839b",
  "system": "linux",
  "is_docker": true,
  "server_time_utc": "2023-10-04T14:59:40",
  "uptime": 120
}
```

<!-- What notable changes does this PR make? -->
## Changes

* Add a `/_localstack/info` endpoint
* Add two new metadata methods: getting the edition (from files we create in the Dockerfiles), and checking whether license activation has been successful
* Add the `edition` key also to the health endpoint, since that has long since been requested
* Add the output of info also to the diagnose endpoint


## Testing

* You can use the dev run script and call `curl -s https://localhost.localstack.cloud:4566/_localstack/info | jq .`
