### PR TITLE
s3: add regex transformer for different regions

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -48,6 +48,7 @@ from localstack.services.s3.utils import (
 )
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
+from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -4814,12 +4815,14 @@ class TestS3:
         data = b"test-sse"
         bucket_name = f"bucket-test-kms-{short_uid()}"
         region_1 = "us-east-2"
+        snapshot.add_transformer(RegexTransformer(region_1, "<region_1>"))
         client = aws_client_factory(region_name=region_1).s3
         s3_create_bucket_with_client(
             client, Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region_1}
         )
         # create key in a different region than the bucket
         region_2 = "us-west-2"
+        snapshot.add_transformer(RegexTransformer(region_2, "<region_2>"))
         kms_key = kms_create_key(region_name=region_2)
         # snapshot the KMS key to save the UUID for replacement in Error message.
         snapshot.match("create-kms-key", kms_key)

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -4267,11 +4267,11 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
-    "recorded-date": "07-11-2023, 14:17:45",
+    "recorded-date": "08-11-2023, 14:59:10",
     "recorded-content": {
       "create-kms-key": {
         "AWSAccountId": "111111111111",
-        "Arn": "arn:aws:kms:us-west-2:111111111111:key/<uuid:1>",
+        "Arn": "arn:aws:kms:<region_2>:111111111111:key/<uuid:1>",
         "CreationDate": "datetime",
         "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
         "Description": "<description:1>",
@@ -4300,7 +4300,7 @@
       "put-obj-wrong-kms-key-real-uuid": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+          "Message": "Key 'arn:aws:kms:<region_1>:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4310,7 +4310,7 @@
       "put-obj-wrong-kms-key-real-uuid-arn": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+          "Message": "Key 'arn:aws:kms:<region_1>:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4320,7 +4320,7 @@
       "put-obj-different-region-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Invalid arn us-west-2"
+          "Message": "Invalid arn <region_2>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4330,7 +4330,7 @@
       "put-obj-different-region-kms-key-no-arn": {
         "Error": {
           "Code": "KMS.NotFoundException",
-          "Message": "Key 'arn:aws:kms:us-east-2:111111111111:key/<uuid:1>' does not exist"
+          "Message": "Key 'arn:aws:kms:<region_1>:111111111111:key/<uuid:1>' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using non-default values for account and region, S3 tests should still create the consequent resources in this accounts and region. If the region is set as `us-west-2` in `TEST_AWS_REGION_NAME` and we create a `KMS` client for the same region I get kms key ARN as `arn:aws:kms:<region>:111111111111:key/<uuid:1>` i.e. the value for `us-west-2` is replaced by the default region regex transformer `<region>`. But now if we create a KMS client say for some other region other than the `TEST_AWS_REGION_NAME`  assume `us-west-1` the value of the ARN is `arn:aws:kms:us-west-1:111111111111:key/<uuid:1>`. 

<!-- What notable changes does this PR make? -->
## Changes
This PR adds a `RegexTransformer` to both the hardcoded regions and updates the corresponding snapshot for `tests.aws.services.s3.test_s3.TestS3.test_s3_sse_validate_kms_key`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

