### PR TITLE
add test for DeleteObjects encoding

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3288,6 +3288,7 @@ class TestS3:
                 ],
             },
         )
+        response["Deleted"].sort(key=itemgetter("Key"))
         snapshot.match("deleted-resp", response)
 
         list_objects = aws_client.s3.list_objects_v2(Bucket=s3_bucket)

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3269,6 +3269,10 @@ class TestS3:
         snapshot.match("error-non-existent-bucket", e.value.response)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=not config.NATIVE_S3_PROVIDER,
+        reason="Issue in moto, see https://github.com/getmoto/moto/pull/6933",
+    )
     def test_delete_objects_encoding(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("Name"))
         object_key_1 = "a%2Fb"

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3276,6 +3276,9 @@ class TestS3:
         aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key_1, Body="percent encoding")
         aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key_2, Body="percent encoded emoji")
 
+        list_objects = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects-before-delete", list_objects)
+
         response = aws_client.s3.delete_objects(
             Bucket=s3_bucket,
             Delete={

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3269,6 +3269,28 @@ class TestS3:
         snapshot.match("error-non-existent-bucket", e.value.response)
 
     @markers.aws.validated
+    def test_delete_objects_encoding(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        object_key_1 = "a%2Fb"
+        object_key_2 = "a/%F0%9F%98%80"
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key_1, Body="percent encoding")
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key_2, Body="percent encoded emoji")
+
+        response = aws_client.s3.delete_objects(
+            Bucket=s3_bucket,
+            Delete={
+                "Objects": [
+                    {"Key": object_key_1},
+                    {"Key": object_key_2},
+                ],
+            },
+        )
+        snapshot.match("deleted-resp", response)
+
+        list_objects = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects", list_objects)
+
+    @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         condition=lambda: not is_native_provider(),
         paths=[

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11240,10 +11240,10 @@
       "deleted-resp": {
         "Deleted": [
           {
-            "Key": "a/%F0%9F%98%80"
+            "Key": "a%2Fb"
           },
           {
-            "Key": "a%2Fb"
+            "Key": "a/%F0%9F%98%80"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11205,5 +11205,36 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_delete_objects_encoding": {
+    "recorded-date": "22-10-2023, 01:19:54",
+    "recorded-content": {
+      "deleted-resp": {
+        "Deleted": [
+          {
+            "Key": "a%2Fb"
+          },
+          {
+            "Key": "a/%F0%9F%98%80"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 0,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11207,15 +11207,43 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_delete_objects_encoding": {
-    "recorded-date": "22-10-2023, 01:19:54",
+    "recorded-date": "22-10-2023, 04:25:14",
     "recorded-content": {
+      "list-objects-before-delete": {
+        "Contents": [
+          {
+            "ETag": "\"1ac438708eff428b768f07249b3e2bb2\"",
+            "Key": "a%2Fb",
+            "LastModified": "datetime",
+            "Size": 16,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"ec53baa61c0c0b736a567bdef59250f3\"",
+            "Key": "a/%F0%9F%98%80",
+            "LastModified": "datetime",
+            "Size": 21,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 2,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "deleted-resp": {
         "Deleted": [
           {
-            "Key": "a%2Fb"
+            "Key": "a/%F0%9F%98%80"
           },
           {
-            "Key": "a/%F0%9F%98%80"
+            "Key": "a%2Fb"
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9428, there's an issue with the URL encoding of S3 object keys. This is an issue in moto, and it's working properly in our `v3` provider.

I have a PR open here: https://github.com/getmoto/moto/pull/6933 but there's still some issue. This PR would only be green once the upstream fix is part of moto-ext, so I will `xfail` it for `v2` until the PR is merged as it's a big change (it requires moto to use `RAW_URI` as well and change how to handle raw path with the update of werkzeug, they are manually re-encoding the path and it has some drawbacks for some edge cases like emoji), knowing that `v3` is going to become default soon so I'd like to have it tested already now.

<!-- What notable changes does this PR make? -->
## Changes
Only introducing tests to validate the proper behaviour. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

