### PR TITLE
add sqlite for metric storage cloudwatch v2

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import sqlite3
+
+from localstack import config
+from localstack.utils.files import mkdir
+
+LOG = logging.getLogger(__name__)
+
+
+class CloudwatchDatabase:
+    DB_NAME = "metrics.db"
+    CLOUDWATCH_DATA_ROOT: str = os.path.join(config.dirs.data, "cloudwatch")
+    METRICS_DB: str = os.path.join(CLOUDWATCH_DATA_ROOT, DB_NAME)
+    TABLE_SINGLE_METRICS = "SINGLE_METRICS"
+    TABLE_AGGREGATED_METRICS = "AGGREGATED_METRICS"
+
+    def __init__(self):
+        if os.path.exists(self.METRICS_DB):
+            LOG.debug(f"database for metrics already exists ({self.METRICS_DB})")
+            return
+
+        mkdir(self.CLOUDWATCH_DATA_ROOT)
+        conn = None
+        try:
+            # TODO check if the SQLITE_THREADSAFE setting is 2 (multi-threaded) or 1 (serialized)
+            conn = sqlite3.connect(
+                self.METRICS_DB,
+                check_same_thread=False,
+            )
+            common_columns = """
+                "id"	                INTEGER,
+                "account_id"	        TEXT,
+                "region"	            TEXT,
+                "metric_name"	        TEXT,
+                "namespace" 	        TEXT,
+                "timestamp"	            NUMERIC,
+                "dimensions"	        TEXT,
+                "unit"	                TEXT,
+                "storage_resolution"	INTEGER
+            """
+            conn.execute(
+                f"""
+            CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
+                {common_columns},
+                "value"	                NUMERIC,
+                PRIMARY KEY("id")
+            );
+            """
+            )
+
+            conn.execute(
+                f"""
+            CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
+                {common_columns},
+                "sample_count"          NUMERIC,
+                "sum"	                NUMERIC,
+                "min"	                NUMERIC,
+                "max"	                NUMERIC,
+                PRIMARY KEY("id")
+            );
+            """
+            )
+            # create indexes
+            conn.executescript(
+                """
+            CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
+            CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
+            """
+            )
+
+        except Exception as e:
+            LOG.error("Could not create sqlite database", e)
+        finally:
+            if conn:
+                conn.close()
+
+    def add_metric_data(self):
+        pass
+
+    def get_metric_data(self):
+        pass
+
+    def clear_tables(self):
+        # TODO clear tables
+        pass
+
+    def shutdown(self):
+        # TODO delete tmpdir/database if we do not have persistence enabled?
+        # anything else we should consider?
+        ...

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import sqlite3
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 from localstack import config
+from localstack.aws.api.cloudwatch import MetricData, MetricStat, ScanBy
 from localstack.utils.files import mkdir
 
 LOG = logging.getLogger(__name__)
@@ -21,13 +24,8 @@ class CloudwatchDatabase:
             return
 
         mkdir(self.CLOUDWATCH_DATA_ROOT)
-        conn = None
-        try:
-            # TODO check if the SQLITE_THREADSAFE setting is 2 (multi-threaded) or 1 (serialized)
-            conn = sqlite3.connect(
-                self.METRICS_DB,
-                check_same_thread=False,
-            )
+        with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
+            cur = conn.cursor()
             common_columns = """
                 "id"	                INTEGER,
                 "account_id"	        TEXT,
@@ -39,7 +37,7 @@ class CloudwatchDatabase:
                 "unit"	                TEXT,
                 "storage_resolution"	INTEGER
             """
