### PR TITLE
improve s3 v3 ListMultipartUploads and ListParts & various List* improvements

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1301,8 +1301,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         s3_objects: list[Object] = []
 
         # sort by key
-        all_objects = sorted(s3_bucket.objects.values(), key=lambda r: r.key)
-        for s3_object in all_objects:
+        for s3_object in sorted(s3_bucket.objects.values(), key=lambda r: r.key):
             if count >= max_keys:
                 is_truncated = True
                 if s3_objects:
@@ -1439,7 +1438,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 prefix_including_delimiter = f"{prefix}{pre_delimiter}{delimiter}"
 
                 if prefix_including_delimiter not in common_prefixes:
-                    # TODO: check going over MaxKeys from CommonPrefix
                     count += 1
                     common_prefixes.add(prefix_including_delimiter)
                 continue

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -646,7 +646,7 @@ class TestS3:
         self, s3_bucket, snapshot, aws_client, aws_http_client_factory
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())
-        keys = ["test/foo/bar/123" "test/foo/bar/456", "test/bar/foo/123"]
+        keys = ["test/foo/bar/123", "test/foo/bar/456", "test/bar/foo/123"]
         for key in keys:
             aws_client.s3.put_object(Bucket=s3_bucket, Key=key, Body=b"content 123")
 
@@ -813,6 +813,142 @@ class TestS3:
 
         resp = aws_client.s3.list_objects(Bucket=s3_bucket, Marker="", MaxKeys=1)
         snapshot.match("list-objects-marker-empty", resp)
