### PR TITLE
fix missing support for eventbridge notifications in legacy AWS::S3::Bucket

### DIFF
--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -180,6 +180,9 @@ class S3Bucket(GenericBaseModel):
                     "TopicConfigurations": topic_configs,
                 },
             }
+            if notif_config.get("EventBridgeConfiguration", {}).get("EventBridgeEnabled"):
+                result["NotificationConfiguration"]["EventBridgeConfiguration"] = {}
+
             return result
 
         def _handle_result(


### PR DESCRIPTION
## Motivation

When writing the workshop sample we noticed that it didn't create the necessary event bridge notification configuration.

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-eventbridgeconfig.html

## Changes

- Adds support for `EventBridgeConfiguration` to legacy `AWS::S3::Bucket` resource provider

