### PR TITLE
Migrate deprecated edge variables

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -92,7 +92,7 @@ def _get_allowed_cors_ports() -> Set[int]:
     Construct the list of allowed ports for CORS enforcement purposes
     Defined as function to allow easier testing with monkeypatch of config values
     """
-    return set([config.EDGE_PORT] + ([config.EDGE_PORT_HTTP] if config.EDGE_PORT_HTTP else []))
+    return set([host_and_port.port for host_and_port in config.GATEWAY_LISTEN])
 
 
 _ALLOWED_INTERNAL_PORTS = _get_allowed_cors_ports()
@@ -110,7 +110,6 @@ def _get_allowed_cors_origins() -> List[str]:
         "file://",
     ]
     # Add allowed origins for localhost domains, using different protocol/port combinations.
-    # If a different port is configured for EDGE_PORT_HTTP, add it to allowed origins as well
     for protocol in {"http", "https"}:
         for port in _get_allowed_cors_ports():
             result.append(f"{protocol}://{LOCALHOST}:{port}")

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1209,6 +1209,9 @@ CONFIG_ENV_VARS = [
     "WAIT_FOR_DEBUGGER",
     "WINDOWS_DOCKER_MOUNT_PREFIX",
     # Removed in 3.0.0
+    "EDGE_BIND_HOST",  # deprecated since 2.0.0
+    "EDGE_PORT",  # deprecated since 2.0.0
+    "EDGE_PORT_HTTP",  # deprecated since 2.0.0
     "LAMBDA_XRAY_INIT",  # deprecated since 2.0.0
     "LAMBDA_CODE_EXTRACT_TIME",  # deprecated since 2.0.0
     "LAMBDA_CONTAINER_REGISTRY",  # deprecated since 2.0.0

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -596,10 +596,6 @@ class UniqueHostAndPortList(List[HostAndPort]):
         super().append(value)
 
 
-def default_gateway_listen() -> List[HostAndPort]:
-    return [HostAndPort(host=default_ip, port=constants.DEFAULT_PORT_EDGE)]
-
-
 def populate_legacy_edge_configuration(
     environment: Mapping[str, str]
 ) -> Tuple[HostAndPort, UniqueHostAndPortList, int]:
@@ -637,7 +633,7 @@ def populate_legacy_edge_configuration(
             )
     else:
         # use default if gateway listen is not defined
-        gateway_listen = default_gateway_listen()
+        gateway_listen = [HostAndPort(host=default_ip, port=localstack_host_port)]
 
     # the actual value of the LOCALSTACK_HOST port now depends on what gateway listen actually listens to.
     if localstack_host_raw is None:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -596,9 +596,10 @@ class UniqueHostAndPortList(List[HostAndPort]):
         super().append(value)
 
 
-def populate_legacy_edge_configuration(
+def populate_edge_configuration(
     environment: Mapping[str, str]
 ) -> Tuple[HostAndPort, UniqueHostAndPortList, int]:
+    """Populate the LocalStack edge configuration from environment variables."""
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
     gateway_listen_raw = environment.get("GATEWAY_LISTEN")
 
@@ -611,14 +612,6 @@ def populate_legacy_edge_configuration(
             default_host=constants.LOCALHOST_HOSTNAME,
             default_port=constants.DEFAULT_PORT_EDGE,
         ).port
-
-    def legacy_fallback(envar_name: str, default: T) -> T:
-        result = default
-        result_raw = environment.get(envar_name)
-        if result_raw is not None and gateway_listen_raw is None:
-            result = result_raw
-
-        return result
 
     # parse gateway listen from multiple components
     if gateway_listen_raw is not None:
@@ -652,7 +645,7 @@ def populate_legacy_edge_configuration(
     assert localstack_host is not None
 
     # derive legacy variables from GATEWAY_LISTEN
-    edge_port = int(legacy_fallback("EDGE_PORT", gateway_listen[0].port))
+    edge_port = gateway_listen[0].port
 
     return (
         localstack_host,
@@ -662,7 +655,6 @@ def populate_legacy_edge_configuration(
 
 
 # How to access LocalStack
-GATEWAY_LISTEN: List[HostAndPort]
 (
     # -- Cosmetic
     LOCALSTACK_HOST,
@@ -672,7 +664,7 @@ GATEWAY_LISTEN: List[HostAndPort]
     GATEWAY_LISTEN,
     # -- Legacy variables
     EDGE_PORT,
-) = populate_legacy_edge_configuration(os.environ)
+) = populate_edge_configuration(os.environ)
 
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1312,7 +1312,10 @@ def get_edge_url(localstack_hostname=None, protocol=None):
 
 
 def edge_ports_info():
-    return f"{get_protocol()} port {GATEWAY_LISTEN[0].port}"
+    """Example: http port 4566,443"""
+    gateway_listen_ports = [gw_listen.port for gw_listen in GATEWAY_LISTEN]
+    port_enumeration = ",".join(str(gateway_listen_ports))
+    return f"{get_protocol()} port {port_enumeration}"
 
 
 class ServiceProviderConfig(Mapping[str, str]):

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1312,10 +1312,9 @@ def get_edge_url(localstack_hostname=None, protocol=None):
 
 
 def edge_ports_info():
-    """Example: http port 4566,443"""
+    """Example: http port [4566,443]"""
     gateway_listen_ports = [gw_listen.port for gw_listen in GATEWAY_LISTEN]
-    port_enumeration = ",".join(str(gateway_listen_ports))
-    return f"{get_protocol()} port {port_enumeration}"
+    return f"{get_protocol()} port {gateway_listen_ports}"
 
 
 class ServiceProviderConfig(Mapping[str, str]):

--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -252,9 +252,9 @@ def run(
     # replicate pro startup
     if pro:
         try:
-            from localstack_ext.plugins import modify_edge_port_config
+            from localstack_ext.plugins import modify_gateway_listen_config
 
-            modify_edge_port_config(config)
+            modify_gateway_listen_config(config)
         except ImportError:
             pass
 

--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -48,7 +48,7 @@ class PortConfigurator:
         self.randomize = randomize
 
     def __call__(self, cfg: ContainerConfiguration):
-        cfg.ports.bind_host = config.EDGE_BIND_HOST
+        cfg.ports.bind_host = config.GATEWAY_LISTEN[0].host
 
         if self.randomize:
             ContainerConfigurators.random_gateway_port(cfg)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -490,7 +490,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
                 # make another call with quiet=False to print detailed error logs
                 is_port_open(config.get_edge_port_http(), quiet=False)
             raise TimeoutError(
-                f"gave up waiting for edge server on {config.EDGE_BIND_HOST}:{config.EDGE_PORT}"
+                f"gave up waiting for edge server on {config.GATEWAY_LISTEN[0].host}:{config.GATEWAY_LISTEN[0].port}"
             )
 
         return t

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1844,9 +1844,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # create function URL config
         url_id = api_utils.generate_random_url_id()
 
-        host_definition = localstack_host(
-            custom_port=config.GATEWAY_LISTEN[0].port
-        )
+        host_definition = localstack_host(custom_port=config.GATEWAY_LISTEN[0].port)
         fn.function_url_configs[normalized_qualifier] = FunctionUrlConfig(
             function_arn=function_arn,
             function_name=function_name,

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1845,7 +1845,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         url_id = api_utils.generate_random_url_id()
 
         host_definition = localstack_host(
-            custom_port=config.EDGE_PORT_HTTP or config.GATEWAY_LISTEN[0].port
+            custom_port=config.GATEWAY_LISTEN[0].port
         )
         fn.function_url_configs[normalized_qualifier] = FunctionUrlConfig(
             function_arn=function_arn,

--- a/localstack/services/opensearch/cluster_manager.py
+++ b/localstack/services/opensearch/cluster_manager.py
@@ -7,7 +7,6 @@ from botocore.utils import ArnParser
 
 from localstack import config
 from localstack.aws.api.opensearch import DomainEndpointOptions, EngineType
-from localstack.config import EDGE_BIND_HOST
 from localstack.constants import LOCALHOST
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.cluster import (
@@ -345,10 +344,12 @@ class MultiClusterManager(ClusterManager):
         else:
             port = _get_port_from_url(url)
             if engine_type == EngineType.OpenSearch:
-                return OpensearchCluster(port=port, host=EDGE_BIND_HOST, arn=arn, version=version)
+                return OpensearchCluster(
+                    port=port, host=config.GATEWAY_LISTEN[0].host, arn=arn, version=version
+                )
             else:
                 return ElasticsearchCluster(
-                    port=port, host=EDGE_BIND_HOST, arn=arn, version=version
+                    port=port, host=config.GATEWAY_LISTEN[0].host, arn=arn, version=version
                 )
 
 
@@ -396,7 +397,7 @@ class SingletonClusterManager(ClusterManager):
             if engine_type == EngineType.OpenSearch:
                 self.cluster = OpensearchCluster(
                     port=port,
-                    host=EDGE_BIND_HOST,
+                    host=config.GATEWAY_LISTEN[0].host,
                     version=version,
                     arn=arn,
                     security_options=security_options,

--- a/localstack/services/stepfunctions/legacy/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/legacy/stepfunctions_starter.py
@@ -43,8 +43,8 @@ class StepFunctionsServer(Server):
 
     def generate_env_vars(self) -> Dict[str, Any]:
         return {
-            "EDGE_PORT": config.EDGE_PORT_HTTP or config.EDGE_PORT,
-            "EDGE_PORT_HTTP": config.EDGE_PORT_HTTP or config.EDGE_PORT,
+            "EDGE_PORT": config.GATEWAY_LISTEN[0].port,
+            "EDGE_PORT_HTTP": config.GATEWAY_LISTEN[0].port,
             "DATA_DIR": config.dirs.data,
             "PORT": self._port,
         }

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -988,7 +988,7 @@ class LocalstackContainerServer(Server):
     def __init__(
         self, container_configuration: ContainerConfiguration | Container | None = None
     ) -> None:
-        super().__init__(config.EDGE_PORT, config.EDGE_BIND_HOST)
+        super().__init__(config.GATEWAY_LISTEN[0].port, config.GATEWAY_LISTEN[0].host)
 
         if container_configuration is None:
             port_configuration = PortMappings(bind_host=config.GATEWAY_LISTEN[0].host)

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -13,7 +13,6 @@ from opensearchpy.exceptions import AuthorizationException
 
 from localstack import config
 from localstack.aws.api.opensearch import AdvancedSecurityOptionsInput, MasterUserOptions
-from localstack.config import EDGE_BIND_HOST
 from localstack.constants import (
     OPENSEARCH_DEFAULT_VERSION,
     OPENSEARCH_PLUGIN_LIST,
@@ -874,7 +873,7 @@ class TestSingletonClusterManager:
         parts = cluster_0.url.split(":")
         assert parts[0] == "http"
         # either f"//{the bind host}" is used, or in the case of "//0.0.0.0" the localstack hostname instead
-        assert parts[1][2:] in [EDGE_BIND_HOST, localstack_host().host]
+        assert parts[1][2:] in [config.GATEWAY_LISTEN[0].host, localstack_host().host]
         assert int(parts[2]) in range(
             config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END
         )

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -13,6 +13,7 @@ import localstack.utils.analytics.cli
 from localstack import config, constants
 from localstack.cli.localstack import create_with_plugins, is_frozen_bundle
 from localstack.cli.localstack import localstack as cli
+from localstack.config import HostAndPort
 from localstack.utils import testutil
 from localstack.utils.common import is_command_available
 from localstack.utils.container_utils.container_client import ContainerException, DockerNotAvailable
@@ -110,9 +111,9 @@ def test_start_host(runner, monkeypatch):
 
 
 def test_status_services(runner, httpserver, monkeypatch):
-    # TODO: legacy API, switch to use GATEWAY_LISTEN in the next step
-    monkeypatch.setattr(config, "EDGE_PORT_HTTP", httpserver.port)
-    monkeypatch.setattr(config, "EDGE_PORT", httpserver.port)
+    monkeypatch.setattr(
+        config, "GATEWAY_LISTEN", [HostAndPort(host="0.0.0.0", port=httpserver.port)]
+    )
 
     services = {"dynamodb": "starting", "s3": "running"}
     httpserver.expect_request("/_localstack/health", method="GET").respond_with_json(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -156,9 +156,7 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=1234)
@@ -169,9 +167,7 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="localhost.localstack.cloud", port=1234)
@@ -182,9 +178,7 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=5555)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -64,8 +64,6 @@ class TestEdgeVariablesDerivedCorrectly:
     Post-v2 we are deriving
 
     * EDGE_PORT
-    * EDGE_PORT_HTTP
-    * EDGE_BIND_HOST
 
     from GATEWAY_LISTEN. We are also ensuring the configuration behaves
     well with LOCALSTACK_HOST, i.e. if LOCALSTACK_HOST is supplied and
@@ -89,93 +87,69 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "localhost.localstack.cloud:4566"
         assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
         assert edge_port == 4566
-        assert edge_port_http == 0
-        assert edge_bind_host == default_ip
 
     def test_custom_hostname(self):
         environment = {"GATEWAY_LISTEN": "192.168.0.1"}
         (
             _,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host="192.168.0.1", port=4566)]
         assert edge_port == 4566
-        assert edge_port_http == 0
-        assert edge_bind_host == "192.168.0.1"
 
     def test_custom_port(self, default_ip):
         environment = {"GATEWAY_LISTEN": ":9999"}
         (
             _,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
         assert edge_port == 9999
-        assert edge_port_http == 0
-        assert edge_bind_host == default_ip
 
     def test_custom_host_and_port(self):
         environment = {"GATEWAY_LISTEN": "192.168.0.1:9999"}
         (
             _,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host="192.168.0.1", port=9999)]
         assert edge_port == 9999
-        assert edge_port_http == 0
-        assert edge_bind_host == "192.168.0.1"
 
     def test_localstack_host_overrides_edge_variables(self, default_ip):
         environment = {"LOCALSTACK_HOST": "hostname:9999"}
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="hostname", port=9999)
         assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
         assert edge_port == 9999
-        assert edge_port_http == 0
-        assert edge_bind_host == default_ip
 
     def test_localstack_host_no_port(self, default_ip):
         environment = {"LOCALSTACK_HOST": "foobar"}
         (
             ls_host,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=4566)
         assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
         assert edge_port == 4566
-        assert edge_port_http == 0
-        assert edge_bind_host == default_ip
 
     def test_localstack_host_no_port_gateway_listen_set(self, default_ip):
         environment = {"LOCALSTACK_HOST": "foobar", "GATEWAY_LISTEN": ":1234"}
@@ -221,9 +195,7 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             _,
             gateway_listen,
-            edge_bind_host,
             edge_port,
-            edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert gateway_listen == [
@@ -232,30 +204,6 @@ class TestEdgeVariablesDerivedCorrectly:
         ]
         # take the first value
         assert edge_port == 9999
-        assert edge_port_http == 0
-        assert edge_bind_host == "0.0.0.0"
-
-    def test_legacy_variables_override_if_given(self, default_ip):
-        environment = {
-            "EDGE_BIND_HOST": "192.168.0.1",
-            "EDGE_PORT": "10101",
-            "EDGE_PORT_HTTP": "20202",
-        }
-        (
-            _,
-            gateway_listen,
-            edge_bind_host,
-            edge_port,
-            edge_port_http,
-        ) = config.populate_legacy_edge_configuration(environment)
-
-        assert gateway_listen == [
-            HostAndPort(host=default_ip, port=10101),
-            HostAndPort(host=default_ip, port=20202),
-        ]
-        assert edge_bind_host == "192.168.0.1"
-        assert edge_port == 10101
-        assert edge_port_http == 20202
 
 
 class TestUniquePortList:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -88,7 +88,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == "localhost.localstack.cloud:4566"
         assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
@@ -100,7 +100,7 @@ class TestEdgeVariablesDerivedCorrectly:
             _,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host="192.168.0.1", port=4566)]
         assert edge_port == 4566
@@ -111,7 +111,7 @@ class TestEdgeVariablesDerivedCorrectly:
             _,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
         assert edge_port == 9999
@@ -122,7 +122,7 @@ class TestEdgeVariablesDerivedCorrectly:
             _,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert gateway_listen == [HostAndPort(host="192.168.0.1", port=9999)]
         assert edge_port == 9999
@@ -133,7 +133,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="hostname", port=9999)
         assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
@@ -145,7 +145,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=4566)
         assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
@@ -157,7 +157,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=1234)
         assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
@@ -168,7 +168,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="localhost.localstack.cloud", port=1234)
         assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
@@ -179,7 +179,7 @@ class TestEdgeVariablesDerivedCorrectly:
             ls_host,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert ls_host == HostAndPort(host="foobar", port=5555)
         assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
@@ -190,7 +190,7 @@ class TestEdgeVariablesDerivedCorrectly:
             _,
             gateway_listen,
             edge_port,
-        ) = config.populate_legacy_edge_configuration(environment)
+        ) = config.populate_edge_configuration(environment)
 
         assert gateway_listen == [
             HostAndPort(host="0.0.0.0", port=9999),
@@ -198,6 +198,25 @@ class TestEdgeVariablesDerivedCorrectly:
         ]
         # take the first value
         assert edge_port == 9999
+
+    def test_legacy_variables_ignored_if_given(self, default_ip):
+        """Providing legacy variables removed in 3.0 should not affect the default configuration"""
+        environment = {
+            "EDGE_BIND_HOST": "192.168.0.1",
+            "EDGE_PORT": "10101",
+            "EDGE_PORT_HTTP": "20202",
+        }
+        (
+            localstack_host,
+            gateway_listen,
+            edge_port,
+        ) = config.populate_edge_configuration(environment)
+
+        assert localstack_host == "localhost.localstack.cloud:4566"
+        assert gateway_listen == [
+            HostAndPort(host=default_ip, port=4566),
+        ]
+        assert edge_port == 4566
 
 
 class TestUniquePortList:


### PR DESCRIPTION
Depends on `LOCALSTACK_HOST` migration: https://github.com/localstack/localstack/pull/9390

## Motivation

`EDGE_PORT`, `EDGE_PORT_HTTP` and `EDGE_BIND_HOST` are replaced by `GATEWAY_LISTEN`, and have been deprecated since version 2.0. These variables should be removed in a major version, and can be done in version 3.0.

## Changes

* Make `EDGE_PORT` read-only. Internal use is widespread and therefore we consider it as a shortcut for now with the semantics `EDGE_PORT == GATEWAY_LISTEN[0].port`. We also keep exposing `EDGE_PORT` in LocalStack compute services because we have not advertised a migration path yet.
* Remove `EDGE_PORT_HTTP`
* Remove `EDGE_BIND_HOST`

## Background

* Announced networking changes upon 2.0: https://discuss.localstack.cloud/t/upcoming-changes-for-localstack-v2/239#networking-7
* GATEWAY_LISTEN behavior regarding protocols `http` vs `https`:
    
    > When we bind to a ip/port, we accept both http and https requests, so the protocol distinction is not important for the purposes of our hypercorn server. For example you can send HTTPS requests to both 4566 and 443 in your example above. I think that means that we allow all combinations of port and protocol
    >

* More details in internal decision document: https://www.notion.so/localstack/Migration-path-for-LOCALSTACK_HOSTNAME-and-EDGE_PORT-9cf800595f854add96ce2788a6d93367?pvs=4

## Discussion

* CORS is now more permissive (see `localstack/aws/handlers/cors.py`) and the tests required updates (`tests/unit/test_cors.py`). Is this ok?
* Monkeypatching of `GATEWAY_LISTEN` needs to use typed `[HostAndPort]` rather than the user-facing string-based API. Does this work properly without side effects? Do we need to provide any guards when used with strings?
* StepFunctions V1: Does anything depend on the environment variable `EDGE_PORT_HTTP` (generated in localstack.services.stepfunctions.stepfunctions_starter.StepFunctionsServer.generate_env_vars) used when starting the Java StepFunctionsLocal.jar ? (I would leave it for now as this StepFunctions implementation will be deprecated anyway).

## TODO

- [x] Rebase upon the dependent `LOCALSTACK_HOST` migration https://github.com/localstack/localstack/pull/9390
- [x] Fix `tests.unit.test_config.TestEdgeVariablesDerivedCorrectly.test_localstack_host_overrides_edge_variables` depending on the migration to `LOCALSTACK_HOST` https://github.com/localstack/localstack/pull/9390/files#diff-8ee48b2bcad465473db1a1b202781ca2c7c23db7bd1670e79d45668fb2bd718fR616
- [x] Remove duplicated commit from Viren from this PR (upon next rebase)
- [x] Synchronize merge with Lambda removal PRs (might have to resolve a few conflicts) https://github.com/localstack/localstack/pull/9543

## Follow-up

- [ ] Remove `get_edge_port_http()` (this refactoring can also be done post v3 to limit the impact; used 13x in LS + 13x in ext)