### PR TITLE
Fix CFn schema json name resolution for -ext

### DIFF
--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -97,6 +97,6 @@ def fix_boto_parameters_based_on_report(original_params: dict, report: str) -> d
 
 #  LocalStack specific utilities
 def get_schema_path(file_path: Path) -> Path:
-    file_name_base = file_path.name.removesuffix(".py")
+    file_name_base = file_path.name.removesuffix(".py").removesuffix(".py.enc")
     with Path(file_path).parent.joinpath(f"{file_name_base}.schema.json").open() as fd:
         return json.load(fd)


### PR DESCRIPTION
## Motivation

Since we have resource providers in -ext now, we need to fix the schema json lookup. Since -ext code is encrypted, files are renamed and have an `.py.enc` file suffix instead of the `.py` suffix in community.

## Changes

- tries to remove both `.py.enc` as well as `.py` when searching for the schema json file.