### PR TITLE
remove dependency on legacy boto

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -86,9 +86,8 @@ from xml.etree import ElementTree as ETree
 
 import cbor2
 import xmltodict
-from boto.utils import ISO8601
 from botocore.model import ListShape, MapShape, OperationModel, ServiceModel, Shape, StructureShape
-from botocore.serialize import ISO8601_MICRO
+from botocore.serialize import ISO8601, ISO8601_MICRO
 from botocore.utils import calculate_md5, is_json_value_header, parse_to_aware_datetime
 from werkzeug import Request as WerkzeugRequest
 from werkzeug import Response as WerkzeugResponse

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ runtime =
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     awscrt>=0.13.14
-    boto>=2.49.0
     boto3>=1.26.121
     botocore>=1.31.2
     cbor2>=5.2.0


### PR DESCRIPTION
## Motivation
While working on the integration of Python 3.12, I realized that we still have a dependency on the legacy Python AWS SDK [`boto`](https://github.com/boto/boto) (not to confuse with [`boto3`](https://github.com/boto/boto3)).
This PR removes this direct dependency.

## Changes
- Removes the only direct import from the legacy `boto` (which was a mistake anyways)
- Removes `boto` as an explicit direct dependency of `localstack-core`.
