### PR TITLE
Organize config list

### DIFF
--- a/doc/interaction/README.md
+++ b/doc/interaction/README.md
@@ -47,8 +47,6 @@ awslocal kinesis list-streams
 }
 ```
 
-**UPDATE**: Use the environment variable `$LOCALSTACK_HOSTNAME` to determine the target host inside your Lambda function. See [Configuration](#configuration) section for more details.
-
 ## AWS CLI v2 with Docker and LocalStack
 
 By default, the container running [amazon/aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-docker.html) is isolated from `0.0.0.0:4566` on the host machine, that means that aws-cli cannot reach localstack through your shell.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -825,9 +825,7 @@ SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL = int(
     os.environ.get("SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL") or 60
 )
 
-# DEPRECATED: deprecated since 2.0.0 but added back upon customer request for the new Lambda provider
-# Keep a bit longer until we are sure that LOCALSTACK_HOST covers the special scenario but do not advertise publicly.
-# Endpoint host under which LocalStack APIs are accessible from Lambda Docker containers.
+# PUBLIC: Endpoint host under which LocalStack APIs are accessible from Lambda Docker containers.
 HOSTNAME_FROM_LAMBDA = os.environ.get("HOSTNAME_FROM_LAMBDA", "").strip()
 
 # PUBLIC: hot-reload (default v2), __local__ (default v1)
@@ -1046,12 +1044,13 @@ DISABLE_CUSTOM_BOTO_WAITER_CONFIG = is_env_true("DISABLE_CUSTOM_BOTO_WAITER_CONF
 # if `DISABLE_BOTO_RETRIES=1` is set, all our created boto clients will have retries disabled
 DISABLE_BOTO_RETRIES = is_env_true("DISABLE_BOTO_RETRIES")
 
-# HINT: Please add deprecated environment variables to deprecations.py
-
 # List of environment variable names used for configuration that are passed from the host into the LocalStack container.
-# Make sure to keep this in sync with the above!
-# Do *not* include any internal developer configurations that apply to host-mode only in this list.
-# Note: do *not* include DATA_DIR in this list, as it is treated separately
+# => Synchronize this list with the above and the configuration docs:
+# https://docs.localstack.cloud/references/configuration/
+# => Sort this list alphabetically
+# => Add deprecated environment variables to deprecations.py and add a comment in this list
+# => Move removed legacy variables to the section grouped by release (still relevant for deprecation warnings)
+# => Do *not* include any internal developer configurations that apply to host-mode only in this list.
 CONFIG_ENV_VARS = [
     "ALLOW_NONSTANDARD_REGIONS",
     "BOTO_WAITER_DELAY",
@@ -1064,7 +1063,6 @@ CONFIG_ENV_VARS = [
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEBUG_HANDLER_CHAIN",
-    "DEFAULT_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "DEVELOP",
     "DEVELOP_PORT",
     "DISABLE_BOTO_RETRIES",
@@ -1090,24 +1088,17 @@ CONFIG_ENV_VARS = [
     "DYNAMODB_READ_ERROR_PROBABILITY",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
     "EAGER_SERVICE_LOADING",
-    "EDGE_FORWARD_URL",  # Not functional; Deprecated in 1.4.0, removed in 3.0.0
     "ENABLE_CONFIG_UPDATES",
-    "ES_CUSTOM_BACKEND",
-    "ES_ENDPOINT_STRATEGY",
-    "ES_MULTI_CLUSTER",
     "EXTRA_CORS_ALLOWED_HEADERS",
     "EXTRA_CORS_ALLOWED_ORIGINS",
     "EXTRA_CORS_EXPOSE_HEADERS",
     "GATEWAY_LISTEN",
     "HOSTNAME",
-    "HOSTNAME_EXTERNAL",
-    "HOSTNAME_FROM_LAMBDA",  # deprecated since 2.0.0 but added to new Lambda provider
+    "HOSTNAME_FROM_LAMBDA",
     "KINESIS_ERROR_PROBABILITY",
-    "KINESIS_INITIALIZE_STREAMS",  # Not functional; Deprecated in 1.4.0, removed in 3.0.0
     "KINESIS_MOCK_PERSIST_INTERVAL",
     "KINESIS_MOCK_LOG_LEVEL",
     "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT",
-    "KMS_PROVIDER",  # Not functional; Deprecated in 1.4.0, removed in 3.0.0
     "LAMBDA_DOCKER_DNS",
     "LAMBDA_DOCKER_FLAGS",
     "LAMBDA_DOCKER_NETWORK",
@@ -1121,7 +1112,6 @@ CONFIG_ENV_VARS = [
     "LAMBDA_INIT_RELEASE_VERSION",
     "LAMBDA_KEEPALIVE_MS",
     "LAMBDA_RUNTIME_IMAGE_MAPPING",
-    "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOVE_CONTAINERS",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
@@ -1135,14 +1125,11 @@ CONFIG_ENV_VARS = [
     "LAMBDA_LIMITS_CODE_SIZE_UNZIPPED",
     "LAMBDA_LIMITS_CREATE_FUNCTION_REQUEST_SIZE",
     "LAMBDA_LIMITS_MAX_FUNCTION_ENVVAR_SIZE_BYTES",
-    "LEGACY_DIRECTORIES",
     "LEGACY_DOCKER_CLIENT",
-    "LEGACY_EDGE_PROXY",  # Not functional; Deprecated in 1.0.0, removed in 3.0.0
     "LEGACY_SNS_GCM_PUBLISHING",
     "LOCALSTACK_API_KEY",
     "LOCALSTACK_AUTH_TOKEN",
     "LOCALSTACK_HOST",
-    "LOCALSTACK_HOSTNAME",
     "LOG_LICENSE_ISSUES",
     "LS_LOG",
     "MAIN_CONTAINER_NAME",
@@ -1171,29 +1158,43 @@ CONFIG_ENV_VARS = [
     "STRICT_SERVICE_LOADING",
     "TEST_AWS_ACCOUNT_ID",
     "TF_COMPAT_MODE",
-    "USE_SINGLE_REGION",  # Not functional; deprecated in 0.12.7, removed in 3.0.0
     "USE_SSL",
     "WAIT_FOR_DEBUGGER",
     "WINDOWS_DOCKER_MOUNT_PREFIX",
-    # Removed in 3.0.0
+    # Removed legacy variables in 2.0.0
+    # DATA_DIR => do *not* include in this list, as it is treated separately.  # deprecated since 1.0.0
+    "LEGACY_DIRECTORIES",  # deprecated since 1.0.0
+    "SYNCHRONOUS_API_GATEWAY_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_DYNAMODB_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_SNS_EVENTS",  # deprecated since 1.3.0
+    "SYNCHRONOUS_SQS_EVENTS",  # deprecated since 1.3.0
+    # Removed legacy variables in 3.0.0
+    "DEFAULT_REGION",  # deprecated since 0.12.7
     "EDGE_BIND_HOST",  # deprecated since 2.0.0
+    "EDGE_FORWARD_URL",  # deprecated since 1.4.0
     "EDGE_PORT",  # deprecated since 2.0.0
     "EDGE_PORT_HTTP",  # deprecated since 2.0.0
+    "ES_CUSTOM_BACKEND",  # deprecated since 0.14.0
+    "ES_ENDPOINT_STRATEGY",  # deprecated since 0.14.0
+    "ES_MULTI_CLUSTER",  # deprecated since 0.14.0
+    "HOSTNAME_EXTERNAL",  # deprecated since 2.0.0
+    "KINESIS_INITIALIZE_STREAMS",  # deprecated since 1.4.0
+    "KINESIS_PROVIDER",  # deprecated since 1.3.0
+    "KMS_PROVIDER",  # deprecated since 1.4.0
     "LAMBDA_XRAY_INIT",  # deprecated since 2.0.0
     "LAMBDA_CODE_EXTRACT_TIME",  # deprecated since 2.0.0
     "LAMBDA_CONTAINER_REGISTRY",  # deprecated since 2.0.0
     "LAMBDA_EXECUTOR",  # deprecated since 2.0.0
     "LAMBDA_FALLBACK_URL",  # deprecated since 2.0.0
     "LAMBDA_FORWARD_URL",  # deprecated since 2.0.0
+    "LAMBDA_JAVA_OPTS",  # currently only supported in old Lambda provider but not officially deprecated
     "LAMBDA_REMOTE_DOCKER",  # deprecated since 2.0.0
     "LAMBDA_STAY_OPEN_MODE",  # deprecated since 2.0.0
-    "SQS_PORT_EXTERNAL",  # deprecated in docs since 2022-07-13
+    "LEGACY_EDGE_PROXY",  # deprecated since 1.0.0
+    "LOCALSTACK_HOSTNAME",  # deprecated since 2.0.0
+    "SQS_PORT_EXTERNAL",  # deprecated only in docs since 2022-07-13
     "SYNCHRONOUS_KINESIS_EVENTS",  # deprecated since 1.3.0
-    "SYNCHRONOUS_SNS_EVENTS",  # deprecated since 1.3.0
-    "SYNCHRONOUS_DYNAMODB_EVENTS",  # deprecated since 1.3.0
-    "SYNCHRONOUS_API_GATEWAY_EVENTS",  # deprecated since 1.3.0
-    "SYNCHRONOUS_SQS_EVENTS",  # deprecated since 1.3.0
-    "KINESIS_PROVIDER",  # deprecated since 1.3.0
+    "USE_SINGLE_REGION",  # deprecated since 0.12.7
     "MOCK_UNIMPLEMENTED",  # deprecated since 1.3.0
 ]
 

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -232,12 +232,6 @@ DEPRECATIONS = [
         "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2",
     ),
     EnvVarDeprecation(
-        "HOSTNAME_FROM_LAMBDA",
-        "2.0.0",
-        "This feature is currently not supported in the new lambda provider "
-        "https://docs.localstack.cloud/user-guide/aws/lambda/#migrating-to-lambda-v2",
-    ),
-    EnvVarDeprecation(
         "LAMBDA_XRAY_INIT",
         "2.0.0",
         "The X-Ray daemon is always initialized in the new lambda provider "

--- a/localstack/testing/pytest/cloudtrail_tracking/cloudtrail_tracking/handler/index.py
+++ b/localstack/testing/pytest/cloudtrail_tracking/cloudtrail_tracking/handler/index.py
@@ -6,7 +6,7 @@ from typing import Any, List
 import boto3
 
 S3_BUCKET = os.environ["BUCKET"]
-LOCALSTACK_HOST = os.getenv("LOCALSTACK_HOSTNAME")
+AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 
 
 class Encoder(json.JSONEncoder):
@@ -21,10 +21,10 @@ class Encoder(json.JSONEncoder):
 
 
 def get_client(service: str):
-    if LOCALSTACK_HOST is not None:
+    if AWS_ENDPOINT_URL is not None:
         client = boto3.client(
             service,
-            endpoint_url=f"http://{LOCALSTACK_HOST}:4566",
+            endpoint_url=AWS_ENDPOINT_URL,
             region_name="us-east-1",
         )
     else:

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -441,7 +441,6 @@ def get_docker_host_from_container() -> str:
             # If we're running outside Docker (in host mode), and would like the Lambda containers to be able
             # to access services running on the local machine, return `host.docker.internal` accordingly
             result = "host.docker.internal"
-        # update LOCALSTACK_HOSTNAME if host.docker.internal is available
         if config.is_in_docker:
             try:
                 result = socket.gethostbyname("host.docker.internal")


### PR DESCRIPTION
## Motivation

`localstack.config.py` has become bloated by mixing up deprecated, removed, and current configurations.

`HOSTNAME_FROM_LAMBDA` is deprecated but still supported.

## Changes

This PR primarily improves the organization of the config list and removes a deprecation:

* Synchronize removal grouping with the docs PR https://github.com/localstack/docs/pull/918
* Remove `HOSTNAME_FROM_LAMBDA` from deprecations. This was deprecated but then added to the new Lambda provider upon request. The Lambda team decided to un-deprecate it given the need and currently no supported alternatives.
* Migrate a leftover `AWS_ENDPOINT_URL`
* Remove some outdated comments with deprecated references to `LOCALSTACK_HOSTNAME`
