### PR TITLE
Ensure backdoor endpoint tests respect the test account ID

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -277,7 +277,7 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
             return access_id[0]
 
 
-# TODO remove the `internal` arg
+# TODO Ensure region and access key are mandatory; remove the `internal` arg
 def mock_aws_request_headers(
     service="dynamodb", region_name=None, access_key=None, internal=False
 ) -> Dict[str, str]:

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -277,7 +277,7 @@ class TestSNSPublishCrud:
         )
 
         if is_aws_cloud():
-            endpoint_url = "https://sns.us-east-1.amazonaws.com"
+            endpoint_url = f"https://sns.{TEST_AWS_REGION_NAME}.amazonaws.com"
         else:
             endpoint_url = config.get_edge_url()
 


### PR DESCRIPTION
## Motivation

Certains tests related to the backdoor/developer endpoints did not account for the multi-account nature of LocalStack.

This PR ensures that the this is tested appropriately.

## Implementation

With SNS, the assertions against the endpoints are performed in the account where the SNS resource was created.

With SQS, the tests are parametrised so that they run with endpoint schemes that support multi-region.