### PR TITLE
SQS: Use the 'standard' queue URL strategy by default

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -863,8 +863,8 @@ SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 # expose SQS on a specific port externally
 SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
 
-# Strategy used when creating SQS queue urls. can be "off" (default), "standard", "domain", or "path"
-SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "off"
+# Strategy used when creating SQS queue urls. can be "off", "standard" (default), "domain", or "path"
+SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "standard"
 
 # Disable the check for MaxNumberOfMessage in SQS ReceiveMessage
 SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT = is_env_true("SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT")


### PR DESCRIPTION
## Motivation

This PR makes the `standard` SQS queue URL strategy the default. 

This will enable out-of-the-box multi-account and multi-region support in LocalStack SQS.

## Related

Depends on https://github.com/localstack/localstack/pull/9454