### PR TITLE
Integrate lambda init upstream changes

### DIFF
--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.21-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.22-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.20-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.21-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -131,6 +131,24 @@ class TransformerUtility:
         ]
 
     @staticmethod
+    def lambda_report_logs():
+        """Transformers for Lambda REPORT logs replacing dynamic metrics including:
+        * Duration
+        * Billed Duration
+        * Max Memory Used
+        * Init Duration
+
+        Excluding:
+        * Memory Size
+        """
+        return [
+            TransformerUtility.regex(
+                re.compile(r"Duration: \d+(\.\d{2})? ms"), "Duration: <duration> ms"
+            ),
+            TransformerUtility.regex(re.compile(r"Used: \d+ MB"), "Used: <memory> MB"),
+        ]
+
+    @staticmethod
     def apigateway_api():
         return [
             TransformerUtility.key_value("id"),

--- a/tests/aws/services/lambda_/functions/lambda_request_id.py
+++ b/tests/aws/services/lambda_/functions/lambda_request_id.py
@@ -1,0 +1,11 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    # Logger format: [<log_level>]\tdate\t<request_id>\t<log_message>
+    LOGGER.info("RequestId log message")
+    return context.aws_request_id

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -50,6 +50,7 @@ FUNCTION_MAX_UNZIPPED_SIZE = 262144000
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_LAMBDA_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_integration.py")
 TEST_LAMBDA_PYTHON_ECHO = os.path.join(THIS_FOLDER, "functions/lambda_echo.py")
+TEST_LAMBDA_PYTHON_REQUEST_ID = os.path.join(THIS_FOLDER, "functions/lambda_request_id.py")
 TEST_LAMBDA_PYTHON_ROLE = os.path.join(THIS_FOLDER, "functions/lambda_role.py")
 TEST_LAMBDA_MAPPING_RESPONSES = os.path.join(THIS_FOLDER, "functions/lambda_mapping_responses.py")
 TEST_LAMBDA_PYTHON_SELECT_PATTERN = os.path.join(THIS_FOLDER, "functions/lambda_select_pattern.py")
@@ -1027,15 +1028,8 @@ class TestLambdaFeatures:
         # assert that logs are contained in response
         logs = result.get("LogResult", "")
         logs = to_str(base64.b64decode(to_str(logs)))
-        snapshot.add_transformer(
-            snapshot.transform.regex(
-                re.compile(r"Duration: \d+(\.\d{2})? ms"), "Duration: <duration> ms"
-            )
-        )
-        snapshot.add_transformer(
-            snapshot.transform.regex(re.compile(r"Used: \d+ MB"), "Used: <memory> MB")
-        )
-        snapshot.match("logs", {"logs": logs})
+        snapshot.add_transformer(snapshot.transform.lambda_report_logs())
+        snapshot.match("logs", {"logs": logs.splitlines(keepends=True)})
         assert "START" in logs
         assert "{}" in logs
         assert "END" in logs
@@ -2426,21 +2420,24 @@ class TestRequestIdHandling:
             r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", request_id
         )
 
+    # TODO remove, currently missing init duration in REPORT
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_old_provider(), paths=["$..logs"]
+    )
     @markers.aws.validated
     def test_request_id_invoke(self, aws_client, create_lambda_function, snapshot):
+        """Test that the request_id within the Lambda context matches with CloudWatch logs."""
         func_name = f"test_lambda_{short_uid()}"
         log_group_name = f"/aws/lambda/{func_name}"
 
         create_lambda_function(
             func_name=func_name,
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            handler_file=TEST_LAMBDA_PYTHON_REQUEST_ID,
             runtime=Runtime.python3_10,
             client=aws_client.lambda_,
         )
 
