### PR TITLE
make SNS Delivery Logs opt-in 

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -360,10 +360,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
     def unsubscribe(self, context: RequestContext, subscription_arn: subscriptionARN) -> None:
         count = len(subscription_arn.split(":"))
-        if count < 6:
-            raise InvalidParameterException(
-                f"Invalid parameter: SubscriptionArn Reason: An ARN must have at least 6 elements, not {count}"
-            )
         try:
             parsed_arn = parse_arn(subscription_arn)
         except InvalidArnException:

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -66,7 +66,6 @@ from localstack.utils.aws.arns import (
     extract_region_from_arn,
     parse_arn,
 )
-from localstack.utils.bootstrap import log_duration
 from localstack.utils.strings import short_uid
 
 # set up logger
@@ -432,7 +431,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         attributes = {k: v for k, v in sub.items() if k not in removed_attrs}
         return GetSubscriptionAttributesResponse(Attributes=attributes)
 
-    @log_duration(min_ms=0)
     def publish(
         self,
         context: RequestContext,

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -8,7 +8,7 @@ import logging
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Union
 
 import requests
@@ -47,7 +47,8 @@ LOG = logging.getLogger(__name__)
 class SnsPublishContext:
     message: SnsMessage
     store: SnsStore
-    request_headers: Dict[str, str]
+    request_headers: dict[str, str]
+    topic_attributes: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -55,6 +56,7 @@ class SnsBatchPublishContext:
     messages: List[SnsMessage]
     store: SnsStore
     request_headers: Dict[str, str]
+    topic_attributes: dict[str, str] = field(default_factory=dict)
 
 
 class TopicPublisher(abc.ABC):
@@ -186,13 +188,24 @@ class LambdaTopicPublisher(TopicPublisher):
                         {"lambdaRequestId": inv_result["ResponseMetadata"]["RequestId"]}
                     ),
                 }
-                store_delivery_log(context.message, subscriber, success=True, delivery=delivery)
+                store_delivery_log(
+                    context.message,
+                    subscriber,
+                    success=True,
+                    topic_attributes=context.topic_attributes,
+                    delivery=delivery,
+                )
 
         except Exception as exc:
             LOG.info(
                 "Unable to run Lambda function on SNS message: %s %s", exc, traceback.format_exc()
             )
-            store_delivery_log(context.message, subscriber, success=False)
+            store_delivery_log(
+                context.message,
+                subscriber,
+                success=False,
+                topic_attributes=context.topic_attributes,
+            )
             message_body = create_sns_message_body(
                 message_context=context.message, subscriber=subscriber
             )
@@ -263,10 +276,17 @@ class SqsTopicPublisher(TopicPublisher):
                 MessageSystemAttributes=create_sqs_system_attributes(context.request_headers),
                 **kwargs,
             )
-            store_delivery_log(message_context, subscriber, success=True)
+            store_delivery_log(
+                message_context, subscriber, success=True, topic_attributes=context.topic_attributes
+            )
         except Exception as exc:
             LOG.info("Unable to forward SNS message to SQS: %s %s", exc, traceback.format_exc())
-            store_delivery_log(message_context, subscriber, success=False)
+            store_delivery_log(
+                message_context,
+                subscriber,
+                success=False,
+                topic_attributes=context.topic_attributes,
+            )
             sns_error_to_dead_letter_queue(subscriber, message_body, str(exc), **kwargs)
             if "NonExistentQueue" in str(exc):
                 LOG.debug("The SQS queue endpoint does not exist anymore")
@@ -343,7 +363,9 @@ class SqsBatchTopicPublisher(SqsTopicPublisher):
             response = sqs_client.send_message_batch(QueueUrl=queue_url, Entries=entries)
 
             for message_ctx in context.messages:
-                store_delivery_log(message_ctx, subscriber, success=True)
+                store_delivery_log(
+                    message_ctx, subscriber, success=True, topic_attributes=context.topic_attributes
+                )
 
             if failed_messages := response.get("Failed"):
                 for failed_msg in failed_messages:
@@ -353,7 +375,12 @@ class SqsBatchTopicPublisher(SqsTopicPublisher):
                         failed_msg["Code"],
                         failed_msg["Message"],
                     )
-                    store_delivery_log(failure_data["context"], subscriber, success=False)
+                    store_delivery_log(
+                        failure_data["context"],
+                        subscriber,
+                        success=False,
+                        topic_attributes=context.topic_attributes,
+                    )
                     kwargs = {}
                     if msg_attrs := failure_data["entry"].get("MessageAttributes"):
                         kwargs["MessageAttributes"] = msg_attrs
@@ -374,7 +401,12 @@ class SqsBatchTopicPublisher(SqsTopicPublisher):
         except Exception as exc:
             LOG.info("Unable to forward SNS message to SQS: %s %s", exc, traceback.format_exc())
             for message_ctx in context.messages:
-                store_delivery_log(message_ctx, subscriber, success=False)
+                store_delivery_log(
+                    message_ctx,
+                    subscriber,
+                    success=False,
+                    topic_attributes=context.topic_attributes,
+                )
                 msg_body = self.prepare_message(message_ctx, subscriber)
                 kwargs = self.get_sqs_kwargs(message_ctx, subscriber)
 
