### PR TITLE
Use region-agnostic bucket create for Transcribe tests

### DIFF
--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -241,6 +241,7 @@ class TestTranscribe:
         output_bucket,
         output_key,
         s3_bucket,
+        s3_create_bucket,
         cleanups,
         snapshot,
         aws_client,
@@ -263,7 +264,7 @@ class TestTranscribe:
 
         if output_bucket is not None:
             params["OutputBucketName"] = output_bucket
-            aws_client.s3.create_bucket(Bucket=output_bucket)
+            s3_create_bucket(Bucket=output_bucket)
             cleanups.append(_cleanup)
         if output_key is not None:
             params["OutputKey"] = output_key


### PR DESCRIPTION
## Motivation

This PR fixes test execution error when a non-default `TEST_AWS_REGION_NAME` is used.

This happens because S3 CreateBucket requires `LocationConstraint` information when any region other than `us-east-1` is used. Our `s3_create_bucket` fixture takes care of such situations.

## Implementation

Just use the `s3_create_bucket` fixture to create the S3 bucket instead of the direct S3 CreateBucket.