### PR TITLE
fix test cdk multi account

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from localstack import config
+from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.aws import aws_stack
@@ -49,7 +50,9 @@ class TestCdkInit:
         change_set_name = "cdk-deploy-change-set-a4b98b18"
         stack_name = "CDKToolkit-a4b98b18"
         try:
-            headers = aws_stack.mock_aws_request_headers("cloudformation")
+            headers = aws_stack.mock_aws_request_headers(
+                "cloudformation", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCOUNT_ID
+            )
             base_url = config.get_edge_url()
             for op in operations:
                 url = f"{base_url}{op['path']}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fix multi account stabilty. This PR fixes request headers in the test case to create resources in the correct region and account.


<!-- What notable changes does this PR make? -->
## Changes
Added access key and the region in header of the request in the test case.

## Testing

Fixes the test `test_cdk` when using non-default account id and region.