### PR TITLE
Refactor aws_stack.mock_aws_request_headers()

### DIFF
--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -31,7 +31,7 @@ class MissingAuthHeaderInjector(Handler):
         headers = context.request.headers
 
         if not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.generate_aws_request_headers(
+            headers["Authorization"] = aws_stack.mock_aws_request_headers(
                 api, aws_access_key_id="injectedaccesskey", region_name=AWS_REGION_US_EAST_1
             )["Authorization"]
 

--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -5,7 +5,11 @@ from localstack.aws.accounts import (
     set_aws_access_key_id,
     set_aws_account_id,
 )
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID
+from localstack.constants import (
+    AWS_REGION_US_EAST_1,
+    DEFAULT_AWS_ACCOUNT_ID,
+    TEST_AWS_ACCESS_KEY_ID,
+)
 from localstack.http import Response
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
 
@@ -26,10 +30,13 @@ class MissingAuthHeaderInjector(Handler):
 
         api = context.service.service_name
         headers = context.request.headers
+        # Account ID or region may not be available based on the ordering of the handlers, if so use defaults
+        account_id = context.account_id or DEFAULT_AWS_ACCOUNT_ID
+        region_name = context.region or AWS_REGION_US_EAST_1
 
         if not headers.get("Authorization"):
             headers["Authorization"] = aws_stack.mock_aws_request_headers(
-                api, access_key="injectedaccesskey"
+                api, aws_access_key_id=account_id, region_name=region_name
             )["Authorization"]
 
 

--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -7,7 +7,6 @@ from localstack.aws.accounts import (
 )
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
-    DEFAULT_AWS_ACCOUNT_ID,
     TEST_AWS_ACCESS_KEY_ID,
 )
 from localstack.http import Response
@@ -30,13 +29,10 @@ class MissingAuthHeaderInjector(Handler):
 
         api = context.service.service_name
         headers = context.request.headers
-        # Account ID or region may not be available based on the ordering of the handlers, if so use defaults
-        account_id = context.account_id or DEFAULT_AWS_ACCOUNT_ID
-        region_name = context.region or AWS_REGION_US_EAST_1
 
         if not headers.get("Authorization"):
             headers["Authorization"] = aws_stack.generate_aws_request_headers(
-                api, aws_access_key_id=account_id, region_name=region_name
+                api, aws_access_key_id="injectedaccesskey", region_name=AWS_REGION_US_EAST_1
             )["Authorization"]
 
 

