### PR TITLE
fix s3 notification for lambda

### DIFF
--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -635,10 +635,10 @@ class LambdaNotifier(BaseNotifier):
         lambda_client = connect_to(region_name=arn_data["region"]).lambda_.request_metadata(
             source_arn=s3_bucket_arn(ctx.bucket_name), service_principal=ServicePrincipal.s3
         )
-        lambda_function_config = arns.lambda_function_name(lambda_arn)
+
         try:
             lambda_client.invoke(
-                FunctionName=lambda_function_config,
+                FunctionName=lambda_arn,
                 InvocationType="Event",
                 Payload=payload,
             )
@@ -646,7 +646,7 @@ class LambdaNotifier(BaseNotifier):
             LOG.exception(
                 'Unable to send notification for S3 bucket "%s" to Lambda function "%s".',
                 ctx.bucket_name,
-                lambda_function_config,
+                lambda_arn,
             )
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fix multi account stabilty. This PR fixes s3 notification for lambda function invocation.

<!-- What notable changes does this PR make? -->
## Changes

Modified the `lambda_client.invoke` function parameter to use the **Lambda Function ARN** (Amazon Resource Name) instead of the **Lambda function name**.


## Testing

This PR fixes the test case mentioned below, when ran using non-default account id.

Required envs for the test
```
TEST_AWS_ACCOUNT_ID=111111111111;TEST_AWS_ACCESS_KEY_ID=111111111111;TEST_AWS_REGION=us-west-1
```

Test Case
```
tests/aws/services/s3/test_s3_notifications_lambda.py
```