### PR TITLE
fix S3 v3 HeadObject with checksum

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -839,7 +839,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         if checksum_algorithm := s3_object.checksum_algorithm:
             if (request.get("ChecksumMode") or "").upper() == "ENABLED":
-                response[f"Checksum{checksum_algorithm.upper()}"] = checksum  # noqa
+                response[f"Checksum{checksum_algorithm.upper()}"] = s3_object.checksum_value
 
         if s3_object.parts:
             response["PartsCount"] = len(s3_object.parts)

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -805,8 +805,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["ObjectLockLegalHoldStatus"] = s3_object.lock_legal_status
 
         for request_param, response_param in ALLOWED_HEADER_OVERRIDES.items():
-            if request_param_value := request.get(request_param):  # noqa
-                response[response_param] = request_param_value  # noqa
+            if request_param_value := request.get(request_param):
+                response[response_param] = request_param_value
 
         return response
 
@@ -1634,7 +1634,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "ObjectSize" in object_attrs:
             response["ObjectSize"] = s3_object.size
         if "Checksum" in object_attrs and (checksum_algorithm := s3_object.checksum_algorithm):
-            response["Checksum"] = {  # noqa
+            response["Checksum"] = {
                 f"Checksum{checksum_algorithm.upper()}": s3_object.checksum_value
             }
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1169,10 +1169,10 @@ class TestS3:
                 ObjectAttributes=["ETag", "Checksum"],
             )
             snapshot.match("get-object-attrs-auto-generated", object_attrs)
-        get_object_with_checksum = aws_client.s3.get_object(
+        get_object_with_checksum = aws_client.s3.head_object(
             Bucket=bucket, Key=key, ChecksumMode="ENABLED"
         )
-        snapshot.match("get-object-with-checksum", get_object_with_checksum)
+        snapshot.match("head-object-with-checksum", get_object_with_checksum)
 
     @markers.aws.validated
     @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "SHA1", "SHA256", None])

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -529,7 +529,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
-    "recorded-date": "03-08-2023, 04:14:32",
+    "recorded-date": "05-10-2023, 20:33:28",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -581,9 +581,8 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-object-with-checksum": {
+      "head-object-with-checksum": {
         "AcceptRanges": "bytes",
-        "Body": "test data..",
         "ChecksumCRC32": "cZWHwQ==",
         "ContentEncoding": "",
         "ContentLength": 11,
@@ -600,7 +599,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
-    "recorded-date": "03-08-2023, 04:14:35",
+    "recorded-date": "05-10-2023, 20:33:33",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -652,9 +651,8 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-object-with-checksum": {
+      "head-object-with-checksum": {
         "AcceptRanges": "bytes",
-        "Body": "test data..",
         "ChecksumCRC32C": "Pf4upw==",
         "ContentEncoding": "",
         "ContentLength": 11,
@@ -671,7 +669,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
-    "recorded-date": "03-08-2023, 04:14:38",
+    "recorded-date": "05-10-2023, 20:33:38",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -723,9 +721,8 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-object-with-checksum": {
+      "head-object-with-checksum": {
         "AcceptRanges": "bytes",
-        "Body": "test data..",
         "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
         "ContentEncoding": "",
         "ContentLength": 11,
@@ -742,7 +739,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
-    "recorded-date": "03-08-2023, 04:14:41",
+    "recorded-date": "05-10-2023, 20:33:43",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -794,9 +791,8 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-object-with-checksum": {
+      "head-object-with-checksum": {
         "AcceptRanges": "bytes",
-        "Body": "test data..",
         "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
         "ContentEncoding": "",
         "ContentLength": 11,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in https://github.com/localstack/localstack/issues/6659#issuecomment-1749013552, calling `HeadObject` on a an object with `ChecksumMode=ENABLED` will raise an exception. I totally missed it when copy/pasting the implementation from `GetObject`, because of a `#noqa` put there because of typing (dynamic key value inside the `*Response` object). 

<!-- What notable changes does this PR make? -->
## Changes
Fixed the line to use the object checksum instead of a non-existent variable.
I've also removed all the `noqa` from the provider because some type warnings are better than fully failing that this.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

