### PR TITLE
fix S3 timestamp precision

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1577,6 +1577,14 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         if root and not root.tail:
             root.tail = "\n"
 
+    @staticmethod
+    def _timestamp_iso8601(value: datetime) -> str:
+        """
+        This is very specific to S3, S3 returns an ISO8601 timestamp but with milliseconds always set to 000
+        Some SDKs are very picky about the length
+        """
+        return value.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
 
 class SqsQueryResponseSerializer(QueryResponseSerializer):
     """

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -685,12 +685,6 @@ def str_to_rfc_1123_datetime(value: str) -> datetime.datetime:
     return datetime.datetime.strptime(value, RFC1123).replace(tzinfo=_gmt_zone_info)
 
 
-def iso_8601_datetime_without_milliseconds_s3(
-    value: datetime,
-) -> Optional[str]:
-    return value.strftime("%Y-%m-%dT%H:%M:%S.000Z") if value else None
-
-
 def add_expiration_days_to_datetime(user_datatime: datetime.datetime, exp_days: int) -> str:
     """
     This adds expiration days to a datetime, rounding to the next day at midnight UTC.

--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -68,10 +68,7 @@ from localstack.services.s3.constants import (
     DEFAULT_PUBLIC_BLOCK_ACCESS,
     S3_UPLOAD_PART_MIN_SIZE,
 )
-from localstack.services.s3.utils import (
-    iso_8601_datetime_without_milliseconds_s3,
-    rfc_1123_datetime,
-)
+from localstack.services.s3.utils import rfc_1123_datetime
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -81,9 +78,6 @@ from localstack.services.stores import (
 )
 from localstack.utils.aws import arns
 from localstack.utils.tagging import TaggingService
-
-# TODO: beware of timestamp data, we need the snapshot to be more precise for S3, with the different types
-# moto had a lot of issue with it? not sure about our parser/serializer
 
 LOG = logging.getLogger(__name__)
 
@@ -345,11 +339,6 @@ class S3Object:
             headers["StorageClass"] = self.storage_class
 
         return headers
-
-    @property
-    def last_modified_iso8601(self) -> str:
-        # TODO: verify if we need them with proper snapshot testing, for now it's copied from moto
-        return iso_8601_datetime_without_milliseconds_s3(self.last_modified)  # type: ignore
 
     @property
     def last_modified_rfc1123(self) -> str:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1692,6 +1692,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["VersionId"] = s3_object.version_id
 
         if s3_object.parts:
