### PR TITLE
Fixed lambda invoke to use 1 or more characters

### DIFF
--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -329,11 +329,15 @@ class ExecutionEnvironment:
         return self.runtime_executor.invoke(payload=invoke_payload)
 
     def get_credentials(self) -> Credentials:
-        sts_client = connect_to().sts.request_metadata(service_principal="lambda")
+        sts_client = connect_to().sts.request_metadata(service_principal="lambda")        
+        role_session_name = self.function_version.id.function_name        
+        # Use a conditional for the special case where function length is 1 character
+        if len(role_session_name) == 1:
+            role_session_name = f"{role_session_name}@lambda_function"
         # TODO we should probably set a maximum alive duration for environments, due to the session expiration
         return sts_client.assume_role(
             RoleArn=self.function_version.config.role,
-            RoleSessionName=self.function_version.id.function_name,
+            RoleSessionName=role_session_name,
             DurationSeconds=43200,
         )["Credentials"]
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Raising this PR to fix the bug on issue #9016.

<!-- What notable changes does this PR make? -->
## Changes
Added in a condition to make sure that a function name of length 1 gets a suffix of '@lambda_function ' added to it

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

```python -m localstack.dev.run --mount-dependencies \
          -v $PWD/tests:/opt/code/localstack/tests \
          -- .venv/bin/python -m pytest tests/aws/services/lambda_/test_lambda.py::TestLambdaBaseFeatures::test_assume_role```


