### PR TITLE
CFn: allow for pro resource provider overrides

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -29,7 +29,7 @@ from localstack.services.cloudformation.service_models import KEY_RESOURCE_STATE
 
 PRO_RESOURCE_PROVIDERS = False
 try:
-    from localstack_ext.services.cloudformation.cloudformation_extended import (
+    from localstack_ext.services.cloudformation.resource_provider import (
         CloudFormationResourceProviderPluginExt,
     )
 

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -799,7 +799,7 @@ class ResourceProviderExecutor:
                 return plugin.factory()
             except Exception:
                 LOG.warning(
-                    "Failed to load resource type from pro as a ResourceProvider.",
+                    "Failed to load resource type %s from pro as a ResourceProvider.",
                     resource_type,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -798,10 +798,12 @@ class ResourceProviderExecutor:
                 plugin = pro_plugin_manager.load(resource_type)
                 return plugin.factory()
             except Exception:
-                LOG.warning(
-                    "Failed to load resource type %s from pro as a ResourceProvider.",
+                LOG.debug(
+                    (
+                        "Failed to load resource type %s from pro as a ResourceProvider. "
+                        "Maybe this resource is implemented in community."
+                    ),
                     resource_type,
-                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 
         try:

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -797,13 +797,13 @@ class ResourceProviderExecutor:
             try:
                 plugin = pro_plugin_manager.load(resource_type)
                 return plugin.factory()
+            except ValueError:
+                # could not load the plugin
+                pass
             except Exception:
-                LOG.debug(
-                    (
-                        "Failed to load resource type %s from pro as a ResourceProvider. "
-                        "Maybe this resource is implemented in community."
-                    ),
-                    resource_type,
+                LOG.warning(
+                    "error loading plugin from plugin manager",
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 
         try:

--- a/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack/services/cloudformation/scaffolding/__main__.py
@@ -298,6 +298,7 @@ class TemplateRenderer:
             case FileType.plugin:
                 kwargs["service"] = resource_name.python_compatible_service_name.lower()
                 kwargs["lower_resource"] = resource_name.resource.lower()
+                kwargs["pro"] = False
             case FileType.integration_test:
                 kwargs["black_box_template_path"] = str(
                     template_path(resource_name, FileType.minimal_template, tests_output_path)

--- a/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
+++ b/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
@@ -1,14 +1,23 @@
 from typing import Optional, Type
 
-from localstack.services.cloudformation.resource_provider import CloudFormationResourceProviderPlugin, ResourceProvider
+from localstack.services.cloudformation.resource_provider import ResourceProvider
+{%- if pro %}
+{%- set base_class = "CloudFormationResourceProviderPluginExt" %}
+{%- set root_module = "localstack_ext" %}
+from {{ root_module }}.services.cloudformation.cloudformation_extended import {{ base_class }}
+{%- else %}
+{%- set base_class = "CloudFormationResourceProviderPlugin" %}
+{%- set root_module = "localstack" %}
+from {{ root_module }}.services.cloudformation.resource_provider import {{ base_class }}
+{%- endif %}
 
-class {{ resource }}ProviderPlugin(CloudFormationResourceProviderPlugin):
+class {{ resource }}ProviderPlugin({{ base_class }}):
     name = "{{ name }}"
 
     def __init__(self):
         self.factory: Optional[Type[ResourceProvider]] = None
 
     def load(self):
-        from localstack.services.{{ service }}.resource_providers.aws_{{ service }}_{{ lower_resource }} import {{ resource }}Provider
+        from {{ root_module }}.services.{{ service }}.resource_providers.aws_{{ service }}_{{ lower_resource }} import {{ resource }}Provider
 
         self.factory = {{ resource }}Provider

--- a/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
+++ b/localstack/services/cloudformation/scaffolding/templates/plugin_template.py.j2
@@ -4,12 +4,11 @@ from localstack.services.cloudformation.resource_provider import ResourceProvide
 {%- if pro %}
 {%- set base_class = "CloudFormationResourceProviderPluginExt" %}
 {%- set root_module = "localstack_ext" %}
-from {{ root_module }}.services.cloudformation.cloudformation_extended import {{ base_class }}
 {%- else %}
 {%- set base_class = "CloudFormationResourceProviderPlugin" %}
 {%- set root_module = "localstack" %}
-from {{ root_module }}.services.cloudformation.resource_provider import {{ base_class }}
 {%- endif %}
+from {{ root_module }}.services.cloudformation.resource_provider import {{ base_class }}
 
 class {{ resource }}ProviderPlugin({{ base_class }}):
     name = "{{ name }}"

--- a/localstack/services/cloudformation/scaffolding/templates/provider_template.py.j2
+++ b/localstack/services/cloudformation/scaffolding/templates/provider_template.py.j2
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Type, TypedDict
+from typing import Optional, TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
 from localstack.services.cloudformation.resource_provider import (
-    CloudFormationResourceProviderPlugin,
     OperationStatus,
     ProgressEvent,
     ResourceProvider,


### PR DESCRIPTION
## Motivation

We disabled AWS::ECR::Repository in #9315 because we did not have an override system for resource providers in community vs pro. In particular, we had:

* a community `GenericBaseModel` subclass
* a (new) community `ResourceProvider`
* a pro `GenericBaseModel` subclass

In this case, the community resource provider was being chosen, rather than the pro `GenericBaseModel` subclass.



<!-- What notable changes does this PR make? -->
## Changes

Most of the changes to allow us to revert #9315 have been made in the pro repository. In addition, we are trying to handle the case where we have pro and community resource providers.

* Prioritise pro resource providers if present
* Update scaffolding to support scaffolding into the pro repo (partially, only the plugin for now)
* Fix scaffolding issues with unused imports

## TODO

- [ ] allow for scaffolding into the pro repo


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

