### PR TITLE
Fix int exception for API GW

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -828,11 +828,6 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
                 path = operation["path"]
                 common.assign_to_path(subject, path, value={}, delimiter="/")
 
-            # minimum_compression_size is a unique path as it's a nullable integer,
-            # it would throw an error if it's an empty string
-            if operation["path"] == "/minimum_compression_size" and operation.get("value") == "":
-                operation["value"] = None
-
             result = apply_patch(subject, [operation], in_place=in_place)
             if not in_place:
                 subject = result

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -828,6 +828,11 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
                 path = operation["path"]
                 common.assign_to_path(subject, path, value={}, delimiter="/")
 
+            # minimum_compression_size is a unique path as it's a nullable integer,
+            # it would throw an error if it's an empty string
+            if operation["path"] == "/minimum_compression_size" and operation.get("value") == "":
+                operation["value"] = None
+
             result = apply_patch(subject, [operation], in_place=in_place)
             if not in_place:
                 subject = result

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -342,6 +342,11 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if isinstance(endpoint_configs.get("vpcEndpointIds"), str):
             endpoint_configs["vpcEndpointIds"] = [endpoint_configs["vpcEndpointIds"]]
 
+        # minimum_compression_size is a unique path as it's a nullable integer,
+        # it would throw an error if it stays an empty string
+        if rest_api.minimum_compression_size == "":
+            rest_api.minimum_compression_size = None
+
         response = rest_api.to_dict()
         remove_empty_attributes_from_rest_api(response, remove_tags=False)
         store = get_apigateway_store(context=context)

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -417,10 +417,8 @@ class TestApiGatewayApi:
         snapshot.match("enable-compression", response)
 
         # check that listing is not exploding after update, null -> 10
-        try:
-            aws_client.apigateway.get_rest_api(restApiId=api_id)
-        except ClientError:
-            assert False
+        response = aws_client.apigateway.get_rest_api(restApiId=api_id)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
         # from the docs: to disable compression, apply a replace operation with the value property set to null or
         # omit the value property.
@@ -434,10 +432,8 @@ class TestApiGatewayApi:
         snapshot.match("disable-compression", response)
 
         # check that listing is not exploding after update, 10 -> null
-        try:
-            aws_client.apigateway.get_rest_api(restApiId=api_id)
-        except ClientError:
-            assert False
+        response = aws_client.apigateway.get_rest_api(restApiId=api_id)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
         patch_operations = [
             {"op": "replace", "path": "/minimumCompressionSize", "value": "0"},
@@ -448,10 +444,8 @@ class TestApiGatewayApi:
         snapshot.match("set-compression-zero", response)
 
         # check that listing is not exploding after update, null -> 0
-        try:
-            aws_client.apigateway.get_rest_api(restApiId=api_id)
-        except ClientError:
-            assert False
+        response = aws_client.apigateway.get_rest_api(restApiId=api_id)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
         with pytest.raises(ClientError) as e:
             patch_operations = [

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -416,6 +416,12 @@ class TestApiGatewayApi:
         )
         snapshot.match("enable-compression", response)
 
+        # check that listing is not exploding after update, null -> 10
+        try:
+            aws_client.apigateway.get_rest_api(restApiId=api_id)
+        except ClientError:
+            assert False
+
         # from the docs: to disable compression, apply a replace operation with the value property set to null or
         # omit the value property.
         # it seems an empty string is accepted as well
@@ -427,6 +433,12 @@ class TestApiGatewayApi:
         )
         snapshot.match("disable-compression", response)
 
+        # check that listing is not exploding after update, 10 -> null
+        try:
+            aws_client.apigateway.get_rest_api(restApiId=api_id)
+        except ClientError:
+            assert False
+
         patch_operations = [
             {"op": "replace", "path": "/minimumCompressionSize", "value": "0"},
         ]
@@ -434,6 +446,12 @@ class TestApiGatewayApi:
             restApiId=api_id, patchOperations=patch_operations
         )
         snapshot.match("set-compression-zero", response)
+
+        # check that listing is not exploding after update, null -> 0
+        try:
+            aws_client.apigateway.get_rest_api(restApiId=api_id)
+        except ClientError:
+            assert False
 
         with pytest.raises(ClientError) as e:
             patch_operations = [


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Botocore exception for integer casting on empty strings when changing API gateway's minimum compression size from 0 to disabled.

<!-- What notable changes does this PR make? -->
## Changes
- not allowing minimum compression size to be an empty string
- add some get api calls after update operations during tests

<!-- The following sections are optional, but can be useful! 

## Testing

Try to list your API GWs after GW created with no minimum compression size.

-->