--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -35,7 +35,7 @@ class MissingAuthHeaderInjector(Handler):
         region_name = context.region or AWS_REGION_US_EAST_1
 
         if not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.mock_aws_request_headers(
+            headers["Authorization"] = aws_stack.generate_aws_request_headers(
                 api, aws_access_key_id=account_id, region_name=region_name
             )["Authorization"]
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -148,7 +148,7 @@ def get_internal_mocked_headers(
         )
     else:
         access_key_id = None
-    headers = aws_stack.mock_aws_request_headers(
+    headers = aws_stack.generate_aws_request_headers(
         service=service_name, aws_access_key_id=access_key_id, region_name=region_name
     )
 
@@ -586,7 +586,7 @@ class S3Integration(BackendIntegration):
             LOG.debug(msg)
             return make_error_response(msg, 404)
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             service="s3",
             aws_access_key_id=invocation_context.account_id,
             region_name=invocation_context.region_name,
@@ -712,7 +712,7 @@ class SNSIntegration(BackendIntegration):
             LOG.warning("Failed to apply template for SNS integration", e)
             raise
         region_name = uri.split(":")[3]
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             service="sns", aws_access_key_id=invocation_context.account_id, region_name=region_name
         )
         result = make_http_request(
@@ -777,7 +777,7 @@ class StepFunctionIntegration(BackendIntegration):
         result = json_safe(remove_attributes(result, ["ResponseMetadata"]))
         response = StepFunctionIntegration._create_response(
             HTTPStatus.OK.value,
-            aws_stack.mock_aws_request_headers(
+            aws_stack.generate_aws_request_headers(
                 "stepfunctions",
                 aws_access_key_id=invocation_context.account_id,
                 region_name=invocation_context.region_name,

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -148,7 +148,7 @@ def get_internal_mocked_headers(
         )
     else:
         access_key_id = None
-    headers = aws_stack.generate_aws_request_headers(
+    headers = aws_stack.mock_aws_request_headers(
         service=service_name, aws_access_key_id=access_key_id, region_name=region_name
     )
 
@@ -586,7 +586,7 @@ class S3Integration(BackendIntegration):
             LOG.debug(msg)
             return make_error_response(msg, 404)
 
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             service="s3",
             aws_access_key_id=invocation_context.account_id,
             region_name=invocation_context.region_name,
@@ -712,7 +712,7 @@ class SNSIntegration(BackendIntegration):
             LOG.warning("Failed to apply template for SNS integration", e)
             raise
         region_name = uri.split(":")[3]
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             service="sns", aws_access_key_id=invocation_context.account_id, region_name=region_name
         )
         result = make_http_request(
@@ -777,7 +777,7 @@ class StepFunctionIntegration(BackendIntegration):
         result = json_safe(remove_attributes(result, ["ResponseMetadata"]))
         response = StepFunctionIntegration._create_response(
             HTTPStatus.OK.value,
-            aws_stack.generate_aws_request_headers(
+            aws_stack.mock_aws_request_headers(
                 "stepfunctions",
                 aws_access_key_id=invocation_context.account_id,
                 region_name=invocation_context.region_name,

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -171,7 +171,7 @@ class ProxyListenerEdge(ProxyListener):
             return response
 
         if api and not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.mock_aws_request_headers(
+            headers["Authorization"] = aws_stack.generate_aws_request_headers(
                 api, aws_access_key_id=access_key_id, region_name=AWS_REGION_US_EAST_1
             )["Authorization"]
         headers[HEADER_TARGET_API] = str(api)

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -21,6 +21,7 @@ from localstack.aws.accounts import (
 from localstack.aws.protocol.service_router import determine_aws_service_name
 from localstack.config import HostAndPort
 from localstack.constants import (
+    AWS_REGION_US_EAST_1,
     HEADER_LOCALSTACK_ACCOUNT_ID,
     HEADER_LOCALSTACK_EDGE_URL,
     HEADER_LOCALSTACK_REQUEST_URL,
@@ -170,7 +171,9 @@ class ProxyListenerEdge(ProxyListener):
             return response
 
         if api and not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.mock_aws_request_headers(api)["Authorization"]
+            headers["Authorization"] = aws_stack.mock_aws_request_headers(
+                api, aws_access_key_id=access_key_id, region_name=AWS_REGION_US_EAST_1
+            )["Authorization"]
         headers[HEADER_TARGET_API] = str(api)
 
         headers["Host"] = host

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -171,7 +171,7 @@ class ProxyListenerEdge(ProxyListener):
             return response
 
         if api and not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.generate_aws_request_headers(
+            headers["Authorization"] = aws_stack.mock_aws_request_headers(
                 api, aws_access_key_id=access_key_id, region_name=AWS_REGION_US_EAST_1
             )["Authorization"]
         headers[HEADER_TARGET_API] = str(api)

--- a/localstack/services/lambda_/legacy/aws_models.py
+++ b/localstack/services/lambda_/legacy/aws_models.py
@@ -158,6 +158,9 @@ class LambdaFunction(Component):
     def region(self):
         return self.id.split(":")[3]
 
+    def account_id(self):
+        return self.id.split(":")[4]
+
     def arn(self):
         return self.id
 

--- a/localstack/services/lambda_/legacy/lambda_executors.py
+++ b/localstack/services/lambda_/legacy/lambda_executors.py
@@ -303,7 +303,7 @@ class LambdaInvocationForwarderPlugin(LambdaExecutorPlugin):
         copied_env_vars["LOCALSTACK_HOSTNAME"] = config.HOSTNAME_EXTERNAL
         copied_env_vars["LOCALSTACK_EDGE_PORT"] = str(config.EDGE_PORT)
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "lambda",
             aws_access_key_id=lambda_function.account_id(),
             region_name=lambda_function.region(),

--- a/localstack/services/lambda_/legacy/lambda_executors.py
+++ b/localstack/services/lambda_/legacy/lambda_executors.py
@@ -303,7 +303,7 @@ class LambdaInvocationForwarderPlugin(LambdaExecutorPlugin):
         copied_env_vars["LOCALSTACK_HOSTNAME"] = config.HOSTNAME_EXTERNAL
         copied_env_vars["LOCALSTACK_EDGE_PORT"] = str(config.EDGE_PORT)
 
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "lambda",
             aws_access_key_id=lambda_function.account_id(),
             region_name=lambda_function.region(),

--- a/localstack/services/lambda_/legacy/lambda_executors.py
+++ b/localstack/services/lambda_/legacy/lambda_executors.py
@@ -303,7 +303,11 @@ class LambdaInvocationForwarderPlugin(LambdaExecutorPlugin):
         copied_env_vars["LOCALSTACK_HOSTNAME"] = config.HOSTNAME_EXTERNAL
         copied_env_vars["LOCALSTACK_EDGE_PORT"] = str(config.EDGE_PORT)
 
-        headers = aws_stack.mock_aws_request_headers("lambda")
+        headers = aws_stack.mock_aws_request_headers(
+            "lambda",
+            aws_access_key_id=lambda_function.account_id(),
+            region_name=lambda_function.region(),
+        )
         headers["X-Amz-Region"] = lambda_function.region()
         headers["X-Amz-Request-Id"] = context.aws_request_id
         headers["X-Amz-Handler"] = lambda_function.handler

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -14,6 +14,7 @@ from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
     APPLICATION_X_WWW_FORM_URLENCODED,
+    DEFAULT_AWS_ACCOUNT_ID,
     ENV_DEV,
     HEADER_LOCALSTACK_ACCOUNT_ID,
     INTERNAL_AWS_ACCESS_KEY_ID,
@@ -210,9 +211,9 @@ def set_default_region_in_headers(headers, service=None, region=None):
     region = region or get_region()
     if not auth_header:
         if service:
-            headers["Authorization"] = mock_aws_request_headers(service, region_name=region)[
-                "Authorization"
-            ]
+            headers["Authorization"] = mock_aws_request_headers(
+                service, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=region
+            )["Authorization"]
         return
     replaced = re.sub(r"(.*Credential=[^/]+/[^/]+/)([^/])+/", r"\1%s/" % region, auth_header)
     headers["Authorization"] = replaced
@@ -279,7 +280,7 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
 
 # TODO remove the `internal` arg
 def mock_aws_request_headers(
-    service="dynamodb", region_name=None, access_key=None, internal=False
+    service, aws_access_key_id, region_name, internal=False
 ) -> Dict[str, str]:
     ctype = APPLICATION_AMZ_JSON_1_0
     if service == "kinesis":
@@ -290,7 +291,7 @@ def mock_aws_request_headers(
     # For S3 presigned URLs, we require that the client and server use the same
     # access key ID to sign requests. So try to use the access key ID for the
     # current request if available
-    access_key = access_key or get_aws_access_key_id()
+    aws_access_key_id = aws_access_key_id or get_aws_access_key_id()
     region_name = region_name or get_region()
     headers = {
         "Content-Type": ctype,
@@ -298,10 +299,12 @@ def mock_aws_request_headers(
         "X-Amz-Date": "20160623T103251Z",
         "Authorization": (
             "AWS4-HMAC-SHA256 "
-            + f"Credential={access_key}/20160623/{region_name}/{service}/aws4_request, "
+            + f"Credential={aws_access_key_id}/20160623/{region_name}/{service}/aws4_request, "
             + "SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=1234"
         ),
     }
     if internal:
+        # TODO: This method of detecting internal calls is no longer valid
+        # We now use the `INTERNAL_REQUEST_PARAMS_HEADER` header which is set to the DTO
         headers[HEADER_LOCALSTACK_ACCOUNT_ID] = get_aws_account_id()
     return headers

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union
 import boto3
 
 from localstack import config
-from localstack.aws.accounts import get_aws_access_key_id, get_aws_account_id
+from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
@@ -291,8 +291,6 @@ def mock_aws_request_headers(
     # For S3 presigned URLs, we require that the client and server use the same
     # access key ID to sign requests. So try to use the access key ID for the
     # current request if available
-    aws_access_key_id = aws_access_key_id or get_aws_access_key_id()
-    region_name = region_name or get_region()
     headers = {
         "Content-Type": ctype,
         "Accept-Encoding": "identity",

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -211,7 +211,7 @@ def set_default_region_in_headers(headers, service=None, region=None):
     region = region or get_region()
     if not auth_header:
         if service:
-            headers["Authorization"] = generate_aws_request_headers(
+            headers["Authorization"] = mock_aws_request_headers(
                 service, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=region
             )["Authorization"]
         return
@@ -279,7 +279,7 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
 
 
 # TODO remove the `internal` arg
-def generate_aws_request_headers(
+def mock_aws_request_headers(
     service, aws_access_key_id, region_name, internal=False
 ) -> Dict[str, str]:
     ctype = APPLICATION_AMZ_JSON_1_0

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -294,7 +294,7 @@ def generate_aws_request_headers(
     headers = {
         "Content-Type": ctype,
         "Accept-Encoding": "identity",
-        "X-Amz-Date": "20160623T103251Z",
+        "X-Amz-Date": "20160623T103251Z",  # TODO: Use current date
         "Authorization": (
             "AWS4-HMAC-SHA256 "
             + f"Credential={aws_access_key_id}/20160623/{region_name}/{service}/aws4_request, "

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -280,8 +280,11 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
 
 # TODO remove the `internal` arg
 def mock_aws_request_headers(
-    service, aws_access_key_id, region_name, internal=False
+    service: str, aws_access_key_id: str, region_name: str, internal: bool = False
 ) -> Dict[str, str]:
+    """
+    Returns a mock set of headers that resemble SigV4 signing method.
+    """
     ctype = APPLICATION_AMZ_JSON_1_0
     if service == "kinesis":
         ctype = APPLICATION_AMZ_JSON_1_1

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -211,7 +211,7 @@ def set_default_region_in_headers(headers, service=None, region=None):
     region = region or get_region()
     if not auth_header:
         if service:
-            headers["Authorization"] = mock_aws_request_headers(
+            headers["Authorization"] = generate_aws_request_headers(
                 service, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=region
             )["Authorization"]
         return
@@ -279,7 +279,7 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
 
 
 # TODO remove the `internal` arg
-def mock_aws_request_headers(
+def generate_aws_request_headers(
     service, aws_access_key_id, region_name, internal=False
 ) -> Dict[str, str]:
     ctype = APPLICATION_AMZ_JSON_1_0

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -159,9 +159,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
         _context_to_update.headers = CaseInsensitiveDict({**headers, "Authorization": auth_header})
 
 
-def mock_request_for_region(
-    account_id: str, region_name: str, service_name: str = "dummy"
-) -> Request:
+def mock_request_for_region(service_name: str, account_id: str, region_name: str) -> Request:
     result = Request()
     result.headers["Authorization"] = aws_stack.generate_aws_request_headers(
         service_name, aws_access_key_id=account_id, region_name=region_name

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -145,7 +145,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
     auth_header = headers.get("Authorization")
     auth_header = (
         auth_header
-        or aws_stack.generate_aws_request_headers(
+        or aws_stack.mock_aws_request_headers(
             service_name, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=AWS_REGION_US_EAST_1
         )["Authorization"]
     )
@@ -161,7 +161,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
 
 def mock_request_for_region(service_name: str, account_id: str, region_name: str) -> Request:
     result = Request()
-    result.headers["Authorization"] = aws_stack.generate_aws_request_headers(
+    result.headers["Authorization"] = aws_stack.mock_aws_request_headers(
         service_name, aws_access_key_id=account_id, region_name=region_name
     )["Authorization"]
     return result

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -145,7 +145,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
     auth_header = headers.get("Authorization")
     auth_header = (
         auth_header
-        or aws_stack.mock_aws_request_headers(
+        or aws_stack.generate_aws_request_headers(
             service_name, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=AWS_REGION_US_EAST_1
         )["Authorization"]
     )
@@ -163,7 +163,7 @@ def mock_request_for_region(
     account_id: str, region_name: str, service_name: str = "dummy"
 ) -> Request:
     result = Request()
-    result.headers["Authorization"] = aws_stack.mock_aws_request_headers(
+    result.headers["Authorization"] = aws_stack.generate_aws_request_headers(
         service_name, aws_access_key_id=account_id, region_name=region_name
     )["Authorization"]
     return result

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -517,7 +517,7 @@ def send_dynamodb_request(path, action, request_body):
     headers = {
         "Host": "dynamodb.amazonaws.com",
         "x-amz-target": "DynamoDB_20120810.{}".format(action),
-        "Authorization": aws_stack.mock_aws_request_headers(
+        "Authorization": aws_stack.generate_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"],
     }

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -30,6 +30,7 @@ from localstack.constants import (
     LOCALHOST_HOSTNAME,
     LOCALSTACK_ROOT_FOLDER,
     LOCALSTACK_VENV_FOLDER,
+    TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_REGION_NAME,
 )
 from localstack.services.lambda_.lambda_utils import (
@@ -516,7 +517,9 @@ def send_dynamodb_request(path, action, request_body):
     headers = {
         "Host": "dynamodb.amazonaws.com",
         "x-amz-target": "DynamoDB_20120810.{}".format(action),
-        "Authorization": aws_stack.mock_aws_request_headers("dynamodb")["Authorization"],
+        "Authorization": aws_stack.mock_aws_request_headers(
+            "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )["Authorization"],
     }
     url = f"{config.service_url('dynamodb')}/{path}"
     return requests.put(url, data=request_body, headers=headers, verify=False)

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -517,7 +517,7 @@ def send_dynamodb_request(path, action, request_body):
     headers = {
         "Host": "dynamodb.amazonaws.com",
         "x-amz-target": "DynamoDB_20120810.{}".format(action),
-        "Authorization": aws_stack.generate_aws_request_headers(
+        "Authorization": aws_stack.mock_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"],
     }

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -19,6 +19,7 @@ from localstack.config import get_edge_url
 from localstack.constants import (
     APPLICATION_JSON,
     LOCALHOST_HOSTNAME,
+    TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
 )
@@ -1669,7 +1670,9 @@ def test_apigateway_rust_lambda(
 
 @markers.aws.unknown
 def test_apigw_call_api_with_aws_endpoint_url(aws_client):
-    headers = aws_stack.mock_aws_request_headers("apigateway")
+    headers = aws_stack.mock_aws_request_headers(
+        "apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
+    )
     headers["Host"] = "apigateway.us-east-2.amazonaws.com:4566"
     url = f"{get_edge_url()}/apikeys?includeValues=true&name=test%40example.org"
     response = requests.get(url, headers=headers)

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1670,7 +1670,7 @@ def test_apigateway_rust_lambda(
 
 @markers.aws.unknown
 def test_apigw_call_api_with_aws_endpoint_url(aws_client):
-    headers = aws_stack.mock_aws_request_headers(
+    headers = aws_stack.generate_aws_request_headers(
         "apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
     )
     headers["Host"] = "apigateway.us-east-2.amazonaws.com:4566"

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1670,7 +1670,7 @@ def test_apigateway_rust_lambda(
 
 @markers.aws.unknown
 def test_apigw_call_api_with_aws_endpoint_url(aws_client):
-    headers = aws_stack.generate_aws_request_headers(
+    headers = aws_stack.mock_aws_request_headers(
         "apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
     )
     headers["Host"] = "apigateway.us-east-2.amazonaws.com:4566"

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -50,7 +50,7 @@ class TestCdkInit:
         change_set_name = "cdk-deploy-change-set-a4b98b18"
         stack_name = "CDKToolkit-a4b98b18"
         try:
-            headers = aws_stack.mock_aws_request_headers(
+            headers = aws_stack.generate_aws_request_headers(
                 "cloudformation", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
             )
             base_url = config.get_edge_url()

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from localstack import config
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.aws import aws_stack
@@ -49,7 +50,9 @@ class TestCdkInit:
         change_set_name = "cdk-deploy-change-set-a4b98b18"
         stack_name = "CDKToolkit-a4b98b18"
         try:
-            headers = aws_stack.mock_aws_request_headers("cloudformation")
+            headers = aws_stack.mock_aws_request_headers(
+                "cloudformation", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
+            )
             base_url = config.get_edge_url()
             for op in operations:
                 url = f"{base_url}{op['path']}"

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -50,7 +50,7 @@ class TestCdkInit:
         change_set_name = "cdk-deploy-change-set-a4b98b18"
         stack_name = "CDKToolkit-a4b98b18"
         try:
-            headers = aws_stack.generate_aws_request_headers(
+            headers = aws_stack.mock_aws_request_headers(
                 "cloudformation", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
             )
             base_url = config.get_edge_url()

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -73,14 +73,12 @@ class TestCloudwatch:
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers(
             "cloudwatch",
-            internal=True,
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,
-            access_key=TEST_AWS_ACCESS_KEY_ID,
+            internal=True,
         )
         authorization = aws_stack.mock_aws_request_headers(
-            "monitoring",
-            region_name=TEST_AWS_REGION_NAME,
-            access_key=TEST_AWS_ACCESS_KEY_ID,
+            "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"]
 
         headers.update(
@@ -204,9 +202,7 @@ class TestCloudwatch:
         )
         url = f"{config.get_edge_url()}{PATH_GET_RAW_METRICS}"
         headers = aws_stack.mock_aws_request_headers(
-            "cloudwatch",
-            region_name=TEST_AWS_REGION_NAME,
-            access_key=TEST_AWS_ACCESS_KEY_ID,
+            "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         result = requests.get(url, headers=headers)
         assert 200 == result.status_code

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -71,13 +71,13 @@ class TestCloudwatch:
         encoded_data = gzip.compress(bytes_data)
 
         url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "cloudwatch",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,
             internal=True,
         )
-        authorization = aws_stack.generate_aws_request_headers(
+        authorization = aws_stack.mock_aws_request_headers(
             "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"]
 
@@ -201,7 +201,7 @@ class TestCloudwatch:
             Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
         )
         url = f"{config.get_edge_url()}{PATH_GET_RAW_METRICS}"
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         result = requests.get(url, headers=headers)

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -71,13 +71,13 @@ class TestCloudwatch:
         encoded_data = gzip.compress(bytes_data)
 
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "cloudwatch",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,
             internal=True,
         )
-        authorization = aws_stack.mock_aws_request_headers(
+        authorization = aws_stack.generate_aws_request_headers(
             "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"]
 
@@ -201,7 +201,7 @@ class TestCloudwatch:
             Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
         )
         url = f"{config.get_edge_url()}{PATH_GET_RAW_METRICS}"
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         result = requests.get(url, headers=headers)

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -252,7 +252,7 @@ class TestKinesis:
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers(
-            "kinesis", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
+            "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
         headers["X-Amz-Target"] = "Kinesis_20131202.GetRecords"
@@ -286,7 +286,7 @@ class TestKinesis:
         # empty get records with CBOR encoding
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers(
-            "kinesis", region_name=TEST_AWS_REGION_NAME, access_key=TEST_AWS_ACCESS_KEY_ID
+            "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
         headers["X-Amz-Target"] = "Kinesis_20131202.GetRecords"

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -251,7 +251,7 @@ class TestKinesis:
         # get records with CBOR encoding
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
@@ -285,7 +285,7 @@ class TestKinesis:
 
         # empty get records with CBOR encoding
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -251,7 +251,7 @@ class TestKinesis:
         # get records with CBOR encoding
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
         url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
@@ -285,7 +285,7 @@ class TestKinesis:
 
         # empty get records with CBOR encoding
         url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2959,7 +2959,9 @@ class TestS3:
         object_key = "data"
         body = "Hello\r\n\r\n\r\n\r\n"
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers("s3")["Authorization"],
+            "Authorization": aws_stack.mock_aws_request_headers(
+                "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+            )["Authorization"],
             "Content-Type": "audio/mpeg",
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
             "X-Amz-Date": "20190918T051509Z",
@@ -2992,7 +2994,9 @@ class TestS3:
         body = "Hello Blob"
         valid_checksum = hash_sha256(body)
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers("s3")["Authorization"],
+            "Authorization": aws_stack.mock_aws_request_headers(
+                "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+            )["Authorization"],
             "Content-Type": "audio/mpeg",
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
             "X-Amz-Date": "20190918T051509Z",
@@ -3043,7 +3047,9 @@ class TestS3:
         body = "Hello Blob"
         precalculated_etag = hashlib.md5(body.encode()).hexdigest()
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers("s3")["Authorization"],
+            "Authorization": aws_stack.mock_aws_request_headers(
+                "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+            )["Authorization"],
             "Content-Type": "audio/mpeg",
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
             "X-Amz-Date": "20190918T051509Z",
@@ -8024,7 +8030,9 @@ class TestS3Routing:
 
         path = s3_key if use_virtual_address else f"{s3_bucket}/{s3_key}"
         url = f"{config.get_edge_url()}/{path}"
-        headers = aws_stack.mock_aws_request_headers("s3")
+        headers = aws_stack.mock_aws_request_headers(
+            "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["host"] = f"{s3_bucket}.{domain}" if use_virtual_address else domain
 
         # get object via *.amazonaws.com host header

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2959,7 +2959,7 @@ class TestS3:
         object_key = "data"
         body = "Hello\r\n\r\n\r\n\r\n"
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": aws_stack.generate_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -2994,7 +2994,7 @@ class TestS3:
         body = "Hello Blob"
         valid_checksum = hash_sha256(body)
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": aws_stack.generate_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -3047,7 +3047,7 @@ class TestS3:
         body = "Hello Blob"
         precalculated_etag = hashlib.md5(body.encode()).hexdigest()
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": aws_stack.generate_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -8030,7 +8030,7 @@ class TestS3Routing:
 
         path = s3_key if use_virtual_address else f"{s3_bucket}/{s3_key}"
         url = f"{config.get_edge_url()}/{path}"
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["host"] = f"{s3_bucket}.{domain}" if use_virtual_address else domain

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2959,7 +2959,7 @@ class TestS3:
         object_key = "data"
         body = "Hello\r\n\r\n\r\n\r\n"
         headers = {
-            "Authorization": aws_stack.generate_aws_request_headers(
+            "Authorization": aws_stack.mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -2994,7 +2994,7 @@ class TestS3:
         body = "Hello Blob"
         valid_checksum = hash_sha256(body)
         headers = {
-            "Authorization": aws_stack.generate_aws_request_headers(
+            "Authorization": aws_stack.mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -3047,7 +3047,7 @@ class TestS3:
         body = "Hello Blob"
         precalculated_etag = hashlib.md5(body.encode()).hexdigest()
         headers = {
-            "Authorization": aws_stack.generate_aws_request_headers(
+            "Authorization": aws_stack.mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -8030,7 +8030,7 @@ class TestS3Routing:
 
         path = s3_key if use_virtual_address else f"{s3_bucket}/{s3_key}"
         url = f"{config.get_edge_url()}/{path}"
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["host"] = f"{s3_bucket}.{domain}" if use_virtual_address else domain

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -177,7 +177,7 @@ class TestS3Cors:
         origin = ALLOWED_CORS_ORIGINS[0]
         # we need to "sign" the request so that our service name parser recognize ListBuckets as an S3 operation
         # if the request isn't signed, AWS will redirect to https://aws.amazon.com/s3/
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = origin

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -177,7 +177,7 @@ class TestS3Cors:
         origin = ALLOWED_CORS_ORIGINS[0]
         # we need to "sign" the request so that our service name parser recognize ListBuckets as an S3 operation
         # if the request isn't signed, AWS will redirect to https://aws.amazon.com/s3/
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = origin

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -8,7 +8,12 @@ from botocore.exceptions import ClientError
 from localstack import config
 from localstack.aws.handlers.cors import ALLOWED_CORS_ORIGINS
 from localstack.config import LEGACY_S3_PROVIDER
-from localstack.constants import LOCALHOST_HOSTNAME, S3_VIRTUAL_HOSTNAME
+from localstack.constants import (
+    LOCALHOST_HOSTNAME,
+    S3_VIRTUAL_HOSTNAME,
+    TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_REGION_NAME,
+)
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
@@ -172,7 +177,9 @@ class TestS3Cors:
         origin = ALLOWED_CORS_ORIGINS[0]
         # we need to "sign" the request so that our service name parser recognize ListBuckets as an S3 operation
         # if the request isn't signed, AWS will redirect to https://aws.amazon.com/s3/
-        headers = aws_stack.mock_aws_request_headers("s3")
+        headers = aws_stack.mock_aws_request_headers(
+            "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["Origin"] = origin
         response = requests.options(
             url, headers={**headers, "Access-Control-Request-Method": "GET"}

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -1205,7 +1205,7 @@ class TestSecretsManager:
 
     @staticmethod
     def secretsmanager_http_json_headers(amz_target: str) -> dict:
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "secretsmanager",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -1205,7 +1205,7 @@ class TestSecretsManager:
 
     @staticmethod
     def secretsmanager_http_json_headers(amz_target: str) -> dict:
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "secretsmanager",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -1206,7 +1206,9 @@ class TestSecretsManager:
     @staticmethod
     def secretsmanager_http_json_headers(amz_target: str) -> dict:
         headers = aws_stack.mock_aws_request_headers(
-            "secretsmanager", access_key=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+            "secretsmanager",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            region_name=TEST_AWS_REGION_NAME,
         )
         headers["X-Amz-Target"] = amz_target
         return headers

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1086,7 +1086,7 @@ class TestSqsProvider:
         sqs_create_queue(QueueName=queue_name)
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         payload = f"Action=GetQueueUrl&QueueName={queue_name}"
@@ -1115,7 +1115,7 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         port = 12345

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1086,7 +1086,9 @@ class TestSqsProvider:
         sqs_create_queue(QueueName=queue_name)
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers("sqs")
+        headers = aws_stack.mock_aws_request_headers(
+            "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         payload = f"Action=GetQueueUrl&QueueName={queue_name}"
 
         # assert regular/default queue URL is returned
@@ -1113,7 +1115,9 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers("sqs")
+        headers = aws_stack.mock_aws_request_headers(
+            "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         port = 12345
         hostname = "aws-local"
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1086,7 +1086,7 @@ class TestSqsProvider:
         sqs_create_queue(QueueName=queue_name)
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         payload = f"Action=GetQueueUrl&QueueName={queue_name}"
@@ -1115,7 +1115,7 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
 
         edge_url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         port = 12345

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -177,7 +177,7 @@ class TestSTSIntegrations:
     def test_expiration_date_format(self):
         url = config.get_edge_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Accept"] = APPLICATION_JSON

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -177,7 +177,7 @@ class TestSTSIntegrations:
     def test_expiration_date_format(self):
         url = config.get_edge_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Accept"] = APPLICATION_JSON

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 
 from localstack import config
-from localstack.constants import APPLICATION_JSON
+from localstack.constants import APPLICATION_JSON, TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.testing.aws.util import create_client_with_keys
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
@@ -177,7 +177,9 @@ class TestSTSIntegrations:
     def test_expiration_date_format(self):
         url = config.get_edge_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
-        headers = aws_stack.mock_aws_request_headers("sts")
+        headers = aws_stack.mock_aws_request_headers(
+            "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["Accept"] = APPLICATION_JSON
         response = requests.post(url, data=data, headers=headers)
         assert response

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -11,7 +11,12 @@ from requests.models import Request as RequestsRequest
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
-from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL
+from localstack.constants import (
+    APPLICATION_JSON,
+    HEADER_LOCALSTACK_EDGE_URL,
+    TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_REGION_NAME,
+)
 from localstack.services.generic_proxy import (
     MessageModifyingProxyListener,
     ProxyListener,
@@ -319,7 +324,9 @@ class TestEdgeAPI:
         data = {"Action": "GetCallerIdentity", "Version": "2011-06-15"}
 
         # receive response as XML (default)
-        headers = aws_stack.mock_aws_request_headers("sts")
+        headers = aws_stack.mock_aws_request_headers(
+            "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         response = requests.post(url, data=data, headers=headers)
         assert response
         content1 = to_str(response.content)
@@ -330,7 +337,9 @@ class TestEdgeAPI:
         assert content1_result["Account"] == get_aws_account_id()
 
         # receive response as JSON (via Accept header)
-        headers = aws_stack.mock_aws_request_headers("sts")
+        headers = aws_stack.mock_aws_request_headers(
+            "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["Accept"] = APPLICATION_JSON
         response = requests.post(url, data=data, headers=headers)
         assert response
@@ -344,7 +353,9 @@ class TestEdgeAPI:
     def test_request_with_custom_host_header(self):
         url = config.get_edge_url()
 
-        headers = aws_stack.mock_aws_request_headers("lambda")
+        headers = aws_stack.mock_aws_request_headers(
+            "lambda", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
 
         # using a simple for-loop here (instead of pytest parametrization), for simplicity
         for host in ["localhost", "example.com"]:

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -324,7 +324,7 @@ class TestEdgeAPI:
         data = {"Action": "GetCallerIdentity", "Version": "2011-06-15"}
 
         # receive response as XML (default)
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         response = requests.post(url, data=data, headers=headers)
@@ -337,7 +337,7 @@ class TestEdgeAPI:
         assert content1_result["Account"] == get_aws_account_id()
 
         # receive response as JSON (via Accept header)
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Accept"] = APPLICATION_JSON
@@ -353,7 +353,7 @@ class TestEdgeAPI:
     def test_request_with_custom_host_header(self):
         url = config.get_edge_url()
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "lambda", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
 

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -324,7 +324,7 @@ class TestEdgeAPI:
         data = {"Action": "GetCallerIdentity", "Version": "2011-06-15"}
 
         # receive response as XML (default)
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         response = requests.post(url, data=data, headers=headers)
@@ -337,7 +337,7 @@ class TestEdgeAPI:
         assert content1_result["Account"] == get_aws_account_id()
 
         # receive response as JSON (via Accept header)
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Accept"] = APPLICATION_JSON
@@ -353,7 +353,7 @@ class TestEdgeAPI:
     def test_request_with_custom_host_header(self):
         url = config.get_edge_url()
 
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "lambda", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
 

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -101,7 +101,7 @@ class TestCSRF:
 
     def test_disable_cors_headers(self, monkeypatch):
         """Test DISABLE_CORS_CHECKS=1 (most restrictive setting, not sending any CORS headers)"""
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = "https://app.localstack.cloud"
@@ -129,7 +129,7 @@ class TestCSRF:
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
 
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         data = {"Action": "ListTopics", "Version": "2010-03-31"}

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -101,7 +101,7 @@ class TestCSRF:
 
     def test_disable_cors_headers(self, monkeypatch):
         """Test DISABLE_CORS_CHECKS=1 (most restrictive setting, not sending any CORS headers)"""
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = "https://app.localstack.cloud"
@@ -129,7 +129,7 @@ class TestCSRF:
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
 
         url = config.get_edge_url()
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         data = {"Action": "ListTopics", "Version": "2010-03-31"}

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -4,6 +4,7 @@ import requests
 from localstack import config
 from localstack.aws.handlers import cors as cors_handler
 from localstack.aws.handlers.cors import _get_allowed_cors_origins
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid, to_str
 
@@ -100,7 +101,9 @@ class TestCSRF:
 
     def test_disable_cors_headers(self, monkeypatch):
         """Test DISABLE_CORS_CHECKS=1 (most restrictive setting, not sending any CORS headers)"""
-        headers = aws_stack.mock_aws_request_headers("sns")
+        headers = aws_stack.mock_aws_request_headers(
+            "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         headers["Origin"] = "https://app.localstack.cloud"
         url = config.get_edge_url()
         data = {"Action": "ListTopics", "Version": "2010-03-31"}
@@ -126,7 +129,9 @@ class TestCSRF:
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
 
         url = config.get_edge_url()
-        headers = aws_stack.mock_aws_request_headers("sns")
+        headers = aws_stack.mock_aws_request_headers(
+            "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+        )
         data = {"Action": "ListTopics", "Version": "2010-03-31"}
 
         # test successful request

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -19,7 +19,7 @@ def test_fix_region_in_headers():
     # TODO: this may need to be updated once we migrate DynamoDB to ASF
 
     for region_name in ["local", "localhost"]:
-        headers = aws_stack.mock_aws_request_headers(
+        headers = aws_stack.generate_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=region_name
         )
         assert TEST_AWS_REGION_NAME not in headers.get("Authorization")

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.dynamodb.provider import DynamoDBProvider, get_store
 from localstack.services.dynamodb.utils import (
     SCHEMA_CACHE,
@@ -19,7 +19,9 @@ def test_fix_region_in_headers():
     # TODO: this may need to be updated once we migrate DynamoDB to ASF
 
     for region_name in ["local", "localhost"]:
-        headers = aws_stack.mock_aws_request_headers("dynamodb", region_name=region_name)
+        headers = aws_stack.mock_aws_request_headers(
+            "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=region_name
+        )
         assert TEST_AWS_REGION_NAME not in headers.get("Authorization")
 
         # Ensure that the correct namespacing key is passed as Access Key ID to DynamoDB Local

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -19,7 +19,7 @@ def test_fix_region_in_headers():
     # TODO: this may need to be updated once we migrate DynamoDB to ASF
 
     for region_name in ["local", "localhost"]:
-        headers = aws_stack.generate_aws_request_headers(
+        headers = aws_stack.mock_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=region_name
         )
         assert TEST_AWS_REGION_NAME not in headers.get("Authorization")

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -13,7 +13,7 @@ from localstack.aws.handlers.partition_rewriter import ArnPartitionRewriteHandle
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request, Response
 from localstack.http.request import get_full_raw_path, get_raw_path
-from localstack.utils.aws.aws_stack import mock_aws_request_headers
+from localstack.utils.aws.aws_stack import generate_aws_request_headers
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests
@@ -57,7 +57,7 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     # if this test is parameterized to be an internal call, set the internal auth
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
-        headers = mock_aws_request_headers(
+        headers = generate_aws_request_headers(
             "dummy",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,
@@ -354,7 +354,7 @@ def test_arn_partition_rewriting_in_request_and_response(
     # if this test is parameterized to be an internal call, set the internal auth
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
-        headers = mock_aws_request_headers(
+        headers = generate_aws_request_headers(
             "dummy",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -10,7 +10,7 @@ from localstack import config
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.handlers.partition_rewriter import ArnPartitionRewriteHandler
-from localstack.constants import INTERNAL_AWS_ACCESS_KEY_ID
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request, Response
 from localstack.http.request import get_full_raw_path, get_raw_path
 from localstack.utils.aws.aws_stack import mock_aws_request_headers
@@ -58,8 +58,9 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
+            "dummy",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,
-            access_key=INTERNAL_AWS_ACCESS_KEY_ID,
             internal=True,
         )
     else:
@@ -354,8 +355,9 @@ def test_arn_partition_rewriting_in_request_and_response(
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
+            "dummy",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,
-            access_key=INTERNAL_AWS_ACCESS_KEY_ID,
             internal=True,
         )
     else:

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -13,7 +13,7 @@ from localstack.aws.handlers.partition_rewriter import ArnPartitionRewriteHandle
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request, Response
 from localstack.http.request import get_full_raw_path, get_raw_path
-from localstack.utils.aws.aws_stack import generate_aws_request_headers
+from localstack.utils.aws.aws_stack import mock_aws_request_headers
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests
@@ -57,7 +57,7 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     # if this test is parameterized to be an internal call, set the internal auth
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
-        headers = generate_aws_request_headers(
+        headers = mock_aws_request_headers(
             "dummy",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,
@@ -354,7 +354,7 @@ def test_arn_partition_rewriting_in_request_and_response(
     # if this test is parameterized to be an internal call, set the internal auth
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
-        headers = generate_aws_request_headers(
+        headers = mock_aws_request_headers(
             "dummy",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=origin_partition,


### PR DESCRIPTION
## Motivation

The `aws_stack.mock_aws_request_headers()` utility is used in our codebase to generate headers for AWS requests. Among these headers include `Content-Type`, `Accept-Encoding`, date and especially the `Authorization` header.

The issue this PR is addressing is the optional nature of the access key and region name arguments for this function, in which the `get_aws_access_key_id()` and `aws_stack.get_region()` are used. We already know that these are problematic functions that rely on thread context storage and are not guaranteed to return the correct values. Furthermore they must not be used in tests, indirectly which is exactly what is happening.

## Implementation

This PR makes the access key ID and region name field mandatory.

<!--
The function is also renamed to from `mock_aws_request_headers()` to `generate_aws_request_headers()`. `mock_` implies non-production or fake values whereas this function is perfectly capable of generating headers that work fine with AWS. This is evidenced in several `aws_validated` tests that use this function.
-->