-            conn.execute(
+            cur.execute(
                 f"""
             CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
                 {common_columns},
@@ -49,7 +47,7 @@ class CloudwatchDatabase:
             """
             )
 
-            conn.execute(
+            cur.execute(
                 f"""
             CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
                 {common_columns},
@@ -62,30 +60,146 @@ class CloudwatchDatabase:
             """
             )
             # create indexes
-            conn.executescript(
+            cur.executescript(
                 """
             CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
             CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
             """
             )
+            conn.commit()
 
-        except Exception as e:
-            LOG.error("Could not create sqlite database", e)
-        finally:
-            if conn:
-                conn.close()
+    def add_metric_data(
+        self, account_id: str, region: str, namespace: str, metric_data: MetricData
+    ):
+        # TODO consider using thread-lock here instead of increasing busy-timeout
+        with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
+            conn.execute(
+                "PRAGMA busy_timeout = 20000"
+            )  # TODO check if we need to set timeout higher, testing with 20 seconds
+            cur = conn.cursor()
 
-    def add_metric_data(self):
-        pass
+            def _get_current_timestamp_utc():  # TODO verify if this is the standard format, might need to convert
+                now = datetime.utcnow().replace(tzinfo=timezone.utc)
+                return int(now.timestamp())
 
-    def get_metric_data(self):
-        pass
+            for metric in metric_data:
+                if metric.get("Value"):
+                    # TODO convert timestamp
+                    # TODO convert dimensions
+                    timestamp = (
+                        self._convert_timestamp_to_unix(metric.get("Timestamp"))
+                        if metric.get("Timestamp")
+                        else _get_current_timestamp_utc()
+                    )
+                    cur.execute(
+                        f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
+                        ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        (
+                            account_id,
+                            region,
+                            metric.get("MetricName"),
+                            namespace,
+                            timestamp,
+                            self._get_ordered_dimensions_with_separator(metric.get("Dimensions")),
+                            metric.get("Unit"),
+                            metric.get("StorageResolution"),
+                            metric["Value"],
+                        ),
+                    )
+                elif metric.get("Values"):
+                    pass
+                elif metric.get("StatisticValues"):
+                    pass
+
+            conn.commit()
+
+    def get_metric_data_stat(
+        self,
+        account_id: str,
+        region: str,
+        query: MetricStat,
+        start_time: datetime,
+        end_time: datetime,
+        scan_by: str,
+    ):
+        with sqlite3.connect(self.METRICS_DB) as conn:
+            cur = conn.cursor()
+            metric_stat = query.get("MetricStat")
+            metric = metric_stat.get("Metric")
+            # period = metric_stat.get("Period")
+            stat = metric_stat.get("Stat")
+            # unit = metric_stat.get("Unit")
+
+            # TODO test default order
+            order_by = (
+                "timestamp DESC"
+                if scan_by and scan_by == ScanBy.TimestampDescending
+                else "timestamp ASC"
+            )
+            data = (
+                account_id,
+                region,
+                metric.get("Namespace"),
+                metric.get("MetricName"),
+                self._convert_timestamp_to_unix(start_time),
+                self._convert_timestamp_to_unix(end_time),
+            )
+            fun = ""
+            if stat == "Sum":
+                fun = "SUM(value)"
+            if stat == "Average":
+                fun = "AVG(value)"
+            if stat == "Minimum":
+                fun = "MIN(value)"
+            if stat == "Maximum":
+                fun = "MAX(value)"
+            if stat == "SampleCount":
+                fun = "COUNT(value)"
+
+            # TODO select by period
+            # TODO exclude null values, check if dimensions must be null though if missing
+            cur.execute(
+                f"""SELECT {fun} FROM {self.TABLE_SINGLE_METRICS}
+                                    WHERE account_id = ? AND region = ?
+                                        AND namespace = ? AND metric_name = ?
+                                        AND timestamp BETWEEN ? AND ?
+                                    ORDER BY {order_by}""",
+                data,
+            )
+            # cur.execute(
+            #     f"""SELECT {fun} FROM {self.TABLE_SINGLE_METRICS}
+            #             WHERE account_id = ? AND region = ?
+            #                 AND namespace = ? AND metric_name = ? AND dimensions = ?
+            #                 AND unit = ?
+            #                 AND timestamp BETWEEN ? AND ?
+            #             ORDER BY {order_by}""",
+            #     data,
+            # )
+            results = cur.fetchall()
+            # TODO return datapoints, create results, join with aggregated data
+            return {"id": query.get("Id"), "result": results}
 
     def clear_tables(self):
-        # TODO clear tables
+        # TODO clear tables for reset calls on cloudwatch
         pass
 
     def shutdown(self):
         # TODO delete tmpdir/database if we do not have persistence enabled?
         # anything else we should consider?
         ...
+
+    def _get_ordered_dimensions_with_separator(self, dims: Optional[List[Dict]]):
+        if not dims:
+            return None
+        dims.sort(key=lambda d: d["Name"])
+        dimensions = ""
+        for d in dims:
+            dimensions += f"{d['Name']}={d['Value']}\t"  # aws does not allow ascii control characters, we can use it a sa separator
+
+        return dimensions
+
+    def _convert_timestamp_to_unix(
+        self, timestamp: datetime
+    ):  # TODO verify if this is the standard format, might need to convert
+        return int(timestamp.timestamp())

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -208,14 +208,18 @@ class CloudwatchDatabase:
 
             namespace_filter = f"AND namespace = '{namespace}'" if namespace else ""
             metric_name_filter = f"AND metric_name = '{metric_name}'" if metric_name else ""
-            # TODO check how to filter dimmension correctly
+
+            dimension_filter = ""
+            for dimension in dimensions:
+                dimension_filter += f"AND dimensions LIKE '%{dimension['Name']}={dimension.get('Value','')}%' "
+
             # TODO add support for next token
             data = (account_id, region)
 
             cur.execute(
                 f"""SELECT DISTINCT metric_name, namespace ,dimensions FROM {self.TABLE_SINGLE_METRICS}
                                     WHERE account_id = ? AND region = ?
-                                        {namespace_filter} {metric_name_filter}
+                                        {namespace_filter} {metric_name_filter} {dimension_filter}
                                     ORDER BY timestamp DESC""",
                 data,
             )
@@ -225,6 +229,7 @@ class CloudwatchDatabase:
                 f"""SELECT DISTINCT metric_name, namespace ,dimensions FROM {self.TABLE_AGGREGATED_METRICS}
                                     WHERE account_id = ? AND region = ?
                                         {namespace_filter} {metric_name_filter}
+                                        {dimension_filter}
                                     ORDER BY timestamp DESC""",
                 data,
             )

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -106,7 +106,7 @@ class CloudwatchDatabase:
                 )
 
                 inserts = []
-                if metric.get("Value"):
+                if metric.get("Value") is not None:
                     inserts.append({"Value": metric.get("Value"), "TimesToInsert": 1})
                 elif metric.get("Values"):
                     counts = metric.get("Counts", [1] * len(metric.get("Values")))
@@ -232,7 +232,7 @@ class CloudwatchDatabase:
                     ),
                 )
                 single_result = cur.fetchone()[0]
