### PR TITLE
remove old deprecations

### DIFF
--- a/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
+++ b/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - DATA_DIR=${DATA_DIR- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1017,11 +1017,6 @@ LAMBDA_RETRY_BASE_DELAY_SECONDS = int(os.getenv("LAMBDA_RETRY_BASE_DELAY") or 60
 # to match the behavior of the old lambda provider.
 LAMBDA_SYNCHRONOUS_CREATE = is_env_true("LAMBDA_SYNCHRONOUS_CREATE")
 
-# A comma-delimited string of stream names and its corresponding shard count to
-# initialize during startup (DEPRECATED).
-# For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
-KINESIS_INITIALIZE_STREAMS = os.environ.get("KINESIS_INITIALIZE_STREAMS", "").strip()
-
 # URL to a custom OpenSearch/Elasticsearch backend cluster. If this is set to a valid URL, then localstack will not
 # create OpenSearch/Elasticsearch cluster instances, but instead forward all domains to the given backend.
 OPENSEARCH_CUSTOM_BACKEND = os.environ.get("OPENSEARCH_CUSTOM_BACKEND", "").strip()
@@ -1151,7 +1146,7 @@ CONFIG_ENV_VARS = [
     "HOSTNAME_EXTERNAL",
     "HOSTNAME_FROM_LAMBDA",  # deprecated since 2.0.0 but added to new Lambda provider
     "KINESIS_ERROR_PROBABILITY",
-    "KINESIS_INITIALIZE_STREAMS",
+    "KINESIS_INITIALIZE_STREAMS",  # Not functional; Deprecated in 1.4.0, removed in 3.0.0
     "KINESIS_MOCK_PERSIST_INTERVAL",
     "KINESIS_MOCK_LOG_LEVEL",
     "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1247,6 +1247,9 @@ CONFIG_ENV_VARS = [
     "LAMBDA_STAY_OPEN_MODE",  # deprecated since 2.0.0
     "SYNCHRONOUS_KINESIS_EVENTS",  # deprecated since 1.3.0
     "SYNCHRONOUS_SNS_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_DYNAMODB_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_API_GATEWAY_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_SQS_EVENTS",  # deprecated since 1.3.0
 ]
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -423,9 +423,6 @@ WAIT_FOR_DEBUGGER = is_env_true("WAIT_FOR_DEBUGGER")
 # TODO: this is deprecated and should be removed (edge port supports HTTP/HTTPS multiplexing)
 USE_SSL = is_env_true("USE_SSL")
 
-# whether to use the legacy edge proxy or the newer Gateway/HandlerChain framework
-LEGACY_EDGE_PROXY = is_env_true("LEGACY_EDGE_PROXY")
-
 # whether the S3 legacy V2/ASF provider is enabled
 LEGACY_V2_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") in ("v2", "legacy_v2", "asf")
 
@@ -691,9 +688,6 @@ GATEWAY_LISTEN: List[HostAndPort]
     EDGE_PORT,
     EDGE_PORT_HTTP,
 ) = populate_legacy_edge_configuration(os.environ)
-
-# optional target URL to forward all edge requests to
-EDGE_FORWARD_URL = os.environ.get("EDGE_FORWARD_URL", "").strip()
 
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
@@ -1148,7 +1142,7 @@ CONFIG_ENV_VARS = [
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
     "EAGER_SERVICE_LOADING",
     "EDGE_BIND_HOST",
-    "EDGE_FORWARD_URL",
+    "EDGE_FORWARD_URL",  # Not functional; Deprecated in 1.4.0, removed in 3.0.0
     "EDGE_PORT",
     "EDGE_PORT_HTTP",
     "ENABLE_CONFIG_UPDATES",
@@ -1197,7 +1191,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_LIMITS_MAX_FUNCTION_ENVVAR_SIZE_BYTES",
     "LEGACY_DIRECTORIES",
     "LEGACY_DOCKER_CLIENT",
-    "LEGACY_EDGE_PROXY",
+    "LEGACY_EDGE_PROXY",  # Not functional; Deprecated in 1.0.0, removed in 3.0.0
     "LEGACY_SNS_GCM_PUBLISHING",
     "LOCALSTACK_API_KEY",
     "LOCALSTACK_AUTH_TOKEN",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1250,6 +1250,7 @@ CONFIG_ENV_VARS = [
     "SYNCHRONOUS_DYNAMODB_EVENTS",  # deprecated since 1.3.0
     "SYNCHRONOUS_API_GATEWAY_EVENTS",  # deprecated since 1.3.0
     "SYNCHRONOUS_SQS_EVENTS",  # deprecated since 1.3.0
+    "KINESIS_PROVIDER",  # deprecated since 1.3.0
 ]
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1237,6 +1237,7 @@ CONFIG_ENV_VARS = [
     "WAIT_FOR_DEBUGGER",
     "WINDOWS_DOCKER_MOUNT_PREFIX",
     # Removed in 3.0.0
+    "LAMBDA_XRAY_INIT",  # deprecated since 2.0.0
     "LAMBDA_CODE_EXTRACT_TIME",  # deprecated since 2.0.0
     "LAMBDA_CONTAINER_REGISTRY",  # deprecated since 2.0.0
     "LAMBDA_EXECUTOR",  # deprecated since 2.0.0

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -403,9 +403,6 @@ VOLUME_DIR = os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip() or TMP_FOLDER
 if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_FOLDER):
     TMP_FOLDER = "/private%s" % TMP_FOLDER
 
-# temporary folder of the host (required when running in Docker). Fall back to local tmp folder if not set. (DEPRECATED!)
-HOST_TMP_FOLDER = os.environ.get("HOST_TMP_FOLDER", TMP_FOLDER)
-
 # whether to enable verbose debug logging
 LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
@@ -762,9 +759,6 @@ ARN_PARTITION_FALLBACK = os.environ.get("ARN_PARTITION_FALLBACK", "") or "aws"
 
 # whether to skip waiting for the infrastructure to shut down, or exit immediately
 FORCE_SHUTDOWN = is_env_not_false("FORCE_SHUTDOWN")
-
-# whether to return mocked success responses for still unimplemented API methods
-MOCK_UNIMPLEMENTED = is_env_true("MOCK_UNIMPLEMENTED")
 
 # set variables no_proxy, i.e., run internal service calls directly
 no_proxy = ",".join([constants.LOCALHOST_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]"])
@@ -1245,6 +1239,7 @@ CONFIG_ENV_VARS = [
     "SYNCHRONOUS_API_GATEWAY_EVENTS",  # deprecated since 1.3.0
     "SYNCHRONOUS_SQS_EVENTS",  # deprecated since 1.3.0
     "KINESIS_PROVIDER",  # deprecated since 1.3.0
+    "MOCK_UNIMPLEMENTED",  # deprecated since 1.3.0
 ]
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1036,28 +1036,18 @@ KINESIS_INITIALIZE_STREAMS = os.environ.get("KINESIS_INITIALIZE_STREAMS", "").st
 
 # URL to a custom OpenSearch/Elasticsearch backend cluster. If this is set to a valid URL, then localstack will not
 # create OpenSearch/Elasticsearch cluster instances, but instead forward all domains to the given backend.
-# `ES_CUSTOM_BACKEND` is DEPRECATED!
-OPENSEARCH_CUSTOM_BACKEND = (
-    os.environ.get("OPENSEARCH_CUSTOM_BACKEND", "").strip()
-    or os.environ.get("ES_CUSTOM_BACKEND", "").strip()
-)
+OPENSEARCH_CUSTOM_BACKEND = os.environ.get("OPENSEARCH_CUSTOM_BACKEND", "").strip()
 
 # Strategy used when creating OpenSearch/Elasticsearch domain endpoints routed through the edge proxy
 # valid values: domain | path | port (off)
-# `ES_ENDPOINT_STRATEGY` is DEPRECATED!
 OPENSEARCH_ENDPOINT_STRATEGY = (
-    os.environ.get("OPENSEARCH_ENDPOINT_STRATEGY", "").strip()
-    or os.environ.get("ES_ENDPOINT_STRATEGY", "").strip()
-    or "domain"
+    os.environ.get("OPENSEARCH_ENDPOINT_STRATEGY", "").strip() or "domain"
 )
 if OPENSEARCH_ENDPOINT_STRATEGY == "off":
     OPENSEARCH_ENDPOINT_STRATEGY = "port"
 
 # Whether to start one cluster per domain (default), or multiplex opensearch domains to a single clusters
-# `ES_MULTI_CLUSTER` is DEPRECATED!
-OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER") or is_env_true(
-    "ES_MULTI_CLUSTER"
-)
+OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER")
 
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -65,11 +65,15 @@ DEPRECATIONS = [
         "1.0.0",
         "Please use PERSISTENCE instead. The state will be stored in your LocalStack volume in the state/ directory.",
     ),
-    EnvVarDeprecation("HOST_TMP_FOLDER", "1.0.0", "Please remove this environment variable."),
+    EnvVarDeprecation(
+        "HOST_TMP_FOLDER",
+        "1.0.0",
+        "This option has no effect anymore. Please remove this environment variable.",
+    ),
     EnvVarDeprecation(
         "LEGACY_DIRECTORIES",
         "1.0.0",
-        "Please migrate to the new filesystem layout (introduced with v1.0).",
+        "This option has no effect anymore. Please migrate to the new filesystem layout (introduced with v1.0).",
     ),
     EnvVarDeprecation(
         "TMPDIR", "1.0.0", "Please migrate to the new filesystem layout (introduced with v1.0)."
@@ -95,11 +99,13 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "LEGACY_INIT_DIR",
         "1.1.0",
+        "This option has no effect anymore. "
         "Please use the pluggable initialization hooks in /etc/localhost/init/<stage>.d instead.",
     ),
     EnvVarDeprecation(
         "INIT_SCRIPTS_PATH",
         "1.1.0",
+        "This option has no effect anymore. "
         "Please use the pluggable initialization hooks in /etc/localhost/init/<stage>.d instead.",
     ),
     # Since 1.3.0 - Synchronous events break AWS parity
@@ -138,7 +144,7 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "MOCK_UNIMPLEMENTED",
         "1.3.0",
-        "This feature will not be supported in the future. Please remove this environment variable.",
+        "This feature is not supported anymore. Please remove this environment variable.",
     ),
     # Since 1.4.0 - The Edge Forwarding is only used for legacy HTTPS proxying and will be removed
     EnvVarDeprecation(

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -246,7 +246,7 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "KINESIS_INITIALIZE_STREAMS",
         "1.4.0",
-        "This feature is marked for removal. Please use AWS client API to seed Kinesis streams.",
+        "This option has no effect anymore. Please use the AWS client and init hooks instead.",
     ),
     EnvVarDeprecation(
         "PROVIDER_OVERRIDE_LAMBDA",

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -106,27 +106,27 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "SYNCHRONOUS_SNS_EVENTS",
         "1.3.0",
-        "This configuration breaks parity with AWS. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     EnvVarDeprecation(
         "SYNCHRONOUS_SQS_EVENTS",
         "1.3.0",
-        "This configuration breaks parity with AWS. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     EnvVarDeprecation(
         "SYNCHRONOUS_API_GATEWAY_EVENTS",
         "1.3.0",
-        "This configuration breaks parity with AWS. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     EnvVarDeprecation(
         "SYNCHRONOUS_KINESIS_EVENTS",
         "1.3.0",
-        "This configuration breaks with parity AWS. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     EnvVarDeprecation(
         "SYNCHRONOUS_DYNAMODB_EVENTS",
         "1.3.0",
-        "This configuration breaks with parity AWS. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     # Since 1.3.0 - All non-pre-seeded infra is downloaded asynchronously
     EnvVarDeprecation(

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -252,17 +252,17 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "ES_CUSTOM_BACKEND",
         "0.14.0",
-        "This option is marked for removal. Please use OPENSEARCH_CUSTOM_BACKEND instead.",
+        "This option has no effect anymore. Please use OPENSEARCH_CUSTOM_BACKEND instead.",
     ),
     EnvVarDeprecation(
         "ES_MULTI_CLUSTER",
         "0.14.0",
-        "This option is marked for removal. Please use OPENSEARCH_MULTI_CLUSTER instead.",
+        "This option has no effect anymore. Please use OPENSEARCH_MULTI_CLUSTER instead.",
     ),
     EnvVarDeprecation(
         "ES_ENDPOINT_STRATEGY",
         "0.14.0",
-        "This option is marked for removal. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
+        "This option has no effect anymore. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
     ),
 ]
 

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -83,7 +83,7 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "LEGACY_EDGE_PROXY",
         "1.0.0",
-        "Please migrate to the new HTTP gateway by removing this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     # Since 1.1.0 - Kinesalite removed with 1.3, only kinesis-mock is used as kinesis provider / backend
     EnvVarDeprecation(
@@ -144,7 +144,7 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "EDGE_FORWARD_URL",
         "1.4.0",
-        "This feature will not be supported in the future. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     # Deprecated in 1.4.0, removed in 3.0.0
     EnvVarDeprecation(

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -89,7 +89,7 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "KINESIS_PROVIDER",
         "1.1.0",
-        "Only a single provider is supported for kinesis. Please remove this environment variable.",
+        "This option has no effect anymore. Please remove this environment variable.",
     ),
     # Since 1.1.0 - Init dir has been deprecated in favor of pluggable init hooks
     EnvVarDeprecation(

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -17,7 +17,7 @@ TRACKED_ENV_VAR = [
     "EDGE_PORT",
     "ENFORCE_IAM",
     "IAM_SOFT_MODE",
-    "KINESIS_PROVIDER",
+    "KINESIS_PROVIDER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "KMS_PROVIDER",
     "LAMBDA_DOWNLOAD_AWS_LAYERS",
     "LAMBDA_EXECUTOR",  # Not functional; deprecated in 2.0.0, removed in 3.0.0

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -78,6 +78,7 @@ def _publish_config_as_analytics_event():
         if key.startswith("PROVIDER_OVERRIDE_"):
             env_vars.append(key)
         elif key.startswith("SYNCHRONOUS_") and key.endswith("_EVENTS"):
+            # these config variables have been removed with 3.0.0
             env_vars.append(key)
 
     env_vars = {key: os.getenv(key) for key in env_vars}

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -43,6 +43,9 @@ TRACKED_ENV_VAR = [
     "SQS_ENDPOINT_STRATEGY",
     "USE_SINGLE_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "USE_SSL",
+    "ES_CUSTOM_BACKEND",  # deprecated in 0.14.0, removed in 3.0.0
+    "ES_MULTI_CLUSTER",  # deprecated in 0.14.0, removed in 3.0.0
+    "ES_ENDPOINT_STRATEGY",  # deprecated in 0.14.0, removed in 3.0.0
 ]
 
 PRESENCE_ENV_VAR = [

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -31,7 +31,7 @@ TRACKED_ENV_VAR = [
     "LAMBDA_PREBUILD_IMAGES",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LEGACY_DIRECTORIES",
-    "LEGACY_EDGE_PROXY",
+    "LEGACY_EDGE_PROXY",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
     "LS_LOG",
     "MOCK_UNIMPLEMENTED",
     "OPENSEARCH_ENDPOINT_STRATEGY",
@@ -54,7 +54,7 @@ TRACKED_ENV_VAR = [
 
 PRESENCE_ENV_VAR = [
     "DATA_DIR",
-    "EDGE_FORWARD_URL",
+    "EDGE_FORWARD_URL",  # Not functional; deprecated in 1.4.0, removed in 3.0.0
     "GATEWAY_LISTEN",
     "HOSTNAME",
     "HOSTNAME_EXTERNAL",

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -20,11 +20,15 @@ TRACKED_ENV_VAR = [
     "KINESIS_PROVIDER",
     "KMS_PROVIDER",
     "LAMBDA_DOWNLOAD_AWS_LAYERS",
-    # Irrelevant post v3 but intentionally tracked for some time
-    "LAMBDA_EXECUTOR",
+    "LAMBDA_EXECUTOR",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_STAY_OPEN_MODE",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_REMOTE_DOCKER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_CODE_EXTRACT_TIME",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_CONTAINER_REGISTRY",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_FALLBACK_URL",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_FORWARD_URL",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "LAMBDA_XRAY_INIT",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "LAMBDA_PREBUILD_IMAGES",
-    # Irrelevant post v3 but intentionally tracked for some time
-    "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LEGACY_DIRECTORIES",
     "LEGACY_EDGE_PROXY",

--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -30,10 +30,9 @@ TRACKED_ENV_VAR = [
     "LAMBDA_XRAY_INIT",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "LAMBDA_PREBUILD_IMAGES",
     "LAMBDA_RUNTIME_EXECUTOR",
-    "LEGACY_DIRECTORIES",
     "LEGACY_EDGE_PROXY",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
     "LS_LOG",
-    "MOCK_UNIMPLEMENTED",
+    "MOCK_UNIMPLEMENTED",  # Not functional; deprecated in 1.3.0, removed in 3.0.0
     "OPENSEARCH_ENDPOINT_STRATEGY",
     "PERSISTENCE",
     "PERSISTENCE_SINGLE_FILE",
@@ -59,10 +58,10 @@ PRESENCE_ENV_VAR = [
     "HOSTNAME",
     "HOSTNAME_EXTERNAL",
     "HOSTNAME_FROM_LAMBDA",
-    "HOST_TMP_FOLDER",
-    "INIT_SCRIPTS_PATH",
-    "LEGACY_DIRECTORIES",
-    "LEGACY_INIT_DIR",
+    "HOST_TMP_FOLDER",  # Not functional; deprecated in 1.0.0, removed in 2.0.0
+    "INIT_SCRIPTS_PATH",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
+    "LEGACY_DIRECTORIES",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
+    "LEGACY_INIT_DIR",  # Not functional; deprecated in 1.1.0, removed in 2.0.0
     "LOCALSTACK_HOST",
     "LOCALSTACK_HOSTNAME",
     "S3_DIR",

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -27,11 +27,9 @@ class KinesisMockServer(Server):
         host: str = "localhost",
         log_level: str = "INFO",
         data_dir: Optional[str] = None,
-        initialize_streams: Optional[str] = None,
     ) -> None:
         self._account_id = account_id
         self._latency = latency
-        self._initialize_streams = initialize_streams
         self._data_dir = data_dir
         self._data_filename = f"{self._account_id}.json"
         self._js_path = js_path
@@ -94,9 +92,6 @@ class KinesisMockServer(Server):
             env_vars["PERSIST_FILE_NAME"] = self._data_filename
             env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
 
-        if self._initialize_streams:
-            env_vars["INITIALIZE_STREAMS"] = self._initialize_streams
-
         env_vars["LOG_LEVEL"] = self._log_level
         cmd = ["node", self._js_path]
         return cmd, env_vars
@@ -141,7 +136,6 @@ class KinesisServerManager:
         config.dirs.data -> if set, the server runs with persistence using the path to store data
         config.LS_LOG -> configure kinesis mock log level (defaults to INFO)
         config.KINESIS_LATENCY -> configure stream latency (in milliseconds)
-        config.KINESIS_INITIALIZE_STREAMS -> Initialize the given streams on startup
         """
         port = get_free_tcp_port()
         kinesismock_package.install()
@@ -160,16 +154,12 @@ class KinesisServerManager:
         else:
             log_level = "INFO"
         latency = config.KINESIS_LATENCY + "ms"
-        initialize_streams = (
-            config.KINESIS_INITIALIZE_STREAMS if config.KINESIS_INITIALIZE_STREAMS else None
-        )
 
         server = KinesisMockServer(
             port=port,
             js_path=kinesis_mock_js_path,
             log_level=log_level,
             latency=latency,
-            initialize_streams=initialize_streams,
             data_dir=persist_path,
             account_id=account_id,
         )

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -8,19 +8,13 @@ from flask import request
 from requests.models import Request
 from requests.structures import CaseInsensitiveDict
 
-from localstack import config
 from localstack.constants import (
-    APPLICATION_JSON,
-    APPLICATION_XML,
     AWS_REGION_US_EAST_1,
     DEFAULT_AWS_ACCOUNT_ID,
-    HEADER_CONTENT_TYPE,
 )
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import (
-    is_json_request,
     requests_error_response,
-    requests_response,
     requests_to_flask_response,
 )
 from localstack.utils.coverage_docs import get_coverage_link_for_service
@@ -189,14 +183,7 @@ def patch_moto_request_handling():
             exception_message: str | None = e.args[0] if e.args else None
             msg = exception_message or get_coverage_link_for_service(service, action)
             response = requests_error_response(request.headers, msg, code=501)
-            if config.MOCK_UNIMPLEMENTED:
-                is_json = is_json_request(request.headers)
-                headers = {HEADER_CONTENT_TYPE: APPLICATION_JSON if is_json else APPLICATION_XML}
-                content = "{}" if is_json else "<Response />"  # TODO: return proper mocked response
-                response = requests_response(content, headers=headers)
-                LOG.info(f"{msg}. Returning mocked response due to MOCK_UNIMPLEMENTED=1")
-            else:
-                LOG.info(msg)
+            LOG.info(msg)
             # TODO: publish analytics event ...
             return requests_to_flask_response(response)
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -162,7 +162,6 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -5,7 +5,6 @@ import requests
 from pytest_httpserver.httpserver import HTTPServer
 from werkzeug.datastructures import Headers
 
-from localstack import config, constants
 from localstack.config import HostAndPort
 from localstack.services.edge import get_auth_string, start_proxy
 from localstack.utils.net import get_free_tcp_port
@@ -78,54 +77,6 @@ def test_edge_tcp_proxy(httpserver):
         response = requests.get(f"http://localhost:{port}")
         assert response.status_code == 200
         assert response.text == "Target Server Response"
-    finally:
-        proxy_server.stop()
-
-
-def test_edge_tcp_proxy_raises_exception_on_invalid_url(monkeypatch):
-    # Point the Edge TCP proxy towards the target server
-    monkeypatch.setattr(config, "EDGE_FORWARD_URL", "this-is-no-url")
-
-    # Start the TCP proxy
-    port = get_free_tcp_port()
-    with pytest.raises(ValueError):
-        start_proxy(
-            listen_str=f"127.0.0.1:{port}",
-            target_address=HostAndPort(host="127.0.0.1", port=constants.DEFAULT_PORT_EDGE),
-            asynchronous=True,
-        ).stop()
-
-
-def test_edge_tcp_proxy_raises_exception_on_url_without_port(monkeypatch):
-    # Point the Edge TCP proxy towards the target server
-    monkeypatch.setattr(config, "EDGE_FORWARD_URL", "http://url-without-port/")
-
-    # Start the TCP proxy
-    port = get_free_tcp_port()
-    with pytest.raises(ValueError):
-        start_proxy(
-            listen_str=f"127.0.0.1:{port}",
-            asynchronous=True,
-            target_address=HostAndPort(host="127.0.0.1", port=constants.DEFAULT_PORT_EDGE),
-        ).stop()
-
-
-def test_edge_tcp_proxy_raises_connection_refused_on_missing_target_server(monkeypatch):
-    # Point the Edge TCP proxy towards a port which is not bound to any server
-    dst_port = get_free_tcp_port()
-    monkeypatch.setattr(config, "EDGE_FORWARD_URL", f"http://unused-host-part:{dst_port}/")
-
-    # Start the TCP proxy
-    port = get_free_tcp_port()
-    proxy_server = start_proxy(
-        listen_str=f"127.0.0.1:{port}",
-        target_address=HostAndPort(host="127.0.0.1", port=dst_port),
-        asynchronous=True,
-    )
-    try:
-        # Start the proxy server and send a request (which is proxied towards a non-bound port)
-        with pytest.raises(requests.exceptions.ConnectionError):
-            requests.get(f"http://localhost:{port}")
     finally:
         proxy_server.stop()
 


### PR DESCRIPTION
## Motivation
This PR aims at collectively removing a lot of configuration variables which have been deprecated for a long time.

## Changes
- This PR removes or cleans up:
  - `KINESIS_INITIALIZE_STREAMS`
  - `MOCK_UNIMPLEMENTED`
  - `INIT_SCRIPTS_PATH`
  - `LEGACY_INIT_DIR`
  - `HOST_TMP_FOLDER`
  - `LEGACY_DIRECTORIES`
  - `LEGACY_EDGE_PROXY` (a proper cleanup of the legacy edge proxy code will follow in another PR)
  - `EDGE_FORWARD_URL`
  - `SYNCHRONOUS_*_EVENTS`
  - `KINESIS_PROVIDER`
  - `LAMBDA_EXECUTOR`
  - `LAMBDA_STAY_OPEN_MODE`
  - `LAMBDA_REMOTE_DOCKER`
  - `LAMBDA_CODE_EXTRACT_TIME`
  - `LAMBDA_CONTAINER_REGISTRY`
  - `LAMBDA_FALLBACK_URL`
  - `LAMBDA_FORWARD_URL`
  - `LAMBDA_XRAY_INIT`
  - `ES_CUSTOM_BACKEND`
  - `ES_MULTI_CLUSTER`
  - `ES_ENDPOINT_STRATEGY`
- Most of these environment variables were already non-functional and long deprecated, where I only ensured that their usage is logged properly.