### PR TITLE
fix SQS JSON leftovers

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1633,7 +1633,7 @@ class SqsResponseSerializer(JSONResponseSerializer):
     ) -> None:
         """
         Overrides _serialize_error as SQS has a special header for query API legacy reason: 'x-amzn-query-error',
-        which contatained the exception code as well as a Sender field.
+        which contained the exception code as well as a Sender field.
         Ex: 'x-amzn-query-error': 'InvalidParameterValue;Sender'
         """
         # TODO: for body["__type"] = error.code, it seems AWS differs from what we send for SQS

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -357,7 +357,7 @@ def determine_aws_service_name(request: Request, services: ServiceCatalog = None
                 if len(services_per_prefix) == 1:
                     return services_per_prefix[0]
                 candidates.update(services_per_prefix)
-        print(f"{candidates=}")
+
         custom_host_match = custom_host_addressing_rules(host)
         if custom_host_match:
             return custom_host_match

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -282,11 +282,16 @@ def sns():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-# TODO fix this ugly hack to reuse a single provider instance
 sqs_provider = None
 
 
 def get_sqs_provider():
+    """
+    Creates the SQS provider instance (and registers the query API routes) in a singleton fashion, such that the
+    same instance of the provider can be used by multiple services (i.e. the `sqs` as well as the `sqs-query` service).
+
+    TODO it would be great if we could find a better solution to use a single provider for multiple services
+    """
     global sqs_provider
 
     if not sqs_provider:

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -48,6 +48,7 @@ API_DEPENDENCIES = {
     "es": ["opensearch"],
     "lambda": ["s3", "sqs", "sts"],
     "firehose": ["kinesis"],
+    "sqs": ["sqs-query"],
 }
 # composites define an abstract name like "serverless" that maps to a set of services
 API_COMPOSITES = {

--- a/localstack/utils/coverage_docs.py
+++ b/localstack/utils/coverage_docs.py
@@ -10,7 +10,7 @@ def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
 
     available_services = SERVICE_PLUGINS.list_available()
 
-    # TODO remove this once the sqs-query API has been phased out
+    # TODO we could maybe find a better way of handling this service alias (or maybe we can phase it out at some point)
     if service_name == "sqs-query":
         service_name = "sqs"
 

--- a/tests/bootstrap/test_strict_service_loading.py
+++ b/tests/bootstrap/test_strict_service_loading.py
@@ -39,6 +39,7 @@ def test_strict_service_loading(
     assert services.pop("sqs") == "available"
     assert services.pop("s3") == "available"
     assert services.pop("sns") == "available"
+    assert services.pop("sqs-query") == "available"  # dependency of SQS
 
     assert services
     assert all(services.get(key) == "disabled" for key in services.keys())

--- a/tests/unit/aws/test_spec.py
+++ b/tests/unit/aws/test_spec.py
@@ -63,10 +63,7 @@ def test_patching_loaders():
 
 
 def test_loading_own_specs():
-    """
-    This test ensures that the Patching
-    :return:
-    """
+    """Ensure that the internalized specifications (f.e. the sqs-query spec) can be handled by the CustomLoader."""
     loader = CustomLoader({})
     # first test that specs remain intact
     sqs_query_description = loader.load_service_model("sqs-query", "service-2")

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -46,12 +46,12 @@ class TestGetPreloadedServices:
         assert result == set(SERVICE_PLUGINS.list_available())
 
     def test_with_service_subset(self):
-        with temporary_env({"SERVICES": "s3,sqs", "EAGER_SERVICE_LOADING": "1"}):
+        with temporary_env({"SERVICES": "s3,sns", "EAGER_SERVICE_LOADING": "1"}):
             result = get_preloaded_services()
 
         assert len(result) == 2
         assert "s3" in result
-        assert "sqs" in result
+        assert "sns" in result
 
     def test_custom_service_without_port(self):
         with temporary_env({"SERVICES": "foobar", "EAGER_SERVICE_LOADING": "1"}):
@@ -111,20 +111,20 @@ class TestGetEnabledApis:
         assert result == set(SERVICE_PLUGINS.list_available())
 
     def test_strict_service_loading_enabled_by_default(self):
-        with temporary_env({"SERVICES": "s3,sqs"}):
+        with temporary_env({"SERVICES": "s3,sns"}):
             result = get_enabled_apis()
 
         assert len(result) == 2
         assert "s3" in result
-        assert "sqs" in result
+        assert "sns" in result
 
     def test_with_service_subset(self):
-        with temporary_env({"SERVICES": "s3,sqs", "STRICT_SERVICE_LOADING": "1"}):
+        with temporary_env({"SERVICES": "s3,sns", "STRICT_SERVICE_LOADING": "1"}):
             result = get_enabled_apis()
 
         assert len(result) == 2
         assert "s3" in result
-        assert "sqs" in result
+        assert "sns" in result
 
     def test_custom_service_not_supported(self):
         with temporary_env({"SERVICES": "foobar", "STRICT_SERVICE_LOADING": "1"}):
@@ -156,7 +156,7 @@ class TestGetEnabledApis:
         with temporary_env({"SERVICES": "es,lambda", "STRICT_SERVICE_LOADING": "1"}):
             result = get_enabled_apis()
 
-        assert len(result) == 6
+        assert len(result) == 7
         assert result == {
             # directly given
             "lambda",
@@ -167,6 +167,8 @@ class TestGetEnabledApis:
             "s3",
             "sqs",
             "sts",
+            # secondary dependency from sqs, which is a dependency from lambda
+            "sqs-query",
         }
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
To quickly merge the changes, the PR comments of #8268 had not been addressed yet. This PR does the second iteration.

<!-- What notable changes does this PR make? -->
## Changes
- remove a debug print statement and fix a typo
- add a comment regarding the conflict resolution between `sqs` and `sqs-query` service names, might need to create a specific step in the service name parser resolution if more services start to migrate to the `json` protocol, based on `Content-Type` header?
- add `sqs-query` as a dependency of SQS in the API dependencies for `SERVICES`, so that we enable both in case `sqs` is enabled. 

## TODO

What's left to do:

- [ ] keep an eye on https://github.com/boto/botocore/commit/50861b96f9d51632d6ddd8bafac8d50f4e8b027a, which will be in release  >1.31.84 (not yet released then), which explains this change in the previous PR:
  ```diff
  -        with pytest.raises(aws_client.sqs.exceptions.QueueNameExists):
  +        with pytest.raises(ClientError) as e:
  ```
  (I don't think it would change anything in snapshot but we can verify then)

