### PR TITLE
unpin botocore, update minimum version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ runtime =
     awscli>=1.22.90
     awscrt>=0.13.14
     boto3>=1.26.121
-    botocore==1.31.85
+    botocore>=1.32.2
     cbor2>=5.2.0
     crontab>=0.22.6
     dnspython>=1.16.0


### PR DESCRIPTION
## Motivation
With 815d6c77245e3ebfb9d298a70fe16bd12df032f7 we pinned `botocore` to version `1.31.85` to prevent incompatibilities with `moto`.
These issues were fixed in https://github.com/getmoto/moto/pull/7030.
This PR will coordinate the update of `botocore` to the newest version, once we have the `moto` fix in, which might be addressed in https://github.com/localstack/localstack/pull/9624.

## Changes
- Remove the pin on `botocore` and update the minimum version.

## Testing
- We have lots of tests in place and `botocore` used basically everywhere. If we're green, we're fine. :)

## TODO
- [x] Make sure the moto fix is available / wait for https://github.com/localstack/localstack/pull/9624.
- [x] Rebase this PR on `master` after the upgrade of `moto`.
- [x] Make sure the test are green afterwards.
  - Also tested integration with Pro. 💚 