-        result = aws_client.lambda_.invoke(
-            FunctionName=func_name, Payload=json.dumps({"hello": "world"})
-        )
+        result = aws_client.lambda_.invoke(FunctionName=func_name)
         snapshot.match("invoke_result", result)
         snapshot.add_transformer(
             snapshot.transform.regex(result["ResponseMetadata"]["RequestId"], "<request-id>")
@@ -2452,10 +2449,13 @@ class TestRequestIdHandling:
             return log_events_result
 
         log_events = retry(fetch_logs, retries=10, sleep=2)
-        end_log_entries = [
-            e["message"].rstrip() for e in log_events["events"] if e["message"].startswith("END")
+        log_entries = [
+            line["message"].rstrip()
+            for line in log_events["events"]
+            if "RequestId" in line["message"]
         ]
-        snapshot.match("end_log_entries", end_log_entries)
+        snapshot.match("log_entries", {"logs": log_entries})
+        snapshot.add_transformer(snapshot.transform.lambda_report_logs())
 
     @markers.aws.validated
     def test_request_id_invoke_url(self, aws_client, create_lambda_function, snapshot):

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -414,26 +414,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.9]": {
-    "recorded-date": "17-02-2023, 14:01:27",
-    "recorded-content": {
-      "invoke": {
-        "ExecutedVersion": "$LATEST",
-        "LogResult": "log-result",
-        "Payload": {},
-        "StatusCode": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "logs": {
-        "logs": "START RequestId: <request-id> Version: $LATEST\n{}\nEND RequestId: <request-id>\nREPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
-      }
-    }
-  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.10]": {
-    "recorded-date": "02-05-2023, 16:52:42",
+    "recorded-date": "17-10-2023, 15:46:02",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -446,12 +428,17 @@
         }
       },
       "logs": {
-        "logs": "START RequestId: <request-id> Version: $LATEST\n{}\nEND RequestId: <request-id>\nREPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
+        "logs": [
+          "START RequestId: <request-id> Version: $LATEST\n",
+          "{}\n",
+          "END RequestId: <request-id>\n",
+          "REPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
+        ]
       }
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[nodejs16.x]": {
-    "recorded-date": "02-05-2023, 16:52:40",
+    "recorded-date": "17-10-2023, 15:45:59",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -464,7 +451,12 @@
         }
       },
       "logs": {
-        "logs": "START RequestId: <request-id> Version: $LATEST\ndate\t<request-id>\tINFO\t{}\nEND RequestId: <request-id>\nREPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
+        "logs": [
+          "START RequestId: <request-id> Version: $LATEST\n",
+          "date\t<request-id>\tINFO\t{}\n",
+          "END RequestId: <request-id>\n",
+          "REPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms\t\n"
+        ]
       }
     }
   },
@@ -3191,22 +3183,25 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda.py::TestRequestIdHandling::test_request_id_invoke": {
-    "recorded-date": "02-05-2023, 17:01:20",
+    "recorded-date": "17-10-2023, 16:13:59",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
-        "Payload": {
-          "hello": "world"
-        },
+        "Payload": "\"<request-id>\"",
         "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
-      "end_log_entries": [
-        "END RequestId: <request-id>"
-      ]
+      "log_entries": {
+        "logs": [
+          "START RequestId: <request-id> Version: $LATEST",
+          "[INFO]\tdate\t<request-id>\tRequestId log message",
+          "END RequestId: <request-id>",
+          "REPORT RequestId: <request-id>\tDuration: <duration> ms\tBilled Duration: <duration> ms\tMemory Size: 128 MB\tMax Memory Used: <memory> MB\tInit Duration: <duration> ms"
+        ]
+      }
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestRequestIdHandling::test_request_id_async_invoke_with_retry": {

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import platform
 import time
 import zipfile
 
@@ -10,6 +9,7 @@ from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils.files import cp_r
+from localstack.utils.platform import get_arch
 from localstack.utils.strings import short_uid, to_bytes, to_str
 
 LOG = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def snapshot_transformers(snapshot):
     reason="Local executor does not support the majority of the runtimes",
 )
 @pytest.mark.skipif(
-    condition=platform.machine() != "x86_64", reason="build process doesn't support arm64 right now"
+    condition=get_arch() != "x86_64", reason="build process doesn't support arm64 right now"
 )
 class TestLambdaRuntimesCommon:
     """
@@ -255,7 +255,7 @@ class TestLambdaRuntimesCommon:
     reason="Local executor does not support the majority of the runtimes",
 )
 @pytest.mark.skipif(
-    condition=platform.machine() != "x86_64", reason="build process doesn't support arm64 right now"
+    condition=get_arch() != "x86_64", reason="build process doesn't support arm64 right now"
 )
 class TestLambdaCallingLocalstack:
     @markers.multiruntime(


### PR DESCRIPTION
Depends on https://github.com/localstack/lambda-runtime-init/pull/24

## Motivation

The official AWS lambda-runtime-init received some upstream updates (typically merged in big blobs from their internal repository). We should update our customized localstack version to support the latest features (e.g., response streaming) and updates (e.g., the new Golang version).

See https://github.com/localstack/lambda-runtime-init/pull/24

## Changes

* Bump Lambda init version
* Improve the `request_id` test to cover a regression where the ID didn't match
* Extract `lambda_report_logs` transformers
* Update logs snapshots to yield individual lines for easier visual and more accurate matching (still missing selective list skip 😿 )
* Standardize Lambda commons test `get_arch`

## Testing

See https://github.com/localstack/lambda-runtime-init/pull/24

## TODO

- [x] Wait for full CI run and then follow up on potential issues

