### PR TITLE
Disable AWS::ECR::Repository mock resource provider

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -66,7 +66,7 @@ PROVIDER_DEFAULTS = {
     "AWS::DynamoDB::Table": "ResourceProvider",
     "AWS::CloudWatch::Alarm": "ResourceProvider",
     "AWS::CloudWatch::CompositeAlarm": "ResourceProvider",
-    "AWS::ECR::Repository": "ResourceProvider",
+    # "AWS::ECR::Repository": "ResourceProvider",  # FIXME: add full -ext provider & override logic for -ext
 }
 
 


### PR DESCRIPTION

## Motivation

The current code isn't set up to handle this case where -ext overwrites a resource provider, especially with the -ext provider being a GenericBaseModel. We'll handle this later but for now we should unblock the pipeline again.

## Changes

- Disables the activation of the `AWS::ECR::Repository` resource provider, which should unblock -ext

