### PR TITLE
fix s3 v3 CopyObject in place + general validations for S3

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -613,8 +613,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
         src_moto_bucket = get_bucket_from_moto(moto_backend, bucket=src_bucket)
         source_key_object = get_key_from_moto_bucket(
-            src_moto_bucket, key=src_key, version_id=src_version_id
+            src_moto_bucket,
+            key=src_key,
+            version_id=src_version_id,
         )
+        # if the source object does not have an etag, it means it's a DeleteMarker
+        if not hasattr(source_key_object, "etag"):
+            if src_version_id:
+                raise InvalidRequest(
+                    "The source of a copy request may not specifically refer to a delete marker by version id."
+                )
+            raise NoSuchKey("The specified key does not exist.", Key=src_key)
 
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
         source_object_last_modified = source_key_object.last_modified.replace(
@@ -783,7 +792,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         bucket_name = request["Bucket"]
         moto_bucket = get_bucket_from_moto(get_moto_s3_backend(context), bucket_name)
-        if (upload_id := request.get("UploadId")) not in moto_bucket.multiparts:
+        upload_id = request.get("UploadId")
+        if not (
+            multipart := moto_bucket.multiparts.get(upload_id)
+        ) or not multipart.key_name == request.get("Key"):
             raise NoSuchUpload(
                 "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
@@ -801,7 +813,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         bucket_name = request["Bucket"]
         moto_backend = get_moto_s3_backend(context)
         moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket_name)
-        if (upload_id := request.get("UploadId")) not in moto_bucket.multiparts:
+        upload_id = request.get("UploadId")
+        if not (
+            multipart := moto_bucket.multiparts.get(upload_id)
+        ) or not multipart.key_name == request.get("Key"):
             raise NoSuchUpload(
                 "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -2113,7 +2113,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO: implements PartNumberMarker
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
-        if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
+        if (
+            not (s3_multipart := s3_bucket.multiparts.get(upload_id))
+            or s3_multipart.object.key != key
+        ):
             raise NoSuchUpload(
                 "The specified upload does not exist. "
                 "The upload ID may be invalid, or the upload may have been aborted or completed.",

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1161,15 +1161,19 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             dest_s3_bucket.encryption_rule is DEFAULT_BUCKET_ENCRYPTION
             and src_s3_object.encryption == "AES256"
         )
-        if src_key == dest_key and not any(
-            (
-                storage_class,
-                server_side_encryption,
-                metadata_directive == "REPLACE",
-                website_redirect_location,
-                dest_s3_bucket.encryption_rule
-                and not is_default_encryption,  # S3 will allow copy in place if the bucket has encryption configured
-                src_s3_object.restore,
+        if (
+            src_bucket == dest_bucket
+            and src_key == dest_key
+            and not any(
+                (
+                    storage_class,
+                    server_side_encryption,
+                    metadata_directive == "REPLACE",
+                    website_redirect_location,
+                    dest_s3_bucket.encryption_rule
+                    and not is_default_encryption,  # S3 will allow copy in place if the bucket has encryption configured
+                    src_s3_object.restore,
+                )
             )
         ):
             raise InvalidRequest(

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -122,6 +122,7 @@ from localstack.aws.api.s3 import (
     MaxKeys,
     MaxParts,
     MaxUploads,
+    MethodNotAllowed,
     MissingSecurityHeader,
     MultipartUpload,
     MultipartUploadId,
@@ -658,7 +659,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if tagging:
             store.TAGS.tags[key_id] = tagging
 
-        # TODO: returned fields
         # RequestCharged: Optional[RequestCharged]  # TODO
         response = PutObjectOutput(
             ETag=s3_object.quoted_etag,
@@ -693,15 +693,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> GetObjectOutput:
         # TODO: missing handling parameters:
         #  request_payer: RequestPayer = None,
-        #  part_number: PartNumber = None,
         #  expected_bucket_owner: AccountId = None,
 
         bucket_name = request["Bucket"]
         object_key = request["Key"]
         version_id = request.get("VersionId")
         store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
-
-        # TODO implement PartNumber once multipart is done (being able to select only a Part)
 
         s3_object = s3_bucket.get_object(
             key=object_key,
@@ -821,7 +818,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         version_id = request.get("VersionId")
         store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
-        # TODO implement PartNumber, don't know about part number + version id?
         s3_object = s3_bucket.get_object(
             key=object_key,
             version_id=version_id,
@@ -909,7 +905,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         bypass_governance_retention: BypassGovernanceRetention = None,
         expected_bucket_owner: AccountId = None,
     ) -> DeleteObjectOutput:
-        # TODO: implement bypass_governance_retention, it is done in moto
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if bypass_governance_retention is not None and not s3_bucket.object_lock_enabled:
@@ -938,8 +933,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not version_id:
             delete_marker_id = generate_version_id(s3_bucket.versioning_status)
             delete_marker = S3DeleteMarker(key=key, version_id=delete_marker_id)
-            # TODO: verify with Suspended bucket? does it override last version or still append?? big question
-            #  I think it puts a delete marker with a `null` VersionId, which deletes the object under
             s3_bucket.objects.set(key, delete_marker)
             # TODO: make a proper difference between DeleteMarker and S3Object, not done yet
             #  s3:ObjectRemoved:DeleteMarkerCreated
@@ -996,8 +989,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             raise MalformedXML()
 
         # TODO: max 1000 delete at once? test against AWS?
-        # TODO: implement ByPassGovernance
-        # TODO: implement Locking error
 
         quiet = delete.get("Quiet", False)
         deleted = []
@@ -1005,7 +996,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         to_remove = []
         for to_delete_object in objects:
-            # TODO: beware of key encoding (XML?)
             object_key = to_delete_object.get("Key")
             version_id = to_delete_object.get("VersionId")
             if s3_bucket.versioning_status is None:
@@ -1113,8 +1103,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
-        # TODO: handle those parameters next:
-        # request_payer: RequestPayer = None,
+        # request_payer: RequestPayer = None,  # TODO:
         dest_bucket = request["Bucket"]
         dest_key = request["Key"]
         store = self.get_store(context.account_id, context.region)
@@ -1127,15 +1116,18 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
 
         if not (src_s3_bucket := store.buckets.get(src_bucket)):
-            # TODO: validate this
             raise NoSuchBucket("The specified bucket does not exist", BucketName=src_bucket)
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, dest_s3_bucket)
 
-        # validate method not allowed?
-        # if the object is a delete marker, get_object will raise, like AWS
-        src_s3_object = src_s3_bucket.get_object(key=src_key, version_id=src_version_id)
+        # if the object is a delete marker, get_object will raise NotFound if no versionId, like AWS
+        try:
+            src_s3_object = src_s3_bucket.get_object(key=src_key, version_id=src_version_id)
+        except MethodNotAllowed:
+            raise InvalidRequest(
+                "The source of a copy request may not specifically refer to a delete marker by version id."
+            )
 
         if src_s3_object.storage_class in ARCHIVES_STORAGE_CLASSES and not src_s3_object.restore:
             raise InvalidObjectState(
@@ -1428,7 +1420,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         for s3_object in all_objects:
             key = urlparse.quote(s3_object.key) if encoding_type else s3_object.key
             # skip all keys that alphabetically come before key_marker
-            # TODO: what if there's StartAfter AND ContinuationToken
             if continuation_token:
                 if key < decoded_continuation_token:
                     continue
@@ -1676,7 +1667,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if s3_bucket.versioning_status:
             response["VersionId"] = s3_object.version_id
 
-        # TODO implement PartNumber test once multipart is done
         if s3_object.parts:
             response["ObjectParts"] = GetObjectAttributesParts(TotalPartsCount=len(s3_object.parts))
 
@@ -1833,7 +1823,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store, s3_bucket = self._get_cross_account_bucket(context, bucket_name)
 
         upload_id = request.get("UploadId")
-        if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
+        if not (
+            s3_multipart := s3_bucket.multiparts.get(upload_id)
+        ) or s3_multipart.object.key != request.get("Key"):
             raise NoSuchUpload(
                 "The specified upload does not exist. "
                 "The upload ID may be invalid, or the upload may have been aborted or completed.",
@@ -1845,10 +1837,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 ArgumentName="partNumber",
                 ArgumentValue=part_number,
             )
-
-        # TODO: validate key?
-        if s3_multipart.object.key != request.get("Key"):
-            pass
 
         checksum_algorithm = request.get("ChecksumAlgorithm")
         checksum_value = (
@@ -1905,7 +1893,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #  copy_source_if_unmodified_since: CopySourceIfUnmodifiedSince = None,
         #  request_payer: RequestPayer = None,
         dest_bucket = request["Bucket"]
-        dest_key = request["Bucket"]
+        dest_key = request["Key"]
         store = self.get_store(context.account_id, context.region)
         # TODO: validate cross-account UploadPartCopy
         if not (dest_s3_bucket := store.buckets.get(dest_bucket)):
@@ -1916,11 +1904,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
 
         if not (src_s3_bucket := store.buckets.get(src_bucket)):
-            # TODO: validate this
             raise NoSuchBucket("The specified bucket does not exist", BucketName=src_bucket)
 
-        # validate method not allowed?
-        src_s3_object = src_s3_bucket.get_object(key=src_key, version_id=src_version_id)
+        # if the object is a delete marker, get_object will raise NotFound if no versionId, like AWS
+        try:
+            src_s3_object = src_s3_bucket.get_object(key=src_key, version_id=src_version_id)
+        except MethodNotAllowed:
+            raise InvalidRequest(
+                "The source of a copy request may not specifically refer to a delete marker by version id."
+            )
 
         if src_s3_object.storage_class in ARCHIVES_STORAGE_CLASSES and not src_s3_object.restore:
             raise InvalidObjectState(
@@ -1929,7 +1921,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             )
 
         upload_id = request.get("UploadId")
-        if not (s3_multipart := dest_s3_bucket.multiparts.get(upload_id)):
+        if (
+            not (s3_multipart := dest_s3_bucket.multiparts.get(upload_id))
+            or s3_multipart.object.key != dest_key
+        ):
             raise NoSuchUpload(
                 "The specified upload does not exist. "
                 "The upload ID may be invalid, or the upload may have been aborted or completed.",
@@ -1942,10 +1937,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 ArgumentName="partNumber",
                 ArgumentValue=part_number,
             )
-
-        # TODO: validate key?
-        if s3_multipart.object.key != dest_key:
-            pass
 
         source_range = request.get("CopySourceRange")
         # TODO implement copy source IF (done in ASF provider)
@@ -2000,15 +1991,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> CompleteMultipartUploadOutput:
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
-        if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
+        if (
+            not (s3_multipart := s3_bucket.multiparts.get(upload_id))
+            or s3_multipart.object.key != key
+        ):
             raise NoSuchUpload(
                 "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
             )
-
-        # TODO: validate key?
-        if s3_multipart.object.key != key:
-            pass
 
         parts = multipart_upload.get("Parts", [])
         if not parts:
@@ -2087,15 +2077,18 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
     ) -> AbortMultipartUploadOutput:
-        # TODO: write tests around this
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
-        if not (s3_multipart := s3_bucket.multiparts.pop(upload_id, None)):
+        if (
+            not (s3_multipart := s3_bucket.multiparts.get(upload_id))
+            or s3_multipart.object.key != key
+        ):
             raise NoSuchUpload(
                 "The specified upload does not exist. "
                 "The upload ID may be invalid, or the upload may have been aborted or completed.",
                 UploadId=upload_id,
             )
+        s3_bucket.multiparts.pop(upload_id, None)
 
         self._storage_backend.remove_multipart(bucket, s3_multipart)
         response = AbortMultipartUploadOutput()
@@ -2116,6 +2109,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         sse_customer_key: SSECustomerKey = None,
         sse_customer_key_md5: SSECustomerKeyMD5 = None,
     ) -> ListPartsOutput:
+        # TODO: implement MaxParts
+        # TODO: implements PartNumberMarker
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not (s3_multipart := s3_bucket.multiparts.get(upload_id)):
@@ -2128,7 +2123,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         #     AbortDate: Optional[AbortDate] TODO: lifecycle
         #     AbortRuleId: Optional[AbortRuleId] TODO: lifecycle
         #     RequestCharged: Optional[RequestCharged]
-        #     ChecksumAlgorithm: Optional[ChecksumAlgorithm]
 
         response = ListPartsOutput(
             Bucket=bucket,
@@ -2141,8 +2135,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             MaxParts=max_parts or 1000,
         )
 
-        # TODO: implement MaxParts
-        # TODO: implement locking for iteration
         parts = [
             Part(
                 ETag=part.quoted_etag,
@@ -2192,7 +2184,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if delimiter:
             response["Delimiter"] = delimiter
 
-        # TODO: implement locking for iteration
         uploads = [
             MultipartUpload(
                 UploadId=multipart.id,
@@ -3075,8 +3066,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         confirm_remove_self_bucket_access: ConfirmRemoveSelfBucketAccess = None,
         expected_bucket_owner: AccountId = None,
     ) -> None:
-        # TODO: there is not validation of the policy at the moment, as there was none in moto
-        #  we store the JSON policy as is, as we do not need to decode it
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         if not policy or policy[0] != "{":

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1575,7 +1575,9 @@ class TestS3:
         condition=lambda: not is_native_provider(),
         paths=["$..ServerSideEncryption"],
     )
-    def test_s3_copy_object_in_place(self, s3_bucket, allow_bucket_acl, snapshot, aws_client):
+    def test_s3_copy_object_in_place(
+        self, s3_bucket, s3_create_bucket, allow_bucket_acl, snapshot, aws_client
+    ):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformer(
             [
@@ -1609,6 +1611,12 @@ class TestS3:
                 Bucket=s3_bucket, CopySource=f"{s3_bucket}/{object_key}", Key=object_key
             )
         snapshot.match("copy-object-in-place-no-change", e.value.response)
+
+        s3_bucket_2 = s3_create_bucket()
+        copy_obj_diff_bucket = aws_client.s3.copy_object(
+            Bucket=s3_bucket_2, CopySource=f"{s3_bucket}/{object_key}", Key=object_key
+        )
+        snapshot.match("copy-object-same-key-diff-bucket", copy_obj_diff_bucket)
 
         # it seems as long as you specify the field necessary, it does not check if the previous value was the same
         # and allows the copy

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3110,7 +3110,6 @@ class TestS3:
         # Boto still does not support chunk encoding, which means we can't test with the client nor
         # aws_http_client_factory. See open issue: https://github.com/boto/boto3/issues/751
         # Test for https://github.com/localstack/localstack/issues/8703
-        object_key = "data"
         body = "Hello Blob"
         precalculated_etag = hashlib.md5(body.encode()).hexdigest()
         headers = {
@@ -3136,7 +3135,9 @@ class TestS3:
         upload_id = response["UploadId"]
 
         # # upload the part 1
-        url = f"{config.service_url('s3')}/{s3_bucket}/{object_key}?partNumber={1}&uploadId={upload_id}"
+        url = (
+            f"{config.service_url('s3')}/{s3_bucket}/{key_name}?partNumber={1}&uploadId={upload_id}"
+        )
         response = requests.put(url, data, headers=headers, verify=False)
         assert response.ok
         part_etag = response.headers.get("ETag")

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4883,8 +4883,16 @@ class TestS3:
             )
         snapshot.match("complete-multipart-wrong-key-name", e.value.response)
 
-        # ASF provider completely defers this to moto, and moto does not properly handle it
+        # ASF provider completely defers those to moto, and moto does not properly handle it
         if is_aws_cloud() or config.NATIVE_S3_PROVIDER:
+            with pytest.raises(ClientError) as e:
+                aws_client.s3.list_parts(
+                    Bucket=s3_bucket,
+                    Key="fake-fake-name",
+                    UploadId=upload_id,
+                )
+            snapshot.match("list-parts-wrong-key-name", e.value.response)
+
             with pytest.raises(ClientError) as e:
                 aws_client.s3.abort_multipart_upload(
                     Bucket=s3_bucket,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1414,6 +1414,66 @@ class TestS3:
         snapshot.match("get-object-attrs", object_attrs)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
+    def test_s3_copy_object_src_not_exists(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        object_key = "random-src-key"
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"fake-bucket-{short_uid()}-{short_uid()}/{object_key}",
+                Key="fake-dest-key",
+            )
+        snapshot.match("copy-object-src-bucket-not-exists", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key="fake-dest-key",
+            )
+        snapshot.match("copy-object-src-object-not-exists", e.value.response)
+
+        # enable versioning so that we can test DeleteMarker behaviour
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        put_obj = aws_client.s3.put_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("put-obj-versioned", put_obj)
+        object_version = put_obj["VersionId"]
+
+        # put a DeleteMarker on top
+        del_obj = aws_client.s3.delete_object(Bucket=s3_bucket, Key=object_key)
+        delete_marker_version = del_obj["VersionId"]
+        snapshot.match("del-obj-versioned", del_obj)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}",
+                Key="fake-dest-key",
+            )
+        snapshot.match("copy-object-src-delete-marker-current-version", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource=f"{s3_bucket}/{object_key}?versionId={delete_marker_version}",
+                Key="fake-dest-key",
+            )
+        snapshot.match("copy-object-src-target-delete-marker", e.value.response)
+
+        copy_obj_version = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}?versionId={object_version}",
+            Key="fake-dest-key",
+        )
+        snapshot.match("copy-object-src-target-object-version", copy_obj_version)
+
+    @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
     @markers.snapshot.skip_snapshot_verify(
         condition=lambda: not is_native_provider(),
@@ -4791,6 +4851,47 @@ class TestS3:
             UploadId=upload_id,
         )
         snapshot.match("complete-multipart-with-step-2", response)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=lambda: not is_native_provider(),
+        paths=["$..ServerSideEncryption"],
+    )
+    def test_multipart_key_validation(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.key_value("UploadId"))
+
+        key_name = "test-multipart-key-validation"
+        response = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key_name)
+        upload_id = response["UploadId"]
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.upload_part(
+                Bucket=s3_bucket,
+                Key="fake-key-name",
+                Body=BytesIO(b"a"),
+                PartNumber=1,
+                UploadId=upload_id,
+            )
+        snapshot.match("upload-part-wrong-key-name", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key="fake-fake-name",
+                MultipartUpload={"Parts": []},
+                UploadId=upload_id,
+            )
+        snapshot.match("complete-multipart-wrong-key-name", e.value.response)
+
+        # ASF provider completely defers this to moto, and moto does not properly handle it
+        if is_aws_cloud() or config.NATIVE_S3_PROVIDER:
+            with pytest.raises(ClientError) as e:
+                aws_client.s3.abort_multipart_upload(
+                    Bucket=s3_bucket,
+                    Key="fake-fake-name",
+                    UploadId=upload_id,
+                )
+            snapshot.match("abort-multipart-wrong-key-name", e.value.response)
 
     @markers.aws.validated
     @pytest.mark.parametrize(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5989,7 +5989,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place": {
-    "recorded-date": "03-08-2023, 16:51:58",
+    "recorded-date": "26-10-2023, 14:34:19",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -6030,6 +6030,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "copy-object-same-key-diff-bucket": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "copy-object-in-place-with-storage-class": {

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11402,7 +11402,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_key_validation": {
-    "recorded-date": "26-10-2023, 15:45:28",
+    "recorded-date": "26-10-2023, 16:04:23",
     "recorded-content": {
       "upload-part-wrong-key-name": {
         "Error": {
@@ -11416,6 +11416,17 @@
         }
       },
       "complete-multipart-wrong-key-name": {
+        "Error": {
+          "Code": "NoSuchUpload",
+          "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list-parts-wrong-key-name": {
         "Error": {
           "Code": "NoSuchUpload",
           "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11322,5 +11322,121 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_src_not_exists": {
+    "recorded-date": "26-10-2023, 15:03:13",
+    "recorded-content": {
+      "copy-object-src-bucket-not-exists": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "copy-object-src-object-not-exists": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "random-src-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-obj-versioned": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-obj-versioned": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "copy-object-src-delete-marker-current-version": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "random-src-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "copy-object-src-target-delete-marker": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "The source of a copy request may not specifically refer to a delete marker by version id."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-object-src-target-object-version": {
+        "CopyObjectResult": {
+          "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+          "LastModified": "datetime"
+        },
+        "CopySourceVersionId": "<version-id:1>",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_key_validation": {
+    "recorded-date": "26-10-2023, 15:45:28",
+    "recorded-content": {
+      "upload-part-wrong-key-name": {
+        "Error": {
+          "Code": "NoSuchUpload",
+          "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "complete-multipart-wrong-key-name": {
+        "Error": {
+          "Code": "NoSuchUpload",
+          "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "abort-multipart-wrong-key-name": {
+        "Error": {
+          "Code": "NoSuchUpload",
+          "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I was looking at the S3 v3 `CopyObject` code and spotted an issue in the code: we wouldn't check the bucket equality when validating the in-place checks.

The v3 provider has parity with the v2, but it could be nice to push things a bit further for `ListMultipartUploads` and `ListParts`, as well as adding more validated tests of `UploadPartCopy`. This is to be done in a follow up PR.

<!-- What notable changes does this PR make? -->
## Changes
The PR was so small I also took a stab at the leftovers TODO in the v3 provider and added tests when removing some, and fixed the behaviour in both `v2` and `v3` for the following operations:
- `UploadPart`
- `CompleteMultipartUpload`
- `AbortMultipartUpload` and `ListParts` only for v3
- `CopyObject` additional validations for source object

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