+            # TODO: implements ObjectParts, this is basically a simplified `ListParts` call on the object, we might
+            #  need to store more data about the Parts once we implement checksums for them
             response["ObjectParts"] = GetObjectAttributesParts(TotalPartsCount=len(s3_object.parts))
 
         return response

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4540,8 +4540,6 @@ class TestS3:
             parsed_ts = datetime.datetime.strptime(_timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
             assert parsed_ts.microsecond == 0
 
-            return True
-
         s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
         list_buckets_endpoint = _endpoint_url()
         list_buckets_resp = s3_http_client.get(
@@ -4556,7 +4554,7 @@ class TestS3:
         else:
             bucket = buckets["Bucket"]
         bucket_timestamp: str = bucket["CreationDate"]
-        assert assert_timestamp_is_iso8061_s3_format(bucket_timestamp)
+        assert_timestamp_is_iso8061_s3_format(bucket_timestamp)
 
         bucket_url = _bucket_url(s3_bucket)
         object_url = f"{bucket_url}/{object_key}"
@@ -4593,7 +4591,7 @@ class TestS3:
         )
         copy_resp_dict = xmltodict.parse(copy_resp.content)
         copy_timestamp: str = copy_resp_dict["CopyObjectResult"]["LastModified"]
-        assert assert_timestamp_is_iso8061_s3_format(copy_timestamp)
+        assert_timestamp_is_iso8061_s3_format(copy_timestamp)
 
     # This test doesn't work against AWS anymore because of some authorization error.
     @markers.aws.only_localstack

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -40,6 +40,18 @@ def _endpoint_url(region: str = "", localstack_host: str = None) -> str:
     return config.internal_service_url(host=f"s3.{region}.{LOCALHOST_HOSTNAME}")
 
 
+def assert_timestamp_is_iso8061_s3_format(timestamp: str):
+    # the timestamp should be looking like the following
+    # 2023-11-15T12:02:40.000Z
+    assert timestamp.endswith(".000Z")
+    assert len(timestamp) == 24
+    # assert that it follows the right format and it does not raise an exception during parsing
+    parsed_ts = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    assert parsed_ts.microsecond == 0
+
+    return True
+
+
 class TestS3ListObjects:
     @markers.aws.validated
     @pytest.mark.parametrize("delimiter", ["", "/", "%2F"])
@@ -179,13 +191,9 @@ class TestS3ListObjects:
         resp = s3_http_client.get(bucket_url, headers={"x-amz-content-sha256": "UNSIGNED-PAYLOAD"})
         resp_dict = xmltodict.parse(resp.content)
         timestamp: str = resp_dict["ListBucketResult"]["Contents"]["LastModified"]
-        # the timestamp should be looking like the following
-        # 2023-11-15T12:02:40.000Z
-        assert timestamp.endswith(".000Z")
-        assert len(timestamp) == 24
-        # assert that it follows the right format and it does not raise an exception during parsing
-        parsed_ts = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
-        assert parsed_ts.microsecond == 0
+
+        # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
+        assert assert_timestamp_is_iso8061_s3_format(timestamp)
 
 
 class TestS3ListObjectsV2:
@@ -526,6 +534,31 @@ class TestS3ListObjectVersions:
         resp_dict["ListVersionsResult"].pop("@xmlns", None)
         snapshot.match("list-objects-versions-no-encoding", resp_dict)
 
+    @markers.aws.validated
+    def test_s3_list_object_versions_timestamp_precision(
+        self, s3_bucket, aws_client, aws_http_client_factory
+    ):
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket,
+            VersioningConfiguration={"Status": "Enabled"},
+        )
+        # put Objects and DeleteMarker
+        aws_client.s3.put_object(Bucket=s3_bucket, Key="test-key", Body="test-body")
+        aws_client.s3.delete_object(Bucket=s3_bucket, Key="test-key")
+
+        bucket_url = f"{_bucket_url(s3_bucket)}?versions"
+        # Boto automatically parses the timestamp to ISO8601 with no precision, but AWS returns a different format
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        resp = s3_http_client.get(bucket_url, headers={"x-amz-content-sha256": "UNSIGNED-PAYLOAD"})
+        resp_dict = xmltodict.parse(resp.content)
+
+        timestamp_obj: str = resp_dict["ListVersionsResult"]["Version"]["LastModified"]
+        timestamp_marker: str = resp_dict["ListVersionsResult"]["DeleteMarker"]["LastModified"]
+
+        for timestamp in (timestamp_obj, timestamp_marker):
+            # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
+            assert assert_timestamp_is_iso8061_s3_format(timestamp)
+
 
 class TestS3ListMultipartUploads:
     @markers.aws.validated
@@ -794,9 +827,27 @@ class TestS3ListMultipartUploads:
         )
         snapshot.match("list-multiparts-manual-first-file", response)
 
+    @markers.aws.validated
+    def test_s3_list_multiparts_timestamp_precision(
+        self, s3_bucket, aws_client, aws_http_client_factory
+    ):
+        object_key = "test-list-part-empty-marker"
+        response = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=object_key)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        bucket_url = f"{_bucket_url(s3_bucket)}?uploads"
+        # Boto automatically parses the timestamp to ISO8601 with no precision, but AWS returns a different format
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        resp = s3_http_client.get(bucket_url, headers={"x-amz-content-sha256": "UNSIGNED-PAYLOAD"})
+        resp_dict = xmltodict.parse(resp.content)
+
+        timestamp: str = resp_dict["ListMultipartUploadsResult"]["Upload"]["Initiated"]
+        # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
+        assert assert_timestamp_is_iso8061_s3_format(timestamp)
+
 
 class TestS3ListParts:
-    @pytest.mark.xfail(condition=is_v2_provider, reason="not implemented in moto")
+    @pytest.mark.xfail(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     @markers.aws.validated
     def test_list_parts_pagination(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
@@ -853,7 +904,7 @@ class TestS3ListParts:
         snapshot.match("list-parts-wrong-part", response)
 
     @pytest.mark.xfail(
-        condition=is_v2_provider(), reason="moto does not handle empty query string parameters"
+        condition=LEGACY_V2_S3_PROVIDER, reason="moto does not handle empty query string parameters"
     )
     @markers.aws.validated
     def test_list_parts_empty_part_number_marker(self, s3_bucket, snapshot, aws_client_factory):
@@ -889,3 +940,29 @@ class TestS3ListParts:
             Bucket=s3_bucket, UploadId=upload_id, Key=object_key, MaxParts=""
         )
         snapshot.match("list-parts-empty-max-parts", response)
+
+    @markers.aws.validated
+    def test_s3_list_parts_timestamp_precision(
+        self, s3_bucket, aws_client, aws_http_client_factory
+    ):
+        object_key = "test-list-part-empty-marker"
+        response = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=object_key)
+        upload_id = response["UploadId"]
+
+        aws_client.s3.upload_part(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body=BytesIO(b"data"),
+            PartNumber=1,
+            UploadId=upload_id,
+        )
+
+        bucket_url = f"{_bucket_url(s3_bucket)}/{object_key}?uploadId={upload_id}"
+        # Boto automatically parses the timestamp to ISO8601 with no precision, but AWS returns a different format
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        resp = s3_http_client.get(bucket_url, headers={"x-amz-content-sha256": "UNSIGNED-PAYLOAD"})
+        resp_dict = xmltodict.parse(resp.content)
+
+        timestamp: str = resp_dict["ListPartsResult"]["Part"]["LastModified"]
+        # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
+        assert assert_timestamp_is_iso8061_s3_format(timestamp)

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -49,8 +49,6 @@ def assert_timestamp_is_iso8061_s3_format(timestamp: str):
     parsed_ts = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
     assert parsed_ts.microsecond == 0
 
