### PR TITLE
Update remaining usages of LOCALHOST_HOSTNAME

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -603,16 +603,6 @@ def populate_edge_configuration(
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
     gateway_listen_raw = environment.get("GATEWAY_LISTEN")
 
-    # new for v2
-    # get the potentially set port from LOCALSTACK_HOST first to use for gateway listen
-    localstack_host_port = constants.DEFAULT_PORT_EDGE
-    if localstack_host_raw is not None:
-        localstack_host_port = HostAndPort.parse(
-            localstack_host_raw,
-            default_host=constants.LOCALHOST_HOSTNAME,
-            default_port=constants.DEFAULT_PORT_EDGE,
-        ).port
-
     # parse gateway listen from multiple components
     if gateway_listen_raw is not None:
         gateway_listen = []
@@ -621,16 +611,15 @@ def populate_edge_configuration(
                 HostAndPort.parse(
                     address.strip(),
                     default_host=default_ip,
-                    default_port=localstack_host_port,
+                    default_port=constants.DEFAULT_PORT_EDGE,
                 )
             )
     else:
         # use default if gateway listen is not defined
-        gateway_listen = [HostAndPort(host=default_ip, port=localstack_host_port)]
+        gateway_listen = [HostAndPort(host=default_ip, port=constants.DEFAULT_PORT_EDGE)]
 
     # the actual value of the LOCALSTACK_HOST port now depends on what gateway listen actually listens to.
     if localstack_host_raw is None:
-        # TODO use actual gateway port?
         localstack_host = HostAndPort(
             host=constants.LOCALHOST_HOSTNAME, port=gateway_listen[0].port
         )

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1047,6 +1047,10 @@ def use_custom_dns():
     return str(DNS_ADDRESS) not in FALSE_STRINGS
 
 
+# s3 virtual host name
+S3_VIRTUAL_HOSTNAME = "s3.%s" % LOCALSTACK_HOST.host
+S3_STATIC_WEBSITE_HOSTNAME = "s3-website.%s" % LOCALSTACK_HOST.host
+
 BOTO_WAITER_DELAY = int(os.environ.get("BOTO_WAITER_DELAY") or "1")
 BOTO_WAITER_MAX_ATTEMPTS = int(os.environ.get("BOTO_WAITER_MAX_ATTEMPTS") or "120")
 DISABLE_CUSTOM_BOTO_WAITER_CONFIG = is_env_true("DISABLE_CUSTOM_BOTO_WAITER_CONFIG")

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -181,10 +181,6 @@ OFFICIAL_IMAGES = [
     "localstack/localstack-pro",
 ]
 
-# s3 virtual host name
-S3_VIRTUAL_HOSTNAME = "s3.%s" % LOCALHOST_HOSTNAME
-S3_STATIC_WEBSITE_HOSTNAME = "s3-website.%s" % LOCALHOST_HOSTNAME
-
 # port for debug py
 DEFAULT_DEVELOP_PORT = 5678
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -617,9 +617,8 @@ def host_based_url(rest_api_id: str, path: str, stage_name: str = None):
 
 
 def get_execute_api_endpoint(api_id: str, protocol: str = "") -> str:
-    port = config.get_edge_port_http()
-    host = localstack_host().host
-    return f"{protocol}{api_id}.execute-api.{host}:{port}"
+    host = localstack_host()
+    return f"{protocol}{api_id}.execute-api.{host.host_and_port()}"
 
 
 def tokenize_path(path):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -33,7 +33,6 @@ from localstack.aws.connect import connect_to
 from localstack.constants import (
     APPLICATION_JSON,
     HEADER_LOCALSTACK_EDGE_URL,
-    LOCALHOST_HOSTNAME,
     PATH_USER_REQUEST,
 )
 from localstack.services.apigateway.context import ApiInvocationContext
@@ -619,7 +618,8 @@ def host_based_url(rest_api_id: str, path: str, stage_name: str = None):
 
 def get_execute_api_endpoint(api_id: str, protocol: str = "") -> str:
     port = config.get_edge_port_http()
-    return f"{protocol}{api_id}.execute-api.{LOCALHOST_HOSTNAME}:{port}"
+    host = localstack_host().host
+    return f"{protocol}{api_id}.execute-api.{host}:{port}"
 
 
 def tokenize_path(path):
@@ -1574,4 +1574,5 @@ def get_regional_domain_name(domain_name: str) -> str:
     In LocalStack, we're returning this format: "d-<domain_hash>.execute-api.localhost.localstack.cloud"
     """
     domain_name_hash = get_domain_name_hash(domain_name)
-    return f"d-{domain_name_hash}.execute-api.{LOCALHOST_HOSTNAME}"
+    host = localstack_host().host
+    return f"d-{domain_name_hash}.execute-api.{host}"

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -3,8 +3,7 @@ import re
 from botocore.exceptions import ClientError
 
 from localstack.aws.connect import connect_to
-from localstack.config import get_edge_port_http
-from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
+from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME, get_edge_port_http
 from localstack.services.cloudformation.cfn_utils import rename_params
 from localstack.services.cloudformation.deployment_utils import (
     dump_json_params,

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -19,7 +19,7 @@ from localstack.aws.chain import Handler, HandlerChain
 from localstack.aws.handlers.cors import CorsEnforcer, CorsResponseEnricher
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
 from localstack.aws.protocol.service_router import get_service_catalog
-from localstack.constants import S3_VIRTUAL_HOSTNAME
+from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.http import Request, Response
 from localstack.services.s3.utils import S3_VIRTUAL_HOSTNAME_REGEX
 

--- a/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -8,8 +8,7 @@ from typing import Optional, TypedDict
 from botocore.exceptions import ClientError
 
 import localstack.services.cloudformation.provider_utils as util
-from localstack.config import get_edge_port_http
-from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
+from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME, get_edge_port_http
 from localstack.services.cloudformation.resource_provider import (
     OperationStatus,
     ProgressEvent,

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
@@ -15,7 +15,6 @@ from localstack.aws.api.stepfunctions import HistoryEventType, TaskFailedEventDe
 from localstack.constants import (
     APPLICATION_JSON,
     HEADER_CONTENT_TYPE,
-    LOCALHOST_HOSTNAME,
     PATH_USER_REQUEST,
 )
 from localstack.services.stepfunctions.asl.component.common.error_name.custom_error_name import (
@@ -34,6 +33,7 @@ from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import long_uid
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -164,7 +164,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         #  there's an argument to be made that this may mast implementation mistakes: investigate further.
         url_spec = urlparse(api_endpoint)
         url_path = url_spec.path
-        if not url_path.endswith(LOCALHOST_HOSTNAME):
+        if not url_path.endswith(localstack_host().host):
             return api_endpoint
         path_parts = url_path.split(".")
         api_id = path_parts[0]

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -10,6 +10,7 @@ import boto3
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
+from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
@@ -20,7 +21,6 @@ from localstack.constants import (
     INTERNAL_AWS_ACCESS_KEY_ID,
     LOCALHOST,
     REGION_LOCAL,
-    S3_VIRTUAL_HOSTNAME,
 )
 from localstack.utils.strings import is_string, is_string_or_bytes, to_str
 

--- a/localstack/utils/urls.py
+++ b/localstack/utils/urls.py
@@ -18,10 +18,6 @@ def localstack_host(custom_port: Optional[int] = None) -> HostAndPort:
     - the user's configuration (e.g environment variable overrides)
     - the defaults of the system
     """
-    port = config.EDGE_PORT
-    if custom_port is not None:
-        port = custom_port
-
+    port = custom_port or config.LOCALSTACK_HOST.port
     host = config.LOCALSTACK_HOST.host
-
     return HostAndPort(host=host, port=port)

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -5,24 +5,6 @@ from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
 
 
-@pytest.fixture
-def hosted_zone(aws_client):
-    zone_ids = []
-
-    def factory(**kwargs):
-        if "CallerReference" not in kwargs:
-            kwargs["CallerReference"] = f"ref-{short_uid()}"
-        response = aws_client.route53.create_hosted_zone(**kwargs)
-        zone_id = response["HostedZone"]["Id"]
-        zone_ids.append(zone_id)
-        return response
-
-    yield factory
-
-    for zone_id in zone_ids:
-        aws_client.route53.delete_hosted_zone(Id=zone_id)
-
-
 @pytest.fixture(autouse=True)
 def route53_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.route53_api())

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -7,10 +7,10 @@ from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.aws.handlers.cors import ALLOWED_CORS_ORIGINS
+from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
     LOCALHOST_HOSTNAME,
