### PR TITLE
fix APIGW UpdateStage for methods settings

### DIFF
--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -143,8 +143,19 @@ def apply_patches():
     @patch(apigateway_models.Stage._get_default_method_settings)
     def _get_default_method_settings(fn, self):
         result = fn(self)
-        result["cacheDataEncrypted"] = False
-        result["throttlingRateLimit"] = 10000.0
+        default_settings = self.method_settings.get("*/*", {})
+        result["cacheDataEncrypted"] = default_settings.get("cacheDataEncrypted", False)
+        result["throttlingRateLimit"] = default_settings.get("throttlingRateLimit", 10000.0)
+        result["metricsEnabled"] = default_settings.get("metricsEnabled", False)
+        result["dataTraceEnabled"] = default_settings.get("dataTraceEnabled", False)
+        result["unauthorizedCacheControlHeaderStrategy"] = default_settings.get(
+            "unauthorizedCacheControlHeaderStrategy", "SUCCEED_WITH_RESPONSE_HEADER"
+        )
+        result["cacheTtlInSeconds"] = default_settings.get("cacheTtlInSeconds", 300)
+        result["cachingEnabled"] = default_settings.get("cachingEnabled", False)
+        result["requireAuthorizationForCacheControl"] = default_settings.get(
+            "requireAuthorizationForCacheControl", True
+        )
         return result
 
     # patch integration error responses

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -138,7 +138,9 @@ STAGE_UPDATE_PATHS = [
     "/{resourcePath}/{httpMethod}/metrics/enabled",
     "/{resourcePath}/{httpMethod}/logging/dataTrace",
     "/{resourcePath}/{httpMethod}/logging/loglevel",
-    "/{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds",
+    "/{resourcePath}/{httpMethod}/throttling/burstLimit",
+    "/{resourcePath}/{httpMethod}/throttling/rateLimit",
+    "/{resourcePath}/{httpMethod}/caching/ttlInSeconds",
     "/{resourcePath}/{httpMethod}/caching/enabled",
     "/{resourcePath}/{httpMethod}/caching/dataEncrypted",
     "/{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl",
@@ -940,6 +942,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             if not path_valid:
                 valid_paths = f"[{', '.join(STAGE_UPDATE_PATHS)}]"
                 # note: weird formatting in AWS - required for snapshot testing
+                valid_paths = valid_paths.replace(
+                    "/{resourcePath}/{httpMethod}/throttling/burstLimit, /{resourcePath}/{httpMethod}/throttling/rateLimit, /{resourcePath}/{httpMethod}/caching/ttlInSeconds",
+                    "/{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds",
+                )
                 valid_paths = valid_paths.replace("/burstLimit, /", "/burstLimit /")
                 valid_paths = valid_paths.replace("/rateLimit, /", "/rateLimit /")
                 raise BadRequestException(

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -539,7 +539,6 @@ class TestStages:
         snapshot.match("error-update-tags", ctx.value.response)
 
         # update & get stage
-
         response = client.update_stage(
             restApiId=api_id,
             stageName="s1",
@@ -550,12 +549,24 @@ class TestStages:
                 {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "123"},
                 {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
                 {"op": "replace", "path": "/tracingEnabled", "value": "true"},
+                {"op": "replace", "path": "/test/GET/throttling/burstLimit", "value": "124"},
             ],
         )
         snapshot.match("update-stage", response)
 
         response = client.get_stage(restApiId=api_id, stageName="s1")
         snapshot.match("get-stage", response)
+
+        # show that updating */* does not override previously set values, only provides default values then like shown
+        # above
+        response = client.update_stage(
+            restApiId=api_id,
+            stageName="s1",
+            patchOperations=[
+                {"op": "replace", "path": "/*/*/throttling/burstLimit", "value": "100"},
+            ],
+        )
+        snapshot.match("update-stage-override", response)
 
 
 class TestDeployments:

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -371,7 +371,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
-    "recorded-date": "01-09-2023, 00:33:13",
+    "recorded-date": "11-10-2023, 17:39:23",
     "recorded-content": {
       "create-stage": {
         "cacheClusterEnabled": false,
@@ -430,6 +430,17 @@
             "throttlingBurstLimit": 123,
             "throttlingRateLimit": 10000.0,
             "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          },
+          "test/GET": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 124,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
           }
         },
         "stageName": "s1",
@@ -460,6 +471,103 @@
             "metricsEnabled": false,
             "requireAuthorizationForCacheControl": true,
             "throttlingBurstLimit": 123,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          },
+          "test/GET": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 124,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          }
+        },
+        "stageName": "s1",
+        "tracingEnabled": true,
+        "variables": {
+          "var1": "test",
+          "var2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-override": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "stage new",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {
+          "*/*": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 100,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          },
+          "test/GET": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 124,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          }
+        },
+        "stageName": "s1",
+        "tracingEnabled": true,
+        "variables": {
+          "var1": "test",
+          "var2": "test2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage-override": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "stage new",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {
+          "*/*": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 100,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          },
+          "test/GET": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 124,
             "throttlingRateLimit": 10000.0,
             "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
           }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in a LocalStack Slack Community post, we would raise an exception when trying to update a stage with some method settings.
