### PR TITLE
Tests for Cloudwatch v2

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -64,9 +64,9 @@ class TestCloudwatch:
         metric_name = "test-metric"
         namespace = "namespace"
         data = (
-                "Action=PutMetricData&MetricData.member.1."
-                "MetricName=%s&MetricData.member.1.Value=1&"
-                "Namespace=%s&Version=2010-08-01" % (metric_name, namespace)
+            "Action=PutMetricData&MetricData.member.1."
+            "MetricName=%s&MetricData.member.1.Value=1&"
+            "Namespace=%s&Version=2010-08-01" % (metric_name, namespace)
         )
         bytes_data = bytes(data, encoding="utf-8")
         encoded_data = gzip.compress(bytes_data)
@@ -274,7 +274,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     def test_put_composite_alarm_describe_alarms_converts_date_format_correctly(
-            self, aws_client, cleanups
+        self, aws_client, cleanups
     ):
         composite_alarm_name = f"composite-a-{short_uid()}"
         alarm_name = f"a-{short_uid()}"
@@ -551,7 +551,7 @@ class TestCloudwatch:
         condition=not is_aws_cloud(), reason="SQS messages do not work reliably, test is flaky"
     )
     def test_put_metric_alarm(
-            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -644,7 +644,8 @@ class TestCloudwatch:
 
         # describe alarms for metric
         alarms = aws_client.cloudwatch.describe_alarms_for_metric(
-            MetricName=metric_name, Namespace=namespace,
+            MetricName=metric_name,
+            Namespace=namespace,
             Dimensions=dimension,
             Statistic="Average",
         )
@@ -670,7 +671,7 @@ class TestCloudwatch:
         paths=["$..evaluatedDatapoints", "$..StateTransitionedTimestamp"]
     )
     def test_breaching_alarm_actions(
-            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -738,7 +739,7 @@ class TestCloudwatch:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..MetricAlarms..StateTransitionedTimestamp"])
     def test_enable_disable_alarm_actions(
-            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -874,8 +875,8 @@ class TestCloudwatch:
             res = aws_client.cloudwatch.list_metrics(Dimensions=dimensions)
             metrics = [metric["MetricName"] for metric in res["Metrics"]]
             if all(
-                    m in metrics
-                    for m in ["NumberOfMessagesSent", "SentMessageSize", "NumberOfEmptyReceives"]
+                m in metrics
+                for m in ["NumberOfMessagesSent", "SentMessageSize", "NumberOfEmptyReceives"]
             ):
                 res = aws_client.cloudwatch.get_metric_data(
                     MetricDataQueries=[sent, sent_size, empty],
@@ -884,9 +885,9 @@ class TestCloudwatch:
                 )
                 # add check for values, because AWS is sometimes a bit slower to fill those values up...
                 if (
-                        res["MetricDataResults"][0]["Values"]
-                        and res["MetricDataResults"][1]["Values"]
-                        and res["MetricDataResults"][2]["Values"]
+                    res["MetricDataResults"][0]["Values"]
+                    and res["MetricDataResults"][1]["Values"]
+                    and res["MetricDataResults"][2]["Values"]
                 ):
                     return True
             return False
@@ -940,9 +941,7 @@ class TestCloudwatch:
         snapshot.match("get_metric_data_2", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn"]  # ARN has a typo
-    )
+    @markers.snapshot.skip_snapshot_verify(paths=["$..DashboardArn"])  # ARN has a typo
     def test_dashboard_lifecycle(self, aws_client, snapshot):
         dashboard_name = f"test-{short_uid()}"
         dashboard_body = {
@@ -983,23 +982,33 @@ class TestCloudwatch:
         assert dashboard_name not in dashboards
 
     @markers.aws.validated
-    @pytest.mark.skipif(
-        condition=not is_aws_cloud(), reason="Operations not supported"
-    )
-    def test_create_metric_stream(self, aws_client, firehose_create_delivery_stream, s3_create_bucket,
-                                  create_role_with_policy, snapshot):
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Operations not supported")
+    def test_create_metric_stream(
+        self,
+        aws_client,
+        firehose_create_delivery_stream,
+        s3_create_bucket,
+        create_role_with_policy,
+        snapshot,
+    ):
         bucket_name = f"test-bucket-{short_uid()}"
         s3_create_bucket(Bucket=bucket_name)
 
         _, subscription_role_arn = create_role_with_policy(
-            "Allow", "s3:*", json.dumps(
+            "Allow",
+            "s3:*",
+            json.dumps(
                 {
                     "Statement": {
                         "Sid": "",
                         "Effect": "Allow",
                         "Principal": {"Service": "firehose.amazonaws.com"},
-                        "Action": "sts:AssumeRole"}
-                }), "*")
+                        "Action": "sts:AssumeRole",
+                    }
+                }
+            ),
+            "*",
+        )
 
         if is_aws_cloud():
             time.sleep(15)
