### PR TITLE
Expose configured routes for introspection

### DIFF
--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -392,6 +392,10 @@ class Router(Generic[E]):
         else:
             self._remove_rules(rules)
 
+    def list_route_mapping(self) -> Map:
+        with self._mutex:
+            return self.url_map
+
     def _remove_rules(self, rules: Iterable[Rule]):
         """
         Removes a set of Rules from the Router.

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -318,6 +318,25 @@ class ConfigResource:
         }
 
 
+class RoutesResource:
+    def on_get(self, request):
+        from localstack.services.edge import ROUTER
+
+        mapping = ROUTER.list_route_mapping()
+
+        routes = []
+
+        for rule in mapping.iter_rules():
+            routes.append(
+                {
+                    "host": rule.host,
+                    "path": rule.rule,
+                }
+            )
+
+        return {"routes": routes}
+
+
 class LocalstackResources(Router):
     """
     Router for localstack-internal HTTP resources.
@@ -338,6 +357,7 @@ class LocalstackResources(Router):
         self.add(Resource("/_localstack/init", InitScriptsResource()))
         self.add(Resource("/_localstack/init/<stage>", InitScriptsStageResource()))
         self.add(Resource("/_localstack/cloudformation/deploy", CloudFormationUi()))
+        self.add(Resource("/_localstack/routes", RoutesResource()))
 
         if config.ENABLE_CONFIG_UPDATES:
             LOG.warning(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While I was updating route matchers for #9642, I was interested to know what routes had been registered. I wanted to check anything that expected `localhost.localstack.cloud`, but it might be useful for debugging why a service is not able to be reached. For example, if a user gets the classic "NoSuchBucket" error with no further information when trying to access a LocalStack service.




<!-- What notable changes does this PR make? -->
## Changes


* Add a new route `/_localstack/routes` which lists the host header and path matching

## Testing

Here is an example after adding an OpenSearch domain after customising `LOCALSTACK_HOST` to be `foo.bar`:

```
$ aws opensearch create-domain --domain-name mydomain
# ... output

$ curl -s localhost:4566/_localstack/routes | jq
{
  "routes": [
    {
      "host": "mydomain.us-east-1.opensearch.foo.bar<port:port>",
      "path": "/<path:path>"
    },
    {
      "host": "mydomain.us-east-1.opensearch.foo.bar<port:port>",
      "path": "/"
    }
  ]
}
```

Note: ideally opensearch should accept a whildcard for the domain, however it accepts whatever `LOCALSTACK_HOST` is set to, which is good enough at the moment.

After adding an API Gateway REST API:

```
$ aws apigateway create-rest-api --name foo
# ... output

$ curl -s localhost:4566/_localstack/routes | jq
{
  "routes": [
    {
      "host": "<regex('[^-]+'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>",
      "path": "/"
    },
    {
      "host": "<regex('[^-]+'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>",
      "path": "/<stage>/"
    },
    {
      "host": "<regex('[^-]+'):api_id><regex('(-vpce-[^.]+)?'):vpce_suffix>.execute-api.<regex('.*'):server>",
      "path": "/<stage>/<path:path>"
    },
    {
      "host": "<__host__>",
      "path": "/restapis/<api_id>/<stage>/_user_request_"
    },
    {
      "host": "<__host__>",
      "path": "/restapis/<api_id>/<stage>/_user_request_/<path:path>"
    }
  ]
}
```
