### PR TITLE
apigateway: remove get_aws_account_id() from integration tests

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -11,7 +11,7 @@ from werkzeug import Request, Response
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
-from localstack.constants import APPLICATION_JSON, LOCALHOST
+from localstack.constants import APPLICATION_JSON, LOCALHOST, TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.services.lambda_.networking import get_main_endpoint_from_container
 from localstack.testing.aws.lambda_utils import is_old_provider
@@ -377,7 +377,7 @@ def test_put_integration_validation(aws_client, echo_http_server, echo_http_serv
             restApiId=api_id,
             resourceId=root_id,
             credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
-                get_aws_account_id()
+                TEST_AWS_ACCOUNT_ID
             ),
             httpMethod="GET",
             type=_type,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The function `get_aws_account_id()` relies on the thread local storage. The LocalStack handler chain sets the right values for these functions on a per request basis.

Consequently, these utilities do not work as expected in multi-threaded environments and we are in process of deprecating these utilities. This is with the ultimate goal of having full multi-account and multi-region compatibility in LS.

This resolution fixes failing test `tests.aws.services.apigateway.test_apigateway_integrations` for non-default account and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR removes the use of the `get_aws_account_id()` function and instead use `TEST_AWS_ACCOUNT_ID`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

