### PR TITLE
fix S3 v3 VirtualHost removing trailing slash

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -991,18 +991,12 @@ class S3RequestParser(RestXMLRequestParser):
                 # remove the bucket name from the host part of the request
                 new_host = self.old_host.removeprefix(f"{bucket_name}.")
 
-                # split the url and put the bucket name at the front
-                path_parts = self.old_path.split("/")
-                path_parts = [bucket_name] + path_parts
-                path_parts = [part for part in path_parts if part]
-                new_path = "/" + "/".join(path_parts) or "/"
+                # put the bucket name at the front
+                new_path = "/" + bucket_name + self.old_path or "/"
 
                 # create a new RAW_URI for the WSGI environment, this is necessary because of our `get_raw_path` utility
                 if self.old_raw_uri:
-                    path_parts = self.old_raw_uri.split("/")
-                    path_parts = [bucket_name] + path_parts
-                    path_parts = [part for part in path_parts if part]
-                    new_raw_uri = "/" + "/".join(path_parts) or "/"
+                    new_raw_uri = "/" + bucket_name + self.old_raw_uri or "/"
                     if qs := self.request.query_string:
                         new_raw_uri += "?" + qs.decode("utf-8")
                 else:

--- a/localstack/services/s3/virtual_host.py
+++ b/localstack/services/s3/virtual_host.py
@@ -6,6 +6,7 @@ from localstack import config
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.http import Request, Response
 from localstack.http.proxy import Proxy
+from localstack.http.request import get_raw_path
 from localstack.runtime import hooks
 from localstack.services.edge import ROUTER
 from localstack.services.s3.utils import S3_VIRTUAL_HOST_FORWARDED_HEADER
@@ -34,7 +35,7 @@ class S3VirtualHostProxyHandler:
 
     def __call__(self, request: Request, **kwargs) -> Response:
         # TODO region pattern currently not working -> removing it from url
-        rewritten_url = self._rewrite_url(url=request.url, **kwargs)
+        rewritten_url = self._rewrite_url(request=request, **kwargs)
 
         LOG.debug(f"Rewritten original host url: {request.url} to path-style url: {rewritten_url}")
 
@@ -65,7 +66,7 @@ class S3VirtualHostProxyHandler:
         )
 
     @staticmethod
-    def _rewrite_url(url: str, domain: str, bucket: str, region: str, **kwargs) -> str:
+    def _rewrite_url(request: Request, domain: str, bucket: str, region: str, **kwargs) -> str:
         """
         Rewrites the url so that it can be forwarded to moto. Used for vhost-style and for any url that contains the region.
 
@@ -81,14 +82,15 @@ class S3VirtualHostProxyHandler:
         :param region: the region name (includes the '.' at the end)
         :return: re-written url as string
         """
-        splitted = urlsplit(url)
+        splitted = urlsplit(request.url)
+        raw_path = get_raw_path(request)
         if splitted.netloc.startswith(f"{bucket}."):
             netloc = splitted.netloc.replace(f"{bucket}.", "")
-            path = f"{bucket}{splitted.path}"
+            path = f"{bucket}{raw_path}"
         else:
             # we already have a path-style addressing, only need to remove the region
             netloc = splitted.netloc
