### PR TITLE
Remove deprecated networking config helpers

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -101,7 +101,7 @@ class ArnPartitionRewriteHandler(Handler):
         # forward to the handler chain again
         result_response = forward(
             request=request,
-            forward_base_url=config.get_edge_url(),
+            forward_base_url=config.internal_service_url(),
             forward_path=get_raw_path(request),
             headers=request.headers,
         )

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -376,7 +376,7 @@ def cmd_status_services(format_: str) -> None:
     """
     import requests
 
-    url = config.get_edge_url()
+    url = config.external_service_url()
 
     try:
         health = requests.get(f"{url}/_localstack/health", timeout=2)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1271,7 +1271,6 @@ def get_protocol():
     return "https" if USE_SSL else "http"
 
 
-# TODO: refactor internal codebase to use external_service_url and internal_service_url
 def external_service_url(host=None, port=None, protocol=None) -> str:
     """Returns a service URL to an external client used outside where LocalStack runs.
     The configurations LOCALSTACK_HOST and USE_SSL can customize these returned URLs.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1276,7 +1276,9 @@ def get_protocol():
     return "https" if USE_SSL else "http"
 
 
-def external_service_url(host=None, port=None, protocol=None) -> str:
+def external_service_url(
+    host: Optional[str] = None, port: Optional[int] = None, protocol: Optional[str] = None
+) -> str:
     """Returns a service URL to an external client used outside where LocalStack runs.
     The configurations LOCALSTACK_HOST and USE_SSL can customize these returned URLs.
     `host` can be used to overwrite the default for subdomains.
@@ -1287,7 +1289,9 @@ def external_service_url(host=None, port=None, protocol=None) -> str:
     return f"{protocol}://{host}:{port}"
 
 
-def internal_service_url(host=None, port=None, protocol=None) -> str:
+def internal_service_url(
+    host: Optional[str] = None, port: Optional[int] = None, protocol: Optional[str] = None
+) -> str:
     """Returns a service URL for internal use within where LocalStack runs.
     Cannot be customized through LOCALSTACK_HOST because we assume LocalStack runs on the same host (i.e., localhost).
     """
@@ -1339,7 +1343,7 @@ def get_edge_url(localstack_hostname=None, protocol=None):
     return internal_service_url(host=localstack_hostname, protocol=protocol)
 
 
-def gateway_listen_ports_info():
+def gateway_listen_ports_info() -> str:
     """Example: http port [4566,443]"""
     gateway_listen_ports = [gw_listen.port for gw_listen in GATEWAY_LISTEN]
     return f"{get_protocol()} port {gateway_listen_ports}"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import tempfile
 import time
+import warnings
 from typing import Any, Dict, List, Mapping, Optional, Tuple, TypeVar, Union
 
 from localstack import constants
@@ -1262,6 +1263,10 @@ populate_config_env_var_names()
 
 def service_port(service_key: str, external: bool = False) -> int:
     """@deprecated: Use `localstack_host().port` for external and `GATEWAY_LISTEN[0].port` for internal use."""
+    warnings.warn(
+        "Deprecated: use `localstack_host().port` for external and `GATEWAY_LISTEN[0].port` for internal use.",
+        DeprecationWarning,
+    )
     if external:
         return LOCALSTACK_HOST.port
     return GATEWAY_LISTEN[0].port
@@ -1297,6 +1302,12 @@ def service_url(service_key, host=None, port=None):
     """@deprecated: Use `internal_service_url()` instead.
     We assume that most usages are internal but really need to check and update each usage accordingly.
     """
+    warnings.warn(
+        """@deprecated: Use `internal_service_url()` instead.
+        We assume that most usages are internal but really need to check and update each usage accordingly.
+        """,
+        DeprecationWarning,
+    )
     return internal_service_url(host=host, port=port)
 
 
@@ -1305,6 +1316,12 @@ def get_edge_port_http():
     """@deprecated: Use `localstack_host().port` for external and `GATEWAY_LISTEN[0].port` for internal use.
     This function is also not needed anymore because we don't separate between HTTP and HTTP ports anymore since
     LocalStack listens to both."""
+    warnings.warn(
+        """@deprecated: Use `localstack_host().port` for external and `GATEWAY_LISTEN[0].port` for internal use.
+        This function is also not needed anymore because we don't separate between HTTP and HTTP ports anymore since
+        LocalStack listens to both.""",
+        DeprecationWarning,
+    )
     return GATEWAY_LISTEN[0].port
 
 
@@ -1313,6 +1330,12 @@ def get_edge_url(localstack_hostname=None, protocol=None):
     """@deprecated: Use `internal_service_url()` instead.
     We assume that most usages are internal but really need to check and update each usage accordingly.
     """
+    warnings.warn(
+        """@deprecated: Use `internal_service_url()` instead.
+    We assume that most usages are internal but really need to check and update each usage accordingly.
+    """,
+        DeprecationWarning,
+    )
     return internal_service_url(host=localstack_hostname, protocol=protocol)
 
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -602,7 +602,7 @@ def get_stage_variables(context: ApiInvocationContext) -> Optional[Dict[str, str
 def path_based_url(api_id: str, stage_name: str, path: str) -> str:
     """Return URL for inbound API gateway for given API ID, stage name, and path"""
     pattern = "%s/restapis/{api_id}/{stage_name}/%s{path}" % (
-        config.service_url("apigateway"),
+        config.external_service_url(),
         PATH_USER_REQUEST,
     )
     return pattern.format(api_id=api_id, stage_name=stage_name, path=path)
@@ -611,14 +611,15 @@ def path_based_url(api_id: str, stage_name: str, path: str) -> str:
 def host_based_url(rest_api_id: str, path: str, stage_name: str = None):
     """Return URL for inbound API gateway for given API ID, stage name, and path with custom dns
     format"""
-    pattern = "http://{endpoint}{stage}{path}"
+    pattern = "{endpoint}{stage}{path}"
     stage = stage_name and f"/{stage_name}" or ""
     return pattern.format(endpoint=get_execute_api_endpoint(rest_api_id), stage=stage, path=path)
 
 
-def get_execute_api_endpoint(api_id: str, protocol: str = "") -> str:
+def get_execute_api_endpoint(api_id: str, protocol: str | None = None) -> str:
     host = localstack_host()
-    return f"{protocol}{api_id}.execute-api.{host.host_and_port()}"
+    protocol = protocol or config.get_protocol()
+    return f"{protocol}://{api_id}.execute-api.{host.host_and_port()}"
 
 
 def tokenize_path(path):

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -487,7 +487,7 @@ class KinesisIntegration(BackendIntegration):
         headers["X-Amz-Target"] = target
 
         result = common.make_http_request(
-            url=config.service_url("kinesis"), data=payload, headers=headers, method="POST"
+            url=config.internal_service_url(), data=payload, headers=headers, method="POST"
         )
 
         # apply response template
@@ -689,7 +689,7 @@ class SQSIntegration(BackendIntegration):
             queue_url = f"{config.get_edge_url()}/{account_id}/{queue}"
             new_request = f"{payload}&QueueUrl={queue_url}"
 
-        url = urljoin(config.service_url("sqs"), f"{get_aws_account_id()}/{queue}")
+        url = urljoin(config.internal_service_url(), f"{get_aws_account_id()}/{queue}")
         response = common.make_http_request(url, method="POST", headers=headers, data=new_request)
 
         # apply response template
@@ -716,7 +716,7 @@ class SNSIntegration(BackendIntegration):
             service="sns", aws_access_key_id=invocation_context.account_id, region_name=region_name
         )
         result = make_http_request(
-            config.service_url("sns"), method="POST", headers=headers, data=payload
+            config.internal_service_url(), method="POST", headers=headers, data=payload
         )
         return self.apply_response_parameters(invocation_context, result)
 
@@ -926,7 +926,7 @@ class EventBridgeIntegration(BackendIntegration):
         )
         headers.update({"X-Amz-Target": invocation_context.headers.get("X-Amz-Target")})
         response = make_http_request(
-            config.service_url("events"), method="POST", headers=headers, data=payload
+            config.internal_service_url(), method="POST", headers=headers, data=payload
         )
 
         invocation_context.response = response

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -686,7 +686,7 @@ class SQSIntegration(BackendIntegration):
             new_request = f"{payload}&QueueName={queue}"
         else:
             payload = self.request_templates.render(invocation_context)
-            queue_url = f"{config.get_edge_url()}/{account_id}/{queue}"
+            queue_url = f"{config.internal_service_url()}/{account_id}/{queue}"
             new_request = f"{payload}&QueueUrl={queue_url}"
 
         url = urljoin(config.internal_service_url(), f"{get_aws_account_id()}/{queue}")

--- a/localstack/services/cloudformation/api_utils.py
+++ b/localstack/services/cloudformation/api_utils.py
@@ -97,7 +97,7 @@ def convert_s3_to_local_url(url: str) -> str:
 
     # note: make sure to normalize the bucket name here!
     bucket_name = normalize_bucket_name(bucket_name)
-    local_url = f"{config.service_url('s3')}/{bucket_name}/{key_name}"
+    local_url = f"{config.internal_service_url()}/{bucket_name}/{key_name}"
     return local_url
 
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -44,7 +44,7 @@ from localstack.utils.urls import localstack_host
 
 ACTION_CREATE = "create"
 ACTION_DELETE = "delete"
-AWS_URL_SUFFIX = "localhost.localstack.cloud"  # value is "amazonaws.com" in real AWS
+AWS_URL_SUFFIX = localstack_host().host  # value is "amazonaws.com" in real AWS
 
 REGEX_OUTPUT_APIGATEWAY = re.compile(
     rf"^(https?://.+\.execute-api\.)(?:[^-]+-){{2,3}}\d\.(amazonaws\.com|{AWS_URL_SUFFIX})/?(.*)$"

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -446,7 +446,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         return self.server.url
 
     def handle_shell_ui_redirect(self, request: werkzeug.Request) -> Response:
-        headers = {"Refresh": f"0; url={config.service_url('dynamodb')}/shell/index.html"}
+        headers = {"Refresh": f"0; url={config.external_service_url()}/shell/index.html"}
         return Response("", headers=headers)
 
     def handle_shell_ui_request(self, request: werkzeug.Request, req_path: str) -> Response:

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -174,8 +174,14 @@ def cleanup_resources():
             )
 
 
+def gateway_listen_ports_info() -> str:
+    """Example: http port [4566,443]"""
+    gateway_listen_ports = [gw_listen.port for gw_listen in config.GATEWAY_LISTEN]
+    return f"{config.get_protocol()} port {gateway_listen_ports}"
+
+
 def log_startup_message(service):
-    LOG.info("Starting mock %s service on %s ...", service, config.gateway_listen_ports_info())
+    LOG.info("Starting mock %s service on %s ...", service, gateway_listen_ports_info())
 
 
 def check_aws_credentials():

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -262,24 +262,20 @@ def register_cluster(
             )
         )
     elif strategy == "domain":
-        host_pattern = (
-            "<regex('.*'):domain-name>.<regex('.*'):region>.opensearch.<regex('.*'):host>"
-        )
-
         LOG.debug(f"Registering route from {host} to {endpoint.proxy.forward_base_url}")
+        assert not host == localstack_host().host, "trying to register an illegal catch all route"
         rules.append(
             ROUTER.add(
                 "/",
                 endpoint=endpoint,
-                host=host_pattern,
-                defaults={"path": "/"},
+                host=f"{host}<port:port>",
             )
         )
         rules.append(
             ROUTER.add(
                 "/<path:path>",
                 endpoint=endpoint,
-                host=host_pattern,
+                host=f"{host}<port:port>",
             )
         )
     elif strategy == "path":

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -262,20 +262,24 @@ def register_cluster(
             )
         )
     elif strategy == "domain":
+        host_pattern = (
+            "<regex('.*'):domain-name>.<regex('.*'):region>.opensearch.<regex('.*'):host>"
+        )
+
         LOG.debug(f"Registering route from {host} to {endpoint.proxy.forward_base_url}")
-        assert not host == localstack_host().host, "trying to register an illegal catch all route"
         rules.append(
             ROUTER.add(
                 "/",
                 endpoint=endpoint,
-                host=f"{host}<port:port>",
+                host=host_pattern,
+                defaults={"path": "/"},
             )
         )
         rules.append(
             ROUTER.add(
                 "/<path:path>",
                 endpoint=endpoint,
-                host=f"{host}<port:port>",
+                host=host_pattern,
             )
         )
     elif strategy == "path":

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -267,10 +267,14 @@ class SqsQueue:
         return f"arn:aws:sqs:{self.region}:{self.account_id}:{self.name}"
 
     def url(self, context: RequestContext) -> str:
-        """Return queue URL using either SQS_PORT_EXTERNAL (if configured), the SQS_ENDPOINT_STRATEGY (if configured)
-        or based on the 'Host' request header"""
+        """Return queue URL which depending on the endpoint strategy returns e.g.:
+        * (standard) http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/myqueue
+        * (domain) http://eu-west-1.queue.localhost.localstack.cloud:4566/000000000000/myqueue
+        * (path) http://localhost.localstack.cloud:4566/queue/eu-central-1/000000000000/myqueue
+        * otherwise: http://localhost.localstack.cloud:4566/000000000000/myqueue
+        """
 
-        scheme = context.request.scheme
+        scheme = config.get_protocol()
         host_definition = localstack_host()
 
         if config.SQS_ENDPOINT_STRATEGY == "standard":

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
@@ -168,7 +168,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
             return api_endpoint
         path_parts = url_path.split(".")
         api_id = path_parts[0]
-        path_based_api_endpoint = f"{config.service_url('apigateway')}/restapis/{api_id}"
+        path_based_api_endpoint = f"{config.internal_service_url()}/restapis/{api_id}"
         return path_based_api_endpoint
 
     @staticmethod

--- a/localstack/testing/aws/eventbus_utils.py
+++ b/localstack/testing/aws/eventbus_utils.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from localstack.config import get_edge_url
+from localstack import config
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws.client_types import TypedServiceClientFactory
 
@@ -18,7 +18,7 @@ def trigger_scheduled_rule(rule_arn: str):
     if is_aws_cloud():
         return
 
-    url = get_edge_url() + f"/_aws/events/rules/{rule_arn}/trigger"
+    url = config.internal_service_url() + f"/_aws/events/rules/{rule_arn}/trigger"
     response = requests.get(url)
     if not response.ok:
         raise ValueError(

--- a/localstack/testing/aws/util.py
+++ b/localstack/testing/aws/util.py
@@ -93,7 +93,7 @@ def create_client_with_keys(
         aws_secret_access_key=keys["SecretAccessKey"],
         aws_session_token=keys.get("SessionToken"),
         config=client_config,
-        endpoint_url=config.get_edge_url()
+        endpoint_url=config.internal_service_url()
         if os.environ.get("TEST_TARGET") != "AWS_CLOUD"
         else None,
     )

--- a/localstack/testing/pytest/container.py
+++ b/localstack/testing/pytest/container.py
@@ -165,7 +165,7 @@ def container_factory() -> Generator[ContainerFactory, None, None]:
     factory.remove_all_containers()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def wait_for_localstack_ready():
     def _wait_for(container: RunningContainer, timeout: Optional[float] = None):
         container.wait_until_ready(timeout)

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1900,7 +1900,7 @@ def appsync_create_api(aws_client):
 def assert_host_customisation(monkeypatch):
     localstack_host = "foo.bar"
     monkeypatch.setattr(
-        config, "LOCALSTACK_HOST", config.HostAndPort(host=localstack_host, port=config.EDGE_PORT)
+        config, "LOCALSTACK_HOST", config.HostAndPort(host=localstack_host, port=8888)
     )
 
     def asserter(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -98,7 +98,7 @@ def aws_http_client_factory(aws_session):
                 resolver: EndpointResolver = aws_session._session.get_component("endpoint_resolver")
                 endpoint_url = "https://" + resolver.construct_endpoint(service, region)["hostname"]
             else:
-                endpoint_url = config.get_edge_url()
+                endpoint_url = config.internal_service_url()
 
         return SigningHttpClient(signer_factory(creds, service, region), endpoint_url=endpoint_url)
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -164,14 +164,10 @@ def get_boto3_region() -> str:
 
 def get_local_service_url(service_name_or_port: Union[str, int]) -> str:
     """Return the local service URL for the given service name or port."""
+    # TODO(srw): we don't need to differentiate on service name any more, so remove the argument
     if isinstance(service_name_or_port, int):
         return f"{config.get_protocol()}://{LOCALHOST}:{service_name_or_port}"
-    service_name = service_name_or_port
-    if service_name == "s3api":
-        service_name = "s3"
-    elif service_name == "runtime.sagemaker":
-        service_name = "sagemaker-runtime"
-    return config.service_url(service_name)
+    return config.internal_service_url()
 
 
 def get_s3_hostname():

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -376,8 +376,8 @@ def start_kcl_client_process(
     kwargs = {"metricsLevel": "NONE", "initialPositionInStream": "LATEST"}
     # set parameters for local connection
     if aws_stack.is_local_env(env):
-        kwargs["kinesisEndpoint"] = config.get_edge_url(protocol="http")
-        kwargs["dynamoDBEndpoint"] = config.get_edge_url(protocol="http")
+        kwargs["kinesisEndpoint"] = config.internal_service_url(protocol="http")
+        kwargs["dynamoDBEndpoint"] = config.internal_service_url(protocol="http")
         kwargs["disableCertChecking"] = "true"
     kwargs.update(configs)
     # create config file

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -23,6 +23,7 @@ from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
 from localstack.utils.threads import TMP_THREADS
 from localstack.utils.time import now
+from localstack.utils.urls import localstack_host
 
 EVENTS_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.fifo")
 LOG_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.log")
@@ -305,7 +306,7 @@ def get_stream_info(
     if aws_stack.is_local_env(env):
         stream_info["conn_kwargs"] = {
             "host": LOCALHOST,
-            "port": config.service_port("kinesis"),
+            "port": localstack_host().port,
             "is_secure": bool(config.USE_SSL),
         }
     if endpoint_url:

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -23,7 +23,6 @@ from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
 from localstack.utils.threads import TMP_THREADS
 from localstack.utils.time import now
-from localstack.utils.urls import localstack_host
 
 EVENTS_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.fifo")
 LOG_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.log")
@@ -306,7 +305,7 @@ def get_stream_info(
     if aws_stack.is_local_env(env):
         stream_info["conn_kwargs"] = {
             "host": LOCALHOST,
-            "port": localstack_host().port,
+            "port": config.GATEWAY_LISTEN[0].port,
             "is_secure": bool(config.USE_SSL),
         }
     if endpoint_url:

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -500,7 +500,7 @@ def send_dynamodb_request(path, action, request_body):
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"],
     }
-    url = f"{config.service_url('dynamodb')}/{path}"
+    url = f"{config.internal_service_url()}/{path}"
     return requests.put(url, data=request_body, headers=headers, verify=False)
 
 

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -15,7 +15,6 @@ from requests.structures import CaseInsensitiveDict
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
 from localstack.aws.handlers import cors
-from localstack.config import get_edge_url
 from localstack.constants import (
     APPLICATION_JSON,
     LOCALHOST_HOSTNAME,
@@ -1668,7 +1667,7 @@ def test_apigw_call_api_with_aws_endpoint_url(aws_client):
         "apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
     )
     headers["Host"] = "apigateway.us-east-2.amazonaws.com:4566"
-    url = f"{get_edge_url()}/apikeys?includeValues=true&name=test%40example.org"
+    url = f"{config.internal_service_url()}/apikeys?includeValues=true&name=test%40example.org"
     response = requests.get(url, headers=headers)
     assert response.ok
     content = json.loads(to_str(response.content))

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -53,7 +53,7 @@ class TestCdkInit:
             headers = aws_stack.mock_aws_request_headers(
                 "cloudformation", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
             )
-            base_url = config.get_edge_url()
+            base_url = config.internal_service_url()
             for op in operations:
                 url = f"{base_url}{op['path']}"
                 data = op["data"]

--- a/tests/aws/services/cloudformation/resources/test_kinesis.py
+++ b/tests/aws/services/cloudformation/resources/test_kinesis.py
@@ -120,7 +120,7 @@ def test_describe_template(s3_create_bucket, aws_client, cleanups, snapshot):
             f"https://{bucket_name}.s3.{aws_client.s3.meta.region_name}.amazonaws.com/template.yml"
         )
     else:
-        template_url = f"{config.get_edge_url()}/{bucket_name}/template.yml"
+        template_url = f"{config.internal_service_url()}/{bucket_name}/template.yml"
 
     # get summary by template URL
     get_template_summary_by_url = aws_client.cloudformation.get_template_summary(

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.py
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.py
@@ -149,7 +149,7 @@ def test_apigateway_invoke_localhost(deploy_cfn_template, aws_client):
     stage = state["States"]["LsCallApi"]["Parameters"]["Stage"]
     state["States"]["LsCallApi"]["Parameters"][
         "ApiEndpoint"
-    ] = f"{config.service_url('apigateway')}/restapis/{api_id}"
+    ] = f"{config.internal_service_url()}/restapis/{api_id}"
     state["States"]["LsCallApi"]["Parameters"]["Stage"] = stage
 
     aws_client.stepfunctions.update_state_machine(
@@ -194,7 +194,7 @@ def test_apigateway_invoke_localhost_with_path(deploy_cfn_template, aws_client):
     stage = state["States"]["LsCallApi"]["Parameters"]["Stage"]
     state["States"]["LsCallApi"]["Parameters"][
         "ApiEndpoint"
-    ] = f"{config.service_url('apigateway')}/restapis/{api_id}"
+    ] = f"{config.internal_service_url()}/restapis/{api_id}"
     state["States"]["LsCallApi"]["Parameters"]["Stage"] = stage
 
     aws_client.stepfunctions.update_state_machine(

--- a/tests/aws/services/cloudformation/test_cloudformation_ui.py
+++ b/tests/aws/services/cloudformation/test_cloudformation_ui.py
@@ -9,7 +9,10 @@ CLOUDFORMATION_UI_PATH = "/_localstack/cloudformation/deploy"
 class TestCloudFormationUi:
     @markers.aws.only_localstack
     def test_get_cloudformation_ui(self):
-        cfn_ui_url = config.get_edge_url() + CLOUDFORMATION_UI_PATH
+        # note: we get the external service url here because the UI is hosted on the external
+        # URL, however if `LOCALSTACK_HOST` is set to a hostname that does not resolve to
+        # `127.0.0.1` this test will fail.
+        cfn_ui_url = config.external_service_url() + CLOUDFORMATION_UI_PATH
         response = requests.get(cfn_ui_url)
 
         # we simply test that the UI is available at the right path and that it returns HTML.

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -71,7 +71,6 @@ class TestCloudwatch:
         bytes_data = bytes(data, encoding="utf-8")
         encoded_data = gzip.compress(bytes_data)
 
-        url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers(
             "cloudwatch",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
@@ -91,6 +90,7 @@ class TestCloudwatch:
                 "Authorization": authorization,
             }
         )
+        url = config.external_service_url()
         request = Request(url, encoded_data, headers, method="POST")
         urlopen(request)
 
@@ -201,10 +201,10 @@ class TestCloudwatch:
         aws_client.cloudwatch.put_metric_data(
             Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
         )
-        url = f"{config.get_edge_url()}{PATH_GET_RAW_METRICS}"
         headers = aws_stack.mock_aws_request_headers(
             "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
+        url = f"{config.external_service_url()}{PATH_GET_RAW_METRICS}"
         result = requests.get(url, headers=headers)
         assert 200 == result.status_code
         result = json.loads(to_str(result.content))

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -250,7 +250,7 @@ class TestKinesis:
 
         # get records with CBOR encoding
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
-        url = config.get_edge_url()
+        url = config.internal_service_url()
         headers = aws_stack.mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
@@ -284,7 +284,7 @@ class TestKinesis:
         assert 0 == len(json_records)
 
         # empty get records with CBOR encoding
-        url = config.get_edge_url()
+        url = config.internal_service_url()
         headers = aws_stack.mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2611,7 +2611,7 @@ class TestS3:
             f"{body}\r\n0;chunk-signature=f2a50a8c0ad4d212b579c2489c6d122db88d8a0d0b987ea1f3e9d081074a5937\r\n"
         )
         # put object
-        url = f"{config.service_url('s3')}/{s3_bucket}/{object_key}"
+        url = f"{config.internal_service_url()}/{s3_bucket}/{object_key}"
         requests.put(url, data, headers=headers, verify=False)
         # get object and assert content length
         downloaded_object = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key)
@@ -2653,7 +2653,7 @@ class TestS3:
                 "x-amz-trailer-signature:712fb67227583c88ac32f468fc30a249cf9ceeb0d0e947ea5e5209a10b99181c\r\n\r\n"
             )
 
-        url = f"{config.service_url('s3')}/{s3_bucket}/{object_key}"
+        url = f"{config.internal_service_url()}/{s3_bucket}/{object_key}"
 
         # test with wrong checksum
         wrong_data = get_data(body, "wrongchecksum")
@@ -2708,9 +2708,7 @@ class TestS3:
         upload_id = response["UploadId"]
 
         # # upload the part 1
-        url = (
-            f"{config.service_url('s3')}/{s3_bucket}/{key_name}?partNumber={1}&uploadId={upload_id}"
-        )
+        url = f"{config.internal_service_url()}/{s3_bucket}/{key_name}?partNumber={1}&uploadId={upload_id}"
         response = requests.put(url, data, headers=headers, verify=False)
         assert response.ok
         part_etag = response.headers.get("ETag")

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -5440,7 +5440,7 @@ class TestS3TerraformRawRequests:
             req, _, headers = header.strip().partition("\n")
             headers = {h.split(":")[0]: h.partition(":")[2].strip() for h in headers.split("\n")}
             method, path, _ = req.split(" ")
-            url = f"{config.get_edge_url()}{path}"
+            url = f"{config.internal_service_url()}{path}"
             result = requests.request(method=method, url=url, data=body, headers=headers)
             assert result.status_code < 400
 
@@ -7445,7 +7445,7 @@ class TestS3Routing:
         aws_client.s3.head_object(Bucket=s3_bucket, Key=s3_key)
 
         path = s3_key if use_virtual_address else f"{s3_bucket}/{s3_key}"
-        url = f"{config.get_edge_url()}/{path}"
+        url = f"{config.internal_service_url()}/{path}"
         headers = aws_stack.mock_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -172,7 +172,7 @@ class TestS3Cors:
         # ListBuckets is an operation outside S3 CORS configuration management
         # it should follow the default rules of LocalStack
 
-        url = f"{config.get_edge_url()}/"
+        url = f"{config.internal_service_url()}/"
         origin = ALLOWED_CORS_ORIGINS[0]
         # we need to "sign" the request so that our service name parser recognize ListBuckets as an S3 operation
         # if the request isn't signed, AWS will redirect to https://aws.amazon.com/s3/

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -30,7 +30,7 @@ def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str =
     host = localstack_host or (
         f"s3.{region}.{LOCALHOST_HOSTNAME}" if region != "us-east-1" else S3_VIRTUAL_HOSTNAME
     )
-    s3_edge_url = config.internal_service_url(host=host)
+    s3_edge_url = config.external_service_url(host=host)
     # TODO might add the region here
     return s3_edge_url.replace(f"://{host}", f"://{bucket_name}.{host}")
 

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -902,7 +902,7 @@ class TestSESRetrospection:
         assert "Body" not in contents2
 
         # Ensure all sent messages can be retrieved using the API endpoint
-        emails_url = config.get_edge_url() + EMAILS_ENDPOINT
+        emails_url = config.internal_service_url() + EMAILS_ENDPOINT
         api_contents = []
         api_contents.extend(requests.get(emails_url + f"?id={message1_id}").json()["messages"])
         api_contents.extend(requests.get(emails_url + f"?id={message2_id}").json()["messages"])
@@ -914,12 +914,12 @@ class TestSESRetrospection:
         assert api_contents[message2_id] == contents2
 
         # Ensure messages can be filtered by email source via the REST endpoint
-        emails_url = config.get_edge_url() + EMAILS_ENDPOINT + "?email=none@example.com"
+        emails_url = config.internal_service_url() + EMAILS_ENDPOINT + "?email=none@example.com"
         assert len(requests.get(emails_url).json()["messages"]) == 0
-        emails_url = config.get_edge_url() + EMAILS_ENDPOINT + f"?email={email}"
+        emails_url = config.internal_service_url() + EMAILS_ENDPOINT + f"?email={email}"
         assert len(requests.get(emails_url).json()["messages"]) == 2
 
-        emails_url = config.get_edge_url() + EMAILS_ENDPOINT
+        emails_url = config.internal_service_url() + EMAILS_ENDPOINT
         assert requests.delete(emails_url + f"?id={message1_id}").status_code == 204
         assert requests.delete(emails_url + f"?id={message2_id}").status_code == 204
         assert requests.get(emails_url).json() == {"messages": []}

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -262,7 +262,7 @@ class TestSNSPublishCrud:
         if is_aws_cloud():
             endpoint_url = f"https://sns.{TEST_AWS_REGION_NAME}.amazonaws.com"
         else:
-            endpoint_url = config.get_edge_url()
+            endpoint_url = config.internal_service_url()
 
         response = client.post(
             endpoint_url,
@@ -4466,7 +4466,7 @@ class TestSNSRetrospectionEndpoints:
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
-        msgs_url = config.get_edge_url() + PLATFORM_ENDPOINT_MSGS_ENDPOINT
+        msgs_url = config.internal_service_url() + PLATFORM_ENDPOINT_MSGS_ENDPOINT
         api_contents = requests.get(
             msgs_url, params={"region": TEST_AWS_REGION_NAME, "accountId": TEST_AWS_ACCOUNT_ID}
         ).json()
@@ -4568,7 +4568,7 @@ class TestSNSRetrospectionEndpoints:
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
-        msgs_url = config.get_edge_url() + SMS_MSGS_ENDPOINT
+        msgs_url = config.internal_service_url() + SMS_MSGS_ENDPOINT
         api_contents = requests.get(
             msgs_url, params={"region": TEST_AWS_REGION_NAME, "accountId": TEST_AWS_ACCOUNT_ID}
         ).json()
@@ -4655,7 +4655,7 @@ class TestSNSRetrospectionEndpoints:
 
         # we won't confirm the subscription, to simulate an external provider that wouldn't be able to access LocalStack
         # try to access the internal to confirm the Token is there
-        tokens_base_url = config.get_edge_url() + SUBSCRIPTION_TOKENS_ENDPOINT
+        tokens_base_url = config.internal_service_url() + SUBSCRIPTION_TOKENS_ENDPOINT
         api_contents = requests.get(f"{tokens_base_url}/{subscription_arn}").json()
         assert api_contents["subscription_token"] == token
         assert api_contents["subscription_arn"] == subscription_arn

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1111,7 +1111,7 @@ class TestSqsProvider:
 
         queue_name = f"queue-{short_uid()}"
 
-        edge_url = config.get_edge_url()
+        edge_url = config.internal_service_url()
         headers = aws_stack.mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
@@ -2795,7 +2795,7 @@ class TestSqsProvider:
         if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
             endpoint_url = "https://queue.amazonaws.com"
         else:
-            endpoint_url = config.get_edge_url()
+            endpoint_url = config.internal_service_url()
 
         # assert that AWS has some sort of content negotiation for query GET requests, even if not `json` protocol
         response = client.get(

--- a/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_apigetway_task_service.py
@@ -179,7 +179,7 @@ class TestTaskApiGateway:
         if is_aws_cloud():
             invocation_url = f"{api_id}.execute-api.{aws_stack.get_boto3_region()}.amazonaws.com"
         else:
-            invocation_url = f"{config.service_url('apigateway')}/restapis/{api_id}"
+            invocation_url = f"{config.internal_service_url()}/restapis/{api_id}"
         return invocation_url, stage_name
 
     @markers.aws.validated

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -175,7 +175,7 @@ class TestSTSIntegrations:
 
     @markers.aws.only_localstack
     def test_expiration_date_format(self):
-        url = config.get_edge_url()
+        url = config.internal_service_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
         headers = aws_stack.mock_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME

--- a/tests/aws/test_multiregion.py
+++ b/tests/aws/test_multiregion.py
@@ -89,7 +89,7 @@ class TestMultiRegion:
 
     def _gateway_request_url(self, api_id, stage_name, path):
         pattern = "%s/restapis/{api_id}/{stage_name}/%s{path}" % (
-            config.service_url("apigateway"),
+            config.internal_service_url(),
             PATH_USER_REQUEST,
         )
         return pattern.format(api_id=api_id, stage_name=stage_name, path=path)

--- a/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
+++ b/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
@@ -18,7 +18,7 @@
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
         },
-        "DomainName": "domain-65913c6b",
+        "DomainName": "domain-cf686810",
         "EBSOptions": {
           "EBSEnabled": true,
           "VolumeSize": 10,
@@ -137,7 +137,7 @@
         },
         "Environment": {
           "Variables": {
-            "CUSTOM_LOCALSTACK_HOSTNAME": "5c00fc80",
+            "CUSTOM_LOCALSTACK_HOSTNAME": "foo.invalid",
             "TOPIC_ARN": {
               "Ref": "TopicBFC7AF6E"
             }
@@ -444,7 +444,7 @@
         },
         "Environment": {
           "Variables": {
-            "CUSTOM_LOCALSTACK_HOSTNAME": "5c00fc80",
+            "CUSTOM_LOCALSTACK_HOSTNAME": "foo.invalid",
             "DOMAIN_ENDPOINT": {
               "Fn::GetAtt": [
                 "Domain66AC69E0",

--- a/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
+++ b/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
@@ -18,6 +18,7 @@
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
         },
+        "DomainName": "domain-65913c6b",
         "EBSOptions": {
           "EBSEnabled": true,
           "VolumeSize": 10,
@@ -136,7 +137,7 @@
         },
         "Environment": {
           "Variables": {
-            "CUSTOM_LOCALSTACK_HOST": "1796bffb",
+            "CUSTOM_LOCALSTACK_HOSTNAME": "5c00fc80",
             "TOPIC_ARN": {
               "Ref": "TopicBFC7AF6E"
             }
@@ -443,7 +444,7 @@
         },
         "Environment": {
           "Variables": {
-            "CUSTOM_LOCALSTACK_HOST": "1796bffb",
+            "CUSTOM_LOCALSTACK_HOSTNAME": "5c00fc80",
             "DOMAIN_ENDPOINT": {
               "Fn::GetAtt": [
                 "Domain66AC69E0",
@@ -489,6 +490,14 @@
     "ResultsBucketName": {
       "Value": {
         "Ref": "ResultsBucketA95A2103"
+      }
+    },
+    "DomainEndpoint": {
+      "Value": {
+        "Fn::GetAtt": [
+          "Domain66AC69E0",
+          "DomainEndpoint"
+        ]
       }
     },
     "RestApiEndpoint0551178A": {

--- a/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
+++ b/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
@@ -1,0 +1,547 @@
+{
+  "Resources": {
+    "ResultsBucketA95A2103": {
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "Domain66AC69E0": {
+      "Type": "AWS::OpenSearchService::Domain",
+      "Properties": {
+        "ClusterConfig": {
+          "DedicatedMasterEnabled": false,
+          "InstanceCount": 1,
+          "InstanceType": "r5.large.search",
+          "ZoneAwarenessEnabled": false
+        },
+        "DomainEndpointOptions": {
+          "EnforceHTTPS": false,
+          "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
+        },
+        "EBSOptions": {
+          "EBSEnabled": true,
+          "VolumeSize": 10,
+          "VolumeType": "gp2"
+        },
+        "EncryptionAtRestOptions": {
+          "Enabled": false
+        },
+        "EngineVersion": "OpenSearch_2.3",
+        "LogPublishingOptions": {},
+        "NodeToNodeEncryptionOptions": {
+          "Enabled": false
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "Queue4A7E3555": {
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
+    },
+    "QueuePolicy25439813": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "TopicBFC7AF6E"
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "Queue4A7E3555",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "Queue4A7E3555"
+          }
+        ]
+      }
+    },
+    "QueueClusterStackTopicBE55F55AB4F9C07F": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "Queue4A7E3555",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "TopicBFC7AF6E"
+        }
+      },
+      "DependsOn": [
+        "QueuePolicy25439813"
+      ]
+    },
+    "TopicBFC7AF6E": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "ApiHandlerFnServiceRole70F766AA": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "ApiHandlerFn96B5BE01": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "localstack-testing-000000000000-us-east-1",
+          "S3Key": "fn-apihandlerfn"
+        },
+        "Environment": {
+          "Variables": {
+            "CUSTOM_LOCALSTACK_HOST": "1796bffb",
+            "TOPIC_ARN": {
+              "Ref": "TopicBFC7AF6E"
+            }
+          }
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiHandlerFnServiceRole70F766AA",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.10"
+      },
+      "DependsOn": [
+        "ApiHandlerFnServiceRole70F766AA"
+      ]
+    },
+    "RestApi0C43BF4B": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "RestApi"
+      }
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+              ]
+            ]
+          }
+        ]
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "RestApiAccount7C83CF5A": {
+      "Type": "AWS::ApiGateway::Account",
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "RestApi0C43BF4B"
+      ],
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    },
+    "RestApiDeployment180EC5035e91cf9b45e2e822ce17f2f264a06fe3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B"
+        }
+      },
+      "DependsOn": [
+        "RestApiuploadPOST0F5E2849",
+        "RestApiuploadB3DA5A15"
+      ]
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC5035e91cf9b45e2e822ce17f2f264a06fe3"
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B"
+        },
+        "StageName": "prod"
+      },
+      "DependsOn": [
+        "RestApiAccount7C83CF5A"
+      ]
+    },
+    "RestApiuploadB3DA5A15": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "upload",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B"
+        }
+      }
+    },
+    "RestApiuploadPOSTApiPermissionClusterStackRestApi40286FD9POSTuploadE91A7ADE": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandlerFn96B5BE01",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B"
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66"
+              },
+              "/POST/upload"
+            ]
+          ]
+        }
+      }
+    },
+    "RestApiuploadPOSTApiPermissionTestClusterStackRestApi40286FD9POSTupload2805A171": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiHandlerFn96B5BE01",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B"
+              },
+              "/test-invoke-stage/POST/upload"
+            ]
+          ]
+        }
+      }
+    },
+    "RestApiuploadPOST0F5E2849": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "ApiHandlerFn96B5BE01",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "ResourceId": {
+          "Ref": "RestApiuploadB3DA5A15"
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B"
+        }
+      }
+    },
+    "EventHandlerFnServiceRoleC1FDCF6F": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "EventHandlerFnServiceRoleDefaultPolicyC178F440": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "Queue4A7E3555",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "EventHandlerFnServiceRoleDefaultPolicyC178F440",
+        "Roles": [
+          {
+            "Ref": "EventHandlerFnServiceRoleC1FDCF6F"
+          }
+        ]
+      }
+    },
+    "EventHandlerFnFCB55A70": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "localstack-testing-000000000000-us-east-1",
+          "S3Key": "fn-eventhandlerfn"
+        },
+        "Environment": {
+          "Variables": {
+            "CUSTOM_LOCALSTACK_HOST": "1796bffb",
+            "DOMAIN_ENDPOINT": {
+              "Fn::GetAtt": [
+                "Domain66AC69E0",
+                "DomainEndpoint"
+              ]
+            },
+            "RESULTS_BUCKET": {
+              "Ref": "ResultsBucketA95A2103"
+            },
+            "RESULTS_KEY": "result"
+          }
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "EventHandlerFnServiceRoleC1FDCF6F",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.10"
+      },
+      "DependsOn": [
+        "EventHandlerFnServiceRoleDefaultPolicyC178F440",
+        "EventHandlerFnServiceRoleC1FDCF6F"
+      ]
+    },
+    "EventHandlerFnSqsEventSourceClusterStackQueueEDD98E89D69A7573": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "Queue4A7E3555",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "EventHandlerFnFCB55A70"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ResultsBucketName": {
+      "Value": {
+        "Ref": "ResultsBucketA95A2103"
+      }
+    },
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66"
+            },
+            "/"
+          ]
+        ]
+      }
+    },
+    "ApiUrl": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66"
+            },
+            "/"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/tests/bootstrap/conftest.py
+++ b/tests/bootstrap/conftest.py
@@ -1,3 +1,39 @@
+import os
+from typing import Optional
+
+import pytest
+
+from localstack import constants
+from localstack.testing.scenario.provisioning import InfraProvisioner
+
 pytest_plugins = [
     "localstack.testing.pytest.bootstrap",
 ]
+
+
+@pytest.fixture(scope="session")
+def cdk_template_path():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "cdk_templates"))
+
+
+# Duplicated from tests/aws/conftest.py so we can use CDK with bootstrap tests
+@pytest.fixture(scope="session")
+def infrastructure_setup(cdk_template_path, aws_client_factory):
+    def _infrastructure_setup(
+        namespace: str, force_synth: Optional[bool] = False, port: int = constants.DEFAULT_PORT_EDGE
+    ) -> InfraProvisioner:
+        """
+        :param namespace: repo-unique identifier for this CDK app.
+            A directory with this name will be created at `tests/aws/cdk_templates/<namespace>/`
+        :param force_synth: set to True to always re-synth the CDK app
+        :return: an instantiated CDK InfraProvisioner which can be used to deploy a CDK app
+        """
+        return InfraProvisioner(
+            base_path=cdk_template_path,
+            aws_client=aws_client_factory(endpoint_url=f"http://localhost:{port}"),
+            namespace=namespace,
+            force_synth=force_synth,
+            persist_output=True,
+        )
+
+    return _infrastructure_setup

--- a/tests/bootstrap/resources/apigw_handler.py
+++ b/tests/bootstrap/resources/apigw_handler.py
@@ -10,17 +10,16 @@ if TYPE_CHECKING:
 
 client: "SNSClient" = boto3.client("sns", endpoint_url=os.environ["AWS_ENDPOINT_URL"])
 
-TOPIC_ARN = os.environ["TOPIC_ARN"]
-
 
 def handler(event, context):
     print(f"API Gateway handler {context.function_name} invoked ({event=})")
+    topic_arn = os.environ["TOPIC_ARN"]
 
     message = json.loads(event["body"])
 
     try:
         client.publish(
-            TopicArn=TOPIC_ARN,
+            TopicArn=topic_arn,
             Message=json.dumps(message),
         )
         print("Publish successful")

--- a/tests/bootstrap/resources/apigw_handler.py
+++ b/tests/bootstrap/resources/apigw_handler.py
@@ -1,0 +1,48 @@
+import json
+import os
+from typing import TYPE_CHECKING
+
+import boto3
+
+if TYPE_CHECKING:
+    from mypy_boto3_sns import SNSClient
+
+
+client: "SNSClient" = boto3.client("sns", endpoint_url=os.environ["AWS_ENDPOINT_URL"])
+
+TOPIC_ARN = os.environ["TOPIC_ARN"]
+
+
+def handler(event, context):
+    print(f"API Gateway handler {context.function_name} invoked ({event=})")
+
+    message = json.loads(event["body"])
+
+    try:
+        client.publish(
+            TopicArn=TOPIC_ARN,
+            Message=json.dumps(message),
+        )
+        print("Publish successful")
+        return {
+            "isBase64Encoded": False,
+            "statusCode": 200,
+            "headers": {},
+            "body": json.dumps(
+                {
+                    "status": "ok",
+                }
+            ),
+        }
+    except Exception as e:
+        return {
+            "isBase64Encoded": False,
+            "statusCode": 500,
+            "headers": {},
+            "body": json.dumps(
+                {
+                    "status": "error",
+                    "error": str(e),
+                }
+            ),
+        }

--- a/tests/bootstrap/resources/event_handler.py
+++ b/tests/bootstrap/resources/event_handler.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-# import requests
 import boto3
 import requests
 

--- a/tests/bootstrap/resources/event_handler.py
+++ b/tests/bootstrap/resources/event_handler.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+# import requests
+import boto3
+
+# CUSTOM_LOCALSTACK_HOSTNAME = os.environ["CUSTOM_LOCALSTACK_HOSTNAME"]
+DOMAIN_ENDPOINT = os.environ["DOMAIN_ENDPOINT"]
+RESULTS_BUCKET = os.environ["RESULTS_BUCKET"]
+RESULTS_KEY = os.environ["RESULTS_KEY"]
+# assert CUSTOM_LOCALSTACK_HOSTNAME in DOMAIN_ENDPOINT
+
+client = boto3.client("s3", endpoint_url=os.environ["AWS_ENDPOINT_URL"])
+
+
+def handler(event, context):
+    print(f"Event handler function {context.function_name} invoked")
+
+    for record in event["Records"]:
+        body = json.loads(record["body"])
+        message = json.loads(body["Message"])
+        print(f"Got message: {message}")
+
+        # wait for cluster ready
+        # r = requests.get(
+        #     f"http://{DOMAIN_ENDPOINT}/_cluster/health?wait_for_status=yellow,timeout=50s"
+        # )
+        # r.raise_for_status()
+
+        # assert CUSTOM_LOCALSTACK_HOSTNAME in body["UnsubscribeURL"]
+
+        # write the result to s3
+        client.put_object(
+            Bucket=RESULTS_BUCKET, Key=RESULTS_KEY, Body=message["message"].encode("utf8")
+        )
+
+        # just take the first record for now
+        return

--- a/tests/bootstrap/resources/event_handler.py
+++ b/tests/bootstrap/resources/event_handler.py
@@ -13,7 +13,9 @@ def handler(event, context):
     domain_endpoint = os.environ["DOMAIN_ENDPOINT"]
     results_bucket = os.environ["RESULTS_BUCKET"]
     results_key = os.environ["RESULTS_KEY"]
-    assert custom_localstack_hostname in domain_endpoint
+    assert (
+        custom_localstack_hostname in domain_endpoint
+    ), f"{custom_localstack_hostname} not in {domain_endpoint}"
 
     print(f"Event handler function {context.function_name} invoked")
 

--- a/tests/bootstrap/test_cosmetic_configuration.py
+++ b/tests/bootstrap/test_cosmetic_configuration.py
@@ -1,0 +1,229 @@
+import os
+from typing import Generator
+
+import aws_cdk as cdk
+import pytest
+import requests
+
+from localstack.config import in_docker
+from localstack.testing.pytest import markers
+from localstack.testing.pytest.container import ContainerFactory, LogStreamFactory
+from localstack.testing.scenario.cdk_lambda_helper import load_python_lambda_to_s3
+from localstack.testing.scenario.provisioning import InfraProvisioner
+from localstack.utils.bootstrap import ContainerConfigurators
+from localstack.utils.net import get_free_tcp_port
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+pytestmarks = [
+    pytest.mark.skipif(condition=in_docker(), reason="cannot run bootstrap tests in docker"),
+    markers.aws.only_localstack,
+]
+
+STACK_NAME = "ClusterStack"
+RESULT_KEY = "result"
+
+
+@pytest.fixture(scope="class")
+def port() -> int:
+    return get_free_tcp_port()
+
+
+@pytest.fixture(scope="class")
+def random_localstack_host() -> str:
+    return short_uid()
+
+
+# these fixtures have been copied from the pre-existing fixtures
+@pytest.fixture(scope="class")
+def class_container_factory() -> Generator[ContainerFactory, None, None]:
+    factory = ContainerFactory()
+    yield factory
+    factory.remove_all_containers()
+
+
+@pytest.fixture(scope="class")
+def class_stream_container_logs() -> Generator[LogStreamFactory, None, None]:
+    factory = LogStreamFactory()
+    yield factory
+    factory.close()
+
+
+@pytest.fixture(scope="class", autouse=True)
+def container(
+    port,
+    class_container_factory: ContainerFactory,
+    class_stream_container_logs,
+    wait_for_localstack_ready,
+    random_localstack_host,
+):
+    ls_container = class_container_factory(
+        configurators=[
+            ContainerConfigurators.mount_localstack_volume(),
+            ContainerConfigurators.debug,
+            ContainerConfigurators.mount_docker_socket,
+            ContainerConfigurators.gateway_listen(port),
+            ContainerConfigurators.env_vars(
+                {
+                    "LOCALSTACK_HOST": random_localstack_host,
+                }
+            ),
+        ]
+    )
+    with ls_container.start() as running_container:
+        class_stream_container_logs(ls_container)
+        wait_for_localstack_ready(running_container)
+        yield running_container
+
+
+class TestLocalStackHost:
+    """
+    Scenario test that runs LocalStack in a docker container with `LOCALSTACK_HOST` set to a
+    non-default value. This ensures that setting the cosmetic "LOCALSTACK_HOST" does not affect
+    the internal functionality of LocalStack.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def infrastructure(
+        self, aws_client_factory, infrastructure_setup, port, random_localstack_host
+    ):
+        aws_client = aws_client_factory(endpoint_url=f"http://localhost:{port}")
+
+        infra: InfraProvisioner = infrastructure_setup(
+            namespace="LocalStackHostBootstrap", port=port
+        )
+
+        stack = cdk.Stack(infra.cdk_app, STACK_NAME)
+
+        # results bucket
+        results_bucket = cdk.aws_s3.Bucket(stack, "ResultsBucket")
+        cdk.CfnOutput(stack, "ResultsBucketName", value=results_bucket.bucket_name)
+
+        # OpenSearch domain
+        domain = cdk.aws_opensearchservice.Domain(
+            stack,
+            "Domain",
+            version=cdk.aws_opensearchservice.EngineVersion.OPENSEARCH_2_3,
+        )
+
+        def create_lambda_function(
+            stack: cdk.Stack,
+            resource_name: str,
+            resources_path: str,
+            additional_packages: list[str] | None = None,
+            runtime: cdk.aws_lambda.Runtime = cdk.aws_lambda.Runtime.PYTHON_3_10,
+            environment: dict[str, str] | None = None,
+            **kwargs,
+        ) -> cdk.aws_lambda.Function:
+            # needs to be deterministic so we can turn `infrastructure_setup(force_synth=True)` off
+            key_name = f"fn-{resource_name.lower()}"
+            assert os.path.isfile(resources_path), f"Cannot find function file {resources_path}"
+
+            infra.add_custom_setup(
+                lambda: load_python_lambda_to_s3(
+                    s3_client=aws_client.s3,
+                    bucket_name=infra.get_asset_bucket(),
+                    key_name=key_name,
+                    code_path=resources_path,
+                    additional_python_packages=additional_packages or [],
+                )
+            )
+
+            given_environment = environment or {}
+            base_environment = {"CUSTOM_LOCALSTACK_HOST": random_localstack_host}
+            full_environment = {**base_environment, **given_environment}
+            return cdk.aws_lambda.Function(
+                stack,
+                resource_name,
+                handler="index.handler",
+                code=cdk.aws_lambda.S3Code(bucket=asset_bucket, key=key_name),
+                runtime=runtime,
+                environment=full_environment,
+                **kwargs,
+            )
+
+        # SQS queue
+        queue = cdk.aws_sqs.Queue(stack, "Queue")
+
+        # SNS topic
+        topic = cdk.aws_sns.Topic(stack, "Topic")
+        topic.add_subscription(cdk.aws_sns_subscriptions.SqsSubscription(queue))
+
+        # API Gateway
+        asset_bucket = cdk.aws_s3.Bucket.from_bucket_name(
+            stack,
+            "BucketName",
+            bucket_name=infra.get_asset_bucket(),
+        )
+        apigw_handler_fn = create_lambda_function(
+            stack,
+            resource_name="ApiHandlerFn",
+            resources_path=os.path.join(os.path.dirname(__file__), "resources/apigw_handler.py"),
+            environment={
+                "TOPIC_ARN": topic.topic_arn,
+            },
+        )
+
+        api = cdk.aws_apigateway.RestApi(stack, "RestApi")
+        upload_url_resource = api.root.add_resource("upload")
+        upload_url_resource.add_method(
+            "POST", cdk.aws_apigateway.LambdaIntegration(apigw_handler_fn)
+        )
+        cdk.CfnOutput(stack, "ApiUrl", value=api.url)
+
+        # event handler lambda
+        create_lambda_function(
+            stack,
+            resource_name="EventHandlerFn",
+            resources_path=os.path.join(os.path.dirname(__file__), "resources/event_handler.py"),
+            additional_packages=["requests", "boto3"],
+            events=[
+                cdk.aws_lambda_event_sources.SqsEventSource(queue),
+            ],
+            environment={
+                "DOMAIN_ENDPOINT": domain.domain_endpoint,
+                "RESULTS_BUCKET": results_bucket.bucket_name,
+                "RESULTS_KEY": RESULT_KEY,
+            },
+        )
+
+        with infra.provisioner() as prov:
+            yield prov
+
+    def test_scenario(self, port, infrastructure, aws_client_factory, random_localstack_host):
+        """
+        Scenario:
+            * API Gateway handles web request
+            * Broadcasts message onto SNS topic
+            * Lambda subscribes via SQS and inserts message into OpenSearch
+        """
+        aws_client = aws_client_factory(
+            endpoint_url=f"http://localhost:{port}",
+        )
+
+        stack_outputs = infrastructure.get_stack_outputs(STACK_NAME)
+        api_url = stack_outputs["ApiUrl"].rstrip("/")
+
+        url = f"{api_url}/upload"
+
+        message = short_uid()
+        r = requests.post(url, json={"message": message})
+        r.raise_for_status()
+
+        result_bucket = stack_outputs["ResultsBucketName"]
+
+        def _is_result_file_ready():
+            aws_client.s3.head_object(
+                Bucket=result_bucket,
+                Key=RESULT_KEY,
+            )
+
+        # wait a maximum of 10 seconds
+        retry(_is_result_file_ready, retries=10)
+
+        body = (
+            aws_client.s3.get_object(Bucket=result_bucket, Key=RESULT_KEY)["Body"]
+            .read()
+            .decode("utf8")
+        )
+        assert body.strip() == message

