### PR TITLE
kinesis-lambda: Remove aws_stack.get_region() and get_aws_account_id()

### DIFF
--- a/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
+++ b/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
@@ -1,11 +1,10 @@
 import base64
 from typing import Dict, List, Optional
 
-from localstack.aws.accounts import get_aws_account_id
 from localstack.services.lambda_.event_source_listeners.stream_event_source_listener import (
     StreamEventSourceListener,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.common import first_char_to_lower, to_str
 from localstack.utils.threads import FuncThread
 
@@ -66,8 +65,8 @@ class KinesisEventSourceListener(StreamEventSourceListener):
                     "eventSource": "aws:kinesis",
                     "eventVersion": "1.0",
                     "eventName": "aws:kinesis:record",
-                    "invokeIdentityArn": f"arn:aws:iam::{get_aws_account_id()}:role/lambda-role",
-                    "awsRegion": aws_stack.get_region(),
+                    "invokeIdentityArn": f"arn:aws:iam::{extract_account_id_from_arn(stream_arn)}:role/lambda-role",
+                    "awsRegion": extract_region_from_arn(stream_arn),
                     "kinesis": record_payload,
                 }
             )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The functions `aws_stack.get_region()` and `get_aws_account_id()` rely on the thread local storage. The LocalStack handler chain sets the right values for these functions on a per request basis.

Consequently, these utilities do not work as expected in multi-threaded environments and we are in process of deprecating these utilities. This is with the ultimate goal of having full multi-account and multi-region compatibility in LS.

This resolution also fixes failing `tests.aws.services.lambda_.test_lambda_integration_kinesis.TestKinesisSource.test_create_kinesis_event_source_mapping` for non-default account and region. 

<!-- What notable changes does this PR make? -->
## Changes
This PR removes the use of the above helper functions and instead use region and account id from parsed ARN. 

## Testing
When using values other than `000000000000` for account ID or `us-east-1` for region, the tests should still create the consequent resources in this accounts and region.

<!-- The following sections are optional, but can be useful! 
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

