### PR TITLE
Make OpensearchProvider inherit ServiceLifecycleHook

### DIFF
--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -93,6 +93,7 @@ from localstack.services.opensearch.cluster_manager import (
     create_cluster_manager,
 )
 from localstack.services.opensearch.models import OpenSearchStore, opensearch_stores
+from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
@@ -399,7 +400,7 @@ def is_valid_domain_name(name: str) -> bool:
     return True if _domain_name_pattern.match(name) else False
 
 
-class OpensearchProvider(OpensearchApi):
+class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
     @staticmethod
     def get_store(account_id: str, region_name: str) -> OpenSearchStore:
         return opensearch_stores[account_id][region_name]


### PR DESCRIPTION
Fixes #8092

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
`OpensearchProvider` implements the methods `on_after_state_load`, `on_before_state_reset`, and `on_before_stop`. However, they currently are never invoked because the provider is not a `ServiceLifecycleHook` ([which is checked here](https://github.com/localstack/localstack/blob/master/localstack/services/plugins.py#L165-L168)). This causes loaded elasticsearch/opensearch state to not behave correctly (i.e. #8092).

I didn't add a new test for this because I'm not sure where it should go - are there existing tests covering persistence? Fortunately, this change itself is fairly minimal.