-    S3_VIRTUAL_HOSTNAME,
     TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_REGION_NAME,
 )
@@ -227,11 +227,14 @@ class TestS3Cors:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
-            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Body.Error.HostId",
+            # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",
+            # it's because RequestId is supposed to match x-amz-request-id ^
             "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
             "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
-            "$..Headers.Transfer-Encoding",  # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
+            "$..Headers.Transfer-Encoding",
+            # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
         ]
     )
     @markers.snapshot.skip_snapshot_verify(
@@ -317,11 +320,14 @@ class TestS3Cors:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
-            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Body.Error.HostId",
+            # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",
+            # it's because RequestId is supposed to match x-amz-request-id ^
             "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
             "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
-            "$..Headers.Transfer-Encoding",  # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
+            "$..Headers.Transfer-Encoding",
+            # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
             "$.put-op.Body",  # TODO: We should not return a body for almost all PUT requests
             "$.put-op.Headers.Content-Type",  # issue with default Response values
         ]
@@ -382,8 +388,10 @@ class TestS3Cors:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
-            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Body.Error.HostId",
+            # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",
+            # it's because RequestId is supposed to match x-amz-request-id ^
             "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
             "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
             "$..Headers.Transfer-Encoding",
@@ -596,8 +604,10 @@ class TestS3Cors:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
-            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Body.Error.HostId",
+            # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",
+            # it's because RequestId is supposed to match x-amz-request-id ^
             "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
             "$..Headers.Transfer-Encoding",
         ]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,6 +59,13 @@ class TestProviderConfig:
         assert provider_config.get_provider("kinesis") == default_value
 
 
