### PR TITLE
fix get_object_tagging should work on versioned buckets without providing an explicit VersionId

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -2518,7 +2518,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         validate_tag_set(tagging["TagSet"], type_set="object")
 
-        key_id = get_unique_key_id(bucket, key, version_id)
+        key_id = get_unique_key_id(bucket, key, s3_object.version_id)
         # remove the previous tags before setting the new ones, it overwrites the whole TagSet
         store.TAGS.tags.pop(key_id, None)
         store.TAGS.tag_resource(key_id, tags=tagging["TagSet"])
@@ -2553,9 +2553,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             e.Key = f"{bucket}/{key}"
             raise e
 
-        tag_set = store.TAGS.list_tags_for_resource(get_unique_key_id(bucket, key, version_id))[
-            "Tags"
-        ]
+        tag_set = store.TAGS.list_tags_for_resource(
+            get_unique_key_id(bucket, key, s3_object.version_id)
+        )["Tags"]
         response = GetObjectTaggingOutput(TagSet=tag_set)
         if s3_object.version_id:
             response["VersionId"] = s3_object.version_id

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -1827,7 +1827,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
-    "recorded-date": "02-08-2023, 23:14:16",
+    "recorded-date": "20-11-2023, 17:25:12",
     "recorded-content": {
       "put-obj-0": {
         "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
@@ -1867,6 +1867,19 @@
           "HTTPStatusCode": 200
         }
       },
+      "get-object-tags-previous-version": {
+        "TagSet": [
+          {
+            "Key": "test_tag",
+            "Value": "tagv1"
+          }
+        ],
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "put-object-tags-previous-version": {
         "VersionId": "<version-id:1>",
         "ResponseMetadata": {
@@ -1874,7 +1887,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "get-object-tags-previous-version": {
+      "get-object-tags-previous-version-again": {
         "TagSet": [
           {
             "Key": "tag1",


### PR DESCRIPTION
## Motivation

previously  `s3.get_object_tagging` worked on versioned buckets, without specifying an explicit `VersionId`

## Changes
* localstack/services/s3/v3/provider.py::put_object_tagging sets tags version to `s3_object.version_id` if present
* localstack/services/s3/v3/provider.py::get_object_tagging uses `s3_object.version_id` if pesent
* small addtion to `tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned` to also exercise `put_object` with `Tagging` set on a versioned bucket

## Testing

covered by `tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned`



