### PR TITLE
Add support for fn::select in conditional

### DIFF
--- a/localstack/services/cloudformation/engine/template_utils.py
+++ b/localstack/services/cloudformation/engine/template_utils.py
@@ -262,6 +262,21 @@ def resolve_condition(
                         ]
                     )
                     return result
+                case "Fn::Select":
+                    index = v[0]
+                    options = v[1]
+                    for i, option in enumerate(options):
+                        if isinstance(option, dict):
+                            options[i] = resolve_condition(
+                                account_id,
+                                region_name,
+                                option,
+                                conditions,
+                                parameters,
+                                mappings,
+                                stack_name,
+                            )
+                    return options[index]
                 case "Fn::Sub":
                     # we can assume anything in there is a ref
                     if isinstance(v, str):

--- a/tests/aws/services/cloudformation/engine/test_conditions.py
+++ b/tests/aws/services/cloudformation/engine/test_conditions.py
@@ -396,3 +396,15 @@ class TestCloudFormationConditions:
             assert stack.outputs["Result"] == "true"
         else:
             assert stack.outputs["Result"] == "false"
+
+    @markers.aws.validated
+    def test_conditional_with_select(self, deploy_cfn_template, aws_client):
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__),
+                "../../../templates/conditions/conditional-with-select.yml",
+            ),
+        )
+
+        managed_policy_arn = stack.outputs["PolicyArn"]
+        assert aws_client.iam.get_policy(PolicyArn=managed_policy_arn)

--- a/tests/aws/templates/conditions/conditional-with-select.yml
+++ b/tests/aws/templates/conditions/conditional-with-select.yml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Conditions:
+  IsGrapes: !Equals [!Select [ 1, ['apples', 'grapes', 'bananas']], 'grapes']
+
+Resources:
+  StreamWriterPolicy2:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Condition: IsGrapes
+    Properties:
+      ManagedPolicyName: Test2
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "kinesis:PutRecord"
+            Resource: !Join
+              - ':'
+              - - arn:aws:kinesis
+                - !Ref AWS::Region
+                - !Ref AWS::AccountId
+                - !Sub stream/${AWS::StackName}-*
+Outputs:
+  PolicyArn:
+    Description: StreamWriterPolicy2
+    Value: !Ref StreamWriterPolicy2


### PR DESCRIPTION
## Motivation
As shown in the issue #9300 CFn should be able to support using a `!Select` function in a Conditional. 

## Changes
The `resolve_condition` function now also supports a case for `Fn::Select`. According to the[ function documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-select.html), the select can also resolve references. 

## Testing
Added a simplet AWS validated test to confirm the expected behaviour.
