### PR TITLE
Migrate Lambda to gateway listen

### DIFF
--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -436,7 +436,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             CONTAINER_CLIENT.remove_image(get_image_name_for_function(function_version))
 
     def get_runtime_endpoint(self) -> str:
-        return f"http://{self.get_endpoint_from_executor()}:{config.EDGE_PORT}{self.executor_endpoint.get_endpoint_prefix()}"
+        return f"http://{self.get_endpoint_from_executor()}:{config.GATEWAY_LISTEN[0].port}{self.executor_endpoint.get_endpoint_prefix()}"
 
     @classmethod
     def validate_environment(cls) -> bool:

--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -136,8 +136,8 @@ class ExecutionEnvironment:
             "AWS_LAMBDA_FUNCTION_TIMEOUT": self.function_version.config.timeout,
             # 3) Public LocalStack endpoint
             "LOCALSTACK_HOSTNAME": self.runtime_executor.get_endpoint_from_executor(),
-            "EDGE_PORT": str(config.EDGE_PORT),
-            "AWS_ENDPOINT_URL": f"http://{self.runtime_executor.get_endpoint_from_executor()}:{config.EDGE_PORT}",
+            "EDGE_PORT": str(config.GATEWAY_LISTEN[0].port),
+            "AWS_ENDPOINT_URL": f"http://{self.runtime_executor.get_endpoint_from_executor()}:{config.GATEWAY_LISTEN[0].port}",
             # 4) Internal LocalStack runtime API
             "LOCALSTACK_RUNTIME_ID": self.id,
             "LOCALSTACK_RUNTIME_ENDPOINT": self.runtime_executor.get_runtime_endpoint(),

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1823,7 +1823,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         url_id = api_utils.generate_random_url_id()
 
         host_definition = localstack_host(
-            use_localhost_cloud=True, custom_port=config.EDGE_PORT_HTTP or config.EDGE_PORT
+            use_localhost_cloud=True,
+            custom_port=config.EDGE_PORT_HTTP or config.GATEWAY_LISTEN[0].port,
         )
         fn.function_url_configs[normalized_qualifier] = FunctionUrlConfig(
             function_arn=function_arn,


### PR DESCRIPTION
## Motivation

Adopt the new gateway-listen network configuration instead of `config.EDGE_PORT` (deprecated, at least as a configurable variable)

## Changes

Change `config.EDGE_PORT` to `GATEWAY_LISTEN[0].port`

## Discussion

* The K8 executor still uses `config.get_edge_port_http()` but that will be migrated with the deprecation of `EDGE_PORT_HTTP` upon 3.0.
* The old provider still uses `EDGE_PORT` but will be removed anyways upon 3.0