### PR TITLE
add multi account support to failing tests in apigateway-sqs integration

### DIFF
--- a/localstack/utils/aws/resources.py
+++ b/localstack/utils/aws/resources.py
@@ -7,12 +7,6 @@ from localstack.utils.functions import run_safe
 from localstack.utils.sync import poll_condition
 
 
-def create_sqs_queue(queue_name, region_name: str = None, account_id: str = None):
-    return connect_to(aws_access_key_id=account_id, region_name=region_name).sqs.create_queue(
-        QueueName=queue_name
-    )
-
-
 # TODO: make s3_client mandatory
 def get_or_create_bucket(bucket_name: str, s3_client=None):
     s3_client = s3_client or connect_to().s3

--- a/localstack/utils/aws/resources.py
+++ b/localstack/utils/aws/resources.py
@@ -7,8 +7,10 @@ from localstack.utils.functions import run_safe
 from localstack.utils.sync import poll_condition
 
 
-def create_sqs_queue(queue_name):
-    return connect_to().sqs.create_queue(QueueName=queue_name)
+def create_sqs_queue(queue_name, region_name: str = None, account_id: str = None):
+    return connect_to(aws_access_key_id=account_id, region_name=region_name).sqs.create_queue(
+        QueueName=queue_name
+    )
 
 
 # TODO: make s3_client mandatory

--- a/tests/aws/services/apigateway/test_apigateway_sqs.py
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.py
@@ -7,8 +7,7 @@ import requests
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs, path_based_url
 from localstack.testing.pytest import markers
-from localstack.utils.aws import arns, queries
-from localstack.utils.aws import resources as resource_util
+from localstack.utils.aws import queries
 from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
 from localstack.utils.xml import is_valid_xml
@@ -18,21 +17,16 @@ from tests.aws.services.apigateway.test_apigateway_basic import TEST_STAGE_NAME
 
 
 @markers.aws.unknown
-def test_api_gateway_sqs_integration(aws_client):
-    # create target SQS stream'
+def test_api_gateway_sqs_integration(aws_client, sqs_create_queue, sqs_get_queue_arn):
+    # create target SQS stream
     queue_name = f"queue-{short_uid()}"
-    queue_arn = arns.sqs_queue_arn(
-        queue_name, region_name=TEST_AWS_REGION_NAME, account_id=TEST_AWS_ACCOUNT_ID
-    )
-    resource_util.create_sqs_queue(
-        queue_name, account_id=TEST_AWS_ACCOUNT_ID, region_name=TEST_AWS_REGION_NAME
-    )
+    sqs_create_queue(QueueName=queue_name)
 
     # create API Gateway and connect it to the target queue
     result = connect_api_gateway_to_sqs(
         "test_gateway4",
         stage_name=TEST_STAGE_NAME,
-        queue_arn=queue_arn,
+        queue_arn=queue_name,
         path="/data",
         account_id=TEST_AWS_ACCOUNT_ID,
         region_name=TEST_AWS_REGION_NAME,
@@ -49,6 +43,7 @@ def test_api_gateway_sqs_integration(aws_client):
     result = requests.post(url, data=json.dumps(test_data))
     assert 200 == result.status_code
 
+    queue_arn = sqs_get_queue_arn(queue_name)
     messages = queries.sqs_receive_message(queue_arn)["Messages"]
     assert 1 == len(messages)
     assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, sns tests should still create the consequent resources in this accounts and region.


<!-- What notable changes does this PR make? -->
## Changes
This PR fixes `tests.aws.services.apigateway.test_apigateway_sqs` test cases when using non-default region and account id by:
- fixing `create_sqs_queue`, adding `region_name` and `aws_access_key_id` to the `connect_to()` client. 
- use queue arn for various sqs operations, this helps us fetching correct region and account id from arn instead of falling back to the default values. 
- remove `create_sqs_queue` in `localstack/utils/aws/resources.py`.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

