### PR TITLE
Remove SQS_PORT_EXTERNAL and unify networking helpers

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1321,7 +1321,7 @@ def get_edge_url(localstack_hostname=None, protocol=None):
     return internal_service_url(host=localstack_hostname, protocol=protocol)
 
 
-def gateway_listen_port_info():
+def gateway_listen_ports_info():
     """Example: http port [4566,443]"""
     gateway_listen_ports = [gw_listen.port for gw_listen in GATEWAY_LISTEN]
     return f"{get_protocol()} port {gateway_listen_ports}"

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -249,6 +249,11 @@ DEPRECATIONS = [
         "This option has no effect anymore. Please use the AWS client and init hooks instead.",
     ),
     EnvVarDeprecation(
+        "SQS_PORT_EXTERNAL",
+        "1.0.0",
+        "This option has no effect anymore. Please use LOCALSTACK_HOST instead.",
+    ),
+    EnvVarDeprecation(
         "PROVIDER_OVERRIDE_LAMBDA",
         "3.0.0",
         "This option is ignored because the legacy Lambda provider (v1) has been removed since 3.0.0. "

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -40,6 +40,7 @@ from localstack.utils.strings import to_bytes, to_str
 from localstack.utils.threads import start_worker_thread
 
 from localstack.services.cloudformation.models import *  # noqa: F401, isort:skip
+from localstack.utils.urls import localstack_host
 
 ACTION_CREATE = "create"
 ACTION_DELETE = "delete"
@@ -199,7 +200,7 @@ def resolve_refs_recursively(
             prefix = api_match[1]
             host = api_match[2]
             path = api_match[3]
-            port = config.service_port("apigateway")
+            port = localstack_host().port
             return f"{prefix}{host}:{port}/{path}"
 
         # basic dynamic reference support

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -3,7 +3,7 @@ import re
 from botocore.exceptions import ClientError
 
 from localstack.aws.connect import connect_to
-from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME, get_edge_port_http
+from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.cfn_utils import rename_params
 from localstack.services.cloudformation.deployment_utils import (
     dump_json_params,
@@ -14,6 +14,7 @@ from localstack.services.s3.utils import normalize_bucket_name
 from localstack.utils.aws import arns
 from localstack.utils.common import canonical_json, md5
 from localstack.utils.testutil import delete_all_s3_objects
+from localstack.utils.urls import localstack_host
 
 
 class S3BucketPolicy(GenericBaseModel):
@@ -200,7 +201,7 @@ class S3Bucket(GenericBaseModel):
             #   you can use Amazon CloudFront [...]"
             resource["Properties"][
                 "WebsiteURL"
-            ] = f"http://{bucket_name}.{S3_STATIC_WEBSITE_HOSTNAME}:{get_edge_port_http()}"
+            ] = f"http://{bucket_name}.{S3_STATIC_WEBSITE_HOSTNAME}:{localstack_host().port}"
             # resource["Properties"]["DualStackDomainName"] = ?
 
         def _pre_delete(

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -328,7 +328,7 @@ def cleanup_resources():
 
 
 def log_startup_message(service):
-    LOG.info("Starting mock %s service on %s ...", service, config.edge_ports_info())
+    LOG.info("Starting mock %s service on %s ...", service, config.gateway_listen_port_info())
 
 
 def check_aws_credentials():
@@ -484,13 +484,13 @@ def do_start_infra(asynchronous, apis, is_in_docker):
 
         # TODO: properly encapsulate starting/stopping of edge server in a class
         if not poll_condition(
-            lambda: is_port_open(config.get_edge_port_http()), timeout=15, interval=0.3
+            lambda: is_port_open(config.GATEWAY_LISTEN[0].port), timeout=15, interval=0.3
         ):
             if LOG.isEnabledFor(logging.DEBUG):
                 # make another call with quiet=False to print detailed error logs
-                is_port_open(config.get_edge_port_http(), quiet=False)
+                is_port_open(config.GATEWAY_LISTEN[0].port, quiet=False)
             raise TimeoutError(
-                f"gave up waiting for edge server on {config.GATEWAY_LISTEN[0].host}:{config.GATEWAY_LISTEN[0].port}"
+                f"gave up waiting for edge server on {config.GATEWAY_LISTEN[0].host_and_port()}"
             )
 
         return t

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -328,7 +328,7 @@ def cleanup_resources():
 
 
 def log_startup_message(service):
-    LOG.info("Starting mock %s service on %s ...", service, config.gateway_listen_port_info())
+    LOG.info("Starting mock %s service on %s ...", service, config.gateway_listen_ports_info())
 
 
 def check_aws_credentials():

--- a/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -8,7 +8,7 @@ from typing import Optional, TypedDict
 from botocore.exceptions import ClientError
 
 import localstack.services.cloudformation.provider_utils as util
-from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME, get_edge_port_http
+from localstack.config import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.resource_provider import (
     OperationStatus,
     ProgressEvent,
@@ -18,6 +18,7 @@ from localstack.services.cloudformation.resource_provider import (
 from localstack.services.s3.utils import normalize_bucket_name
 from localstack.utils.aws import arns
 from localstack.utils.testutil import delete_all_s3_objects
+from localstack.utils.urls import localstack_host
 
 
 class S3BucketProperties(TypedDict):
@@ -589,7 +590,7 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
         #   you can use Amazon CloudFront [...]"
         model[
             "WebsiteURL"
-        ] = f"http://{model['BucketName']}.{S3_STATIC_WEBSITE_HOSTNAME}:{get_edge_port_http()}"
+        ] = f"http://{model['BucketName']}.{S3_STATIC_WEBSITE_HOSTNAME}:{localstack_host().port}"
         # resource["Properties"]["DualStackDomainName"] = ?
 
     def _create_bucket_if_does_not_exist(self, model, region_name, s3_client):

--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -59,7 +59,7 @@ class S3VirtualHostProxyHandler:
         """
         return Proxy(
             # Just use localhost for proxying, do not rely on external - potentially dangerous - configuration
-            forward_base_url=config.get_edge_url(localstack_hostname="localhost"),
+            forward_base_url=config.internal_service_url(),
             # do not preserve the Host when forwarding (to avoid an endless loop)
             preserve_host=False,
         )
@@ -96,7 +96,7 @@ class S3VirtualHostProxyHandler:
         # the user can specify whatever domain & port he wants in the Host header
         # we need to make sure we're redirecting the request to our edge URL, possibly s3.localhost.localstack.cloud
         host = domain
-        edge_host = f"{LOCALHOST_HOSTNAME}:{config.get_edge_port_http()}"
+        edge_host = f"{LOCALHOST_HOSTNAME}:{config.GATEWAY_LISTEN[0].port}"
         if host != edge_host:
             netloc = netloc.replace(host, edge_host)
 

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -218,7 +218,7 @@ class LambdaTopicPublisher(TopicPublisher):
         :param subscriber: the SNS subscription
         :return: an SNS message body formatted as a lambda Event in a JSON string
         """
-        external_url = external_service_url("sns")
+        external_url = external_service_url()
         unsubscribe_url = create_unsubscribe_url(external_url, subscriber["SubscriptionArn"])
         message_attributes = prepare_message_attributes(message_context.message_attributes)
         region_name = extract_region_from_arn(subscriber["SubscriptionArn"])
@@ -829,7 +829,7 @@ def create_sns_message_body(message_context: SnsMessage, subscriber: SnsSubscrip
     if message_type == "Notification" and is_raw_message_delivery(subscriber):
         return message_content
 
-    external_url = external_service_url("sns")
+    external_url = external_service_url()
 
     data = {
         "Type": message_type,

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -20,7 +20,6 @@ from localstack.aws.api.sqs import (
     ReceiptHandleIsInvalid,
     TagMap,
 )
-from localstack.config import get_protocol
 from localstack.services.sqs import constants as sqs_constants
 from localstack.services.sqs.exceptions import (
     InvalidAttributeValue,
@@ -287,9 +286,6 @@ class SqsQueue:
             host_url = f"{scheme}://{host_definition.host_and_port()}/queue/{self.region}"
         else:
             host_url = f"{scheme}://{host_definition.host_and_port()}"
-            if config.SQS_PORT_EXTERNAL:
-                host_definition = localstack_host(custom_port=config.SQS_PORT_EXTERNAL)
-                host_url = f"{get_protocol()}://{host_definition.host_and_port()}"
 
         return "{host}/{account_id}/{name}".format(
             host=host_url.rstrip("/"),

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -586,7 +586,7 @@ def test_create_execute_api_vpc_endpoint(
     # create Lambda function that invokes the API GW (private VPC endpoint not accessible from outside of AWS)
     if not is_aws_cloud():
         api_host = get_main_endpoint_from_container()
-        endpoint = endpoint.replace(host_header, f"{api_host}:{config.get_edge_port_http()}")
+        endpoint = endpoint.replace(host_header, f"{api_host}:{config.GATEWAY_LISTEN[0].port}")
     lambda_code = textwrap.dedent(
         f"""
     def handler(event, context):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10166,8 +10166,8 @@ def _endpoint_url(region: str = "", localstack_host: str = None) -> str:
         else:
             return f"http://s3.{region}.amazonaws.com"
     if region == "us-east-1":
-        return f"{config.get_edge_url(localstack_hostname=localstack_host or S3_VIRTUAL_HOSTNAME)}"
-    return config.get_edge_url(f"s3.{region}.{LOCALHOST_HOSTNAME}")
+        return f"{config.internal_service_url(host=localstack_host or S3_VIRTUAL_HOSTNAME)}"
+    return config.internal_service_url(host=f"s3.{region}.{LOCALHOST_HOSTNAME}")
 
 
 def _bucket_url(bucket_name: str, region: str = "", localstack_host: str = None) -> str:
@@ -10195,7 +10195,7 @@ def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str =
 
     host_definition = get_localstack_host()
     if localstack_host:
-        host_and_port = f"{localstack_host}:{config.get_edge_port_http()}"
+        host_and_port = f"{localstack_host}:{config.GATEWAY_LISTEN[0].port}"
     else:
         host_and_port = (
             f"s3.{region}.{host_definition.host_and_port()}"

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -30,7 +30,7 @@ def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str =
     host = localstack_host or (
         f"s3.{region}.{LOCALHOST_HOSTNAME}" if region != "us-east-1" else S3_VIRTUAL_HOSTNAME
     )
-    s3_edge_url = config.get_edge_url(localstack_hostname=host)
+    s3_edge_url = config.internal_service_url(host=host)
     # TODO might add the region here
     return s3_edge_url.replace(f"://{host}", f"://{bucket_name}.{host}")
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1059,12 +1059,11 @@ class TestSqsProvider:
     @markers.aws.only_localstack
     def test_external_endpoint(self, monkeypatch, sqs_create_queue, aws_client):
         external_host = "external-host"
-        external_port = "12345"
+        external_port = 12345
 
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
-        monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
         monkeypatch.setattr(
-            config, "LOCALSTACK_HOST", config.HostAndPort(host=external_host, port=config.EDGE_PORT)
+            config, "LOCALSTACK_HOST", config.HostAndPort(host=external_host, port=external_port)
         )
 
         queue_url = sqs_create_queue()

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1084,19 +1084,18 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
         sqs_create_queue(QueueName=queue_name)
 
-        edge_url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         payload = f"Action=GetQueueUrl&QueueName={queue_name}"
 
         # assert regular/default queue URL is returned
-        url = f"{edge_url}"
+        url = config.external_service_url()
         result = requests.post(url, data=payload, headers=headers)
         assert result
         content = to_str(result.content)
         kwargs = {"flags": re.MULTILINE | re.DOTALL}
-        assert re.match(rf".*<QueueUrl>\s*{edge_url}/[^<]+</QueueUrl>.*", content, **kwargs)
+        assert re.match(rf".*<QueueUrl>\s*{url}/[^<]+</QueueUrl>.*", content, **kwargs)
 
     @markers.aws.only_localstack
     def test_external_host_via_header_complete_message_lifecycle(self, monkeypatch):

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -1,4 +1,5 @@
 from localstack.testing.pytest import markers
+from localstack.utils.urls import localstack_host
 
 """
 This test file captures the _current_ state of returning URLs before making
@@ -143,9 +144,8 @@ class TestSQS:
     """
     Test all combinations of:
 
-    * endpoint_strategy
-    * sqs_port_external
-    * hostname_external
+    * SQS_ENDPOINT_STRATEGY
+    * LOCALSTACK_HOST
     """
 
     @markers.aws.only_localstack
@@ -166,7 +166,11 @@ class TestSQS:
     ):
         external_port = 12345
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
-        monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
+        monkeypatch.setattr(
+            config,
+            "LOCALSTACK_HOST",
+            config.HostAndPort(host=localstack_host().host, port=external_port),
+        )
 
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -220,7 +224,7 @@ class TestLambda:
 
         assert_host_customisation(function_url)
 
-    @pytest.mark.skipif(reason="Not implemented for new provider (was tested for old provider)")
+    @pytest.mark.skip(reason="Not implemented for new provider (was tested for old provider)")
     @markers.aws.only_localstack
     def test_http_api_for_function_url(
         self, assert_host_customisation, create_lambda_function, aws_http_client_factory

--- a/tests/unit/services/s3/test_virtual_host.py
+++ b/tests/unit/services/s3/test_virtual_host.py
@@ -27,7 +27,7 @@ class _RequestCollectingClient(HttpClient):
         :return: a proxy using this client
         """
         return Proxy(
-            config.get_edge_url(localstack_hostname="localhost"), preserve_host=False, client=self
+            config.internal_service_url(host="localhost"), preserve_host=False, client=self
         )
 
 


### PR DESCRIPTION
## Motivation

* `<SERVICE>_PORT_EXTERNAL` has been deprecated since 2022-07-13 in [this docs PR](https://github.com/localstack/docs/pull/201/files#diff-0502d352f33bf9d3db34ba16e95a02f45a111e7f9029f0577c2f37749c148d9fR328). However, it has never made it into `deprecations.py`. The migrations of `LOCALSTACK_HOST` offers a consistent way throughout LocalStack to achieve the same goal and should be preferred over service-specific solutions such as `SQS_PORT_EXTERNAL`.
* The migrations of `LOCALSTACK_HOST` (https://github.com/localstack/localstack/pull/9390) and removal of the legacy edge variables (https://github.com/localstack/localstack/pull/9405) has left some networking helpers in `config.py` in an inconsistent state.
  * Some combine elements of internal and external usage (e.g., `get_edge_url()`). This breaks the proper `LOCALSTACK_HOST` configuration.
  * Internal and external usage was previously not separated. Therefore, `LOCALSTACK_HOST` is not yet fully supported and we need to inspect all usages of these deprecated helpers to fix this.
* `SQS_PORT_EXTERNAL` is used in one of these helpers `service_port()` and therefore these changes are related (at least partially).

## Changes

* Remove `SQS_PORT_EXTERNAL`
* Unify the networking helpers in `config.py` by adding a deprecation path and attempting to fix inconsistencies following the migrations of `LOCALSTACK_HOST` and edge variables.

## Testing

* Adjusted tests for `SQS_PORT_EXTERNAL` to use `LOCALSTACK_HOST` instead for achieving the same behavior.
* Our tests have insufficient coverage of configuration scenarios for `LOCALSTACK_HOST` usage: internal vs. external ⚠️ 

## Follow up

We need to go over all usages of these deprecated helpers and migrate them to either `external_service_url` or `internal_service_url`.