### PR TITLE
Fix updates of event source mapping targeting new function versions

### DIFF
--- a/tests/aws/services/lambda_/functions/lambda_echo_version_env.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_version_env.py
@@ -1,0 +1,16 @@
+import json
+import os
+
+
+def handler(event, context):
+    # Just print the event that was passed to the Lambda
+    print(
+        json.dumps(
+            {
+                "function_version": os.environ.get("AWS_LAMBDA_FUNCTION_VERSION"),
+                "CUSTOM_VAR": os.environ.get("CUSTOM_VAR"),
+                "event": event,
+            }
+        )
+    )
+    return event

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -52,6 +52,9 @@ THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_LAMBDA_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_integration.py")
 TEST_LAMBDA_PYTHON_ECHO = os.path.join(THIS_FOLDER, "functions/lambda_echo.py")
 TEST_LAMBDA_PYTHON_REQUEST_ID = os.path.join(THIS_FOLDER, "functions/lambda_request_id.py")
+TEST_LAMBDA_PYTHON_ECHO_VERSION_ENV = os.path.join(
+    THIS_FOLDER, "functions/lambda_echo_version_env.py"
+)
 TEST_LAMBDA_PYTHON_ROLE = os.path.join(THIS_FOLDER, "functions/lambda_role.py")
 TEST_LAMBDA_MAPPING_RESPONSES = os.path.join(THIS_FOLDER, "functions/lambda_mapping_responses.py")
 TEST_LAMBDA_PYTHON_SELECT_PATTERN = os.path.join(THIS_FOLDER, "functions/lambda_select_pattern.py")

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -1259,7 +1259,7 @@ class TestSQSEventSourceMapping:
         )
         assert mapping_uuid == updated_esm["UUID"]
         assert publish_v2["FunctionArn"] == updated_esm["FunctionArn"]
-        # snapshot.match("updated_esm", updated_esm)
+        snapshot.match("updated_esm", updated_esm)
         _await_event_source_mapping_enabled(aws_client.lambda_, mapping_uuid)
 
         # TODO: we actually would probably need to wait for an updating state here.

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -13,7 +13,11 @@ from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length, get_lambda_log_events
 from tests.aws.services.lambda_.functions import lambda_integration
-from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON, TEST_LAMBDA_PYTHON_ECHO
+from tests.aws.services.lambda_.test_lambda import (
+    TEST_LAMBDA_PYTHON,
+    TEST_LAMBDA_PYTHON_ECHO,
+    TEST_LAMBDA_PYTHON_ECHO_VERSION_ENV,
+)
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 LAMBDA_SQS_INTEGRATION_FILE = os.path.join(THIS_FOLDER, "functions", "lambda_sqs_integration.py")
@@ -1163,5 +1167,119 @@ class TestSQSEventSourceMapping:
         snapshot.match("create_event_source_mapping_exception", expected.value.response)
         expected.match(InvalidParameterValueException.code)
 
