### PR TITLE
fix inter services IAM for S3 Notifications

### DIFF
--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -492,9 +492,7 @@ class SqsNotifier(BaseNotifier):
         queue_arn = config["QueueArn"]
 
         parsed_arn = parse_arn(queue_arn)
-        sqs_client = connect_to(
-            aws_access_key_id=parsed_arn["account"], region_name=parsed_arn["region"]
-        ).sqs.request_metadata(
+        sqs_client = connect_to(region_name=parsed_arn["region"]).sqs.request_metadata(
             source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
         )
         try:
@@ -575,9 +573,7 @@ class SnsNotifier(BaseNotifier):
         topic_arn = config["TopicArn"]
 
         arn_data = parse_arn(topic_arn)
-        sns_client = connect_to(
-            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
-        ).sns.request_metadata(
+        sns_client = connect_to(region_name=arn_data["region"]).sns.request_metadata(
             source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
         )
         try:
@@ -636,9 +632,7 @@ class LambdaNotifier(BaseNotifier):
 
         arn_data = parse_arn(lambda_arn)
 
-        lambda_client = connect_to(
-            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
-        ).lambda_.request_metadata(
+        lambda_client = connect_to(region_name=arn_data["region"]).lambda_.request_metadata(
             source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
         )
         lambda_function_config = arns.lambda_function_name(lambda_arn)
@@ -757,8 +751,10 @@ class EventBridgeNotifier(BaseNotifier):
     def notify(self, ctx: S3EventNotificationContext, config: EventBridgeConfiguration):
         # does not require permissions
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-permissions.html
+        # the account_id should be the bucket owner
+        # - account — The 12-digit AWS account ID of the bucket owner.
         events_client = connect_to(
-            aws_access_key_id=ctx.account_id, region_name=ctx.bucket_location
+            aws_access_key_id=ctx.bucket_account_id, region_name=ctx.bucket_location
         ).events
         entry = self._get_event_payload(ctx)
         try:

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -467,9 +467,7 @@ class SqsNotifier(BaseNotifier):
             )
         # send test event with the request metadata for permissions
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types
-        sqs_client = connect_to(
-            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
-        ).sqs.request_metadata(
+        sqs_client = connect_to(region_name=arn_data["region"]).sqs.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )
@@ -541,9 +539,7 @@ class SnsNotifier(BaseNotifier):
                 value="The destination topic does not exist",
             )
 
-        sns_client = connect_to(
-            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
-        ).sns.request_metadata(
+        sns_client = connect_to(region_name=arn_data["region"]).sns.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )
@@ -620,9 +616,7 @@ class LambdaNotifier(BaseNotifier):
                 name=target_arn,
                 value="The destination Lambda does not exist",
             )
-        lambda_client = connect_to(
-            aws_access_key_id=arn_data["account"], region_name=arn_data["region"]
-        ).lambda_.request_metadata(
+        lambda_client = connect_to(region_name=arn_data["region"]).lambda_.request_metadata(
             source_arn=s3_bucket_arn(verification_ctx.bucket_name),
             service_principal=ServicePrincipal.s3,
         )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from  #9370, to add proper region support to S3 notifications, I've added the region to the client's creation, but also added the account id as done in #9023 for sending notifications. I'll trigger an -ext run on this PR and link it here. Sorry!

https://github.com/localstack/localstack-ext/actions/runs/6582528350

https://github.com/localstack/localstack-ext/runs/17885245621
S3 notifications are fixed, only appsync remains

<!-- What notable changes does this PR make? -->
## Changes
Remove the account id from the client creation to trigger test event.

Also removed the account id from the client's creation to send to SQS/Lambda/SNS. But this might create issue again with multi account? \cc @viren-nadkarni why was this change made in the first place?

I believe that SNS/Lambda/SQS will retrieve the account id from the ARN passed and not from the credentials of the request to then retrieve the resource in their store, is that right?

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