+def ip() -> str:
+    if config.is_in_docker:
+        return "0.0.0.0"
+    else:
+        return "127.0.0.1"
+
+
 class TestEdgeVariablesDerivedCorrectly:
     """
     Post-v2 we are deriving
@@ -75,114 +82,68 @@ class TestEdgeVariablesDerivedCorrectly:
     function that populates the configuration variables.
     """
 
-    @pytest.fixture
-    def default_ip(self):
-        if config.is_in_docker:
-            return "0.0.0.0"
-        else:
-            return "127.0.0.1"
-
-    def test_defaults(self, default_ip):
+    # This parameterised test forms a table of scenarios we need to cover. Each
+    # input variable (gateway_listen, localstack_host) has four unique
+    # combinations of inputs:
+    # * default
+    # * host only
+    # * ip only
+    # * host and ip
+    # and there are two variables so 16 total tests
+    @pytest.mark.parametrize(
+        [
+            "gateway_listen",
+            "localstack_host",
+            "expected_gateway_listen",
+            "expected_localstack_host",
+            "expected_edge_port",
+        ],
+        [
+            ###
+            (None, None, [f"{ip()}:4566"], "localhost.localstack.cloud:4566", 4566),
+            ("1.1.1.1", None, ["1.1.1.1:4566"], "localhost.localstack.cloud:4566", 4566),
+            (":5555", None, [f"{ip()}:5555"], "localhost.localstack.cloud:5555", 5555),
+            ("1.1.1.1:5555", None, ["1.1.1.1:5555"], "localhost.localstack.cloud:5555", 5555),
+            ###
+            (None, "foo.bar", [f"{ip()}:4566"], "foo.bar:4566", 4566),
+            ("1.1.1.1", "foo.bar", ["1.1.1.1:4566"], "foo.bar:4566", 4566),
+            (":5555", "foo.bar", [f"{ip()}:5555"], "foo.bar:5555", 5555),
+            ("1.1.1.1:5555", "foo.bar", ["1.1.1.1:5555"], "foo.bar:5555", 5555),
+            ###
+            (None, ":7777", [f"{ip()}:4566"], "localhost.localstack.cloud:7777", 4566),
+            ("1.1.1.1", ":7777", ["1.1.1.1:4566"], "localhost.localstack.cloud:7777", 4566),
+            (":5555", ":7777", [f"{ip()}:5555"], "localhost.localstack.cloud:7777", 5555),
+            ("1.1.1.1:5555", ":7777", ["1.1.1.1:5555"], "localhost.localstack.cloud:7777", 5555),
+            ###
+            (None, "foo.bar:7777", [f"{ip()}:4566"], "foo.bar:7777", 4566),
+            ("1.1.1.1", "foo.bar:7777", ["1.1.1.1:4566"], "foo.bar:7777", 4566),
+            (":5555", "foo.bar:7777", [f"{ip()}:5555"], "foo.bar:7777", 5555),
+            ("1.1.1.1:5555", "foo.bar:7777", ["1.1.1.1:5555"], "foo.bar:7777", 5555),
+        ],
+    )
+    def test_edge_configuration(
+        self,
+        gateway_listen: str | None,
+        localstack_host: str | None,
+        expected_gateway_listen: list[str],
+        expected_localstack_host: str,
+        expected_edge_port: int,
+    ):
         environment = {}
+        if gateway_listen is not None:
+            environment["GATEWAY_LISTEN"] = gateway_listen
+        if localstack_host is not None:
+            environment["LOCALSTACK_HOST"] = localstack_host
+
         (
-            ls_host,
-            gateway_listen,
-            edge_port,
+            actual_ls_host,
+            actual_gateway_listen,
+            actual_edge_port,
         ) = config.populate_edge_configuration(environment)
 