-                if single_result:
+                if single_result is not None:
                     datapoints[str(start_time_unix)]["values"].append(single_result)
 
                 cur.execute(

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -93,7 +93,7 @@ class CloudwatchDatabase:
                 if metric.get("Value"):
                     inserts.append({"Value": metric.get("Value"), "TimesToInsert": 1})
                 elif metric.get("Values"):
-                    inserts = [{"Value": value, "TimesToInsert": metric.get("Counts")[indexValue]} for indexValue,value in enumerate(metric.get("Values"))]
+                    inserts = [{"Value": value, "TimesToInsert": int(metric.get("Counts")[indexValue])} for indexValue,value in enumerate(metric.get("Values"))]
 
                 for insert in inserts:
                     for _ in range(insert.get("TimesToInsert")):

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from localstack import config
-from localstack.aws.api.cloudwatch import MetricData, MetricStat, ScanBy
+from localstack.aws.api.cloudwatch import MetricData, MetricDataQuery, ScanBy
 from localstack.utils.files import mkdir
 
 LOG = logging.getLogger(__name__)
@@ -159,7 +159,7 @@ class CloudwatchDatabase:
         self,
         account_id: str,
         region: str,
-        query: MetricStat,
+        query: MetricDataQuery,
         start_time: datetime,
         end_time: datetime,
         scan_by: str,
@@ -232,7 +232,7 @@ class CloudwatchDatabase:
                     ),
                 )
                 single_result = cur.fetchone()[0]
-                if single_result is not None:
+                if single_result or (single_result == 0 and stat != "SampleCount"):
                     datapoints[str(start_time_unix)]["values"].append(single_result)
 
                 cur.execute(

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -175,7 +175,7 @@ class CloudwatchDatabase:
             metric = metric_stat.get("Metric")
             period = metric_stat.get("Period")
             stat = metric_stat.get("Stat")
-            dimensions = metric.get("Dimensions")
+            dimensions = metric.get("Dimensions", [])
             # unit = metric_stat.get("Unit")
 
             # prepare SQL query
@@ -288,7 +288,11 @@ class CloudwatchDatabase:
                             count += 1
                     cleaned_datapoints[timestamp] = total_sum / count
 
-            return {"id": query.get("Id"), "datapoints": cleaned_datapoints}
+            return {
+                "id": query.get("Id"),
+                "datapoints": cleaned_datapoints,
+                "label": f"{metric.get('MetricName')} {stat}",
+            }
 
     def list_metrics(self, account_id, region, namespace, metric_name, dimensions) -> dict:
         with sqlite3.connect(self.METRICS_DB) as conn:

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -245,12 +245,17 @@ class CloudwatchDatabase:
                 for r in cur.fetchall()
             ]
 
