### PR TITLE
Fix lambda file permissions with layer

### DIFF
--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.23-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.24-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime


### PR DESCRIPTION
Depends on https://github.com/localstack/lambda-runtime-init/pull/27

## Motivation

Fixes a parity issue of file permissions in `/var/task` when using Lambda layers. This fixes sample applications on LocalStack using the [aws-lambda-web-adapter](https://github.com/awslabs/aws-lambda-web-adapter). For example: https://github.com/awslabs/aws-lambda-web-adapter/tree/main/examples/expressjs-zip

## Changes

* Bump lambda-runtime-init version

## Testing

See localstack-ext https://github.com/localstack/localstack-ext/pull/2250