Here's the message to reproduce:

```hcl
> resource "aws_api_gateway_method_settings" "this" {


rest_api_id = var.rest_api_id
stage_name  = var.stage_name
method_path = "${trimprefix(var.path, "/")}/${var.method}"

settings {
  metrics_enabled        = var.metrics_enabled
  logging_level          = var.logging_level
  caching_enabled        = var.caching_enabled
  cache_ttl_in_seconds   = var.cache_ttl_in_seconds
  cache_data_encrypted   = var.cache_data_encrypted
  throttling_rate_limit  = var.rate_limit.rate
  throttling_burst_limit = var.rate_limit.burst
}
```

> Here is the error:
> │ Error: updating API Gateway Stage failed: BadRequestException: Invalid method setting path: /test/GET/throttling/burstLimit. Must be one of: [/deploymentId, /description, /cacheClusterEnabled, /cacheClusterSize, /clientCertificateId, /accessLogSettings, /accessLogSettings/destinationArn, /accessLogSettings/format, /{resourcePath}/{httpMethod}/metrics/enabled, /{resourcePath}/{httpMethod}/logging/dataTrace, /{resourcePath}/{httpMethod}/logging/loglevel, /{resourcePath}/{httpMethod}/throttling/burstLimit/{resourcePath}/{httpMethod}/throttling/rateLimit/{resourcePath}/{httpMethod}/caching/ttlInSeconds, /{resourcePath}/{httpMethod}/caching/enabled, /{resourcePath}/{httpMethod}/caching/dataEncrypted, /{resourcePath}/{httpMethod}/caching/requireAuthorizationForCacheControl, /{resourcePath}/{httpMethod}/caching/unauthorizedCacheControlHeaderStrategy, /*/*/metrics/enabled, /*/*/logging/dataTrace, /*/*/logging/loglevel, /*/*/throttling/burstLimit /*/*/throttling/rateLimit /*/*/caching/ttlInSeconds, /*/*/caching/enabled, /*/*/caching/dataEncrypted, /*/*/caching/requireAuthorizationForCacheControl, /*/*/caching/unauthorizedCacheControlHeaderStrategy, /variables/{variable_name}, /tracingEnabled]
> │ 
> │   with module.apgw.module.testlambda.aws_api_gateway_method_settings.this,
> │   on ../modules/definitions/apgw/method/main.tf line 22, in resource "aws_api_gateway_method_settings" "this":
> │   22: resource "aws_api_gateway_method_settings" "this" {

User's repo to reproduce:
https://github.com/joecolly/localstack-tf-apgw

This PR is a follow up from #9039 and #8873. There was still an issue with the formatting of the error, and we didn't get all the fields from it properly.

https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html#UpdateStage-Patch

We also didn't use the default values from `*/*` method settings when creating a new one by update.

<!-- What notable changes does this PR make? -->
## Changes
Fix the `STAGE_UPDATE_PATHS` list to have all the right paths, and adapted the logic for the error message (maybe we should just create it once?)
I've added some logic in an existing patch to get the default values from `*/*` method settings.

Added snapshots tests to validate the behaviour with default settings and being able to set a `{resource}/`{method`}/*` path. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

