### PR TITLE
sns: add multi-account capability to failing tests

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -352,8 +352,24 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         return result
 
     def unsubscribe(self, context: RequestContext, subscription_arn: subscriptionARN) -> None:
-        call_moto(context)
-        store = self.get_store(account_id=context.account_id, region_name=context.region)
+        try:
+            parsed_arn = parse_arn(subscription_arn)
+        except InvalidArnException:
+            raise InvalidParameterException("Invalid parameter: SubscriptionId")
+
+        account_id = parsed_arn["account"]
+        region_name = parsed_arn["region"]
+
+        moto_sns_backend = self.get_moto_backend(parsed_arn["account"], parsed_arn["region"])
+        moto_sns_backend.unsubscribe(subscription_arn)
+
+        response = {
+            "UnsubscribeResponse": {
+                "ResponseMetadata": {"RequestId": context.request_id},
+            }
+        }
+
+        store = self.get_store(account_id=account_id, region_name=region_name)
 
         # pop the subscription at the end, to avoid race condition by iterating over the topic subscriptions
         subscription = store.subscriptions.get(subscription_arn)
@@ -383,6 +399,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store.topic_subscriptions[subscription["TopicArn"]].remove(subscription_arn)
         store.subscription_filter_policy.pop(subscription_arn, None)
         store.subscriptions.pop(subscription_arn, None)
