### PR TITLE
CFn: fix embedded secretsmanager references

### DIFF
--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -446,7 +446,7 @@ class TestSecretsManagerParameters:
                         "TopicName": f"topic-{short_uid()}",
                     },
                 },
-                "ConfigOpsgenieSubscription": {
+                "Subscription": {
                     "Type": "AWS::SNS::Subscription",
                     "Properties": {
                         "Endpoint": endpoint_definition,

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -600,8 +600,8 @@
       }
     }
   },
-  "tests/aws/services/cloudformation/test_template_engine.py::TestSecretsManagerParameters::test_foo": {
-    "recorded-date": "10-10-2023, 15:04:55",
+  "tests/aws/services/cloudformation/test_template_engine.py::TestSecretsManagerParameters::test_embedded_references": {
+    "recorded-date": "10-10-2023, 15:15:06",
     "recorded-content": {
       "endpoint-url": "https://example.com/v0/json/cloudwatch?apiKey=dummy-key"
     }

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -599,5 +599,11 @@
         "Timestamp": "timestamp"
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestSecretsManagerParameters::test_foo": {
+    "recorded-date": "10-10-2023, 15:04:55",
+    "recorded-content": {
+      "endpoint-url": "https://example.com/v0/json/cloudwatch?apiKey=dummy-key"
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

**This PR currently only includes the (skipped) tests, not the fix itself.**

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Currently embedded dynamic references do not work in LocalStack. For example

```
"Endpoint": "https://example.com?apiKey={{resolve:secretsmanager:<secret-name>:SecretString:<json-field>"
```


<!-- What notable changes does this PR make? -->
## TODO

Fix this missing behaviour


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

