### PR TITLE
Bump supported versions in opensearch to 2.9

### DIFF
--- a/localstack/services/opensearch/versions.py
+++ b/localstack/services/opensearch/versions.py
@@ -15,6 +15,7 @@ from localstack.utils.common import get_arch
 
 # Internal representation of the OpenSearch versions (without the "OpenSearch_" prefix)
 _opensearch_install_versions = {
+    "2.9": "2.9.0",
     "2.7": "2.7.0",
     "2.5": "2.5.0",
     "2.3": "2.3.0",

--- a/localstack/services/opensearch/versions.py
+++ b/localstack/services/opensearch/versions.py
@@ -221,6 +221,7 @@ compatible_versions = [
         TargetVersions=["OpenSearch_2.5"],
     ),
     CompatibleVersionsMap(SourceVersion="OpenSearch_2.5", TargetVersions=["OpenSearch_2.7"]),
+    CompatibleVersionsMap(SourceVersion="OpenSearch_2.7", TargetVersions=["OpenSearch_2.9"]),
 ]
 
 

--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -14,7 +14,10 @@ from localstack.utils.common import short_uid, start_worker_thread
 LOG = logging.getLogger(__name__)
 
 # Common headers used when sending requests to OpenSearch
-COMMON_HEADERS = {"content-type": "application/json", "Accept-encoding": "identity"}
+COMMON_HEADERS = {
+    "content-type": "application/json",
+    "Accept-encoding": "identity"
+}
 
 # Lock and event to ensure that the installation is executed before the tests
 INIT_LOCK = threading.Lock()
@@ -22,190 +25,201 @@ installed = threading.Event()
 
 
 def install_async():
