### PR TITLE
fix SQS json requests sent to query route

### DIFF
--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -138,7 +138,7 @@ def handle_request(request: Request, region: str) -> Response:
     # some SDK (PHP) still send requests to the Queue URL even though the JSON spec does not allow it in the
     # documentation. If the request is `json`, raise `NotFound` so that we continue the handler chain and the provider
     # can handle the request
-    if request.headers.get("Content-Type").lower() == "application/x-amz-json-1.0":
+    if request.headers.get("Content-Type", "").lower() == "application/x-amz-json-1.0":
         raise NotFound
 
     request_id = long_uid()

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -1323,5 +1323,17 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsQueryApi::test_send_message_via_queue_url_with_json_protocol": {
+    "recorded-date": "14-11-2023, 21:27:28",
+    "recorded-content": {
+      "receive-json-on-queue-url": {
+        "Messages": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in https://github.com/localstack/localstack/issues/8267#issuecomment-1810805915, it seems the [PHP SDK](https://github.com/aws/aws-sdk-php) still struggles to communicate with LocalStack.

After investigation, it showed that the PHP SDK is still sending the requests to the queue URL even though the specs are specifying that it should be against `/`. Our router caught the request and assumed it was a Query API. 

<!-- What notable changes does this PR make? -->
## Changes
- if the `Content-Type` header is `application/x-amz-json-1.0`, raise `NotFound` in the route so that the handler chain can take of the request
- add a test testing this very weird behavior by creating a client with an endpoint set to the queue URL (tested against AWS, it weirdly works...)

Tested with a PHP sample, it solves the issue now



## Testing

To test the changes with the PHP SDK:
- `docker pull php`
- `docker run --rm -it php bash`
- `curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer`
- `apt update`
- `apt install zip`
- `cd /usr/src` & `mkdir app` & `cd app`
- `composer require aws/aws-sdk-php`
- set this in the file `test.php`: 
```php
<?php
// Require the Composer autoloader.
require 'vendor/autoload.php';

use Aws\Sqs\SqsClient;

$sqs = new SqsClient([
    'version' => 'latest',
    'region'  => 'us-west-2'
]);

$params = [
    'DelaySeconds' => 10,
    'MessageAttributes' => [
        "Title" => [
            'DataType' => "String",
            'StringValue' => "The Hitchhiker's Guide to the Galaxy"
        ]
    ],
    'MessageBody' => "Information about current NY Times fiction bestseller for week of 12/11/2016.",
    'QueueUrl' => 'http://host.docker.internal:4566/queue/us-east-1/000000000000/test'
];

$result = $sqs->sendMessage($params);
var_dump($result);
```
- `export AWS_ACCESS_KEY_ID=test`
- `export AWS_SECRET_ACCESS_KEY=test`
- `php test.php`
- run, it should now properly show the result and not an exception

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

