### PR TITLE
update kms invalid key format and fix a broken multi account test for s3

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -261,7 +261,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
         # regular KeyId are UUID, and MultiRegion keys starts with 'mrk-' and 32 hex chars
         if not PATTERN_UUID.match(key_id) and not MULTI_REGION_PATTERN.match(key_id):
-            raise NotFoundException(f"Invalid keyId {key_id}")
+            raise NotFoundException(f"Invalid keyId '{key_id}'")
 
         if key_id not in store.keys:
             if not key_arn:

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -301,14 +301,14 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_invalid_uuid": {
-    "recorded-date": "13-04-2023, 11:29:34",
+    "recorded-date": "07-11-2023, 14:05:57",
     "recorded-content": {
       "describe-key-with-invalid-uuid": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId fake-key-id"
+          "Message": "Invalid keyId 'fake-key-id'"
         },
-        "message": "Invalid keyId fake-key-id",
+        "message": "Invalid keyId 'fake-key-id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -317,9 +317,9 @@
       "describe-key-with-invalid-uuid-2": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId 134f2428cec14b25a1ae9048164dba47"
+          "Message": "Invalid keyId '134f2428cec14b25a1ae9048164dba47'"
         },
-        "message": "Invalid keyId 134f2428cec14b25a1ae9048164dba47",
+        "message": "Invalid keyId '134f2428cec14b25a1ae9048164dba47'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -328,9 +328,9 @@
       "describe-key-with-invalid-uuid-mrk": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId mrk-fake-key-id"
+          "Message": "Invalid keyId 'mrk-fake-key-id'"
         },