-    """
+  """
     Installs the default elasticsearch version in a worker thread. Used by conftest.py to make
     sure elasticsearch is downloaded once the tests arrive here.
     """
-    if installed.is_set():
+  if installed.is_set():
+    return
+
+  def run_install(*args):
+    with INIT_LOCK:
+      if installed.is_set():
         return
+      LOG.info("installing elasticsearch default version")
+      elasticsearch_package.install()
+      LOG.info("done installing elasticsearch default version")
+      LOG.info("installing opensearch default version")
+      opensearch_package.install()
+      LOG.info("done installing opensearch default version")
+      installed.set()
 
-    def run_install(*args):
-        with INIT_LOCK:
-            if installed.is_set():
-                return
-            LOG.info("installing elasticsearch default version")
-            elasticsearch_package.install()
-            LOG.info("done installing elasticsearch default version")
-            LOG.info("installing opensearch default version")
-            opensearch_package.install()
-            LOG.info("done installing opensearch default version")
-            installed.set()
-
-    start_worker_thread(run_install)
+  start_worker_thread(run_install)
 
 
 @pytest.fixture(autouse=True)
 def elasticsearch():
-    if not installed.is_set():
-        install_async()
+  if not installed.is_set():
+    install_async()
 
-    assert installed.wait(timeout=5 * 60), "gave up waiting for elasticsearch to install"
-    yield
+  assert installed.wait(timeout=5 *
+                        60), "gave up waiting for elasticsearch to install"
+  yield
 
 
 def try_cluster_health(cluster_url: str):
-    response = requests.get(cluster_url)
-    assert response.ok, f"cluster endpoint returned an error: {response.text}"
+  response = requests.get(cluster_url)
+  assert response.ok, f"cluster endpoint returned an error: {response.text}"
 
-    response = requests.get(f"{cluster_url}/_cluster/health")
-    assert response.ok, f"cluster health endpoint returned an error: {response.text}"
-    assert response.json()["status"] in [
-        "orange",
-        "yellow",
-        "green",
-    ], "expected cluster state to be in a valid state"
+  response = requests.get(f"{cluster_url}/_cluster/health")
+  assert response.ok, f"cluster health endpoint returned an error: {response.text}"
+  assert response.json()["status"] in [
+      "orange",
+      "yellow",
+      "green",
+  ], "expected cluster state to be in a valid state"
 
 
 class TestElasticsearchProvider:
-    @markers.aws.unknown
-    def test_list_versions(self, aws_client):
-        response = aws_client.es.list_elasticsearch_versions()
 
-        assert "ElasticsearchVersions" in response
-        versions = response["ElasticsearchVersions"]
+  @markers.aws.unknown
+  def test_list_versions(self, aws_client):
+    response = aws_client.es.list_elasticsearch_versions()
 
-        assert "OpenSearch_1.0" in versions
-        assert "OpenSearch_1.1" in versions
-        assert "7.10" in versions
+    assert "ElasticsearchVersions" in response
+    versions = response["ElasticsearchVersions"]
 
-    @markers.aws.unknown
-    def test_get_compatible_versions(self, aws_client):
-        response = aws_client.es.get_compatible_elasticsearch_versions()
+    assert "OpenSearch_1.0" in versions
+    assert "OpenSearch_1.1" in versions
+    assert "7.10" in versions
 
-        assert "CompatibleElasticsearchVersions" in response
+  @markers.aws.unknown
+  def test_get_compatible_versions(self, aws_client):
+    response = aws_client.es.get_compatible_elasticsearch_versions()
 
-        versions = response["CompatibleElasticsearchVersions"]
+    assert "CompatibleElasticsearchVersions" in response
 
-        assert len(versions) == 23
+    versions = response["CompatibleElasticsearchVersions"]
 
-        assert {
-            "SourceVersion": "OpenSearch_1.0",
-            "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
-        } in versions
-        assert {
-            "SourceVersion": "7.10",
-            "TargetVersions": [
-                "OpenSearch_1.0",
-                "OpenSearch_1.1",
-                "OpenSearch_1.2",
-                "OpenSearch_1.3",
-            ],
-        } in versions
-        assert {
-            "SourceVersion": "7.7",
-            "TargetVersions": [
-                "7.8",
-                "7.9",
-                "7.10",
-                "OpenSearch_1.0",
-                "OpenSearch_1.1",
-                "OpenSearch_1.2",
-                "OpenSearch_1.3",
-            ],
-        } in versions
+    assert len(versions) == 24
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_get_compatible_version_for_domain(self, opensearch_domain, aws_client):
-        response = aws_client.es.get_compatible_elasticsearch_versions(DomainName=opensearch_domain)
-        assert "CompatibleElasticsearchVersions" in response
-        versions = response["CompatibleElasticsearchVersions"]
-        # The default version is 2.5 version (current latest is 2.7)
-        assert len(versions) == 1
+    assert {
+        "SourceVersion":
+            "OpenSearch_1.0",
+        "TargetVersions": [
+            "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"
+        ],
+    } in versions
+    assert {
+        "SourceVersion":
+            "7.10",
+        "TargetVersions": [
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    } in versions
+    assert {
+        "SourceVersion":
+            "7.7",
+        "TargetVersions": [
+            "7.8",
+            "7.9",
+            "7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    } in versions
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_create_domain(self, opensearch_create_domain, aws_client):
-        es_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-        response = aws_client.es.list_domain_names(EngineType="Elasticsearch")
-        domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
-        assert es_domain in domain_names
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_get_compatible_version_for_domain(self, opensearch_domain,
+                                             aws_client):
+    response = aws_client.es.get_compatible_elasticsearch_versions(
+        DomainName=opensearch_domain)
+    assert "CompatibleElasticsearchVersions" in response
+    versions = response["CompatibleElasticsearchVersions"]
+    # The default version is 2.5 version (current latest is 2.9)
+    assert len(versions) == 1
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_create_existing_domain_causes_exception(self, opensearch_create_domain, aws_client):
-        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_create_domain(self, opensearch_create_domain, aws_client):
+    es_domain = opensearch_create_domain(
+        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+    response = aws_client.es.list_domain_names(EngineType="Elasticsearch")
+    domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
+    assert es_domain in domain_names
 
-        with pytest.raises(botocore.exceptions.ClientError) as exc_info:
-            aws_client.es.create_elasticsearch_domain(DomainName=domain_name)
-        assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_create_existing_domain_causes_exception(self,
+                                                   opensearch_create_domain,
+                                                   aws_client):
+    domain_name = opensearch_create_domain(
+        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_describe_domains(self, opensearch_create_domain, aws_client):
-        opensearch_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-        response = aws_client.es.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
-        assert len(response["DomainStatusList"]) == 1
-        assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
+    with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+      aws_client.es.create_elasticsearch_domain(DomainName=domain_name)
+    assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_domain_version(self, opensearch_domain, opensearch_create_domain, aws_client):
-        response = aws_client.es.describe_elasticsearch_domain(DomainName=opensearch_domain)
-        assert "DomainStatus" in response
-        status = response["DomainStatus"]
-        assert "ElasticsearchVersion" in status
-        assert status["ElasticsearchVersion"] == OPENSEARCH_DEFAULT_VERSION
-        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-        response = aws_client.es.describe_elasticsearch_domain(DomainName=domain_name)
-        assert "DomainStatus" in response
-        status = response["DomainStatus"]
-        assert "ElasticsearchVersion" in status
-        assert status["ElasticsearchVersion"] == "7.10"
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_describe_domains(self, opensearch_create_domain, aws_client):
+    opensearch_domain = opensearch_create_domain(
+        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+    response = aws_client.es.describe_elasticsearch_domains(
+        DomainNames=[opensearch_domain])
+    assert len(response["DomainStatusList"]) == 1
+    assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
 
-    @markers.skip_offline
-    @markers.aws.unknown
-    def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain, aws_client):
-        monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
-        monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_domain_version(self, opensearch_domain, opensearch_create_domain,
+                          aws_client):
+    response = aws_client.es.describe_elasticsearch_domain(
+        DomainName=opensearch_domain)
+    assert "DomainStatus" in response
+    status = response["DomainStatus"]
+    assert "ElasticsearchVersion" in status
+    assert status["ElasticsearchVersion"] == OPENSEARCH_DEFAULT_VERSION
+    domain_name = opensearch_create_domain(
+        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+    response = aws_client.es.describe_elasticsearch_domain(
+        DomainName=domain_name)
+    assert "DomainStatus" in response
+    status = response["DomainStatus"]
+    assert "ElasticsearchVersion" in status
+    assert status["ElasticsearchVersion"] == "7.10"
 
-        domain_name = f"es-domain-{short_uid()}"
+  @markers.skip_offline
+  @markers.aws.unknown
+  def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain,
+                                  aws_client):
+    monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
+    monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
 
-        opensearch_create_domain(DomainName=domain_name)
-        status = aws_client.es.describe_elasticsearch_domain(DomainName=domain_name)["DomainStatus"]
+    domain_name = f"es-domain-{short_uid()}"
 
-        assert "Endpoint" in status
-        endpoint = status["Endpoint"]
-        assert endpoint.endswith(f"/{domain_name}")
+    opensearch_create_domain(DomainName=domain_name)
+    status = aws_client.es.describe_elasticsearch_domain(
+        DomainName=domain_name)["DomainStatus"]
 
-    @markers.aws.unknown
-    def test_update_domain_config(self, opensearch_domain, aws_client):
-        initial_response = aws_client.es.describe_elasticsearch_domain_config(
-            DomainName=opensearch_domain
-        )
-        update_response = aws_client.es.update_elasticsearch_domain_config(
-            DomainName=opensearch_domain,
-            ElasticsearchClusterConfig={"InstanceType": "r4.16xlarge.elasticsearch"},
-        )
-        final_response = aws_client.es.describe_elasticsearch_domain_config(
-            DomainName=opensearch_domain
-        )
+    assert "Endpoint" in status
+    endpoint = status["Endpoint"]
+    assert endpoint.endswith(f"/{domain_name}")
 
-        assert (
-            initial_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
-                "InstanceType"
-            ]
-            != update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
-                "InstanceType"
-            ]
-        )
-        assert (
-            update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"]["InstanceType"]
-            == "r4.16xlarge.elasticsearch"
-        )
-        assert (
-            update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"]["InstanceType"]
-            == final_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
-                "InstanceType"
-            ]
-        )
+  @markers.aws.unknown
+  def test_update_domain_config(self, opensearch_domain, aws_client):
+    initial_response = aws_client.es.describe_elasticsearch_domain_config(
+        DomainName=opensearch_domain)
+    update_response = aws_client.es.update_elasticsearch_domain_config(
+        DomainName=opensearch_domain,
+        ElasticsearchClusterConfig={
+            "InstanceType": "r4.16xlarge.elasticsearch"
+        },
+    )
+    final_response = aws_client.es.describe_elasticsearch_domain_config(
+        DomainName=opensearch_domain)
+
+    assert (initial_response["DomainConfig"]["ElasticsearchClusterConfig"]
+            ["Options"]["InstanceType"] != update_response["DomainConfig"]
+            ["ElasticsearchClusterConfig"]["Options"]["InstanceType"])
+    assert (update_response["DomainConfig"]["ElasticsearchClusterConfig"]
+            ["Options"]["InstanceType"] == "r4.16xlarge.elasticsearch")
+    assert (update_response["DomainConfig"]["ElasticsearchClusterConfig"]
+            ["Options"]["InstanceType"] == final_response["DomainConfig"]
+            ["ElasticsearchClusterConfig"]["Options"]["InstanceType"])

--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -14,10 +14,7 @@ from localstack.utils.common import short_uid, start_worker_thread
 LOG = logging.getLogger(__name__)
 
 # Common headers used when sending requests to OpenSearch
-COMMON_HEADERS = {
-    "content-type": "application/json",
-    "Accept-encoding": "identity"
-}
+COMMON_HEADERS = {"content-type": "application/json", "Accept-encoding": "identity"}
 
 # Lock and event to ensure that the installation is executed before the tests
 INIT_LOCK = threading.Lock()
@@ -25,201 +22,190 @@ installed = threading.Event()
 
 
 def install_async():
-  """
+    """
     Installs the default elasticsearch version in a worker thread. Used by conftest.py to make
     sure elasticsearch is downloaded once the tests arrive here.
     """