@@ -433,14 +465,25 @@ class HttpTopicPublisher(TopicPublisher):
                 "statusCode": response.status_code,
                 "providerResponse": response.content.decode("utf-8"),
             }
-            store_delivery_log(message_context, subscriber, success=True, delivery=delivery)
+            store_delivery_log(
+                message_context,
+                subscriber,
+                success=True,
+                delivery=delivery,
+                topic_attributes=context.topic_attributes,
+            )
 
             response.raise_for_status()
         except Exception as exc:
             LOG.info(
                 "Received error on sending SNS message, putting to DLQ (if configured): %s", exc
             )
-            store_delivery_log(message_context, subscriber, success=False)
+            store_delivery_log(
+                message_context,
+                subscriber,
+                success=False,
+                topic_attributes=context.topic_attributes,
+            )
             # AWS doesn't send to the DLQ if there's an error trying to deliver a UnsubscribeConfirmation msg
             if message_context.type != "UnsubscribeConfirmation":
                 sns_error_to_dead_letter_queue(subscriber, message_body, str(exc))
@@ -472,7 +515,6 @@ class EmailJsonTopicPublisher(TopicPublisher):
                 },
                 Destination={"ToAddresses": [endpoint]},
             )
-            store_delivery_log(context.message, subscriber, success=True)
 
 
 class EmailTopicPublisher(EmailJsonTopicPublisher):
@@ -515,7 +557,9 @@ class ApplicationTopicPublisher(TopicPublisher):
         # TODO: rewrite the platform application publishing logic
         #  will need to validate credentials when creating platform app earlier, need thorough testing
 
