### PR TITLE
fix s3 v3 preconditions

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -936,6 +936,8 @@ def validate_failed_precondition(
     :raises NotModified, 304 with an empty body
     """
     precondition_failed = None
+    # last_modified needs to be rounded to a second so that strict equality can be enforced from a RFC1123 header
+    last_modified = last_modified.replace(microsecond=0)
     if (if_match := request.get("IfMatch")) and etag != if_match.strip('"'):
         precondition_failed = "If-Match"
 
@@ -952,7 +954,7 @@ def validate_failed_precondition(
 
     if ((if_none_match := request.get("IfNoneMatch")) and etag == if_none_match.strip('"')) or (
         (if_modified_since := request.get("IfModifiedSince"))
-        and last_modified < if_modified_since < datetime.datetime.now(tz=_gmt_zone_info)
+        and last_modified <= if_modified_since < datetime.datetime.now(tz=_gmt_zone_info)
     ):
         raise CommonServiceException(
             message="Not Modified",

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1950,6 +1950,7 @@ class TestS3:
             Key=object_key,
             Body=b"data",
         )
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
 
         client_method = getattr(aws_client.s3, method)
 
@@ -2016,6 +2017,23 @@ class TestS3:
                 IfNoneMatch=put_object["ETag"].strip('"'),
             )
         snapshot.match("etag-missing-quotes", e.value.response)
+
+        # test If*ModifiedSince precision
+        response = client_method(
+            Bucket=s3_bucket,
+            Key=object_key,
+            IfUnmodifiedSince=head_object["LastModified"],
+        )
+        snapshot.match("precondition-if-unmodified-since-is-object", response)
+
+        with pytest.raises(ClientError) as e:
+            client_method(
+                Bucket=s3_bucket,
+                Key=object_key,
+                IfModifiedSince=head_object["LastModified"],
+            )
+        snapshot.match("precondition-if-modified-since-is-object", e.value.response)
+
         # Positive tests with all conditions checked
         get_obj_all_positive = client_method(
             Bucket=s3_bucket,

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -9669,7 +9669,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_preconditions[get_object]": {
-    "recorded-date": "10-08-2023, 01:14:32",
+    "recorded-date": "23-10-2023, 18:17:15",
     "recorded-content": {
       "precondition-if-match": {
         "Error": {
@@ -9737,6 +9737,30 @@
           "HTTPStatusCode": 304
         }
       },
+      "precondition-if-unmodified-since-is-object": {
+        "AcceptRanges": "bytes",
+        "Body": "data",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "precondition-if-modified-since-is-object": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
       "obj-success": {
         "AcceptRanges": "bytes",
         "Body": "data",
@@ -9754,7 +9778,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_preconditions[head_object]": {
-    "recorded-date": "10-08-2023, 01:14:38",
+    "recorded-date": "23-10-2023, 18:17:21",
     "recorded-content": {
       "precondition-if-match": {
         "Error": {
@@ -9810,6 +9834,29 @@
         }
       },
       "etag-missing-quotes": {
+        "Error": {
+          "Code": "304",
+          "Message": "Not Modified"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 304
+        }
+      },
+      "precondition-if-unmodified-since-is-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "precondition-if-modified-since-is-object": {
         "Error": {
           "Code": "304",
           "Message": "Not Modified"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Using the `object_store` rust crate test suite, I've spotted an issue in our handling of preconditions for v3.
Basically, the `LastModified` field on the S3 object is stored with millisecond precision for internal use like sorting when calling `ListObjects*`. 

But when comparing against `ModifiedSince`/`UnmodifiedSince` preconditions headers, those are sent using second precision, and we need to check for strict equality/superiority/inferiority. So something like the following should not be true if the precision is second:
`last_modified=datetime.datetime(2023, 10, 23, 16, 19, 41, 798495, tzinfo=zoneinfo.ZoneInfo(key='GMT')) > if_unmodified_since=datetime.datetime(2023, 10, 23, 16, 19, 41, tzinfo=datetime.timezone.utc)`

<!-- What notable changes does this PR make? -->
## Changes
Adapted the check by rounding last modified before comparison, and created 2 AWS tests. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

