### PR TITLE
fix awsRegion field in S3 notification

### DIFF
--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -381,7 +381,7 @@ class BaseNotifier:
         record = EventRecord(
             eventVersion="2.1",
             eventSource="aws:s3",
-            awsRegion=ctx.region,
+            awsRegion=ctx.bucket_location,
             eventTime=timestamp_millis(ctx.event_time),
             eventName=ctx.event_type.removeprefix("s3:"),
             userIdentity={"principalId": "AIDAJDPLRKLG7UEXAMPLE"},  # TODO: use the real one?

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -763,7 +763,9 @@ class EventBridgeNotifier(BaseNotifier):
     def notify(self, ctx: S3EventNotificationContext, config: EventBridgeConfiguration):
         # does not require permissions
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-permissions.html
-        events_client = connect_to(aws_access_key_id=ctx.account_id, region_name=ctx.region).events
+        events_client = connect_to(
+            aws_access_key_id=ctx.account_id, region_name=ctx.bucket_location
+        ).events
         entry = self._get_event_payload(ctx)
         try:
             events_client.put_events(Entries=[entry])

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -453,6 +453,7 @@ class SqsNotifier(BaseNotifier):
         sqs_client = connect_to(
             aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
         ).sqs
+        # test if the destination exists (done on AWS side, no permission required)
         try:
             queue_url = sqs_client.get_queue_url(
                 QueueName=arn_data["resource"], QueueOwnerAWSAccountId=arn_data["account"]
@@ -464,9 +465,11 @@ class SqsNotifier(BaseNotifier):
                 name=target_arn,
                 value="The destination queue does not exist",
             )
-        # send test event
+        # send test event with the request metadata for permissions
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types
-        sqs_client = connect_to().sqs.request_metadata(
+        sqs_client = connect_to(
+            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
+        ).sqs.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )
@@ -538,7 +541,9 @@ class SnsNotifier(BaseNotifier):
                 value="The destination topic does not exist",
             )
 
-        sns_client = connect_to().sns.request_metadata(
+        sns_client = connect_to(
+            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
+        ).sns.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )
@@ -615,7 +620,9 @@ class LambdaNotifier(BaseNotifier):
                 name=target_arn,
                 value="The destination Lambda does not exist",
             )
-        lambda_client = connect_to().lambda_.request_metadata(
+        lambda_client = connect_to(
+            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
+        ).lambda_.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )

--- a/tests/aws/services/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/aws/services/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -233,5 +233,70 @@
         ]
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put_in_different_region": {
+    "recorded-date": "18-10-2023, 01:26:55",
+    "recorded-content": {
+      "object-created-different-regions": {
+        "messages": [
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "8d777f385d3dfec8815d20f7496026dc",
+                "key": "<key-name:1>",
+                "sequencer": "object-sequencer",
+                "size": 4
+              },
+              "reason": "PutObject",
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object Created",
+            "id": "<uuid:1>",
+            "region": "<region:1>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          },
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "8d777f385d3dfec8815d20f7496026dc",
+                "key": "<key-name:1>",
+                "sequencer": "object-sequencer",
+                "size": 4
+              },
+              "reason": "PutObject",
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object Created",
+            "id": "<uuid:2>",
+            "region": "<region:1>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
@@ -317,12 +317,12 @@
     }
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
-    "recorded-date": "05-08-2023, 00:55:49",
+    "recorded-date": "17-10-2023, 17:13:15",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "awsRegion": "<region>",
+            "awsRegion": "<aws-region:1>",
             "eventName": "ObjectCreated:Put",
             "eventSource": "aws:s3",
             "eventTime": "date",
@@ -343,6 +343,44 @@
                 }
               },
               "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "key-by-hostname",
+                "sequencer": "sequencer",
+                "size": 9
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          }
+        ]
+      },
+      "receive_messages_region_2": {
+        "messages": [
+          {
+            "awsRegion": "<aws-region:2>",
+            "eventName": "ObjectCreated:Put",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:2>",
+                "name": "<resource:2>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:2>",
               "object": {
                 "eTag": "437b930db84b8079c2dd804a71936b5f",
                 "key": "key-by-hostname",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It had been shown in the multi-account tests that we've had an issue where the `awsRegion` was not correct. It was using the client request region, when it should have been the bucket region.

Also, per the documentation for `events`: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html, the `region` field for the event should be the bucket region, which means the `events` client needs to be created with the bucket region and not the client region, as the `region` field in the event is from the internal client.

Also validated the behaviour with AWS, that the region was of the bucket and not the client.

<!-- What notable changes does this PR make? -->
## Changes
Fix the event payload for SQS/SNS/Lambda to use the region of the bucket for the `awsRegion` field.
Fix the region for the `events` client used in the notifier.

Add 2 tests to validate AWS behaviour (one created a bucket in another region than the default client for SQS, and one creating a client in a secondary region and the bucket in the default one). 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

