### PR TITLE
Rebase release branches once a day instead of on every push

### DIFF
--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -1,8 +1,8 @@
 name: Rebase Release PRs
 on:
-  push:
-    branches:
-    - master
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 * * MON-FRI
 jobs:
   find-release-branches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The automatic rebase of the release branches is useful, although can get very noisy if we rebase on every commit on master.

With limiting the rebase to once a day (on weekdays), we can limit unnecessary CI spending, while still keeping the release branch reasonable up to date. If someone needs it more current, I also added a workflow dispatch trigger.

Once the change is discussed here, I will do the same in ext.

<!-- What notable changes does this PR make? -->
## Changes
* Remove push event to trigger workflow
* Add workflow_dispatch and a schedule which runs the workflow Monday-Friday at 5am UTC

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

