### PR TITLE
remove mount for persistence plugin

### DIFF
--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -143,14 +143,6 @@ class SourceVolumeMountConfigurator:
         # postgresql-proxy code if available
         self.try_mount_to_site_packages(cfg, self.host_paths.postgresql_proxy / "postgresql_proxy")
 
-        # persistence plugin
-        self.try_mount_to_site_packages(
-            cfg,
-            self.host_paths.workspace_dir
-            / "localstack-plugin-persistence"
-            / "localstack_persistence",
-        )
-
         # plux
         self.try_mount_to_site_packages(cfg, self.host_paths.workspace_dir / "plux" / "plugin")
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are internalizing the persistence plugin (see [2298](https://github.com/localstack/localstack-ext/pull/2298)). 
This step is not needed anymore.

<!-- What notable changes does this PR make? -->
## Changes
- removed the mount of the persistence code.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