-        "message": "Invalid keyId mrk-fake-key-id",
+        "message": "Invalid keyId 'mrk-fake-key-id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -924,7 +924,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_224-HMAC_SHA_224]": {
-    "recorded-date": "13-04-2023, 11:31:08",
+    "recorded-date": "07-11-2023, 14:06:46",
     "recorded-content": {
       "generate-mac": {
         "KeyId": "<key-id:1>",
@@ -947,9 +947,9 @@
       "generate-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -958,9 +958,9 @@
       "verify-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -969,7 +969,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_256-HMAC_SHA_256]": {
-    "recorded-date": "13-04-2023, 11:31:10",
+    "recorded-date": "07-11-2023, 14:06:48",
     "recorded-content": {
       "generate-mac": {
         "KeyId": "<key-id:1>",
@@ -992,9 +992,9 @@
       "generate-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1003,9 +1003,9 @@
       "verify-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1014,7 +1014,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_384-HMAC_SHA_384]": {
-    "recorded-date": "13-04-2023, 11:31:12",
+    "recorded-date": "07-11-2023, 14:06:51",
     "recorded-content": {
       "generate-mac": {
         "KeyId": "<key-id:1>",
@@ -1037,9 +1037,9 @@
       "generate-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1048,9 +1048,9 @@
       "verify-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1059,7 +1059,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_generate_and_verify_mac[HMAC_512-HMAC_SHA_512]": {
-    "recorded-date": "13-04-2023, 11:31:13",
+    "recorded-date": "07-11-2023, 14:06:52",
     "recorded-content": {
       "generate-mac": {
         "KeyId": "<key-id:1>",
@@ -1082,9 +1082,9 @@
       "generate-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -1093,9 +1093,9 @@
       "verify-mac-invalid-key-id": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid keyId key_id"
+          "Message": "Invalid keyId 'key_id'"
         },
-        "message": "Invalid keyId key_id",
+        "message": "Invalid keyId 'key_id'",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4793,23 +4793,32 @@ class TestS3:
         condition=LEGACY_S3_PROVIDER, reason="Validation not implemented in legacy provider"
     )
     def test_s3_sse_validate_kms_key(
-        self, s3_create_bucket, kms_create_key, monkeypatch, snapshot, aws_client
+        self,
+        aws_client_factory,
+        s3_create_bucket_with_client,
+        kms_create_key,
+        monkeypatch,
+        snapshot,
+        aws_client,
     ):
         snapshot.add_transformer(snapshot.transform.key_value("Description"))
         data = b"test-sse"
         bucket_name = f"bucket-test-kms-{short_uid()}"
-        s3_create_bucket(
-            Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+        region_1 = "us-east-2"
+        client = aws_client_factory(region_name=region_1).s3
+        s3_create_bucket_with_client(
+            client, Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region_1}
         )
         # create key in a different region than the bucket
-        kms_key = kms_create_key(region_name="us-east-1")
+        region_2 = "us-west-2"
+        kms_key = kms_create_key(region_name=region_2)
         # snapshot the KMS key to save the UUID for replacement in Error message.
         snapshot.match("create-kms-key", kms_key)
 
         # test whether the validation is skipped when not disabling the validation
         if not is_aws_cloud():
             key_name = "test-sse-validate-kms-key-no-check"
-            response = aws_client.s3.put_object(
+            response = client.put_object(
                 Bucket=bucket_name,
                 Key=key_name,
                 Body=data,
@@ -4818,7 +4827,7 @@ class TestS3:
             )
             assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-            response = aws_client.s3.create_multipart_upload(
+            response = client.create_multipart_upload(
                 Bucket=bucket_name,
                 Key="multipart-test-sse-validate-kms-key-no-check",
                 ServerSideEncryption="aws:kms",
@@ -4826,7 +4835,7 @@ class TestS3:
             )
             assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-            response = aws_client.s3.copy_object(
+            response = client.copy_object(
                 Bucket=bucket_name,
                 Key="copy-test-sse-validate-kms-key-no-check",
                 CopySource={"Bucket": bucket_name, "Key": key_name},
@@ -4841,7 +4850,7 @@ class TestS3:
         # activating the validation, for AWS parity
         monkeypatch.setattr(config, "S3_SKIP_KMS_KEY_VALIDATION", False)
         with pytest.raises(ClientError) as e:
-            aws_client.s3.put_object(
+            client.put_object(
                 Bucket=bucket_name,
                 Key=key_name,
                 Body=data,
@@ -4851,7 +4860,7 @@ class TestS3:
         snapshot.match("put-obj-wrong-kms-key", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.s3.put_object(
+            client.put_object(
                 Bucket=bucket_name,
                 Key=key_name,
                 Body=data,
@@ -4862,12 +4871,10 @@ class TestS3:
 
         # we create a wrong arn but with the right region to test error message
         wrong_id_arn = (
-            kms_key["Arn"]
-            .replace("us-east-1", "us-west-2")
-            .replace(kms_key["KeyId"], fake_key_uuid)
+            kms_key["Arn"].replace(region_2, region_1).replace(kms_key["KeyId"], fake_key_uuid)
         )
         with pytest.raises(ClientError) as e:
-            aws_client.s3.put_object(
+            client.put_object(
                 Bucket=bucket_name,
                 Key=key_name,
                 Body=data,
@@ -4877,7 +4884,7 @@ class TestS3:
         snapshot.match("put-obj-wrong-kms-key-real-uuid-arn", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.s3.put_object(
+            client.put_object(
                 Bucket=bucket_name,
                 Key="test-sse-validate-kms-key-no-check-region",
                 Body=data,
@@ -4887,7 +4894,7 @@ class TestS3:
         snapshot.match("put-obj-different-region-kms-key", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.s3.put_object(
+            client.put_object(
                 Bucket=bucket_name,
                 Key="test-sse-validate-kms-key-different-region-no-arn",
                 Body=data,
@@ -4897,7 +4904,7 @@ class TestS3:
         snapshot.match("put-obj-different-region-kms-key-no-arn", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.s3.create_multipart_upload(
+            client.create_multipart_upload(
                 Bucket=bucket_name,
                 Key="multipart-test-sse-validate-kms-key-no-check",
                 ServerSideEncryption="aws:kms",
@@ -4907,9 +4914,9 @@ class TestS3:
 
         # create a object to be copied
         src_key = "key-to-be-copied"
-        aws_client.s3.put_object(Bucket=bucket_name, Key=src_key, Body=b"test-data")
+        client.put_object(Bucket=bucket_name, Key=src_key, Body=b"test-data")
         with pytest.raises(ClientError) as e:
-            aws_client.s3.copy_object(
+            client.copy_object(
                 Bucket=bucket_name,
                 Key="copy-test-sse-validate-kms-key-no-check",
                 CopySource={"Bucket": bucket_name, "Key": src_key},

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -4267,11 +4267,11 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
-    "recorded-date": "03-08-2023, 04:23:56",
+    "recorded-date": "07-11-2023, 14:17:45",
     "recorded-content": {
       "create-kms-key": {
         "AWSAccountId": "111111111111",
-        "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "Arn": "arn:aws:kms:us-west-2:111111111111:key/<uuid:1>",
         "CreationDate": "datetime",
         "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
         "Description": "<description:1>",
@@ -4290,7 +4290,7 @@
       "put-obj-wrong-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Invalid keyId fake-key-id"
+          "Message": "Invalid keyId 'fake-key-id'"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4300,7 +4300,7 @@
       "put-obj-wrong-kms-key-real-uuid": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4310,7 +4310,7 @@
       "put-obj-wrong-kms-key-real-uuid-arn": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4320,7 +4320,7 @@
       "put-obj-different-region-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Invalid arn <region>"
+          "Message": "Invalid arn us-west-2"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4330,7 +4330,7 @@
       "put-obj-different-region-kms-key-no-arn": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/<uuid:1>' does not exist"
+          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/<uuid:1>' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4340,7 +4340,7 @@
       "create-multipart-wrong-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Invalid keyId fake-key-id"
+          "Message": "Invalid keyId 'fake-key-id'"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4350,7 +4350,7 @@
       "copy-obj-wrong-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Invalid keyId fake-key-id"
+          "Message": "Invalid keyId 'fake-key-id'"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on broken multi account and region `s3` tests in [#9560](https://github.com/localstack/localstack/pull/9560) , we figured out some outdated snapshot tests for invalid `kms` key id giving `NotFoundException` exception throwing incorrect error message. 

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- Updates the incorrect invalid key id error message. 
- Updates the corresponding snapshot tests for `tests/aws/services/kms/test_kms` and `tests/aws/services/s3/test_s3`. 
- Adds support for multi account to `tests/aws/services/s3/test_s3/test_s3_sse_validate_kms_key` when using when using values other than `000000000000` for account ID or `us-east-1` for region, tests should still create the consequent resources in required accounts and region. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

