### PR TITLE
[minor] skip mounting binary pip dependencies in dev container

### DIFF
--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -274,6 +274,9 @@ class DependencyMountConfigurator:
 
     dependency_glob = "/opt/code/localstack/.venv/lib/python3.*/site-packages/*"
 
+    # skip mounting dependencies with incompatible binaries (e.g., on MacOS)
+    skipped_dependencies = ["cryptography", "psutil", "rpds"]
+
     def __init__(
         self,
         *,
@@ -303,6 +306,9 @@ class DependencyMountConfigurator:
             if dep_path.name.endswith(".dist-info"):
                 continue
             if dep_path.name == "__pycache__":
+                continue
+
+            if dep_path.name in self.skipped_dependencies:
                 continue
 
             if dep_path.name in container_path_index:


### PR DESCRIPTION
## Motivation

This PR skips mounting a few pip dependencies into the dev container, to improve compatibility for non-Linux environments (running on Macbook Pro M1 here).

Discovered this recently when running some integration tests that are spawning external dev containers, e.g.,  `tests/pod_remotes/test_remotes_save_load.py::TestSmokePodPlatform`

```
...
ls-dev-29ad46fe:   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/cryptography/hazmat/primitives/ciphers/base.py", line 10, in <module>
ls-dev-29ad46fe:     from cryptography.exceptions import (
ls-dev-29ad46fe:   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/cryptography/exceptions.py", line 9, in <module>
ls-dev-29ad46fe:     from cryptography.hazmat.bindings._rust import exceptions as rust_exceptions
ls-dev-29ad46fe: ImportError: /opt/code/localstack/.venv/lib/python3.11/site-packages/cryptography/hazmat/bindings/_rust.abi3.so: invalid ELF header
```

## Changes

Add list of `skipped_dependencies` and skip mounting those into the dev container for testing.