### PR TITLE
Install nodejs using http1.1 to work around download issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,11 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
-  && curl -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
+  && curl --retry 3 --retry-max-time 300 -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
   && LATEST_VERSION_FILENAME=$(cat SHASUMS256.txt | grep -o "node-v.*-linux-$ARCH" | sort | uniq) \
   && rm SHASUMS256.txt \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt.asc" \
+  && curl --retry 3 --retry-max-time 300 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz" \
+  && curl --retry 3 --retry-max-time 300 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " $LATEST_VERSION_FILENAME.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "$LATEST_VERSION_FILENAME.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,11 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
-  && curl --retry 3 --retry-max-time 300 -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
+  && curl --http1.1 -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt \
   && LATEST_VERSION_FILENAME=$(cat SHASUMS256.txt | grep -o "node-v.*-linux-$ARCH" | sort | uniq) \
   && rm SHASUMS256.txt \
-  && curl --retry 3 --retry-max-time 300 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz" \
-  && curl --retry 3 --retry-max-time 300 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt.asc" \
+  && curl --http1.1 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz" \
+  && curl --http1.1 -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " $LATEST_VERSION_FILENAME.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "$LATEST_VERSION_FILENAME.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Quite a few docker builds in the CI pipeline are failing when trying to install nodejs via curl. Based on some initial research, this is felt elsewhere outside of LocalStack. Claims are that it's either something like IP address banning (we have multiple concurrent CI runs with an unknown system architecture possibly spamming their servers), or some form of some transient CDN caching on the part of nodejs.org.

```
100  3153    0  3153    0     0  71016      0 --:--:-- --:--:-- --:--:-- 71659
#11 6.919 + cat+ uniq
#11 6.919  SHASUMS256.txt
#11 6.920 + sort
#11 6.920 + grep -o node-v.*-linux-x64
#11 6.921 + LATEST_VERSION_FILENAME=node-v18.18.2-linux-x64
#11 6.922 + rm SHASUMS256.txt
#11 6.922 + curl -fsSLO --compressed https://nodejs.org/dist/latest-v18.x/node-v18.18.2-linux-x64.tar.xz
#11 164.1 curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)
------
ERROR: failed to solve: executor failed running [/bin/sh -c ARCH= && dpkgArch="$(dpkg --print-architecture)"   && case "${dpkgArch##*-}" in     amd64) ARCH='x64';;     arm64) ARCH='arm64';;     *) echo "unsupported architecture"; exit 1 ;;   esac   && set -ex   && for key in     4ED778F539E3634C779C87C6D7062848A1AB005C     141F07595B7B3FFE74309A937405533BE57C7D57     74F12602B6F1C4E913FAA37AD3A89613643B6201     DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7     61FC681DFB92A079F1685E77973F295594EC4689     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8     890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4     C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C     108F52B48DB57BB0CC439B2997B01419BD92F80A     A363A499291CBBC940DD62E41F10027AF002F8B0   ; do       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ||       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ;   done   && curl -O https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt   && LATEST_VERSION_FILENAME=$(cat SHASUMS256.txt | grep -o "node-v.*-linux-$ARCH" | sort | uniq)   && rm SHASUMS256.txt   && curl -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/$LATEST_VERSION_FILENAME.tar.xz"   && curl -fsSLO --compressed "https://nodejs.org/dist/latest-v18.x/SHASUMS256.txt.asc"   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc   && grep " $LATEST_VERSION_FILENAME.tar.xz\$" SHASUMS256.txt | sha256sum -c -   && tar -xJf "$LATEST_VERSION_FILENAME.tar.xz" -C /usr/local --strip-components=1 --no-same-owner   && rm "$LATEST_VERSION_FILENAME.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt   && ln -s /usr/local/bin/node /usr/local/bin/nodejs   && node --version   && npm --version   && test ! $(which python3.9)]: exit code: 92
make: *** [Makefile:89: docker-build] Error 1

Exited with code exit status 2
```

In order to prevent pipeline failures, two options present themselves:
1. specify http1.1 [source](https://stackoverflow.com/a/68591734)
2. add retries

This PR implements option 2

References: 
- https://github.com/nodejs/help/issues/4254#issuecomment-1738740736
- https://github.com/tj/n/issues/784#issuecomment-1738813821
- https://github.com/nvm-sh/nvm/issues/3074
- https://stackoverflow.com/a/68591734


<!-- What notable changes does this PR make? -->
## Changes


Use http1.1 when downloading nodejs

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

