### PR TITLE
show available/disabled services in health endpoint + fix sqs strict loading

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -13,7 +13,7 @@ from localstack import config
 from localstack.aws.skeleton import DispatchTable
 from localstack.config import ServiceProviderConfig
 from localstack.state import StateLifecycleHook, StateVisitable, StateVisitor
-from localstack.utils.bootstrap import get_enabled_apis, log_duration
+from localstack.utils.bootstrap import get_enabled_apis, is_api_enabled, log_duration
 from localstack.utils.functions import call_safe
 from localstack.utils.net import wait_for_port_status
 from localstack.utils.sync import SynchronizedDefaultDict, poll_condition
@@ -127,7 +127,7 @@ class Service:
         return self.plugin_name
 
     def is_enabled(self):
-        return True
+        return is_api_enabled(self.plugin_name)
 
     def accept_state_visitor(self, visitor: StateVisitor):
         """
@@ -545,7 +545,7 @@ class ServicePluginManager(ServiceManager):
         if self.plugin_errors.has_errors(name, provider):
             return ServiceState.ERROR
 
-        return ServiceState.AVAILABLE
+        return ServiceState.AVAILABLE if is_api_enabled(name) else ServiceState.DISABLED
 
     def get_service_container(self, name: str) -> Optional[ServiceContainer]:
         if container := self._services.get(name):

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -84,6 +84,7 @@ from localstack.services.sqs.utils import (
 )
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.request_context import extract_region_from_headers
+from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.cloudwatch.cloudwatch_util import publish_sqs_metric
 from localstack.utils.run import FuncThread
 from localstack.utils.scheduler import Scheduler
@@ -1270,19 +1271,21 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 )
 
     def _init_cloudwatch_metrics_reporting(self):
-        self._cloudwatch_publish_worker = (
-            None if config.SQS_DISABLE_CLOUDWATCH_METRICS else CloudwatchPublishWorker()
-        )
-        self._cloudwatch_dispatcher = (
-            None if config.SQS_DISABLE_CLOUDWATCH_METRICS else CloudwatchDispatcher()
+        self.cloudwatch_disabled: bool = (
+            config.SQS_DISABLE_CLOUDWATCH_METRICS or not is_api_enabled("cloudwatch")
         )
 
+        self._cloudwatch_publish_worker = (
+            None if self.cloudwatch_disabled else CloudwatchPublishWorker()
+        )
+        self._cloudwatch_dispatcher = None if self.cloudwatch_disabled else CloudwatchDispatcher()
+
     def _start_cloudwatch_metrics_reporting(self):
-        if not config.SQS_DISABLE_CLOUDWATCH_METRICS:
+        if not self.cloudwatch_disabled:
             self._cloudwatch_publish_worker.start()
 
     def _stop_cloudwatch_metrics_reporting(self):
-        if not config.SQS_DISABLE_CLOUDWATCH_METRICS:
+        if not self.cloudwatch_disabled:
             self._cloudwatch_publish_worker.stop()
             self._cloudwatch_dispatcher.shutdown()
 

--- a/tests/bootstrap/test_strict_service_loading.py
+++ b/tests/bootstrap/test_strict_service_loading.py
@@ -1,0 +1,70 @@
+import pytest
+import requests
+from botocore.exceptions import ClientError
+
+from localstack.config import in_docker
+from localstack.testing.pytest.container import ContainerFactory
+from localstack.utils.bootstrap import ContainerConfigurators, get_gateway_url
+
+pytestmarks = pytest.mark.skipif(
+    condition=in_docker(), reason="cannot run bootstrap tests in docker"
+)
+
+
+def test_strict_service_loading(
+    container_factory: ContainerFactory,
+    wait_for_localstack_ready,
+    aws_client_factory,
+):
+    ls_container = container_factory(
+        configurators=[
+            ContainerConfigurators.random_container_name,
+            ContainerConfigurators.random_gateway_port,
+            ContainerConfigurators.random_service_port_range(20),
+            ContainerConfigurators.env_vars(
+                {"STRICT_SERVICE_LOADING": "1", "SERVICES": "s3,sqs,sns"}
+            ),
+        ]
+    )
+    running_container = ls_container.start()
+    wait_for_localstack_ready(running_container)
+    url = get_gateway_url(ls_container)
+
+    # check service-status returned by health endpoint
+    response = requests.get(f"{url}/_localstack/health")
+    assert response.ok
+
+    services = response.json().get("services")
+
+    assert services.pop("sqs") == "available"
+    assert services.pop("s3") == "available"
+    assert services.pop("sns") == "available"
+
+    assert services
+    assert all(services.get(key) == "disabled" for key in services.keys())
+
+    # activate sqs service
+    client = aws_client_factory(endpoint_url=url)
+    result = client.sqs.list_queues()
+    assert result
+
+    # verify cloudwatch is not activated
+    with pytest.raises(ClientError) as e:
+        client.cloudwatch.list_metrics()
+
+    e.match(
+        "Service 'cloudwatch' is not enabled. Please check your 'SERVICES' configuration variable."
+    )
+    assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 501
+
+    # check status again
+    response = requests.get(f"{url}/_localstack/health")
+    assert response.ok
+
+    services = response.json().get("services")
+
+    # sqs should be running now
+    assert services.get("sqs") == "running"
+    assert services.get("s3") == "available"
+    assert services.get("sns") == "available"
+    assert services.get("cloudwatch") == "disabled"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With `STRICT_SERVICE_LOADING` added in https://github.com/localstack/localstack/pull/9494, we can now start selected services only.
In this PR we fix the loading of `sqs` only (disable init of `cloudwatch` workers). 
Additionally, the `_localstack/health` endpoint returns the `available` and `disabled` services.

<!-- What notable changes does this PR make? -->
## Changes
* `SQS` provider: skip init of cloudwatch workers if the service `cloudwatch` is not enabled
*  return the correct `ServiceState` if the service is not available

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