+
+    @markers.aws.validated
+    @pytest.mark.xfail(condition=not NATIVE_S3_PROVIDER, reason="not implemented in moto")
+    def test_list_multiparts_next_marker(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("Bucket"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value(
+                    "ID", value_replacement="owner-id", reference_replacement=False
+                ),
+            ]
+        )
+        snapshot.add_transformer(snapshot.transform.key_value("Key"), priority=-1)
+
+        response = aws_client.s3.list_multipart_uploads(Bucket=s3_bucket)
+        snapshot.match("list-multiparts-empty", response)
+
+        keys = ["test_c", "test_b", "test_a"]
+        uploads_ids = []
+        for key in keys:
+            # create 1 upload per key, except for the last one
+            resp = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+            uploads_ids.append(resp["UploadId"])
+            if key == "test_a":
+                for _ in range(2):
+                    # add more upload for the last key to test UploadId ordering
+                    resp = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+                    uploads_ids.append(resp["UploadId"])
+
+        # snapshot the upload ids ordering to compare with listing
+        snapshot.match(
+            "upload-ids-order",
+            {"UploadIds": [{"UploadId": upload_id} for upload_id in uploads_ids]},
+        )
+
+        # AWS is saying on the doc that `UploadId` are sorted lexicographically, however tests shows that it's sorted
+        # by the Initiated time of the multipart
+        response = aws_client.s3.list_multipart_uploads(Bucket=s3_bucket)
+        snapshot.match("list-multiparts-all", response)
+
+        response = aws_client.s3.list_multipart_uploads(Bucket=s3_bucket, MaxUploads=1)
+        snapshot.match("list-multiparts-max-1", response)
+
+        next_key_marker = response["NextKeyMarker"]
+        next_upload_id_marker = response["NextUploadIdMarker"]
+
+        # try to see what's next when specifying only one
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket, MaxUploads=1, KeyMarker=next_key_marker
+        )
+        snapshot.match("list-multiparts-next-key-only", response)
+
+        # try with last key lexicographically
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket, MaxUploads=1, KeyMarker=keys[0]
+        )
+        snapshot.match("list-multiparts-next-key-last", response)
+
+        # UploadIdMarker is ignored if KeyMarker is not specified
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket,
+            MaxUploads=1,
+            UploadIdMarker=next_upload_id_marker,
+        )
+        snapshot.match("list-multiparts-next-upload-only", response)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket,
+            MaxUploads=1,
+            KeyMarker=next_key_marker,
+            UploadIdMarker=next_upload_id_marker,
+        )
+        snapshot.match("list-multiparts-both-markers", response)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket,
+            MaxUploads=1,
+            KeyMarker=next_key_marker,
+            UploadIdMarker=uploads_ids[-1],
+        )
+        snapshot.match("list-multiparts-both-markers-2", response)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket, MaxUploads=1, KeyMarker=""
+        )
+        snapshot.match("list-multiparts-next-key-empty", response)
+
+    @markers.aws.validated
+    @pytest.mark.xfail(condition=not NATIVE_S3_PROVIDER, reason="not implemented in moto")
+    def test_list_multiparts_with_prefix_and_delimiter(
+        self, s3_bucket, snapshot, aws_client, aws_http_client_factory
+    ):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("Bucket"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value(
+                    "ID", value_replacement="owner-id", reference_replacement=False
+                ),
+            ]
+        )
+        snapshot.add_transformer(snapshot.transform.key_value("Key"), priority=-1)
+        keys = ["test/foo/bar/123", "test/foo/bar/456", "test/bar/foo/123"]
+        for key in keys:
+            aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket,
+            Prefix="test/",
+            EncodingType="url",
+            Delimiter="/",
+        )
+        snapshot.match("list-multiparts-1", response)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket, Prefix="test/foo/", EncodingType="url", Delimiter="/"
+        )
+        snapshot.match("list-multiparts-2", response)
+
+        response = aws_client.s3.list_multipart_uploads(
+            Bucket=s3_bucket, Prefix="test/foo/bar", EncodingType="url", Delimiter="/"
+        )
+        snapshot.match("list-multiparts-3", response)
+
+        # test without EncodingUrl, manually encode parameters
+        bucket_url = f"{_bucket_url(s3_bucket)}?uploads&prefix=test%2Ffoo"
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        resp = s3_http_client.get(bucket_url, headers={"x-amz-content-sha256": "UNSIGNED-PAYLOAD"})
+        resp_dict = xmltodict.parse(resp.content)
+        resp_dict["ListMultipartUploadsResult"].pop("@xmlns", None)
+        snapshot.match("list-multiparts-no-encoding", resp_dict)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(condition=is_old_provider, path="$..Error.BucketName")

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10592,7 +10592,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_continuation_start_after": {
-    "recorded-date": "22-10-2023, 02:21:09",
+    "recorded-date": "26-10-2023, 19:49:18",
     "recorded-content": {
       "list-objects-v2-max-5": {
         "Contents": [
@@ -10728,7 +10728,7 @@
         "EncodingType": "url",
         "IsTruncated": false,
         "KeyCount": 2,
-        "MaxKeys": 1000,
+        "MaxKeys": 2,
         "Name": "<bucket-name:1>",
         "Prefix": "",
         "StartAfter": "test_7",
@@ -10815,7 +10815,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_versions_markers": {
-    "recorded-date": "22-10-2023, 04:04:58",
+    "recorded-date": "26-10-2023, 19:41:47",
     "recorded-content": {
       "version-order": {
         "Versions": [
@@ -11126,6 +11126,34 @@
             "Size": 9,
             "StorageClass": "STANDARD",
             "VersionId": "<version-id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-last-key-last-version": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "test_2",
+        "MaxKeys": 1,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "VersionIdMarker": "<version-id:4>",
+        "Versions": [
+          {
+            "ETag": "\"db3ec040e20dfc657dab510aeab74759\"",
+            "IsLatest": false,
+            "Key": "test_2",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 9,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:3>"
           }
         ],
         "ResponseMetadata": {
@@ -12081,6 +12109,87 @@
         "PartNumberMarker": 10,
         "StorageClass": "STANDARD",
         "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix_and_delimiter": {
+    "recorded-date": "26-10-2023, 20:12:20",
+    "recorded-content": {
+      "list-objects-v2-1": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/bar/"
+          },
+          {
+            "Prefix": "test/foo/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 2,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-1-with-max-keys": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/bar/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": true,
+        "KeyCount": 1,
+        "MaxKeys": 1,
+        "Name": "<bucket-name:1>",
+        "NextContinuationToken": "<next-continuation-token:1>",
+        "Prefix": "test/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-2": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/foo",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-3": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/bar/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/foo/bar",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11481,7 +11481,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_multiparts_next_marker": {
-    "recorded-date": "26-10-2023, 17:56:45",
+    "recorded-date": "26-10-2023, 18:58:41",
     "recorded-content": {
       "list-multiparts-empty": {
         "Bucket": "<bucket:1>",
@@ -11758,6 +11758,47 @@
           "HTTPStatusCode": 200
         }
       },
+      "list-multiparts-get-last-upload-no-truncate": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": false,
+        "KeyMarker": "<key:2>",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:3>",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "<upload-id:2>",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:3>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-wrong-id-for-key": {
+        "Error": {
+          "ArgumentName": "upload-id-marker",
+          "ArgumentValue": "<upload-id:2>",
+          "Code": "InvalidArgument",
+          "Message": "Invalid uploadId marker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "list-multiparts-next-key-empty": {
         "Bucket": "<bucket:1>",
         "IsTruncated": true,
@@ -11898,6 +11939,151 @@
             }
           ],
           "UploadIdMarker": null
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_list_parts_pagination": {
+    "recorded-date": "26-10-2023, 18:31:09",
+    "recorded-content": {
+      "list-parts-empty": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-part-pagination",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 0,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts-all": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-part-pagination",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 2,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 4
+          },
+          {
+            "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 4
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts-1": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": true,
+        "Key": "test-list-part-pagination",
+        "MaxParts": 1,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 4
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts-next": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-part-pagination",
+        "MaxParts": 1,
+        "NextPartNumberMarker": 2,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 1,
+        "Parts": [
+          {
+            "ETag": "\"8d777f385d3dfec8815d20f7496026dc\"",
+            "LastModified": "datetime",
+            "PartNumber": 2,
+            "Size": 4
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts-wrong-part": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-part-pagination",
+        "MaxParts": 1,
+        "NextPartNumberMarker": 0,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 10,
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -5540,7 +5540,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix": {
-    "recorded-date": "22-10-2023, 00:35:27",
+    "recorded-date": "26-10-2023, 18:10:52",
     "recorded-content": {
       "list-objects-v2-1": {
         "Contents": [
@@ -5553,7 +5553,14 @@
           },
           {
             "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123test/foo/bar/456",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/456",
             "LastModified": "datetime",
             "Size": 11,
             "StorageClass": "STANDARD"
@@ -5561,7 +5568,7 @@
         ],
         "EncodingType": "url",
         "IsTruncated": false,
-        "KeyCount": 2,
+        "KeyCount": 3,
         "MaxKeys": 1000,
         "Name": "<bucket-name:1>",
         "Prefix": "test/",
@@ -5574,7 +5581,14 @@
         "Contents": [
           {
             "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123test/foo/bar/456",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/456",
             "LastModified": "datetime",
             "Size": 11,
             "StorageClass": "STANDARD"
@@ -5582,7 +5596,7 @@
         ],
         "EncodingType": "url",
         "IsTruncated": false,
-        "KeyCount": 1,
+        "KeyCount": 2,
         "MaxKeys": 1000,
         "Name": "<bucket-name:1>",
         "Prefix": "test/foo",
@@ -5595,7 +5609,14 @@
         "Contents": [
           {
             "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123test/foo/bar/456",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/456",
             "LastModified": "datetime",
             "Size": 11,
             "StorageClass": "STANDARD"
@@ -5603,7 +5624,7 @@
         ],
         "EncodingType": "url",
         "IsTruncated": false,
-        "KeyCount": 1,
+        "KeyCount": 2,
         "MaxKeys": 1000,
         "Name": "<bucket-name:1>",
         "Prefix": "test/foo/bar",
@@ -5614,15 +5635,24 @@
       },
       "list-objects-v2-no-encoding": {
         "ListBucketResult": {
-          "Contents": {
-            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123test/foo/bar/456",
-            "LastModified": "date",
-            "Size": "11",
-            "StorageClass": "STANDARD"
-          },
+          "Contents": [
+            {
+              "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+              "Key": "test/foo/bar/123",
+              "LastModified": "date",
+              "Size": "11",
+              "StorageClass": "STANDARD"
+            },
+            {
+              "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+              "Key": "test/foo/bar/456",
+              "LastModified": "date",
+              "Size": "11",
+              "StorageClass": "STANDARD"
+            }
+          ],
           "IsTruncated": "false",
-          "KeyCount": "1",
+          "KeyCount": "2",
           "MaxKeys": "1000",
           "Name": "<bucket-name:1>",
           "Prefix": "test/foo"
@@ -11446,6 +11476,428 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_list_multiparts_next_marker": {
+    "recorded-date": "26-10-2023, 17:56:45",
+    "recorded-content": {
+      "list-multiparts-empty": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "",
+        "NextUploadIdMarker": "",
+        "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-ids-order": {
+        "UploadIds": [
+          {
+            "UploadId": "<upload-id:1>"
+          },
+          {
+            "UploadId": "<upload-id:2>"
+          },
+          {
+            "UploadId": "<upload-id:3>"
+          },
+          {
+            "UploadId": "<upload-id:4>"
+          },
+          {
+            "UploadId": "<upload-id:5>"
+          }
+        ]
+      },
+      "list-multiparts-all": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "<key:3>",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:3>"
+          },
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:4>"
+          },
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:5>"
+          },
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:2>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:2>"
+          },
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:3>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-max-1": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:1>",
+        "NextUploadIdMarker": "<upload-id:3>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-next-key-only": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "<key:1>",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:2>",
+        "NextUploadIdMarker": "<upload-id:2>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:2>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-next-key-last": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": false,
+        "KeyMarker": "<key:3>",
+        "MaxUploads": 1,
+        "NextKeyMarker": "",
+        "NextUploadIdMarker": "",
+        "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-next-upload-only": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:1>",
+        "NextUploadIdMarker": "<upload-id:3>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-both-markers": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "<key:1>",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:1>",
+        "NextUploadIdMarker": "<upload-id:4>",
+        "UploadIdMarker": "<upload-id:3>",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-both-markers-2": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "<key:1>",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:2>",
+        "NextUploadIdMarker": "<upload-id:2>",
+        "UploadIdMarker": "<upload-id:5>",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:2>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-next-key-empty": {
+        "Bucket": "<bucket:1>",
+        "IsTruncated": true,
+        "KeyMarker": "",
+        "MaxUploads": 1,
+        "NextKeyMarker": "<key:1>",
+        "NextUploadIdMarker": "<upload-id:3>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "Key": "<key:1>",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "owner-id"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_list_multiparts_with_prefix_and_delimiter": {
+    "recorded-date": "26-10-2023, 18:17:18",
+    "recorded-content": {
+      "list-multiparts-1": {
+        "Bucket": "<bucket:1>",
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/bar/"
+          },
+          {
+            "Prefix": "test/foo/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "",
+        "NextUploadIdMarker": "",
+        "Prefix": "test/",
+        "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-2": {
+        "Bucket": "<bucket:1>",
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/bar/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "",
+        "NextUploadIdMarker": "",
+        "Prefix": "test/foo/",
+        "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-3": {
+        "Bucket": "<bucket:1>",
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/bar/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "",
+        "NextUploadIdMarker": "",
+        "Prefix": "test/foo/bar",
+        "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-multiparts-no-encoding": {
+        "ListMultipartUploadsResult": {
+          "Bucket": "<bucket:1>",
+          "IsTruncated": "false",
+          "KeyMarker": null,
+          "MaxUploads": "1000",
+          "NextKeyMarker": "<key:2>",
+          "NextUploadIdMarker": "<upload-id:2>",
+          "Prefix": "test/foo",
+          "Upload": [
+            {
+              "Initiated": "date",
+              "Initiator": {
+                "DisplayName": "display-name",
+                "ID": "owner-id"
+              },
+              "Key": "<key:1>",
+              "Owner": {
+                "DisplayName": "display-name",
+                "ID": "owner-id"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "<upload-id:1>"
+            },
+            {
+              "Initiated": "date",
+              "Initiator": {
+                "DisplayName": "display-name",
+                "ID": "owner-id"
+              },
+              "Key": "<key:2>",
+              "Owner": {
+                "DisplayName": "display-name",
+                "ID": "owner-id"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "<upload-id:2>"
+            }
+          ],
+          "UploadIdMarker": null
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Going over the left overs TODOs from the v3 provider, I wanted to fixed the remaining important ones, namely handling the pagination for `ListMultipartUploads` and `ListParts`, and validate some behaviour that wasn't tested related to `List*` operations and pagination. 

~Currently based on #9483~

<!-- What notable changes does this PR make? -->
## Changes
Added handling of pagination parameters for `ListMultipartUploads` and `ListParts`.
Improve handling of `isTruncated`. 
Added a lot of snapshot tests to validate ordering, filtering and pagination of `List*` operations.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

