### PR TITLE
Migrate endpoints to use LOCALSTACK_HOST only

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -264,7 +264,6 @@ jobs:
           DEBUG: 1
           DISABLE_BOTO_RETRIES: 1
           DNS_ADDRESS: 0
-          LAMBDA_EXECUTOR: "local"
           LOCALSTACK_API_KEY: "test"
           AWS_SECRET_ACCESS_KEY: "test"
           AWS_ACCESS_KEY_ID: "test"

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -22,6 +22,7 @@ from localstack.aws.chain import Handler, HandlerChain
 from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEADERS
 from localstack.constants import LOCALHOST, LOCALHOST_HOSTNAME, PATH_USER_REQUEST
 from localstack.http import Response
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ def _get_allowed_cors_internal_domains() -> Set[str]:
     Construct the list of allowed internal domains for CORS enforcement purposes
     Defined as function to allow easier testing with monkeypatch of config values
     """
-    return {LOCALHOST, LOCALHOST_HOSTNAME, config.HOSTNAME_EXTERNAL}
+    return {LOCALHOST, LOCALHOST_HOSTNAME, localstack_host().host}
 
 
 _ALLOWED_INTERNAL_DOMAINS = _get_allowed_cors_internal_domains()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -540,6 +540,9 @@ class HostAndPort:
     def is_unprivileged(self) -> bool:
         return self.port >= self._get_unprivileged_port_range_start()
 
+    def host_and_port(self):
+        return f"{self.host}:{self.port}" if self.port is not None else self.host
+
     def __hash__(self) -> int:
         return hash((self.host, self.port))
 
@@ -553,7 +556,7 @@ class HostAndPort:
             raise TypeError(f"cannot compare {self.__class__} to {other.__class__}")
 
     def __str__(self) -> str:
-        return f"{self.host}:{self.port}" if self.port is not None else self.host
+        return self.host_and_port()
 
     def __repr__(self) -> str:
         return f"HostAndPort(host={self.host}, port={self.port})"
@@ -609,6 +612,7 @@ def populate_legacy_edge_configuration(
     # populate LOCALSTACK_HOST first since GATEWAY_LISTEN may be derived from LOCALSTACK_HOST
     localstack_host = localstack_host_raw
     if localstack_host is None:
+        # TODO use actual gateway port?
         localstack_host = HostAndPort(
             host=constants.LOCALHOST_HOSTNAME, port=constants.DEFAULT_PORT_EDGE
         )
@@ -1362,7 +1366,7 @@ def service_url(service_key, host=None, port=None):
 
 
 def external_service_url(service_key, host=None, port=None):
-    host = host or HOSTNAME_EXTERNAL
+    host = host or LOCALSTACK_HOST.host
     port = port or service_port(service_key, external=True)
     return service_url(service_key, host=host, port=port)
 
@@ -1376,7 +1380,7 @@ def get_edge_port_http():
 def get_edge_url(localstack_hostname=None, protocol=None):
     port = get_edge_port_http()
     protocol = protocol or get_protocol()
-    localstack_hostname = localstack_hostname or LOCALSTACK_HOSTNAME
+    localstack_hostname = localstack_hostname or LOCALSTACK_HOST.host
     return "%s://%s:%s" % (protocol, localstack_hostname, port)
 
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -166,7 +166,7 @@ class OpenAPISpecificationResolver:
         # cache which maps known refs to part of the document
         self._cache = {}
         self._refpaths = ["#"]
-        host_definition = localstack_host(use_localhost_cloud=True)
+        host_definition = localstack_host()
         self._base_url = f"{config.get_protocol()}://apigateway.{host_definition.host_and_port()}/restapis/{rest_api_id}/models/"
 
     def _is_ref(self, item) -> bool:

--- a/localstack/services/cloudformation/api_utils.py
+++ b/localstack/services/cloudformation/api_utils.py
@@ -11,6 +11,7 @@ from localstack.services.s3.utils import (
 from localstack.utils.functions import run_safe
 from localstack.utils.http import safe_requests
 from localstack.utils.strings import to_str
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -68,8 +69,7 @@ def is_local_service_url(url: str) -> bool:
     candidates = (
         constants.LOCALHOST,
         constants.LOCALHOST_HOSTNAME,
-        config.LOCALSTACK_HOSTNAME,
-        config.HOSTNAME_EXTERNAL,
+        localstack_host().host,
     )
     if any(re.match(r"^[^:]+://[^:/]*%s([:/]|$)" % host, url) for host in candidates):
         return True

--- a/localstack/services/lambda_/legacy/lambda_api.py
+++ b/localstack/services/lambda_/legacy/lambda_api.py
@@ -1554,9 +1554,7 @@ def create_url_config(function):
 
     custom_id = md5(str(random()))
     region_name = aws_stack.get_region()
-    host_definition = localstack_host(
-        use_localhost_cloud=True, custom_port=config.EDGE_PORT_HTTP or config.EDGE_PORT
-    )
+    host_definition = localstack_host(custom_port=config.EDGE_PORT_HTTP or config.EDGE_PORT)
     url = f"http://{custom_id}.lambda-url.{region_name}.{host_definition.host_and_port()}/"
     # TODO: HTTPS support
 

--- a/localstack/services/lambda_/legacy/lambda_executors.py
+++ b/localstack/services/lambda_/legacy/lambda_executors.py
@@ -1401,7 +1401,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         lambda_cwd = lambda_function.cwd
         environment = self._prepare_environment(lambda_function)
 
-        environment["LOCALSTACK_HOSTNAME"] = config.LOCALSTACK_HOSTNAME
+        environment["LOCALSTACK_HOSTNAME"] = localstack_host().host
         environment["EDGE_PORT"] = str(config.EDGE_PORT)
         if lambda_function.timeout:
             environment["AWS_LAMBDA_FUNCTION_TIMEOUT"] = str(lambda_function.timeout)

--- a/localstack/services/lambda_/legacy/lambda_executors.py
+++ b/localstack/services/lambda_/legacy/lambda_executors.py
@@ -74,6 +74,7 @@ from localstack.utils.container_utils.container_client import (
 from localstack.utils.docker_utils import DOCKER_CLIENT, get_host_path_for_path_in_docker
 from localstack.utils.run import CaptureOutputProcess, FuncThread
 from localstack.utils.time import timestamp_millis
+from localstack.utils.urls import localstack_host
 
 # constants
 LAMBDA_EXECUTOR_CLASS = "cloud.localstack.LambdaExecutor"
@@ -300,7 +301,7 @@ class LambdaInvocationForwarderPlugin(LambdaExecutorPlugin):
         url = "%s%s/functions/%s/invocations" % (forward_url, API_PATH_ROOT, func_name)
 
         copied_env_vars = lambda_function.envvars.copy()
-        copied_env_vars["LOCALSTACK_HOSTNAME"] = config.HOSTNAME_EXTERNAL
+        copied_env_vars["LOCALSTACK_HOSTNAME"] = localstack_host().host
         copied_env_vars["LOCALSTACK_EDGE_PORT"] = str(config.EDGE_PORT)
 
         headers = aws_stack.mock_aws_request_headers(

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1845,8 +1845,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         url_id = api_utils.generate_random_url_id()
 
         host_definition = localstack_host(
-            use_localhost_cloud=True,
-            custom_port=config.EDGE_PORT_HTTP or config.GATEWAY_LISTEN[0].port,
+            custom_port=config.EDGE_PORT_HTTP or config.GATEWAY_LISTEN[0].port
         )
         fn.function_url_configs[normalized_qualifier] = FunctionUrlConfig(
             function_arn=function_arn,

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -14,7 +14,7 @@ from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, Rule
 
 from localstack import __version__ as localstack_version
-from localstack import config
+from localstack import constants
 from localstack.aws.api import (
     CommonServiceException,
     HttpRequest,
@@ -140,7 +140,7 @@ def get_dispatcher(service: str, path: str) -> MotoDispatcher:
         rule = next(url_map.iter_rules())
         return rule.endpoint
 
-    matcher = url_map.bind(config.LOCALSTACK_HOSTNAME)
+    matcher = url_map.bind(constants.LOCALHOST)
     try:
         endpoint, _ = matcher.match(path_info=path)
     except NotFound as e:

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -32,6 +32,7 @@ from localstack.utils.common import (
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 from localstack.utils.sync import poll_condition
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 INTERNAL_USER_AUTH = ("localstack-internal", "localstack-internal")
@@ -239,7 +240,7 @@ def register_cluster(
     if custom_endpoint and custom_endpoint.enabled:
         LOG.debug(f"Registering route from {host}{path} to {endpoint.proxy.forward_base_url}")
         assert not (
-            host == config.LOCALSTACK_HOSTNAME and (not path or path == "/")
+            host == localstack_host().host and (not path or path == "/")
         ), "trying to register an illegal catch all route"
         rules.append(
             ROUTER.add(
@@ -257,9 +258,7 @@ def register_cluster(
         )
     elif strategy == "domain":
         LOG.debug(f"Registering route from {host} to {endpoint.proxy.forward_base_url}")
-        assert (
-            not host == config.LOCALSTACK_HOSTNAME
-        ), "trying to register an illegal catch all route"
+        assert not host == localstack_host().host, "trying to register an illegal catch all route"
         rules.append(
             ROUTER.add(
                 "/",

--- a/localstack/services/opensearch/cluster_manager.py
+++ b/localstack/services/opensearch/cluster_manager.py
@@ -117,14 +117,14 @@ def build_cluster_endpoint(
         else:
             assigned_port = external_service_ports.reserve_port()
 
-        host_definition = localstack_host(use_localstack_hostname=True, custom_port=assigned_port)
+        host_definition = localstack_host(custom_port=assigned_port)
         return host_definition.host_and_port()
     if config.OPENSEARCH_ENDPOINT_STRATEGY == "path":
-        host_definition = localstack_host(use_localstack_hostname=True)
+        host_definition = localstack_host()
         return f"{host_definition.host_and_port()}/{engine_domain}/{domain_key.region}/{domain_key.domain_name}"
 
     # or through a subdomain (domain-name.region.opensearch.localhost.localstack.cloud)
-    host_definition = localstack_host(use_localhost_cloud=True)
+    host_definition = localstack_host()
     return f"{domain_key.domain_name}.{domain_key.region}.{engine_domain}.{host_definition.host_and_port()}"
 
 

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -83,7 +83,6 @@ from localstack.aws.api.opensearch import (
     VPCDerivedInfoStatus,
     VPCOptions,
 )
-from localstack.config import LOCALSTACK_HOSTNAME
 from localstack.constants import OPENSEARCH_DEFAULT_VERSION
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.cluster import SecurityOptions
@@ -97,6 +96,7 @@ from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
 from localstack.utils.serving import Server
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -169,7 +169,7 @@ def create_cluster(
     # Replacing only 0.0.0.0 here as usage of this bind address mostly means running in docker which is used locally
     # If another bind address is used we want to keep it in the endpoint as this is a conscious user decision to
     # access from another device on the network.
-    status["Endpoint"] = cluster.url.split("://")[-1].replace("0.0.0.0", LOCALSTACK_HOSTNAME)
+    status["Endpoint"] = cluster.url.split("://")[-1].replace("0.0.0.0", localstack_host().host)
     status["EngineVersion"] = engine_version
 
     if cluster.is_up():

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -200,14 +200,8 @@ S3_MAX_FILE_SIZE_BYTES = 512 * 1024
 
 
 def get_full_default_bucket_location(bucket_name):
-    if config.HOSTNAME_EXTERNAL != config.LOCALHOST:
-        host_definition = localstack_host(
-            use_hostname_external=True, custom_port=config.get_edge_port_http()
-        )
-        return f"{config.get_protocol()}://{host_definition.host_and_port()}/{bucket_name}/"
-    else:
-        host_definition = localstack_host(use_localhost_cloud=True)
-        return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
+    host_definition = localstack_host()
+    return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
 
 
 class S3Provider(S3Api, ServiceLifecycleHook):

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -159,6 +159,7 @@ from localstack.services.s3.utils import (
     extract_bucket_key_version_id_from_copy_source,
     get_bucket_from_moto,
     get_failed_precondition_copy_source,
+    get_full_default_bucket_location,
     get_key_from_moto_bucket,
     get_lifecycle_rule_from_object,
     get_object_checksum_for_algorithm,
@@ -186,7 +187,6 @@ from localstack.utils.collections import get_safe
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid
 from localstack.utils.time import parse_timestamp
-from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -197,11 +197,6 @@ os.environ[
 MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
 # max file size for S3 objects kept in memory (500 KB by default)
 S3_MAX_FILE_SIZE_BYTES = 512 * 1024
-
-
-def get_full_default_bucket_location(bucket_name):
-    host_definition = localstack_host()
-    return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
 
 
 class S3Provider(S3Api, ServiceLifecycleHook):

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -307,14 +307,8 @@ def parse_copy_source_range_header(copy_source_range: str, object_size: int) -> 
 
 
 def get_full_default_bucket_location(bucket_name: BucketName) -> str:
-    if config.HOSTNAME_EXTERNAL != config.LOCALHOST:
-        host_definition = localstack_host(
-            use_hostname_external=True, custom_port=config.get_edge_port_http()
-        )
-        return f"{config.get_protocol()}://{host_definition.host_and_port()}/{bucket_name}/"
-    else:
-        host_definition = localstack_host(use_localhost_cloud=True)
-        return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
+    host_definition = localstack_host()
+    return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
 
 
 def get_object_checksum_for_algorithm(checksum_algorithm: str, data: bytes) -> str:

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -16,7 +16,7 @@ from moto.s3.exceptions import MissingBucket
 from moto.s3.models import FakeBucket, FakeDeleteMarker, FakeKey
 from zoneinfo import ZoneInfo
 
-from localstack import config
+from localstack import config, constants
 from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api.s3 import (
     AccessControlPolicy,
@@ -308,7 +308,12 @@ def parse_copy_source_range_header(copy_source_range: str, object_size: int) -> 
 
 def get_full_default_bucket_location(bucket_name: BucketName) -> str:
     host_definition = localstack_host()
-    return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
+    if host_definition.host != constants.LOCALHOST_HOSTNAME:
+        # the user has customised their LocalStack hostname, and may not support subdomains.
+        # Return the location in path form.
+        return f"{config.get_protocol()}://{host_definition.host_and_port()}/{bucket_name}/"
+    else:
+        return f"{config.get_protocol()}://{bucket_name}.s3.{host_definition.host_and_port()}/"
 
 
 def get_object_checksum_for_algorithm(checksum_algorithm: str, data: bytes) -> str:

--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -58,7 +58,8 @@ class S3VirtualHostProxyHandler:
         :return: a proxy instance
         """
         return Proxy(
-            forward_base_url=config.get_edge_url(),
+            # Just use localhost for proxying, do not rely on external - potentially dangerous - configuration
+            forward_base_url=config.get_edge_url(localstack_hostname="localhost"),
             # do not preserve the Host when forwarding (to avoid an endless loop)
             preserve_host=False,
         )

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -284,9 +284,9 @@ class SqsQueue:
             host_url = f"{scheme}://{region}queue.{host_definition.host_and_port()}"
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
-            host_url = f"{scheme}://{host_definition.host}/queue/{self.region}"
+            host_url = f"{scheme}://{host_definition.host_and_port()}/queue/{self.region}"
         else:
-            host_url = f"{scheme}://{host_definition.host}"
+            host_url = f"{scheme}://{host_definition.host_and_port()}"
             if config.SQS_PORT_EXTERNAL:
                 host_definition = localstack_host(custom_port=config.SQS_PORT_EXTERNAL)
                 host_url = f"{get_protocol()}://{host_definition.host_and_port()}"

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -281,16 +281,14 @@ class SqsQueue:
             region = "" if self.region == "us-east-1" else self.region + "."
             scheme = context.request.scheme
 
-            host_definition = localstack_host(use_localhost_cloud=True)
+            host_definition = localstack_host()
             host_url = f"{scheme}://{region}queue.{host_definition.host_and_port()}"
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
             host_url = f"{context.request.host_url}queue/{self.region}"
         else:
             if config.SQS_PORT_EXTERNAL:
-                host_definition = localstack_host(
-                    use_hostname_external=True, custom_port=config.SQS_PORT_EXTERNAL
-                )
+                host_definition = localstack_host(custom_port=config.SQS_PORT_EXTERNAL)
                 host_url = f"{get_protocol()}://{host_definition.host_and_port()}"
 
         return "{host}/{account_id}/{name}".format(

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -265,7 +265,8 @@ class SqsQueue:
         """Return queue URL using either SQS_PORT_EXTERNAL (if configured), the SQS_ENDPOINT_STRATEGY (if configured)
         or based on the 'Host' request header"""
 
-        host_url = context.request.host_url
+        scheme = context.request.scheme
+        host_definition = localstack_host()
 
         if config.SQS_ENDPOINT_STRATEGY == "standard":
             # Region is always part of the queue URL
@@ -279,14 +280,13 @@ class SqsQueue:
             # queue.localhost.localstack.cloud:4566/000000000000/my-queue (us-east-1)
             # or us-east-2.queue.localhost.localstack.cloud:4566/000000000000/my-queue
             region = "" if self.region == "us-east-1" else self.region + "."
-            scheme = context.request.scheme
 
-            host_definition = localstack_host()
             host_url = f"{scheme}://{region}queue.{host_definition.host_and_port()}"
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
-            host_url = f"{context.request.host_url}queue/{self.region}"
+            host_url = f"{scheme}://{host_definition.host}/queue/{self.region}"
         else:
+            host_url = f"{scheme}://{host_definition.host}"
             if config.SQS_PORT_EXTERNAL:
                 host_definition = localstack_host(custom_port=config.SQS_PORT_EXTERNAL)
                 host_url = f"{get_protocol()}://{host_definition.host_and_port()}"

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -272,7 +272,7 @@ class SqsQueue:
             # Region is always part of the queue URL
             # sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/my-queue
             scheme = context.request.scheme
-            host_definition = localstack_host(use_localhost_cloud=True)
+            host_definition = localstack_host()
             host_url = f"{scheme}://sqs.{self.region}.{host_definition.host_and_port()}"
 
         elif config.SQS_ENDPOINT_STRATEGY == "domain":

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1918,7 +1918,7 @@ def assert_host_customisation(monkeypatch):
     # running LocalStack, so use that here.
     #
     # Note: We cannot use `localhost` since we explicitly check that the URL
-    # passed in does not contain `localhost`, unless it is requried to.
+    # passed in does not contain `localhost`, unless it is required to.
     localstack_hostname = socket.gethostname()
     monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", hostname_external)
     monkeypatch.setattr(config, "LOCALSTACK_HOSTNAME", localstack_hostname)

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1905,8 +1905,7 @@ def appsync_create_api(aws_client):
 
 @pytest.fixture
 def assert_host_customisation(monkeypatch):
-    # subdomain localhost.localstack.cloud to make sure it resolves
-    localstack_host = f"external-host-{short_uid()}.localhost.localstack.cloud"
+    localstack_host = "foo.bar"
     monkeypatch.setattr(
         config, "LOCALSTACK_HOST", config.HostAndPort(host=localstack_host, port=config.EDGE_PORT)
     )

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-import socket
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -21,7 +20,7 @@ from moto.core import BackendDict, BaseBackend
 from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
-from localstack import config, constants
+from localstack import config
 from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -1906,63 +1905,23 @@ def appsync_create_api(aws_client):
 
 @pytest.fixture
 def assert_host_customisation(monkeypatch):
-    hostname_external = f"external-host-{short_uid()}"
-    # `LOCALSTACK_HOSTNAME` is really an internal variable that has been
-    # exposed to the user at some point in the past. It is used by some
-    # services that start resources (e.g. OpenSearch) to determine if the
-    # service has been started correctly (i.e. a health check). This means that
-    # the value must be resolvable by LocalStack or else the service resources
-    # won't start properly.
-    #
-    # One hostname that's always resolvable is the hostname of the process
-    # running LocalStack, so use that here.
-    #
-    # Note: We cannot use `localhost` since we explicitly check that the URL
-    # passed in does not contain `localhost`, unless it is required to.
-    localstack_hostname = socket.gethostname()
-    monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", hostname_external)
-    monkeypatch.setattr(config, "LOCALSTACK_HOSTNAME", localstack_hostname)
+    # subdomain localhost.localstack.cloud to make sure it resolves
+    localstack_host = f"external-host-{short_uid()}.localhost.localstack.cloud"
+    monkeypatch.setattr(
+        config, "LOCALSTACK_HOST", config.HostAndPort(host=localstack_host, port=config.EDGE_PORT)
+    )
 
     def asserter(
         url: str,
         *,
-        use_hostname_external: bool = False,
-        use_localstack_hostname: bool = False,
-        use_localstack_cloud: bool = False,
-        use_localhost: bool = False,
         custom_host: Optional[str] = None,
     ):
-        if use_hostname_external:
-            assert hostname_external in url
-
-            assert localstack_hostname not in url
-            assert constants.LOCALHOST_HOSTNAME not in url
-            assert constants.LOCALHOST not in url
-        elif use_localstack_hostname:
-            assert localstack_hostname in url
-
-            assert hostname_external not in url
-            assert constants.LOCALHOST_HOSTNAME not in url
-            assert constants.LOCALHOST not in url
-        elif use_localstack_cloud:
-            assert constants.LOCALHOST_HOSTNAME in url
-
-            assert hostname_external not in url
-            assert localstack_hostname not in url
-        elif use_localhost:
-            assert constants.LOCALHOST in url
-
-            assert constants.LOCALHOST_HOSTNAME not in url
-            assert hostname_external not in url
-            assert localstack_hostname not in url
-        elif custom_host is not None:
+        if custom_host is not None:
             assert custom_host in url
 
-            assert constants.LOCALHOST_HOSTNAME not in url
-            assert hostname_external not in url
-            assert localstack_hostname not in url
+            assert localstack_host not in url
         else:
-            raise ValueError("no assertions made")
+            assert localstack_host in url
 
     yield asserter
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1916,11 +1916,11 @@ def assert_host_customisation(monkeypatch):
         custom_host: Optional[str] = None,
     ):
         if custom_host is not None:
