### PR TITLE
Use account and region aware test assertions

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -233,7 +233,7 @@ class TestAPIGateway:
             handler_file=TEST_LAMBDA_AWS_PROXY,
             runtime=Runtime.python3_9,
         )
-        lambda_arn = arns.lambda_function_arn(fn_name)
+        lambda_arn = arns.lambda_function_arn(fn_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
 
         api_id, _, root = create_rest_apigw(name="aws lambda api")
         resource_id, _ = create_rest_resource(
@@ -449,7 +449,7 @@ class TestAPIGateway:
           data dictionary before sending it off to the lambda.
         """
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = arns.lambda_function_arn(fn_name)
+        lambda_uri = arns.lambda_function_arn(fn_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
         invocation_uri = "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations"
         target_uri = invocation_uri % (TEST_AWS_REGION_NAME, lambda_uri)
 
@@ -576,7 +576,7 @@ class TestAPIGateway:
         create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=Runtime.nodejs16_x
         )
-        lambda_arn = arns.lambda_function_arn(fn_name)
+        lambda_arn = arns.lambda_function_arn(fn_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
 
         spec_file = load_file(TEST_IMPORT_REST_API_ASYNC_LAMBDA)
         spec_file = spec_file.replace("${lambda_invocation_arn}", lambda_arn)
@@ -662,7 +662,9 @@ class TestAPIGateway:
             handler="apigw_502.handler",
         )
 
-        lambda_uri = arns.lambda_function_arn(lambda_name)
+        lambda_uri = arns.lambda_function_arn(
+            lambda_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+        )
         target_uri = f"arn:aws:apigateway:{TEST_AWS_REGION_NAME}:lambda:path/2015-03-31/functions/{lambda_uri}/invocations"
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway",
@@ -692,8 +694,8 @@ class TestAPIGateway:
     def _test_api_gateway_lambda_proxy_integration_any_method(self, fn_name, path):
 
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = arns.lambda_function_arn(fn_name)
-        target_uri = arns.apigateway_invocations_arn(lambda_uri)
+        lambda_uri = arns.lambda_function_arn(fn_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
+        target_uri = arns.apigateway_invocations_arn(lambda_uri, TEST_AWS_REGION_NAME)
 
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway3",
@@ -724,7 +726,9 @@ class TestAPIGateway:
     ):
 
         # create Lambda function
-        lambda_uri = arns.lambda_function_arn(integration_lambda)
+        lambda_uri = arns.lambda_function_arn(
+            integration_lambda, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+        )
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api")
@@ -1388,7 +1392,7 @@ class TestAPIGateway:
         create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=Runtime.nodejs16_x
         )
-        lambda_arn_1 = arns.lambda_function_arn(fn_name)
+        lambda_arn_1 = arns.lambda_function_arn(fn_name, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME)
 
         # create REST API and test resource
         rest_api_id, _, _ = create_rest_apigw(name="test", description="test")
@@ -1743,8 +1747,10 @@ def test_rest_api_multi_region(
     )
     lambda_eu_west_1_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
     lambda_us_west_1_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
-    lambda_eu_arn = arns.lambda_function_arn(lambda_name, region_name="eu-west-1")
-    uri_eu = arns.apigateway_invocations_arn(lambda_eu_arn, region_name="eu-west-1")
+    lambda_eu_arn = arns.lambda_function_arn(lambda_name, TEST_AWS_ACCOUNT_ID, "eu-west-1")
+    uri_eu = arns.apigateway_invocations_arn(
+        lambda_eu_arn, TEST_AWS_ACCOUNT_ID, region_name="eu-west-1"
+    )
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_eu,
@@ -1756,7 +1762,7 @@ def test_rest_api_multi_region(
         uri=uri_eu,
     )
 
-    lambda_us_arn = arns.lambda_function_arn(lambda_name, region_name="us-west-1")
+    lambda_us_arn = arns.lambda_function_arn(lambda_name, TEST_AWS_ACCOUNT_ID, "us-west-1")
     uri_us = arns.apigateway_invocations_arn(lambda_us_arn, region_name="us-west-1")
 
     integration_uri, _ = create_rest_api_integration(

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1748,9 +1748,7 @@ def test_rest_api_multi_region(
     lambda_eu_west_1_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
     lambda_us_west_1_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
     lambda_eu_arn = arns.lambda_function_arn(lambda_name, TEST_AWS_ACCOUNT_ID, "eu-west-1")
-    uri_eu = arns.apigateway_invocations_arn(
-        lambda_eu_arn, TEST_AWS_ACCOUNT_ID, region_name="eu-west-1"
-    )
+    uri_eu = arns.apigateway_invocations_arn(lambda_eu_arn, region_name="eu-west-1")
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_eu,

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -6,7 +6,6 @@ from moto.ec2 import ec2_backends
 
 from localstack.constants import TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
-from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
 
 # public amazon image used for ec2 launch templates
@@ -287,12 +286,11 @@ class TestEc2Integrations:
             ],
         )
 
-        region = aws_stack.get_region()
         assert 200 == vpc_endpoint_gateway_services["ResponseMetadata"]["HTTPStatusCode"]
         services = vpc_endpoint_gateway_services["ServiceNames"]
         assert 2 == len(services)
-        assert f"com.amazonaws.{region}.dynamodb" in services
-        assert f"com.amazonaws.{region}.s3" in services
+        assert f"com.amazonaws.{TEST_AWS_REGION_NAME}.dynamodb" in services
+        assert f"com.amazonaws.{TEST_AWS_REGION_NAME}.s3" in services
 
         # test filter of Interface endpoint services
         vpc_endpoint_interface_services = aws_client.ec2.describe_vpc_endpoint_services(
@@ -304,8 +302,10 @@ class TestEc2Integrations:
         assert 200 == vpc_endpoint_interface_services["ResponseMetadata"]["HTTPStatusCode"]
         services = vpc_endpoint_interface_services["ServiceNames"]
         assert len(services) > 0
-        assert f"com.amazonaws.{region}.s3" in services  # S3 is both gateway and interface service
-        assert f"com.amazonaws.{region}.kinesis-firehose" in services
+        assert (
+            f"com.amazonaws.{TEST_AWS_REGION_NAME}.s3" in services
+        )  # S3 is both gateway and interface service
+        assert f"com.amazonaws.{TEST_AWS_REGION_NAME}.kinesis-firehose" in services
 
         # test filter that does not exist
         vpc_endpoint_interface_services = aws_client.ec2.describe_vpc_endpoint_services(

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -9,6 +9,7 @@ from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
 from localstack import config, constants
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack, resources
@@ -250,7 +251,9 @@ class TestKinesis:
         # get records with CBOR encoding
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers("kinesis")
+        headers = aws_stack.mock_aws_request_headers(
+            "kinesis", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
+        )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
         headers["X-Amz-Target"] = "Kinesis_20131202.GetRecords"
         data = cbor2.dumps({"ShardIterator": iterator})
@@ -282,7 +285,9 @@ class TestKinesis:
 
         # empty get records with CBOR encoding
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers("kinesis")
+        headers = aws_stack.mock_aws_request_headers(
+            "kinesis", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
+        )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
         headers["X-Amz-Target"] = "Kinesis_20131202.GetRecords"
         data = cbor2.dumps({"ShardIterator": iterator})
@@ -441,6 +446,7 @@ class TestKinesisPythonClient:
             listener_func=process_records,
             kcl_log_level=logging.INFO,
             wait_until_started=True,
+            region_name=TEST_AWS_REGION_NAME,
         )
 
         try:

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -1,6 +1,7 @@
 import re
 
 from localstack import config
+from localstack.constants import SECONDARY_TEST_AWS_REGION_NAME
 from localstack.services.lambda_.api_utils import ARCHITECTURES, RUNTIMES
 from localstack.testing.pytest import markers
 
@@ -31,7 +32,7 @@ from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active, is
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
@@ -4728,9 +4729,9 @@ class TestLambdaLayer:
             )
         snapshot.match("add_layer_arn_without_version_exc", e.value.response)
 
-        other_region = "us-west-2"
-        assert other_region != aws_stack.get_region()
-        other_region_lambda_client = aws_client_factory(region_name=other_region).lambda_
+        other_region_lambda_client = aws_client_factory(
+            region_name=SECONDARY_TEST_AWS_REGION_NAME
+        ).lambda_
         other_region_layer_result = other_region_lambda_client.publish_layer_version(
             LayerName=layer_name,
             CompatibleRuntimes=[],

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -19,6 +19,7 @@ from localstack.aws.api.secretsmanager import (
     DeleteSecretResponse,
     ListSecretsResponse,
 )
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.testing.aws.lambda_utils import is_new_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
@@ -1204,7 +1205,9 @@ class TestSecretsManager:
 
     @staticmethod
     def secretsmanager_http_json_headers(amz_target: str) -> dict:
-        headers = aws_stack.mock_aws_request_headers("secretsmanager")
+        headers = aws_stack.mock_aws_request_headers(
+            "secretsmanager", access_key=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["X-Amz-Target"] = amz_target
         return headers
 


### PR DESCRIPTION
## Motivation

LocalStack test suite uses the `TEST_AWS_ACCOUNT_ID` and `TEST_AWS_REGION_NAME` to control the namespace of the test execution. Some of our tests do not run the correct assertions when these config options are set to non-default values.

## Implementation

This PR makes some of the test assertions account/region aware. Specifically, ARN constructions now make use of the proper account/region that was used to create the original testing resource. Plus, there is correct use of client fixtures in places.