### PR TITLE
APIGW: Use proper account ID and region during Invocation construction

### DIFF
--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -346,9 +346,9 @@ def kinesis_stream_name(kinesis_arn):
     return kinesis_arn.split(":stream/")[-1]
 
 
-def apigateway_invocations_arn(lambda_uri, region_name: str = None):
+def apigateway_invocations_arn(lambda_uri: str, region_name: str) -> str:
     return "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (
-        region_name or get_region(),
+        region_name,
         lambda_uri,
     )
 

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -25,7 +25,12 @@ import requests
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
-from localstack.constants import LOCALHOST_HOSTNAME, LOCALSTACK_ROOT_FOLDER, LOCALSTACK_VENV_FOLDER
+from localstack.constants import (
+    LOCALHOST_HOSTNAME,
+    LOCALSTACK_ROOT_FOLDER,
+    LOCALSTACK_VENV_FOLDER,
+    TEST_AWS_REGION_NAME,
+)
 from localstack.services.lambda_.lambda_api import LAMBDA_TEST_ROLE
 from localstack.services.lambda_.lambda_utils import (
     LAMBDA_DEFAULT_HANDLER,
@@ -338,7 +343,7 @@ def create_lambda_api_gateway_integration(
         func_name=func_name, zip_file=zip_file, runtime=runtime, client=lambda_client
     )
     func_arn = arns.lambda_function_arn(func_name)
-    target_arn = arns.apigateway_invocations_arn(func_arn)
+    target_arn = arns.apigateway_invocations_arn(func_arn, TEST_AWS_REGION_NAME)
 
     # connect API GW to Lambda
     result = connect_api_gateway_to_http_with_lambda_proxy(

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 from localstack import config
 from localstack.aws.api.apigateway import Resources
 from localstack.aws.api.lambda_ import Runtime
+from localstack.constants import TEST_AWS_REGION_NAME
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
@@ -225,7 +226,9 @@ def apigateway_placeholder_authorizer_lambda_invocation_arn(aws_client, lambda_s
         # localstack should normally not require the retries and will just continue here
         response = retry(_create_function, retries=3, sleep=4)
 
-        lambda_invocation_arn = arns.apigateway_invocations_arn(response["FunctionArn"])
+        lambda_invocation_arn = arns.apigateway_invocations_arn(
+            response["FunctionArn"], TEST_AWS_REGION_NAME
+        )
 
         yield lambda_invocation_arn
 

--- a/tests/aws/services/apigateway/test_apigateway_lambda.py
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.py
@@ -6,6 +6,7 @@ import requests
 from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import Runtime
+from localstack.constants import TEST_AWS_REGION_NAME
 from localstack.services.lambda_.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
@@ -271,7 +272,7 @@ def test_lambda_aws_integration(
         "Allow", "lambda:InvokeFunction", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
     )
     lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
-    target_uri = arns.apigateway_invocations_arn(lambda_arn)
+    target_uri = arns.apigateway_invocations_arn(lambda_arn, TEST_AWS_REGION_NAME)
 
     api_id, _, root = create_rest_apigw(name=f"test-api-{short_uid()}")
     resource_id, _ = create_rest_resource(
@@ -354,7 +355,7 @@ def test_lambda_aws_integration_with_request_template(
     )
 
     lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
-    target_uri = arns.apigateway_invocations_arn(lambda_arn)
+    target_uri = arns.apigateway_invocations_arn(lambda_arn, TEST_AWS_REGION_NAME)
 
     api_id, _, root = create_rest_apigw(name=f"test-api-{short_uid()}")
     resource_id, _ = create_rest_resource(

--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from localstack import config
+from localstack.constants import TEST_AWS_REGION_NAME
 from localstack.services.lambda_.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
@@ -106,7 +107,7 @@ class TestTaskApiGateway:
             "Allow", "lambda:InvokeFunction", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
         )
         lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
-        target_uri = arns.apigateway_invocations_arn(lambda_arn)
+        target_uri = arns.apigateway_invocations_arn(lambda_arn, TEST_AWS_REGION_NAME)
 
         api_id, _, root = create_rest_apigw(name=f"sfn-test-api-{short_uid()}")
         resource_id, _ = create_rest_resource(


### PR DESCRIPTION
## Motivation

The functions `aws_stack.get_region()` and `get_aws_account_id()` rely on the thread local storage. The LocalStack handler chain sets the right values for these functions on a per request basis.

Consequently, these utilities must not be used in tests because tests run in a different thread, this causes the functions to return the wrong values.

The ARN contruction utility `apigateway_invocations_arn` makes use of these helpers which is wrong. This leads to bugs when using multi-region and multi-accounts in LocalStack.

## Implementation

This PR removes the use of the above utilties from the tests and makes use of proper constants for ARN construction.