### PR TITLE
fix s3 v3 multipart overwrite when key exists

### DIFF
--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -92,6 +92,9 @@ class S3StoredObject(abc.ABC, Iterable[bytes]):
     def seek(self, offset: int, whence: int = 0) -> int:
         pass
 
+    def truncate(self, size: int = None) -> int:
+        pass
+
     @property
     @abc.abstractmethod
     def checksum(self) -> Optional[str]:

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -87,8 +87,7 @@ class EphemeralS3StoredObject(S3StoredObject):
         :return: the position after seeking, from beginning of the stream
         """
         with self.file.position_lock:
-            self.file.seek(offset, whence)
-            self._pos = self.file.tell()
+            self._pos = self.file.seek(offset, whence)
 
         return self._pos
 
@@ -258,6 +257,9 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :return: the resulting EphemeralS3StoredObject
         """
         s3_stored_object = self._s3_store.open(self.bucket, self.s3_multipart.object)
+        # reset the file to overwrite
+        s3_stored_object.file.seek(0)
+        s3_stored_object.file.truncate()
         for s3_part in parts:
             stored_part = self.parts.get(s3_part.part_number)
             s3_stored_object.append(stored_part)

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10459,5 +10459,29 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_overwrite_key": {
+    "recorded-date": "18-10-2023, 17:40:12",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"eee506dd7ada7ded524c77e359a0e7c6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "multipart-upload": {
+        "Bucket": "<bucket:1>",
+        "ETag": "\"b972025bc34adf8d76d6d51e93c035cc-1\"",
+        "Key": "test.file",
+        "Location": "<location:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Reported in #9387: when creating a multipart upload on an existing key, we would not truncate the key before overwrite it like we do when calling `PutObject`.

This was due to our optimization with `append` on the StoredS3Object, which was stateless, and bad oversight on my side.

Flow for the sample in the linked issue is:
- CreateMultipart on key `test`
- UploadPart with value "first"
- CompletePart on key `test`
- GetObject on key `test` -> value is "first"
- CreateMultipart again on key `test`
- UploadPart with the result of previous GetObject ("first") + "second" -> value = "firstsecond"
- CompleteMultipart on key `test`
- GetObject on key `test`, result should be "firstsecond"

Issue was appending on top of existing key, resulting in "firstfirstsecond".

<!-- What notable changes does this PR make? -->
## Changes
Added a new `truncate` method to the base `S3StoredObject` to be able to reset the file from the StoredMultipart.
Add `s3_object.seek(0) + s3_object.truncate()` in `complete_multipart` so that the existing file object representing the key is properly truncated before we write and we do not append the multipart on top of the existing key. 

Added an AWS validated test validating this behaviour.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

