### PR TITLE
add config variable DYNAMODB_LOCAL_PORT to control ddb local port

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -852,6 +852,9 @@ DYNAMODB_HEAP_SIZE = os.environ.get("DYNAMODB_HEAP_SIZE", "").strip() or "256m"
 # single DB instance across multiple credentials are regions
 DYNAMODB_SHARE_DB = int(os.environ.get("DYNAMODB_SHARE_DB") or 0)
 
+# the port on which to expose dynamodblocal
+DYNAMODB_LOCAL_PORT = int(os.environ.get("DYNAMODB_LOCAL_PORT") or 0)
+
 # Used to toggle PurgeInProgress exceptions when calling purge within 60 seconds
 SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
 
@@ -1186,6 +1189,7 @@ CONFIG_ENV_VARS = [
     "DYNAMODB_ERROR_PROBABILITY",
     "DYNAMODB_HEAP_SIZE",
     "DYNAMODB_IN_MEMORY",
+    "DYNAMODB_LOCAL_PORT",
     "DYNAMODB_SHARE_DB",
     "DYNAMODB_READ_ERROR_PROBABILITY",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We are investigating performance issues with dynamodb, and there it will be helpful to control which port dynamodb is created on. Moreover, this will enable workarounds where people may need to access ddb local directly. Tested locally.

cc @bentsku 

<!-- What notable changes does this PR make? -->
## Changes

* add `DYNAMODB_LOCAL_PORT` port config, that is used if not None or > 0
* also sneaked in a changed that avoids a call to `random` when using `put_item`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

