### PR TITLE
unpin opensearch-py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ runtime =
     jsonschema<=4.19.0
     localstack-client>=2.0
     moto-ext[all]==4.2.7.post1
-    opensearch-py>=2.3.2,<2.4
+    opensearch-py>=2.4.1
     pymongo>=4.2.0
     pyopenssl>=23.0.0
     Quart>=0.19.2


### PR DESCRIPTION
## Motivation
Shortly before the v3 release we have seen some releases of dependencies which broke our pipelines.
This PR reverts the pin on `opensearch-py` and increases the minimum version:
The pin was introduced in b2b323019f0cebfaec6016a0fc62828aea13f81d due to https://github.com/opensearch-project/opensearch-py/issues/592, which has been addressed in https://github.com/opensearch-project/opensearch-py/pull/594 and is contained in [`opensearch-py==2.4.1`](https://github.com/opensearch-project/opensearch-py/releases/tag/v2.4.1).

## Changes
- Reverts the pin on `opensearch-py` and increases the minimum version.