### PR TITLE
Issue 9602 use salt lengths in parity with real kms

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -352,7 +352,7 @@ class KmsKey:
                 kwargs["padding"] = padding.PKCS1v15()
             elif "PSS" in signing_algorithm:
                 kwargs["padding"] = padding.PSS(
-                    mgf=padding.MGF1(hasher), salt_length=padding.PSS.MAX_LENGTH
+                    mgf=padding.MGF1(hasher), salt_length=padding.PSS.DIGEST_LENGTH
                 )
             else:
                 LOG.warning("Unsupported padding in SigningAlgorithm '%s'", signing_algorithm)

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -472,6 +472,7 @@ class TestKMS:
         snapshot.match("verification", verification)
         assert verification["SignatureValid"]
 
+        # Ensure signatures can be verified using the public key and specific params
         response = aws_client.kms.get_public_key(KeyId=key_id)
         public_key_bytes = response.get("PublicKey")
         key = load_der_public_key(public_key_bytes)
@@ -486,6 +487,10 @@ class TestKMS:
             MessageType="DIGEST", Signature=signature["Signature"], Message=digest, **kwargs
         )
         assert verification["SignatureValid"]
+
+        digest_vargs = enforce_salt_length(sign_algo, "DIGEST")
+
+        key.verify(signature=signature["Signature"], data=digest, **digest_vargs)
 
         # Ensure bad digest raises during signing
         with pytest.raises(ClientError) as exc:


### PR DESCRIPTION
Modified KMS to use specific salt lengths to PSS signatures in line with AWS KMS

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I discovered a disparity between AWS KMS and localstack KMS during signing of some mtls 
messages and raised this issue

https://github.com/localstack/localstack/issues/9602

<!-- What notable changes does this PR make? -->

When constructing the parameters for a PSS signature, an appropriate salt length is selected, rather than allowing a default which proves to be non-deterministic.

## Testing

Signing a message with a probabilistic scheme, and then verifying the signature offline with, for example, OpenSSL. The verification will fail. Contrast with AWS KMS, where it will not.

