### PR TITLE
Dev script can load extensions

### DIFF
--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -287,18 +287,21 @@ def run(
         configurators.append(ContainerConfigurators.develop)
     if dev_extensions:
         if pro:
-            from localstack_ext.extensions.bootstrap import (
-                run_on_configure_host_hook,
-                run_on_configure_localstack_container_hook,
-            )
+            try:
+                from localstack_ext.extensions.bootstrap import (
+                    run_on_configure_host_hook,
+                    run_on_configure_localstack_container_hook,
+                )
 
-            # collect dev extensions
-            run_on_configure_host_hook()
+                # collect dev extensions
+                run_on_configure_host_hook()
 
-            # create stub container with configuration to apply
-            c = Container(container_config=container_config)
-            run_on_configure_localstack_container_hook(c)
+                # create stub container with configuration to apply
+                c = Container(container_config=container_config)
+                run_on_configure_localstack_container_hook(c)
 
+            except ImportError:
+                pass
         else:
             click.echo("Pro mode is required for extensions support")
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When using LocalStack extensions, the CLI can be used to automatically mount the code in the correct place in the container to run dev extensions. This removes the possibility of making changes to LocalStack internals (e.g. to prototype any changes/monkeypatches that are required).

<!-- What notable changes does this PR make? -->
## Changes

* Add a `--dev-extensions` flag which performs the same steps as the CLI when
    * `EXTENSION_DEV_MODE=1` is supplied
    * pro is enabled

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

