### PR TITLE
relax cachetools dependency constraint to >=5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages=find:
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
     click>=7.0
-    cachetools~=5.0.0
+    cachetools>=5.0
     cryptography
     dill==0.3.6
     dnslib>=0.9.10


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

* Fixes #9340

<!-- What notable changes does this PR make? -->
## Changes

* cachetools~=5.0.0 -> cachetools>=5.0

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