-            assert custom_host in url
+            assert custom_host in url, f"Could not find `{custom_host}` in `{url}`"
 
             assert localstack_host not in url
         else:
-            assert localstack_host in url
+            assert localstack_host in url, f"Could not find `{localstack_host}` in `{url}`"
 
     yield asserter
 

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -440,18 +440,15 @@ def get_docker_host_from_container() -> str:
         if not config.is_in_docker and not config.is_in_linux:
             # If we're running outside Docker (in host mode), and would like the Lambda containers to be able
             # to access services running on the local machine, return `host.docker.internal` accordingly
-            if config.LOCALSTACK_HOSTNAME == constants.LOCALHOST:
-                result = "host.docker.internal"
+            result = "host.docker.internal"
         # update LOCALSTACK_HOSTNAME if host.docker.internal is available
         if config.is_in_docker:
             try:
                 result = socket.gethostbyname("host.docker.internal")
             except socket.error:
                 result = socket.gethostbyname("host.containers.internal")
-            # TODO still required? - remove
-            # if config.LOCALSTACK_HOSTNAME == config.DOCKER_BRIDGE_IP:
-            #     LOCALSTACK_HOSTNAME = result
     except socket.error:
+        # TODO if neither host resolves, we might be in linux. We could just use the default gateway then
         pass
     return result
 

