### PR TITLE
harden s3 v3 concurrency

### DIFF
--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -543,7 +543,7 @@ class KeyStore:
         return self._store.pop(object_key, default)
 
     def values(self, *_, **__) -> list[S3Object | S3DeleteMarker]:
-        # we create a shallow copy with dict to avoid size hanged during iteration
+        # we create a shallow copy with dict to avoid size changed during iteration
         return [value for value in dict(self._store).values()]
 
     def is_empty(self) -> bool:
@@ -624,7 +624,7 @@ class VersionedKeyStore:
 
     def values(self, with_versions: bool = False) -> list[S3Object | S3DeleteMarker]:
         if with_versions:
-            # we create a shallow copy with dict to avoid size hanged during iteration
+            # we create a shallow copy with dict to avoid size changed during iteration
             return [
                 object_version
                 for values in dict(self._store).values()

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -57,7 +57,7 @@ class TestParallelBucketCreation:
                         Bucket=s3_bucket, Key=f"random-key-{runner}", Body="random"
                     )
             except Exception:
-                LOG.exception("Create bucket failed")
+                LOG.exception("Listing objects failed")
                 errored = True
 
         thread_list = []

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -39,3 +39,34 @@ class TestParallelBucketCreation:
             thread.join()
 
         assert not errored
+
+    @markers.aws.only_localstack
+    def test_parallel_object_creation_and_listing(self, aws_client, s3_bucket):
+        num_threads = 20
+        create_barrier = threading.Barrier(num_threads)
+        errored = False
+
+        def _create_or_list(runner: int):
+            nonlocal errored
+            create_barrier.wait()
+            try:
+                if runner % 2:
+                    aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+                else:
+                    aws_client.s3.put_object(
+                        Bucket=s3_bucket, Key=f"random-key-{runner}", Body="random"
+                    )
+            except Exception:
+                LOG.exception("Create bucket failed")
+                errored = True
+
+        thread_list = []
+        for i in range(1, num_threads + 1):
+            thread = threading.Thread(target=_create_or_list, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        assert not errored


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following a failure when trying to set the v3 provider as default, I had this PR shelved since a while as I was expecting it to happen.
https://app.circleci.com/pipelines/github/localstack/localstack/19625/workflows/c064060a-3962-4b34-96a0-6c0bfe0efc00/jobs/153568/tests

This PR hardens S3 v3 concurrency, by shallow copying `dict` that will be accessed concurrently before calling `.values`, `.keys` or `.items` on them, which could trigger exception as they would be modified during iteration.

\cc @dfangl since we worked on this together for the v2 provider

<!-- What notable changes does this PR make? -->
## Changes
Shallow-copy some dictionaries so that they wouldn't be modified during iteration from concurrent requests. 
Also added a test to check for iteration during `List*` calls. 
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

