### PR TITLE
Remove redundant SQS ARN helper

### DIFF
--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -42,11 +42,6 @@ def sqs_queue_url_for_arn(queue_arn: str) -> str:
     return result
 
 
-# TODO: remove and merge with sqs_queue_url_for_arn(..) above!!
-def get_sqs_queue_url(queue_arn: str) -> str:
-    return sqs_queue_url_for_arn(queue_arn)
-
-
 class ArnData(TypedDict):
     partition: str
     service: str

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -55,7 +55,7 @@ def _send_to_dead_letter_queue(source_arn: str, dlq_arn: str, event: Dict, error
     else:
         clients = connect_to(region_name=region)
     if ":sqs:" in dlq_arn:
-        queue_url = arns.get_sqs_queue_url(dlq_arn)
+        queue_url = arns.sqs_queue_url_for_arn(dlq_arn)
         sqs_client = clients.sqs.request_metadata(
             source_arn=source_arn, service_principal=source_service
         )

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -14,7 +14,7 @@ from localstack.utils.aws.arns import (
     extract_account_id_from_arn,
     extract_region_from_arn,
     firehose_name,
-    get_sqs_queue_url,
+    sqs_queue_url_for_arn,
 )
 from localstack.utils.http import add_path_parameters_to_url, add_query_params_to_url
 from localstack.utils.http import safe_requests as requests
@@ -69,7 +69,7 @@ def send_event_to_target(
         sqs_client = clients.sqs.request_metadata(
             service_principal=source_service, source_arn=source_arn
         )
-        queue_url = get_sqs_queue_url(target_arn)
+        queue_url = sqs_queue_url_for_arn(target_arn)
         msg_group_id = collections.get_safe(target_attributes, "$.SqsParameters.MessageGroupId")
         kwargs = {"MessageGroupId": msg_group_id} if msg_group_id else {}
         sqs_client.send_message(

--- a/localstack/utils/aws/queries.py
+++ b/localstack/utils/aws/queries.py
@@ -1,12 +1,12 @@
 from localstack.aws.connect import connect_to
-from localstack.utils.aws.arns import extract_region_from_arn, get_sqs_queue_url
+from localstack.utils.aws.arns import extract_region_from_arn, sqs_queue_url_for_arn
 from localstack.utils.strings import to_str
 
 
 def sqs_receive_message(queue_arn):
     region_name = extract_region_from_arn(queue_arn)
     client = connect_to(region_name=region_name).sqs
-    queue_url = get_sqs_queue_url(queue_arn)
+    queue_url = sqs_queue_url_for_arn(queue_arn)
     response = client.receive_message(QueueUrl=queue_url)
     return response
 

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -130,7 +130,7 @@ class TestServerless:
 
         assert event_source_arn == arns.sqs_queue_arn(queue_name)
         result = sqs_client.get_queue_attributes(
-            QueueUrl=arns.get_sqs_queue_url(queue_name),
+            QueueUrl=arns.sqs_queue_url_for_arn(queue_name),
             AttributeNames=[
                 "RedrivePolicy",
             ],

--- a/tests/performance/test_sqs_performance.py
+++ b/tests/performance/test_sqs_performance.py
@@ -6,7 +6,7 @@ from localstack.constants import (
     TEST_AWS_REGION_NAME,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
-from localstack.utils.aws.arns import get_sqs_queue_url
+from localstack.utils.aws.arns import sqs_queue_url_for_arn
 
 QUEUE_NAME = "test-perf-3610"
 NUM_MESSAGES = 300
@@ -42,7 +42,7 @@ def receive_messages():
         aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
         aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
     ).sqs
-    queue_url = get_sqs_queue_url(QUEUE_NAME)
+    queue_url = sqs_queue_url_for_arn(QUEUE_NAME)
     messages = []
 
     start = datetime.now()


### PR DESCRIPTION
This PR removes a redundant SQS ARN helper.

Ext codebase is not impacted.