--- a/localstack/utils/urls.py
+++ b/localstack/utils/urls.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
 from typing import Optional
 
-from localstack import config, constants
+from localstack import config
+from localstack.config import HostAndPort
 
 
 def path_from_url(url: str) -> str:
@@ -12,21 +12,7 @@ def hostname_from_url(url: str) -> str:
     return url.split("://")[-1].split("/")[0].split(":")[0]
 
 
-@dataclass
-class HostDefinition:
-    host: str
-    port: int
-
-    def host_and_port(self):
-        return f"{self.host}:{self.port}"
-
-
-def localstack_host(
-    use_hostname_external: bool = False,
-    use_localstack_hostname: bool = False,
-    use_localhost_cloud: bool = False,
-    custom_port: Optional[int] = None,
-) -> HostDefinition:
+def localstack_host(custom_port: Optional[int] = None) -> HostAndPort:
     """
     Determine the host and port to return to the user based on:
     - the user's configuration (e.g environment variable overrides)
@@ -36,12 +22,6 @@ def localstack_host(
     if custom_port is not None:
         port = custom_port
 
-    host = config.LOCALHOST
-    if use_hostname_external:
-        host = config.HOSTNAME_EXTERNAL
-    elif use_localstack_hostname:
-        host = config.LOCALSTACK_HOSTNAME
-    elif use_localhost_cloud:
-        host = constants.LOCALHOST_HOSTNAME
+    host = config.LOCALSTACK_HOST.host
 
-    return HostDefinition(host=host, port=port)
+    return HostAndPort(host=host, port=port)

--- a/tests/aws/scenario/bookstore/functions/search.py
+++ b/tests/aws/scenario/bookstore/functions/search.py
@@ -17,7 +17,7 @@ index = "lambda-index"
 type = "lambda-type"
 if os.getenv("LOCALSTACK_HOSTNAME"):
     url = "http://" + os.environ["ESENDPOINT"] + "/_search"  # TODO ssl error for localstack
-    url = url.replace("localhost", os.getenv("LOCALSTACK_HOSTNAME"))
+    url = url.replace("localhost.localstack.cloud", os.getenv("LOCALSTACK_HOSTNAME"))
 else:
     url = (
         "https://" + os.environ["ESENDPOINT"] + "/_search"

--- a/tests/aws/scenario/bookstore/functions/update_search_cluster.py
+++ b/tests/aws/scenario/bookstore/functions/update_search_cluster.py
@@ -14,9 +14,9 @@ awsauth = AWS4Auth(
 )
 if os.getenv("LOCALSTACK_HOSTNAME"):
     host = "http://" + os.environ["ESENDPOINT"]  # TODO ssl error for localstack
-    host = host.replace("localhost", os.getenv("LOCALSTACK_HOSTNAME"))
+    host = host.replace("localhost.localstack.cloud", os.getenv("LOCALSTACK_HOSTNAME"))
 else:
-    host = "https://" + os.environ["ESENDPOINT"]  # the Amazon ElaticSearch domain, with https://
+    host = "https://" + os.environ["ESENDPOINT"]  # the Amazon ElasticSearch domain, with https://
 
 index = "lambda-index"
 type = "_doc"

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -124,7 +124,7 @@ def apigw_snapshot_transformer(request, snapshot):
     if is_aws_cloud():
         model_base_url = "https://apigateway.amazonaws.com"
     else:
-        host_definition = localstack_host(use_localhost_cloud=True)
+        host_definition = localstack_host()
         model_base_url = f"{config.get_protocol()}://apigateway.{host_definition.host_and_port()}"
 
     snapshot.add_transformer(snapshot.transform.regex(model_base_url, "<model-base-url>"))

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -13,7 +13,7 @@ from opensearchpy.exceptions import AuthorizationException
 
 from localstack import config
 from localstack.aws.api.opensearch import AdvancedSecurityOptionsInput, MasterUserOptions
-from localstack.config import EDGE_BIND_HOST, LOCALSTACK_HOSTNAME
+from localstack.config import EDGE_BIND_HOST
 from localstack.constants import (
     OPENSEARCH_DEFAULT_VERSION,
     OPENSEARCH_PLUGIN_LIST,
@@ -34,6 +34,7 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import call_safe, poll_condition, retry, short_uid, start_worker_thread
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.strings import to_str
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -873,7 +874,7 @@ class TestSingletonClusterManager:
         parts = cluster_0.url.split(":")
         assert parts[0] == "http"
         # either f"//{the bind host}" is used, or in the case of "//0.0.0.0" the localstack hostname instead
-        assert parts[1][2:] in [EDGE_BIND_HOST, LOCALSTACK_HOSTNAME]
+        assert parts[1][2:] in [EDGE_BIND_HOST, localstack_host().host]
         assert int(parts[2]) in range(
             config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END
         )

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -639,7 +639,7 @@ class TestOpensearchProvider:
         assert "Endpoint" in status
         endpoint = status["Endpoint"]
         parts = endpoint.split(":")
-        assert parts[0] in ("localhost", "127.0.0.1")
+        assert parts[0] in (localstack_host().host, "127.0.0.1")
         assert int(parts[1]) in range(
             config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END
         )

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3823,10 +3823,7 @@ class TestS3:
         response = s3_multipart_upload(bucket=s3_bucket, key=key, data=content, acl=acl)
         snapshot.match("multipart-upload", response)
 
-        if is_aws_cloud():  # TODO: default addressing is vhost for AWS
-            expected_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
-        else:  # LS default is path addressing
-            expected_url = f"{_bucket_url(bucket_name=s3_bucket, localstack_host=get_localstack_host().host)}/{key}"
+        expected_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
         assert response["Location"] == expected_url
 
         # download object via API

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10165,7 +10165,7 @@ def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str =
         else:
             return f"https://{bucket_name}.s3.{region}.amazonaws.com"
 
-    host_definition = get_localstack_host(use_localhost_cloud=True)
+    host_definition = get_localstack_host()
     if localstack_host:
         host_and_port = f"{localstack_host}:{config.get_edge_port_http()}"
     else:

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3813,8 +3813,11 @@ class TestS3:
                 snapshot.transform.key_value("Bucket"),
             ]
         )
+        custom_hostname = "foobar"
         monkeypatch.setattr(
-            config, "LOCALSTACK_HOST", config.HostAndPort(host="foobar", port=config.EDGE_PORT)
+            config,
+            "LOCALSTACK_HOST",
+            config.HostAndPort(host=custom_hostname, port=config.EDGE_PORT),
         )
         key = "test.file"
         content = "test content 123"
@@ -3823,7 +3826,9 @@ class TestS3:
         response = s3_multipart_upload(bucket=s3_bucket, key=key, data=content, acl=acl)
         snapshot.match("multipart-upload", response)
 
-        expected_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
+        expected_url = (
+            f"{_bucket_url(bucket_name=s3_bucket, localstack_host=custom_hostname)}/{key}"
+        )
         assert response["Location"] == expected_url
 
         # download object via API

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3832,7 +3832,9 @@ class TestS3:
         assert content == to_str(downloaded_object["Body"].read())
 
         # download object directly from download link
-        download_url = response["Location"].replace(f"{get_localstack_host().host}:", "localhost:")
+        download_url = response["Location"].replace(
+            f"{get_localstack_host().host}:", "localhost.localstack.cloud:"
+        )
         response = requests.get(download_url)
         assert response.status_code == 200
         assert to_str(response.content) == content

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3812,7 +3812,9 @@ class TestS3:
                 snapshot.transform.key_value("Bucket"),
             ]
         )
-        monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", "foobar")
+        monkeypatch.setattr(
+            config, "LOCALSTACK_HOST", config.HostAndPort(host="foobar", port=config.EDGE_PORT)
+        )
         key = "test.file"
         content = "test content 123"
         acl = "public-read"
@@ -3823,7 +3825,7 @@ class TestS3:
         if is_aws_cloud():  # TODO: default addressing is vhost for AWS
             expected_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
         else:  # LS default is path addressing
-            expected_url = f"{_bucket_url(bucket_name=s3_bucket, localstack_host=config.HOSTNAME_EXTERNAL)}/{key}"
+            expected_url = f"{_bucket_url(bucket_name=s3_bucket, localstack_host=get_localstack_host().host)}/{key}"
         assert response["Location"] == expected_url
 
         # download object via API
@@ -3832,7 +3834,7 @@ class TestS3:
         assert content == to_str(downloaded_object["Body"].read())
 
         # download object directly from download link
-        download_url = response["Location"].replace(f"{config.HOSTNAME_EXTERNAL}:", "localhost:")
+        download_url = response["Location"].replace(f"{get_localstack_host().host}:", "localhost:")
         response = requests.get(download_url)
         assert response.status_code == 200
         assert to_str(response.content) == content

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -67,6 +67,7 @@ from localstack.utils.strings import (
 )
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
+from localstack.utils.urls import localstack_host
 from localstack.utils.urls import localstack_host as get_localstack_host
 
 if TYPE_CHECKING:
@@ -4388,7 +4389,7 @@ class TestS3:
             ACL="public-read-write",
         )
 
-        url = f"{_bucket_url(s3_bucket, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=localstack_host().host)}?delete"
 
         data = f"""
         <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -4445,7 +4446,7 @@ class TestS3:
         )
 
         # TODO delete does currently not work with S3_VIRTUAL_HOSTNAME
