### PR TITLE
Allow setting numeric config variables in config update endpoint

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -27,6 +27,7 @@ from localstack.utils.config_listener import update_config_variable
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
 from localstack.utils.json import parse_json_or_yaml
+from localstack.utils.numbers import is_number
 from localstack.utils.objects import singleton_factory
 from localstack.utils.server.http2_server import HTTP_METHODS
 
@@ -303,6 +304,8 @@ class ConfigResource:
         if not re.match(r"^[_a-zA-Z0-9]+$", variable):
             return Response("{}", mimetype="application/json", status=400)
         new_value = data.get("value")
+        if is_number(new_value):
+            new_value = float(new_value)
         update_config_variable(variable, new_value)
         value = getattr(config, variable, None)
         return {

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -39,7 +39,7 @@ def test_config_endpoint(config_endpoint):
     body = {"variable": "FOO", "value": "BAR"}
     url = f"{config.get_edge_url()}{CONFIG_UPDATE_PATH}"
     response = requests.post(url, json=body)
-    assert 200 == response.status_code
+    assert response.ok
     response_body = response.json()
     assert body == response_body
     assert body["value"] == config.FOO
@@ -48,15 +48,22 @@ def test_config_endpoint(config_endpoint):
 
     # test the Route
     body = {"variable": "FOO", "value": "BAZ"}
-    config_listener.CONFIG_LISTENERS.append(custom_listener)
     # test the ProxyListener
     url = f"{config.get_edge_url()}/_localstack/config"
     response = requests.post(url, json=body)
-    assert 200 == response.status_code
+    assert response.ok
     response_body = response.json()
     assert body == response_body
     assert body["value"] == config.FOO
     assert body["variable"] == key
     assert body["value"] == value
 
+    # test numeric value update
+    body = {"variable": "FOO", "value": 0.9}
+    response = requests.post(url, json=body)
+    assert response.ok
+    assert config.FOO == 0.9
+    assert isinstance(config.FOO, float)
+
     del config.FOO
+    config_listener.CONFIG_LISTENERS.remove(custom_listener)


### PR DESCRIPTION
## Motivation

One of the Chaos Engineering features we want to enable in the Web app with @webdev51  is setting the `KINESIS_ERROR_PROBABILITY`/`DYNAMODB_ERROR_PROBABILITY` config variables, to simulate rate limiting for Kinesis/DynamoDB.

This can be enabled by asking the user to enable `ENABLE_CONFIG_UPDATES=1` on LS startup (with the caveats / security implications that come with it, and which we have also documented in our docs), and then using the config update endpoint.

However, currently updating the value to `ENABLE_CONFIG_UPDATES=1` is not fully working, as the service providers expect those values to be numeric, whereas the config update listener sets them as string. It seems reasonable to check if config values are numeric, and then convert them to float (the other approach would be to fix the logic in the provider, to be able to handle both `float` and `str` values).

## Changes

* add `is_number(..)` check to config update, to automatically convert numeric strings to numbers
