### PR TITLE
fix ASF update action if there are no changes

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           source .venv/bin/activate
           python3 -m localstack.aws.scaffold upgrade
-          make format-modified
 
       - name: Check for changes
         id: check-for-changes
@@ -59,6 +58,12 @@ jobs:
           echo "changed-services<<EOF" >> $GITHUB_OUTPUT
           echo "$(git diff --name-only origin/master localstack/aws/api/ | sed 's#localstack/aws/api/#- #g' | sed 's#/__init__.py##g' | sed 's/_/-/g')" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Format code
+        if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}
+        run: |
+          # execute the format-modified target (only if we have changes, otherwise the black invocation fails)
+          make format-modified
 
       - name: Read PR markdown template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack-ext/pull/2217, we changed to `ruff` which replaces a bunch of tools (`flake8`, `isort`, `autoflake`). Previously, these tools were directly called in the ASF scaffold and the result of the code generation was already perfectly formatted.
`ruff` cannot be called from Python code on in-memory strings, which is why we switched to our `format-modified` `make` target.
Turns out, the target does not work in case there are no changes (since then black does not get any input).
This PR slightly modifies the ASF update action such that this issue is prevented.

## Changes
- Changes the ASF Update action such that the `format-modified` target is only executed if there are changes in the repo.

## Testing
- [x] We will execute the action from this branch. Since there currently no changes, this change is safe if the action run is successful.
  - https://github.com/localstack/localstack/actions/runs/6610132434/job/17951451836 💚 