### PR TITLE
Remove edge port config

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -594,7 +594,7 @@ class UniqueHostAndPortList(List[HostAndPort]):
 
 def populate_edge_configuration(
     environment: Mapping[str, str]
-) -> Tuple[HostAndPort, UniqueHostAndPortList, int]:
+) -> Tuple[HostAndPort, UniqueHostAndPortList]:
     """Populate the LocalStack edge configuration from environment variables."""
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
     gateway_listen_raw = environment.get("GATEWAY_LISTEN")
@@ -629,13 +629,9 @@ def populate_edge_configuration(
     assert gateway_listen is not None
     assert localstack_host is not None
 
-    # derive legacy variables from GATEWAY_LISTEN
-    edge_port = gateway_listen[0].port
-
     return (
         localstack_host,
         UniqueHostAndPortList(gateway_listen),
-        edge_port,
     )
 
 
@@ -647,8 +643,6 @@ def populate_edge_configuration(
     # Main configuration of the listen address of the hypercorn proxy. Of the form
     # <ip_address>:<port>(,<ip_address>:port>)*
     GATEWAY_LISTEN,
-    # -- Legacy variables
-    EDGE_PORT,
 ) = populate_edge_configuration(os.environ)
 
 # IP of the docker bridge used to enable access between containers

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -359,7 +359,7 @@ def validate_localstack_config(name: str):
     docker_env = dict(
         (env.split("=")[0], env.split("=")[1]) for env in ls_service_details.get("environment", {})
     )
-    edge_port = str(docker_env.get("EDGE_PORT") or config.GATEWAY_LISTEN[0].port)
+    edge_port = config.GATEWAY_LISTEN[0].port
     main_container = config.MAIN_CONTAINER_NAME
 
     # docker-compose file validation cases

--- a/tests/integration/utils/test_diagnose.py
+++ b/tests/integration/utils/test_diagnose.py
@@ -10,7 +10,6 @@ def test_diagnose_resource():
 
     assert "/tmp" in result["file-tree"]
     assert "/var/lib/localstack" in result["file-tree"]
-    assert result["config"]["EDGE_PORT"] == config.EDGE_PORT
     assert result["config"]["DATA_DIR"] == config.DATA_DIR
     assert result["config"]["GATEWAY_LISTEN"] == [config.HostAndPort("0.0.0.0", 4566)]
     assert result["important-endpoints"]["localhost.localstack.cloud"].startswith("127.0.")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -138,30 +138,26 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             actual_ls_host,
             actual_gateway_listen,
-            actual_edge_port,
         ) = config.populate_edge_configuration(environment)
 
         assert actual_ls_host == expected_localstack_host
         assert actual_gateway_listen == expected_gateway_listen
-        assert actual_edge_port == expected_edge_port
 
     def test_gateway_listen_multiple_addresses(self):
         environment = {"GATEWAY_LISTEN": "0.0.0.0:9999,0.0.0.0:443"}
         (
             _,
             gateway_listen,
-            edge_port,
         ) = config.populate_edge_configuration(environment)
 
         assert gateway_listen == [
             HostAndPort(host="0.0.0.0", port=9999),
             HostAndPort(host="0.0.0.0", port=443),
         ]
-        # take the first value
-        assert edge_port == 9999
 
     def test_legacy_variables_ignored_if_given(self):
-        """Providing legacy variables removed in 3.0 should not affect the default configuration"""
+        """Providing legacy variables removed in 3.0 should not affect the default configuration.
+        This test can be removed around >3.1-4.0."""
         environment = {
             "EDGE_BIND_HOST": "192.168.0.1",
             "EDGE_PORT": "10101",
@@ -170,14 +166,12 @@ class TestEdgeVariablesDerivedCorrectly:
         (
             localstack_host,
             gateway_listen,
-            edge_port,
         ) = config.populate_edge_configuration(environment)
 
         assert localstack_host == "localhost.localstack.cloud:4566"
         assert gateway_listen == [
             HostAndPort(host=ip(), port=4566),
         ]
-        assert edge_port == 4566
 
 
 class TestUniquePortList:


### PR DESCRIPTION
Depends on https://github.com/localstack/localstack/pull/9633

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We initially discussed about keeping internal read-access of `EDGE_PORT` as an alias for `GATEWAY_LISTEN[0].port`. Partly because it was used all over the place. However, after finally removing its usages in https://github.com/localstack/localstack/pull/9633, @simonrw suggested removing `EDGE_PORT` altogether with 3.0. Keeping `EDGE_PORT` would risk legacy usages leading to several networking consistency issues, especially when returning URLs manually.

<!-- What notable changes does this PR make? -->
## Changes

* Remove the deprecated internal read-access to `config.EDGE_PORT` and all remaining (test) usages.

Read-access to the provided environment variable `EDGE_PORT` in compute services such as Lambda, EMR, Batch, ECS, etc will remain supported in LocalStack 3.0. Our [networking migration guide](https://discuss.localstack.cloud/t/networking-migration-guide-for-localstack-3-0/588#access-environment-variables-in-compute-services-3) introduces the deprecation path.

## TODO

What's left to do:

- [x] Remove commits from https://github.com/localstack/localstack/pull/9633 after merging

## Impact Analysis

I didn't find any usages in the public extensions:

* https://github.com/localstack/localstack-extensions
* Authress Extension: https://github.com/Authress/localstack-extension

These extensions use other helper utils that we deprecated, hence providing a deprecation path.

I skimmed over several code searches using `gh search` (2023-11-15):
* `gh search code "EDGE_PORT"` (124 results but valid occurrences and other Lambda read-only access will remain supported; I will migrate the remaining samples this week)
* `gh search code "import EDGE_PORT" --language python` (5 usages, mostly localstack forks)
* `gh search code "config.EDGE_PORT" --language python --limit 1000` (105 usages; skimmed over, mostly from not yet merged localstack or forks)

## Discussion

❓ Do you know any other implicit usages of `config.EDGE_PORT`?