-        store_delivery_log(context.message, subscriber, success=True)
+        store_delivery_log(
+            context.message, subscriber, success=True, topic_attributes=context.topic_attributes
+        )
 
     def prepare_message(
         self, message_context: SnsMessage, subscriber: SnsSubscription
@@ -614,7 +658,12 @@ class FirehoseTopicPublisher(TopicPublisher):
                 firehose_client.put_record(
                     DeliveryStreamName=delivery_stream, Record={"Data": to_bytes(message_body)}
                 )
-                store_delivery_log(context.message, subscriber, success=True)
+                store_delivery_log(
+                    context.message,
+                    subscriber,
+                    success=True,
+                    topic_attributes=context.topic_attributes,
+                )
         except Exception as exc:
             LOG.info(
                 "Received error on sending SNS message, putting to DLQ (if configured): %s", exc
@@ -857,11 +906,51 @@ def is_fifo_topic(subscriber: SnsSubscription) -> bool:
 
 
 def store_delivery_log(
-    message_context: SnsMessage, subscriber: SnsSubscription, success: bool, delivery: dict = None
+    message_context: SnsMessage,
+    subscriber: SnsSubscription,
+    success: bool,
+    topic_attributes: dict[str, str] = None,
+    delivery: dict = None,
 ):
-    """Store the delivery logs in CloudWatch"""
-    # TODO: this is enabled by default in LocalStack, but not in AWS
+    """
+    Store the delivery logs in CloudWatch, configured as TopicAttributes
+    See: https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html#msg-status-sdk
+
+    TODO: for Application, you can also configure Platform attributes:
+    See:https://docs.aws.amazon.com/sns/latest/dg/sns-msg-status.html
+    """
+    # TODO: effectively use `<ENDPOINT>SuccessFeedbackSampleRate` to sample delivery logs
     # TODO: validate format of `delivery` for each Publisher
+
+    # map Protocol to TopicAttribute
+    available_delivery_logs_services = {
+        "http",
+        "https",
+        "firehose",
+        "lambda",
+        "application",
+        "sqs",
+    }
+    # SMS is a special case: https://docs.aws.amazon.com/sns/latest/dg/sms_stats_cloudwatch.html
+    # seems like you need to configure on the Console, leave it on by default now in LocalStack
+    protocol = subscriber.get("Protocol")
+
+    if protocol != "sms":
+        if protocol not in available_delivery_logs_services or not topic_attributes:
+            # this service does not have DeliveryLogs feature, return
+            return
+
+        # TODO: for now, those attributes are stored as attributes of the moto Topic model in snake case
+        # see to work this in our store instead
+        role_type = "success" if success else "failure"
+        topic_attribute = f"{protocol}_{role_type}_feedback_role_arn"
+
+        # check if topic has the right attribute and a role, otherwise return
+        # TODO: on purpose not using walrus operator to show that we get the RoleArn here for CloudWatch
+        role_arn = topic_attributes.get(topic_attribute)
+        if not role_arn:
+            return
+
     log_group_name = subscriber.get("TopicArn", "").replace("arn:aws:", "").replace(":", "/")
     log_stream_name = long_uid()
     invocation_time = int(time.time() * 1000)
@@ -890,6 +979,7 @@ def store_delivery_log(
 
     log_output = json.dumps(delivery_log)
 
+    # TODO: use the account/region from the role in the TopicAttribute instead, this is what AWS uses
     account_id = extract_account_id_from_arn(subscriber["TopicArn"])
     region_name = extract_region_from_arn(subscriber["TopicArn"])
     logs_client = connect_to(aws_access_key_id=account_id, region_name=region_name).logs

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -3999,7 +3999,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishDelivery::test_delivery_lambda": {
-    "recorded-date": "25-08-2023, 00:31:30",
+    "recorded-date": "07-11-2023, 11:11:37",
     "recorded-content": {
       "get-topic-attrs": {
         "Attributes": {
@@ -4021,7 +4021,74 @@
               }
             }
           },
-          "LambdaSuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish-no-logs": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-topic-attrs-with-success-feedback": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "LambdaSuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/<resource:2>",
           "LambdaSuccessFeedbackSampleRate": "100",
           "Owner": "111111111111",
           "Policy": {
@@ -4044,7 +4111,7 @@
                   "SNS:ListSubscriptionsByTopic",
                   "SNS:Publish"
                 ],
-                "Resource": "arn:aws:sns:<region>:111111111111:<resource:2>",
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:1>",
                 "Condition": {
                   "StringEquals": {
                     "AWS:SourceOwner": "111111111111"
@@ -4056,8 +4123,15 @@
           "SubscriptionsConfirmed": "0",
           "SubscriptionsDeleted": "0",
           "SubscriptionsPending": "0",
-          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
         },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish-logs": {
+        "MessageId": "<uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4069,19 +4143,19 @@
             "ingestionTime": "timestamp",
             "message": {
               "delivery": {
-                "deliveryId": "<uuid:1>",
+                "deliveryId": "<uuid:3>",
                 "destination": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
                 "dwellTimeMs": "<time-ms>",
                 "providerResponse": {
-                  "lambdaRequestId": "<uuid:2>"
+                  "lambdaRequestId": "<uuid:4>"
                 },
                 "statusCode": 202
               },
               "notification": {
-                "messageId": "<uuid:3>",
-                "messageMD5Sum": "764569e58f53ea8b6404f6fa7fc0247f",
+                "messageId": "<uuid:2>",
+                "messageMD5Sum": "c1c7ff780647014d463e6801bf83c59d",
                 "timestamp": "timestamp",
-                "topicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+                "topicArn": "arn:aws:sns:<region>:111111111111:<resource:1>"
               },
               "status": "SUCCESS"
             },

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4674,7 +4674,7 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_unsubscribe_wrong_arn_format": {
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_unsubscribe_wrong_arn_format": {
     "recorded-date": "20-10-2023, 12:52:36",
     "recorded-content": {
       "invalid-unsubscribe-arn-1": {
@@ -4708,6 +4708,23 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_unsubscribe_idempotency": {
+    "recorded-date": "07-11-2023, 00:36:06",
+    "recorded-content": {
+      "unsubscribe-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "unsubscribe-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had a TODO in the code because SNS Delivery logs were always-on for LocalStack when it's opt-in in AWS.
Also it has been shown they are making performance quite a bit worse.

Here are some numbers:

  | Base | Disable SQS metrics | Disable SNS Delivery logs | Both
-- | -- | -- | -- | --
Throughput for 1kb publish (req/s) | 20.17 | 28.72 | 31.87 | 68.78

- Base: `1000 requests took 49.5744 s = 49.5744 ms/op = 20.17 req/sec`
- Disable SQS metrics: `1000 requests took 34.8189 s = 34.8189 ms/op = 28.72 req/sec`
- Disable SNS Delivery logs: `1000 requests took 31.3768 s = 31.3768 ms/op = 31.87 req/sec`
- Both: `1000 requests took 14.5392 s = 14.5392 ms/op = 68.78 req/sec`

From a simple benchmark with one topic, one SQS queue subscribed to it, pushing 1000 messages/

I suspect the fact that the publisher is pushing a lot of SQS requests concurrently, plus the CloudWatch Events one, are making the gateway struggle to serve them concurrently and the latency grows quite significantly.

To push further, we will revisit the in-memory client dispatching which might provide a boost in performance, and we now have a good simple benchmark for it.

Here's all resources:
- https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html#msg-status-sdk
- https://docs.aws.amazon.com/sns/latest/dg/sns-msg-status.html
- https://docs.aws.amazon.com/sns/latest/dg/sms_stats_cloudwatch.html

<!-- What notable changes does this PR make? -->
## Changes
Make publishing the delivery logs opt-in like AWS, by setting a role as a Topic Attribute (`<ENDPOINT>SuccessFeedbackRoleArn` and `<ENDPOINT>FailureFeedbackRoleArn`).
We do not support yet `<ENDPOINT>SuccessFeedbackSampleRate` and will publish every message without sampling. 

For SMS messages, I left the behaviour as always-on, as the documentation only mention the console, and it's a niche use-case.

We have an AWS validated test `tests.aws.services.sns.test_sns.TestSNSPublishDelivery.test_delivery_lambda` testing this behaviour. We should add test to this class for SQS, HTTP and Firehose deliveries as well. 

Also sneaked a small change regarding unsubscribe + an AWS test for it.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

