### PR TITLE
add utility function to check comma-delimited strings

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -517,3 +517,11 @@ def split_list_by(
             falsy.append(item)
 
     return truthy, falsy
+
+
+def is_comma_delimited_list(string: str) -> bool:
+    """Checks is a string is comma-delimited"""
+    pattern = re.compile(r"^(\w+)(,\s*\w+)*$")
+    if pattern.match(string) is None:
+        return False
+    return True

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -8,6 +8,7 @@ from localstack.utils.collections import (
     ImmutableDict,
     ImmutableList,
     convert_to_typed_dict,
+    is_comma_delimited_list,
     select_from_typed_dict,
 )
 
@@ -178,3 +179,13 @@ def test_convert_to_typed_dict_with_typed_subdict():
     result = convert_to_typed_dict(TestTypedDict, test_dict)
     assert isinstance(result, dict)
     assert result["subdict"] == {"str_member": "1"}
+
+
+def test_is_comma_limited_list():
+    assert is_comma_delimited_list("foo")
+    assert is_comma_delimited_list("foo,bar")
+    assert is_comma_delimited_list("foo, bar")
+
+    assert not is_comma_delimited_list("foo, bar baz")
+    assert not is_comma_delimited_list("foo,")
+    assert not is_comma_delimited_list("")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In [2263](https://github.com/localstack/localstack-ext/pull/2263) we moved quite some CLI-related code around.
During the core review, it turned out that `localstack.utils.collections` is a better place for this utility function.

<!-- What notable changes does this PR make? -->
## Changes
- Moving the function;
- Adding a small unit test.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

