### PR TITLE
Fix CFn resource deployment into non-default accounts

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1398,7 +1398,8 @@ class TemplateDeployer:
     def create_resource_provider_payload(
         self, action: str, logical_resource_id: str
     ) -> ResourceProviderPayload:
-        # FIXME: use proper credentials
+        # FIXME: this isn't the right solution and will not work with identity-based IAM enforcement.
+        #  replace this with proper new session credentials
         creds: Credentials = {
             "accessKeyId": self.account_id,
             "secretAccessKey": INTERNAL_AWS_SECRET_ACCESS_KEY,


### PR DESCRIPTION
## Motivation

We received a report that CloudFormation creates resources in the default account even though a different target account was used when creating the stack. This PR attempts to provide a quick fix.

## Changes

- When creating the boto3 client factory that will be passed down to resource providers, we now add the stack account ID as the ACCESS_KEY_ID to target the proper account.
  - In the future this should be replaced with a proper session.


## Testing

Reproduction sample provided by a user in slack.

```python
import os
import json

os.environ["AWS_ENDPOINT_URL"] = "http://localhost:4566"
os.environ["AWS_ACCESS_KEY_ID"] = "test"
os.environ["AWS_SECRET_ACCESS_KEY"] = "test"

import boto3

TARGET_ACCOUNT = "111111111111"

BUCKET_TEMPLATE = """
AWSTemplateFormatVersion: "2010-09-09"
Resources:
  S3Bucket:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: mybucket
"""

KMS_KEY_TEMPLATE = """
AWSTemplateFormatVersion: "2010-09-09"
Resources:
  Key:
    Type: AWS::KMS::Key
    Properties:
      Description: MyKey
      EnableKeyRotation: true
      KeyPolicy:
        Version: "2012-10-17"
        Id: Default
        Statement:
          - Effect: Allow
            Principal:
              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
            Action:
              - 'kms:*'
            Resource: '*'
  KeyAlias:
    Type: AWS::KMS::Alias
    Properties:
      AliasName: alias/my-key
      TargetKeyId: !Ref Key
"""

IAM_POLICY_TEMPLATE = """
AWSTemplateFormatVersion: "2010-09-09"
Resources:
  ManagedPolicy:
    Type: AWS::IAM::ManagedPolicy
    Properties:
      Path: /
      PolicyDocument:
        Version: "2012-10-17"
        Statement:
          - Sid: Demo
            Effect: Allow
            Action: 's3:GetObject'
            Resource: '*'
"""


def create_role(account):
    iam = boto3.client("iam", aws_access_key_id=account, aws_secret_access_key="test")
    response = iam.create_role(
        RoleName="foo",
        AssumeRolePolicyDocument=json.dumps(
            {
                "Version": "2012-10-17",
                "Statement": [
                    {"Effect": "Allow", "Principal": "*", "Action": "sts:AssumeRole"}
                ],
            }
        ),
    )
    print(f"Created role {response['Role']['Arn']}")


def assume_role(sts_client, role):
    credentials = sts_client.assume_role(RoleArn=role, RoleSessionName="target")[
        "Credentials"
    ]
    return boto3.session.Session(
        aws_access_key_id=credentials["AccessKeyId"],
        aws_secret_access_key=credentials["SecretAccessKey"],
        aws_session_token=credentials["SessionToken"],
    )


def create_stack(session, stack_name, template_body, capabilities):
    identity = session.client("sts").get_caller_identity()
    cfn_client = session.client("cloudformation")
    response = cfn_client.create_stack(
        StackName=stack_name,
        TemplateBody=template_body,
        Capabilities=capabilities,
    )
    waiter = cfn_client.get_waiter("stack_create_complete")
    waiter.wait(StackName=stack_name)
    stack_id = response["StackId"]
    print(f"Created stack {stack_id} using identity {identity['Arn']}")

    stacks_response = cfn_client.describe_stacks(StackName=stack_name)
    stacks = ", ".join(
        [f'{s["StackId"]} ({s["StackName"]})' for s in stacks_response["Stacks"]]
    )
    print(f"Found stacks in target account: {stacks}")

    resource_response = cfn_client.describe_stack_resources(StackName=stack_name)
    resources = ", ".join(
        [
            f"{r['ResourceType']} -> {r['PhysicalResourceId']}"
            for r in resource_response["StackResources"]
        ]
    )
    print(
        f"Found stack resources for stack {stack_name} in target account: {resources}"
    )

    cfn_client = boto3.client("cloudformation")
    stacks_response = cfn_client.list_stacks()
    stacks = ", ".join(
        [
            f'{s["StackId"]} ({s["StackName"]})'
            for s in stacks_response["StackSummaries"]
        ]
    )
    print(f"Found stacks in default account: {stacks}")


def create_and_check_s3(session):
    stack_name = "s3-bucket"
    create_stack(session, stack_name, BUCKET_TEMPLATE, [])

    s3_client = session.client("s3")
    buckets = s3_client.list_buckets()["Buckets"]
    bucket_names = ", ".join([b["Name"] for b in buckets])
    print(f"Found buckets in target account: {bucket_names}")

    s3_client = boto3.client("s3")
    buckets = s3_client.list_buckets()["Buckets"]
    bucket_names = ", ".join([b["Name"] for b in buckets])
    print(f"Found buckets in default account: {bucket_names}\n")


def create_and_check_kms(session):
    stack_name = "kms-keys"
    create_stack(session, stack_name, KMS_KEY_TEMPLATE, [])

    kms_client = session.client("kms")
    key_response = kms_client.list_keys()
    keys = ", ".join([k["KeyArn"] for k in key_response["Keys"]])
    alias_response = kms_client.list_aliases()
    aliases = ", ".join(
        [f'{k["AliasName"]} -> {k["TargetKeyId"]}' for k in alias_response["Aliases"]]
    )
    print(f"Found keys in target account: {keys}")
    print(f"Found aliases in target account: {aliases}")

    kms_client = boto3.client("kms")
    key_response = kms_client.list_keys()
    keys = ", ".join([k["KeyArn"] for k in key_response["Keys"]])
    alias_response = kms_client.list_aliases()
    aliases = ", ".join(
        [f'{k["AliasName"]} -> {k["TargetKeyId"]}' for k in alias_response["Aliases"]]
    )
    print(f"Found keys in default account: {keys}")
    print(f"Found aliases in default account: {aliases}\n")


def create_and_check_iam(session):
    stack_name = "iam-policy"
    create_stack(session, stack_name, IAM_POLICY_TEMPLATE, [])

    iam_client = session.client("iam")
    iam_response = iam_client.list_policies(Scope="Local")
    policies = ", ".join([p["Arn"] for p in iam_response["Policies"]])
    print(f"Found policies in target account: {policies}")

    iam_client = boto3.client("iam")
    iam_response = iam_client.list_policies(Scope="Local")
    policies = ", ".join([p["PolicyName"] for p in iam_response["Policies"]])
    print(f"Found policies in default account: {policies}\n")


def main():
    default_sts = boto3.client("sts")
    default_identity = default_sts.get_caller_identity()
    print(
        f'Initial session started as {default_identity["Arn"]} in account {default_identity["Account"]}'
    )
    create_role(TARGET_ACCOUNT)

    target_session = assume_role(default_sts, "arn:aws:iam::111111111111:role/foo")
    target_identity = target_session.client("sts").get_caller_identity()
    print(
        f'Assumed role as {target_identity["Arn"]} in account {target_identity["Account"]}\n'
    )

    print("==========================")
    create_and_check_s3(target_session)
    print("==========================")
    create_and_check_kms(target_session)
    print("==========================")
    create_and_check_iam(target_session)


if __name__ == "__main__":
    main()
```

