### PR TITLE
Add state visitor handler for StepFunctions v2 persistence support

### DIFF
--- a/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack/services/stepfunctions/backend/execution.py
@@ -79,7 +79,6 @@ class BaseExecutionWorkerComm(ExecutionWorkerComm):
 
 
 class Execution:
-
     name: Final[str]
     role_arn: Final[Arn]
     exec_arn: Final[Arn]

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -118,7 +118,6 @@ class TagManager:
 
 
 class StateMachineRevision(StateMachineInstance):
-
     _next_version_number: int
     versions: Final[dict[RevisionId, Arn]]
     tag_manager: Final[TagManager]

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -81,41 +81,43 @@ class StateMachineInstance:
         ...
 
 
+class TagManager:
+    _tags: Final[dict[str, Optional[str]]]
+
+    def __init__(self):
+        self._tags = OrderedDict()
+
+    @staticmethod
+    def _validate_key_value(key: str) -> None:
+        if not key:
+            raise ValidationException()
+
+    @staticmethod
+    def _validate_tag_value(value: str) -> None:
+        if value is None:
+            raise ValidationException()
+
+    def add_all(self, tags: TagList) -> None:
+        for tag in tags:
+            tag_key = tag["key"]
+            tag_value = tag["value"]
+            self._validate_key_value(key=tag_key)
+            self._validate_tag_value(value=tag_value)
+            self._tags[tag_key] = tag_value
+
+    def remove_all(self, keys: TagKeyList):
+        for key in keys:
+            self._validate_key_value(key=key)
+            self._tags.pop(key, None)
+
+    def to_tag_list(self) -> TagList:
+        tag_list = list()
+        for key, value in self._tags.items():
+            tag_list.append(Tag(key=key, value=value))
+        return tag_list
+
+
 class StateMachineRevision(StateMachineInstance):
-    class TagManager:
-        _tags: Final[dict[str, Optional[str]]]
-
-        def __init__(self):
-            self._tags = OrderedDict()
-
-        @staticmethod
-        def _validate_key_value(key: str) -> None:
-            if not key:
-                raise ValidationException()
-
-        @staticmethod
-        def _validate_tag_value(value: str) -> None:
-            if value is None:
-                raise ValidationException()
-
-        def add_all(self, tags: TagList) -> None:
-            for tag in tags:
-                tag_key = tag["key"]
-                tag_value = tag["value"]
-                self._validate_key_value(key=tag_key)
-                self._validate_tag_value(value=tag_value)
-                self._tags[tag_key] = tag_value
-
-        def remove_all(self, keys: TagKeyList):
-            for key in keys:
-                self._validate_key_value(key=key)
-                self._tags.pop(key, None)
-
-        def to_tag_list(self) -> TagList:
-            tag_list = list()
-            for key, value in self._tags.items():
-                tag_list.append(Tag(key=key, value=value))
-            return tag_list
 
     _next_version_number: int
     versions: Final[dict[RevisionId, Arn]]
@@ -146,7 +148,7 @@ class StateMachineRevision(StateMachineInstance):
         )
         self.versions = dict()
         self._version_number = 0
-        self.tag_manager = StateMachineRevision.TagManager()
+        self.tag_manager = TagManager()
 
     def create_revision(
         self, definition: Optional[str], role_arn: Optional[Arn]

--- a/localstack/services/stepfunctions/provider_v2.py
+++ b/localstack/services/stepfunctions/provider_v2.py
@@ -94,6 +94,7 @@ from localstack.services.stepfunctions.backend.state_machine import (
     StateMachineVersion,
 )
 from localstack.services.stepfunctions.backend.store import SFNStore, sfn_stores
+from localstack.state import StateVisitor
 from localstack.utils.aws.arns import ArnData, parse_arn, state_machine_arn
 from localstack.utils.strings import long_uid
 
@@ -104,6 +105,9 @@ class StepFunctionsProvider(StepfunctionsApi):
     @staticmethod
     def get_store(context: RequestContext) -> SFNStore:
         return sfn_stores[context.account_id][context.region]
+
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(sfn_stores)
 
     def _get_execution(self, context: RequestContext, execution_arn: Arn) -> Execution:
         execution: Optional[Execution] = self.get_store(context).executions.get(execution_arn)

--- a/localstack/testing/pytest/cloudtrail_tracking.py
+++ b/localstack/testing/pytest/cloudtrail_tracking.py
@@ -34,9 +34,7 @@ def cfn_store_events_role_arn(request, create_iam_role_with_policy, aws_client):
     # check that the user has run the bootstrap stack
 
     try:
-        step_function_arn = aws_client.ssm.get_parameter(
-            Name="cloudtrail-stepfunction-arn",
-        )[
+        step_function_arn = aws_client.ssm.get_parameter(Name="cloudtrail-stepfunction-arn",)[
             "Parameter"
         ]["Value"]
     except aws_client.ssm.exceptions.ParameterNotFound:

--- a/localstack/testing/pytest/cloudtrail_tracking.py
+++ b/localstack/testing/pytest/cloudtrail_tracking.py
@@ -34,7 +34,7 @@ def cfn_store_events_role_arn(request, create_iam_role_with_policy, aws_client):
     # check that the user has run the bootstrap stack
 
     try:
-        step_function_arn = aws_client.ssm.get_parameter(Name="cloudtrail-stepfunction-arn",)[
+        step_function_arn = aws_client.ssm.get_parameter(Name="cloudtrail-stepfunction-arn")[
             "Parameter"
         ]["Value"]
     except aws_client.ssm.exceptions.ParameterNotFound:


### PR DESCRIPTION
## Motivation

Persistence support has been requested by a customer using the v2 StepFunctions provider (running LS with `PROVIDER_OVERRIDE_STEPFUNCTIONS=v2 PERSISTENCE=1`). Addresses https://github.com/localstack/localstack/issues/9258

## Changes

* Add state visitor handler (`accept_state_visitor(..)`) to the StepFunctions v2 provider, to enable persistence support and persist the `sfn_stores` object
* Pull out the nested classes in the store models as top-level classes - nested classes can be problematic from a persistence/pickle perspective, in fact, I did a quick check with the nested classes, and ran into a `EOFError: Ran out of input` error when attempting to load the pickled state from disk)

As a next step, tests will be added in the upstream repo.