### PR TITLE
enhancement: dynamodb performance optimization

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -997,7 +997,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         result = self.forward_request(context)
 
         # determine and forward stream records
-        streams_enabled_cache = {}
         records = self.prepare_transact_write_item_records(
             account_id=context.account_id,
             region_name=context.region,
@@ -1007,11 +1006,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         event_sources_or_streams_enabled = False
         for record in records:
             event_sources_or_streams_enabled = (
-                event_sources_or_streams_enabled
-                or has_streams_enabled(
-                    record["eventSourceARN"],
-                    streams_enabled_cache,
-                )
+                event_sources_or_streams_enabled or has_streams_enabled(record["eventSourceARN"])
             )
         if event_sources_or_streams_enabled:
             self.forward_stream_records(context.account_id, context.region, records)

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -711,8 +711,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         table_name = put_item_input["TableName"]
 
         existing_item = None
-        event_sources_or_streams_enabled = has_event_sources_or_streams_enabled(table_name)
-        if event_sources_or_streams_enabled:
+        if streams_enabled := has_streams_enabled(table_name):
+            # TODO: we could manually override ReturnValues to return the old value?
             existing_item = ItemFinder.find_existing_item(
                 put_item_input,
                 table_name,
@@ -728,7 +728,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # region, eg. when getting the stream spec
 
         # Get stream specifications details for the table
-        if event_sources_or_streams_enabled:
+        if streams_enabled:
             stream_spec = dynamodb_get_table_stream_specification(
                 account_id=context.account_id,
                 region_name=global_table_region,
@@ -771,7 +771,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         global_table_region = self.get_global_table_region(context, table_name)
 
         existing_item = None
-        if has_event_sources_or_streams_enabled(table_name):
+        if has_streams_enabled(table_name):
             existing_item = ItemFinder.find_existing_item(
                 delete_item_input, table_name, context.account_id, context.region
             )
@@ -780,7 +780,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
         # determine and forward stream record
         if existing_item:
-            event_sources_or_streams_enabled = has_event_sources_or_streams_enabled(table_name)
+            event_sources_or_streams_enabled = has_streams_enabled(table_name)
             if event_sources_or_streams_enabled:
                 # create record
                 record = self.get_record_template(context.region)
@@ -814,8 +814,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         global_table_region = self.get_global_table_region(context, table_name)
 
         existing_item = None
-        event_sources_or_streams_enabled = has_event_sources_or_streams_enabled(table_name)
+        event_sources_or_streams_enabled = has_streams_enabled(table_name)
         if event_sources_or_streams_enabled:
+            # TODO: we could manually override ReturnValues to return the old value?
             existing_item = ItemFinder.find_existing_item(
                 update_item_input, table_name, context.account_id, context.region
             )
@@ -928,14 +929,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             unprocessed_delete_items=unprocessed_delete_items,
             existing_items=existing_items,
         )
-        streams_enabled_cache = {}
+
         event_sources_or_streams_enabled = False
         for record in records:
             event_sources_or_streams_enabled = (
-                event_sources_or_streams_enabled
-                or has_event_sources_or_streams_enabled(
-                    record["eventSourceARN"], cache=streams_enabled_cache
-                )
+                event_sources_or_streams_enabled or has_streams_enabled(record["eventSourceARN"])
             )
         if event_sources_or_streams_enabled:
             self.forward_stream_records(context.account_id, context.region, records)
@@ -1007,7 +1005,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         for record in records:
             event_sources_or_streams_enabled = (
                 event_sources_or_streams_enabled
-                or has_event_sources_or_streams_enabled(
+                or has_streams_enabled(
                     record["eventSourceARN"],
                     streams_enabled_cache,
                 )
@@ -1042,7 +1040,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         statement = execute_statement_input["Statement"]
         table_name = extract_table_name_from_partiql_update(statement)
         existing_items = None
-        if table_name and has_event_sources_or_streams_enabled(table_name):
+        if table_name and has_streams_enabled(table_name):
             # Note: fetching the entire list of items is hugely inefficient, especially for larger tables
             # TODO: find a mechanism to hook into the PartiQL update mechanism of DynamoDB Local directly!
             existing_items = ItemFinder.list_existing_items_for_statement(
@@ -1052,9 +1050,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         result = self.forward_request(context)
 
         # construct and forward stream record
-        event_sources_or_streams_enabled = table_name and has_event_sources_or_streams_enabled(
-            table_name
-        )
+        event_sources_or_streams_enabled = table_name and has_streams_enabled(table_name)
         if event_sources_or_streams_enabled:
             records = get_updated_records(
                 context.account_id, context.region, table_name, existing_items
@@ -1739,37 +1735,24 @@ def is_index_query_valid(account_id: str, region_name: str, query_data: dict) ->
     return True
 
 
-def has_event_sources_or_streams_enabled(table_name: str, cache: Dict = None):
-    if cache is None:
-        cache = {}
+def has_streams_enabled(table_name: str):
     if not table_name:
         return
     table_arn = arns.dynamodb_table_arn(table_name)
+    # TODO: change this, it's using `_resource_arn` which calls get_aws_account_id() and get_region() which we
+    #  are extracting from the ARN after?
     account_id = extract_account_id_from_arn(table_arn)
     region_name = extract_region_from_arn(table_arn)
-    cached = cache.get(table_arn)
-    if isinstance(cached, bool):
-        return cached
-    lambda_client = connect_to(aws_access_key_id=account_id, region_name=region_name).lambda_
-    sources = lambda_client.list_event_source_mappings(EventSourceArn=table_arn)[
-        "EventSourceMappings"
-    ]
-    result = False
-    if sources:
-        result = True
-    if not result and dynamodbstreams_api.get_stream_for_table(account_id, region_name, table_arn):
-        result = True
+
+    if dynamodbstreams_api.get_stream_for_table(account_id, region_name, table_arn):
+        return True
 
     # if kinesis streaming destination is enabled
-    # get table name from table_arn
-    # since batch_write and transact write operations passing table_arn instead of table_name
-    table_name = table_arn.split("/", 1)[-1]
-    table_definitions: Dict = get_store(account_id, region_name).table_definitions
-    if not result and table_definitions.get(table_name):
-        if table_definitions[table_name].get("KinesisDataStreamDestinationStatus") == "ACTIVE":
-            result = True
-    cache[table_arn] = result
-    return result
+    if table_definition := get_store(account_id, region_name).table_definitions.get(table_name):
+        if table_definition.get("KinesisDataStreamDestinationStatus") == "ACTIVE":
+            return True
+
+    return False
 
 
 def get_updated_records(

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -42,7 +42,7 @@ def dynamodbstreams_snapshot_transformers(snapshot):
             snapshot.transform.key_value("TableName"),
             snapshot.transform.key_value("TableStatus"),
             snapshot.transform.key_value("LatestStreamLabel"),
-            snapshot.transform.key_value("StartingSequenceNumber"),
+            snapshot.transform.key_value("StartingSequenceNumber", reference_replacement=False),
             snapshot.transform.key_value("ShardId"),
             snapshot.transform.key_value("StreamLabel"),
             snapshot.transform.key_value("SequenceNumber"),

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 import pytest
 from boto3.dynamodb.types import STRING
+from botocore.exceptions import ClientError
 
 from localstack.aws.api.dynamodb import PointInTimeRecoverySpecification
 from localstack.constants import AWS_REGION_US_EAST_1, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
@@ -30,8 +31,26 @@ TEST_DDB_TAGS = [
 
 
 @pytest.fixture(autouse=True)
-def transcribe_snapshot_transformer(snapshot):
+def dynamodb_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.dynamodb_api())
+
+
+@pytest.fixture
+def dynamodbstreams_snapshot_transformers(snapshot):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("TableName"),
+            snapshot.transform.key_value("TableStatus"),
+            snapshot.transform.key_value("LatestStreamLabel"),
+            snapshot.transform.key_value("StartingSequenceNumber"),
+            snapshot.transform.key_value("ShardId"),
+            snapshot.transform.key_value("StreamLabel"),
+            snapshot.transform.key_value("SequenceNumber"),
+            snapshot.transform.key_value("eventID"),
+        ]
+    )
+    snapshot.add_transformer(snapshot.transform.key_value("NextShardIterator"), priority=-1)
+    snapshot.add_transformer(snapshot.transform.key_value("ShardIterator"), priority=-1)
 
 
 class TestDynamoDB:
@@ -724,14 +743,29 @@ class TestDynamoDB:
         assert len(items) == 0
         aws_client.dynamodb.delete_table(TableName=table_name)
 
-    @markers.aws.only_localstack
-    def test_dynamodb_stream_stream_view_type(self, aws_client):
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..SizeBytes",
+            "$..DeletionProtectionEnabled",
+            "$..ProvisionedThroughput.NumberOfDecreasesToday",
+            "$..StreamDescription.CreationRequestDateTime",
+        ]
+    )
+    def test_dynamodb_stream_stream_view_type(
+        self,
+        aws_client,
+        dynamodb_create_table_with_parameters,
+        wait_for_dynamodb_stream_ready,
+        snapshot,
+        dynamodbstreams_snapshot_transformers,
+    ):
         dynamodb = aws_client.dynamodb
         ddbstreams = aws_client.dynamodbstreams
-        table_name = "table_with_stream_%s" % short_uid()
+        table_name = f"table_with_stream_{short_uid()}"
 
         # create table
-        table = dynamodb.create_table(
+        table = dynamodb_create_table_with_parameters(
             TableName=table_name,
             KeySchema=[{"AttributeName": "Username", "KeyType": "HASH"}],
             AttributeDefinitions=[{"AttributeName": "Username", "AttributeType": "S"}],
@@ -742,8 +776,8 @@ class TestDynamoDB:
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         )
         stream_arn = table["TableDescription"]["LatestStreamArn"]
-        # wait for stream to be created
-        sleep(1)
+        snapshot.match("create-table", table)
+        wait_for_dynamodb_stream_ready(stream_arn=stream_arn)
 
         # put item in table - INSERT event
         dynamodb.put_item(TableName=table_name, Item={"Username": {"S": "Fred"}})
@@ -757,7 +791,10 @@ class TestDynamoDB:
         )
         # delete item in table - REMOVE event
         dynamodb.delete_item(TableName=table_name, Key={"Username": {"S": "Fred"}})
+
         result = ddbstreams.describe_stream(StreamArn=stream_arn)
+        snapshot.match("describe-stream", result)
+
         # assert stream_view_type of the table
         assert result["StreamDescription"]["StreamViewType"] == "KEYS_ONLY"
 
@@ -781,26 +818,24 @@ class TestDynamoDB:
             .get("SequenceNumberRange")
             .get("StartingSequenceNumber"),
         )
+        snapshot.match("get-shard-iterator", response)
 
+        shard_iterator = response["ShardIterator"]
         # get stream records
-        records = ddbstreams.get_records(ShardIterator=response["ShardIterator"])["Records"]
-        assert len(records) == 6
-        events = [rec["eventName"] for rec in records]
-        assert events == ["INSERT", "MODIFY", "REMOVE"] * 2
-        # assert that all records contain proper event IDs
-        event_ids = [rec.get("eventID") for rec in records]
-        assert all(event_ids)
+        records = []
 
-        # assert that updates have been received from regular table operations and PartiQL query operations
-        for idx, record in enumerate(records):
-            assert "SequenceNumber" in record["dynamodb"]
-            assert record["dynamodb"]["StreamViewType"] == "KEYS_ONLY"
-            assert record["dynamodb"]["Keys"] == {"Username": {"S": "Fred" if idx < 3 else "Alice"}}
-            assert "OldImage" not in record["dynamodb"]
-            assert "NewImage" not in record["dynamodb"]
+        def _get_records_amount(record_amount: int):
+            nonlocal shard_iterator
+            if len(records) < record_amount:
+                _resp = aws_client.dynamodbstreams.get_records(ShardIterator=shard_iterator)
+                records.extend(_resp["Records"])
+                if next_shard_iterator := _resp.get("NextShardIterator"):
+                    shard_iterator = next_shard_iterator
 
-        # clean up
-        dynamodb.delete_table(TableName=table_name)
+            assert len(records) >= record_amount
+
+        retry(lambda: _get_records_amount(6), sleep=1, retries=3)
+        snapshot.match("get-records", {"Records": records})
 
     @markers.aws.only_localstack
     def test_dynamodb_with_kinesis_stream(self, aws_client, secondary_aws_client):
@@ -1260,6 +1295,91 @@ class TestDynamoDB:
         )
         snapshot.match("BatchWriteResponse", response)
 
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..SizeBytes",
+            "$..DeletionProtectionEnabled",
+            "$..ProvisionedThroughput.NumberOfDecreasesToday",
+            "$..StreamDescription.CreationRequestDateTime",
+        ]
+    )
+    def test_batch_write_items_streaming(
+        self,
+        dynamodb_create_table_with_parameters,
+        wait_for_dynamodb_stream_ready,
+        snapshot,
+        aws_client,
+        dynamodbstreams_snapshot_transformers,
+    ):
+        # TODO: add a test with both Kinesis and DDBStreams destinations
+        table_name = f"test-ddb-table-{short_uid()}"
+        create_table = dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"},
+        )
+        snapshot.match("create-table", create_table)
+        stream_arn = create_table["TableDescription"]["LatestStreamArn"]
+        wait_for_dynamodb_stream_ready(stream_arn=stream_arn)
+
+        describe_stream_result = aws_client.dynamodbstreams.describe_stream(StreamArn=stream_arn)
+        snapshot.match("describe-stream", describe_stream_result)
+
+        shard_id = describe_stream_result["StreamDescription"]["Shards"][0]["ShardId"]
+        shard_iterator = aws_client.dynamodbstreams.get_shard_iterator(
+            StreamArn=stream_arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
+        )["ShardIterator"]
+
+        resp = aws_client.dynamodb.put_item(TableName=table_name, Item={"id": {"S": "Fred"}})
+        snapshot.match("put-item-1", resp)
+
+        # Overwrite the key, show that no event are sent for this one
+        response = aws_client.dynamodb.batch_write_item(
+            RequestItems={
+                table_name: [
+                    {"PutRequest": {"Item": {"id": {"S": "Fred"}}}},
+                    {"PutRequest": {"Item": {"id": {"S": "NewKey"}}}},
+                ]
+            }
+        )
+        snapshot.match("batch-write-response-overwrite-item-1", response)
+
+        # delete the key
+        response = aws_client.dynamodb.batch_write_item(
+            RequestItems={
+                table_name: [
+                    {"DeleteRequest": {"Key": {"id": {"S": "NewKey"}}}},
+                    {"PutRequest": {"Item": {"id": {"S": "Fred"}, "name": {"S": "Fred"}}}},
+                ]
+            }
+        )
+        snapshot.match("batch-write-response-delete", response)
+
+        # Total amount of records should be 4:
+        # - PutItem
+        # - BatchWriteItem on NewKey insert
+        # - BatchWriteItem on NewKey delete
+        # - BatchWriteItem on Fred modify
+        # don't send an event when Fred is overwritten with the same value
+        # get all records:
+        records = []
+
+        def _get_records_amount(record_amount: int):
+            nonlocal shard_iterator
+            if len(records) < record_amount:
+                _resp = aws_client.dynamodbstreams.get_records(ShardIterator=shard_iterator)
+                records.extend(_resp["Records"])
+                if next_shard_iterator := _resp.get("NextShardIterator"):
+                    shard_iterator = next_shard_iterator
+
+            assert len(records) >= record_amount
+
+        retry(lambda: _get_records_amount(4), sleep=1, retries=3)
+        snapshot.match("get-records", {"Records": records})
+
     @pytest.mark.xfail(reason="this test flakes regularly in CI")
     @markers.aws.unknown
     def test_dynamodb_stream_records_with_update_item(
@@ -1442,31 +1562,43 @@ class TestDynamoDB:
         )
         snapshot.match("Response", result)
 
