### PR TITLE
SQS: Rework is_sqs_queue_url() utility

### DIFF
--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -32,9 +32,9 @@ INTERNAL_QUEUE_ATTRIBUTES = [
 ]
 
 # URL regexes for various endpoint strategies
-STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-DOMAIN_STRATEGY_URL_REGEX = r"((?P<region_name>[a-z0-9-]{1,}).)?queue.localhost.localstack.cloud:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-PATH_STRATEGY_URL_REGEX = r"localhost:\d{4,5}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,})\.[^:]+:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+DOMAIN_STRATEGY_URL_REGEX = r"((?P<region_name>[a-z0-9-]{1,})\.)?queue\.[^:]+:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+PATH_STRATEGY_URL_REGEX = r"[^:]+:\d{4,5}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 LEGACY_STRATEGY_URL_REGEX = (
-    r"localhost:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+    r"[^:]+:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 )

--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -32,9 +32,9 @@ INTERNAL_QUEUE_ATTRIBUTES = [
 ]
 
 # URL regexes for various endpoint strategies
-STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-DOMAIN_STRATEGY_URL_REGEX = r"(?P<region_name>[a-z0-9-]{1,}).queue.localhost.localstack.cloud:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+DOMAIN_STRATEGY_URL_REGEX = r"(?P<region_name>[a-z0-9-]{1,}).queue.localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,}\/queue\/(?P<region_name>[a-z0-9-]{1,5})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 LEGACY_STRATEGY_URL_REGEX = (
-    r"localhost:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+    r"localhost:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 )

--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -30,3 +30,11 @@ INTERNAL_QUEUE_ATTRIBUTES = [
     QueueAttributeName.LastModifiedTimestamp,
     QueueAttributeName.QueueArn,
 ]
+
+# URL regexes for various endpoint strategies
+STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+DOMAIN_STRATEGY_URL_REGEX = r"(?P<region_name>[a-z0-9-]{1,}).queue.localhost.localstack.cloud:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+LEGACY_STRATEGY_URL_REGEX = (
+    r"localhost:\d{1,}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+)

--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -32,9 +32,9 @@ INTERNAL_QUEUE_ATTRIBUTES = [
 ]
 
 # URL regexes for various endpoint strategies
-STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-DOMAIN_STRATEGY_URL_REGEX = r"((?P<region_name>[a-z0-9-]{1,}).)?queue.localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,5}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+DOMAIN_STRATEGY_URL_REGEX = r"((?P<region_name>[a-z0-9-]{1,}).)?queue.localhost.localstack.cloud:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+PATH_STRATEGY_URL_REGEX = r"localhost:\d{4,5}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 LEGACY_STRATEGY_URL_REGEX = (
-    r"localhost:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+    r"localhost:\d{4,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 )

--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -33,8 +33,8 @@ INTERNAL_QUEUE_ATTRIBUTES = [
 
 # URL regexes for various endpoint strategies
 STANDARD_STRATEGY_URL_REGEX = r"sqs.(?P<region_name>[a-z0-9-]{1,}).localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-DOMAIN_STRATEGY_URL_REGEX = r"(?P<region_name>[a-z0-9-]{1,}).queue.localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
-PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,}\/queue\/(?P<region_name>[a-z0-9-]{1,5})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+DOMAIN_STRATEGY_URL_REGEX = r"((?P<region_name>[a-z0-9-]{1,}).)?queue.localhost.localstack.cloud:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
+PATH_STRATEGY_URL_REGEX = r"localhost:\d{1,5}\/queue\/(?P<region_name>[a-z0-9-]{1,})\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 LEGACY_STRATEGY_URL_REGEX = (
     r"localhost:\d{1,5}\/(?P<account_id>\d{12})\/(?P<queue_name>[a-zA-Z0-9_-]+(.fifo)?)$"
 )

--- a/localstack/services/sqs/utils.py
+++ b/localstack/services/sqs/utils.py
@@ -20,14 +20,19 @@ from localstack.utils.common import clone
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid
 