--- a/tests/bootstrap/test_cosmetic_configuration.py
+++ b/tests/bootstrap/test_cosmetic_configuration.py
@@ -237,7 +237,7 @@ class TestLocalStackHost:
         Scenario:
             * API Gateway handles web request
             * Broadcasts message onto SNS topic
-            * Lambda subscribes via SQS and inserts message into OpenSearch
+            * Lambda subscribes via SQS and queries the OpenSearch domain health endpoint
         """
         # check cluster health endpoint
 

--- a/tests/bootstrap/test_cosmetic_configuration.py
+++ b/tests/bootstrap/test_cosmetic_configuration.py
@@ -129,7 +129,6 @@ class TestLocalStackHost:
         infra: InfraProvisioner = infrastructure_setup(
             namespace="LocalStackHostBootstrap",
             port=port,
-            # force_synth=True,
         )
 
         stack = cdk.Stack(infra.cdk_app, STACK_NAME)
@@ -253,7 +252,12 @@ class TestLocalStackHost:
         r = requests.get(f"http://{health_url}/_cluster/health")
         r.raise_for_status()
 
-        api_url = stack_outputs["ApiUrl"].rstrip("/")
+        assert chosen_localstack_host in stack_outputs["ApiUrl"]
+        api_url = (
+            stack_outputs["ApiUrl"]
+            .rstrip("/")
+            .replace(chosen_localstack_host, constants.LOCALHOST_HOSTNAME)
+        )
 
         url = f"{api_url}/upload"
 

--- a/tests/integration/services/test_internal.py
+++ b/tests/integration/services/test_internal.py
@@ -1,12 +1,12 @@
 import pytest
 import requests
 
-from localstack.config import get_edge_url
+from localstack import config
 
 
 class TestInitScriptsResource:
     def test_stages_have_completed(self):
-        response = requests.get(get_edge_url() + "/_localstack/init")
+        response = requests.get(config.internal_service_url() + "/_localstack/init")
         assert response.status_code == 200
         doc = response.json()
 
@@ -18,7 +18,7 @@ class TestInitScriptsResource:
         }
 
     def test_query_nonexisting_stage(self):
-        response = requests.get(get_edge_url() + "/_localstack/init/does_not_exist")
+        response = requests.get(config.internal_service_url() + "/_localstack/init/does_not_exist")
         assert response.status_code == 404
 
     @pytest.mark.parametrize(
@@ -26,27 +26,27 @@ class TestInitScriptsResource:
         [("boot", True), ("start", True), ("ready", True), ("shutdown", False)],
     )
     def test_query_individual_stage_completed(self, stage, completed):
-        response = requests.get(get_edge_url() + f"/_localstack/init/{stage}")
+        response = requests.get(config.internal_service_url() + f"/_localstack/init/{stage}")
         assert response.status_code == 200
         assert response.json()["completed"] == completed
 
 
 class TestHealthResource:
     def test_get(self):
-        response = requests.get(get_edge_url() + "/_localstack/health")
+        response = requests.get(config.internal_service_url() + "/_localstack/health")
         assert response.ok
         assert "services" in response.json()
         assert "edition" in response.json()
 
     def test_head(self):
-        response = requests.head(get_edge_url() + "/_localstack/health")
+        response = requests.head(config.internal_service_url() + "/_localstack/health")
         assert response.ok
         assert not response.text
 
 
 class TestInfoEndpoint:
     def test_get(self):
-        response = requests.get(get_edge_url() + "/_localstack/info")
+        response = requests.get(config.internal_service_url() + "/_localstack/info")
         assert response.ok
         doc = response.json()
 

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -34,7 +34,7 @@ def test_config_endpoint(config_endpoint):
     # test the Route
     body = {"variable": "FOO", "value": "BAZ"}
     # test the ProxyListener
-    url = f"{config.get_edge_url()}/_localstack/config"
+    url = f"{config.internal_service_url()}/_localstack/config"
     response = requests.post(url, json=body)
     assert response.ok
     response_body = response.json()

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -13,24 +13,28 @@ class TestCSRF:
     def test_CSRF(self):
         headers = {"Origin": "http://attacker.com"}
         # Test if lambdas are enumerable
-        response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/", headers=headers)
+        response = requests.get(
+            f"{config.internal_service_url()}/2015-03-31/functions/", headers=headers
+        )
         assert response.status_code == 403
 
         # Test if config endpoint is reachable
         config_body = {"variable": "harmful", "value": "config"}
 
         response = requests.post(
-            f"{config.get_edge_url()}/?_config_", headers=headers, json=config_body
+            f"{config.internal_service_url()}/?_config_", headers=headers, json=config_body
         )
         assert response.status_code == 403
 
         # Test if endpoints are reachable without origin header
-        response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/")
+        response = requests.get(f"{config.internal_service_url()}/2015-03-31/functions/")
         assert response.status_code == 200
 
     def test_default_cors_headers(self):
         headers = {"Origin": "https://app.localstack.cloud"}
-        response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/", headers=headers)
+        response = requests.get(
+            f"{config.internal_service_url()}/2015-03-31/functions/", headers=headers
+        )
         assert response.status_code == 200
         assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
         assert "GET" in response.headers["access-control-allow-methods"].split(",")
@@ -40,7 +44,7 @@ class TestCSRF:
     @pytest.mark.parametrize("path", ["/health", "/_localstack/health"])
     def test_internal_route_cors_headers(self, path):
         headers = {"Origin": "https://app.localstack.cloud"}
-        response = requests.get(f"{config.get_edge_url()}{path}", headers=headers)
+        response = requests.get(f"{config.internal_service_url()}{path}", headers=headers)
         assert response.status_code == 200
         assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
         assert "GET" in response.headers["access-control-allow-methods"].split(",")
@@ -86,7 +90,7 @@ class TestCSRF:
     def test_disable_cors_checks(self, monkeypatch):
         """Test DISABLE_CORS_CHECKS=1 (most permissive setting)"""
         headers = {"Origin": "https://invalid.localstack.cloud"}
-        url = f"{config.get_edge_url()}/2015-03-31/functions/"
+        url = f"{config.internal_service_url()}/2015-03-31/functions/"
         response = requests.get(url, headers=headers)
         assert response.status_code == 403
 
@@ -105,7 +109,7 @@ class TestCSRF:
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = "https://app.localstack.cloud"
-        url = config.get_edge_url()
+        url = config.internal_service_url()
         data = {"Action": "ListTopics", "Version": "2010-03-31"}
         response = requests.post(url, headers=headers, data=data)
         assert response.status_code == 200
@@ -128,7 +132,7 @@ class TestCSRF:
         monkeypatch.setattr(config, "EXTRA_CORS_ALLOWED_ORIGINS", f"https://{test_domain}")
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
 
-        url = config.get_edge_url()
+        url = config.internal_service_url()
         headers = aws_stack.mock_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
@@ -146,6 +150,6 @@ class TestCSRF:
         assert not response.ok
 
     def test_no_cors_without_origin_header(self):
-        response = requests.get(f"{config.get_edge_url()}/2015-03-31/functions/")
+        response = requests.get(f"{config.internal_service_url()}/2015-03-31/functions/")
         assert response.status_code == 200
         assert "access-control-allow-origin" not in response.headers

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -111,8 +111,15 @@ def test_start_host(runner, monkeypatch):
 
 
 def test_status_services(runner, httpserver, monkeypatch):
+    # configure LOCALSTACK_HOST because the services endpoint makes a request against the
+    # external URL of LocalStack, which may be different to the edge port
     monkeypatch.setattr(
-        config, "GATEWAY_LISTEN", [HostAndPort(host="0.0.0.0", port=httpserver.port)]
+        config,
+        "LOCALSTACK_HOST",
+        HostAndPort(
+            host="localhost.localstack.cloud",
+            port=httpserver.port,
+        ),
     )
 
     services = {"dynamodb": "starting", "s3": "running"}
@@ -122,7 +129,7 @@ def test_status_services(runner, httpserver, monkeypatch):
 
     result = runner.invoke(cli, ["status", "services"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result
 
     assert "dynamodb" in result.output
     assert "s3" in result.output

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -168,11 +168,11 @@ def test_arn_partition_rewriting_url_encoding(httpserver, monkeypatch):
     # httpserver matches on the URL-decoded path
     httpserver.expect_request("/query:encoded/path/").respond_with_handler(echo_path)
 
-    def mock_get_edge_url() -> str:
+    def mock_internal_service_url() -> str:
         # Set the forwarding URL to the mock HTTP server
         return httpserver.url_for("/")
 
-    monkeypatch.setattr(config, "get_edge_url", mock_get_edge_url)
+    monkeypatch.setattr(config, "internal_service_url", mock_internal_service_url)
 
     request = Request(
         method="POST",
@@ -337,11 +337,11 @@ def test_arn_partition_rewriting_in_request_and_response(
 
     httpserver.expect_request("").respond_with_handler(echo)
 
-    def mock_get_edge_url() -> str:
+    def mock_internal_service_url() -> str:
         # Set the forwarding URL to the mock HTTP server
         return httpserver.url_for("/")
 
-    monkeypatch.setattr(config, "get_edge_url", mock_get_edge_url)
+    monkeypatch.setattr(config, "internal_service_url", mock_internal_service_url)
     data = encoding(
         json.dumps(
             {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

With the introduction of `GATEWAY_LISTEN` and `LOCALSTACK_HOST`, we introduced the split between cosmetic and functional configuration variables. Cosmetic variables were not used internally to define internal routes for e.g. health checks or service-to-service calls. They were only used when returning URLs outside of LocalStack. The motivation was that some users may wish to customise the domain name of LocalStack, for example when using the docker container name to resolve to the LocalStack container.

Previous to #9584 the helper functions in `localstack.config` used a mix of "cosmetic" and "functional" variables. For example, `get_edge_url` took the host from `LOCALSTACK_HOST` but the port from `GATEWAY_LISTEN`. This mixing of variable types led to strange situations. #9584 introduced a new API which was much clearer to use, and this PR updates all internal call sites of the old API to use the new API.

‼️ While migrating the functions, I found that OpenSearch adds a route handler for the specific URL that it returns, i.e. if it returns `mydomain.us-east-1.opensearch.foo.bar`, it only matches requests with that header. This makes testing annoying since it would be good to make a request to `mydomain.us-east-1.opensearch.localhost.localstack.cloud` (i.e. `127.0.0.1`) instead. I have had to work around this by setting the `Host` header manually, which in fact is the same thing done in the [`EdgeProxiedOpensearchCluster`](https://github.com/localstack/localstack/blob/80a6e272b1fd26be515e4bca991c9edbf28b6268/localstack/services/opensearch/cluster.py#L602-L609).

https://github.com/localstack/localstack/blob/80a6e272b1fd26be515e4bca991c9edbf28b6268/tests/bootstrap/test_cosmetic_configuration.py#L253-L258

It might be nice to accept any domain suffix. This might be good to do in a follow up PR as it does not remove functionality.

<!-- What notable changes does this PR make? -->
## Changes

* Remove all usages of `get_service_url`, `service_port` and `get_edge_url` from the LocalStack codebase
* Add a scenario test covering internal communication between services that have their URLs customised
* Add more obvious deprecation warnings for deprecated functions
* Address comments in #9584


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

