### PR TITLE
disable pro tests for forks, fix label check for fork PRs

### DIFF
--- a/.github/workflows/pr-enforce-no-major-master.yml
+++ b/.github/workflows/pr-enforce-no-major-master.yml
@@ -1,7 +1,7 @@
 name: Enforce no major on master
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
     # only enforce for PRs targeting the master branch
     branches:

--- a/.github/workflows/pr-enforce-pr-labels.yml
+++ b/.github/workflows/pr-enforce-pr-labels.yml
@@ -1,7 +1,7 @@
 name: Enforce PR Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
 
 jobs:

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -69,6 +69,8 @@ env:
 jobs:
   test-pro:
     name: "Community Integration Tests against Pro"
+    # This job needs secrets and cannot be executed on forks, skip it in this case
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
## Motivation
Currently, some GitHub workflows which are automatically triggered when a PR is created are failing due to the missing access to certain secrets
This PR should fix these issues such that workflow executions triggered by PRs coming from community forks can get fully green (after they have been approved by a contributor).
/cc @joe4dev 

## Changes
- Disables the Pro integration tests for community forks.
- Changes the workflow trigger for the label checks from `pull_request` to `pull_request_target`.
  - This is similar to the `pr-cla` action.
  - This trigger is executed on the default branch of the target repo, rather than in the branch, which prevents secret leaking.
  - This is why these workflows _can_  access secrets other than the default github token.
  - More info on `pull_request_target` can be found here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Testing
- These changes are somewhat hard to test, since they need to be merged to the default branch before they can be properly tested if the execution works for forks now.
- Once this PR is merged, we can evaluate if the pipelines are now working for community raised fork-PRs.