### PR TITLE
Update remaining host matching for localhost.localstack.cloud

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -60,7 +60,7 @@ PATH_REGEX_USER_REQUEST = (
     r"^/restapis/([A-Za-z0-9_\\-]+)(?:/([A-Za-z0-9\_($|%%24)\\-]+))?/%s/(.*)$" % PATH_USER_REQUEST
 )
 # URL pattern for invocations
-HOST_REGEX_EXECUTE_API = r"(?:.*://)?([a-zA-Z0-9]+)(?:(-vpce-[^.]+))?\.execute-api\.(localhost.localstack.cloud|([^\.]+)\.amazonaws\.com)(.*)"
+HOST_REGEX_EXECUTE_API = r"(?:.*://)?([a-zA-Z0-9]+)(?:(-vpce-[^.]+))?\.execute-api\.(.*)"
 
 # regex path patterns
 PATH_REGEX_MAIN = r"^/restapis/([A-Za-z0-9_\-]+)/[a-z]+(\?.*)?"

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -18,6 +18,7 @@ from localstack.services.cloudformation.engine.entities import Stack, StackChang
 from localstack.services.cloudformation.engine.parameters import StackParameter
 from localstack.services.cloudformation.engine.quirks import VALID_GETATT_PROPERTIES
 from localstack.services.cloudformation.engine.template_utils import (
+    AWS_URL_SUFFIX,
     fn_equals_type_conversion,
     get_deps_for_resource,
 )
@@ -44,7 +45,6 @@ from localstack.utils.urls import localstack_host
 
 ACTION_CREATE = "create"
 ACTION_DELETE = "delete"
-AWS_URL_SUFFIX = localstack_host().host  # value is "amazonaws.com" in real AWS
 
 REGEX_OUTPUT_APIGATEWAY = re.compile(
     rf"^(https?://.+\.execute-api\.)(?:[^-]+-){{2,3}}\d\.(amazonaws\.com|{AWS_URL_SUFFIX})/?(.*)$"

--- a/localstack/services/cloudformation/engine/template_utils.py
+++ b/localstack/services/cloudformation/engine/template_utils.py
@@ -2,9 +2,9 @@ import re
 from typing import Any
 
 from localstack.services.cloudformation.deployment_utils import PLACEHOLDER_AWS_NO_VALUE
+from localstack.utils.urls import localstack_host
 
-# TODO: deduplicate
-AWS_URL_SUFFIX = "localhost.localstack.cloud"
+AWS_URL_SUFFIX = localstack_host().host  # value is "amazonaws.com" in real AWS
 
 
 def get_deps_for_resource(resource: dict, evaluated_conditions: dict[str, bool]) -> set[str]:

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -187,12 +187,13 @@ from localstack.utils.collections import get_safe
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid
 from localstack.utils.time import parse_timestamp
+from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
 os.environ[
     "MOTO_S3_CUSTOM_ENDPOINTS"
-] = "s3.localhost.localstack.cloud:4566,s3.localhost.localstack.cloud"
+] = f"s3.{localstack_host().host_and_port()},s3.{localstack_host().host}"
 
 MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
 # max file size for S3 objects kept in memory (500 KB by default)

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -38,11 +38,16 @@ serializer = create_serializer(service)
 
 @route(
     '/<regex("[0-9]{12}"):account_id>/<regex("[a-zA-Z0-9_-]+(.fifo)?"):queue_name>',
-    host='sqs.<regex("([a-z0-9-]+\\.)?"):region>localhost.localstack.cloud<regex("(:[0-9]{2,5})?"):port>',
+    host='sqs.<regex("([a-z0-9-]+\\.)?"):region><regex(".*"):domain><regex("(:[0-9]{2,5})?"):port>',
     methods=["POST", "GET"],
 )
 def standard_strategy_handler(
-    request: Request, account_id: str, queue_name: str, region: str = None, port: int = None
+    request: Request,
+    account_id: str,
+    queue_name: str,
+    region: str = None,
+    domain: str = None,
+    port: int = None,
 ):
     """
     Handler for modern-style endpoints which always have the region encoded.
@@ -61,11 +66,16 @@ def path_strategy_handler(request: Request, region, account_id: str, queue_name:
 
 @route(
     '/<regex("[0-9]{12}"):account_id>/<regex("[a-zA-Z0-9_-]+(.fifo)?"):queue_name>',
-    host='<regex("([a-z0-9-]+\\.)?"):region>queue.localhost.localstack.cloud<regex("(:[0-9]{2,5})?"):port>',
+    host='<regex("([a-z0-9-]+\\.)?"):region>queue.<regex(".*"):domain><regex("(:[0-9]{2,5})?"):port>',
     methods=["POST", "GET"],
 )
 def domain_strategy_handler(
-    request: Request, account_id: str, queue_name: str, region: str = None, port: int = None
+    request: Request,
+    account_id: str,
+    queue_name: str,
+    region: str = None,
+    domain: str = None,
+    port: int = None,
 ):
     """Uses the endpoint host to extract the region. See:
     https://docs.aws.amazon.com/general/latest/gr/sqs-service.html"""

--- a/localstack/utils/crypto.py
+++ b/localstack/utils/crypto.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from .files import TMP_FILES, file_exists_not_empty, load_file, new_tmp_file, save_file
 from .strings import short_uid, to_bytes, to_str
 from .sync import synchronized
+from .urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
@@ -82,6 +83,8 @@ def generate_ssl_cert(
     k = crypto.PKey()
     k.generate_key(crypto.TYPE_RSA, 2048)
 
+    host_definition = localstack_host()
+
     # create a self-signed cert
     cert = crypto.X509()
     subj = cert.get_subject()
@@ -101,8 +104,8 @@ def generate_ssl_cert(
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(k)
     alt_names = (
-        b"DNS:localhost,DNS:test.localhost.atlassian.io,DNS:localhost.localstack.cloud,IP:127.0.0.1"
-    )
+        f"DNS:localhost,DNS:test.localhost.atlassian.io,DNS:localhost.localstack.cloud,DNS:{host_definition.host}IP:127.0.0.1"
+    ).encode("utf8")
     cert.add_extensions(
         [
             crypto.X509Extension(b"subjectAltName", False, alt_names),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

There were a few usages of the constant `localhost.localstack.cloud` that remain after #9578 and #9600. This PR updates these. Ideally all routes should match on a wildcard domain suffix, e.g. `*.opensearch.*` or `*.execute-api.*` rather than e.g. `*.localhost.localstack.cloud` as we currently have. If this is not possible, we should at least match on `*.LOCALSTACK_HOST` since this has been customised.

Thanks @bentsku for [pointing out that I missed some](https://github.com/localstack/localstack/pull/9638#pullrequestreview-1731644001).


<!-- What notable changes does this PR make? -->
## Changes

* Update remaining functional uses of `localhost.localstack.cloud`. Note: the value is still ok in tests since they target localhost anyway.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

