### PR TITLE
Add SHUTDOWN_TIMEOUT config to allow for shutdown handlers of more than 5sec

### DIFF
--- a/bin/localstack-supervisor
+++ b/bin/localstack-supervisor
@@ -22,6 +22,9 @@ LOCALSTACK_COMMAND = [sys.executable, "-m", "localstack.runtime.main"]
 
 DEBUG = os.getenv("DEBUG", "").strip().lower() in ["1", "true"]
 
+# configurable process shutdown timeout, to allow for longer shutdown procedures
+DEFAULT_SHUTDOWN_TIMEOUT = int(os.getenv("SHUTDOWN_TIMEOUT", "").strip() or 5)
+
 
 class AlarmException(Exception):
     """Special exception raise if SIGALRM is received."""
@@ -77,7 +80,7 @@ def waitpid_reap_other_children(pid: int) -> Optional[int]:
     return status
 
 
-def stop_child_process(name: str, pid: int, sig: int = signal.SIGTERM, timeout: int = 5):
+def stop_child_process(name: str, pid: int, sig: int = signal.SIGTERM, timeout: int | None = None):
     """
     Sends a signal to the given process and then waits for all child processes to avoid zombie processes.
 
@@ -92,6 +95,7 @@ def stop_child_process(name: str, pid: int, sig: int = signal.SIGTERM, timeout: 
         os.kill(pid, sig)
     except OSError:
         pass
+    timeout = timeout or DEFAULT_SHUTDOWN_TIMEOUT
     signal.alarm(timeout)
     try:
         waitpid_reap_other_children(pid)


### PR DESCRIPTION
## Motivation

We're currently hardcoding a maximum of 5 seconds for orderly process shutdown in `localstack-supervisor` before forcefully killing the process. This can be problematic in cases where a couple more seconds are required to perform shutdown logic, e.g., when storing cloud pods or CI run logs as part of the termination procedure of the LS container.

This PR adds a config option `SHUTDOWN_TIMEOUT` to make the shutdown timeout configurable. The change is backwards compatible and should not break existing functionality.

/cc @giograno @alexrashed @thrau 

## Changes

* add `SHUTDOWN_TIMEOUT` environment config, to allow for shutdown handlers of more than 5sec (use `5` as default value, as before)
