### PR TITLE
Cfn: Add account ID and region awareness to Stacks and StackChangeSets

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -335,7 +335,7 @@ class StackChangeSet(Stack):
             template = {}
         if params is None:
             params = {}
-        super(StackChangeSet, self).__init__(params, template)
+        super(StackChangeSet, self).__init__(account_id, region_name, params, template)
 
         name = self.metadata["ChangeSetName"]
         if not self.metadata.get("ChangeSetId"):

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -62,10 +62,15 @@ class StackTemplate(TypedDict):
 class Stack:
     def __init__(
         self,
+        account_id: str,
+        region_name: str,
         metadata: Optional[StackMetadata] = None,
         template: Optional[StackTemplate] = None,
         template_body: Optional[str] = None,
     ):
+        self.account_id = account_id
+        self.region_name = region_name
+
         if template is None:
             template = {}
 
@@ -85,7 +90,10 @@ class Stack:
             ] = (resource.get("LogicalResourceId") or resource_id)
         # initialize stack template attributes
         stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
-            self.stack_name, short_uid()
+            self.stack_name,
+            short_uid(),
+            account_id=account_id,
+            region_name=region_name,
         )
         self.template["StackId"] = self.metadata["StackId"] = stack_id
         self.template["Parameters"] = self.template.get("Parameters") or {}
@@ -312,12 +320,17 @@ class Stack:
         return resource
 
     def copy(self):
-        return Stack(metadata=dict(self.metadata), template=dict(self.template))
+        return Stack(
+            account_id=self.account_id,
+            region_name=self.region_name,
+            metadata=dict(self.metadata),
+            template=dict(self.template),
+        )
 
 
 # FIXME: remove inheritance
 class StackChangeSet(Stack):
-    def __init__(self, stack: Stack, params=None, template=None):
+    def __init__(self, account_id: str, region_name: str, stack: Stack, params=None, template=None):
         if template is None:
             template = {}
         if params is None:
@@ -326,8 +339,12 @@ class StackChangeSet(Stack):
 
         name = self.metadata["ChangeSetName"]
         if not self.metadata.get("ChangeSetId"):
-            self.metadata["ChangeSetId"] = arns.cf_change_set_arn(name, change_set_id=short_uid())
+            self.metadata["ChangeSetId"] = arns.cf_change_set_arn(
+                name, change_set_id=short_uid(), account_id=account_id, region_name=region_name
+            )
 
+        self.account_id = account_id
+        self.region_name = region_name
         self.stack = stack
         self.metadata["StackId"] = stack.stack_id
         self.metadata["Status"] = "CREATE_PENDING"

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -203,7 +203,7 @@ class CloudformationProvider(CloudformationApi):
         )
 
         # handle conditions
-        stack = Stack(request, template)
+        stack = Stack(context.account_id, context.region, request, template)
 
         try:
             template = template_preparer.transform_template(
@@ -228,7 +228,7 @@ class CloudformationProvider(CloudformationApi):
             state.stacks[stack.stack_id] = stack
             return CreateStackOutput(StackId=stack.stack_id)
 
-        stack = Stack(request, template)
+        stack = Stack(context.account_id, context.region, request, template)
 
         # resolve conditions
         raw_conditions = template.get("Conditions", {})
@@ -341,7 +341,7 @@ class CloudformationProvider(CloudformationApi):
 
         deployer = template_deployer.TemplateDeployer(context.account_id, context.region, stack)
         # TODO: there shouldn't be a "new" stack on update
-        new_stack = Stack(request, template)
+        new_stack = Stack(context.account_id, context.region, request, template)
         new_stack.set_resolved_parameters(resolved_parameters)
         stack.set_resolved_parameters(resolved_parameters)
         stack.set_resolved_stack_conditions(resolved_stack_conditions)
@@ -442,7 +442,7 @@ class CloudformationProvider(CloudformationApi):
             api_utils.prepare_template_body(request)
             template = template_preparer.parse_template(request["TemplateBody"])
             request["StackName"] = "tmp-stack"
-            stack = Stack(request, template)
+            stack = Stack(context.account_id, context.region, request, template)
 
         result: GetTemplateSummaryOutput = stack.describe_details()
 
@@ -540,6 +540,8 @@ class CloudformationProvider(CloudformationApi):
             empty_stack_template["Resources"] = {}
             req_params_copy = clone_stack_params(req_params)
             stack = Stack(
+                context.account_id,
+                context.region,
                 req_params_copy,
                 empty_stack_template,
                 template_body=template_body,
@@ -574,7 +576,7 @@ class CloudformationProvider(CloudformationApi):
         #   currently we need to create a stack with existing resources + parameters so that resolve refs recursively in here will work.
         #   The correct way to do it would be at a later stage anyway just like a normal intrinsic function
         req_params_copy = clone_stack_params(req_params)
-        temp_stack = Stack(req_params_copy, template)
+        temp_stack = Stack(context.account_id, context.region, req_params_copy, template)
         temp_stack.set_resolved_parameters(resolved_parameters)
 
         # TODO: everything below should be async
@@ -592,7 +594,9 @@ class CloudformationProvider(CloudformationApi):
         )
 
         # create change set for the stack and apply changes
-        change_set = StackChangeSet(stack, req_params, transformed_template)
+        change_set = StackChangeSet(
+            context.account_id, context.region, stack, req_params, transformed_template
+        )
         # only set parameters for the changeset, then switch to stack on execute_change_set
         change_set.set_resolved_parameters(resolved_parameters)
 


### PR DESCRIPTION
This PR ensures that CloudFormation Stacks and StackChangeSets have the correct ARNs when used in multi-account and multi-region setups.