### PR TITLE
raise exception for undefined dependency in CFn template

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -964,6 +964,10 @@ class TemplateDeployer:
     ):
         result = {}
         for resource_id, resource in resources.items():
+            if not resource:
+                raise Exception(
+                    f"Resource {resource_id} not found in stack {self.stack.stack_name}"
+                )
             if not self.is_deployed(resource):
                 LOG.debug(
                     "Dependency for resource %s not yet deployed: %s %s",

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -966,7 +966,7 @@ class TemplateDeployer:
         for resource_id, resource in resources.items():
             if not resource:
                 raise Exception(
-                    f"Resource {resource_id} not found in stack {self.stack.stack_name}"
+                    f"Resource '{resource_id}' not found in stack {self.stack.stack_name}"
                 )
             if not self.is_deployed(resource):
                 LOG.debug(

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.py
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.py
@@ -83,3 +83,21 @@ def test_sub_resolving(deploy_cfn_template, aws_client, snapshot):
     # Verify resource was created
     topic_arns = [t["TopicArn"] for t in aws_client.sns.list_topics()["Topics"]]
     assert topic_arn in topic_arns
+
+
+@markers.aws.only_localstack
+def test_unexisting_resource_dependency(deploy_cfn_template, aws_client):
+    stack_name = f"s-{short_uid()}"
+
+    with pytest.raises(Exception):
+        deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__),
+                "../../../templates/cfn_unexisting_resource_dependency.yml",
+            ),
+            stack_name=stack_name,
+        )
+
+    description = aws_client.cloudformation.describe_stacks(StackName=stack_name)["Stacks"][0]
+    assert description["StackStatus"] == "CREATE_FAILED"
+    assert "Resource 'UnexistingResource' not found in stack" in description["StackStatusReason"]

--- a/tests/aws/templates/cfn_unexisting_resource_dependency.yml
+++ b/tests/aws/templates/cfn_unexisting_resource_dependency.yml
@@ -1,0 +1,7 @@
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter::Value<String>
+    Properties:
+      Value: test
+      Type: String
+    DependsOn: UnexistingResource


### PR DESCRIPTION
## Motivation
 The Logs are pretty hard to understand and are not helpful when a CloudFormation template resource uses a dependency or refers to a resource that is not defined in the template.

## Changes
Now the TemplateDeployer raises an exception indicating that it doesn't find in the template the definition for a referenced resource.

## Testing
Simple 'only_localstack' tests to validated the failed deployed with a readable reason for it

## Note:
The alternative to raising an error is to just print a LOG and continue with the rest of resources but this can lead to unexpected results and it's an error that should make the template deployment fail.

AWS validates the template and dependencies before deployment, but that's a big issue to resolve in LocalStack.

cc/ @alexrashed 