+    # TODO: test integration with lambda logs
+    @markers.aws.validated
+    def test_sqs_event_source_mapping_update(
+        self,
+        create_lambda_function,
+        sqs_create_queue,
+        sqs_get_queue_arn,
+        lambda_su_role,
+        snapshot,
+        cleanups,
+        aws_client,
+    ):
+        """
+        Testing an update to an event source mapping that changes the targeted lambda function version
 
-# TODO: test integration with lambda logs
+        Resources used:
+        - Lambda function
+        - 2 published versions of that lambda function
+        - 1 event source mapping
+
+        First the event source mapping points towards the qualified ARN of the first version.
+        A message is sent to the SQS queue, triggering the function version with ID 1.
+        The lambda function is updated with a different value for the environment variable and a new version published.
+        Then we update the event source mapping and make the qualified ARN of the function version with ID 2 the new target.
+        A message is sent to the SQS queue, triggering the function with version ID 2.
+
+        We should have one log entry for each of the invocations.
+
+        """
+        function_name = f"lambda_func-{short_uid()}"
+        queue_name_1 = f"queue-{short_uid()}-1"
+        mapping_uuid = None
+
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO_VERSION_ENV,
+            runtime=Runtime.python3_11,
+            role=lambda_su_role,
+        )
+
+        aws_client.lambda_.update_function_configuration(
+            FunctionName=function_name, Environment={"Variables": {"CUSTOM_VAR": "a"}}
+        )
+        aws_client.lambda_.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+        publish_v1 = aws_client.lambda_.publish_version(FunctionName=function_name)
+        aws_client.lambda_.get_waiter("function_active_v2").wait(
+            FunctionName=publish_v1["FunctionArn"]
+        )
+
+        queue_url_1 = sqs_create_queue(QueueName=queue_name_1)
+        queue_arn_1 = sqs_get_queue_arn(queue_url_1)
+        create_event_source_mapping_response = aws_client.lambda_.create_event_source_mapping(
+            EventSourceArn=queue_arn_1,
+            FunctionName=publish_v1["FunctionArn"],
+            MaximumBatchingWindowInSeconds=1,
+        )
+        mapping_uuid = create_event_source_mapping_response["UUID"]
+        cleanups.append(lambda: aws_client.lambda_.delete_event_source_mapping(UUID=mapping_uuid))
+        snapshot.match("create-event-source-mapping-response", create_event_source_mapping_response)
+        _await_event_source_mapping_enabled(aws_client.lambda_, mapping_uuid)
+
+        aws_client.sqs.send_message(QueueUrl=queue_url_1, MessageBody=json.dumps({"foo": "bar"}))
+
+        events = retry(
+            check_expected_lambda_log_events_length,
+            retries=10,
+            sleep=1,
+            function_name=function_name,
+            expected_length=1,
+            logs_client=aws_client.logs,
+        )
+        snapshot.match("events", events)
+
+        rs = aws_client.sqs.receive_message(QueueUrl=queue_url_1)
+        assert rs.get("Messages") is None
+
+        # # create new function version
+        aws_client.lambda_.update_function_configuration(
+            FunctionName=function_name, Environment={"Variables": {"CUSTOM_VAR": "b"}}
+        )
+        aws_client.lambda_.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+        publish_v2 = aws_client.lambda_.publish_version(FunctionName=function_name)
+        aws_client.lambda_.get_waiter("function_active_v2").wait(
+            FunctionName=publish_v2["FunctionArn"]
+        )
+        # we're now pointing the existing event source mapping towards the new version.
+        # only v2 should now be called
+        updated_esm = aws_client.lambda_.update_event_source_mapping(
+            UUID=mapping_uuid, FunctionName=publish_v2["FunctionArn"]
+        )
+        assert mapping_uuid == updated_esm["UUID"]
+        assert publish_v2["FunctionArn"] == updated_esm["FunctionArn"]
+        # snapshot.match("updated_esm", updated_esm)
+        _await_event_source_mapping_enabled(aws_client.lambda_, mapping_uuid)
+
+        # TODO: we actually would probably need to wait for an updating state here.
+        #   we experience flaky cases on AWS where the next send actually goes to the old version.
+        #   Not sure yet how we could prevent this
+        if is_aws_cloud():
+            time.sleep(10)
+
+        # verify function v2 was called, not latest and not v1
+        aws_client.sqs.send_message(QueueUrl=queue_url_1, MessageBody=json.dumps({"foo": "bar2"}))
+        # get the event message
+        events_postupdate = retry(
+            check_expected_lambda_log_events_length,
+            retries=10,
+            sleep=1,
+            function_name=function_name,
+            expected_length=2,
+            logs_client=aws_client.logs,
+        )
+        snapshot.match("events_postupdate", events_postupdate)
+
+        rs = aws_client.sqs.receive_message(QueueUrl=queue_url_1)
+        assert rs.get("Messages") is None

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -1167,7 +1167,7 @@ class TestSQSEventSourceMapping:
         snapshot.match("create_event_source_mapping_exception", expected.value.response)
         expected.match(InvalidParameterValueException.code)
 
