### PR TITLE
make strict service loading default for v3

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -720,7 +720,7 @@ DEBUG_HANDLER_CHAIN = is_env_true("DEBUG_HANDLER_CHAIN")
 EAGER_SERVICE_LOADING = is_env_true("EAGER_SERVICE_LOADING")
 
 # whether to selectively load services in SERVICES
-STRICT_SERVICE_LOADING = is_env_true("STRICT_SERVICE_LOADING")
+STRICT_SERVICE_LOADING = is_env_not_false("STRICT_SERVICE_LOADING")
 
 # Whether to skip downloading additional infrastructure components (e.g., custom Elasticsearch versions)
 SKIP_INFRA_DOWNLOADS = os.environ.get("SKIP_INFRA_DOWNLOADS", "").strip()

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -13,7 +13,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Union
 
 from localstack import config, constants
-from localstack.config import HostAndPort, default_ip, is_env_true
+from localstack.config import HostAndPort, default_ip, is_env_not_false, is_env_true
 from localstack.runtime import hooks
 from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import (
@@ -232,7 +232,7 @@ def get_enabled_apis() -> Set[str]:
     services_env = os.environ.get("SERVICES", "").strip()
     services = SERVICE_PLUGINS.list_available()
 
-    if services_env and is_env_true("STRICT_SERVICE_LOADING"):
+    if services_env and is_env_not_false("STRICT_SERVICE_LOADING"):
         # SERVICES and STRICT_SERVICE_LOADING are set
         # we filter the result of SERVICE_PLUGINS.list_available() to cross the user-provided list with
         # the available ones

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -110,6 +110,14 @@ class TestGetEnabledApis:
 
         assert result == set(SERVICE_PLUGINS.list_available())
 
+    def test_strict_service_loading_enabled_by_default(self):
+        with temporary_env({"SERVICES": "s3,sqs"}):
+            result = get_enabled_apis()
+
+        assert len(result) == 2
+        assert "s3" in result
+        assert "sqs" in result
+
     def test_with_service_subset(self):
         with temporary_env({"SERVICES": "s3,sqs", "STRICT_SERVICE_LOADING": "1"}):
             result = get_enabled_apis()

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -102,6 +102,14 @@ class TestGetEnabledApis:
 
         assert result == set(SERVICE_PLUGINS.list_available())
 
+    def test_strict_service_loading_disabled(self):
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        with temporary_env({"STRICT_SERVICE_LOADING": "0", "SERVICES": "s3,sqs"}):
+            result = get_enabled_apis()
+
+        assert result == set(SERVICE_PLUGINS.list_available())
+
     def test_with_service_subset(self):
         with temporary_env({"SERVICES": "s3,sqs", "STRICT_SERVICE_LOADING": "1"}):
             result = get_enabled_apis()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following the change merged in `master` with #9494, we now want to make it enabled by default with `v3.0`. 


<!-- What notable changes does this PR make? -->
## Changes

Make use of `is_env_not_false` to validate if the feature is not disabled (which makes it enabled by default). 
Added a test for the default enabling and disabling of the feature as well. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

