### PR TITLE
update Docker base images in a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/9288, we introduced a second base image in addition to the Python base image: Eclipse Temurin (in order to build our custom JRE).
This now causes Dependabot to create multiple PRs to update the base images:
- https://github.com/localstack/localstack/pull/9365
- https://github.com/localstack/localstack/pull/9364

This PR groups all docker base image updates into a single PR (still filed once a week).

## Changes
- Introduce a Dependabot Group for docker base image updates.