### PR TITLE
add Python 3.12 to the CLI test version matrix

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     timeout-minutes: 10
     env:
       # Set job-specific environment variables for pytest-tinybird

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - ".github/workflows/cli-tests.yml"
+      - ".github/workflows/tests-cli.yml"
       - "localstack/**"
       - "tests/**"
       - "setup.py"
@@ -18,7 +18,7 @@ on:
       - release/*
   push:
     paths:
-      - ".github/workflows/cli-tests.yml"
+      - ".github/workflows/tests-cli.yml"
       - "localstack/**"
       - "tests/**"
       - "setup.py"


### PR DESCRIPTION
## Motivation
Python 3.12 has been released on 2nd of October 2023.
We got an issue report explaining that the CLI installation is not working correctly (which is not reproducible).
But this is a good reminder to update the CLI tests to include the new version in the tests.

## Changes
- Add Python 3.12 to the list of Python versions to test the CLI against.

/cc @thrau 