### PR TITLE
Add fallback partition config option for ARN partition rewriter

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse
 from localstack import config
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import Handler, HandlerChain
-from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.http import Response
 from localstack.http.proxy import forward
 from localstack.http.request import Request, get_full_raw_path, get_raw_path, restore_payload
@@ -257,13 +256,9 @@ class ArnPartitionRewriteHandler(Handler):
             try:
                 partition = self._get_partition_for_region(request_region)
             except self.InvalidRegionException:
-                try:
-                    # If the region is not properly set (f.e. because it is set to a wildcard),
-                    # the partition is determined based on the default region.
-                    partition = self._get_partition_for_region(config.DEFAULT_REGION)
-                except self.InvalidRegionException:
-                    # If it also fails with the DEFAULT_REGION, we use us-east-1 as a fallback
-                    partition = self._get_partition_for_region(AWS_REGION_US_EAST_1)
+                # If the region is not properly set (f.e. because it is set to a wildcard),
+                # the fallback partition is used.
+                partition = config.ARN_PARTITION_FALLBACK
         return partition
 
     @staticmethod

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -756,6 +756,10 @@ OUTBOUND_HTTPS_PROXY = os.environ.get("OUTBOUND_HTTPS_PROXY", "")
 # Whether to enable the partition adjustment listener (in order to support other partitions that the default)
 ARN_PARTITION_REWRITING = is_env_true("ARN_PARTITION_REWRITING")
 
+# Fallback partition to use if not possible to determine from ARN region.
+# Applicable only when ARN partition rewriting is enabled.
+ARN_PARTITION_FALLBACK = os.environ.get("ARN_PARTITION_FALLBACK", "") or "aws"
+
 # whether to skip waiting for the infrastructure to shut down, or exit immediately
 FORCE_SHUTDOWN = is_env_not_false("FORCE_SHUTDOWN")
 


### PR DESCRIPTION
## Motivation

The ARN partition rewriter depends on the deprecated environment config variable `DEFAULT_REGION`. It uses this to determine which partition to use as a fallback.

This is preventing us from removing the `DEFAULT_REGION` config option with the upcoming major release.

## Implementation

This PR introduces a new config option `ARN_PARTITION_FALLBACK` which can be used to set which partition to use as fallback. It defaults to `aws`, which is identical to old behaviour where it would be determined from the `us-east-1` region.

The `DEFAULT_REGION` config option will no longer have any effect on the rewriter.

Acceptance of this PR will entail an update to enterprise image build steps.

## Tests

Slightly tweaks existing tests to assert the new behaviour.