### PR TITLE
follow up on CloudFormation template URLs S3 URI

### DIFF
--- a/localstack/services/cloudformation/api_utils.py
+++ b/localstack/services/cloudformation/api_utils.py
@@ -86,14 +86,14 @@ def convert_s3_to_local_url(url: str) -> str:
     headers = {"host": url_parsed.netloc}
     bucket_name, key_name = extract_bucket_name_and_key_from_headers_and_path(headers, path)
 
-    if not bucket_name or not key_name:
-        if url_parsed.scheme != "s3" and not (
-            url_parsed.netloc.startswith("s3.") or ".s3." in url_parsed.netloc
-        ):
-            raise ValidationError("TemplateURL must be a supported URL.")
+    if url_parsed.scheme == "s3":
         raise ValidationError(
             f"S3 error: Domain name specified in {url_parsed.netloc} is not a valid S3 domain"
         )
+
+    if not bucket_name or not key_name:
+        if not (url_parsed.netloc.startswith("s3.") or ".s3." in url_parsed.netloc):
+            raise ValidationError("TemplateURL must be a supported URL.")
 
     # note: make sure to normalize the bucket name here!
     bucket_name = normalize_bucket_name(bucket_name)

--- a/tests/aws/services/cloudformation/api/test_templates.py
+++ b/tests/aws/services/cloudformation/api/test_templates.py
@@ -55,15 +55,15 @@ def test_create_stack_from_s3_template_url(
     """
     )
 
-    aws_client.s3.put_object(Bucket=bucket_name, Key="template.yml", Body=to_bytes(template))
+    aws_client.s3.put_object(Bucket=bucket_name, Key="test/template.yml", Body=to_bytes(template))
 
     match url_style:
         case "s3_url":
-            template_url = f"s3://{bucket_name}/template.yml"
+            template_url = f"s3://{bucket_name}/test/template.yml"
         case "http_path":
-            template_url = f"https://s3.amazonaws.com/{bucket_name}/template.yml"
+            template_url = f"https://s3.amazonaws.com/{bucket_name}/test/template.yml"
         case "http_host":
-            template_url = f"https://{bucket_name}.s3.amazonaws.com/template.yml"
+            template_url = f"https://{bucket_name}.s3.amazonaws.com/test/template.yml"
         case "http_invalid":
             # note: using an invalid (non-existing) URL here, but in fact all non-S3 HTTP URLs are invalid in real AWS
             template_url = "https://example.com/dummy.yml"

--- a/tests/aws/services/cloudformation/api/test_templates.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_templates.snapshot.json
@@ -25,7 +25,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_from_s3_template_url[s3_url]": {
-    "recorded-date": "08-10-2023, 16:15:04",
+    "recorded-date": "11-10-2023, 00:03:44",
     "recorded-content": {
       "create-error": {
         "Error": {
@@ -41,7 +41,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_from_s3_template_url[http_path]": {
-    "recorded-date": "08-10-2023, 16:15:14",
+    "recorded-date": "11-10-2023, 00:03:53",
     "recorded-content": {
       "matching-topic": [
         {
@@ -51,7 +51,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_from_s3_template_url[http_host]": {
-    "recorded-date": "08-10-2023, 16:15:24",
+    "recorded-date": "11-10-2023, 00:04:02",
     "recorded-content": {
       "matching-topic": [
         {
@@ -61,7 +61,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_from_s3_template_url[http_invalid]": {
-    "recorded-date": "08-10-2023, 16:15:26",
+    "recorded-date": "11-10-2023, 00:04:04",
     "recorded-content": {
       "create-error": {
         "Error": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #9312 and following up a Community Slack issue, it seems the new validation added was missing one exception handling when the S3 key would be containing slashes.

For example:
`awslocal cloudformation create-stack --stack-name vpc-us-east-1 --template-url s3://cloudformation-templates/aws-account-cfn/vpc.json`

Is raising:
```python
File "/opt/code/localstack/localstack/services/cloudformation/api_utils.py", line 55, in get_template_body
    result = client.get_object(Bucket=parts[0], Key=parts[2])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/botocore/client.py", line 980, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the GetObject operation: The specified bucket does not exist
```

Because the split occurring in `convert_s3_to_local_url` was returning 3 parts so it worked.

If I understood well, `s3://`-type URIs are not accepted in `--template-url` parameter, is that right? So I believe if the scheme is `s3`, we could trigger the validation error straight away.

Weirdly, this is an accepted answer by AWS employees... https://repost.aws/questions/QUvDk684FkRW2wvFLybXoSuA/templateurl-must-be-a-supported-url
But testing shows that it's not supported?

Adding a link showing how the url should look:
https://aws.amazon.com/blogs/infrastructure-and-automation/best-practices-for-using-amazon-s3-endpoints-in-aws-cloudformation-templates/

\cc @whummer 

<!-- What notable changes does this PR make? -->
## Changes
Added a check for the scheme, and raises the exception straight if the scheme is `s3`. 
Added the test to have a long key with `/` in it to trigger the issue if not fixed. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

