### PR TITLE
Remove aws_stack.get_region() and get_aws_account_id() from tests

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -10,8 +10,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
-from localstack.constants import APPLICATION_JSON, LOCALHOST
+from localstack.constants import APPLICATION_JSON, LOCALHOST, TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.services.lambda_.networking import get_main_endpoint_from_container
 from localstack.testing.aws.lambda_utils import is_old_provider
@@ -377,7 +376,7 @@ def test_put_integration_validation(aws_client, echo_http_server, echo_http_serv
             restApiId=api_id,
             resourceId=root_id,
             credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
-                get_aws_account_id()
+                TEST_AWS_ACCOUNT_ID,
             ),
             httpMethod="GET",
             type=_type,
@@ -402,7 +401,7 @@ def test_put_integration_validation(aws_client, echo_http_server, echo_http_serv
                 restApiId=api_id,
                 resourceId=root_id,
                 credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
-                    get_aws_account_id()
+                    TEST_AWS_ACCOUNT_ID,
                 ),
                 httpMethod="GET",
                 type=_type,

--- a/tests/aws/services/cloudformation/resources/test_legacy.py
+++ b/tests/aws/services/cloudformation/resources/test_legacy.py
@@ -7,7 +7,6 @@ import yaml
 from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 
-from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.cloudformation.engine import template_preparer
 from localstack.testing.aws.lambda_utils import is_new_provider
@@ -84,7 +83,7 @@ Resources:
             - 'MessageFooHandler'
             - !FindInMap [ AccountInfo, !Ref "AWS::AccountId", ENV ]
 """
-    % get_aws_account_id()
+    % TEST_AWS_ACCOUNT_ID
 )
 
 TEST_TEMPLATE_13 = """
@@ -198,7 +197,7 @@ Resources:
     Properties:
       BucketName: cf-prd-{id}
 """
-    % get_aws_account_id()
+    % TEST_AWS_ACCOUNT_ID
 )
 
 TEST_TEMPLATE_20 = """

--- a/tests/aws/services/lambda_/test_lambda_legacy.py
+++ b/tests/aws/services/lambda_/test_lambda_legacy.py
@@ -4,7 +4,6 @@ import os.path
 
 import pytest
 
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.lambda_.legacy import lambda_api
@@ -206,7 +205,7 @@ class TestLambdaLegacyProvider:
     def test_create_lambda_function(self, aws_client):
         """Basic test that creates and deletes a Lambda function"""
         func_name = f"lambda_func-{short_uid()}"