-    return True
-
 
 class TestS3ListObjects:
     @markers.aws.validated
@@ -193,7 +191,7 @@ class TestS3ListObjects:
         timestamp: str = resp_dict["ListBucketResult"]["Contents"]["LastModified"]
 
         # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
-        assert assert_timestamp_is_iso8061_s3_format(timestamp)
+        assert_timestamp_is_iso8061_s3_format(timestamp)
 
 
 class TestS3ListObjectsV2:
@@ -557,7 +555,7 @@ class TestS3ListObjectVersions:
 
         for timestamp in (timestamp_obj, timestamp_marker):
             # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
-            assert assert_timestamp_is_iso8061_s3_format(timestamp)
+            assert_timestamp_is_iso8061_s3_format(timestamp)
 
 
 class TestS3ListMultipartUploads:
@@ -843,7 +841,7 @@ class TestS3ListMultipartUploads:
 
         timestamp: str = resp_dict["ListMultipartUploadsResult"]["Upload"]["Initiated"]
         # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
-        assert assert_timestamp_is_iso8061_s3_format(timestamp)
+        assert_timestamp_is_iso8061_s3_format(timestamp)
 
 
 class TestS3ListParts:
@@ -965,4 +963,4 @@ class TestS3ListParts:
 
         timestamp: str = resp_dict["ListPartsResult"]["Part"]["LastModified"]
         # the timestamp should be looking like the following: 2023-11-15T12:02:40.000Z
-        assert assert_timestamp_is_iso8061_s3_format(timestamp)
+        assert_timestamp_is_iso8061_s3_format(timestamp)

--- a/tests/aws/services/s3/test_s3_list_operations.snapshot.json
+++ b/tests/aws/services/s3/test_s3_list_operations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjects::test_list_objects_with_prefix[]": {
-    "recorded-date": "12-11-2023, 01:53:30",
+    "recorded-date": "15-11-2023, 12:42:39",
     "recorded-content": {
       "list-objects": {
         "Contents": [
@@ -30,7 +30,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjects::test_list_objects_with_prefix[/]": {
-    "recorded-date": "12-11-2023, 01:53:33",
+    "recorded-date": "15-11-2023, 12:42:41",
     "recorded-content": {
       "list-objects": {
         "CommonPrefixes": [
@@ -53,7 +53,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_list_operations.py::TestS3ListObjects::test_list_objects_with_prefix[%2F]": {
-    "recorded-date": "12-11-2023, 01:53:35",
+    "recorded-date": "15-11-2023, 12:42:43",
     "recorded-content": {
       "list-objects": {
         "Contents": [


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9637, we return too precise timestamps. AWS returns ISO6081 milliseconds timestamps for S3 List operations, but with the milliseconds set to `000` (`%Y-%m-%dT%H:%M:%S.000Z`). This is handled in the serializer, as the declared type of the fields of the `TypedDict` is `datetime`

On a related note, AWS also returns RFC1123 timestamps for `LastModified` headers, as they should, but I've validated the behavior as well with AWS validated tests. 

## Changes
- updated the S3 serializer to return `ISO6081` datetime with this specific format. 
- wrote a whole bunch of test to validate that this does not alter behavior everywhere where we return timestamp in S3. I've checked most of the specs and the stubs, there might be some edge cases but I doubt they are using the base datetime parsing. 

## TODO

What's left to do:

Check all date times returned by S3, the specific ones are already covered by test, this is the rest.

- [X] write test for ListObjects and ListObjectsV2 
- [x] write test for `CopyObject`, `HeadObject`, `GetObject`, `GetObjectAttributes` (this can all be done in one test) -> `LastModified` with RFC1123 format, should be okay already
- [x] write test for `ListParts`, `ListObjectVersions` -> `LastModified` with ISO8601 format, should be same as ListObjects and ListObjectsV2
- [x] write test for `ListBuckets` (`CreationDate`), should be ISO8601 with 0 milliseconds too, to be verified
- [x] write test for `ListMultipartUploads` -> `Initiated`, should be ISO8601 with 0ms, to be verified

