### PR TITLE
fixed describe sfn exception

### DIFF
--- a/localstack/services/stepfunctions/provider_v2.py
+++ b/localstack/services/stepfunctions/provider_v2.py
@@ -253,7 +253,7 @@ class StepFunctionsProvider(StepfunctionsApi):
         # TODO: add arn validation.
         state_machine = self.get_store(context).state_machines.get(state_machine_arn)
         if state_machine is None:
-            raise ExecutionDoesNotExist()
+            raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{state_machine_arn}'")
         return state_machine.describe()
 
     def describe_state_machine_for_execution(

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -112,6 +112,30 @@ class TestSnfApi:
         sfn_snapshot.match("deletion_resp_1", deletion_resp_1)
 
     @markers.aws.validated
+    def test_describe_nonexistent_sm(
+        self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+        sm_name = f"statemachine_{short_uid()}"
+
+        creation_resp_1 = create_state_machine(
+            name=sm_name, definition=definition_str, roleArn=snf_role_arn
+        )
+        state_machine_arn: str = creation_resp_1["stateMachineArn"]
+
+        sm_nonexistent_name = f"statemachine_{short_uid()}"
+        sm_nonexistent_arn = state_machine_arn.replace(sm_name, sm_nonexistent_name)
+        sfn_snapshot.add_transformer(RegexTransformer(sm_nonexistent_arn, "sm_nonexistent_arn"))
+
+        with pytest.raises(Exception) as exc:
+            aws_client.stepfunctions.describe_state_machine(stateMachineArn=sm_nonexistent_arn)
+        sfn_snapshot.match("describe_nonexistent_sm", exc.value)
+
+    @markers.aws.validated
     def test_create_exact_duplicate_sm(
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1314,5 +1314,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_describe_nonexistent_sm": {
+    "recorded-date": "26-10-2023, 17:10:22",
+    "recorded-content": {
+      "describe_nonexistent_sm": "An error occurred (StateMachineDoesNotExist) when calling the DescribeStateMachine operation: State Machine Does Not Exist: 'sm_nonexistent_arn'"
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes the exception raised when calling describe api on non-existing state machine. Which was causing the terraform to fail.

<!-- What notable changes does this PR make? -->
## Changes
Replaced the `ExecutionDoesNotExists` exception to `StateMachineDoesNot` exists


## Testing
Added AWS validated test cases for the updated exception


## Related Issue
- https://github.com/localstack/localstack/issues/9439
