### PR TITLE
Update README.md, remove dollar sign from brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please make sure that you have a working [`docker` environment](https://docs.doc
 ### Brew (MacOS or Linux with Homebrew)
 Install the LocalStack CLI by using our [official LocalStack Brew Tap](https://github.com/localstack/homebrew-tap):
 ```
-$ brew install localstack/tap/localstack-cli
+brew install localstack/tap/localstack-cli
 ```
 
 ### Binary download (MacOS, Linux, Windows)


### PR DESCRIPTION
Upon clicking on the copy button, the $ sign is copied as well, resulting in invalid command

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
<img width="387" alt="image" src="https://github.com/localstack/localstack/assets/1456931/df903053-622f-44ff-844f-c9086b513be5">


<!-- What notable changes does this PR make? -->
## Changes


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

