### PR TITLE
remove s3 encoding tets xfail marker and xfail flaky events scheduler test

### DIFF
--- a/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
+++ b/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
@@ -65,6 +65,9 @@ def add_logs_resource_policy_for_rule(aws_client):
         "$..storedBytes",
     ]
 )
+@pytest.mark.xfail(
+    reason="This test is flaky is CI, might be race conditions"  # FIXME: investigate and fix
+)
 def test_scheduled_rule_logs(
     logs_log_group,
     events_put_rule,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3284,10 +3284,6 @@ class TestS3:
         snapshot.match("error-non-existent-bucket", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
-        condition=not config.NATIVE_S3_PROVIDER,
-        reason="Issue in moto, see https://github.com/getmoto/moto/pull/6933",
-    )
     def test_delete_objects_encoding(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.key_value("Name"))
         object_key_1 = "a%2Fb"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Now that #9464 has been merged (thanks @viren-nadkarni!), the fix for S3 object key encoding is contained in LocalStack.
We need to remove the xfail marker to validate the fix and close the related the issue.

Also, `test_scheduled_rule_logs` has been really flaky, it might be a race condition but to not block the pipeline and force re-run, I've xfailed the test for now.

<!-- What notable changes does this PR make? -->
## Changes
Remove the xfail marker for `test_delete_objects_encoding`. 
xfail `tests.aws.services.events.scheduled_rules.test_events_scheduled_rules_logs.test_scheduled_rule_logs`

_fixes #9428_ 
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

