### PR TITLE
fix change_message_visibility behaviour for expired handles

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -14,7 +14,6 @@ from localstack.aws.api import RequestContext
 from localstack.aws.api.sqs import (
     InvalidAttributeName,
     Message,
-    MessageNotInflight,
     QueueAttributeMap,
     QueueAttributeName,
     ReceiptHandleIsInvalid,
@@ -366,7 +365,7 @@ class SqsQueue:
             standard_message = self.receipts[receipt_handle]
 
             if standard_message not in self.inflight:
-                raise MessageNotInflight()
+                return
 
             standard_message.update_visibility_timeout(visibility_timeout)
 

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -1335,5 +1335,16 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_after_visibility_timeout_expiration": {
+    "recorded-date": "14-11-2023, 17:51:55",
+    "recorded-content": {
+      "visibility_timeout_expired": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Customer reported an error when changing message visibility. This most likely comes from a discrepancy between AWS and us when calling `change_message_visibility`. 
Fixes #9598 

<!-- What notable changes does this PR make? -->
## Changes
- fix behaviour when calling  `change_message_visibility` on an already expired handle, where AWS simply sends back an OK and does nothing while we returned an error.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

