### PR TITLE
Remove legacy internal call detection helper

### DIFF
--- a/localstack/aws/handlers/analytics.py
+++ b/localstack/aws/handlers/analytics.py
@@ -11,7 +11,6 @@ from localstack.utils.analytics.service_request_aggregator import (
     ServiceRequestAggregator,
     ServiceRequestInfo,
 )
-from localstack.utils.aws.aws_stack import is_internal_call_context
 
 LOG = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class ServiceRequestCounter:
             return
         if config.DISABLE_EVENTS:
             return
-        if is_internal_call_context(context.request.headers):
+        if context.is_internal_call:
             # don't count internal requests
             return
 

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -9,7 +9,6 @@ from localstack.http import Response
 from localstack.http.request import restore_payload
 from localstack.logging.format import AwsTraceLoggingFormatter, TraceLoggingFormatter
 from localstack.logging.setup import create_default_handler
-from localstack.utils.aws.aws_stack import is_internal_call_context
 
 LOG = logging.getLogger(__name__)
 
@@ -82,10 +81,7 @@ class ResponseLogger:
     def _log(self, context: RequestContext, response: Response):
         aws_logger = self.aws_logger
         http_logger = self.http_logger
-        is_internal_call = (
-            is_internal_call_context(context.request.headers) or context.is_internal_call
-        )
-        if is_internal_call:
+        if context.is_internal_call:
             aws_logger = self.internal_aws_logger
             http_logger = self.internal_http_logger
         if context.operation:

--- a/localstack/aws/handlers/metric_handler.py
+++ b/localstack/aws/handlers/metric_handler.py
@@ -5,7 +5,6 @@ from localstack import config
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.http import Response
-from localstack.utils.aws.aws_stack import is_internal_call_context
 
 LOG = logging.getLogger(__name__)
 
@@ -175,7 +174,6 @@ class MetricHandler:
         if not config.is_collect_metrics_mode() or not context.service_operation:
             return
 
-        is_internal = is_internal_call_context(context.request.headers)
         item = self._get_metric_handler_item_for_context(context)
 
         # parameters might get changed when dispatched to the service - we use the params stored in
@@ -193,7 +191,7 @@ class MetricHandler:
             exception=context.service_exception.__class__.__name__
             if context.service_exception
             else "",
-            origin="internal" if is_internal else "external",
+            origin="internal" if context.is_internal_call else "external",
         )
         # refrain from adding duplicates
         if metric not in MetricHandler.metric_data:

--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -13,7 +13,6 @@ from localstack.http import Response
 from localstack.http.proxy import forward
 from localstack.http.request import Request, get_full_raw_path, get_raw_path, restore_payload
 from localstack.utils.aws.aws_responses import calculate_crc32
-from localstack.utils.aws.aws_stack import is_internal_call_context
 from localstack.utils.aws.request_context import extract_region_from_headers
 from localstack.utils.run import to_str
 from localstack.utils.strings import to_bytes
@@ -88,9 +87,7 @@ class ArnPartitionRewriteHandler(Handler):
         # get arn rewriting mode from header
         # not yet used but would allow manual override (e.g. for testing)
         rewrite_mode = request.headers.pop("LS-INTERNAL-REWRITE-MODE", None)
-        if rewrite_mode is None and (
-            context.is_internal_call or is_internal_call_context(request.headers)
-        ):
+        if rewrite_mode is None and context.is_internal_call:
             # default internal mode
             rewrite_mode = "internal-guard"
         else:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -18,7 +18,6 @@ from localstack.constants import (
     AWS_REGION_US_EAST_1,
     ENV_DEV,
     HEADER_LOCALSTACK_ACCOUNT_ID,
-    INTERNAL_AWS_ACCESS_KEY_ID,
     LOCALHOST,
     REGION_LOCAL,
 )
@@ -161,20 +160,6 @@ def get_local_region():
 def get_boto3_region() -> str:
     """Return the region name, as determined from the environment when creating a new boto3 session"""
     return boto3.session.Session().region_name
-
-
-# TODO: remove this and use the `is_internal_call` property of RequestContext
-def is_internal_call_context(headers) -> bool:
-    """Return whether we are executing in the context of an internal API call, i.e.,
-    the case where one API uses a boto3 client to call another API internally."""
-    if HEADER_LOCALSTACK_ACCOUNT_ID in headers.keys():
-        # TODO: Used by the old client, marked for removal
-        return True
-
-    if INTERNAL_AWS_ACCESS_KEY_ID in headers.get("Authorization", ""):
-        return True
-
-    return False
 
 
 def get_local_service_url(service_name_or_port: Union[str, int]) -> str:


### PR DESCRIPTION
## Motivation

LocalStack now uses the `RequestContext.is_internal_call` attribute to indicate internal cross-service calls.

## Implementation

This PR removes the use of legacy helper which relies on `HEADER_LOCALSTACK_ACCOUNT_ID` header which itself is a vestige of the old `aws_stack.connect_to_service()` utility. 

The old client was removed in https://github.com/localstack/localstack/pull/9343, and this is not a breaking change.