### PR TITLE
Simplify localstack init user config

### DIFF
--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -155,8 +155,9 @@ class ExecutionEnvironment:
             env_vars.update(self.function_version.config.environment)
         if config.LAMBDA_INIT_DEBUG:
             # Disable dropping privileges because it breaks debugging
-            env_vars["LOCALSTACK_USER"] = ""
-        if config.LAMBDA_INIT_USER:
+            env_vars["LOCALSTACK_USER"] = "root"
+        # Forcefully overwrite the user might break debugging!
+        if config.LAMBDA_INIT_USER is not None:
             env_vars["LOCALSTACK_USER"] = config.LAMBDA_INIT_USER
         if config.DEBUG:
             env_vars["LOCALSTACK_INIT_LOG_LEVEL"] = "debug"

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.22-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.23-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime


### PR DESCRIPTION
Depends on https://github.com/localstack/lambda-runtime-init/pull/26

## Motivation

This PR simplifies the user's configuration in the Lambda init Go binary. We drop root privileges in the Lambda init Go binary by default and offer a configuration variable to skip this parity feature. However, it is cumbersome to configure using a misleading empty string `""`. We skip dropping privileges when `LAMBDA_INIT_USER` is set to `root` (`""` is still supported but discouraged).
This is much easier to configure and leads to less errors around escaping quotes etc.

## Changes

* Bump Lambda init version skipping privileges drop with `root`
* Fix the LocalStack configuration logic for `""`