-        kms_key_arn = f"arn:{aws_stack.get_partition()}:kms:{aws_stack.get_region()}:{get_aws_account_id()}:key11"
+        kms_key_arn = f"arn:{aws_stack.get_partition()}:kms:{TEST_AWS_REGION_NAME}:{TEST_AWS_ACCOUNT_ID}:key11"
         vpc_config = {
             "SubnetIds": ["subnet-123456789"],
             "SecurityGroupIds": ["sg-123456789"],
@@ -217,7 +216,7 @@ class TestLambdaLegacyProvider:
             "FunctionName": func_name,
             "Runtime": Runtime.python3_7,
             "Handler": LAMBDA_DEFAULT_HANDLER,
-            "Role": LAMBDA_TEST_ROLE.format(account_id=get_aws_account_id()),
+            "Role": LAMBDA_TEST_ROLE.format(account_id=TEST_AWS_ACCOUNT_ID),
             "KMSKeyArn": kms_key_arn,
             "Code": {
                 "ZipFile": create_lambda_archive(

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -12,10 +12,13 @@ from opensearchpy import OpenSearch
 from opensearchpy.exceptions import AuthorizationException
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.opensearch import AdvancedSecurityOptionsInput, MasterUserOptions
 from localstack.config import EDGE_BIND_HOST, LOCALSTACK_HOSTNAME
-from localstack.constants import OPENSEARCH_DEFAULT_VERSION, OPENSEARCH_PLUGIN_LIST
+from localstack.constants import (
+    OPENSEARCH_DEFAULT_VERSION,
+    OPENSEARCH_PLUGIN_LIST,
+    TEST_AWS_ACCOUNT_ID,
+)
 from localstack.services.opensearch import provider
 from localstack.services.opensearch.cluster import CustomEndpoint, EdgeProxiedOpensearchCluster
 from localstack.services.opensearch.cluster_manager import (
@@ -759,12 +762,12 @@ class TestMultiClusterManager:
         domain_key_0 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         domain_key_1 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         cluster_0 = manager.create(domain_key_0.arn, OPENSEARCH_DEFAULT_VERSION)
         cluster_1 = manager.create(domain_key_1.arn, OPENSEARCH_DEFAULT_VERSION)
@@ -807,12 +810,12 @@ class TestMultiplexingClusterManager:
         domain_key_0 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         domain_key_1 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         cluster_0 = manager.create(domain_key_0.arn, OPENSEARCH_DEFAULT_VERSION)
         cluster_1 = manager.create(domain_key_1.arn, OPENSEARCH_DEFAULT_VERSION)
@@ -855,12 +858,12 @@ class TestSingletonClusterManager:
         domain_key_0 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         domain_key_1 = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         cluster_0 = manager.create(domain_key_0.arn, OPENSEARCH_DEFAULT_VERSION)
         cluster_1 = manager.create(domain_key_1.arn, OPENSEARCH_DEFAULT_VERSION)
@@ -941,7 +944,7 @@ class TestCustomBackendManager:
         domain_key = DomainKey(
             domain_name=f"domain-{short_uid()}",
             region="us-east-1",
-            account=get_aws_account_id(),
+            account=TEST_AWS_ACCOUNT_ID,
         )
         cluster = manager.create(domain_key.arn, OPENSEARCH_DEFAULT_VERSION)
         # check that we're using the domain endpoint strategy

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -10,7 +10,6 @@ import pytest
 import requests
 from botocore.auth import SigV4Auth
 
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.aws.api.secretsmanager import (
     CreateSecretRequest,
@@ -19,7 +18,7 @@ from localstack.aws.api.secretsmanager import (
     DeleteSecretResponse,
     ListSecretsResponse,
 )
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.aws.lambda_utils import is_new_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
@@ -38,7 +37,7 @@ RESOURCE_POLICY = {
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {"AWS": f"arn:aws:iam::{get_aws_account_id()}:root"},
+            "Principal": {"AWS": f"arn:aws:iam::{TEST_AWS_ACCOUNT_ID}:root"},
             "Action": "secretsmanager:GetSecretValue",
             "Resource": "*",
         }

--- a/tests/aws/test_terraform.py
+++ b/tests/aws/test_terraform.py
@@ -5,7 +5,7 @@ import threading
 import pytest
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
+from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.packages.terraform import terraform_package
 from localstack.testing.pytest import markers
 from localstack.utils.common import is_command_available, rm_rf, run, start_worker_thread
@@ -129,18 +129,19 @@ class TestTerraform:
     @markers.skip_offline
     @markers.aws.needs_fixing
     def test_lambda(self, aws_client):
-        account_id = get_aws_account_id()
         response = aws_client.lambda_.get_function(FunctionName=LAMBDA_NAME)
         assert response["Configuration"]["FunctionName"] == LAMBDA_NAME
         assert response["Configuration"]["Handler"] == LAMBDA_HANDLER
         assert response["Configuration"]["Runtime"] == LAMBDA_RUNTIME
-        assert response["Configuration"]["Role"] == LAMBDA_ROLE.format(account_id=account_id)
+        assert response["Configuration"]["Role"] == LAMBDA_ROLE.format(
+            account_id=TEST_AWS_ACCOUNT_ID
+        )
 
     @markers.skip_offline
     @markers.aws.needs_fixing
     def test_event_source_mapping(self, aws_client):
-        queue_arn = QUEUE_ARN.format(account_id=get_aws_account_id())
-        lambda_arn = LAMBDA_ARN.format(account_id=get_aws_account_id(), lambda_name=LAMBDA_NAME)
+        queue_arn = QUEUE_ARN.format(account_id=TEST_AWS_ACCOUNT_ID)
+        lambda_arn = LAMBDA_ARN.format(account_id=TEST_AWS_ACCOUNT_ID, lambda_name=LAMBDA_NAME)
         all_mappings = aws_client.lambda_.list_event_source_mappings(
             EventSourceArn=queue_arn, FunctionName=LAMBDA_NAME
         )

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -10,11 +10,11 @@ import xmltodict
 from requests.models import Request as RequestsRequest
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import (
     APPLICATION_JSON,
     HEADER_LOCALSTACK_EDGE_URL,
     TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
 )
 from localstack.services.generic_proxy import (
@@ -334,7 +334,7 @@ class TestEdgeAPI:
             json.loads(content1)
         content1 = xmltodict.parse(content1)
         content1_result = content1["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
-        assert content1_result["Account"] == get_aws_account_id()
+        assert content1_result["Account"] == TEST_AWS_ACCOUNT_ID
 
         # receive response as JSON (via Accept header)
         headers = aws_stack.mock_aws_request_headers(
@@ -345,7 +345,7 @@ class TestEdgeAPI:
         assert response
         content2 = json.loads(to_str(response.content))
         content2_result = content2["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
-        assert content2_result["Account"] == get_aws_account_id()
+        assert content2_result["Account"] == TEST_AWS_ACCOUNT_ID
         content1.get("GetCallerIdentityResponse", {}).pop("ResponseMetadata", None)
         content2.get("GetCallerIdentityResponse", {}).pop("ResponseMetadata", None)
         assert strip_xmlns(content1) == content2

--- a/tests/unit/services/opensearch/test_cluster_manager.py
+++ b/tests/unit/services/opensearch/test_cluster_manager.py
@@ -1,15 +1,15 @@
 import pytest
 
 from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.opensearch import EngineType
+from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.opensearch.cluster_manager import DomainKey, build_cluster_endpoint
 
 
 class TestBuildClusterEndpoint:
     def test_endpoint_strategy_port(self, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
-        endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", get_aws_account_id()))
+        endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
         parts = endpoint.split(":")
         assert parts[0] == "localhost"
         assert int(parts[1]) in range(
@@ -28,12 +28,12 @@ class TestBuildClusterEndpoint:
         engine_path_prefix = engine[1]
 
         endpoint = build_cluster_endpoint(
-            DomainKey("my-domain", "us-east-1", get_aws_account_id()), engine_type=engine_type
+            DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID), engine_type=engine_type
         )
         assert endpoint == f"localhost:4566/{engine_path_prefix}/us-east-1/my-domain"
 
         endpoint = build_cluster_endpoint(
-            DomainKey("my-domain-1", "eu-central-1", get_aws_account_id()), engine_type=engine_type
+            DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID), engine_type=engine_type
         )
         assert endpoint == f"localhost:4566/{engine_path_prefix}/eu-central-1/my-domain-1"
 
@@ -49,7 +49,7 @@ class TestBuildClusterEndpoint:
         engine_path_prefix = engine[1]
 
         endpoint = build_cluster_endpoint(
-            domain_key=DomainKey("my-domain", "us-east-1", get_aws_account_id()),
+            domain_key=DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID),
             engine_type=engine_type,
         )
         assert (
@@ -57,7 +57,7 @@ class TestBuildClusterEndpoint:
         )
 
         endpoint = build_cluster_endpoint(
-            domain_key=DomainKey("my-domain-1", "eu-central-1", get_aws_account_id()),
+            domain_key=DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID),
             engine_type=engine_type,
         )
         assert (


### PR DESCRIPTION
## Motivation

The functions `aws_stack.get_region()` and `get_aws_account_id()` use thread local storage to retrieve their values. The correct values are set in LocalStack request handler chain. If these values are not set, these functions return the fallback values.

Consequently these functions must not be used in tests. This is because the account ID and regions used by the test fixture `aws_client` do not necessarily match the fallback values.

## Implementation

This PR removes all use of these functions from the community tests.