@@ -1016,14 +1025,20 @@ class TestCloudwatch:
         )["DeliveryStreamARN"]
 
         _, role_arn = create_role_with_policy(
-            "Allow", "firehose:*", json.dumps(
+            "Allow",
+            "firehose:*",
+            json.dumps(
                 {
                     "Statement": {
                         "Sid": "",
                         "Effect": "Allow",
                         "Principal": {"Service": "cloudwatch.amazonaws.com"},
-                        "Action": "sts:AssumeRole"}
-                }), stream_arn)
+                        "Action": "sts:AssumeRole",
+                    }
+                }
+            ),
+            stream_arn,
+        )
 
         if is_aws_cloud():
             time.sleep(15)
@@ -1041,70 +1056,47 @@ class TestCloudwatch:
 
         snapshot.match("create_metric_stream", response_create)
 
-        get_response = aws_client.cloudwatch.get_metric_stream(
-            Name=metric_stream_name
-        )
+        get_response = aws_client.cloudwatch.get_metric_stream(Name=metric_stream_name)
         snapshot.match("get_metric_stream", get_response)
 
         response_list = aws_client.cloudwatch.list_metric_streams()
-        metric_streams = response_list.get('Entries', [])
-        metric_streams_names = [metric_stream['Name'] for metric_stream in metric_streams]
+        metric_streams = response_list.get("Entries", [])
+        metric_streams_names = [metric_stream["Name"] for metric_stream in metric_streams]
         assert metric_stream_name in metric_streams_names
 
-        start_response = aws_client.cloudwatch.start_metric_streams(
-            Names=[metric_stream_name]
-        )
+        start_response = aws_client.cloudwatch.start_metric_streams(Names=[metric_stream_name])
         snapshot.match("start_metric_stream", start_response)
 
-        stop_response = aws_client.cloudwatch.stop_metric_streams(
-            Names=[metric_stream_name]
-        )
+        stop_response = aws_client.cloudwatch.stop_metric_streams(Names=[metric_stream_name])
         snapshot.match("stop_metric_stream", stop_response)
 
-        response_delete = aws_client.cloudwatch.delete_metric_stream(
-            Name=metric_stream_name
-        )
+        response_delete = aws_client.cloudwatch.delete_metric_stream(Name=metric_stream_name)
         snapshot.match("delete_metric_stream", response_delete)
         response_list = aws_client.cloudwatch.list_metric_streams()
-        metric_streams = response_list.get('Entries', [])
-        metric_streams_names = [metric_stream['Name'] for metric_stream in metric_streams]
+        metric_streams = response_list.get("Entries", [])
+        metric_streams_names = [metric_stream["Name"] for metric_stream in metric_streams]
         assert metric_stream_name not in metric_streams_names
 
     @markers.aws.validated
-    @pytest.mark.skipif(
-        condition=not is_aws_cloud(), reason="Operations not supported"
-    )
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Operations not supported")
     def test_insight_rule(self, aws_client, snapshot):
         insight_rule_name = f"MyInsightRule-{short_uid()}"
         response_create = aws_client.cloudwatch.put_insight_rule(
             RuleName=insight_rule_name,
             RuleState="ENABLED",
-            RuleDefinition=json.dumps({
-                "Schema": {
-                    "Name": "CloudWatchLogRule",
-                    "Version": 1
-                },
-                "LogGroupNames": [
-                    "API-Gateway-Access-Logs*"
-                ],
-                "LogFormat": "CLF",
-                "Fields": {
-                    "4": "IpAddress",
-                    "7": "StatusCode"
-                },
-                "Contribution": {
-                    "Keys": [
-                        "IpAddress"
-                    ],
-                    "Filters": [
-                        {
-                            "Match": "StatusCode",
-                            "EqualTo": 200
-                        }
-                    ]
-                },
-                "AggregateOn": "Count"
-            })
+            RuleDefinition=json.dumps(
+                {
+                    "Schema": {"Name": "CloudWatchLogRule", "Version": 1},
+                    "LogGroupNames": ["API-Gateway-Access-Logs*"],
+                    "LogFormat": "CLF",
+                    "Fields": {"4": "IpAddress", "7": "StatusCode"},
+                    "Contribution": {
+                        "Keys": ["IpAddress"],
+                        "Filters": [{"Match": "StatusCode", "EqualTo": 200}],
+                    },
+                    "AggregateOn": "Count",
+                }
+            ),
         )
         snapshot.add_transformer(snapshot.transform.key_value("Name"))
         snapshot.match("create_insight_rule", response_create)