-    @markers.aws.only_localstack
+    @markers.aws.validated
     def test_dynamodb_streams_describe_with_exclusive_start_shard_id(
-        self, aws_client, dynamodb_create_table
+        self,
+        aws_client,
+        dynamodb_create_table_with_parameters,
+        wait_for_dynamodb_stream_ready,
     ):
+        # not using snapshots here as AWS will often return 4 Shards where we return only one
         table_name = f"test-ddb-table-{short_uid()}"
         ddbstreams = aws_client.dynamodbstreams
 
-        dynamodb_create_table(
-            table_name=table_name,
-            partition_key=PARTITION_KEY,
-            stream_view_type="NEW_AND_OLD_IMAGES",
+        create_table = dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": PARTITION_KEY, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": PARTITION_KEY, "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"},
         )
+        stream_arn = create_table["TableDescription"]["LatestStreamArn"]
+        wait_for_dynamodb_stream_ready(stream_arn=stream_arn)
 
         table = aws_client.dynamodb.describe_table(TableName=table_name)
 
         response = ddbstreams.describe_stream(StreamArn=table["Table"]["LatestStreamArn"])
+
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert len(response["StreamDescription"]["Shards"]) == 1
+        assert len(response["StreamDescription"]["Shards"]) >= 1
         shard_id = response["StreamDescription"]["Shards"][0]["ShardId"]
 
