### PR TITLE
regenerate ASF stubs for botocore 1.31.61 upgrade

### DIFF
--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -1906,6 +1906,14 @@ class InstanceType(str):
     c7i_24xlarge = "c7i.24xlarge"
     c7i_48xlarge = "c7i.48xlarge"
     mac2_m2pro_metal = "mac2-m2pro.metal"
+    r7iz_large = "r7iz.large"
+    r7iz_xlarge = "r7iz.xlarge"
+    r7iz_2xlarge = "r7iz.2xlarge"
+    r7iz_4xlarge = "r7iz.4xlarge"
+    r7iz_8xlarge = "r7iz.8xlarge"
+    r7iz_12xlarge = "r7iz.12xlarge"
+    r7iz_16xlarge = "r7iz.16xlarge"
+    r7iz_32xlarge = "r7iz.32xlarge"
 
 
 class InstanceTypeHypervisor(str):

--- a/localstack/aws/api/route53/__init__.py
+++ b/localstack/aws/api/route53/__init__.py
@@ -188,6 +188,10 @@ class HostedZoneLimitType(str):
     MAX_VPCS_ASSOCIATED_BY_ZONE = "MAX_VPCS_ASSOCIATED_BY_ZONE"
 
 
+class HostedZoneType(str):
+    PrivateHostedZone = "PrivateHostedZone"
+
+
 class InsufficientDataHealthStatus(str):
     Healthy = "Healthy"
     Unhealthy = "Unhealthy"
@@ -1606,6 +1610,7 @@ class ListHostedZonesRequest(ServiceRequest):
     Marker: Optional[PageMarker]
     MaxItems: Optional[PageMaxItems]
     DelegationSetId: Optional[ResourceId]
+    HostedZoneType: Optional[HostedZoneType]
 
 
 class ListHostedZonesResponse(TypedDict, total=False):
@@ -2258,6 +2263,7 @@ class Route53Api:
         marker: PageMarker = None,
         max_items: PageMaxItems = None,
         delegation_set_id: ResourceId = None,
+        hosted_zone_type: HostedZoneType = None,
     ) -> ListHostedZonesResponse:
         raise NotImplementedError
 

--- a/localstack/aws/api/sts/__init__.py
+++ b/localstack/aws/api/sts/__init__.py
@@ -39,6 +39,7 @@ tagKeyType = str
 tagValueType = str
 tokenCodeType = str
 tokenType = str
+unrestrictedSessionPolicyDocumentType = str
 urlType = str
 userIdType = str
 userNameType = str
@@ -121,7 +122,7 @@ class AssumeRoleRequest(ServiceRequest):
     RoleArn: arnType
     RoleSessionName: roleSessionNameType
     PolicyArns: Optional[policyDescriptorListType]
-    Policy: Optional[sessionPolicyDocumentType]
+    Policy: Optional[unrestrictedSessionPolicyDocumentType]
     DurationSeconds: Optional[roleDurationSecondsType]
     Tags: Optional[tagListType]
     TransitiveTagKeys: Optional[tagKeyListType]
@@ -262,7 +263,7 @@ class StsApi:
         role_arn: arnType,
         role_session_name: roleSessionNameType,
         policy_arns: policyDescriptorListType = None,
-        policy: sessionPolicyDocumentType = None,
+        policy: unrestrictedSessionPolicyDocumentType = None,
         duration_seconds: roleDurationSecondsType = None,
         tags: tagListType = None,
         transitive_tag_keys: tagKeyListType = None,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A recent botocore upgrade seems to have introduced some build failures https://pypi.org/project/botocore/1.31.61/
```
E             File "/opt/code/localstack/localstack/aws/api/core.py", line 160, in operation_marker
E               return fn(*args, **kwargs)
E                      ^^^^^^^^^^^^^^^^^^^
E           TypeError: Route53Api.list_hosted_zones() got an unexpected keyword argument 'hosted_zone_type'

.venv/lib/python3.11/site-packages/botocore/client.py:980: ClientError
```

Regenerating the APIs manually to get the build unblocked.

<!-- What notable changes does this PR make? -->
## Changes

* regenerate ASF APIs

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

