### PR TITLE
kms: fix get_parameters_for_import

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1011,11 +1011,14 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             enabled_key_allowed=True,
             disabled_key_allowed=True,
         )
-        if key_to_import_material_to.metadata.get("Origin") != "EXTERNAL":
+        key_arn = key_to_import_material_to.metadata["Arn"]
+        key_origin = key_to_import_material_to.metadata.get("Origin")
+
+        if key_origin != "EXTERNAL":
             raise UnsupportedOperationException(
-                "Key material can only be imported into keys with Origin of EXTERNAL"
+                f"{key_arn} origin is {key_origin} which is not valid for this operation."
             )
-        self._validate_key_for_encryption_decryption(context, key_to_import_material_to)
+
         key_id = key_to_import_material_to.metadata["KeyId"]
 
         key = KmsKey(CreateKeyRequest(KeySpec=wrapping_key_spec))

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1560,5 +1560,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_get_parameters_for_import": {
+    "recorded-date": "25-10-2023, 12:29:27",
+    "recorded-content": {
+      "response-error": {
+        "Error": {
+          "Code": "UnsupportedOperationException",
+          "Message": "<key-arn> origin is AWS_KMS which is not valid for this operation."
+        },
+        "message": "<key-arn> origin is AWS_KMS which is not valid for this operation.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While importing parameters for import when key usage is `SIGN_VERIFY`, we got an `InvalidKeyUsageException` error. 

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- adds correct error response if key origin is not `EXTERNAL` which is mandatory for this operation. 
- removes a validation for checking key usage as `ENCRYPT_DECRYPT`.
- add an aws validated test case to check the above conditions.  

Related Issue: #9111

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

