### PR TITLE
Feat/cloudwatch v2 putalarm describealarms

### DIFF
--- a/localstack/services/cloudwatch/models.py
+++ b/localstack/services/cloudwatch/models.py
@@ -1,22 +1,75 @@
+import datetime
 from typing import Dict
 
 from moto.cloudwatch.models import CloudWatchBackend as MotoCloudWatchBackend
 from moto.cloudwatch.models import cloudwatch_backends as moto_cloudwatch_backend
 
-from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
+from localstack.aws.api.cloudwatch import CompositeAlarm, MetricAlarm, StateValue
+from localstack.services.stores import (
+    AccountRegionBundle,
+    BaseStore,
+    CrossRegionAttribute,
+    LocalAttribute,
+)
+from localstack.utils.aws import arns
 
 
 def get_moto_logs_backend(account_id: str, region_name: str) -> MotoCloudWatchBackend:
     return moto_cloudwatch_backend[account_id][region_name]
 
 
-class CloudWatchStore(BaseStore):
+class LocalStackMetricAlarm:
+    region: str
+    account_id: str
+    alarm: MetricAlarm
 
+    def __init__(self, account_id: str, region: str, alarm: MetricAlarm):
+        self.account_id = account_id
+        self.region = region
+        self.alarm = alarm
+        self.set_default_attributes()
+
+    def set_default_attributes(self):
+        current_time = datetime.datetime.now()
+        self.alarm["AlarmArn"] = arns.cloudwatch_alarm_arn(
+            self.alarm["AlarmName"], account_id=self.account_id, region_name=self.region
+        )
+        self.alarm["AlarmConfigurationUpdatedTimestamp"] = current_time
+        self.alarm.setdefault("ActionsEnabled", True)
+        self.alarm.setdefault("OKActions", [])
+        self.alarm.setdefault("AlarmActions", [])
+        self.alarm.setdefault("InsufficientDataActions", [])
+        self.alarm["StateValue"] = StateValue.INSUFFICIENT_DATA
+        self.alarm["StateReason"] = "Unchecked: Initial alarm creation"
+        self.alarm["StateUpdatedTimestamp"] = current_time
+        self.alarm.setdefault("Dimensions", [])
+        self.alarm["StateTransitionedTimestamp"] = current_time
+
+
+class LocalStackCompositeAlarm:
+    region: str
+    account_id: str
+    alarm: CompositeAlarm
+
+    def __init__(self, account_id: str, region: str, alarm: CompositeAlarm):
+        self.account_id = account_id
+        self.region = region
+        self.alarm = alarm
+        self.set_default_attributes()
+
+    def set_default_attributes(self):
+        # TODO
+        pass
+
+
+class CloudWatchStore(BaseStore):
     # maps resource ARN to tags
     TAGS: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
 
     # maps resource ARN to alarms
-    Alarms: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
+    Alarms: Dict[str, LocalStackMetricAlarm | LocalStackCompositeAlarm] = LocalAttribute(
+        default=dict
+    )
 
 
-logs_stores = AccountRegionBundle("cloudwatch", CloudWatchStore)
+cloudwatch_stores = AccountRegionBundle("cloudwatch", CloudWatchStore)

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -1,11 +1,21 @@
 import logging
 
