### PR TITLE
corrects status for instance profile resource provider

### DIFF
--- a/localstack/services/iam/resource_providers/aws_iam_instanceprofile.py
+++ b/localstack/services/iam/resource_providers/aws_iam_instanceprofile.py
@@ -118,7 +118,7 @@ class IAMInstanceProfileProvider(ResourceProvider[IAMInstanceProfileProperties])
         iam.delete_instance_profile(
             InstanceProfileName=request.previous_state["InstanceProfileName"]
         )
-        return ProgressEvent(status=OperationStatus.IN_PROGRESS, resource_model={})
+        return ProgressEvent(status=OperationStatus.SUCCESS, resource_model={})
 
     def update(
         self,


### PR DESCRIPTION
## Motivation
This resource provider is not returning the correct status after the deletion which causes depending resources to fail during the deletion of a stack. cc/ @dominikschubert 

## Changes
Returns correct event

