### PR TITLE
Deprecate community pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,10 +196,6 @@ RUN echo /var/lib/localstack/lib/python-packages/lib/python3.11/site-packages > 
 RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > localstack-static-python-packages-venv.pth && \
     mv localstack-static-python-packages-venv.pth .venv/lib/python*/site-packages/
 
-# Install the latest version of the LocalStack Persistence Plugin
-RUN --mount=type=cache,target=/root/.cache \
-    (. .venv/bin/activate && pip3 install --upgrade localstack-plugin-persistence)
-
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are discontinuing community pods (see [here](https://github.com/localstack/localstack/issues/9519)).
I will follow up by moving the code in the [persistence plugin](https://github.com/localstack/localstack-plugin-persistence) into `ext`.

<!-- What notable changes does this PR make? -->
## Changes
Remove the installation of the localstack persistence plugin in the community image.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

