### PR TITLE
pin botocore before gzip of services

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ runtime =
     jsonschema<=4.19.0
     localstack-client>=2.0
     moto-ext[all]==4.2.7.post1
-    opensearch-py>=2.3.2
+    opensearch-py>=2.3.2,<2.4
     pymongo>=4.2.0
     pyopenssl>=23.0.0
     Quart>=0.19.2


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
It seems botocore just released a minor version containing their `service-2.json` files now `gzip`.

Our loader should work, but it seems Moto is directly trying to load them manually and this fails.
One of the stack trace:

```python
.venv/lib/python3.11/site-packages/moto/emr/responses.py:61: in ElasticMapReduceResponse
    aws_service_spec = AWSServiceSpec("data/emr/2009-03-31/service-2.json")
.venv/lib/python3.11/site-packages/moto/core/responses.py:964: in __init__
    spec = load_resource("botocore", path)
.venv/lib/python3.11/site-packages/moto/utilities/utils.py:22: in load_resource
    return json.loads(pkgutil.get_data(package, resource))  # type: ignore
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
```

<!-- What notable changes does this PR make? -->
## Changes
- bin botocore to be above SQS changes, but under the `gzip` changes. This doesn't affect us until the next ASF updates. 
- also pin opensearch-py which made an update and now try to import a library that is only in the extra_requires (aiohttp)
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