+STANDARD_ENDPOINT = re.compile(STANDARD_STRATEGY_URL_REGEX)
+DOMAIN_ENDPOINT = re.compile(DOMAIN_STRATEGY_URL_REGEX)
+PATH_ENDPOINT = re.compile(PATH_STRATEGY_URL_REGEX)
+LEGACY_ENDPOINT = re.compile(LEGACY_STRATEGY_URL_REGEX)
+
 
 def is_sqs_queue_url(url: str) -> bool:
     return any(
         [
-            re.search(STANDARD_STRATEGY_URL_REGEX, url),
-            re.search(DOMAIN_STRATEGY_URL_REGEX, url),
-            re.search(PATH_STRATEGY_URL_REGEX, url),
-            re.search(LEGACY_STRATEGY_URL_REGEX, url),
+            STANDARD_ENDPOINT.search(url),
+            DOMAIN_ENDPOINT.search(url),
+            PATH_ENDPOINT.search(url),
+            LEGACY_ENDPOINT.search(url),
         ]
     )
 

--- a/localstack/services/sqs/utils.py
+++ b/localstack/services/sqs/utils.py
@@ -8,18 +8,28 @@ from urllib.parse import urlparse
 from moto.sqs.exceptions import MessageAttributesInvalid
 from moto.sqs.models import TRANSPORT_TYPE_ENCODINGS, Message
 
-from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.sqs import QueueAttributeName, ReceiptHandleIsInvalid
+from localstack.services.sqs.constants import (
+    DOMAIN_STRATEGY_URL_REGEX,
+    LEGACY_STRATEGY_URL_REGEX,
+    PATH_STRATEGY_URL_REGEX,
+    STANDARD_STRATEGY_URL_REGEX,
+)
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.common import clone
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid
-from localstack.utils.urls import path_from_url
 
 
-def is_sqs_queue_url(url):
-    path = path_from_url(url).partition("?")[0]
-    return re.match(r"^/(queue|%s)/[a-zA-Z0-9_-]+(.fifo)?$" % get_aws_account_id(), path)
+def is_sqs_queue_url(url: str) -> bool:
+    return any(
+        [
+            re.search(STANDARD_STRATEGY_URL_REGEX, url),
+            re.search(DOMAIN_STRATEGY_URL_REGEX, url),
+            re.search(PATH_STRATEGY_URL_REGEX, url),
+            re.search(LEGACY_STRATEGY_URL_REGEX, url),
+        ]
+    )
 
 
 def is_message_deduplication_id_required(queue):

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -177,15 +177,12 @@ def test_is_sqs_queue_url():
     assert is_sqs_queue_url("http://localhost:4566/111111111111/bar") is True
 
     # Path strategy uses any domain name
-    assert (
-        is_sqs_queue_url("foo.bar:4566/queue/ap-south-1/222222222222/bar") is True
-    )
+    assert is_sqs_queue_url("foo.bar:4566/queue/ap-south-1/222222222222/bar") is True
     # Domain strategy may omit region
     assert is_sqs_queue_url("http://queue.localhost.localstack.cloud:4566/111111111111/foo") is True
-    
+
     # Custom domain name
     assert is_sqs_queue_url("http://foo.bar:4566/queue/us-east-1/111111111111/foo") is True
     assert is_sqs_queue_url("http://us-east-1.queue.foo.bar:4566/111111111111/foo") is True
     assert is_sqs_queue_url("http://queue.foo.bar:4566/111111111111/foo") is True
     assert is_sqs_queue_url("http://sqs.us-east-1.foo.bar:4566/111111111111/foo") is True
-    

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -176,9 +176,16 @@ def test_is_sqs_queue_url():
     assert is_sqs_queue_url("http://localhost:4566/queue/ap-south-1/222222222222/my-queue") is True
     assert is_sqs_queue_url("http://localhost:4566/111111111111/bar") is True
 
-    # Path strategy uses `localhost`
+    # Path strategy uses any domain name
     assert (
-        is_sqs_queue_url("local.localstack.cloud:4566/queue/ap-south-1/222222222222/bar") is False
+        is_sqs_queue_url("foo.bar:4566/queue/ap-south-1/222222222222/bar") is True
     )
     # Domain strategy may omit region
     assert is_sqs_queue_url("http://queue.localhost.localstack.cloud:4566/111111111111/foo") is True
+    
+    # Custom domain name
+    assert is_sqs_queue_url("http://foo.bar:4566/queue/us-east-1/111111111111/foo") is True
+    assert is_sqs_queue_url("http://us-east-1.queue.foo.bar:4566/111111111111/foo") is True
+    assert is_sqs_queue_url("http://queue.foo.bar:4566/111111111111/foo") is True
+    assert is_sqs_queue_url("http://sqs.us-east-1.foo.bar:4566/111111111111/foo") is True
+    

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -4,7 +4,11 @@ import localstack.services.sqs.exceptions
 import localstack.services.sqs.models
 from localstack.services.sqs import provider
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE
-from localstack.services.sqs.utils import get_message_attributes_md5, parse_queue_url
+from localstack.services.sqs.utils import (
+    get_message_attributes_md5,
+    is_sqs_queue_url,
+    parse_queue_url,
+)
 from localstack.utils.common import convert_to_printable_chars
 
 