-            path = splitted.path
+            path = raw_path
         # TODO region currently ignored
         if region:
             netloc = netloc.replace(f"{region}", "")

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10497,46 +10497,6 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_url_encoded_key": {
-    "recorded-date": "14-09-2023, 00:01:41",
-    "recorded-content": {
-      "list-object-encoded-char": {
-        "Contents": [
-          {
-            "ETag": "\"03dc4443b5f395b54d011fdb7d9e0ae1\"",
-            "Key": "test%40key",
-            "LastModified": "datetime",
-            "Size": 24,
-            "StorageClass": "STANDARD"
-          },
-          {
-            "ETag": "\"51a6065890415b4b299dec1aa33d712c\"",
-            "Key": "test%40key/",
-            "LastModified": "datetime",
-            "Size": 12,
-            "StorageClass": "STANDARD"
-          },
-          {
-            "ETag": "\"b792145c4a8e8d9ac95d3c2f9f0ac42d\"",
-            "Key": "test@key/",
-            "LastModified": "datetime",
-            "Size": 16,
-            "StorageClass": "STANDARD"
-          }
-        ],
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "KeyCount": 3,
-        "MaxKeys": 1000,
-        "Name": "<name:1>",
-        "Prefix": "",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_overwrite_key": {
     "recorded-date": "18-10-2023, 17:40:12",
     "recorded-content": {
@@ -12190,6 +12150,86 @@
         "MaxKeys": 1000,
         "Name": "<bucket-name:1>",
         "Prefix": "test/foo/bar",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_url_encoded_key[True]": {
+    "recorded-date": "11-11-2023, 02:20:59",
+    "recorded-content": {
+      "list-object-encoded-char": {
+        "Contents": [
+          {
+            "ETag": "\"03dc4443b5f395b54d011fdb7d9e0ae1\"",
+            "Key": "test%40key",
+            "LastModified": "datetime",
+            "Size": 24,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"51a6065890415b4b299dec1aa33d712c\"",
+            "Key": "test%40key/",
+            "LastModified": "datetime",
+            "Size": 12,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"b792145c4a8e8d9ac95d3c2f9f0ac42d\"",
+            "Key": "test@key/",
+            "LastModified": "datetime",
+            "Size": 16,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_url_encoded_key[False]": {
+    "recorded-date": "11-11-2023, 02:21:02",
+    "recorded-content": {
+      "list-object-encoded-char": {
+        "Contents": [
+          {
+            "ETag": "\"03dc4443b5f395b54d011fdb7d9e0ae1\"",
+            "Key": "test%40key",
+            "LastModified": "datetime",
+            "Size": 24,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"51a6065890415b4b299dec1aa33d712c\"",
+            "Key": "test%40key/",
+            "LastModified": "datetime",
+            "Size": 12,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"b792145c4a8e8d9ac95d3c2f9f0ac42d\"",
+            "Key": "test@key/",
+            "LastModified": "datetime",
+            "Size": 16,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #9603, I've ran the OpenDAL integration test with `OPENDAL_S3_ENABLE_VIRTUAL_HOST_STYLE=on` to see if there would be any difference, and 2 tests failed. After investigation, it was because calling `ListObjectsV2` would return the keys without the trailing slash, making the test assertions fail. After investigating the difference between the calls, I could see the parsed request was different between the 2 modes:
Virtual-Host before the fix:
`PUT opendal-testing.s3.localhost.localstack.cloud:4566/CI/16b716e8-4cd2-4f6e-9d82-ee338b5e48b1/580cc505-82cf-424e-8448-ca4bf9dfd1ac/`
`-> PutObjectRequest({'ACL': None, 'Bucket': 'opendal-testing', ..., 'Key': 'CI/16b716e8-4cd2-4f6e-9d82-ee338b5e48b1/580cc505-82cf-424e-8448-ca4bf9dfd1ac', 'Metadata': {}...) `

Path style:
`PUT s3.localhost.localstack.cloud:4566/opendal-testing/CI/cc66a8ac-a924-42b2-950a-b5a9b6bca060/23a5e248-3249-436f-881f-cc1b8dcbffbe/`
`-> PutObjectRequest({'ACL': None, 'Bucket': 'opendal-testing', ..., 'Key': 'CI/cc66a8ac-a924-42b2-950a-b5a9b6bca060/23a5e248-3249-436f-881f-cc1b8dcbffbe/', 'Metadata': {}...)`

As we can see, the Virtual Host mangled the trailing slash, thus creating an object with the wrong key. This was due to a previous assertion in the VirtualHostRewriter which was written to actually mangle it. I've changed it to be closer to our previous proxy, and simply prefix the path with the bucket. 

Those test suites are really building confidence in our new S3 implementation, most of them are passing on the first try and some real edge cases are popping up. I'll continue to scour the internet to find S3 test suites to test LocalStack against. Maybe another Apache project which will use LocalStack 😄

Just for info, here are the 2 previously failing tests:
- [test_list_nested_dir](https://github.com/apache/incubator-opendal/blob/c5410f25322ab9daf8dc270bfed6cb70511a2463/core/tests/behavior/list.rs#L263C26-L263C26)
- [test_list_sub_dir](https://github.com/apache/incubator-opendal/blob/c5410f25322ab9daf8dc270bfed6cb70511a2463/core/tests/behavior/list.rs#L240) 

<!-- What notable changes does this PR make? -->
## Changes
- Updated an existing test verifying this behavior for the regular path style (we already have a special case for this in the parser, see `localstack.aws.protocol.parser.S3RequestParser._parse_shape`) to also test for virtual host mode.
- Modified the VirtualHostRewriter to not mangle the trailing slash
- Also spotted a different issue in the V2 legacy provider, where the v-host proxy was not proxying the request with the raw path, so the test would fail. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