@@ -1117,9 +1109,7 @@ class TestCloudwatch:
         )
         snapshot.match("disable_insight_rule", response_disable)
 
-        response_enable = aws_client.cloudwatch.enable_insight_rules(
-            RuleNames=[insight_rule_name]
-        )
+        response_enable = aws_client.cloudwatch.enable_insight_rules(RuleNames=[insight_rule_name])
         snapshot.match("enable_insight_rule", response_enable)
 
         insight_rule_report = aws_client.cloudwatch.get_insight_rule_report(
@@ -1128,23 +1118,21 @@ class TestCloudwatch:
             EndTime=datetime.utcnow(),
             Period=300,
             MaxContributorCount=10,
-            Metrics=["UniqueContributors"]
+            Metrics=["UniqueContributors"],
         )
         snapshot.match("get_insight_rule_report", insight_rule_report)
 
         response_list = aws_client.cloudwatch.describe_insight_rules()
-        insight_rules_names = [insight_rule['Name'] for insight_rule in response_list['InsightRules']]
+        insight_rules_names = [
+            insight_rule["Name"] for insight_rule in response_list["InsightRules"]
+        ]
         assert insight_rule_name in insight_rules_names
 
-        response_delete = aws_client.cloudwatch.delete_insight_rules(
-            RuleNames=[insight_rule_name]
-        )
+        response_delete = aws_client.cloudwatch.delete_insight_rules(RuleNames=[insight_rule_name])
         snapshot.match("delete_insight_rule", response_delete)
 
     @markers.aws.validated
-    @pytest.mark.skipif(
-        condition=not is_aws_cloud(), reason="Operations not supported"
-    )
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Operations not supported")
     def test_anomaly_detector_lifecycle(self, aws_client, snapshot):
         namespace = "MyNamespace"
         metric_name = "MyMetric"
@@ -1154,12 +1142,7 @@ class TestCloudwatch:
             Namespace=namespace,
             Stat="Sum",
             Configuration={},
-            Dimensions=[
-                {
-                    "Name": "DimensionName",
-                    "Value": "DimensionValue"
-                }
-            ]
+            Dimensions=[{"Name": "DimensionName", "Value": "DimensionValue"}],
         )
         snapshot.match("create_anomaly_detector", response_create)
 
@@ -1170,19 +1153,12 @@ class TestCloudwatch:
             MetricName=metric_name,
             Namespace=namespace,
             Stat="Sum",
-            Dimensions=[
-                {
-                    "Name": "DimensionName",
-                    "Value": "DimensionValue"
-                }
-            ]
+            Dimensions=[{"Name": "DimensionName", "Value": "DimensionValue"}],
         )
         snapshot.match("delete_anomaly_detector", response_delete)
 
     @markers.aws.validated
-    @pytest.mark.skipif(
-        condition=not is_aws_cloud(), reason="Operations not supported"
-    )
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="Operations not supported")
     def test_metric_widget(self, aws_client):
         metric_name = f"test-metric-{short_uid()}"
         namespace = f"ns-{short_uid()}"
@@ -1226,13 +1202,13 @@ class TestCloudwatch:
 
 
 def _check_alarm_triggered(
-        expected_state,
-        alarm_name,
-        cloudwatch_client,
-        sqs_client=None,
-        sqs_queue=None,
-        snapshot=None,
-        identifier=None,
+    expected_state,
+    alarm_name,
+    cloudwatch_client,
+    sqs_client=None,
+    sqs_queue=None,
+    snapshot=None,
+    identifier=None,
 ):
     response = cloudwatch_client.describe_alarms(AlarmNames=[alarm_name])
     assert response["MetricAlarms"][0]["StateValue"] == expected_state