+            query = f"""
+                SELECT DISTINCT metric_name, namespace ,dimensions FROM {self.TABLE_AGGREGATED_METRICS}
+                WHERE account_id = ? AND region = ?
+                {namespace_filter}
+                {metric_name_filter}
+                {dimension_filter}
+                ORDER BY timestamp DESC
+            """
+
             cur.execute(
-                f"""SELECT DISTINCT metric_name, namespace ,dimensions FROM {self.TABLE_AGGREGATED_METRICS}
-                                    WHERE account_id = ? AND region = ?
-                                        {namespace_filter} {metric_name_filter}
-                                        {dimension_filter}
-                                    ORDER BY timestamp DESC""",
+                query,
                 data,
             )
             aggregated_metrics_result = [

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -220,7 +220,7 @@ class CloudwatchDatabase:
                         next_start_time,
                     ),
                 )
-                single_result = cur.fetchall()[0][0]
+                single_result = cur.fetchone()[0]
                 if single_result:
                     datapoints[str(start_time_unix)]["values"].append(single_result)
 
@@ -266,12 +266,12 @@ class CloudwatchDatabase:
                 elif stat == "Average":
                     total_sum = 0
                     count = 0
-                    for claned_value in cleaned_values:
-                        if isinstance(claned_value, tuple):
-                            total_sum += claned_value[0]
-                            count += claned_value[1]
+                    for cleaned_value in cleaned_values:
+                        if isinstance(cleaned_value, tuple):
+                            total_sum += cleaned_value[0]
+                            count += cleaned_value[1]
                         else:
-                            total_sum += claned_value
+                            total_sum += cleaned_value
                             count += 1
                     cleaned_datapoints[timestamp] = total_sum / count
 

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -208,7 +208,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         for result in results:
             formatted_result = {
                 "Id": result.get("id"),
-                "Label": "TODO",
+                "Label": result.get("label"),
                 "StatusCode": "Complete",
                 "Timestamps": [],
                 "Values": [],

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -202,8 +202,26 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         nxt: NextToken = None
         # TODO might contain error messages if data could not be retrieved, needs testing
         messages: MetricDataResultMessages = None  # TODO
-        # TODO parse dataresults
-        return GetMetricDataOutput(MetricDataResults=[], NextToken=nxt, Messages=messages)
+
+        formatted_results = []
+        for result in results:
+            formatted_result = {
+                "Id": result.get("id"),
+                "Label": "TODO",
+                "StatusCode": "Complete",
+                "Timestamps": [],
+                "Values": [],
+            }
+            datapoints = result.get("datapoints", {})
+            for timestamp, datapoint_result in datapoints.items():
+                formatted_result["Timestamps"].append(int(timestamp))
+                formatted_result["Values"].append(datapoint_result)
+
+            formatted_results.append(formatted_result)
+
+        return GetMetricDataOutput(
+            MetricDataResults=formatted_results, NextToken=nxt, Messages=messages
+        )
 
     def get_raw_metrics(self, request: Request):
         # TODO this needs to be read from the database

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -383,7 +383,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             context.region,
             namespace,
             metric_name,
-            dimensions,
+            dimensions or [],
         )
 
         metrics = [

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -83,8 +83,9 @@ def _validate_parameters_for_put_metric_data(metric_data: MetricData) -> None:
                 f"The parameters MetricData.member.{indexplusone}.Value and MetricData.member.{indexplusone}.Values are mutually exclusive and you have specified both."
             )
 
-        if (values := metric_item.get("Values")) and (counts := metric_item.get("Counts")):
-            if len(values) != len(counts):
+        if values := metric_item.get("Values"):
+            counts = metric_item.get("Counts", [])
+            if len(values) != len(counts) and len(counts) != 0:
                 raise InvalidParameterValueException(
                     f"The parameters MetricData.member.{indexplusone}.Values and MetricData.member.{indexplusone}.Counts must be of the same size."
                 )

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -367,14 +367,12 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             dimensions,
         )
 
