### PR TITLE
apigateway: add IAM role to apigateway integration with services

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -137,7 +137,6 @@ def get_service_factory(region_name: str, role_arn: str):
 @lru_cache(maxsize=64)
 def get_internal_mocked_headers(
     service_name: str,
-    account_id: str,
     region_name: str,
     source_arn: str,
     role_arn: str | None,
@@ -151,7 +150,7 @@ def get_internal_mocked_headers(
             ]["AccessKeyId"]
         )
     else:
-        access_key_id = account_id
+        access_key_id = None
     headers = aws_stack.mock_aws_request_headers(
         service=service_name, aws_access_key_id=access_key_id, region_name=region_name
     )
@@ -484,7 +483,6 @@ class KinesisIntegration(BackendIntegration):
         # forward records to target kinesis stream
         headers = get_internal_mocked_headers(
             service_name="kinesis",
-            account_id=invocation_context.account_id,
             region_name=invocation_context.region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),
@@ -674,7 +672,6 @@ class SQSIntegration(BackendIntegration):
 
         headers = get_internal_mocked_headers(
             service_name="sqs",
-            account_id=invocation_context.account_id,
             region_name=region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),
@@ -926,7 +923,6 @@ class EventBridgeIntegration(BackendIntegration):
         region_name = uri.split(":")[3]
         headers = get_internal_mocked_headers(
             service_name="events",
-            account_id=invocation_context.account_id,
             region_name=region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -136,7 +136,11 @@ def get_service_factory(region_name: str, role_arn: str):
 
 @lru_cache(maxsize=64)
 def get_internal_mocked_headers(
-    service_name: str, account_id: str, region_name: str, source_arn: str, role_arn: str | None,
+    service_name: str,
+    account_id: str,
+    region_name: str,
+    source_arn: str,
+    role_arn: str | None,
 ) -> dict[str, str]:
     if role_arn:
         access_key_id = (

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -136,7 +136,7 @@ def get_service_factory(region_name: str, role_arn: str):
 
 @lru_cache(maxsize=64)
 def get_internal_mocked_headers(
-    service_name: str, region_name: str, source_arn: str, role_arn: str | None
+    service_name: str, account_id: str, region_name: str, source_arn: str, role_arn: str | None,
 ) -> dict[str, str]:
     if role_arn:
         access_key_id = (
@@ -147,7 +147,7 @@ def get_internal_mocked_headers(
             ]["AccessKeyId"]
         )
     else:
-        access_key_id = None
+        access_key_id = account_id
     headers = aws_stack.mock_aws_request_headers(
         service=service_name, aws_access_key_id=access_key_id, region_name=region_name
     )
@@ -480,6 +480,7 @@ class KinesisIntegration(BackendIntegration):
         # forward records to target kinesis stream
         headers = get_internal_mocked_headers(
             service_name="kinesis",
+            account_id=invocation_context.account_id,
             region_name=invocation_context.region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),
@@ -669,6 +670,7 @@ class SQSIntegration(BackendIntegration):
 
         headers = get_internal_mocked_headers(
             service_name="sqs",
+            account_id=invocation_context.account_id,
             region_name=region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),
@@ -920,6 +922,7 @@ class EventBridgeIntegration(BackendIntegration):
         region_name = uri.split(":")[3]
         headers = get_internal_mocked_headers(
             service_name="events",
+            account_id=invocation_context.account_id,
             region_name=region_name,
             role_arn=invocation_context.integration.get("credentials"),
             source_arn=get_source_arn(invocation_context),

--- a/localstack/utils/aws/resources.py
+++ b/localstack/utils/aws/resources.py
@@ -159,6 +159,7 @@ def create_api_gateway_integrations(api_id, resource_id, method, integrations=No
             uri=integration["uri"],
             requestTemplates=req_templates,
             requestParameters=request_parameters,
+            credentials=integration.get("credentials"),
         )
         response_configs = [
             {"pattern": "^2.*", "code": success_code, "res_templates": res_templates},

--- a/localstack/utils/aws/resources.py
+++ b/localstack/utils/aws/resources.py
@@ -148,6 +148,7 @@ def create_api_gateway_integrations(api_id, resource_id, method, integrations=No
         client_error_code = integration.get("clientErrorCode") or "400"
         server_error_code = integration.get("serverErrorCode") or "500"
         request_parameters = integration.get("requestParameters") or {}
+        credentials = integration.get("credentials") or ""
 
         # create integration
         client.put_integration(
@@ -159,7 +160,7 @@ def create_api_gateway_integrations(api_id, resource_id, method, integrations=No
             uri=integration["uri"],
             requestTemplates=req_templates,
             requestParameters=request_parameters,
-            credentials=integration.get("credentials"),
+            credentials=credentials,
         )
         response_configs = [
             {"pattern": "^2.*", "code": success_code, "res_templates": res_templates},

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -58,6 +58,7 @@ from tests.aws.services.apigateway.apigateway_fixtures import (
 )
 from tests.aws.services.apigateway.conftest import (
     APIGATEWAY_ASSUME_ROLE_POLICY,
+    APIGATEWAY_KINESIS_POLICY,
     APIGATEWAY_LAMBDA_POLICY,
     APIGATEWAY_STEPFUNCTIONS_POLICY,
     STEPFUNCTIONS_ASSUME_ROLE_POLICY,
@@ -1919,7 +1920,12 @@ class TestIntegrations:
 
     @markers.aws.unknown
     def test_api_gateway_kinesis_integration(
-        self, aws_client, kinesis_create_stream, wait_for_stream_ready, aws_client_factory
+        self,
+        aws_client,
+        create_iam_role_with_policy,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        aws_client_factory,
     ):
         # create target Kinesis stream
         stream_name = kinesis_create_stream()
@@ -1930,11 +1936,20 @@ class TestIntegrations:
         client = aws_client_factory(
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         ).apigateway
+
+        role_arn = create_iam_role_with_policy(
+            RoleName=f"role-apigw-{short_uid()}",
+            PolicyName=f"policy-apigw-{short_uid()}",
+            RoleDefinition=APIGATEWAY_ASSUME_ROLE_POLICY,
+            PolicyDefinition=APIGATEWAY_KINESIS_POLICY,
+        )
+
         result = self.connect_api_gateway_to_kinesis(
             client,
             api_name,
             stream_name,
             TEST_AWS_REGION_NAME,
+            role_arn,
         )
 
         # generate test data
@@ -2048,6 +2063,7 @@ class TestIntegrations:
         gateway_name: str,
         kinesis_stream: str,
         region_name: str,
+        role_arn: str,
     ):
         template = APIGATEWAY_DATA_INBOUND_TEMPLATE % kinesis_stream
         resources = {
@@ -2061,6 +2077,7 @@ class TestIntegrations:
                             "type": "AWS",
                             "uri": f"arn:aws:apigateway:{region_name}:kinesis:action/PutRecords",
                             "requestTemplates": {"application/json": template},
+                            "credentials": role_arn,
                         }
                     ],
                 },
@@ -2073,6 +2090,7 @@ class TestIntegrations:
                             "type": "AWS",
                             "uri": f"arn:aws:apigateway:{region_name}:kinesis:action/ListStreams",
                             "requestTemplates": {"application/json": "{}"},
+                            "credentials": role_arn,
                         }
                     ],
                 },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The purpose of this PR is to enhance the stability of apigateway's integration with kinesis with multi-accounts and multi-regions. The main issue addressed is to introduce a proper IAM role required for the integration of these services. 

<!-- What notable changes does this PR make? -->
## Changes
This PR introduces the use of role arn when integrating kinesis with apigateway and add `credentials` field to the api gateway `put_integrations` api.

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). The affected tests are:

`tests.aws.services.apigateway.test_apigateway_basic.TestIntegrations.test_api_gateway_kinesis_integration`

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