@@ -1255,14 +1231,14 @@ def _check_alarm_triggered(
 
 
 def check_message(
-        sqs_client,
-        expected_queue_url,
-        expected_topic_arn,
-        expected_new,
-        expected_reason,
-        alarm_name,
-        alarm_description,
-        expected_trigger,
+    sqs_client,
+    expected_queue_url,
+    expected_topic_arn,
+    expected_new,
+    expected_reason,
+    alarm_name,
+    alarm_description,
+    expected_trigger,
 ):
     receive_result = sqs_client.receive_message(QueueUrl=expected_queue_url)
     message = None

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -635,6 +635,20 @@ class TestCloudwatch:
             identifier="alarm-triggered",
         )
 
+        # describe alarm history
+        history = aws_client.cloudwatch.describe_alarm_history(
+            AlarmName=alarm_name, HistoryItemType="StateUpdate"
+        )
+        snapshot.match("describe-alarm-history", history)
+
+        # describe alarms for metric
+        alarms = aws_client.cloudwatch.describe_alarms_for_metric(
+            MetricName=metric_name, Namespace=namespace,
+            Dimensions=dimension,
+            Statistic="Average",
+        )
+        snapshot.match("describe-alarms-for-metric", alarms)
+
         # missing are treated as not breaching, so we should reach OK state again
         retry(
             _check_alarm_triggered,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -19,6 +19,7 @@ from localstack.utils.sync import poll_condition
 
 PUBLICATION_RETRIES = 5
 
+
 class TestCloudwatch:
     @markers.aws.validated
     def test_put_metric_data_values_list(self, snapshot, aws_client):
@@ -63,9 +64,9 @@ class TestCloudwatch:
         metric_name = "test-metric"
         namespace = "namespace"
         data = (
-            "Action=PutMetricData&MetricData.member.1."
-            "MetricName=%s&MetricData.member.1.Value=1&"
-            "Namespace=%s&Version=2010-08-01" % (metric_name, namespace)
+                "Action=PutMetricData&MetricData.member.1."
+                "MetricName=%s&MetricData.member.1.Value=1&"
+                "Namespace=%s&Version=2010-08-01" % (metric_name, namespace)
         )
         bytes_data = bytes(data, encoding="utf-8")
         encoded_data = gzip.compress(bytes_data)
@@ -273,7 +274,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     def test_put_composite_alarm_describe_alarms_converts_date_format_correctly(
-        self, aws_client, cleanups
+            self, aws_client, cleanups
     ):
         composite_alarm_name = f"composite-a-{short_uid()}"
         alarm_name = f"a-{short_uid()}"
@@ -550,7 +551,7 @@ class TestCloudwatch:
         condition=not is_aws_cloud(), reason="SQS messages do not work reliably, test is flaky"
     )
     def test_put_metric_alarm(
-        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -669,7 +670,7 @@ class TestCloudwatch:
         paths=["$..evaluatedDatapoints", "$..StateTransitionedTimestamp"]
     )
     def test_breaching_alarm_actions(
-        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -737,7 +738,7 @@ class TestCloudwatch:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..MetricAlarms..StateTransitionedTimestamp"])
     def test_enable_disable_alarm_actions(
-        self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
+            self, sns_create_topic, sqs_create_queue, snapshot, aws_client, cleanups
     ):
         sns_topic_alarm = sns_create_topic()
         topic_arn_alarm = sns_topic_alarm["TopicArn"]
@@ -873,8 +874,8 @@ class TestCloudwatch:
             res = aws_client.cloudwatch.list_metrics(Dimensions=dimensions)
             metrics = [metric["MetricName"] for metric in res["Metrics"]]
             if all(
-                m in metrics
-                for m in ["NumberOfMessagesSent", "SentMessageSize", "NumberOfEmptyReceives"]
+                    m in metrics
+                    for m in ["NumberOfMessagesSent", "SentMessageSize", "NumberOfEmptyReceives"]
             ):
                 res = aws_client.cloudwatch.get_metric_data(
                     MetricDataQueries=[sent, sent_size, empty],
@@ -883,9 +884,9 @@ class TestCloudwatch:
                 )
                 # add check for values, because AWS is sometimes a bit slower to fill those values up...
                 if (
-                    res["MetricDataResults"][0]["Values"]
-                    and res["MetricDataResults"][1]["Values"]
-                    and res["MetricDataResults"][2]["Values"]
+                        res["MetricDataResults"][0]["Values"]
+                        and res["MetricDataResults"][1]["Values"]
+                        and res["MetricDataResults"][2]["Values"]
                 ):
                     return True
             return False
@@ -939,6 +940,9 @@ class TestCloudwatch:
         snapshot.match("get_metric_data_2", response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..DashboardArn"]  # ARN has a typo
+    )
     def test_dashboard_lifecycle(self, aws_client, snapshot):
         dashboard_name = f"test-{short_uid()}"
         dashboard_body = {
@@ -979,8 +983,11 @@ class TestCloudwatch:
         assert dashboard_name not in dashboards
 
     @markers.aws.validated
-    def test_create_metric_stream(self, aws_client, firehose_create_delivery_stream, s3_create_bucket, create_role_with_policy, snapshot):
-
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Operations not supported"
+    )
+    def test_create_metric_stream(self, aws_client, firehose_create_delivery_stream, s3_create_bucket,
+                                  create_role_with_policy, snapshot):
         bucket_name = f"test-bucket-{short_uid()}"
         s3_create_bucket(Bucket=bucket_name)
 
@@ -1064,7 +1071,10 @@ class TestCloudwatch:
         assert metric_stream_name not in metric_streams_names
 
     @markers.aws.validated
-    def test_insight_rule(self,aws_client,snapshot):
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Operations not supported"
+    )
+    def test_insight_rule(self, aws_client, snapshot):
         insight_rule_name = f"MyInsightRule-{short_uid()}"
         response_create = aws_client.cloudwatch.put_insight_rule(
             RuleName=insight_rule_name,
@@ -1132,6 +1142,9 @@ class TestCloudwatch:
         snapshot.match("delete_insight_rule", response_delete)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Operations not supported"
+    )
     def test_anomaly_detector_lifecycle(self, aws_client, snapshot):
         namespace = "MyNamespace"
         metric_name = "MyMetric"
