### PR TITLE
improve CORS handler: no CORS headers if no Origin

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from flask_cors.core import (
     ACL_ALLOW_HEADERS,
+    ACL_CREDENTIALS,
     ACL_EXPOSE_HEADERS,
     ACL_METHODS,
     ACL_ORIGIN,
@@ -181,6 +182,7 @@ class CorsEnforcer(Handler):
         elif context.request.method == "OPTIONS" and not config.DISABLE_PREFLIGHT_PROCESSING:
             # we want to return immediately here, but we do not want to omit our response chain for cors headers
             response.status_code = 204
+            print("stopping chain here?")
             chain.stop()
 
     @staticmethod
@@ -229,27 +231,29 @@ class CorsResponseEnricher(Handler):
             if headers.get(header) == "":
                 del headers[header]
 
+        request_headers = context.request.headers
         # CORS headers should only be returned when an Origin header is set.
         # use DISABLE_CORS_HEADERS to disable returning CORS headers entirely (more restrictive security setting)
         # also don't add CORS response headers if the service manages the CORS handling
         if (
-            "Origin" not in headers
+            "Origin" not in request_headers
             or config.DISABLE_CORS_HEADERS
             or not should_enforce_self_managed_service(context)
         ):
             return
 
-        request_headers = context.request.headers
         self.add_cors_headers(request_headers, response_headers=headers)
 
     @staticmethod
     def add_cors_headers(request_headers: Headers, response_headers: Headers):
         if ACL_ORIGIN not in response_headers:
             response_headers[ACL_ORIGIN] = (
-                request_headers["origin"]
-                if request_headers.get("origin") and not config.DISABLE_CORS_CHECKS
+                request_headers["Origin"]
+                if request_headers.get("Origin") and not config.DISABLE_CORS_CHECKS
                 else "*"
             )
+        if "*" not in response_headers.get(ACL_ORIGIN, ""):
+            response_headers[ACL_CREDENTIALS] = "true"
         if ACL_METHODS not in response_headers:
             response_headers[ACL_METHODS] = ",".join(CORS_ALLOWED_METHODS)
         if ACL_ALLOW_HEADERS not in response_headers:
@@ -263,3 +267,6 @@ class CorsResponseEnricher(Handler):
             and ACL_ALLOW_PRIVATE_NETWORK not in response_headers
         ):
             response_headers[ACL_ALLOW_PRIVATE_NETWORK] = "true"
+
+        # we conditionally apply CORS headers depending on the Origin, so add it to `Vary`
+        response_headers["Vary"] = "Origin"

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -182,7 +182,6 @@ class CorsEnforcer(Handler):
         elif context.request.method == "OPTIONS" and not config.DISABLE_PREFLIGHT_PROCESSING:
             # we want to return immediately here, but we do not want to omit our response chain for cors headers
             response.status_code = 204
-            print("stopping chain here?")
             chain.stop()
 
     @staticmethod

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -229,9 +229,14 @@ class CorsResponseEnricher(Handler):
             if headers.get(header) == "":
                 del headers[header]
 
+        # CORS headers should only be returned when an Origin header is set.
         # use DISABLE_CORS_HEADERS to disable returning CORS headers entirely (more restrictive security setting)
         # also don't add CORS response headers if the service manages the CORS handling
-        if config.DISABLE_CORS_HEADERS or not should_enforce_self_managed_service(context):
+        if (
+            "Origin" not in headers
+            or config.DISABLE_CORS_HEADERS
+            or not should_enforce_self_managed_service(context)
+        ):
             return
 
         request_headers = context.request.headers

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -137,3 +137,8 @@ class TestCSRF:
         headers["Origin"] = f"http://{test_domain}"
         response = requests.post(url, headers=headers, data=data)
         assert not response.ok
+
+    def test_no_cors_without_origin_header(self):
+        response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/")
+        assert response.status_code == 200
+        assert "access-control-allow-origin" not in response.headers

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -27,7 +27,6 @@ class TestCSRF:
         # Test if endpoints are reachable without origin header
         response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/")
         assert response.status_code == 200
-        assert response.headers["access-control-allow-origin"] == "*"
 
     def test_default_cors_headers(self):
         headers = {"Origin": "https://app.localstack.cloud"}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
By default, we always add and send the CORS headers to LocalStack responses.
However, those headers should be sent only when the request has an `Origin` header set, indicating that this is a CORS request. 
We can read more about this here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_request_headers
https://jakearchibald.com/2021/cors/

> Note that in any access control request, the [Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) header is always sent.

When debugging and checking logs, we always have the CORS headers being sent, and they pollute the logs quite a lot for no benefits.

<!-- What notable changes does this PR make? -->
## Changes

Added a check for the presence of the `Origin` header, and add the headers only if it's there.
Added the `Vary` header as we conditionally apply CORS headers depending on it.
Added the credentials header. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

