### PR TITLE
fix SNS MessageBody filtering with `.`

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -934,55 +934,29 @@ class SubscriptionFilter:
 
     def _evaluate_nested_filter_policy_on_dict(self, filter_policy, payload: dict) -> bool:
         """
-        This method evaluate the filter policy recursively, while still being able to validate the `exists` condition.
+        This method evaluates the filter policy against the JSON decoded payload.
+        Although it's not documented anywhere, AWS allows `.` in the fields name in the filter policy and the payload,
+        and will evaluate them. However, it's not JSONPath compatible:
         Example:
-        nested_filter_policy = {
-            "object": {
-                "key": [{"prefix": "auto-"}],
-                "nested_key": [{"exists": False}],
-            },
-            "test": [{"exists": False}],
-        }
-        payload = {
-            "object": {
-                "key": "auto-test",
-            }
-        }
-        This function then iterates on top level keys of the filter policy: ("object", "test")
-        The value of "object" is a dict, we need to evaluate this level of the filter policy.
-        We pass the nested property values (the dict) as well as the values of the payload's field to the recursive
-        function, to evaluate the conditions on the same level of depth.
-        We now have these parameters to the function:
-        filter_policy = {
-            "key": [{"prefix": "auto-"}],
-            "nested_key": [{"exists": False}],
-        }
-        payload = {
-            "key": "auto-test",
-        }
-        We can now properly evaluate the conditions on the same level of depth in the dict object.
-        As it passes the filter policy, we then continue to evaluate the top keys, going back to "test".
+        Policy: `{"field1.field2": "value1"}`
+        This policy will match both `{"field1.field2": "value1"}` and  {"field1: {"field2": "value1"}}`, unlike JSONPath
+        for which `.` points to a child node.
+        This might show they are flattening the both dictionaries to a single level for an easier matching without
+        recursion.
         :param filter_policy: a dict, starting at the FilterPolicy
         :param payload: a dict, starting at the MessageBody
         :return: True if the payload respect the filter policy, otherwise False
         """