-        url = f"{_bucket_url(s3_bucket, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=localstack_host().host)}?delete"
 
         data = f"""
             <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -67,7 +67,6 @@ from localstack.utils.strings import (
 )
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
-from localstack.utils.urls import localstack_host
 from localstack.utils.urls import localstack_host as get_localstack_host
 
 if TYPE_CHECKING:
@@ -4393,7 +4392,7 @@ class TestS3:
             ACL="public-read-write",
         )
 
-        url = f"{_bucket_url(s3_bucket, localstack_host=localstack_host().host)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=get_localstack_host().host)}?delete"
 
         data = f"""
         <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -4450,7 +4449,7 @@ class TestS3:
         )
 
         # TODO delete does currently not work with S3_VIRTUAL_HOSTNAME
-        url = f"{_bucket_url(s3_bucket, localstack_host=localstack_host().host)}?delete"
+        url = f"{_bucket_url(s3_bucket, localstack_host=get_localstack_host().host)}?delete"
 
         data = f"""
             <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1059,13 +1059,15 @@ class TestSqsProvider:
         assert bodies == {"0", "1", "2", "3", "4", "5", "6", "7", "8"}
 
     @markers.aws.only_localstack
-    def test_external_hostname(self, monkeypatch, sqs_create_queue, aws_client):
+    def test_external_endpoint(self, monkeypatch, sqs_create_queue, aws_client):
         external_host = "external-host"
         external_port = "12345"
 
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
         monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
-        monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", external_host)
+        monkeypatch.setattr(
+            config, "LOCALSTACK_HOST", config.HostAndPort(host=external_host, port=config.EDGE_PORT)
+        )
 
         queue_url = sqs_create_queue()
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -29,6 +29,7 @@ from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import GenericTransformer
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import poll_condition, retry, short_uid, to_str
+from localstack.utils.urls import localstack_host
 from tests.aws.services.lambda_.functions import lambda_integration
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON
 
@@ -73,7 +74,7 @@ def sqs_snapshot_transformer(snapshot):
 
 class TestSqsProvider:
     @markers.aws.only_localstack
-    def test_get_queue_url_contains_request_host(
+    def test_get_queue_url_contains_localstack_host(
         self, sqs_create_queue, monkeypatch, aws_client, aws_client_factory
     ):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
@@ -84,15 +85,12 @@ class TestSqsProvider:
 
         queue_url = aws_client.sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
 
-        host = config.get_edge_url()
+        host_definition = localstack_host()
         # our current queue pattern looks like this, but may change going forward, or may be configurable
-        assert queue_url == f"{host}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
-
-        # attempt to connect through a different host and make sure the URL contains that host
-        host = f"http://127.0.0.1:{config.EDGE_PORT}"
-        client = aws_client_factory(endpoint_url=host).sqs
-        queue_url = client.get_queue_url(QueueName=queue_name)["QueueUrl"]
-        assert queue_url == f"{host}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
+        assert (
+            queue_url
+            == f"http://{host_definition.host_and_port()}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
+        )
 
     @markers.aws.validated
     def test_list_queues(self, sqs_create_queue, aws_client):
@@ -1101,15 +1099,6 @@ class TestSqsProvider:
         kwargs = {"flags": re.MULTILINE | re.DOTALL}
         assert re.match(rf".*<QueueUrl>\s*{edge_url}/[^<]+</QueueUrl>.*", content, **kwargs)
 
-        # assert custom port is returned in queue URL
-        port = 12345
-        headers["Host"] = f"local-test-host:{port}"
-        result = requests.post(url, data=payload, headers=headers)
-        assert result
-        content = to_str(result.content)
-        # TODO: currently only asserting that the port matches - potentially should also return the custom hostname?
-        assert re.match(rf".*<QueueUrl>\s*http://[^:]+:{port}[^<]+</QueueUrl>.*", content, **kwargs)
-
     @markers.aws.only_localstack
     def test_external_host_via_header_complete_message_lifecycle(self, monkeypatch):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
@@ -1124,11 +1113,9 @@ class TestSqsProvider:
         hostname = "aws-local"
 
         url = f"{hostname}:{port}"
-        headers["Host"] = url
         payload = f"Action=CreateQueue&QueueName={queue_name}"
         result = requests.post(edge_url, data=payload, headers=headers)
         assert result.status_code == 200
-        assert url in result.text
 
         queue_url = f"http://{url}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
         message_body = f"test message {short_uid()}"
@@ -4026,7 +4013,7 @@ class TestSqsQueryApi:
         queue_name = f"path_queue_{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         assert (
-            f"localhost:4566/queue/{TEST_AWS_REGION_NAME}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
+            f"localhost.localstack.cloud:4566/queue/{TEST_AWS_REGION_NAME}/{TEST_AWS_ACCOUNT_ID}/{queue_name}"
             in queue_url
         )
 

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -39,6 +39,9 @@ class TestOpenSearch:
         assert_host_customisation(endpoint)
 
     @markers.aws.only_localstack
+    @pytest.mark.skipif(
+        not config.in_docker(), reason="Replacement does not work in host mode, currently"
+    )
     def test_port_strategy(
         self,
         monkeypatch,

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -250,4 +250,4 @@ class TestLambda:
 
         function_url = r.json()["FunctionUrl"]
 
-        assert_host_customisation(function_url, use_localstack_cloud=True)
+        assert_host_customisation(function_url)

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -36,7 +36,7 @@ class TestOpenSearch:
             "Endpoint"
         ]
 
-        assert_host_customisation(endpoint, use_localstack_cloud=True)
+        assert_host_customisation(endpoint)
 
     @markers.aws.only_localstack
     def test_port_strategy(
@@ -54,10 +54,7 @@ class TestOpenSearch:
             "Endpoint"
         ]
 
-        if config.is_in_docker:
-            assert_host_customisation(endpoint, use_localhost=True)
-        else:
-            assert_host_customisation(endpoint, custom_host="127.0.0.1")
+        assert_host_customisation(endpoint)
 
     @markers.aws.only_localstack
     def test_path_strategy(
@@ -75,7 +72,7 @@ class TestOpenSearch:
             "Endpoint"
         ]
 
-        assert_host_customisation(endpoint, use_localstack_hostname=True)
+        assert_host_customisation(endpoint)
 
 
 class TestS3:
@@ -97,7 +94,7 @@ class TestS3:
 
         cleanups.append(cleanup)
 
-        assert_host_customisation(res["Location"], use_hostname_external=True)
+        assert_host_customisation(res["Location"])
 
     @markers.aws.only_localstack
     def test_multipart_upload(self, s3_bucket, assert_host_customisation, aws_client):
@@ -115,7 +112,7 @@ class TestS3:
             UploadId=upload_id,
         )
 
-        assert_host_customisation(res["Location"], use_hostname_external=True)
+        assert_host_customisation(res["Location"])
 
     @markers.aws.only_localstack
     def test_201_response(self, s3_bucket, assert_host_customisation, aws_client):
@@ -137,7 +134,7 @@ class TestS3:
         res.raise_for_status()
         json_response = xmltodict.parse(res.content)["PostResponse"]
 
-        assert_host_customisation(json_response["Location"], use_hostname_external=True)
+        assert_host_customisation(json_response["Location"])
 
 
 class TestSQS:
@@ -158,7 +155,7 @@ class TestSQS:
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        assert_host_customisation(queue_url, use_localhost=True)
+        assert_host_customisation(queue_url)
         assert queue_name in queue_url
 
     @markers.aws.only_localstack
@@ -172,7 +169,7 @@ class TestSQS:
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        assert_host_customisation(queue_url, use_hostname_external=True)
+        assert_host_customisation(queue_url)
         assert queue_name in queue_url
         assert f":{external_port}" in queue_url
 
@@ -186,7 +183,7 @@ class TestSQS:
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        assert_host_customisation(queue_url, use_localstack_cloud=True)
+        assert_host_customisation(queue_url)
         assert queue_name in queue_url
 
     @markers.aws.only_localstack
@@ -196,7 +193,7 @@ class TestSQS:
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        assert_host_customisation(queue_url, use_localhost=True)
+        assert_host_customisation(queue_url)
         assert queue_name in queue_url
 
 
@@ -220,7 +217,7 @@ class TestLambda:
             AuthType="NONE",
         )["FunctionUrl"]
 
-        assert_host_customisation(function_url, use_localstack_cloud=True)
+        assert_host_customisation(function_url)
 
     @pytest.mark.skipif(condition=is_new_provider(), reason="Not implemented for new provider")
     @markers.aws.only_localstack

--- a/tests/unit/services/opensearch/test_cluster_manager.py
+++ b/tests/unit/services/opensearch/test_cluster_manager.py
@@ -11,7 +11,7 @@ class TestBuildClusterEndpoint:
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
         endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
         parts = endpoint.split(":")
-        assert parts[0] == "localhost"
+        assert parts[0] == "localhost.localstack.cloud"
         assert int(parts[1]) in range(
             config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END
         )
@@ -30,12 +30,17 @@ class TestBuildClusterEndpoint:
         endpoint = build_cluster_endpoint(
             DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID), engine_type=engine_type
         )
-        assert endpoint == f"localhost:4566/{engine_path_prefix}/us-east-1/my-domain"
+        assert (
+            endpoint == f"localhost.localstack.cloud:4566/{engine_path_prefix}/us-east-1/my-domain"
+        )
 
         endpoint = build_cluster_endpoint(
             DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID), engine_type=engine_type
         )
-        assert endpoint == f"localhost:4566/{engine_path_prefix}/eu-central-1/my-domain-1"
+        assert (
+            endpoint
+            == f"localhost.localstack.cloud:4566/{engine_path_prefix}/eu-central-1/my-domain-1"
+        )
 
     @pytest.mark.skipif(
         condition=config.in_docker(), reason="port mapping differs when being run in the container"

--- a/tests/unit/services/s3/test_virtual_host.py
+++ b/tests/unit/services/s3/test_virtual_host.py
@@ -46,7 +46,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost:4566"
+        assert server == "http://localhost.localstack.cloud:4566"
 
         # test root key
         router.dispatch(
@@ -78,7 +78,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost:4566"
+        assert server == "http://localhost.localstack.cloud:4566"
 
         # test key with path (gov cloud
         router.dispatch(
@@ -89,7 +89,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost:4566"
+        assert server == "http://localhost.localstack.cloud:4566"
 
         # test root key
         router.dispatch(
@@ -143,7 +143,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost:4566"
+        assert server == "http://localhost.localstack.cloud:4566"
 
         # test root key
         router.dispatch(

--- a/tests/unit/services/s3/test_virtual_host.py
+++ b/tests/unit/services/s3/test_virtual_host.py
@@ -26,7 +26,9 @@ class _RequestCollectingClient(HttpClient):
         Factory used to plug into S3VirtualHostProxyHandler._create_proxy
         :return: a proxy using this client
         """