-  if installed.is_set():
-    return
-
-  def run_install(*args):
-    with INIT_LOCK:
-      if installed.is_set():
+    if installed.is_set():
         return
-      LOG.info("installing elasticsearch default version")
-      elasticsearch_package.install()
-      LOG.info("done installing elasticsearch default version")
-      LOG.info("installing opensearch default version")
-      opensearch_package.install()
-      LOG.info("done installing opensearch default version")
-      installed.set()
 
-  start_worker_thread(run_install)
+    def run_install(*args):
+        with INIT_LOCK:
+            if installed.is_set():
+                return
+            LOG.info("installing elasticsearch default version")
+            elasticsearch_package.install()
+            LOG.info("done installing elasticsearch default version")
+            LOG.info("installing opensearch default version")
+            opensearch_package.install()
+            LOG.info("done installing opensearch default version")
+            installed.set()
+
+    start_worker_thread(run_install)
 
 
 @pytest.fixture(autouse=True)
 def elasticsearch():
-  if not installed.is_set():
-    install_async()
+    if not installed.is_set():
+        install_async()
 
-  assert installed.wait(timeout=5 *
-                        60), "gave up waiting for elasticsearch to install"
-  yield
+    assert installed.wait(timeout=5 * 60), "gave up waiting for elasticsearch to install"
+    yield
 
 
 def try_cluster_health(cluster_url: str):
