### PR TITLE
EC2: Fix IndexError in ModifyLaunchTemplate

### DIFF
--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -48,6 +48,7 @@ from localstack.aws.api.ec2 import (
     Ec2Api,
     InstanceType,
     IpAddressType,
+    LaunchTemplate,
     ModifyLaunchTemplateRequest,
     ModifyLaunchTemplateResult,
     ModifySubnetAttributeRequest,
@@ -74,7 +75,6 @@ from localstack.aws.api.ec2 import (
     VpcEndpointSubnetIdList,
     scope,
 )
-from localstack.aws.connect import connect_to
 from localstack.services.ec2.exceptions import (
     InvalidLaunchTemplateIdError,
     InvalidLaunchTemplateNameError,
@@ -389,14 +389,16 @@ class Ec2Provider(Ec2Api, ABC):
 
         template.default_version_number = int(request["DefaultVersion"])
 
-        client = connect_to().ec2
-        retrieved_template = client.describe_launch_templates(LaunchTemplateIds=[template.id])
-
-        result: ModifyLaunchTemplateResult = {
-            "LaunchTemplate": retrieved_template["LaunchTemplates"][0],
-        }
-
-        return result
+        return ModifyLaunchTemplateResult(
+            LaunchTemplate=LaunchTemplate(
+                LaunchTemplateId=template.id,
+                LaunchTemplateName=template.name,
+                CreateTime=template.create_time,
+                DefaultVersionNumber=template.default_version_number,
+                LatestVersionNumber=template.latest_version_number,
+                Tags=template.tags,
+            )
+        )
 
     @handler("DescribeVpcEndpointServices", expand=False)
     def describe_vpc_endpoint_services(


### PR DESCRIPTION
## Motivation

EC2 ModifyLaunchTemplate threw an error saying template not found for a template which could be listed. This only happened when a non-default account ID was used.

The cause was the use of a `connect_to()` field which did not take the current request account ID into consideration and instead looked for the template in the default `000000000000` account.

## Implementation

This PR removes the `connect_to()` call and constructs the response in the provider handler.