### PR TITLE
adding route53 snapshot test

### DIFF
--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -448,8 +448,8 @@ class TransformerUtility:
             TransformerUtility.jsonpath(
                 jsonpath="$..ChangeInfo.Status", value_replacement="status"
             ),
+            KeyValueBasedTransformer(_route53_hosted_zone_id_transformer, "zone-id"),
             TransformerUtility.regex(r"/change/[A-Za-z0-9]+", "/change/<change-id>"),
-            TransformerUtility.regex(r"/hostedzone/[A-Za-z0-9]+", "/hostedzone/<zone_id>"),
             TransformerUtility.jsonpath(
                 jsonpath="$..HostedZone.Name", value_replacement="zone_name"
             ),
@@ -681,6 +681,13 @@ def _log_stream_name_transformer(key: str, val: str) -> str:
         if match:
             return val
     return None
+
+
+def _route53_hosted_zone_id_transformer(key: str, val: str) -> str:
+    if isinstance(val, str) and key == "Id":
+        match = re.match(r".*/hostedzone/([A-Za-z0-9]+)", val)
+        if match:
+            return match.groups()[0]
 
 
 # TODO: actual and declared type diverge

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -437,6 +437,25 @@ class TransformerUtility:
         ]
 
     @staticmethod
+    def route53_api():
+        return [
+            TransformerUtility.jsonpath("$..HostedZone.CallerReference", "caller-reference"),
+            TransformerUtility.jsonpath(
+                jsonpath="$..DelegationSet.NameServers",
+                value_replacement="<name-server>",
+                reference_replacement=False,
+            ),
+            TransformerUtility.jsonpath(
+                jsonpath="$..ChangeInfo.Status", value_replacement="status"
+            ),
+            TransformerUtility.regex(r"/change/[A-Za-z0-9]+", "/change/<change-id>"),
+            TransformerUtility.regex(r"/hostedzone/[A-Za-z0-9]+", "/hostedzone/<zone_id>"),
+            TransformerUtility.jsonpath(
+                jsonpath="$..HostedZone.Name", value_replacement="zone_name"
+            ),
+        ]
+
+    @staticmethod
     def sqs_api():
         """
         :return: array with Transformers, for sqs api.

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -5,15 +5,41 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
-# TODO: add proper cleanup
-class TestRoute53:
-    @markers.aws.unknown
-    def test_create_hosted_zone(self, aws_client):
-        response = aws_client.route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
+@pytest.fixture
+def hosted_zone(aws_client):
+    zone_ids = []
 
-        response = aws_client.route53.get_change(Id="string")
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    def factory(**kwargs):
+        if "CallerReference" not in kwargs:
+            kwargs["CallerReference"] = f"ref-{short_uid()}"
+        response = aws_client.route53.create_hosted_zone(**kwargs)
+        zone_id = response["HostedZone"]["Id"]
+        zone_ids.append(zone_id)
+        return response
+
+    yield factory
+
+    for zone_id in zone_ids:
+        aws_client.route53.delete_hosted_zone(Id=zone_id)
+
+
+@pytest.fixture(autouse=True)
+def route53_snapshot_transformer(snapshot):
+    snapshot.add_transformer(snapshot.transform.route53_api())
+
+
+class TestRoute53:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..DelegationSet.Id", "$..HostedZone.CallerReference"]
+    )
+    def test_create_hosted_zone(self, aws_client, hosted_zone, snapshot):
+        response = hosted_zone(Name=f"zone-{short_uid()}.com")
+        zone_id = response["HostedZone"]["Id"]
+        snapshot.match("create_hosted_zone_response", response)
+
+        response = aws_client.route53.get_hosted_zone(Id=zone_id)
+        snapshot.match("get_hosted_zone", response)
 
     @markers.aws.unknown
     def test_crud_health_check(self, aws_client):

--- a/tests/aws/services/route53/test_route53.snapshot.json
+++ b/tests/aws/services/route53/test_route53.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/route53/test_route53.py::TestRoute53::test_create_hosted_zone": {
-    "recorded-date": "02-11-2023, 08:26:25",
+    "recorded-date": "02-11-2023, 12:59:59",
     "recorded-content": {
       "create_hosted_zone_response": {
         "ChangeInfo": {
@@ -16,11 +16,11 @@
           "Config": {
             "PrivateZone": false
           },
-          "Id": "/hostedzone/<zone_id>",
+          "Id": "/hostedzone/<zone-id:1>",
           "Name": "<zone_name:1>",
           "ResourceRecordSetCount": 2
         },
-        "Location": "https://route53.amazonaws.com/2013-04-01/hostedzone/<zone_id>",
+        "Location": "https://route53.amazonaws.com/2013-04-01/hostedzone/<zone-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -35,7 +35,7 @@
           "Config": {
             "PrivateZone": false
           },
-          "Id": "/hostedzone/<zone_id>",
+          "Id": "/hostedzone/<zone-id:1>",
           "Name": "<zone_name:1>",
           "ResourceRecordSetCount": 2
         },

--- a/tests/aws/services/route53/test_route53.snapshot.json
+++ b/tests/aws/services/route53/test_route53.snapshot.json
@@ -1,0 +1,49 @@
+{
+  "tests/aws/services/route53/test_route53.py::TestRoute53::test_create_hosted_zone": {
+    "recorded-date": "02-11-2023, 08:26:25",
+    "recorded-content": {
+      "create_hosted_zone_response": {
+        "ChangeInfo": {
+          "Id": "/change/<change-id>",
+          "Status": "<status:1>",
+          "SubmittedAt": "datetime"
+        },
+        "DelegationSet": {
+          "NameServers": "<name-server>"
+        },
+        "HostedZone": {
+          "CallerReference": "<caller-reference:1>",
+          "Config": {
+            "PrivateZone": false
+          },
+          "Id": "/hostedzone/<zone_id>",
+          "Name": "<zone_name:1>",
+          "ResourceRecordSetCount": 2
+        },
+        "Location": "https://route53.amazonaws.com/2013-04-01/hostedzone/<zone_id>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_hosted_zone": {
+        "DelegationSet": {
+          "NameServers": "<name-server>"
+        },
+        "HostedZone": {
+          "CallerReference": "<caller-reference:1>",
+          "Config": {
+            "PrivateZone": false
+          },
+          "Id": "/hostedzone/<zone_id>",
+          "Name": "<zone_name:1>",
+          "ResourceRecordSetCount": 2
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Looking at a few minor parity gaps issues on our board, I wanted to start introducing snapshot tests for route53.

<!-- What notable changes does this PR make? -->
## Changes
- adding an initial simple snapshot test;
- adding fixture for self-cleaning hosted zones;
- initial set of transformers for route53.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