@@ -1167,6 +1180,9 @@ class TestCloudwatch:
         snapshot.match("delete_anomaly_detector", response_delete)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=not is_aws_cloud(), reason="Operations not supported"
+    )
     def test_metric_widget(self, aws_client):
         metric_name = f"test-metric-{short_uid()}"
         namespace = f"ns-{short_uid()}"
@@ -1210,13 +1226,13 @@ class TestCloudwatch:
 
 
 def _check_alarm_triggered(
-    expected_state,
-    alarm_name,
-    cloudwatch_client,
-    sqs_client=None,
-    sqs_queue=None,
-    snapshot=None,
-    identifier=None,
+        expected_state,
+        alarm_name,
+        cloudwatch_client,
+        sqs_client=None,
+        sqs_queue=None,
+        snapshot=None,
+        identifier=None,
 ):
     response = cloudwatch_client.describe_alarms(AlarmNames=[alarm_name])
     assert response["MetricAlarms"][0]["StateValue"] == expected_state
@@ -1239,14 +1255,14 @@ def _check_alarm_triggered(
 
 
 def check_message(
-    sqs_client,
-    expected_queue_url,
-    expected_topic_arn,
-    expected_new,
-    expected_reason,
-    alarm_name,
-    alarm_description,
-    expected_trigger,
+        sqs_client,
+        expected_queue_url,
+        expected_topic_arn,
+        expected_new,
+        expected_reason,
+        alarm_name,
+        alarm_description,
+        expected_trigger,
 ):
     receive_result = sqs_client.receive_message(QueueUrl=expected_queue_url)
     message = None

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -937,6 +937,7 @@ class TestCloudwatch:
                     "height": 6,
                     "properties": {
                         "metrics": [["AWS/EC2", "CPUUtilization", "InstanceId", "i-12345678"]],
+                        "region": "us-east-1",
                         "view": "timeSeries",
                         "stacked": False,
                     },
@@ -947,6 +948,7 @@ class TestCloudwatch:
             DashboardName=dashboard_name, DashboardBody=json.dumps(dashboard_body)
         )
         response = aws_client.cloudwatch.get_dashboard(DashboardName=dashboard_name)
+        snapshot.add_transformer(snapshot.transform.key_value("DashboardName"))
         snapshot.match("get_dashboard", response)
 
         dashboards_list = aws_client.cloudwatch.list_dashboards()

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1009,13 +1009,16 @@ class TestCloudwatch:
             time.sleep(15)
 
         metric_stream_name = f"MyMetricStream-{short_uid()}"
