### PR TITLE
remove deprecated HTTP endpoints / routes

### DIFF
--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -28,7 +28,6 @@ from localstack.aws.api.cloudwatch import (
 )
 from localstack.aws.connect import connect_to
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
-from localstack.deprecations import deprecated_endpoint
 from localstack.http import Request
 from localstack.services import moto
 from localstack.services.cloudwatch.alarm_scheduler import AlarmScheduler
@@ -232,16 +231,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
 
     def on_after_init(self):
         ROUTER.add(PATH_GET_RAW_METRICS, self.get_raw_metrics)
-        # TODO remove with 2.0
-        ROUTER.add(
-            DEPRECATED_PATH_GET_RAW_METRICS,
-            deprecated_endpoint(
-                self.get_raw_metrics,
-                previous_path=DEPRECATED_PATH_GET_RAW_METRICS,
-                deprecation_version="1.3.0",
-                new_path=PATH_GET_RAW_METRICS,
-            ),
-        )
         self.start_alarm_scheduler()
 
     def on_before_state_reset(self):

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -25,7 +25,7 @@ from localstack.runtime.exceptions import LocalstackExit
 from localstack.services import motoserver
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceDisabled, wait_for_infra_shutdown
-from localstack.utils import config_listener, files, objects
+from localstack.utils import files, objects
 from localstack.utils.analytics import usage
 from localstack.utils.aws.request_context import patch_moto_request_handling
 from localstack.utils.bootstrap import is_api_enabled, log_duration, setup_logging
@@ -65,9 +65,6 @@ SHUTDOWN_INFRA = threading.Event()
 
 # can be set
 EXIT_CODE: objects.Value[int] = objects.Value(0)
-
-# Start config update backdoor
-config_listener.start_listener()
 
 
 # ---------------

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -325,20 +325,7 @@ class LocalstackResources(Router):
         from localstack.services.plugins import SERVICE_PLUGINS
 
         health_resource = HealthResource(SERVICE_PLUGINS)
-        # special route for legacy support (before `/_localstack` was introduced)
-        self.add(
-            Resource(
-                "/health",
-                DeprecatedResource(
-                    health_resource,
-                    previous_path="/health",
-                    deprecation_version="1.3.0",
-                    new_path="/_localstack/health",
-                ),
-            ),
-        )
         self.add(Resource("/_localstack/health", health_resource))
-
         self.add(Resource("/_localstack/info", InfoResource()))
         self.add(Resource("/_localstack/plugins", PluginsResource()))
         self.add(Resource("/_localstack/init", InitScriptsResource()))

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -54,7 +54,6 @@ from localstack.aws.api.ses import (
 from localstack.aws.connect import connect_to
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.http import Resource, Response
-from localstack.services.internal import DeprecatedResource, get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.ses.models import SentEmail, SentEmailBody
@@ -165,23 +164,9 @@ def register_ses_api_resource():
     global _EMAILS_ENDPOINT_REGISTERED
 
     if not _EMAILS_ENDPOINT_REGISTERED:
-        ses_service_api_resource = SesServiceApiResource()
-        get_internal_apis().add(
-            Resource(
-                "/_localstack/ses",
-                DeprecatedResource(
-                    ses_service_api_resource,
-                    previous_path="/_localstack/ses",
-                    deprecation_version="1.4.0",
-                    new_path="/_aws/ses",
-                ),
-            )
-        )
-
         from localstack.services.edge import ROUTER
 
-        ROUTER.add(Resource(EMAILS_ENDPOINT, ses_service_api_resource))
-
+        ROUTER.add(Resource(EMAILS_ENDPOINT, SesServiceApiResource()))
         _EMAILS_ENDPOINT_REGISTERED = True
 
 

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -957,7 +957,7 @@ class TestSESRetrospection:
         assert '{"A key": "A value"}' == contents["TemplateData"]
         assert ["success@example.com"] == contents["Destination"]["ToAddresses"]
 
-        api_contents = requests.get("http://localhost:4566/_localstack/ses").json()
+        api_contents = requests.get("http://localhost:4566/_aws/ses").json()
         api_contents = {msg["Id"]: msg for msg in api_contents["messages"]}
         assert message_id in api_contents
         assert api_contents[message_id] == contents

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 
 from localstack import config
-from localstack.constants import CONFIG_UPDATE_PATH
 from localstack.http import Resource
 from localstack.services.internal import ConfigResource, get_internal_apis
 from localstack.utils import config_listener
@@ -31,17 +30,6 @@ def test_config_endpoint(config_endpoint):
 
     config.FOO = None
     config_listener.CONFIG_LISTENERS.append(custom_listener)
-
-    # test the ProxyListener
-    body = {"variable": "FOO", "value": "BAR"}
-    url = f"{config.get_edge_url()}{CONFIG_UPDATE_PATH}"
-    response = requests.post(url, json=body)
-    assert 200 == response.status_code
-    response_body = response.json()
-    assert body == response_body
-    assert body["value"] == config.FOO
-    assert body["variable"] == key
-    assert body["value"] == value
 
     # test the Route
     body = {"variable": "FOO", "value": "BAZ"}

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -15,12 +15,9 @@ def config_endpoint(monkeypatch):
 
     router = get_internal_apis()
     monkeypatch.setattr(config, "ENABLE_CONFIG_UPDATES", True)
-    # will listen on /?_config_
-    config_listener.start_listener()
     # will listen on /_localstack/config
     rules = router.add(Resource("/_localstack/config", ConfigResource()))
     yield
-    config_listener.remove_listener()
     router.remove(rules)
 
 

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -83,12 +83,6 @@ class TestCloudFormationUiResource:
 class TestLocalstackResourceHandlerIntegration:
     def test_health(self, monkeypatch):
         with proxy_server(LocalstackResourceHandler()) as url:
-            # legacy endpoint
-            response = requests.get(f"{url}/health")
-            assert response.ok
-            assert "services" in response.json()
-
-            # new internal endpoint
             response = requests.get(f"{url}/_localstack/health")
             assert response.ok
             assert "services" in response.json()


### PR DESCRIPTION
## Motivation
This PR removes the routing for endpoints which have been deprecated for a long time:
- `/health` → Now `/_localstack/health` (since `1.3.0` )
- `/cloudwatch/metrics/raw` → Now `/_aws/cloudwatch/metrics/raw` (since `1.3.0`)

## Changes
- Removes the registration of the deprecated routes for the health endpoint and the raw metrics from CloudWatch. /cc @steffyP 

## Associated PRs
Prior to the removal, all known usages in the repos of the `localstack` org on GitHub have been migrated:
- https://github.com/localstack/docs/pull/879
- https://github.com/localstack/localstack-on-k8s/pull/4
- https://github.com/localstack/localstack-terraform-test/pull/32
