### PR TITLE
Add internal endpoint to return config

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -354,6 +354,10 @@ class LocalstackResources(Router):
         self.add(Resource("/_localstack/cloudformation/deploy", CloudFormationUi()))
 
         if config.ENABLE_CONFIG_UPDATES:
+            LOG.warning(
+                "Enabling config endpoint, "
+                "please be aware that this can expose sensitive information via your network."
+            )
             self.add(Resource("/_localstack/config", ConfigResource()))
 
         if config.DEBUG:

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -298,6 +298,10 @@ class InitScriptsStageResource:
 
 
 class ConfigResource:
+    def on_get(self, request):
+        from localstack.utils import diagnose
+        return call_safe(diagnose.get_localstack_config)
+
     def on_post(self, request: Request):
         data = request.get_json(force=True)
         variable = data.get("variable", "")

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -300,6 +300,7 @@ class InitScriptsStageResource:
 class ConfigResource:
     def on_get(self, request):
         from localstack.utils import diagnose
+
         return call_safe(diagnose.get_localstack_config)
 
     def on_post(self, request: Request):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We needed config values in our web app and currently there's no endpoint which returns the config values so I added one.

<!-- What notable changes does this PR make? -->
## Changes
Added an endpoint in  `localstack/services/internal.py` file

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