-    # TODO: test integration with lambda logs
+    @pytest.mark.skipif(condition=is_old_provider(), reason="broken")
     @markers.aws.validated
     def test_sqs_event_source_mapping_update(
         self,

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
@@ -1426,5 +1426,110 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
+    "recorded-date": "23-10-2023, 15:24:12",
+    "recorded-content": {
+      "create-event-source-mapping-response": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "events": [
+        {
+          "function_version": "1",
+          "CUSTOM_VAR": "a",
+          "event": {
+            "Records": [
+              {
+                "messageId": "<uuid:2>",
+                "receiptHandle": "<receipt-handle:1>",
+                "body": {
+                  "foo": "bar"
+                },
+                "attributes": {
+                  "ApproximateReceiveCount": "1",
+                  "SentTimestamp": "timestamp",
+                  "SenderId": "sender-id",
+                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "<md5-of-body:1>",
+                "md5OfMessageAttributes": null,
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                "awsRegion": "<region>"
+              }
+            ]
+          }
+        }
+      ],
+      "events_postupdate": [
+        {
+          "function_version": "1",
+          "CUSTOM_VAR": "a",
+          "event": {
+            "Records": [
+              {
+                "messageId": "<uuid:2>",
+                "receiptHandle": "<receipt-handle:1>",
+                "body": {
+                  "foo": "bar"
+                },
+                "attributes": {
+                  "ApproximateReceiveCount": "1",
+                  "SentTimestamp": "timestamp",
+                  "SenderId": "sender-id",
+                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "<md5-of-body:1>",
+                "md5OfMessageAttributes": null,
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                "awsRegion": "<region>"
+              }
+            ]
+          }
+        },
+        {
+          "function_version": "2",
+          "CUSTOM_VAR": "b",
+          "event": {
+            "Records": [
+              {
+                "messageId": "<uuid:3>",
+                "receiptHandle": "<receipt-handle:2>",
+                "body": {
+                  "foo": "bar2"
+                },
+                "attributes": {
+                  "ApproximateReceiveCount": "1",
+                  "SentTimestamp": "timestamp",
+                  "SenderId": "sender-id",
+                  "ApproximateFirstReceiveTimestamp": "timestamp"
+                },
+                "messageAttributes": {},
+                "md5OfMessageAttributes": null,
+                "md5OfBody": "<md5-of-body:2>",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                "awsRegion": "<region>"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
@@ -1428,7 +1428,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping_update": {
-    "recorded-date": "23-10-2023, 15:24:12",
+    "recorded-date": "31-10-2023, 15:18:45",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
@@ -1464,8 +1464,8 @@
                   "ApproximateFirstReceiveTimestamp": "timestamp"
                 },
                 "messageAttributes": {},
-                "md5OfBody": "<md5-of-body:1>",
                 "md5OfMessageAttributes": null,
+                "md5OfBody": "<md5-of-body:1>",
                 "eventSource": "aws:sqs",
                 "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
                 "awsRegion": "<region>"
@@ -1474,6 +1474,21 @@
           }
         }
       ],
+      "updated_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 1,
+        "State": "Updating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
       "events_postupdate": [
         {
           "function_version": "1",
@@ -1493,8 +1508,8 @@
                   "ApproximateFirstReceiveTimestamp": "timestamp"
                 },
                 "messageAttributes": {},
-                "md5OfBody": "<md5-of-body:1>",
                 "md5OfMessageAttributes": null,
+                "md5OfBody": "<md5-of-body:1>",
                 "eventSource": "aws:sqs",
                 "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
                 "awsRegion": "<region>"


### PR DESCRIPTION
## Motivation

- Initiated by a support case, we saw that we never updated the stored function ARN in the event source mapping, which lead to the event source mapping still calling the previous version instead.

Example scenario (see accompanying test case):
```
  Testing an update to an event source mapping that changes the targeted lambda function version
  Resources used:
  - Lambda function
  - 2 published versions of that lambda function
  - 1 event source mapping
  First the event source mapping points towards the qualified ARN of the first version.
  A message is sent to the SQS queue, triggering the function version with ID 1.
  The lambda function is updated with a different value for the environment variable and a new version published.
  Then we update the event source mapping and make the qualified ARN of the function version with ID 2 the new target.
  A message is sent to the SQS queue, triggering the function with version ID 2.
  We should have one log entry for each of the invocations.
```

## Changes

- Properly overwrite the new lambda function ARN when updating the event source mapping to point towards the new function version.
- Adds a snapshot test verifying this previously broken behavior.