-        return Proxy(config.get_edge_url(), preserve_host=False, client=self)
+        return Proxy(
+            config.get_edge_url(localstack_hostname="localhost"), preserve_host=False, client=self
+        )
 
 
 class TestS3VirtualHostProxyHandler:
@@ -46,7 +48,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost.localstack.cloud:4566"
+        assert server == "http://localhost:4566"
 
         # test root key
         router.dispatch(
@@ -78,7 +80,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost.localstack.cloud:4566"
+        assert server == "http://localhost:4566"
 
         # test key with path (gov cloud
         router.dispatch(
@@ -89,7 +91,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost.localstack.cloud:4566"
+        assert server == "http://localhost:4566"
 
         # test root key
         router.dispatch(
@@ -143,7 +145,7 @@ class TestS3VirtualHostProxyHandler:
         )
         request, server = collector.requests.get()
         assert request.url == "http://s3.localhost.localstack.cloud:4566/abucket/my/key"
-        assert server == "http://localhost.localstack.cloud:4566"
+        assert server == "http://localhost:4566"
 
         # test root key
         router.dispatch(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -177,6 +177,45 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_port_http == 0
         assert edge_bind_host == default_ip
 
+    def test_localstack_host_no_port_gateway_listen_set(self, default_ip):
+        environment = {"LOCALSTACK_HOST": "foobar", "GATEWAY_LISTEN": ":1234"}
+        (
+            ls_host,
+            gateway_listen,
+            edge_bind_host,
+            edge_port,
+            edge_port_http,
+        ) = config.populate_legacy_edge_configuration(environment)
+
+        assert ls_host == HostAndPort(host="foobar", port=1234)
+        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
+
+    def test_localstack_host_not_set_gateway_listen_set(self, default_ip):
+        environment = {"GATEWAY_LISTEN": ":1234"}
+        (
+            ls_host,
+            gateway_listen,
+            edge_bind_host,
+            edge_port,
+            edge_port_http,
+        ) = config.populate_legacy_edge_configuration(environment)
+
+        assert ls_host == HostAndPort(host="localhost.localstack.cloud", port=1234)
+        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
+
+    def test_localstack_host_port_set_gateway_listen_set(self, default_ip):
+        environment = {"LOCALSTACK_HOST": "foobar:5555", "GATEWAY_LISTEN": ":1234"}
+        (
+            ls_host,
+            gateway_listen,
+            edge_bind_host,
+            edge_port,
+            edge_port_http,
+        ) = config.populate_legacy_edge_configuration(environment)
+
+        assert ls_host == HostAndPort(host="foobar", port=5555)
+        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
+
     def test_gateway_listen_multiple_addresses(self):
         environment = {"GATEWAY_LISTEN": "0.0.0.0:9999,0.0.0.0:443"}
         (

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -59,7 +59,11 @@ def test_dynamic_allowed_cors_origins_different_domains(monkeypatch):
     # test dynamic allowed origins for default config (edge port 4566)
     monkeypatch.setattr(config, "EDGE_PORT", 4566)
     monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
-    monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", "my-custom-domain.com")
+    monkeypatch.setattr(
+        config,
+        "LOCALSTACK_HOST",
+        config.HostAndPort(host="my-custom-domain.com", port=config.EDGE_PORT),
+    )
 
     monkeypatch.setattr(
         cors, "_ALLOWED_INTERNAL_DOMAINS", cors._get_allowed_cors_internal_domains()

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -65,7 +65,7 @@ class TestSns:
             "SigningCertURL": "https://sns.jupiter-south-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
             "TopicArn": "arn",
             "Type": "Notification",
-            "UnsubscribeURL": f"http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={subscriber['SubscriptionArn']}",
+            "UnsubscribeURL": f"http://localhost.localstack.cloud:4566/?Action=Unsubscribe&SubscriptionArn={subscriber['SubscriptionArn']}",
         }
         assert expected_sns_body == result
 
@@ -98,7 +98,7 @@ class TestSns:
             "SigningCertURL": "https://sns.jupiter-south-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
             "TopicArn": "arn",
             "Type": "Notification",
-            "UnsubscribeURL": f"http://localhost:4566/?Action=Unsubscribe&SubscriptionArn={subscriber['SubscriptionArn']}",
+            "UnsubscribeURL": f"http://localhost.localstack.cloud:4566/?Action=Unsubscribe&SubscriptionArn={subscriber['SubscriptionArn']}",
             "MessageAttributes": {
                 "attr1": {
                     "Type": "String",


### PR DESCRIPTION
# Motivation

Sometimes the user may want to configure domains returned by LocalStack services. Possibly because they are hosting LocalStack on a machine that is not their local machine, or they are connecting using the (previous) networking advice of using the LocalStack container name. For this reason, they may wish to use either `HOSTNAME_EXTERNAL` or `LOCALSTACK_HOSTNAME` to configure the domains.

With LocalStack v3.0 we want to unify the configuration variables `HOSTNAME_EXTERNAL` and `LOCALSTACK_HOSTNAME` into one variable, but also make it more consistent across services how to customise the domain.

This change uses `LOCALSTACK_HOST` across the board for all relevant LocalStack services to customise the domains returned.

# Changes

* use the `localstack_host` function throughout to be consistent, which in turn reads _only_ the `LOCALSTACK_HOST` variable
* improve `assert_host_customisation` fixture to show the original URL tested

