### PR TITLE
[SFN] Fix TimestampPath Value Access

### DIFF
--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
@@ -1,8 +1,6 @@
 import datetime
 from typing import Final
 
-from jsonpath_ng import parse
-
 from localstack.services.stepfunctions.asl.component.state.state_wait.wait_function.timestamp import (
     Timestamp,
 )
@@ -10,6 +8,7 @@ from localstack.services.stepfunctions.asl.component.state.state_wait.wait_funct
     WaitFunction,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
+from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 
 
 class TimestampPath(WaitFunction):
@@ -21,8 +20,7 @@ class TimestampPath(WaitFunction):
         self.path: Final[str] = path
 
     def _get_wait_seconds(self, env: Environment) -> int:
-        input_expr = parse(self.path)
-        timestamp_str = input_expr.find(env.inp)
+        timestamp_str = JSONPathUtils.extract_json(self.path, env.inp)
         timestamp = datetime.datetime.strptime(timestamp_str, Timestamp.TIMESTAMP_FORMAT)
         delta = timestamp - datetime.datetime.today()
         delta_sec = int(delta.total_seconds())

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -71,3 +71,7 @@ class ScenariosTemplate(TemplateLoader):
     LAMBDA_SERVICE_INVOKE_WITH_RETRY_BASE_EXTENDED_INPUT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/lambda_service_invoke_with_retry_extended_input.json5"
     )
+    WAIT_TIMESTAMP: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/wait_timestamp.json5")
+    WAIT_TIMESTAMP_PATH: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/wait_timestamp_path.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/wait_timestamp.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/wait_timestamp.json5
@@ -1,0 +1,11 @@
+{
+  "Comment": "WAIT_TIMESTAMP",
+  "StartAt": "WaitUntil",
+  "States": {
+    "WaitUntil": {
+      "Type": "Wait",
+      "Timestamp": "2016-03-14T01:59:00Z",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/wait_timestamp_path.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/wait_timestamp_path.json5
@@ -1,0 +1,11 @@
+{
+  "Comment": "WAIT_TIMESTAMP_PATH",
+  "StartAt": "WaitUntil",
+  "States": {
+    "WaitUntil": {
+      "Type": "Wait",
+      "TimestampPath": "$.TimestampValue",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -867,3 +867,45 @@ class TestBaseScenarios:
             definition,
             exec_input,
         )
+
+    @markers.aws.validated
+    def test_wait_timestamp(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.WAIT_TIMESTAMP)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
+    def test_wait_timestamp_path(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.WAIT_TIMESTAMP_PATH)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"TimestampValue": "2016-03-14T01:59:00Z"})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -10760,5 +10760,141 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_wait_timestamp_path": {
+    "recorded-date": "31-10-2023, 18:57:26",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "TimestampValue": "date"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "TimestampValue": "date"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "WaitUntil"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "WaitUntil",
+              "output": {
+                "TimestampValue": "date"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "TimestampValue": "date"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_wait_timestamp": {
+    "recorded-date": "31-10-2023, 19:01:20",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {},
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "WaitUntil"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "WaitUntil",
+              "output": {},
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {},
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In the current implementation of StepFunctions v2, the interpreter is unable to access the string value for `TimestampPath` definitions. This PR adds validated snapshot tests for `Wait` StateMachines with both `Timestamp` and `TimestampPath` invocations.

<!-- What notable changes does this PR make? -->
## Changes
Updated json path access for `TimestampPath` declarations to the interpreter's standard logic.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

