### PR TITLE
fix: allow CopySourceRange to be empty on s3.upload_part_copy

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from operator import itemgetter
 from secrets import token_urlsafe
-from typing import IO, Union
+from typing import IO, Optional, Union
 from urllib import parse as urlparse
 
 from localstack import config
@@ -1965,7 +1965,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         source_range = request.get("CopySourceRange")
         # TODO implement copy source IF (done in ASF provider)
 
-        range_data: Union[ObjectRange, None] = None
+        range_data: Optional[ObjectRange] = None
         if source_range:
             range_data = parse_copy_source_range_header(source_range, src_s3_object.size)
 

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1964,7 +1964,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         source_range = request.get("CopySourceRange")
         # TODO implement copy source IF (done in ASF provider)
-        range_data = parse_copy_source_range_header(source_range, src_s3_object.size)
+
+        range_data: Union[ObjectRange, None] = None
+        if source_range:
+            range_data = parse_copy_source_range_header(source_range, src_s3_object.size)
 
         s3_part = S3Part(part_number=part_number)
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -149,7 +149,7 @@ class S3StoredMultipart(abc.ABC):
         s3_part: S3Part,
         src_bucket: BucketName,
         src_s3_object: S3Object,
-        range_data: Union[ObjectRange, None],
+        range_data: Optional[ObjectRange],
     ) -> None:
         pass
 

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -1,6 +1,6 @@
 import abc
 from io import RawIOBase
-from typing import IO, Iterable, Iterator, Optional, Union
+from typing import IO, Iterable, Iterator, Optional
 
 from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
 from localstack.services.s3.utils import ObjectRange

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -1,6 +1,6 @@
 import abc
 from io import RawIOBase
-from typing import IO, Iterable, Iterator, Optional
+from typing import IO, Iterable, Iterator, Optional, Union
 
 from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
 from localstack.services.s3.utils import ObjectRange
@@ -149,7 +149,7 @@ class S3StoredMultipart(abc.ABC):
         s3_part: S3Part,
         src_bucket: BucketName,
         src_s3_object: S3Object,
-        range_data: ObjectRange,
+        range_data: Union[ObjectRange, None],
     ) -> None:
         pass
 

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from shutil import rmtree
 from tempfile import SpooledTemporaryFile, mkdtemp
 from threading import RLock
-from typing import IO, Iterator, Optional, TypedDict, Union
+from typing import IO, Iterator, Optional, TypedDict
 
 from readerwriterlock import rwlock
 
@@ -290,7 +290,7 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         s3_part: S3Part,
         src_bucket: BucketName,
         src_s3_object: S3Object,
-        range_data: Union[ObjectRange, None],
+        range_data: Optional[ObjectRange],
     ) -> None:
         """
         Create and add an EphemeralS3StoredObject to the Multipart collection, with an S3Object as input. This will

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -631,7 +631,10 @@ class TestS3Multipart:
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto does not handle the exceptions properly",
     )
-    @markers.snapshot.skip_snapshot_verify(paths=["$..PartNumberMarker"])  # TODO: invetigate this
+    @markers.snapshot.skip_snapshot_verify(
+        # Not always present depending on the region
+        paths=["$..Owner.DisplayName"],
+    )
     def test_upload_part_copy_no_copy_source_range(self, aws_client, s3_bucket, snapshot):
         """
         upload_part_copy should not require CopySourceRange to be populated

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -624,7 +624,7 @@ class TestS3Multipart:
                 )
             snapshot.match(f"upload-part-copy-range-exc-{src_range}", e.value.response)
 
-    @markers.aws.validated()
+    @markers.aws.validated
     @pytest.mark.xfail(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto does not handle the exceptions properly",

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -536,6 +536,7 @@ class TestS3ObjectCRUD:
             aws_client.s3.get_object(Bucket=s3_bucket, Key=key, Range="bytes=100-200")
         snapshot.match("get-100-200", e.value.response)
 
+
 @markers.snapshot.skip_snapshot_verify(
     condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
 )
@@ -627,10 +628,6 @@ class TestS3Multipart:
             snapshot.match(f"upload-part-copy-range-exc-{src_range}", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
-        condition=config.LEGACY_V2_S3_PROVIDER,
-        reason="Moto does not handle the exceptions properly",
-    )
     @markers.snapshot.skip_snapshot_verify(
         # Not always present depending on the region
         paths=["$..Owner.DisplayName"],

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -536,7 +536,9 @@ class TestS3ObjectCRUD:
             aws_client.s3.get_object(Bucket=s3_bucket, Key=key, Range="bytes=100-200")
         snapshot.match("get-100-200", e.value.response)
 
-
+@markers.snapshot.skip_snapshot_verify(
+    condition=is_legacy_v2_provider, paths=["$..ServerSideEncryption"]
+)
 class TestS3Multipart:
     # TODO: write a validated test for UploadPartCopy preconditions
 

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -3194,5 +3194,68 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
+    "recorded-date": "14-11-2023, 20:50:28",
+    "recorded-content": {
+      "put-src-object": {
+        "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "test-upload-part-copy",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy": {
+        "CopyPartResult": {
+          "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "test-upload-part-copy",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"781e5e245d69b566979b86e28d23f2c7\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation

s3 multipart copy_from fails when CopySourceRange header not specified with V3 s3 provider

fails with exception 

>   File "/opt/code/localstack/localstack/services/s3/v3/provider.py", line 1967, in upload_part_copy
>     range_data = parse_copy_source_range_header(source_range, src_s3_object.size)
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/code/localstack/localstack/services/s3/utils.py", line 258, in parse_copy_source_range_header
>     _, rspec = copy_source_range.split("=")
>                ^^^^^^^^^^^^^^^^^^^^^^^
> AttributeError: 'NoneType' object has no attribute 'split'

https://github.com/localstack/localstack/issues/9519


![image](https://github.com/localstack/localstack/assets/449892/0dc2f1e4-5dde-4fed-a87e-006fc0b3156f)

not a REQUIRED parameter in current docs https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/multipartuploadpart/copy_from.html


## Changes

* allow ObjectRange to be None in S3StoredMultipart.copy_from_object
* do not attempt to parse empty or missing CopySourceRange
* new snapshot test added `tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range`


## Testing


```python
create_multipart = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=key)
upload_id = create_multipart["UploadId"]
copy_source_key = f"{s3_bucket}/{src_key}"
parts = []
upload_part_copy = aws_client.s3.upload_part_copy(
            Bucket=s3_bucket,
            UploadId=upload_id,
            Key=key,
            PartNumber=1,
            CopySource=copy_source_key
)
```

## TODO
Merge :)


