### PR TITLE
fix S3 pre-signed logic for IGNORED_SIGV4_HEADERS

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -565,11 +565,10 @@ class S3SigV4SignatureContext:
         not_signed_headers = []
         for header, value in headers.items():
             header_low = header.lower()
-            if header_low.startswith("x-amz-"):
-                if header_low not in signed_headers.lower():
-                    if header_low in IGNORED_SIGV4_HEADERS:
-                        continue
-                    not_signed_headers.append(header_low)
+            if header_low.startswith("x-amz-") and header_low not in signed_headers.lower():
+                if header_low in IGNORED_SIGV4_HEADERS:
+                    continue
+                not_signed_headers.append(header_low)
             if header_low in signed_headers:
                 signature_headers[header_low] = value
 

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -64,20 +64,7 @@ SIGNATURE_V4_POST_FIELDS = [
 # headers to blacklist from request_dict.signed_headers
 BLACKLISTED_HEADERS = ["X-Amz-Security-Token"]
 
-# query params overrides for multipart upload and node sdk
-# TODO: this will depends on query/post v2/v4. Manage independently
-ALLOWED_QUERY_PARAMS = [
-    "x-id",
-    "x-amz-user-agent",
-    "x-amz-content-sha256",
-    "versionid",
-    "uploadid",
-    "partnumber",
-]
-
 IGNORED_SIGV4_HEADERS = [
-    "x-id",
-    "x-amz-user-agent",
     "x-amz-content-sha256",
 ]
 

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -579,9 +579,9 @@ class S3SigV4SignatureContext:
         for header, value in headers.items():
             header_low = header.lower()
             if header_low.startswith("x-amz-"):
-                if header_low in IGNORED_SIGV4_HEADERS:
-                    continue
                 if header_low not in signed_headers.lower():
+                    if header_low in IGNORED_SIGV4_HEADERS:
+                        continue
                     not_signed_headers.append(header_low)
             if header_low in signed_headers:
                 signature_headers[header_low] = value

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -6583,8 +6583,9 @@ class TestS3PresignedUrl:
         def add_content_sha_header(request, **kwargs):
             request.headers["x-amz-content-sha256"] = "UNSIGNED-PAYLOAD"
 
-        presigned_client.meta.events.register(
-            "before-sign.s3.PutObject", add_content_sha_header, unique_id="1"
+        presigned_client.meta.events.register_last(
+            "before-sign.s3.PutObject",
+            add_content_sha_header,
         )
         try:
             url = presigned_client.generate_presigned_url(
@@ -6606,7 +6607,8 @@ class TestS3PresignedUrl:
 
         finally:
             presigned_client.meta.events.unregister(
-                "before-sign.s3.PutObject", add_content_sha_header, unique_id="1"
+                "before-sign.s3.PutObject",
+                add_content_sha_header,
             )
 
         # recreate the request, without the signed header

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -6573,12 +6573,9 @@ class TestS3PresignedUrl:
     def test_s3_ignored_special_headers(
         self,
         s3_bucket,
-        snapshot,
         patch_s3_skip_signature_validation_false,
         monkeypatch,
     ):
-        snapshot.add_transformer(snapshot.transform.s3_api())
-
         # if the crt.auth is not available, not need to patch as it will use it by default
         if find_spec("botocore.crt.auth"):
             # the CRT client does not allow us to pass a protected header, it will trigger an exception, so we need


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following up on #9603, I've quickly investigated the issue for the pre-signed URL message showing a non valid signature for a very simple request and quickly found the issue related to signed headers being in the ignore list.

<!-- What notable changes does this PR make? -->
## Changes
- fix the logic when ignoring SigV4 headers, we should still include them if they're in the `SignedHeaders`, and only ignore if they're missing
- add a test validating this behavior and copying the Go SDK behavior with the help of registering handlers. This was extremely tricky to force boto to behave this way, as the AWS CRT library does not allow you to do so. The Go SDK seems a bit weird, but it allowed us to verify the behavior of previously thought "ignored" headers.