-        assert ls_host == "localhost.localstack.cloud:4566"
-        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
-        assert edge_port == 4566
-
-    def test_custom_hostname(self):
-        environment = {"GATEWAY_LISTEN": "192.168.0.1"}
-        (
-            _,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert gateway_listen == [HostAndPort(host="192.168.0.1", port=4566)]
-        assert edge_port == 4566
-
-    def test_custom_port(self, default_ip):
-        environment = {"GATEWAY_LISTEN": ":9999"}
-        (
-            _,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
-        assert edge_port == 9999
-
-    def test_custom_host_and_port(self):
-        environment = {"GATEWAY_LISTEN": "192.168.0.1:9999"}
-        (
-            _,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert gateway_listen == [HostAndPort(host="192.168.0.1", port=9999)]
-        assert edge_port == 9999
-
-    def test_localstack_host_overrides_edge_variables(self, default_ip):
-        environment = {"LOCALSTACK_HOST": "hostname:9999"}
-        (
-            ls_host,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert ls_host == HostAndPort(host="hostname", port=9999)
-        assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
-        assert edge_port == 9999
-
-    def test_localstack_host_no_port(self, default_ip):
-        environment = {"LOCALSTACK_HOST": "foobar"}
-        (
-            ls_host,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert ls_host == HostAndPort(host="foobar", port=4566)
-        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
-        assert edge_port == 4566
-
-    def test_localstack_host_no_port_gateway_listen_set(self, default_ip):
-        environment = {"LOCALSTACK_HOST": "foobar", "GATEWAY_LISTEN": ":1234"}
-        (
-            ls_host,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert ls_host == HostAndPort(host="foobar", port=1234)
-        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
-
-    def test_localstack_host_not_set_gateway_listen_set(self, default_ip):
-        environment = {"GATEWAY_LISTEN": ":1234"}
-        (
-            ls_host,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert ls_host == HostAndPort(host="localhost.localstack.cloud", port=1234)
-        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
-
-    def test_localstack_host_port_set_gateway_listen_set(self, default_ip):
-        environment = {"LOCALSTACK_HOST": "foobar:5555", "GATEWAY_LISTEN": ":1234"}
-        (
-            ls_host,
-            gateway_listen,
-            edge_port,
-        ) = config.populate_edge_configuration(environment)
-
-        assert ls_host == HostAndPort(host="foobar", port=5555)
-        assert gateway_listen == [HostAndPort(host=default_ip, port=1234)]
+        assert actual_ls_host == expected_localstack_host
+        assert actual_gateway_listen == expected_gateway_listen
+        assert actual_edge_port == expected_edge_port
 
     def test_gateway_listen_multiple_addresses(self):
         environment = {"GATEWAY_LISTEN": "0.0.0.0:9999,0.0.0.0:443"}
@@ -199,7 +160,7 @@ class TestEdgeVariablesDerivedCorrectly:
         # take the first value
         assert edge_port == 9999
 
-    def test_legacy_variables_ignored_if_given(self, default_ip):
+    def test_legacy_variables_ignored_if_given(self):
         """Providing legacy variables removed in 3.0 should not affect the default configuration"""
         environment = {
             "EDGE_BIND_HOST": "192.168.0.1",
@@ -214,7 +175,7 @@ class TestEdgeVariablesDerivedCorrectly:
 
         assert localstack_host == "localhost.localstack.cloud:4566"
         assert gateway_listen == [
-            HostAndPort(host=default_ip, port=4566),
+            HostAndPort(host=ip(), port=4566),
         ]
         assert edge_port == 4566
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -9,7 +9,8 @@ import zoneinfo
 
 from localstack.aws.api import RequestContext
 from localstack.aws.api.s3 import InvalidArgument
-from localstack.constants import LOCALHOST, S3_VIRTUAL_HOSTNAME
+from localstack.config import S3_VIRTUAL_HOSTNAME
+from localstack.constants import LOCALHOST
 from localstack.http import Request
 from localstack.services.s3 import presigned_url
 from localstack.services.s3 import utils as s3_utils


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Some usages of `LOCALHOST_HOSTNAME` were missed during the migration to `LOCALSTACK_HOST`. This PR addresses that.

Note: usages of _returning_ `LOCALHOST_HOSTNAME` are changed, not internal usages of `LOCALHOST_HOSTNAME` to return to `localhost`. This is important, because `LOCALSTACK_HOST` is a "cosmetic" variable, and as such should not be used as a value to reach `localhost`.


<!-- What notable changes does this PR make? -->
## Changes

* Update external usages of `LOCALHOST_HOSTNAME` to use `LOCALSTACK_HOST`.
* Move Route53 hosted zone fixture to a common location for use in the network configuration tests in LocalStack Pro
* `LOCALSTACK_HOST` no longer configures the edge port if `GATEWAY_LISTEN` is _not_ specified
    * this was weird behaviour, and a confusing mix of cosmetic and functional variables

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