-        for field_name, values in filter_policy.items():
-            # if values is not a dict, then it's a nested property
-            if not isinstance(values, list):
-                if not self._evaluate_nested_filter_policy_on_dict(
-                    values, payload.get(field_name, {})
-                ):
-                    return False
-            else:
-                # else, values represents the list of conditions of the filter policy
-                if not any(
-                    self._evaluate_condition(
-                        payload.get(field_name), condition, field_exists=field_name in payload
-                    )
-                    for condition in values
-                ):
-                    return False
-
+        flat_policy = self._flatten_dict(filter_policy)
+        flat_payload = self._flatten_dict(payload)
+        for key, values in flat_policy.items():
+            if not any(
+                self._evaluate_condition(
+                    flat_payload.get(key), condition, field_exists=key in flat_payload
+                )
+                for condition in values
+            ):
+                return False
         return True
 
     def _evaluate_filter_policy_conditions_on_attribute(
@@ -1007,13 +981,6 @@ class SubscriptionFilter:
                 value = val or None
                 if self._evaluate_condition(value, condition, field_exists):
                     return True
-
-        return False
-
-    def _evaluate_filter_policy_conditions_on_field(self, conditions, value, field_exists: bool):
-        for condition in conditions:
-            if self._evaluate_condition(value, condition, field_exists):
-                return True
 
         return False
 
@@ -1065,6 +1032,33 @@ class SubscriptionFilter:
                     return False
 
         return True
+
+    @staticmethod
+    def _flatten_dict(nested_dict: dict):
+        """
+        Takes a dictionary as input and will output the dictionary on a single level.
+        Input:
+        `{"field1": {"field2: {"field3: "val1", "field4": "val2"}}}`
+        Output:
+        `{
+            "field1.field2.field3": "val1",
+            "field1.field2.field4": "val1"
+        }`
+        :param nested_dict: a (nested) dictionary
+        :return: flatten_dict: a dictionary with no nested dict inside, flattened to a single level
+        """
+        flatten = {}
+
+        def _traverse(_policy: dict, parent_key=None):
+            for key, values in _policy.items():
+                pkey = key if not parent_key else f"{parent_key}.{key}"
+                if not isinstance(values, dict):
+                    flatten[pkey] = values
+                else:
+                    _traverse(values, parent_key=pkey)
+
+        _traverse(nested_dict)
+        return flatten
 
 
 class PublishDispatcher:

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3100,6 +3100,131 @@ class TestSNSFilter:
         # there should be no messages in this queue
         snapshot.match("messages-with-filter-after-publish-filtered", response_after_publish_filter)
 
+    @markers.aws.validated
+    def test_filter_policy_on_message_body_dot_attribute(
+        self,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
+        snapshot,
+        aws_client,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        nested_filter_policy = json.dumps(
+            {
+                "object.nested": ["string.value"],
+            }
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicyScope",
+            AttributeValue="MessageBody",
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=nested_filter_policy,
+        )
+
+        def get_filter_policy():
+            subscription_attrs = aws_client.sns.get_subscription_attributes(
+                SubscriptionArn=subscription_arn
+            )
+            return subscription_attrs["Attributes"]["FilterPolicy"]
+
+        # wait for the new filter policy to be in effect
+        poll_condition(lambda: get_filter_policy() == nested_filter_policy, timeout=4)
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
+        )
+        snapshot.match("recv-init", response)
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
+        def _verify_and_snapshot_sqs_messages(msg_to_send: list[dict], snapshot_prefix: str):
+            for i, _message in enumerate(msg_to_send):
+                aws_client.sns.publish(
+                    TopicArn=topic_arn,
+                    Message=json.dumps(_message),
+                )
+
+                _response = aws_client.sqs.receive_message(
+                    QueueUrl=queue_url,
+                    VisibilityTimeout=0,
+                    WaitTimeSeconds=5 if is_aws_cloud() else 2,
+                )
+                snapshot.match(f"{snapshot_prefix}-{i}", _response)
+                receipt_handle = _response["Messages"][0]["ReceiptHandle"]
+                aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+
+        # publish messages that satisfies the filter policy, assert that messages are received
+        messages = [
+            {"object": {"nested": "string.value"}},
+            {"object.nested": "string.value"},
+        ]
+        _verify_and_snapshot_sqs_messages(messages, snapshot_prefix="recv-nested-msg")
+
+        # publish messages that do not satisfy the filter policy, assert those messages are not received
+        messages = [
+            {"object": {"nested": "test-auto"}},
+        ]
+        for message in messages:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=json.dumps(message),
+            )
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
+        )
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
+        # assert with more nesting
+        deep_nested_filter_policy = json.dumps(
+            {
+                "object.nested.test": ["string.value"],
+            }
+        )
+
+        aws_client.sns.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=deep_nested_filter_policy,
+        )
+        # wait for the new filter policy to be in effect
+        poll_condition(lambda: get_filter_policy() == deep_nested_filter_policy, timeout=4)
+
+        messages = [
+            {"object": {"nested": {"test": "string.value"}}},
+            {"object.nested.test": "string.value"},
+            {"object.nested": {"test": "string.value"}},
+            {"object": {"nested.test": "string.value"}},
+        ]
+        _verify_and_snapshot_sqs_messages(messages, snapshot_prefix="recv-deep-nested-msg")
+        # publish messages that do not satisfy the filter policy, assert those messages are not received
+        messages = [
+            {"object": {"nested": {"test": "string.notvalue"}}},
+        ]
+        for message in messages:
+            aws_client.sns.publish(
+                TopicArn=topic_arn,
+                Message=json.dumps(message),
+            )
+
+        response = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
+        )
+        # assert there are no messages in the queue
+        assert "Messages" not in response
+
 
 class TestSNSPlatformEndpoint:
     @markers.aws.only_localstack

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4471,5 +4471,160 @@
         "Type": "UnsubscribeConfirmation"
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_dot_attribute": {
+    "recorded-date": "09-10-2023, 15:05:32",
+    "recorded-content": {
+      "recv-init": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-nested-msg-0": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object\": {\"nested\": \"string.value\"}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-nested-msg-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object.nested\": \"string.value\"}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-deep-nested-msg-0": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:5>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object\": {\"nested\": {\"test\": \"string.value\"}}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-deep-nested-msg-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:7>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object.nested.test\": \"string.value\"}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:8>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-deep-nested-msg-2": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:9>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object.nested\": {\"test\": \"string.value\"}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:10>",
+            "ReceiptHandle": "<receipt-handle:5>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-deep-nested-msg-3": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:11>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object\": {\"nested.test\": \"string.value\"}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:12>",
+            "ReceiptHandle": "<receipt-handle:6>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This issue has been reported in our Community Slack.
The following SNS `FilterPolicy` with the `FilterPolicyScope` set `MessageBody` was not working like AWS:
`"FilterPolicy": "{\"detail.eventType\": [\"ride.requested\"]}"`
Note the `.` in the field name, which is very important.
The event that should pass and work this policy looks like this:
```json
{
  "version": "0",
  "id": "6a7e8feb-b491-4cf7-a9f1-bf3703467718",
  "detail-type": "ride.requested",
  "source": "lambda",
  "account": "111122223333",
  "time": "2017-12-22T18:43:48Z",
  "region": "us-west-2",
  "detail": {
    "eventType": "ride.requested",
    "data": "{}"
  }
}
```

After checking with AWS, it seems that indeed, that event should work, even if it seems a bit counter-intuitive.
My first idea was to use JSONPath, but what AWS is doing is every simpler.
With this policy: `{"object.nested.test": ["string.value"]}`
All these messages are working:
```json
{"object": {"nested": {"test": "string.value"}}}
{"object.nested.test": "string.value"}
{"object.nested": {"test": "string.value"}}
{"object": {"nested.test": "string.value"}}
```
JSONPath would not work here, because `.` indicates a child node. But for `{"object.nested.test": "string.value"}`, there are no child nodes, and JSONPath fails. 

So what AWS seems to be doing is flattening the filter policy to a single level, with depths separated with `.`.
They do the same to the payload, and then simply compare key per key, like they do with `MessageAttributes` scope.

This behaviour is not documented anywhere, and we can suspect it could change in the future. In the meantime, I've added this feature which also allows us to remove the previous matching function which was a bit complicated. 

<!-- What notable changes does this PR make? -->
## Changes

Added a new test testing this behaviour, I've done more manual testing with all kind of scenarios but the test was really long, so I've kept it to a minimal which validates the behaviour.

Updated the filtering method to flatten the policy and payload and then compare them on a single level of depth, which is way simpler.
Maybe for performance reason we could cache the result of the `FilterPolicy` flattening, but it doesn't seem to expensive for now. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

