### PR TITLE
fix s3 v3 EncodingType in List* operations

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1296,8 +1296,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         is_truncated = False
         next_key_marker = None
         max_keys = max_keys or 1000
-        prefix = urlparse.quote(prefix or "")
-        delimiter = urlparse.quote(delimiter or "")
+        if encoding_type:
+            prefix = urlparse.quote(prefix or "")
+            delimiter = urlparse.quote(delimiter or "")
 
         s3_objects: list[Object] = []
 
@@ -1311,7 +1312,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                     next_key_marker = s3_objects[-1]["Key"]
                 break
 
-            key = urlparse.quote(s3_object.key)
+            key = urlparse.quote(s3_object.key) if encoding_type else s3_object.key
             # skip all keys that alphabetically come before key_marker
             if marker:
                 if key <= marker:
@@ -1354,12 +1355,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             IsTruncated=is_truncated,
             Name=bucket,
             MaxKeys=max_keys,
-            EncodingType=EncodingType.url,
             Prefix=prefix or "",
             Marker=marker or "",
         )
         if s3_objects:
             response["Contents"] = s3_objects
+        if encoding_type:
+            response["EncodingType"] = EncodingType.url
         if delimiter:
             response["Delimiter"] = delimiter
         if common_prefixes:
@@ -1397,8 +1399,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         is_truncated = False
         next_continuation_token = None
         max_keys = max_keys or 1000
-        prefix = urlparse.quote(prefix or "")
-        delimiter = urlparse.quote(delimiter or "")
+        if encoding_type:
+            prefix = urlparse.quote(prefix or "")
+            delimiter = urlparse.quote(delimiter or "")
         decoded_continuation_token = (
             to_str(base64.urlsafe_b64decode(continuation_token.encode()))
             if continuation_token
@@ -1412,7 +1415,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         all_objects.sort(key=lambda r: r.key)
 
         for s3_object in all_objects:
-            key = urlparse.quote(s3_object.key)
+            key = urlparse.quote(s3_object.key) if encoding_type else s3_object.key
             # skip all keys that alphabetically come before key_marker
             # TODO: what if there's StartAfter AND ContinuationToken
             if continuation_token:
@@ -1466,12 +1469,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             IsTruncated=is_truncated,
             Name=bucket,
             MaxKeys=max_keys,
-            EncodingType=EncodingType.url,
             Prefix=prefix or "",
             KeyCount=count,
         )
         if s3_objects:
             response["Contents"] = s3_objects
+        if encoding_type:
+            response["EncodingType"] = EncodingType.url
         if delimiter:
             response["Delimiter"] = delimiter
         if common_prefixes:
@@ -1510,8 +1514,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         next_key_marker = None
         next_version_id_marker = None
         max_keys = max_keys or 1000
-        prefix = urlparse.quote(prefix or "")
-        delimiter = urlparse.quote(delimiter or "")
+        if encoding_type:
+            prefix = urlparse.quote(prefix or "")
+            delimiter = urlparse.quote(delimiter or "")
 
         object_versions: list[ObjectVersion] = []
         delete_markers: list[DeleteMarkerEntry] = []
@@ -1521,7 +1526,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         all_versions.sort(key=lambda r: (r.key, -r.last_modified.timestamp()))
 
         for version in all_versions:
-            key = urlparse.quote(version.key)
+            key = urlparse.quote(version.key) if encoding_type else version.key
             # skip all keys that alphabetically come before key_marker
             if key_marker:
                 if key < key_marker:
@@ -1588,13 +1593,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             IsTruncated=is_truncated,
             Name=bucket,
             MaxKeys=max_keys,
-            EncodingType=EncodingType.url,
             Prefix=prefix,
             KeyMarker=key_marker or "",
             VersionIdMarker=version_id_marker or "",
         )
         if object_versions:
             response["Versions"] = object_versions