+
+        return response
 
     def get_subscription_attributes(
         self, context: RequestContext, subscription_arn: subscriptionARN

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -356,9 +356,11 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         try:
             parsed_arn = parse_arn(subscription_arn)
         except InvalidArnException:
-            # TODO: check for invalid SubscriptionId and SubscriptionGUID
+            # TODO: check for invalid SubscriptionGUID
             if count < 6:
-                raise InvalidParameterException(f"Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not {count}")
+                raise InvalidParameterException(
+                    f"Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not {count}"
+                )
 
         account_id = parsed_arn["account"]
         region_name = parsed_arn["region"]

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -352,18 +352,24 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         return result
 
     def unsubscribe(self, context: RequestContext, subscription_arn: subscriptionARN) -> None:
+        count = len(subscription_arn.split(":"))
         try:
             parsed_arn = parse_arn(subscription_arn)
         except InvalidArnException:
-            raise InvalidParameterException("Invalid parameter: SubscriptionId")
+            # TODO: check for invalid SubscriptionId and SubscriptionGUID
+            if count < 6:
+                raise InvalidParameterException(f"Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not {count}")
 
         account_id = parsed_arn["account"]
         region_name = parsed_arn["region"]
 
+        store = self.get_store(account_id=account_id, region_name=region_name)
+
+        if count == 6 and subscription_arn not in store.topic_subscriptions:
+            raise InvalidParameterException("Invalid parameter: SubscriptionId")
+
         moto_sns_backend = self.get_moto_backend(account_id, region_name)
         moto_sns_backend.unsubscribe(subscription_arn)
-
-        store = self.get_store(account_id=account_id, region_name=region_name)
 
         # pop the subscription at the end, to avoid race condition by iterating over the topic subscriptions
         subscription = store.subscriptions.get(subscription_arn)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -360,7 +360,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         account_id = parsed_arn["account"]
         region_name = parsed_arn["region"]
 
-        moto_sns_backend = self.get_moto_backend(parsed_arn["account"], parsed_arn["region"])
+        moto_sns_backend = self.get_moto_backend(account_id, region_name)
         moto_sns_backend.unsubscribe(subscription_arn)
 
         response = {

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -363,12 +363,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         moto_sns_backend = self.get_moto_backend(account_id, region_name)
         moto_sns_backend.unsubscribe(subscription_arn)
 
-        response = {
-            "UnsubscribeResponse": {
-                "ResponseMetadata": {"RequestId": context.request_id},
-            }
-        }
-
         store = self.get_store(account_id=account_id, region_name=region_name)
 
         # pop the subscription at the end, to avoid race condition by iterating over the topic subscriptions
@@ -399,8 +393,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store.topic_subscriptions[subscription["TopicArn"]].remove(subscription_arn)
         store.subscription_filter_policy.pop(subscription_arn, None)
         store.subscriptions.pop(subscription_arn, None)
-
-        return response
 
     def get_subscription_attributes(
         self, context: RequestContext, subscription_arn: subscriptionARN

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -15,7 +15,6 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
@@ -178,7 +177,7 @@ class TestSNSTopicCrud:
         assert topic_arn_params[5] == topic_name
 
         if not is_aws_cloud():
-            assert topic_arn_params[4] == get_aws_account_id()
+            assert topic_arn_params[4] == TEST_AWS_ACCOUNT_ID
 
         topic_attrs = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
         snapshot.match("get-topic-attrs", topic_attrs)

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -20,7 +20,6 @@ from localstack.constants import (
     AWS_REGION_US_EAST_1,
     SECONDARY_TEST_AWS_ACCOUNT_ID,
     SECONDARY_TEST_AWS_REGION_NAME,
-    TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
 )
@@ -33,7 +32,6 @@ from localstack.services.sns.provider import SnsProvider
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import parse_arn, sqs_queue_arn
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
@@ -3811,13 +3809,7 @@ class TestSNSSubscriptionHttp:
             snapshot.match("http-message", payload)
             snapshot.match("http-message-headers", _clean_headers(notification_request.headers))
 
-        auth_header = aws_stack.mock_aws_request_headers(
-            "sns", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
-        )["Authorization"]
-
-        unsub_request = requests.get(
-            url=expected_unsubscribe_url, headers={"Authorization": auth_header}
-        )
+        unsub_request = requests.get(expected_unsubscribe_url)
 
         unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
         assert "UnsubscribeResponse" in unsubscribe_confirmation

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3810,7 +3810,6 @@ class TestSNSSubscriptionHttp:
             snapshot.match("http-message-headers", _clean_headers(notification_request.headers))
 
         unsub_request = requests.get(expected_unsubscribe_url)
-
         unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
         assert "UnsubscribeResponse" in unsubscribe_confirmation
         snapshot.match("unsubscribe-response", _get_snapshot_requests_response(unsub_request))

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -20,6 +20,7 @@ from localstack.constants import (
     AWS_REGION_US_EAST_1,
     SECONDARY_TEST_AWS_ACCOUNT_ID,
     SECONDARY_TEST_AWS_REGION_NAME,
+    TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
 )
@@ -32,6 +33,7 @@ from localstack.services.sns.provider import SnsProvider
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
+from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import parse_arn, sqs_queue_arn
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
@@ -3809,7 +3811,14 @@ class TestSNSSubscriptionHttp:
             snapshot.match("http-message", payload)
             snapshot.match("http-message-headers", _clean_headers(notification_request.headers))
 
-        unsub_request = requests.get(expected_unsubscribe_url)
+        auth_header = aws_stack.mock_aws_request_headers(
+            "sns", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
+        )["Authorization"]
+
+        unsub_request = requests.get(
+            url=expected_unsubscribe_url, headers={"Authorization": auth_header}
+        )
+
         unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
         assert "UnsubscribeResponse" in unsubscribe_confirmation
         snapshot.match("unsubscribe-response", _get_snapshot_requests_response(unsub_request))

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -228,6 +228,23 @@ class TestSNSTopicCrud:
         topic1 = sns_create_topic(Name=topic_name, Tags=[{"Key": "Name", "Value": "abc"}])
         snapshot.match("topic-1", topic1)
 
+    @markers.aws.validated
+    def test_unsubscribe_wrong_arn_format(self, snapshot, aws_client):
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.unsubscribe(SubscriptionArn="randomstring")
+
+        snapshot.match("invalid-unsubscribe-arn-1", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:random")
+
+        snapshot.match("invalid-unsubscribe-arn-2", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.unsubscribe(SubscriptionArn="arn:aws:sns:us-east-1:111111111111:random")
+
+        snapshot.match("invalid-unsubscribe-arn-3", e.value.response)
+
 
 class TestSNSPublishCrud:
     """

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4673,5 +4673,43 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_unsubscribe_wrong_arn_format": {
+    "recorded-date": "20-10-2023, 12:52:36",
+    "recorded-content": {
+      "invalid-unsubscribe-arn-1": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not 1",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-unsubscribe-arn-2": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not 5",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-unsubscribe-arn-3": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: SubscriptionId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `sns` tests should still create the consequent resources in this accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR fixes all the failing tests in `tests.aws.services.sns.test_sns.py` by:
- removing the use of `get_aws_account_id()` helper.
- use moto internals in `unsubscribe` handler. 
- use parsed arn instead of context arn 

See #8204 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