-from localstack.aws.api import RequestContext
+from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudwatch import (
+    ActionPrefix,
+    AlarmName,
+    AlarmNamePrefix,
     AlarmNames,
+    AlarmTypes,
     AmazonResourceName,
     CloudwatchApi,
+    DescribeAlarmsOutput,
+    InvalidParameterValueException,
     ListTagsForResourceOutput,
+    MaxRecords,
+    NextToken,
+    PutMetricAlarmInput,
+    StateValue,
     TagKeyList,
     TagList,
     TagResourceOutput,
@@ -13,8 +23,14 @@ from localstack.aws.api.cloudwatch import (
 )
 from localstack.http import Request
 from localstack.services.cloudwatch.alarm_scheduler import AlarmScheduler
+from localstack.services.cloudwatch.models import (
+    CloudWatchStore,
+    LocalStackMetricAlarm,
+    cloudwatch_stores,
+)
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceLifecycleHook
+from localstack.utils.aws import arns
 from localstack.utils.sync import poll_condition
 from localstack.utils.tagging import TaggingService
 from localstack.utils.threads import start_worker_thread
@@ -24,6 +40,12 @@ DEPRECATED_PATH_GET_RAW_METRICS = "/cloudwatch/metrics/raw"
 MOTO_INITIAL_UNCHECKED_REASON = "Unchecked: Initial alarm creation"
 
 LOG = logging.getLogger(__name__)
+
+
+class ValidationError(CommonServiceException):
+    # TODO: check this error against AWS (doesn't exist in the API)
+    def __init__(self, message: str):
+        super().__init__("ValidationError", message, 400, True)
 
 
 class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
@@ -38,6 +60,10 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         self.tags = TaggingService()
         self.alarm_scheduler: AlarmScheduler = None
         self.store = None
+
+    @staticmethod
+    def get_store(account_id: str, region: str) -> CloudWatchStore:
+        return cloudwatch_stores[account_id][region]
 
     def on_after_init(self):
         ROUTER.add(PATH_GET_RAW_METRICS, self.get_raw_metrics)
@@ -79,14 +105,97 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         Delete alarms.
         """
 
-        for alarm_name in alarm_names.alarm_names:
-            alarm_arn = ""  # obtain alarm ARN from alarm name
-            self.alarm_scheduler.delete_alarm(alarm_arn)
+        for alarm_name in alarm_names:
+            alarm_arn = arns.cloudwatch_alarm_arn(alarm_name)  # obtain alarm ARN from alarm name
+            self.alarm_scheduler.delete_scheduler_for_alarm(alarm_arn)
 
     def get_raw_metrics(self, request: Request):
         # TODO this needs to be read from the database
         # FIXME this is just a placeholder for now
         return {"metrics": []}
+
+    @handler("PutMetricAlarm", expand=False)
+    def put_metric_alarm(self, context: RequestContext, request: PutMetricAlarmInput) -> None:
+        # missing will be the default, when not set (but it will not explicitly be set)
+        if request.get("TreatMissingData", "missing") not in [
+            "breaching",
+            "notBreaching",
+            "ignore",
+            "missing",
+        ]:
+            raise ValidationError(
+                f"The value {request['TreatMissingData']} is not supported for TreatMissingData parameter. Supported values are [breaching, notBreaching, ignore, missing]."
+            )
+            # do some sanity checks:
+        if request.get("Period"):
+            # Valid values are 10, 30, and any multiple of 60.
+            value = request.get("Period")
+            if value not in (10, 30):
+                if value % 60 != 0:
+                    raise ValidationError("Period must be 10, 30 or a multiple of 60")
+        if request.get("Statistic"):
+            if request.get("Statistic") not in [
+                "SampleCount",
+                "Average",
+                "Sum",
+                "Minimum",
+                "Maximum",
+            ]:
+                raise ValidationError(
+                    f"Value '{request.get('Statistic')}' at 'statistic' failed to satisfy constraint: Member must satisfy enum value set: [Maximum, SampleCount, Sum, Minimum, Average]"
+                )
+
+        extended_statistic = request.get("ExtendedStatistic")
+        if extended_statistic and not extended_statistic.startswith("p"):
+            raise InvalidParameterValueException(
+                f"The value {extended_statistic} for parameter ExtendedStatistic is not supported."
+            )
+        evaluate_low_sample_count_percentile = request.get("EvaluateLowSampleCountPercentile")
+        if evaluate_low_sample_count_percentile and evaluate_low_sample_count_percentile not in (
+            "evaluate",
+            "ignore",
+        ):
+            raise ValidationError(
+                f"Option {evaluate_low_sample_count_percentile} is not supported. "
+                "Supported options for parameter EvaluateLowSampleCountPercentile are evaluate and ignore."
+            )
+
+        store = self.get_store(context.account_id, context.region)
+        metric_alarm = LocalStackMetricAlarm(context.account_id, context.region, {**request})
+        alarm_arn = metric_alarm.alarm["AlarmArn"]
+        store.Alarms[alarm_arn] = metric_alarm
+        self.alarm_scheduler.schedule_metric_alarm(alarm_arn)
+
+    def describe_alarms(
+        self,
+        context: RequestContext,
+        alarm_names: AlarmNames = None,
+        alarm_name_prefix: AlarmNamePrefix = None,
+        alarm_types: AlarmTypes = None,
+        children_of_alarm_name: AlarmName = None,
+        parents_of_alarm_name: AlarmName = None,
+        state_value: StateValue = None,
+        action_prefix: ActionPrefix = None,
+        max_records: MaxRecords = None,
+        next_token: NextToken = None,
+    ) -> DescribeAlarmsOutput:
+        store = self.get_store(context.account_id, context.region)
+        alarms = list(store.Alarms.values())
+        if action_prefix:
+            alarms = [a.alarm for a in alarms if a.alarm["AlarmAction"].startswith(action_prefix)]
+        elif alarm_name_prefix:
+            alarms = [a.alarm for a in alarms if a.alarm["AlarmName"].startswith(alarm_name_prefix)]
+        elif alarm_names:
+            alarms = [a.alarm for a in alarms if a.alarm["AlarmName"] in alarm_names]
+        elif state_value:
+            alarms = [a.alarm for a in alarms if a.alarm["StateValue"] == state_value]
+        else:
+            alarms = [a.alarm for a in list(store.Alarms.values())]
+
+        # TODO: Pagination
+        metric_alarms = [a for a in alarms if a.get("AlarmRule") is None]
+        composite_alarms = [a for a in alarms if a.get("AlarmRule") is not None]
+        return DescribeAlarmsOutput(CompositeAlarms=composite_alarms, MetricAlarms=metric_alarms)
 
     def list_tags_for_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName
@@ -105,4 +214,3 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     ) -> TagResourceOutput:
         self.tags.tag_resource(resource_arn, tags)
         return TagResourceOutput()
-

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1,6 +1,7 @@
 import copy
 import gzip
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from urllib.request import Request, urlopen
 
@@ -12,6 +13,7 @@ from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.services.cloudwatch.provider import PATH_GET_RAW_METRICS
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
+from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import retry, short_uid, to_str
 from localstack.utils.sync import poll_condition
@@ -923,6 +925,31 @@ class TestCloudwatch:
         )
 
         snapshot.match("get_metric_data_2", response)
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") != "v2", reason="New test for v2 provider"
+    )
+    def test_describe_minimal_metric_alarm(self, snapshot, aws_client, cleanups):
+        snapshot.add_transformer(snapshot.transform.cloudwatch_api())
+        alarm_name = f"a-{short_uid()}"
+        metric_name = f"m-{short_uid()}"
+        name_space = f"n-sp-{short_uid()}"
+
+        snapshot.add_transformer(TransformerUtility.key_value("MetricName"))
+        aws_client.cloudwatch.put_metric_alarm(
+            AlarmName=alarm_name,
+            MetricName=metric_name,
+            Namespace=name_space,
+            EvaluationPeriods=1,
+            Period=10,
+            Statistic="Sum",
+            ComparisonOperator="GreaterThanThreshold",
+            Threshold=30,
+        )
+        cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
+        response = aws_client.cloudwatch.describe_alarms(AlarmNames=[alarm_name])
+        snapshot.match("describe_minimal_metric_alarm", response)
 
 
 def _check_alarm_triggered(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -765,5 +765,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_describe_minimal_metric_alarm": {
+    "recorded-date": "25-10-2023, 17:17:06",
+    "recorded-content": {
+      "describe_minimal_metric_alarm": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "<metric-name:1>",
+            "Namespace": "<namespace:1>",
+            "OKActions": [],
+            "Period": 10,
+            "StateReason": "Unchecked: Initial alarm creation",
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "INSUFFICIENT_DATA",
+            "Statistic": "Sum",
+            "Threshold": 30.0
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Port put_metric_alarm and describe_alarms functions for the new CloudWatch V2 Provider

<!-- What notable changes does this PR make? -->
## Changes
- add the described methods, including error checks from both our v1 provider and Moto
- change models: we now have a LocalStackMetricAlarm and a LocalStackCompositeAlarm. This schema is up to debate
- fixed delete_alarms


## TODO
 - [x] clarify how to proceed with data models. Will we introduce an Alarm class similar to SQS and Queue classes? Or will we keep it as dictionaries (seems impractical to me)
 - [ ] Pagination for describe_alarms (our current approach is not well suited for multiple lists)
 - [ ] Clarify failing tests
 