+        # assert that the excluded shard it not in the response
         response = ddbstreams.describe_stream(
             StreamArn=table["Table"]["LatestStreamArn"], ExclusiveStartShardId=shard_id
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert len(response["StreamDescription"]["Shards"]) == 0
+        assert not any(
+            shard_id == shard["ShardId"] for shard in response["StreamDescription"]["Shards"]
+        )
 
     @markers.aws.validated
     def test_dynamodb_streams_shard_iterator_format(
@@ -1574,14 +1706,16 @@ class TestDynamoDB:
             )
         snapshot.match("ValidationException", ctx.value)
 
-    @markers.aws.unknown
-    def test_batch_write_not_existing_table(self, aws_client):
-        with pytest.raises(Exception) as ctx:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Error.Message", "$..message"],  # error message is not right
+    )
+    def test_batch_write_not_existing_table(self, aws_client, snapshot):
+        with pytest.raises(ClientError) as e:
             aws_client.dynamodb.transact_write_items(
                 TransactItems=[{"Put": {"TableName": "non-existing-table", "Item": {}}}]
             )
-        ctx.match("ResourceNotFoundException")
-        assert "retries" not in str(ctx)
+        snapshot.match("exc-not-found-transact-write-items", e.value.response)
 
     @markers.aws.only_localstack
     def test_nosql_workbench_localhost_region(self, dynamodb_create_table, aws_client_factory):

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -435,7 +435,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_batch_write_items_streaming": {
-    "recorded-date": "22-10-2023, 22:10:31",
+    "recorded-date": "22-10-2023, 23:23:09",
     "recorded-content": {
       "create-table": {
         "TableDescription": {
@@ -488,7 +488,7 @@
           "Shards": [
             {
               "SequenceNumberRange": {
-                "StartingSequenceNumber": "<starting-sequence-number:1>"
+                "StartingSequenceNumber": "starting-sequence-number"
               },
               "ShardId": "<shard-id:1>"
             }
@@ -635,7 +635,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
-    "recorded-date": "22-10-2023, 22:41:05",
+    "recorded-date": "22-10-2023, 23:22:27",
     "recorded-content": {
       "create-table": {
         "TableDescription": {
@@ -688,7 +688,7 @@
           "Shards": [
             {
               "SequenceNumberRange": {
-                "StartingSequenceNumber": "<starting-sequence-number:1>"
+                "StartingSequenceNumber": "starting-sequence-number"
               },
               "ShardId": "<shard-id:1>"
             }

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -417,5 +417,412 @@
         }
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_batch_write_not_existing_table": {
+    "recorded-date": "22-10-2023, 20:45:30",
+    "recorded-content": {
+      "exc-not-found-transact-write-items": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Requested resource not found"
+        },
+        "message": "Requested resource not found",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_batch_write_items_streaming": {
+    "recorded-date": "22-10-2023, 22:10:31",
+    "recorded-content": {
+      "create-table": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "LatestStreamLabel": "<latest-stream-label:1>",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-stream": {
+        "StreamDescription": {
+          "CreationRequestDateTime": "datetime",
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "Shards": [
+            {
+              "SequenceNumberRange": {
+                "StartingSequenceNumber": "<starting-sequence-number:1>"
+              },
+              "ShardId": "<shard-id:1>"
+            }
+          ],
+          "StreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "StreamLabel": "<latest-stream-label:1>",
+          "StreamStatus": "ENABLED",
+          "StreamViewType": "NEW_AND_OLD_IMAGES",
+          "TableName": "<table-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-item-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "batch-write-response-overwrite-item-1": {
+        "UnprocessedItems": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "batch-write-response-delete": {
+        "UnprocessedItems": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-records": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "Fred"
+                }
+              },
+              "NewImage": {
+                "id": {
+                  "S": "Fred"
+                }
+              },
+              "SequenceNumber": "<sequence-number:1>",
+              "SizeBytes": 12,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:1>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "NewKey"
+                }
+              },
+              "NewImage": {
+                "id": {
+                  "S": "NewKey"
+                }
+              },
+              "SequenceNumber": "<sequence-number:2>",
+              "SizeBytes": 16,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:2>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "NewKey"
+                }
+              },
+              "OldImage": {
+                "id": {
+                  "S": "NewKey"
+                }
+              },
+              "SequenceNumber": "<sequence-number:3>",
+              "SizeBytes": 16,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:3>",
+            "eventName": "REMOVE",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "Fred"
+                }
+              },
+              "NewImage": {
+                "id": {
+                  "S": "Fred"
+                },
+                "name": {
+                  "S": "Fred"
+                }
+              },
+              "OldImage": {
+                "id": {
+                  "S": "Fred"
+                }
+              },
+              "SequenceNumber": "<sequence-number:4>",
+              "SizeBytes": 26,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:4>",
+            "eventName": "MODIFY",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_describe_with_exclusive_start_shard_id": {
+    "recorded-date": "22-10-2023, 22:27:28",
+    "recorded-content": {}
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
+    "recorded-date": "22-10-2023, 22:41:05",
+    "recorded-content": {
+      "create-table": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "Username",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "Username",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "LatestStreamLabel": "<latest-stream-label:1>",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "KEYS_ONLY"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-stream": {
+        "StreamDescription": {
+          "CreationRequestDateTime": "datetime",
+          "KeySchema": [
+            {
+              "AttributeName": "Username",
+              "KeyType": "HASH"
+            }
+          ],
+          "Shards": [
+            {
+              "SequenceNumberRange": {
+                "StartingSequenceNumber": "<starting-sequence-number:1>"
+              },
+              "ShardId": "<shard-id:1>"
+            }
+          ],
+          "StreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "StreamLabel": "<latest-stream-label:1>",
+          "StreamStatus": "ENABLED",
+          "StreamViewType": "KEYS_ONLY",
+          "TableName": "<table-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-shard-iterator": {
+        "ShardIterator": "<shard-iterator:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-records": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Fred"
+                }
+              },
+              "SequenceNumber": "<sequence-number:1>",
+              "SizeBytes": 12,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:1>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Fred"
+                }
+              },
+              "SequenceNumber": "<sequence-number:2>",
+              "SizeBytes": 12,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:2>",
+            "eventName": "MODIFY",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Fred"
+                }
+              },
+              "SequenceNumber": "<sequence-number:3>",
+              "SizeBytes": 12,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:3>",
+            "eventName": "REMOVE",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Alice"
+                }
+              },
+              "SequenceNumber": "<sequence-number:4>",
+              "SizeBytes": 13,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:4>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Alice"
+                }
+              },
+              "SequenceNumber": "<sequence-number:5>",
+              "SizeBytes": 13,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:5>",
+            "eventName": "MODIFY",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "Username": {
+                  "S": "Alice"
+                }
+              },
+              "SequenceNumber": "<sequence-number:6>",
+              "SizeBytes": 13,
+              "StreamViewType": "KEYS_ONLY"
+            },
+            "eventID": "<event-i-d:6>",
+            "eventName": "REMOVE",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Ongoing work to optimize DynamoDB performance.

