### PR TITLE
Remove deprecated config DEFAULT_REGION

### DIFF
--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -414,13 +414,11 @@ class ClientFactory(ABC):
         """
         Return the AWS region name from following sources, in order of availability.
         - LocalStack request context
-        - LocalStack default region
         - Boto session
+        - us-east-1
         """
         return (
-            get_region_from_request_context()
-            or self._get_session_region()
-            or localstack_config.DEFAULT_REGION
+            get_region_from_request_context() or self._get_session_region() or AWS_REGION_US_EAST_1
         )
 
 

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -9,7 +9,6 @@ from botocore.awsrequest import AWSPreparedRequest, prepare_request_dict
 from botocore.config import Config as BotoConfig
 from werkzeug.datastructures import Headers
 
-from localstack import config
 from localstack.aws.api.core import (
     Request,
     RequestContext,
@@ -21,6 +20,7 @@ from localstack.aws.client import parse_response, raise_service_exception
 from localstack.aws.connect import connect_to
 from localstack.aws.skeleton import DispatchTable, create_dispatch_table
 from localstack.aws.spec import load_service
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.http import Response
 from localstack.http.proxy import Proxy
 from localstack.utils.strings import to_str
@@ -215,7 +215,7 @@ def create_aws_request_context(
     if parameters is None:
         parameters = {}
     if region is None:
-        region = config.AWS_REGION_US_EAST_1
+        region = AWS_REGION_US_EAST_1
 
     service = load_service(service_name)
     operation = service.operation_model(action)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple, TypeVar, Union
 
 from localstack import constants
 from localstack.constants import (
-    AWS_REGION_US_EAST_1,
     DEFAULT_BUCKET_MARKER_LOCAL,
     DEFAULT_DEVELOP_PORT,
     DEFAULT_LAMBDA_CONTAINER_REGISTRY,
@@ -367,11 +366,6 @@ try:
 except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
     LOADED_PROFILE = None
-
-# default AWS region (DEPRECATED!)
-DEFAULT_REGION = (
-    os.environ.get("DEFAULT_REGION") or os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1
-)
 
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()
@@ -1169,7 +1163,6 @@ CONFIG_ENV_VARS = [
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEBUG_HANDLER_CHAIN",
-    "DEFAULT_REGION",
     "DEVELOP",
     "DEVELOP_PORT",
     "DISABLE_BOTO_RETRIES",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1163,6 +1163,7 @@ CONFIG_ENV_VARS = [
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEBUG_HANDLER_CHAIN",
+    "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "DEVELOP",
     "DEVELOP_PORT",
     "DISABLE_BOTO_RETRIES",

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -135,7 +135,7 @@ ANALYTICS_API = os.environ.get("ANALYTICS_API") or "https://analytics.localstack
 # environment variable to indicates this process should run the localstack infrastructure
 LOCALSTACK_INFRA_PROCESS = "LOCALSTACK_INFRA_PROCESS"
 
-# default AWS region us-east-1
+# AWS region us-east-1
 AWS_REGION_US_EAST_1 = "us-east-1"
 
 # default lambda registry

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -53,6 +53,7 @@ DEPRECATIONS = [
         "0.12.7",
         "LocalStack now has full multi-region support. Please remove this environment variable.",
     ),
+    # Deprecated in 0.12.7, removed in 3.0.0
     EnvVarDeprecation(
         "DEFAULT_REGION",
         "0.12.7",

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -53,6 +53,11 @@ DEPRECATIONS = [
         "0.12.7",
         "LocalStack now has full multi-region support. Please remove this environment variable.",
     ),
+    EnvVarDeprecation(
+        "DEFAULT_REGION",
+        "0.12.7",
+        "LocalStack now has full multi-region support. This option has no effect. Please remove it from your configuration.",  # noqa
+    ),
     # Since 1.0.0 - New Persistence and file system
     EnvVarDeprecation(
         "DATA_DIR",

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -53,11 +53,6 @@ DEPRECATIONS = [
         "0.12.7",
         "LocalStack now has full multi-region support. Please remove this environment variable.",
     ),
-    EnvVarDeprecation(
-        "DEFAULT_REGION",
-        "0.12.7",
-        "LocalStack now has full multi-region support. Please remove this environment variable.",
-    ),
     # Since 1.0.0 - New Persistence and file system
     EnvVarDeprecation(
         "DATA_DIR",

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -9,7 +9,7 @@ LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
     "DEBUG",
-    "DEFAULT_REGION",
+    "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "DISABLE_CORS_CHECK",
     "DISABLE_CORS_HEADERS",
     "DNS_ADDRESS",

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -9,6 +9,7 @@ LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
     "DEBUG",
+    "DEFAULT_REGION",
     "DISABLE_CORS_CHECK",
     "DISABLE_CORS_HEADERS",
     "DNS_ADDRESS",

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -9,7 +9,6 @@ LOG = logging.getLogger(__name__)
 
 TRACKED_ENV_VAR = [
     "DEBUG",
-    "DEFAULT_REGION",
     "DISABLE_CORS_CHECK",
     "DISABLE_CORS_HEADERS",
     "DNS_ADDRESS",

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -14,7 +14,12 @@ from moto.core.base_backend import InstanceTrackerMeta
 
 from localstack import config, constants
 from localstack.aws.accounts import get_aws_account_id
-from localstack.constants import ENV_DEV, LOCALSTACK_INFRA_PROCESS, LOCALSTACK_VENV_FOLDER
+from localstack.constants import (
+    AWS_REGION_US_EAST_1,
+    ENV_DEV,
+    LOCALSTACK_INFRA_PROCESS,
+    LOCALSTACK_VENV_FOLDER,
+)
 from localstack.runtime import events, hooks
 from localstack.runtime.exceptions import LocalstackExit
 from localstack.services import motoserver
@@ -432,7 +437,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     @log_duration()
     def prepare_environment():
         # set environment
-        os.environ["AWS_REGION"] = config.DEFAULT_REGION
+        os.environ["AWS_REGION"] = AWS_REGION_US_EAST_1
         os.environ["ENV"] = ENV_DEV
         # make sure AWS credentials are configured, otherwise boto3 bails on us
         check_aws_credentials()

--- a/localstack/services/kms/local_kms_server.py
+++ b/localstack/services/kms/local_kms_server.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 from localstack import config
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.kms.packages import kms_local_package
 from localstack.utils.net import get_free_tcp_port
 from localstack.utils.run import ShellCommandThread
@@ -54,8 +55,8 @@ class LocalKMSServer(Server):
             "PORT": str(self.port),
             "ACCOUNT_ID": self._account_id,
             "KMS_ACCOUNT_ID": self._account_id,
-            "REGION": config.DEFAULT_REGION,
-            "KMS_REGION": config.DEFAULT_REGION,
+            "REGION": AWS_REGION_US_EAST_1,
+            "KMS_REGION": AWS_REGION_US_EAST_1,
         }
         if self._kms_data_path and config.PERSISTENCE:
             env_vars["KMS_DATA_PATH"] = self._kms_data_path

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -1,7 +1,6 @@
 from moto.s3 import s3_backends as moto_s3_backends
 from moto.s3.models import S3Backend as MotoS3Backend
 
-from localstack import config
 from localstack.aws.api import RequestContext
 from localstack.aws.api.s3 import (
     AnalyticsConfiguration,
@@ -17,7 +16,7 @@ from localstack.aws.api.s3 import (
     ReplicationConfiguration,
     WebsiteConfiguration,
 )
-from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
+from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
 
 
@@ -89,7 +88,7 @@ class BucketCorsIndex:
     def _build_cors_index() -> dict[BucketName, CORSConfiguration]:
         result = {}
         for account_id, regions in s3_stores.items():
-            result.update(regions[config.DEFAULT_REGION].bucket_cors)
+            result.update(regions[AWS_REGION_US_EAST_1].bucket_cors)
         return result
 
     @staticmethod

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -7,7 +7,6 @@ from typing import Literal, NamedTuple, Optional, Union
 
 from zoneinfo import ZoneInfo
 
-from localstack import config
 from localstack.aws.api import CommonServiceException
 from localstack.aws.api.s3 import (
     AccessControlPolicy,
@@ -63,6 +62,7 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
     WebsiteRedirectLocation,
 )
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.s3.constants import (
     DEFAULT_BUCKET_ENCRYPTION,
     DEFAULT_PUBLIC_BLOCK_ACCESS,
@@ -685,7 +685,7 @@ class BucketCorsIndex:
         buckets = set()
         cors_index = {}
         for account_id, regions in s3_stores.items():
-            for bucket_name, bucket in regions[config.DEFAULT_REGION].buckets.items():
+            for bucket_name, bucket in regions[AWS_REGION_US_EAST_1].buckets.items():
                 bucket: S3Bucket
                 buckets.add(bucket_name)
                 if bucket.cors_rules is not None:

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -10,14 +10,17 @@ from botocore.exceptions import ClientError
 from botocore.model import OperationModel
 from werkzeug.datastructures import Headers
 
-from localstack import config
 from localstack.aws.api import CommonServiceException
 from localstack.aws.connect import connect_to
 from localstack.aws.protocol.parser import OperationNotFoundParserError, create_parser
 from localstack.aws.protocol.serializer import create_serializer
 from localstack.aws.protocol.validate import MissingRequiredField, validate_request
 from localstack.aws.spec import load_service
-from localstack.constants import INTERNAL_AWS_ACCESS_KEY_ID, INTERNAL_AWS_SECRET_ACCESS_KEY
+from localstack.constants import (
+    AWS_REGION_US_EAST_1,
+    INTERNAL_AWS_ACCESS_KEY_ID,
+    INTERNAL_AWS_SECRET_ACCESS_KEY,
+)
 from localstack.http import Request, Response, Router, route
 from localstack.http.dispatcher import Handler
 from localstack.services.sqs.exceptions import MissingParameter
@@ -66,7 +69,7 @@ def domain_strategy_handler(
     """Uses the endpoint host to extract the region. See:
     https://docs.aws.amazon.com/general/latest/gr/sqs-service.html"""
     if not region:
-        region = config.DEFAULT_REGION
+        region = AWS_REGION_US_EAST_1
     else:
         region = region.rstrip(".")
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -22,6 +22,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config, constants
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -82,8 +83,7 @@ def aws_http_client_factory(aws_session):
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
     ):
-        region = region or aws_session.region_name
-        region = region or config.DEFAULT_REGION
+        region = region or aws_session.region_name or AWS_REGION_US_EAST_1
 
         if aws_access_key_id or aws_secret_access_key:
             credentials = botocore.credentials.Credentials(

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -14,6 +14,7 @@ from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
     APPLICATION_X_WWW_FORM_URLENCODED,
+    AWS_REGION_US_EAST_1,
     ENV_DEV,
     HEADER_LOCALSTACK_ACCOUNT_ID,
     INTERNAL_AWS_ACCESS_KEY_ID,
@@ -153,7 +154,7 @@ def get_local_region():
     global LOCAL_REGION
     if LOCAL_REGION is None:
         LOCAL_REGION = get_boto3_region() or ""
-    return config.DEFAULT_REGION or LOCAL_REGION
+    return AWS_REGION_US_EAST_1 or LOCAL_REGION
 
 
 def get_boto3_region() -> str:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -150,6 +150,7 @@ def get_partition(region_name: str = None):
     return boto3.session.Session().get_partition_for_region(region_name)
 
 
+# TODO: Deprecate and remove this
 def get_local_region():
     global LOCAL_REGION
     if LOCAL_REGION is None:

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -9,7 +9,12 @@ from requests.models import Request
 from requests.structures import CaseInsensitiveDict
 
 from localstack import config
-from localstack.constants import APPLICATION_JSON, APPLICATION_XML, HEADER_CONTENT_TYPE
+from localstack.constants import (
+    APPLICATION_JSON,
+    APPLICATION_XML,
+    AWS_REGION_US_EAST_1,
+    HEADER_CONTENT_TYPE,
+)
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import (
     is_json_request,
@@ -74,13 +79,7 @@ def extract_region_from_headers(headers):
     if region:
         return region
 
-    region = extract_region_from_auth_header(headers)
-
-    if not region:
-        # fall back to local region
-        region = aws_stack.get_local_region()
-
-    return region
+    return extract_region_from_auth_header(headers) or AWS_REGION_US_EAST_1
 
 
 def get_request_context():

--- a/tests/aws/services/logs/test_logs.py
+++ b/tests/aws/services/logs/test_logs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 import gzip
 import json
@@ -6,9 +5,8 @@ import re
 
 import pytest
 
-from localstack import config
 from localstack.aws.api.lambda_ import Runtime
-from localstack.constants import APPLICATION_AMZ_JSON_1_1
+from localstack.constants import APPLICATION_AMZ_JSON_1_1, AWS_REGION_US_EAST_1
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils import testutil
@@ -19,7 +17,7 @@ from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 logs_role = {
     "Statement": {
         "Effect": "Allow",
-        "Principal": {"Service": f"logs.{config.AWS_REGION_US_EAST_1}.amazonaws.com"},
+        "Principal": {"Service": f"logs.{AWS_REGION_US_EAST_1}.amazonaws.com"},
         "Action": "sts:AssumeRole",
     }
 }
@@ -208,7 +206,7 @@ class TestCloudWatchLogs:
             logGroupIdentifier=arns.log_group_arn(
                 logs_log_group,
                 account_id=aws_client.sts.get_caller_identity()["Account"],
-                region_name=config.AWS_REGION_US_EAST_1,
+                region_name=AWS_REGION_US_EAST_1,
             )
         ).get("logStreams")
         snapshot.match("log_group_identifier-arn", response)
@@ -289,9 +287,9 @@ class TestCloudWatchLogs:
         result = aws_client.lambda_.add_permission(
             FunctionName=test_lambda_name,
             StatementId=test_lambda_name,
-            Principal=f"logs.{config.AWS_REGION_US_EAST_1}.amazonaws.com",
+            Principal=f"logs.{AWS_REGION_US_EAST_1}.amazonaws.com",
             Action="lambda:InvokeFunction",
-            SourceArn=f"arn:aws:logs:{config.AWS_REGION_US_EAST_1}:{account_id}:log-group:{logs_log_group}:*",
+            SourceArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{account_id}:log-group:{logs_log_group}:*",
             SourceAccount=account_id,
         )
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -30,6 +30,7 @@ from localstack import config, constants
 from localstack.aws.api.s3 import StorageClass
 from localstack.config import NATIVE_S3_PROVIDER
 from localstack.constants import (
+    AWS_REGION_US_EAST_1,
     LOCALHOST_HOSTNAME,
     S3_VIRTUAL_HOSTNAME,
     SECONDARY_TEST_AWS_ACCESS_KEY_ID,
@@ -9873,7 +9874,7 @@ def _s3_client_custom_config(conf: Config, endpoint_url: str = None):
 
 def _endpoint_url(region: str = "", localstack_host: str = None) -> str:
     if not region:
-        region = config.AWS_REGION_US_EAST_1
+        region = AWS_REGION_US_EAST_1
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         if region == "us-east-1":
             return "https://s3.amazonaws.com"
@@ -9891,14 +9892,14 @@ def _bucket_url(bucket_name: str, region: str = "", localstack_host: str = None)
 def _website_bucket_url(bucket_name: str):
     # TODO depending on region the syntax of the website vary (dot vs dash before region)
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
-        region = config.AWS_REGION_US_EAST_1
+        region = AWS_REGION_US_EAST_1
         return f"http://{bucket_name}.s3-website-{region}.amazonaws.com"
     return _bucket_url_vhost(bucket_name, localstack_host=constants.S3_STATIC_WEBSITE_HOSTNAME)
 
 
 def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str = None) -> str:
     if not region:
-        region = config.AWS_REGION_US_EAST_1
+        region = AWS_REGION_US_EAST_1
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         if region == "us-east-1":
             return f"https://{bucket_name}.s3.amazonaws.com"

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.aws.handlers.cors import ALLOWED_CORS_ORIGINS
-from localstack.constants import LOCALHOST_HOSTNAME, S3_VIRTUAL_HOSTNAME
+from localstack.constants import AWS_REGION_US_EAST_1, LOCALHOST_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
@@ -15,7 +15,7 @@ from localstack.utils.strings import short_uid
 
 def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str = None) -> str:
     if not region:
-        region = config.AWS_REGION_US_EAST_1
+        region = AWS_REGION_US_EAST_1
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         if region == "us-east-1":
             return f"https://{bucket_name}.s3.amazonaws.com"

--- a/tests/aws/test_moto.py
+++ b/tests/aws/test_moto.py
@@ -5,9 +5,9 @@ import pytest
 from moto.core import DEFAULT_ACCOUNT_ID as DEFAULT_MOTO_ACCOUNT_ID
 
 import localstack.aws.accounts
-from localstack import config
 from localstack.aws.api import ServiceException, handler
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services import moto
 from localstack.services.moto import MotoFallbackDispatcher
 from localstack.testing.pytest import markers
@@ -72,9 +72,9 @@ def test_call_with_sqs_modifies_state_in_moto_backend():
         moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname})
     )
     url = response["QueueUrl"]
-    assert qname in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][config.AWS_REGION_US_EAST_1].queues
+    assert qname in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][AWS_REGION_US_EAST_1].queues
     moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
-    assert qname not in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][config.AWS_REGION_US_EAST_1].queues
+    assert qname not in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][AWS_REGION_US_EAST_1].queues
 
 
 @pytest.mark.parametrize(
@@ -140,8 +140,8 @@ def test_call_with_modified_request():
     response = moto.call_moto_with_request(context, {"QueueName": qname2})  # overwrite old request
 
     url = response["QueueUrl"]
-    assert qname2 in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][config.AWS_REGION_US_EAST_1].queues
-    assert qname1 not in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][config.AWS_REGION_US_EAST_1].queues
+    assert qname2 in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][AWS_REGION_US_EAST_1].queues
+    assert qname1 not in sqs_backends[DEFAULT_MOTO_ACCOUNT_ID][AWS_REGION_US_EAST_1].queues
 
     moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
 

--- a/tests/aws/test_terraform.py
+++ b/tests/aws/test_terraform.py
@@ -4,7 +4,6 @@ import threading
 
 import pytest
 
-from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.packages.terraform import terraform_package
 from localstack.testing.pytest import markers
@@ -43,8 +42,6 @@ def check_terraform_version():
 @pytest.fixture(scope="module", autouse=True)
 def setup_test():
     with INIT_LOCK:
-        if config.DEFAULT_REGION != "us-east-1":
-            pytest.skip("Currently only support us-east-1")
         available, version = check_terraform_version()
 
         if not available:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+# TODO@viren REMOVE THIS
 def switch_region():
     """A fixture which allows to easily switch the region in the config within a `with` context."""
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,27 +1,4 @@
-from contextlib import contextmanager
-from typing import Optional
-
 import pytest
-
-
-@pytest.fixture(autouse=True)
-# TODO@viren REMOVE THIS
-def switch_region():
-    """A fixture which allows to easily switch the region in the config within a `with` context."""
-
-    @contextmanager
-    def _switch_region(region: Optional[str]):
-        from localstack import config
-
-        # FIXME adapt or remove with 2.0
-        previous_region = config.DEFAULT_REGION
-        try:
-            config.DEFAULT_REGION = region
-            yield
-        finally:
-            config.DEFAULT_REGION = previous_region
-
-    return _switch_region
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -7,9 +7,13 @@ from unittest.mock import MagicMock, Mock
 import boto3
 import pytest
 
-from localstack import config
 from localstack.aws.api.apigateway import Model
-from localstack.constants import APPLICATION_JSON, DEFAULT_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+from localstack.constants import (
+    APPLICATION_JSON,
+    AWS_REGION_US_EAST_1,
+    DEFAULT_AWS_ACCOUNT_ID,
+    TEST_AWS_REGION_NAME,
+)
 from localstack.services.apigateway.helpers import (
     ModelResolver,
     OpenAPISpecificationResolver,
@@ -387,7 +391,7 @@ class TestApiGatewayRequestValidator(unittest.TestCase):
         self.assertTrue(validator.is_request_valid())
 
     def _mock_client(self):
-        return Mock(boto3.client("apigateway", region_name=config.AWS_REGION_US_EAST_1))
+        return Mock(boto3.client("apigateway", region_name=AWS_REGION_US_EAST_1))
 
     def _mock_store(self):
         return ApiGatewayStore()

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -274,7 +274,7 @@ def test_arn_partition_rewriting_in_response_with_request_region(encoding):
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_arn_partition_rewriting_in_response_without_region_without_fallback_partition_override(
-    encoding, switch_region, monkeypatch
+    encoding, monkeypatch
 ):
     rewrite_handler = ArnPartitionRewriteHandler()
     response = Response(
@@ -295,7 +295,7 @@ def test_arn_partition_rewriting_in_response_without_region_without_fallback_par
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_arn_partition_rewriting_in_response_without_region_with_fallback_partition_override(
-    encoding, switch_region, monkeypatch
+    encoding, monkeypatch
 ):
     monkeypatch.setattr(config, "ARN_PARTITION_FALLBACK", "aws-us-gov")
 


### PR DESCRIPTION
## Motivation

The `DEFAULT_REGION` environment config variable was used in early years of LocalStack when multi-region was unsupported. It has since been deprecated.

This PR removes this config variable for the upcoming major release.