-        metrics = []
-        for metric in result.get("metrics"):
-            metrics.append(
-                {
-                    "Namespace": metric.get("namespace"),
-                    "MetricName": metric.get("metric_name"),
-                    "Dimensions": metric.get("dimensions"),
-                }
-            )
-
+        metrics = [
+            {
+                "Namespace": metric.get("namespace"),
+                "MetricName": metric.get("metric_name"),
+                "Dimensions": metric.get("dimensions"),
+            }
+            for metric in result.get("metrics", [])
+        ]
         return ListMetricsOutput(Metrics=metrics, NextToken=None)

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -35,6 +35,7 @@ from localstack.aws.api.cloudwatch import (
     MetricData,
     MetricDataQueries,
     MetricDataQuery,
+    MetricDataResult,
     MetricDataResultMessages,
     MetricDataResults,
     MetricName,
@@ -226,7 +227,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 formatted_result["Timestamps"].append(int(timestamp))
                 formatted_result["Values"].append(datapoint_result)
 
-            formatted_results.append(formatted_result)
+            formatted_results.append(MetricDataResult(**formatted_result))
 
         return GetMetricDataOutput(
             MetricDataResults=formatted_results, NextToken=nxt, Messages=messages

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -395,6 +395,7 @@ class TestCloudwatch:
         def _count_metrics():
             results = aws_client.cloudwatch.list_metrics(Namespace=namespace)["Metrics"]
             assert len(results) == 2
+            print(results)
 
         # asserting only unique values are returned
         retry(_count_metrics, retries=retries, sleep_before=sleep_seconds)

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -106,7 +106,6 @@ class TestCloudwatch:
 
     @markers.aws.validated
     def test_put_metric_data_validation(self, aws_client):
-        metric_name = "test-metric"
         namespace = f"ns-{short_uid()}"
         utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -471,7 +471,7 @@ class TestCloudwatch:
         retry(_count_aggregated_metrics, retries=retries, sleep_before=sleep_seconds)
 
     @markers.aws.validated
-    def test_list_metrics_with_querys(self, aws_client):
+    def test_list_metrics_with_filters(self, aws_client):
         namespace = f"test/{short_uid()}"
         sleep_seconds = 10 if is_aws_cloud() else 1
         retries = 100 if is_aws_cloud() else 10

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -23,7 +23,7 @@ PUBLICATION_RETRIES = 5
 
 
 def is_old_provider():
-    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") != "v2"
+    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") == "v2"
 
 
 class TestCloudwatch:
@@ -105,6 +105,7 @@ class TestCloudwatch:
         assert namespace == rs["Metrics"][0]["Namespace"]
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_put_metric_data_validation(self, aws_client):
         namespace = f"ns-{short_uid()}"
         utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
@@ -1612,6 +1613,7 @@ class TestCloudwatch:
         snapshot.match("describe_minimal_metric_alarm", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_get_metric_data_with_zero_and_labels(self, aws_client):
         utc_now = datetime.now(tz=timezone.utc)
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -23,7 +23,7 @@ PUBLICATION_RETRIES = 5
 
 
 def is_old_provider():
-    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") == "v2"
+    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") != "v2"
 
 
 class TestCloudwatch:

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1612,7 +1612,7 @@ class TestCloudwatch:
         snapshot.match("describe_minimal_metric_alarm", response)
 
     @markers.aws.validated
-    def test_get_metric_data_within_timeframe(self, aws_client):
+    def test_get_metric_data_with_zero_and_labels(self, aws_client):
         utc_now = datetime.now(tz=timezone.utc)
 
         namespace1 = f"test/{short_uid()}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
wip, adding sqlite for storing metrics, 

started with:
* adding sqlite tables
* added `cloudwatch_database_helper` class where we will run all the queries
   * started with `add_metric_data` -> only for single value metrics
   * started `get_metric_data_stat` -> several TODOs left (see TODO section)

<!-- What notable changes does this PR make? -->
## Changes

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes
-->
## TODO

What's left to do:

- [x] `put_metrics`
   - [x]  validation of input
   - [x] implement `Values`
   - [x] implement `StatisticValues`
- [x] `get_metric_data`
   - [x] include data from aggregated-metrics
   - [x] aggregate + list by period (check with moto implementation)
   - [x] handle null values
   - [x] add tests
   - [x] filter by dimension
   - [x] Paginate results

- [x] `get_metric_statistics` 
- [x] `list_metrics`
  - [x] single metrics 
  - [x] aggregated-metrics table 
  - [x] filter by dimension
  - [x] filter by dimension value

Follow-up Tasks + TODOs
- [ ] verify that the default timestamp added to the metrics is UTC time (might be local timestamp?)
- [ ] `get_raw_metrics` endpoint
- [ ] persistence -> add directory, check if data is restored
- [ ] handle different units in the metrics
- [ ] add a test where we try to insert single + static values at the same time (in one put-metric-data statement (probably will throw an error, but we need to test)
- [ ] get-metric-data:
     - [ ] null values, check if dimensions must be null though if missing
     - [ ] test default order (asc/desc timestamp for get-metric-data)
     - [ ] handle empty filters for dimensions
     - [ ] handle filters for unit
     - [ ] check if we can simplify the logic for min/max/sum/avg the data query, by selecting everything in one query something like: `SELECT from (SELECT from simpletable ... UNION select from aggregatedtable...`)
 - [ ] shutdown/clear table: placeholders currently, we should delete the table when the `reset` endpoint is called
 - [ ] add pagination tests 
 - [ ] add snapshots to the existing tests
 - [ ] remove the `time.sleep` from the tests and replace with `retry` or other utility


