### PR TITLE
Rename default container name to localstack-main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PIP_CMD ?= pip3
 TEST_PATH ?= .
 PYTEST_LOGLEVEL ?=
 DISABLE_BOTO_RETRIES ?= 1
-MAIN_CONTAINER_NAME ?= localstack_main
+MAIN_CONTAINER_NAME ?= localstack-main
 
 MAJOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f1)
 MINOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f2)

--- a/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
+++ b/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - KAFKA_BROKERS=kafka:29092
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     network_mode: bridge
     ports:

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro  # required for Pro
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -552,7 +552,7 @@ def cmd_stop() -> None:
     Stops the current LocalStack runtime.
 
     This command stops the currently running LocalStack docker container.
-    By default, this command looks for a container named `localstack_main` (which is the default
+    By default, this command looks for a container named `localstack-main` (which is the default
     container name used by the `localstack start` command).
     If your LocalStack container has a different name, set the config variable
     `MAIN_CONTAINER_NAME`.
@@ -597,7 +597,7 @@ def cmd_logs(follow: bool, tail: int) -> None:
     Show the logs of the current LocalStack runtime.
 
     This command shows the logs of the currently running LocalStack docker container.
-    By default, this command looks for a container named `localstack_main` (which is the default
+    By default, this command looks for a container named `localstack-main` (which is the default
     container name used by the `localstack start` command).
     If your LocalStack container has a different name, set the config variable
     `MAIN_CONTAINER_NAME`.
@@ -647,7 +647,7 @@ def cmd_wait(timeout: Optional[float] = None) -> None:
 
     This commands waits for a started LocalStack runtime to be up and running, ready to serve
     requests.
-    By default, this command looks for a container named `localstack_main` (which is the default
+    By default, this command looks for a container named `localstack-main` (which is the default
     container name used by the `localstack start` command).
     If your LocalStack container has a different name, set the config variable
     `MAIN_CONTAINER_NAME`.
@@ -665,7 +665,7 @@ def cmd_ssh() -> None:
     Obtain a shell in the current LocalStack runtime.
 
     This command starts a new interactive shell in the currently running LocalStack container.
-    By default, this command looks for a container named `localstack_main` (which is the default
+    By default, this command looks for a container named `localstack-main` (which is the default
     container name used by the `localstack start` command).
     If your LocalStack container has a different name, set the config variable
     `MAIN_CONTAINER_NAME`.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -730,7 +730,7 @@ if ALLOW_NONSTANDARD_REGIONS:
     os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = "true"
 
 # name of the main Docker container
-MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"
+MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack-main"
 
 # the latest commit id of the repository when the docker image was created
 LOCALSTACK_BUILD_GIT_HASH = os.environ.get("LOCALSTACK_BUILD_GIT_HASH", "").strip() or None

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -146,7 +146,7 @@ def test_validate_config(runner, monkeypatch, tmp_path):
         """version: "3.3"
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     network_mode: bridge
     ports:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -29,7 +29,7 @@ class TestDockerClient:
         mock_container = {
             "ID": "00000000a1",
             "Image": "localstack/localstack",
-            "Names": "localstack_main",
+            "Names": "localstack-main",
             "Labels": "authors=LocalStack Contributors",
             "State": "running",
         }
@@ -52,16 +52,16 @@ class TestDockerClient:
 
     @patch("localstack.utils.container_utils.docker_cmd_client.run")
     def test_container_status(self, run_mock):
-        test_output = "Up 2 minutes - localstack_main"
+        test_output = "Up 2 minutes - localstack-main"
         run_mock.return_value = test_output
         docker_client = CmdDockerClient()
-        status = docker_client.get_container_status("localstack_main")
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.UP
-        run_mock.return_value = "Exited (0) 1 minute ago - localstack_main"
-        status = docker_client.get_container_status("localstack_main")
+        run_mock.return_value = "Exited (0) 1 minute ago - localstack-main"
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.DOWN
         run_mock.return_value = "STATUS    NAME"
-        status = docker_client.get_container_status("localstack_main")
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.NON_EXISTENT
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for `boto3` which refuses to connect.


<!-- What notable changes does this PR make? -->
## Changes


Rename `localstack_main` -> `localstack-main`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

