### PR TITLE
apigateway: add multi-account and region capability

### DIFF
--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -322,5 +322,5 @@ class OpenApiExporter:
     ) -> str:
         exporter = self.exporters.get(export_type)()
         return exporter.export(
-            api_id, stage, export_format, with_extension, region_name, account_id
+            api_id, stage, export_format, with_extension, account_id, region_name
         )

--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -64,8 +64,8 @@ class _BaseOpenApiExporter(abc.ABC):
         stage: str,
         export_format: str,
         with_extension: bool,
-        region_name: str = None,
         account_id: str = None,
+        region_name: str = None,
     ) -> str | dict:
         ...
 
@@ -160,8 +160,8 @@ class _OpenApiSwaggerExporter(_BaseOpenApiExporter):
         stage: str,
         export_format: str,
         with_extension: bool,
-        region_name: str = None,
         account_id: str = None,
+        region_name: str = None,
     ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
@@ -267,8 +267,8 @@ class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
         stage: str,
         export_format: str,
         with_extension: bool,
-        region_name: str = None,
         account_id: str = None,
+        region_name: str = None,
     ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
@@ -317,8 +317,8 @@ class OpenApiExporter:
         export_type: str,
         export_format: str = "application/json",
         with_extension=False,
-        region_name: str = None,
         account_id: str = None,
+        region_name: str = None,
     ) -> str:
         exporter = self.exporters.get(export_type)()
         return exporter.export(

--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -59,7 +59,13 @@ class _BaseOpenApiExporter(abc.ABC):
 
     @abc.abstractmethod
     def export(
-        self, api_id: str, stage: str, export_format: str, with_extension: bool
+        self,
+        api_id: str,
+        stage: str,
+        export_format: str,
+        with_extension: bool,
+        region_name: str = None,
+        account_id: str = None,
     ) -> str | dict:
         ...
 
@@ -148,11 +154,21 @@ class _OpenApiSwaggerExporter(_BaseOpenApiExporter):
 
                 spec.path(path=path, operations={method: method_operations})
 
-    def export(self, api_id: str, stage: str, export_format: str, with_extension: bool) -> str:
+    def export(
+        self,
+        api_id: str,
+        stage: str,
+        export_format: str,
+        with_extension: bool,
+        region_name: str = None,
+        account_id: str = None,
+    ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
         """
-        apigateway_client = connect_to().apigateway
+        apigateway_client = connect_to(
+            aws_access_key_id=account_id, region_name=region_name
+        ).apigateway
 
         rest_api = apigateway_client.get_rest_api(restApiId=api_id)
         resources = apigateway_client.get_resources(restApiId=api_id)
@@ -245,11 +261,21 @@ class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
 
                 spec.path(path=path, operations={method: method_operations})
 
-    def export(self, api_id: str, stage: str, export_format: str, with_extension: bool) -> str:
+    def export(
+        self,
+        api_id: str,
+        stage: str,
+        export_format: str,
+        with_extension: bool,
+        region_name: str = None,
+        account_id: str = None,
+    ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
         """
-        apigateway_client = connect_to().apigateway
+        apigateway_client = connect_to(
+            aws_access_key_id=account_id, region_name=region_name
+        ).apigateway
 
         rest_api = apigateway_client.get_rest_api(restApiId=api_id)
         resources = apigateway_client.get_resources(restApiId=api_id)
@@ -291,6 +317,10 @@ class OpenApiExporter:
         export_type: str,
         export_format: str = "application/json",
         with_extension=False,
+        region_name: str = None,
+        account_id: str = None,
     ) -> str:
         exporter = self.exporters.get(export_type)()
-        return exporter.export(api_id, stage, export_format, with_extension)
+        return exporter.export(
+            api_id, stage, export_format, with_extension, region_name, account_id
+        )

--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -64,8 +64,8 @@ class _BaseOpenApiExporter(abc.ABC):
         stage: str,
         export_format: str,
         with_extension: bool,
-        account_id: str = None,
-        region_name: str = None,
+        account_id: str,
+        region_name: str,
     ) -> str | dict:
         ...
 
@@ -160,8 +160,8 @@ class _OpenApiSwaggerExporter(_BaseOpenApiExporter):
         stage: str,
         export_format: str,
         with_extension: bool,
-        account_id: str = None,
-        region_name: str = None,
+        account_id: str,
+        region_name: str,
     ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
@@ -267,8 +267,8 @@ class _OpenApiOAS30Exporter(_BaseOpenApiExporter):
         stage: str,
         export_format: str,
         with_extension: bool,
-        account_id: str = None,
-        region_name: str = None,
+        account_id: str,
+        region_name: str,
     ) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
@@ -315,10 +315,11 @@ class OpenApiExporter:
         api_id: str,
         stage: str,
         export_type: str,
+        account_id: str,
+        region_name: str,
         export_format: str = "application/json",
         with_extension=False,
-        account_id: str = None,
-        region_name: str = None,
+
     ) -> str:
         exporter = self.exporters.get(export_type)()
         return exporter.export(

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1836,8 +1836,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             export_type=export_type,
             export_format=accepts,
             with_extension=has_extension,
-            region_name=context.region,
             account_id=context.account_id,
+            region_name=context.region,
         )
 
         accepts = accepts or APPLICATION_JSON

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1836,6 +1836,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             export_type=export_type,
             export_format=accepts,
             with_extension=has_extension,
+            region_name=context.region,
+            account_id=context.account_id,
         )
 
         accepts = accepts or APPLICATION_JSON


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, tests should still create the consequent resources in this accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR fixes all the failing tests in `tests/aws/services/apigateway/test_apigateway_extended.py` by adding region and account id to the helper functions.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