-  response = requests.get(cluster_url)
-  assert response.ok, f"cluster endpoint returned an error: {response.text}"
+    response = requests.get(cluster_url)
+    assert response.ok, f"cluster endpoint returned an error: {response.text}"
 
-  response = requests.get(f"{cluster_url}/_cluster/health")
-  assert response.ok, f"cluster health endpoint returned an error: {response.text}"
-  assert response.json()["status"] in [
-      "orange",
-      "yellow",
-      "green",
-  ], "expected cluster state to be in a valid state"
+    response = requests.get(f"{cluster_url}/_cluster/health")
+    assert response.ok, f"cluster health endpoint returned an error: {response.text}"
+    assert response.json()["status"] in [
+        "orange",
+        "yellow",
+        "green",
+    ], "expected cluster state to be in a valid state"
 
 
 class TestElasticsearchProvider:
+    @markers.aws.unknown
+    def test_list_versions(self, aws_client):
+        response = aws_client.es.list_elasticsearch_versions()
 
-  @markers.aws.unknown
-  def test_list_versions(self, aws_client):
-    response = aws_client.es.list_elasticsearch_versions()
+        assert "ElasticsearchVersions" in response
+        versions = response["ElasticsearchVersions"]
 
-    assert "ElasticsearchVersions" in response
-    versions = response["ElasticsearchVersions"]
+        assert "OpenSearch_1.0" in versions
+        assert "OpenSearch_1.1" in versions
+        assert "7.10" in versions
 
