### PR TITLE
Helper changes to support `eksctl` and CDK L2 EKS construct

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -759,7 +759,7 @@ class ResourceProviderExecutor:
             return plugin.factory()
         except Exception:
             LOG.warning(
-                "Failed to load resource type as a ResourceProvider.",
+                "Failed to load resource type %s as a ResourceProvider.",
                 resource_type,
                 exc_info=LOG.isEnabledFor(logging.DEBUG),
             )

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -74,6 +74,7 @@ PROVIDER_DEFAULTS = {
     "AWS::ElasticBeanstalk::Environment": "ResourceProvider",
     "AWS::ElasticBeanstalk::ConfigurationTemplate": "ResourceProvider",
     "AWS::CertificateManager::Certificate": "ResourceProvider",
+    "AWS::EKS::Nodegroup": "ResourceProvider",
 }
 
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1048,7 +1048,8 @@ def deploy_cfn_template(
 
     yield _deploy
 
-    for entry in state:
+    # delete the stacks in the reverse order they were created in case of inter-stack dependencies
+    for entry in state[::-1]:
         entry_stack_id = entry.get("stack_id")
         try:
             if entry_stack_id:

--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -4,7 +4,7 @@ import threading
 from typing import Any, Callable, Dict, Generic, List, Optional, Set, Type, TypeVar, Union
 
 from .collections import ensure_list
-from .strings import first_char_to_lower
+from .strings import first_char_to_lower, first_char_to_upper
 
 ComplexType = Union[List, Dict, object]
 
@@ -155,8 +155,10 @@ def recurse_object(obj: ComplexType, func: Callable, path: str = "") -> ComplexT
     return obj
 
 
-def keys_to_lower(obj: ComplexType, skip_children_of: List[str] = None) -> ComplexType:
-    """Recursively changes all dict keys to first character lowercase. Skip children
+def keys_to(
+    obj: ComplexType, op: Callable[[str], str], skip_children_of: List[str] = None
+) -> ComplexType:
+    """Recursively changes all dict keys to apply op. Skip children
     of any elements whose names are contained in skip_children_of (e.g., ['Tags'])"""
     skip_children_of = ensure_list(skip_children_of or [])
 
@@ -166,11 +168,19 @@ def keys_to_lower(obj: ComplexType, skip_children_of: List[str] = None) -> Compl
         if isinstance(o, dict):
             for k, v in dict(o).items():
                 o.pop(k)
-                o[first_char_to_lower(k)] = v
+                o[op(k)] = v
         return o
 
     result = recurse_object(obj, fix_keys)
     return result
+
+
+def keys_to_lower(obj: ComplexType, skip_children_of: List[str] = None) -> ComplexType:
+    return keys_to(obj, first_char_to_lower, skip_children_of)
+
+
+def keys_to_upper(obj: ComplexType, skip_children_of: List[str] = None) -> ComplexType:
+    return keys_to(obj, first_char_to_upper, skip_children_of)
 
 
 def singleton_factory(factory: Callable[[], _T]) -> Callable[[], _T]:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We want to support `eksctl` in the -ext repo, but this requires some minor changes in utilities imported from community. Also there are some bugs that need fixing.


<!-- What notable changes does this PR make? -->
## Changes

- Enable `AWS::EKS::NodeGroup` resource provider
- Fix logging bug in CFn
- `deploy_cfn_template` deletes stacks in reverse order of creation
- Add `keys_to_upper` function

## TODO

- [ ] delete nodegroup service method for proper cleanup
- [ ] other nodegroup methods

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

