### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,13 +13,13 @@
 /LICENSE.txt @HarshCasper @alexrashed
 
 # Docker
-/bin/docker-entrypoint.sh
-/.dockerignore
+/bin/docker-entrypoint.sh @thrau @alexrashed
+/.dockerignore @alexrashed
 /Dockerfile @alexrashed
 
 # Git, Pipelines, GitHub config
-/.circleci @alexrashed @dfangl @thrau
-/.github @alexrashed @dfangl @thrau
+/.circleci @alexrashed @dfangl @dominikschubert
+/.github @alexrashed @dfangl @dominikschubert
 /.test_durations @alexrashed
 /.git-blame-ignore-revs @alexrashed @thrau
 /bin/release-dev.sh @thrau @alexrashed
@@ -68,7 +68,7 @@
 /localstack/runtime/ @thrau
 
 # Logging
-/localstack/logging/ @thrau @alexrashed @dominikschubert
+/localstack/logging/ @dfangl @alexrashed @dominikschubert
 
 # Stores
 /localstack/services/stores.py @viren-nadkarni

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,26 @@
 # CODEOWNERS
 /CODEOWNERS @thrau @dominikschubert @alexrashed
 
+# README / Docs
+/doc/ @HarshCasper
+/README.md @HarshCasper
+/CODE_OF_CONDUCT.md @HarshCasper
+/CONTRIBUTING.md @HarshCasper
+/LICENSE.txt @HarshCasper @alexrashed
+
+# Docker
+/bin/docker-entrypoint.sh
+/.dockerignore
+/Dockerfile @alexrashed
+
+# Git, Pipelines, GitHub config
+/.circleci @alexrashed @dfangl @thrau
+/.github @alexrashed @dfangl @thrau
+/.test_durations @alexrashed
+/.git-blame-ignore-revs @alexrashed @thrau
+/bin/release-dev.sh @thrau @alexrashed
+/bin/release-helper.sh @thrau @alexrashed
+
 # ASF
 /localstack/aws/ @thrau
 /tests/unit/aws/ @thrau
@@ -33,6 +53,10 @@
 /tests/unit/test_docker_utils.py @dfangl @dominikschubert
 /tests/unit/test_dockerclient.py @dfangl @dominikschubert
 
+# Package Installers
+/localstack/packages/ @alexrashed
+/localstack/services/kinesis/packages.py @alexrashed
+
 # DNS server
 /localstack/dns @simonrw @dfangl
 
@@ -40,19 +64,15 @@
 /localstack/http/ @thrau
 /tests/unit/http_/ @thrau
 
+# Runtime
+/localstack/runtime/ @thrau
+
+# Logging
+/localstack/logging/ @thrau @alexrashed @dominikschubert
+
 # Stores
 /localstack/services/stores.py @viren-nadkarni
 /tests/unit/test_stores.py @viren-nadkarni
-
-# Dockerfile
-/Dockerfile @alexrashed
-
-# Pipelines
-/.circleci/config.yml @thrau @alexrashed @dfangl
-/.github/workflows/ @thrau @alexrashed @dfangl
-
-# Dependabot
-/.github/dependabot.yml @alexrashed
 
 # Analytics client
 /localstack/utils/analytics/ @thrau
@@ -63,6 +83,9 @@
 /localstack/testing/pytest/ @dominikschubert
 /localstack/testing/pytest/snapshot.py @dominikschubert @steffyP
 /tests/unit/utils/testing/ @dominikschubert @steffyP
+
+# Scenario testing
+/localstack/testing/scenario/ @dominikschubert @steffyP
 
 # Bootstrap tests
 /tests/bootstrap @simonrw


### PR DESCRIPTION
## Motivation
We are more and more using the `CODEOWNERS` file in order to define code ownership in a machine readable way, which then can be used by different tools.
This can be GitHub by using it to auto-assigning PR reviewers, but it can also be used by tooling on our side in order to implement some kind of automation / notifications / ... around it.
This PR is another iteration on reducing the amount of uncovered files in this repo.
The enhancements were driven by the validation results created with [mszostok/codeowners-validator](https://github.com/mszostok/codeowners-validator).

## Changes
- Restructure the CODEOWNERS file a bit.
- Add a few more sections / directories / files.

/cc affected codeowners @HarshCasper @thrau @dfangl @dominikschubert @steffyP 