@@ -140,3 +144,34 @@ def test_parse_queue_url_invalid():
         assert parse_queue_url(
             "http://foo.bar.queue.localhost.localstack.cloud:4566/000000000001/my-queue"
         )
+
+
+def test_is_sqs_queue_url():
+    assert is_sqs_queue_url("http://localstack.cloud") is False
+    assert is_sqs_queue_url("https://localstack.cloud:4566") is False
+    assert is_sqs_queue_url("local.localstack.cloud:4566") is False
+
+    assert (
+        is_sqs_queue_url("sqs.us-east-1.localhost.localstack.cloud:4566/111111111111/foo") is True
+    )
+    assert (
+        is_sqs_queue_url("us-east-1.queue.localhost.localstack.cloud:4566/111111111111/foo") is True
+    )
+    assert is_sqs_queue_url("localhost:4566/queue/ap-south-1/222222222222/bar") is True
+    assert is_sqs_queue_url("localhost:4566/111111111111/bar") is True
+
+    assert (
+        is_sqs_queue_url("http://sqs.us-east-1.localhost.localstack.cloud:4566/111111111111/foo")
+        is True
+    )
+    assert (
+        is_sqs_queue_url("http://us-east-1.queue.localhost.localstack.cloud:4566/111111111111/foo")
+        is True
+    )
+    assert is_sqs_queue_url("http://localhost:4566/queue/ap-south-1/222222222222/bar") is True
+    assert is_sqs_queue_url("http://localhost:4566/111111111111/bar") is True
+
+    # Path strategy uses `localhost`
+    assert (
+        is_sqs_queue_url("local.localstack.cloud:4566/queue/ap-south-1/222222222222/bar") is False
+    )

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -147,10 +147,12 @@ def test_parse_queue_url_invalid():
 
 
 def test_is_sqs_queue_url():
+    # General cases
     assert is_sqs_queue_url("http://localstack.cloud") is False
     assert is_sqs_queue_url("https://localstack.cloud:4566") is False
     assert is_sqs_queue_url("local.localstack.cloud:4566") is False
 
+    # Without proto prefix
     assert (
         is_sqs_queue_url("sqs.us-east-1.localhost.localstack.cloud:4566/111111111111/foo") is True
     )
@@ -160,18 +162,23 @@ def test_is_sqs_queue_url():
     assert is_sqs_queue_url("localhost:4566/queue/ap-south-1/222222222222/bar") is True
     assert is_sqs_queue_url("localhost:4566/111111111111/bar") is True
 
+    # With proto prefix
     assert (
-        is_sqs_queue_url("http://sqs.us-east-1.localhost.localstack.cloud:4566/111111111111/foo")
+        is_sqs_queue_url(
+            "http://sqs.us-east-1.localhost.localstack.cloud:4566/111111111111/foo.fifo"
+        )
         is True
     )
     assert (
-        is_sqs_queue_url("http://us-east-1.queue.localhost.localstack.cloud:4566/111111111111/foo")
+        is_sqs_queue_url("http://us-east-1.queue.localhost.localstack.cloud:4566/111111111111/foo1")
         is True
     )
-    assert is_sqs_queue_url("http://localhost:4566/queue/ap-south-1/222222222222/bar") is True
+    assert is_sqs_queue_url("http://localhost:4566/queue/ap-south-1/222222222222/my-queue") is True
     assert is_sqs_queue_url("http://localhost:4566/111111111111/bar") is True
 
     # Path strategy uses `localhost`
     assert (
         is_sqs_queue_url("local.localstack.cloud:4566/queue/ap-south-1/222222222222/bar") is False
     )
+    # Domain strategy may omit region
+    assert is_sqs_queue_url("http://queue.localhost.localstack.cloud:4566/111111111111/foo") is True


### PR DESCRIPTION
## Motivation

The `is_sqs_queue_url()` utility relied on the `get_aws_account_id()` function, which is about to be deprecated and removed.

This PR reworks it to use dedicated regexes for each endpoint scheme.