### PR TITLE
harden flaky test test_events_scheduled_rules_logs

### DIFF
--- a/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
+++ b/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
@@ -107,6 +107,10 @@ def test_scheduled_rule_logs(
             .build_full_result()
         )
         assert len(result["logStreams"]) >= 2
+        # FIXME: this is a check against a flake in LocalStack
+        # sometimes the logStreams are created but not yet populated with events, so the snapshot fails
+        # assert that the stream has the events before returning
+        assert result["logStreams"][0]["firstEventTimestamp"]
         return result["logStreams"]
 
     log_streams = retry(_get_log_stream, 60)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've been having a lot of issues with `tests.aws.services.events.scheduled_rules.test_events_scheduled_rules_logs` lately where it's been flaking in a weird way.
I believe this might stems from a small race condition in moto where we hit the `describe_log_streams` calls in between 2 operations: 
```python
# moto.events.models.Rule._send_to_cw_log_group
log_backend.create_log_stream(name, log_stream_name)
# here is where the `describe_log_streams` also hit? so that the streams are created but not yet populated
log_backend.put_log_events(name, log_stream_name, log_events)
```

One of the failing run:
https://app.circleci.com/pipelines/github/localstack/localstack/19313/workflows/9dfaf4c0-6b06-4a7c-99df-17da978f99ea/jobs/150589/tests#failed-test-0

<!-- What notable changes does this PR make? -->
## Changes
This is not optimal and should be fixed at the root, but the test is still validating behaviour and this is an edge case. We should fix the issue at the root, but for now this at least makes the test more resilient. 


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

