### PR TITLE
fix ASF update service detection

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -44,6 +44,9 @@ jobs:
           source .venv/bin/activate
           python3 -m localstack.aws.scaffold upgrade
 
+      - name: Format code
+        run: make format-modified
+
       - name: Check for changes
         id: check-for-changes
         run: |
@@ -58,12 +61,6 @@ jobs:
           echo "changed-services<<EOF" >> $GITHUB_OUTPUT
           echo "$(git diff --name-only origin/master localstack/aws/api/ | sed 's#localstack/aws/api/#- #g' | sed 's#/__init__.py##g' | sed 's/_/-/g')" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Format code
-        if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}
-        run: |
-          # execute the format-modified target (only if we have changes, otherwise the black invocation fails)
-          make format-modified
 
       - name: Read PR markdown template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}


### PR DESCRIPTION
## Motivation
Recent ASF update PRs wrongly state that all services have changed (f.e. see https://github.com/localstack/localstack/pull/9500).
This is because in https://github.com/localstack/localstack/pull/9436 we moved the code formatting to after the "change" (and "changed service") detection.
Since we now generate all APIs without formatting them, all APIs seem to change.

## Changes
- Move the formatting step in the GitHub action a bit such that it is executed before the changes are detected.

## Testing
This test run shows that the formatting now works correctly (which is what #9500 was aiming at), and the change detection works correctly (which this PR is aiming at): https://github.com/localstack/localstack/actions/runs/6691512704