### PR TITLE
fix GetTopicAttributes exception when arn is malformed

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -112,6 +112,11 @@ class TestSNSTopicCrud:
 
         snapshot.match("get-attrs-nonexistent-topic", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.get_topic_attributes(TopicArn="test-topic")
+
+        snapshot.match("get-attrs-malformed-topic", e.value.response)
+
     @markers.aws.validated
     def test_tags(self, sns_create_topic, snapshot, aws_client):
 

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_with_attributes": {
-    "recorded-date": "24-08-2023, 22:30:43",
+    "recorded-date": "06-10-2023, 20:11:02",
     "recorded-content": {
       "get-topic-attrs": {
         "Attributes": {
@@ -74,6 +74,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      },
+      "get-attrs-malformed-topic": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 1",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9306, we would raise a 500 when the topic is not a properly formed ARN. This exception comes from moto, and should be handled there as well. In the meantime, we can fix it with our utils. 

<!-- What notable changes does this PR make? -->
## Changes
Moved up our method to get the topic, which will raise the proper exception if there's an issue before calling moto. Added a test with a malformed arn to validated the behaviour. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