+        if encoding_type:
+            response["EncodingType"] = EncodingType.url
         if delete_markers:
             response["DeleteMarkers"] = delete_markers
         if delimiter:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1296,9 +1296,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         is_truncated = False
         next_key_marker = None
         max_keys = max_keys or 1000
+        prefix = prefix or ""
+        delimiter = delimiter or ""
         if encoding_type:
-            prefix = urlparse.quote(prefix or "")
-            delimiter = urlparse.quote(delimiter or "")
+            prefix = urlparse.quote(prefix)
+            delimiter = urlparse.quote(delimiter)
 
         s3_objects: list[Object] = []
 
@@ -1399,9 +1401,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         is_truncated = False
         next_continuation_token = None
         max_keys = max_keys or 1000
+        prefix = prefix or ""
+        delimiter = delimiter or ""
         if encoding_type:
-            prefix = urlparse.quote(prefix or "")
-            delimiter = urlparse.quote(delimiter or "")
+            prefix = urlparse.quote(prefix)
+            delimiter = urlparse.quote(delimiter)
         decoded_continuation_token = (
             to_str(base64.urlsafe_b64decode(continuation_token.encode()))
             if continuation_token
@@ -1514,9 +1518,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         next_key_marker = None
         next_version_id_marker = None
         max_keys = max_keys or 1000
+        prefix = prefix or ""
+        delimiter = delimiter or ""
         if encoding_type:
-            prefix = urlparse.quote(prefix or "")
-            delimiter = urlparse.quote(delimiter or "")
+            prefix = urlparse.quote(prefix)
+            delimiter = urlparse.quote(delimiter)
 
         object_versions: list[ObjectVersion] = []
         delete_markers: list[DeleteMarkerEntry] = []

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -571,7 +571,7 @@ class TestS3:
         snapshot.match("list-object-encoded-char", resp)
 
     @markers.aws.validated
-    @pytest.mark.parametrize("delimiter", ["/", "%2F"])
+    @pytest.mark.parametrize("delimiter", ["", "/", "%2F"])
     def test_list_objects_with_prefix(
         self, s3_bucket, delimiter, snapshot, aws_client, aws_http_client_factory
     ):

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -230,7 +230,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_with_prefix[/]": {
-    "recorded-date": "22-10-2023, 00:13:16",
+    "recorded-date": "23-10-2023, 18:32:23",
     "recorded-content": {
       "list-objects": {
         "CommonPrefixes": [
@@ -253,7 +253,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_with_prefix[%2F]": {
-    "recorded-date": "22-10-2023, 00:13:19",
+    "recorded-date": "23-10-2023, 18:32:25",
     "recorded-content": {
       "list-objects": {
         "Contents": [
@@ -10466,6 +10466,36 @@
         "Key": "test.file",
         "Location": "<location:1>",
         "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_with_prefix[]": {
+    "recorded-date": "23-10-2023, 18:32:21",
+    "recorded-content": {
+      "list-objects": {
+        "Contents": [
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 1,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -230,7 +230,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_with_prefix[/]": {
-    "recorded-date": "03-08-2023, 04:13:39",
+    "recorded-date": "22-10-2023, 00:13:16",
     "recorded-content": {
       "list-objects": {
         "CommonPrefixes": [
@@ -253,7 +253,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_with_prefix[%2F]": {
-    "recorded-date": "03-08-2023, 04:13:41",
+    "recorded-date": "22-10-2023, 00:13:19",
     "recorded-content": {
       "list-objects": {
         "Contents": [
@@ -279,6 +279,19 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-no-encoding": {
+        "ListBucketResult": {
+          "CommonPrefixes": {
+            "Prefix": "test/"
+          },
+          "Delimiter": "/",
+          "IsTruncated": "false",
+          "Marker": null,
+          "MaxKeys": "1000",
+          "Name": "<bucket-name:1>",
+          "Prefix": "test"
         }
       }
     }
@@ -4919,7 +4932,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_versions_with_prefix": {
-    "recorded-date": "04-08-2023, 23:47:58",
+    "recorded-date": "22-10-2023, 00:29:59",
     "recorded-content": {
       "list-object-version-1": {
         "CommonPrefixes": [
@@ -5130,6 +5143,20 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-versions-no-encoding": {
+        "ListVersionsResult": {
+          "CommonPrefixes": {
+            "Prefix": "dir/subdir/"
+          },
+          "Delimiter": "/",
+          "IsTruncated": "false",
+          "KeyMarker": null,
+          "MaxKeys": "1000",
+          "Name": "<bucket-name:1>",
+          "Prefix": "dir/subdir",
+          "VersionIdMarker": null
         }
       }
     }
@@ -5512,62 +5539,8 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[None]": {
-    "recorded-date": "28-03-2023, 12:25:25",
-    "recorded-content": {}
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[/]": {
-    "recorded-date": "28-03-2023, 12:25:27",
-    "recorded-content": {
-      "list-objects-v2": {
-        "CommonPrefixes": [
-          {
-            "Prefix": "test/foo/"
-          }
-        ],
-        "Delimiter": "/",
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "KeyCount": 1,
-        "MaxKeys": 1000,
-        "Name": "<bucket-name:1>",
-        "Prefix": "test/",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[%2F]": {
-    "recorded-date": "28-03-2023, 12:25:30",
-    "recorded-content": {
-      "list-objects-v2": {
-        "Contents": [
-          {
-            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123",
-            "LastModified": "datetime",
-            "Size": 11,
-            "StorageClass": "STANDARD"
-          }
-        ],
-        "Delimiter": "%252F",
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "KeyCount": 1,
-        "MaxKeys": 1000,
-        "Name": "<bucket-name:1>",
-        "Prefix": "test/",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix": {
-    "recorded-date": "03-08-2023, 04:13:48",
+    "recorded-date": "22-10-2023, 00:35:27",
     "recorded-content": {
       "list-objects-v2-1": {
         "Contents": [
@@ -5637,6 +5610,22 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-no-encoding": {
+        "ListBucketResult": {
+          "Contents": {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123test/foo/bar/456",
+            "LastModified": "date",
+            "Size": "11",
+            "StorageClass": "STANDARD"
+          },
+          "IsTruncated": "false",
+          "KeyCount": "1",
+          "MaxKeys": "1000",
+          "Name": "<bucket-name:1>",
+          "Prefix": "test/foo"
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -1626,6 +1626,9 @@ class TestS3BucketPolicy:
             aws_client.s3.get_bucket_policy(Bucket=s3_bucket)
         snapshot.match("get-bucket-policy-after-delete", e.value.response)
 
+        response = aws_client.s3.delete_bucket_policy(Bucket=s3_bucket)
+        snapshot.match("delete-bucket-policy-after-delete", response)
+
     @markers.aws.validated
     @pytest.mark.xfail(
         condition=not config.NATIVE_S3_PROVIDER,

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2514,7 +2514,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketPolicy::test_bucket_policy_crud": {
-    "recorded-date": "10-08-2023, 17:27:26",
+    "recorded-date": "20-10-2023, 17:31:38",
     "recorded-content": {
       "get-bucket-default-policy": {
         "Error": {
@@ -2567,6 +2567,12 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      },
+      "delete-bucket-policy-after-delete": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9427, we would return `EncodingType` even when not specified. It was because of a wrong assumption on my side because boto always adds the parameter, which seemed like it was default.

<!-- What notable changes does this PR make? -->
## Changes
Corrected the behaviour and validated it by using an HTTP client instead of boto and manually asserting the absence of the `EncodingType` field and the change in behaviour. 

Also sneaked a tiny test for `DeleteBucketPolicy` validating a question here: https://github.com/localstack/localstack/pull/9404#discussion_r1367149857

_fixes #9427_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