-
         response_create = aws_client.cloudwatch.put_metric_stream(
             Name=metric_stream_name,
             FirehoseArn=stream_arn,
             RoleArn=role_arn,
             OutputFormat="json",
         )
+        snapshot.add_transformer(snapshot.transform.key_value("Name"))
+        snapshot.add_transformer(snapshot.transform.key_value("FirehoseArn"))
+        snapshot.add_transformer(snapshot.transform.key_value("RoleArn"))
+
         snapshot.match("create_metric_stream", response_create)
 
         get_response = aws_client.cloudwatch.get_metric_stream(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -19,7 +19,6 @@ from localstack.utils.sync import poll_condition
 
 PUBLICATION_RETRIES = 5
 
-
 class TestCloudwatch:
     @markers.aws.validated
     def test_put_metric_data_values_list(self, snapshot, aws_client):
@@ -1117,6 +1116,41 @@ class TestCloudwatch:
             RuleNames=[insight_rule_name]
         )
         snapshot.match("delete_insight_rule", response_delete)
+
+    @markers.aws.validated
+    def test_anomaly_detector_lifecycle(self, aws_client, snapshot):
+        namespace = "MyNamespace"
+        metric_name = "MyMetric"
+
+        response_create = aws_client.cloudwatch.put_anomaly_detector(
+            MetricName=metric_name,
+            Namespace=namespace,
+            Stat="Sum",
+            Configuration={},
+            Dimensions=[
+                {
+                    "Name": "DimensionName",
+                    "Value": "DimensionValue"
+                }
+            ]
+        )
+        snapshot.match("create_anomaly_detector", response_create)
+
+        response_list = aws_client.cloudwatch.describe_anomaly_detectors()
+        snapshot.match("describe_anomaly_detector", response_list)
+
+        response_delete = aws_client.cloudwatch.delete_anomaly_detector(
+            MetricName=metric_name,
+            Namespace=namespace,
+            Stat="Sum",
+            Dimensions=[
+                {
+                    "Name": "DimensionName",
+                    "Value": "DimensionValue"
+                }
+            ]
+        )
+        snapshot.match("delete_anomaly_detector", response_delete)
 
 
 def _check_alarm_triggered(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1050,5 +1050,56 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_anomaly_detector_lifecycle": {
+    "recorded-date": "26-10-2023, 10:42:43",
+    "recorded-content": {
+      "create_anomaly_detector": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_anomaly_detector": {
+        "AnomalyDetectors": [
+          {
+            "Configuration": {
+              "ExcludedTimeRanges": []
+            },
+            "Dimensions": [
+              {
+                "Name": "DimensionName",
+                "Value": "DimensionValue"
+              }
+            ],
+            "MetricName": "MyMetric",
+            "Namespace": "MyNamespace",
+            "SingleMetricAnomalyDetector": {
+              "Dimensions": [
+                {
+                  "Name": "DimensionName",
+                  "Value": "DimensionValue"
+                }
+              ],
+              "MetricName": "MyMetric",
+              "Namespace": "MyNamespace",
+              "Stat": "Sum"
+            },
+            "Stat": "Sum",
+            "StateValue": "PENDING_TRAINING"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_anomaly_detector": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -369,7 +369,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm": {
-    "recorded-date": "12-09-2023, 12:05:17",
+    "recorded-date": "26-10-2023, 11:44:13",
     "recorded-content": {
       "describe-alarm": {
         "CompositeAlarms": [],
@@ -440,7 +440,7 @@
               "arn:aws:sns:<region>:111111111111:<topic_arn>"
             ],
             "Period": 30,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (12/09/23 10:03:00)] was greater than the threshold (2.0).",
+            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
             "StateReasonData": {
               "version": "1.0",
               "queryDate": "date",
@@ -484,7 +484,7 @@
         "AlarmDescription": "testing cloudwatch alarms",
         "AlarmName": "<alarm-name:1>",
         "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (12/09/23 10:03:00)] was greater than the threshold (2.0).",
+        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
         "NewStateValue": "ALARM",
         "OKActions": [
           "arn:aws:sns:<region>:111111111111:<topic_arn>"
@@ -510,6 +510,111 @@
           "Threshold": 2.0,
           "TreatMissingData": "notBreaching",
           "Unit": "Seconds"
+        }
+      },
+      "describe-alarm-history": {
+        "AlarmHistoryItems": [
+          {
+            "AlarmName": "<alarm-name:1>",
+            "AlarmType": "MetricAlarm",
+            "HistoryData": {
+              "version": "1.0",
+              "oldState": {
+                "stateValue": "INSUFFICIENT_DATA",
+                "stateReason": "Unchecked: Initial alarm creation"
+              },
+              "newState": {
+                "stateValue": "ALARM",
+                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
+                "stateReasonData": {
+                  "version": "1.0",
+                  "queryDate": "date",
+                  "startDate": "date",
+                  "unit": "Seconds",
+                  "statistic": "Average",
+                  "period": 30,
+                  "recentDatapoints": [
+                    21.5
+                  ],
+                  "threshold": 2.0,
+                  "evaluatedDatapoints": [
+                    {
+                      "timestamp": "date",
+                      "sampleCount": 2.0,
+                      "value": 21.5
+                    }
+                  ]
+                }
+              }
+            },
+            "HistoryItemType": "StateUpdate",
+            "HistorySummary": "Alarm updated from INSUFFICIENT_DATA to ALARM",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-alarms-for-metric": {
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:aws:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "testing cloudwatch alarms",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "InstanceId",
+                "Value": "abc"
+              }
+            ],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "my-metric1",
+            "Namespace": "<namespace:1>",
+            "OKActions": [
+              "arn:aws:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "Period": 30,
+            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
+            "StateReasonData": {
+              "version": "1.0",
+              "queryDate": "date",
+              "startDate": "date",
+              "unit": "Seconds",
+              "statistic": "Average",
+              "period": 30,
+              "recentDatapoints": [
+                21.5
+              ],
+              "threshold": 2.0,
+              "evaluatedDatapoints": [
+                {
+                  "timestamp": "date",
+                  "sampleCount": 2.0,
+                  "value": 21.5
+                }
+              ]
+            },
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "ALARM",
+            "Statistic": "Average",
+            "Threshold": 2.0,
+            "TreatMissingData": "notBreaching",
+            "Unit": "Seconds"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "ok-triggered-describe": {

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -802,5 +802,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_create_metric_stream": {
+    "recorded-date": "25-10-2023, 14:52:47",
+    "recorded-content": {
+      "create_metric_stream": {
+        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/MyMetricStream-530f1757",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_metric_stream": {
+        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/MyMetricStream-530f1757",
+        "CreationDate": "datetime",
+        "FirehoseArn": "arn:aws:firehose:<region>:111111111111:deliverystream/MyStream-4af68047",
+        "IncludeLinkedAccountsMetrics": false,
+        "LastUpdateDate": "datetime",
+        "Name": "MyMetricStream-530f1757",
+        "OutputFormat": "json",
+        "RoleArn": "arn:aws:iam::111111111111:role/role-fa5ff66a",
+        "State": "running",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "start_metric_stream": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stop_metric_stream": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_metric_stream": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -847,5 +847,208 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_insight_rule": {
+    "recorded-date": "26-10-2023, 10:07:59",
+    "recorded-content": {
+      "create_insight_rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_insight_rule": {
+        "InsightRules": [
+          {
+            "Definition": {
+              "Schema": {
+                "Name": "<name:1>",
+                "Version": 1
+              },
+              "LogGroupNames": [
+                "API-Gateway-Access-Logs*"
+              ],
+              "LogFormat": "CLF",
+              "Fields": {
+                "4": "IpAddress",
+                "7": "StatusCode"
+              },
+              "Contribution": {
+                "Keys": [
+                  "IpAddress"
+                ],
+                "Filters": [
+                  {
+                    "Match": "StatusCode",
+                    "EqualTo": 200
+                  }
+                ]
+              },
+              "AggregateOn": "Count"
+            },
+            "ManagedRule": false,
+            "Name": "<name:2>",
+            "Schema": "<name:1>/1",
+            "State": "ENABLED"
+          },
+          {
+            "Definition": {
+              "Schema": {
+                "Name": "<name:1>",
+                "Version": 1
+              },
+              "LogGroupNames": [
+                "API-Gateway-Access-Logs*"
+              ],
+              "LogFormat": "CLF",
+              "Fields": {
+                "4": "IpAddress",
+                "7": "StatusCode"
+              },
+              "Contribution": {
+                "Keys": [
+                  "IpAddress"
+                ],
+                "Filters": [
+                  {
+                    "Match": "StatusCode",
+                    "EqualTo": 200
+                  }
+                ]
+              },
+              "AggregateOn": "Count"
+            },
+            "ManagedRule": false,
+            "Name": "<name:3>",
+            "Schema": "<name:1>/1",
+            "State": "ENABLED"
+          },
+          {
+            "Definition": {
+              "Schema": {
+                "Name": "<name:1>",
+                "Version": 1
+              },
+              "LogGroupNames": [
+                "API-Gateway-Access-Logs*"
+              ],
+              "LogFormat": "CLF",
+              "Fields": {
+                "4": "IpAddress",
+                "7": "StatusCode"
+              },
+              "Contribution": {
+                "Keys": [
+                  "IpAddress"
+                ],
+                "Filters": [
+                  {
+                    "Match": "StatusCode",
+                    "EqualTo": 200
+                  }
+                ]
+              },
+              "AggregateOn": "Count"
+            },
+            "ManagedRule": false,
+            "Name": "<name:4>",
+            "Schema": "<name:1>/1",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "disable_insight_rule": {
+        "Failures": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "enable_insight_rule": {
+        "Failures": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_insight_rule_report": {
+        "AggregateValue": 0.0,
+        "AggregationStatistic": "SampleCount",
+        "ApproximateUniqueCount": 0,
+        "Contributors": [],
+        "KeyLabels": [
+          "IpAddress"
+        ],
+        "MetricDatapoints": [
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          },
+          {
+            "Timestamp": "timestamp",
+            "UniqueContributors": 0.0
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_insight_rule": {
+        "Failures": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -765,5 +765,42 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_dashboard_lifecycle": {
+    "recorded-date": "25-10-2023, 13:16:20",
+    "recorded-content": {
+      "get_dashboard": {
+        "DashboardArn": "arn:aws:cloudwatch::111111111111:dashboard/<dashboard-name:1>",
+        "DashboardBody": {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/EC2",
+                    "CPUUtilization",
+                    "InstanceId",
+                    "i-12345678"
+                  ]
+                ],
+                "region": "<region>",
+                "view": "timeSeries",
+                "stacked": false
+              }
+            }
+          ]
+        },
+        "DashboardName": "<dashboard-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -804,24 +804,24 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_create_metric_stream": {
-    "recorded-date": "25-10-2023, 14:52:47",
+    "recorded-date": "26-10-2023, 09:12:10",
     "recorded-content": {
       "create_metric_stream": {
-        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/MyMetricStream-530f1757",
+        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/<name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "get_metric_stream": {
-        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/MyMetricStream-530f1757",
+        "Arn": "arn:aws:cloudwatch:<region>:111111111111:metric-stream/<name:1>",
         "CreationDate": "datetime",
-        "FirehoseArn": "arn:aws:firehose:<region>:111111111111:deliverystream/MyStream-4af68047",
+        "FirehoseArn": "<firehose-arn:1>",
         "IncludeLinkedAccountsMetrics": false,
         "LastUpdateDate": "datetime",
-        "Name": "MyMetricStream-530f1757",
+        "Name": "<name:1>",
         "OutputFormat": "json",
-        "RoleArn": "arn:aws:iam::111111111111:role/role-fa5ff66a",
+        "RoleArn": "<role-arn:1>",
         "State": "running",
         "ResponseMetadata": {
           "HTTPHeaders": {},


### PR DESCRIPTION
## Motivation
The coverage of the operations tested for Cloudwatch v2 is lacking.

## Changes
More tests

## Testing
AWS validated test should pass with the new provider

## TODO

- [x] delete_anomaly_detector
- [x] delete_dashboards
- [x] delete_insight_rules
- [x] delete_metric_stream
- [x] describe_alarm_history
- [x] describe_alarms_for_metric
- [x] describe_anomaly_detectors
- [x] describe_insight_rules
- [x] disable_insight_rules
- [x] enable_insight_rules
- [x] get_dashboard
- [x] get_insight_rule_report
- [x] get_metric_stream
- [x] get_metric_widget_image
- [x] list_dashboards
- [x] list_metric_streams
- [x] put_anomaly_detector
- [x] put_dashboard
- [x] put_insight_rule
- [x] put_metric_stream
- [x] start_metric_streams
- [x] stop_metric_streams

## This operations are more complex so I'll skip them for now
- put_managed_insight_rules
- list_managed_insight_rules