-    assert "OpenSearch_1.0" in versions
-    assert "OpenSearch_1.1" in versions
-    assert "7.10" in versions
+    @markers.aws.unknown
+    def test_get_compatible_versions(self, aws_client):
+        response = aws_client.es.get_compatible_elasticsearch_versions()
 
-  @markers.aws.unknown
-  def test_get_compatible_versions(self, aws_client):
-    response = aws_client.es.get_compatible_elasticsearch_versions()
+        assert "CompatibleElasticsearchVersions" in response
 
-    assert "CompatibleElasticsearchVersions" in response
+        versions = response["CompatibleElasticsearchVersions"]
 
-    versions = response["CompatibleElasticsearchVersions"]
+        assert len(versions) == 24
 
-    assert len(versions) == 24
+        assert {
+            "SourceVersion": "OpenSearch_1.0",
+            "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
+        } in versions
+        assert {
+            "SourceVersion": "7.10",
+            "TargetVersions": [
+                "OpenSearch_1.0",
+                "OpenSearch_1.1",
+                "OpenSearch_1.2",
+                "OpenSearch_1.3",
+            ],
+        } in versions
+        assert {
+            "SourceVersion": "7.7",
+            "TargetVersions": [
+                "7.8",
+                "7.9",
+                "7.10",
+                "OpenSearch_1.0",
+                "OpenSearch_1.1",
+                "OpenSearch_1.2",
+                "OpenSearch_1.3",
+            ],
+        } in versions
 
