### PR TITLE
switch to shared pr label enforcers, add bugfix only action

### DIFF
--- a/.github/workflows/pr-enforce-no-major-minor-master.yml
+++ b/.github/workflows/pr-enforce-no-major-minor-master.yml
@@ -1,4 +1,4 @@
-name: Enforce no major on master
+name: Enforce no major or minor on master
 
 on:
   pull_request_target:
@@ -8,10 +8,10 @@ on:
     - master
 
 jobs:
-  enforce-no-major:
+  enforce-no-major-minor:
     permissions:
       issues: write
       pull-requests: write
-    uses: localstack/meta/.github/workflows/pr-enforce-no-major.yml@main
+    uses: localstack/meta/.github/workflows/pr-enforce-no-major-minor.yml@main
     secrets:
       github-token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/pr-enforce-pr-labels.yml
+++ b/.github/workflows/pr-enforce-pr-labels.yml
@@ -5,15 +5,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
 
 jobs:
-  # make sure _all_ PRs have a semver label
-  enforce-semver-label:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: mheap/github-action-required-labels@v5
-        with:
-          mode: exactly
-          count: 1
-          labels: "semver: patch, semver: minor, semver: major"
+  enforce-semver-labels:
+    uses: localstack/meta/.github/workflows/pr-enforce-semver-labels.yml@main
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation
We have several repositories where we want to enforce some label constraints on PRs.
This PR migrates these actions to shared workflows in https://github.com/localstack/meta.
These actions are only executed on _newly created_ PRs. The actions will only be triggered if the labels on a PR are changed.
So we still have to watch out for PRs which have already been created!

## Changes
- Switch to shared workflows for:
  - `pr-enforce-no-major-master.yml`
  - `pr-enforce-pr-labels.yml`
- Introduce a new workflow (also using a shared one) to enforce that _neither_ `major` _nor_ `minor` labels are on the PR: `pr-enforce-no-major-minor-master.yml`.

## Testing
- These changes were tested in another private org repo.

## TODO
- After merging these PRs we have to disable the `pr-enforce-no-major-master.yml`, such that only the `pr-enforce-no-major-minor-master.yml` is active (which enforces our current restriction on not merging minor changes until we release the next bugfix release).