### PR TITLE
sns: get region and account from parsed `endpointArn`

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -4458,8 +4458,6 @@ class TestSNSRetrospectionEndpoints:
             msgs_url,
             params={
                 "endpointArn": endpoint_arn,
-                "region": TEST_AWS_REGION_NAME,
-                "accountId": TEST_AWS_ACCOUNT_ID,
             },
         ).json()
         msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
@@ -4472,8 +4470,6 @@ class TestSNSRetrospectionEndpoints:
             msgs_url,
             params={
                 "endpointArn": endpoint_arn,
-                "region": TEST_AWS_REGION_NAME,
-                "accountId": TEST_AWS_ACCOUNT_ID,
             },
         )
         assert delete_res.status_code == 204
@@ -4481,8 +4477,6 @@ class TestSNSRetrospectionEndpoints:
             msgs_url,
             params={
                 "endpointArn": endpoint_arn,
-                "region": TEST_AWS_REGION_NAME,
-                "accountId": TEST_AWS_ACCOUNT_ID,
             },
         ).json()
         msgs_with_endpoint = api_contents_with_endpoint["platform_endpoint_messages"]
@@ -4638,7 +4632,10 @@ class TestSNSRetrospectionEndpoints:
             timeout=2,
         )
 
-        wrong_sub_arn = subscription_arn.replace(TEST_AWS_REGION_NAME, "us-west-1")
+        wrong_sub_arn = subscription_arn.replace(
+            TEST_AWS_REGION_NAME,
+            "il-central-1" if TEST_AWS_REGION_NAME != "il-central-1" else "me-south-1",
+        )
         wrong_region_req = requests.get(f"{tokens_base_url}/{wrong_sub_arn}")
         assert wrong_region_req.status_code == 404
         assert wrong_region_req.json() == {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `sns` tests should still create the consequent resources in this accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR fixes the failing tests in `tests.aws.services.sns.test_sns.py` when using non default region and account by:
- using region and account from parsed `endpointArn` in case of platform endpoint messages. 
- using `TEST_AWS_REGION_NAME` instead of static `us-east-1` value. 
- remove use of region and account id in case `endpointArn` is present.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