-    assert {
-        "SourceVersion":
-            "OpenSearch_1.0",
-        "TargetVersions": [
-            "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"
-        ],
-    } in versions
-    assert {
-        "SourceVersion":
-            "7.10",
-        "TargetVersions": [
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-            "OpenSearch_1.2",
-            "OpenSearch_1.3",
-        ],
-    } in versions
-    assert {
-        "SourceVersion":
-            "7.7",
-        "TargetVersions": [
-            "7.8",
-            "7.9",
-            "7.10",
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-            "OpenSearch_1.2",
-            "OpenSearch_1.3",
-        ],
-    } in versions
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_get_compatible_version_for_domain(self, opensearch_domain, aws_client):
+        response = aws_client.es.get_compatible_elasticsearch_versions(DomainName=opensearch_domain)
+        assert "CompatibleElasticsearchVersions" in response
+        versions = response["CompatibleElasticsearchVersions"]
+        # The default version is 2.5 version (current latest is 2.7)
+        assert len(versions) == 1
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_get_compatible_version_for_domain(self, opensearch_domain,
-                                             aws_client):
-    response = aws_client.es.get_compatible_elasticsearch_versions(
-        DomainName=opensearch_domain)
-    assert "CompatibleElasticsearchVersions" in response
-    versions = response["CompatibleElasticsearchVersions"]
-    # The default version is 2.5 version (current latest is 2.9)
-    assert len(versions) == 1
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_create_domain(self, opensearch_create_domain, aws_client):
+        es_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+        response = aws_client.es.list_domain_names(EngineType="Elasticsearch")
+        domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
+        assert es_domain in domain_names
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_create_domain(self, opensearch_create_domain, aws_client):
-    es_domain = opensearch_create_domain(
-        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-    response = aws_client.es.list_domain_names(EngineType="Elasticsearch")
-    domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
-    assert es_domain in domain_names
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_create_existing_domain_causes_exception(self, opensearch_create_domain, aws_client):
+        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_create_existing_domain_causes_exception(self,
-                                                   opensearch_create_domain,
-                                                   aws_client):
-    domain_name = opensearch_create_domain(
-        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+        with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+            aws_client.es.create_elasticsearch_domain(DomainName=domain_name)
+        assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
-    with pytest.raises(botocore.exceptions.ClientError) as exc_info:
-      aws_client.es.create_elasticsearch_domain(DomainName=domain_name)
-    assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_describe_domains(self, opensearch_create_domain, aws_client):
+        opensearch_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+        response = aws_client.es.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
+        assert len(response["DomainStatusList"]) == 1
+        assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_describe_domains(self, opensearch_create_domain, aws_client):
-    opensearch_domain = opensearch_create_domain(
-        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-    response = aws_client.es.describe_elasticsearch_domains(
-        DomainNames=[opensearch_domain])
-    assert len(response["DomainStatusList"]) == 1
-    assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_domain_version(self, opensearch_domain, opensearch_create_domain, aws_client):
+        response = aws_client.es.describe_elasticsearch_domain(DomainName=opensearch_domain)
+        assert "DomainStatus" in response
+        status = response["DomainStatus"]
+        assert "ElasticsearchVersion" in status
+        assert status["ElasticsearchVersion"] == OPENSEARCH_DEFAULT_VERSION
+        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
+        response = aws_client.es.describe_elasticsearch_domain(DomainName=domain_name)
+        assert "DomainStatus" in response
+        status = response["DomainStatus"]
+        assert "ElasticsearchVersion" in status
+        assert status["ElasticsearchVersion"] == "7.10"
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_domain_version(self, opensearch_domain, opensearch_create_domain,
-                          aws_client):
-    response = aws_client.es.describe_elasticsearch_domain(
-        DomainName=opensearch_domain)
-    assert "DomainStatus" in response
-    status = response["DomainStatus"]
-    assert "ElasticsearchVersion" in status
-    assert status["ElasticsearchVersion"] == OPENSEARCH_DEFAULT_VERSION
-    domain_name = opensearch_create_domain(
-        EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
-    response = aws_client.es.describe_elasticsearch_domain(
-        DomainName=domain_name)
-    assert "DomainStatus" in response
-    status = response["DomainStatus"]
-    assert "ElasticsearchVersion" in status
-    assert status["ElasticsearchVersion"] == "7.10"
+    @markers.skip_offline
+    @markers.aws.unknown
+    def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain, aws_client):
+        monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
+        monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
 
-  @markers.skip_offline
-  @markers.aws.unknown
-  def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain,
-                                  aws_client):
-    monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
-    monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
+        domain_name = f"es-domain-{short_uid()}"
 
-    domain_name = f"es-domain-{short_uid()}"
+        opensearch_create_domain(DomainName=domain_name)
+        status = aws_client.es.describe_elasticsearch_domain(DomainName=domain_name)["DomainStatus"]
 
-    opensearch_create_domain(DomainName=domain_name)
-    status = aws_client.es.describe_elasticsearch_domain(
-        DomainName=domain_name)["DomainStatus"]
+        assert "Endpoint" in status
+        endpoint = status["Endpoint"]
+        assert endpoint.endswith(f"/{domain_name}")
 
-    assert "Endpoint" in status
-    endpoint = status["Endpoint"]
-    assert endpoint.endswith(f"/{domain_name}")
+    @markers.aws.unknown
+    def test_update_domain_config(self, opensearch_domain, aws_client):
+        initial_response = aws_client.es.describe_elasticsearch_domain_config(
+            DomainName=opensearch_domain
+        )
+        update_response = aws_client.es.update_elasticsearch_domain_config(
+            DomainName=opensearch_domain,
+            ElasticsearchClusterConfig={"InstanceType": "r4.16xlarge.elasticsearch"},
+        )
+        final_response = aws_client.es.describe_elasticsearch_domain_config(
+            DomainName=opensearch_domain
+        )
 
-  @markers.aws.unknown
-  def test_update_domain_config(self, opensearch_domain, aws_client):
-    initial_response = aws_client.es.describe_elasticsearch_domain_config(
-        DomainName=opensearch_domain)
-    update_response = aws_client.es.update_elasticsearch_domain_config(
-        DomainName=opensearch_domain,
-        ElasticsearchClusterConfig={
-            "InstanceType": "r4.16xlarge.elasticsearch"
-        },
-    )
-    final_response = aws_client.es.describe_elasticsearch_domain_config(
-        DomainName=opensearch_domain)
-
-    assert (initial_response["DomainConfig"]["ElasticsearchClusterConfig"]
-            ["Options"]["InstanceType"] != update_response["DomainConfig"]
-            ["ElasticsearchClusterConfig"]["Options"]["InstanceType"])
-    assert (update_response["DomainConfig"]["ElasticsearchClusterConfig"]
-            ["Options"]["InstanceType"] == "r4.16xlarge.elasticsearch")
-    assert (update_response["DomainConfig"]["ElasticsearchClusterConfig"]
-            ["Options"]["InstanceType"] == final_response["DomainConfig"]
-            ["ElasticsearchClusterConfig"]["Options"]["InstanceType"])
+        assert (
+            initial_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
+                "InstanceType"
+            ]
+            != update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
+                "InstanceType"
+            ]
+        )
+        assert (
+            update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"]["InstanceType"]
+            == "r4.16xlarge.elasticsearch"
+        )
+        assert (
+            update_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"]["InstanceType"]
+            == final_response["DomainConfig"]["ElasticsearchClusterConfig"]["Options"][
+                "InstanceType"
+            ]
+        )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Resolves https://github.com/localstack/localstack/issues/9408

