### PR TITLE
Remove localstack client dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,6 @@ runtime =
     jsonpath-rw>=1.4.0,<2.0.0
     # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
-    localstack-client>=2.0
     moto-ext[all]==4.2.9.post2
     opensearch-py>=2.4.1
     pymongo>=4.2.0


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The `localstack-client` package used to define some of the core internals of LocalStack, particularly the service endpoints. This is a leftover from before we handled all requests through the single edge port 4566. Now that we don't use per-service ports, we have no need for the `localstack-client` package.


<!-- What notable changes does this PR make? -->
## Changes

This PR has been open for a while, where previous changes removed the usage from within the Python code base itself. However, after rebasing recently I found no usages of the package in the code itself. The only change remaining is to stop installing the package. It is currently in the list of dependencies to support usage in -ext (arguably the dependency should have been moved there at some point, but it's not important), so we can remove it from this repo.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

