### PR TITLE
minor: add mypy types for appconfigdata service client

### DIFF
--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -267,7 +267,7 @@ class LambdaService:
             version_manager = self.get_lambda_version_manager(qualified_arn)
             event_manager = self.get_lambda_event_manager(qualified_arn)
             usage.runtime.record(version_manager.function_version.config.runtime)
-        except ValueError:
+        except ValueError as e:
             version = function.versions.get(version_qualifier)
             state = version and version.config.state.state
             # TODO: make such developer hints optional or remove after initial v2 transition period
@@ -288,7 +288,7 @@ class LambdaService:
                 )
             raise ResourceConflictException(
                 f"The operation cannot be performed at this time. The function is currently in the following state: {state}"
-            )
+            ) from e
         # empty payloads have to work as well
         if payload is None:
             payload = b"{}"

--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_apigatewayv2 import ApiGatewayV2Client
     from mypy_boto3_appconfig import AppConfigClient
+    from mypy_boto3_appconfigdata import AppConfigDataClient
     from mypy_boto3_appsync import AppSyncClient
     from mypy_boto3_athena import AthenaClient
     from mypy_boto3_autoscaling import AutoScalingClient
@@ -101,6 +102,7 @@ class TypedServiceClientFactory(abc.ABC):
     apigateway: Union["APIGatewayClient", "MetadataRequestInjector[APIGatewayClient]"]
     apigatewayv2: Union["ApiGatewayV2Client", "MetadataRequestInjector[ApiGatewayV2Client]"]
     appconfig: Union["AppConfigClient", "MetadataRequestInjector[AppConfigClient]"]
+    appconfigdata: Union["AppConfigDataClient", "MetadataRequestInjector[AppConfigDataClient]"]
     appsync: Union["AppSyncClient", "MetadataRequestInjector[AppSyncClient]"]
     athena: Union["AthenaClient", "MetadataRequestInjector[AthenaClient]"]
     autoscaling: Union["AutoScalingClient", "MetadataRequestInjector[AutoScalingClient]"]

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -40,11 +40,11 @@ ENDPOINT_RESOLVE_LIST = ["localhost.localstack.cloud", "api.localstack.cloud"]
 INSPECT_DIRECTORIES = [DEFAULT_VOLUME_DIR, "/tmp"]
 
 
-def get_localstack_logs() -> Union[str, Dict]:
+def get_localstack_logs() -> Dict:
     try:
         result = DOCKER_CLIENT.get_container_logs(get_main_container_name())
     except Exception as e:
-        result = "error getting docker logs for container: %s" % e
+        result = f"error getting docker logs for container: {e}"
 
     return {"docker": result}
 


### PR DESCRIPTION
## Motivation

Add mypy types for `appconfigdata` service client. Adding the `appconfigdata` provider implementation is done elsewhere - part of a customer issue we're working on with @cabeaulac . Will also address https://github.com/localstack/localstack/issues/6891

## Changes

* Add mypy types for `appconfigdata` service client

The PR also sneaks in a few tiny changes
* add root cause exception in `LambdaService.invoke` - this has proven helpful for some recent persistence tests debugging /cc @giograno 
* fix some f-strings and return types