As far as I can tell, localstack pulls the latest OpenSearch docker images and more or less lets the cluster run as is. 2.9 has significant improvements compared to 2.5 -- most relevant to me, being able to run OpenSearch KNN queries with metadata filters. As far as I can tell, 2.9 is also backwards compatible with 2.5, so I figured a very straightforward version bump would be sufficient to get it running as a first pass.

<!-- What notable changes does this PR make? -->
## Changes
Just adds OpenSearch 2.9 as an accepted version.

I am basing this PR off the following:
https://github.com/localstack/localstack/commit/5f591c7b5569fc8bbcf31c379bda90013bcb4fc7 (which adds OS 2.5)
https://github.com/localstack/localstack/commit/e91ea756a7ee34cc4eb46d6c5d7c6105ea226924 (which adds OS 2.7)

Pulled what seemed like the relevant pieces in to bump version, but may have missed a test or an integration point. The default OpenSearch version is still set to 2.5.

## Testing

Tested this locally, `aws opensearch create-domain --domain-name example --engine-version OpenSearch_2.9 --endpoint-url http://localhost:4566` works as expected, as does `describe-domain` on the same endpoint.

## TODO

What's left to do:

- [ ] Update tests if there are any relevant tests
- [ ] Add other compatible versions in the same file
- [ ] ???

