### PR TITLE
add SNS internal endpoint to fetch SubscriptionTokens

### DIFF
--- a/localstack/services/sns/constants.py
+++ b/localstack/services/sns/constants.py
@@ -32,5 +32,6 @@ GCM_URL = "https://fcm.googleapis.com/fcm/send"
 # Endpoint to access all the PlatformEndpoint sent Messages
 PLATFORM_ENDPOINT_MSGS_ENDPOINT = "/_aws/sns/platform-endpoint-messages"
 SMS_MSGS_ENDPOINT = "/_aws/sns/sms-messages"
+SUBSCRIPTION_TOKENS_ENDPOINT = "/_aws/sns/subscription-tokens"
 
 DUMMY_SUBSCRIPTION_PRINCIPAL = "arn:aws:iam::{{account_id}}:user/DummySNSPrincipal"

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -1071,23 +1071,18 @@ class SNSServiceSubscriptionTokenApiResource:
 
         store: SnsStore = sns_stores[parsed_arn["account"]][parsed_arn["region"]]
 
-        found_token = None
         for token, sub_arn in store.subscription_tokens.items():
             if sub_arn == subscription_arn:
-                found_token = token
-                break
-
-        if not found_token:
-            response = Response("", 404)
-            response.set_json(
-                {
-                    "error": "The provided SubscriptionARN is not found",
+                return {
+                    "subscription_token": token,
                     "subscription_arn": subscription_arn,
                 }
-            )
-            return response
 
-        return {
-            "subscription_token": found_token,
-            "subscription_arn": subscription_arn,
-        }
+        response = Response("", 404)
+        response.set_json(
+            {
+                "error": "The provided SubscriptionARN is not found",
+                "subscription_arn": subscription_arn,
+            }
+        )
+        return response

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3655,7 +3655,8 @@ class TestSNSSubscriptionHttp:
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$.http-message-headers.Accept",  # requests adds the header but not SNS, not very important
-            "$.http-message-headers-raw.Accept",  # requests adds the header but not SNS, not very important
+            "$.http-message-headers-raw.Accept",
+            "$.http-confirm-sub-headers.Accept",
         ]
     )
     def test_subscribe_external_http_endpoint(
@@ -3708,7 +3709,6 @@ class TestSNSSubscriptionHttp:
         assert "SigningCertURL" in payload
 
         snapshot.match("http-confirm-sub-headers", _clean_headers(sub_request.headers))
-        snapshot.match("http-confirm-sub-payload", payload)
 
         token = payload["Token"]
         subscribe_url = payload["SubscribeURL"]

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4284,7 +4284,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[True]": {
-    "recorded-date": "09-10-2023, 16:01:30",
+    "recorded-date": "12-10-2023, 00:47:24",
     "recorded-content": {
       "subscription-confirmation": {
         "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
@@ -4297,6 +4297,17 @@
         "Token": "<token:1>",
         "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
         "Type": "SubscriptionConfirmation"
+      },
+      "http-confirm-sub-headers": {
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "connection",
+        "Content-Length": "content--length",
+        "Content-Type": "text/plain; charset=UTF-8",
+        "Host": "<host:1>",
+        "User-Agent": "Amazon Simple Notification Service Agent",
+        "X-Amz-Sns-Message-Id": "<uuid:1>",
+        "X-Amz-Sns-Message-Type": "SubscriptionConfirmation",
+        "X-Amz-Sns-Topic-Arn": "arn:aws:sns:<region>:111111111111:<resource:1>"
       },
       "broken-topic-arn-confirm": {
         "ErrorResponse": {
@@ -4386,7 +4397,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[False]": {
-    "recorded-date": "09-10-2023, 16:01:39",
+    "recorded-date": "12-10-2023, 00:47:29",
     "recorded-content": {
       "subscription-confirmation": {
         "Message": "You have chosen to subscribe to the topic arn:aws:sns:<region>:111111111111:<resource:1>.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
@@ -4399,6 +4410,17 @@
         "Token": "<token:1>",
         "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
         "Type": "SubscriptionConfirmation"
+      },
+      "http-confirm-sub-headers": {
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "connection",
+        "Content-Length": "content--length",
+        "Content-Type": "text/plain; charset=UTF-8",
+        "Host": "<host:1>",
+        "User-Agent": "Amazon Simple Notification Service Agent",
+        "X-Amz-Sns-Message-Id": "<uuid:1>",
+        "X-Amz-Sns-Message-Type": "SubscriptionConfirmation",
+        "X-Amz-Sns-Topic-Arn": "arn:aws:sns:<region>:111111111111:<resource:1>"
       },
       "broken-topic-arn-confirm": {
         "ErrorResponse": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR will add a new internal endpoint to be able to fetch subscription tokens used to confirm a subscription.

In case of email and most importantly HTTP(S) subscriptions, a special message is sent to the subscriber with a link to confirm the subscription so that it will receive the messages afterwards.

However, when working with external integrations (like Opsgenie: https://support.atlassian.com/opsgenie/docs/integrate-opsgenie-with-incoming-amazon-sns/), the link sent will most probably be a link to your own localhost (you could always use `HOSTNAME_EXTERNAL` and some way to link it to your own computer, but it's not a given the external integration will go on a link which is not AWS related).

Instead, we could expose the sent token with the internal endpoint, so that you can manually confirm the subscription with [`ConfirmSubscription`](https://docs.aws.amazon.com/sns/latest/api/API_ConfirmSubscription.html).

You could fetch the token with the subscriptionArn and manually confirm it this way:
```bash
$ curl "http://localhost:4566/_aws/sns/subscription-tokens?subscriptionArn=arn:aws:sns:us-east-1:000000000000:test-opsgenie:654c8659-2919-4073-9dfd-3b766dbd532d"
{"subscription_tokens": {"arn:aws:sns:us-east-1:000000000000:test-opsgenie:654c8659-2919-4073-9dfd-3b766dbd532d": "75732d656173742d312f345a7e4e345a7e4e345a7e4e345a7e4e345a7e4e345a"}, "region": "us-east-1"}%

$ awslocal sns confirm-subscription --topic-arn arn:aws:sns:us-east-1:000000000000:test-opsgenie --token 75732d656173742d312f345a7e4e345a7e4e345a7e4e345a7e4e345a7e4e345a
{
    "SubscriptionArn": "arn:aws:sns:us-east-1:000000000000:test-opsgenie:654c8659-2919-4073-9dfd-3b766dbd532d"
}
```

This would then enable the subscription and allow you to use the external integration. 

I've done the test with Opsgenie which of course refuse the `SubscriptionConfirmation` message as it points to `localhost:4566`. 
I manually confirm the subscription, and after sending a message I can see the alert created. 

```python
sns_client: SNSClient = session.client("sns", endpoint_url="http://localhost:4566")
sns_client.publish(
    TopicArn="arn:aws:sns:us-east-1:000000000000:test-opsgenie",
    Message="This is the description of Sns Integration test alert",
    Subject="Sns Integration Test alert",
    MessageAttributes={"eventType": {"DataType": "String", "StringValue": "create"}},
)
```
Which gives:

<img width="1384" alt="Screenshot 2023-10-12 at 01 35 18" src="https://github.com/localstack/localstack/assets/42031100/8d297266-5b04-4316-b365-6c10349abd58">

Which is pretty cool. 

<!-- What notable changes does this PR make? -->
## Changes
This adds an internal resource exposing the tokens. Those tokens are never deleted because they can be reused later on, so the filter is nicely useful.
A doc entry will need to be made in a follow up (will add the SMS endpoint documentation as well).

Also update a test to validate the headers sent with the `SubscriptionConfirmation` message just to be sure. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

