### PR TITLE
add iter_stores method to AccountRegionBundle

### DIFF
--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -32,7 +32,7 @@ While not recommended, store classes may define member helper functions and prop
 import re
 from collections.abc import Callable
 from threading import RLock
-from typing import Any, Generic, Type, TypeVar, Union
+from typing import Any, Generic, Iterator, Type, TypeVar, Union
 
 from localstack import config
 from localstack.utils.aws.aws_stack import get_valid_regions_for_service
@@ -333,3 +333,14 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
 
         with self.lock:
             self.clear()
+
+    def iter_stores(self) -> Iterator[tuple[str, str, BaseStoreType]]:
+        """
+        Iterate over a flattened view of all stores in this AccountRegionBundle, where each record is a
+        tuple of account id, region name, and the store within that account and region. Example::
+
+        :return: an iterator
+        """
+        for account_id, region_stores in self.items():
+            for region_name, store in region_stores.items():
+                yield account_id, region_name, store


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I need this pattern of iterating over the hierarchy of stores quite often and thought this little quality of life improvement would make code a bit cleaner.

<!-- What notable changes does this PR make? -->
## Changes

* Add `AccountRegionBundle.iter_stores` method to iterate over all stores in the bundle
* Exemplified use on sqs and opensearch

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

