### PR TITLE
remove duplicate on_extension_load call

### DIFF
--- a/localstack/extensions/api/extension.py
+++ b/localstack/extensions/api/extension.py
@@ -17,7 +17,6 @@ class BaseExtension(Plugin):
         :param kwargs: load keyword arguments
         :return: this extension object
         """
-        self.on_extension_load(*args, **kwargs)
         return self
 
     def on_extension_load(self, *args, **kwargs):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I noticed that extensions' `on_extension_load` methods are called twice. This is because the extension manager in localstack_ext.extension.manager already calls `on_extension_load` via the `ExtensionLifecycleListener` (see ext code [here](https://github.com/localstack/localstack-ext/blob/master/localstack_ext/extensions/manager.py#L24-L28)).

<!-- What notable changes does this PR make? -->
## Changes

* Remove the call to `self.on_extension_load()` in the `load` method of the extension.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