<!-- What notable changes does this PR make? -->
## Changes
- remove the check for Lambda ESM:
  - this is actually not needed, because lambda can only subscribe to a dynamodb stream, [which is what is passed to `CreateEventSourceMapping`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial.html#Streams.Lambda.Tutorial.CreateTrigger). Our check was passing the table ARN, when it should have been the stream ARN, so it never actually returned a result. We have a better in-memory internal way to check if the table has a stream attached, so we should use this (there's actually no public API for DynamoDBStreams).
- optimize the `BatchWriteItem` operation. We would do operations that would have needed to be done only if a stream was attached all the time. Changed those operations to be done only if needed. Refactored the code. (We should still optimize it later on with some batch read, but the priority is performance when no streams are attached).

## Testing

Benchmarks were done and show that an empty provider implementation with only forwarding is as fast as this PR, which provides:
- 1.85x increase in throughput for `PutItem`
- 8.25x increase for `BatchWrite` with batch size = `10`
- 12x increase for `BatchWrite` with batch size = `25`

Small results from the benchmark with LocalStack running in Docker on macOS:
- put 500 items with PutItem = 10.55s -> ~5.5 +-0.1
- put 5000 items with BatchWriteItem = 62s -> 7.6s (to put it in perspective, reducing the time to seed 600k records from 2hrs to 15min)
- put 12500 items with BatchWriteItem = 120s -> 10.2s (which further reduces it from 1h36 to 8min)

## TODO

What's left to do:

- [x] write AWS validated tests to validate the DDB Streams forwarding changes
- [x] write more test around BatchItemWrite to validate behaviour changes


_related issue #1205_