### PR TITLE
Introduce DNS_SKIP_LOCAL_RESOLUTION config

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1015,7 +1015,8 @@ DNS_PORT = int(os.environ.get("DNS_PORT", "53"))
 # Comma-separated list of regex patterns for DNS names to resolve locally.
 # Any DNS name not matched against any of the patterns on this whitelist
 # will resolve to the real DNS entry, rather than the local one.
-DNS_LOCAL_NAME_PATTERNS = (os.environ.get("DNS_LOCAL_NAME_PATTERNS") or "").strip()
+DNS_SKIP_LOCAL_RESOLUTION = (os.environ.get("DNS_SKIP_LOCAL_RESOLUTION") or "").strip()
+DNS_LOCAL_NAME_PATTERNS = (os.environ.get("DNS_LOCAL_NAME_PATTERNS") or "").strip()  # deprecated
 
 # IP address that AWS endpoints should resolve to in our local DNS server. By default,
 # hostnames resolve to 127.0.0.1, which allows to use the LocalStack APIs transparently

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -269,6 +269,11 @@ DEPRECATIONS = [
         "0.14.0",
         "This option has no effect anymore. Please use OPENSEARCH_ENDPOINT_STRATEGY instead.",
     ),
+    EnvVarDeprecation(
+        "DNS_LOCAL_NAME_PATTERNS",
+        "3.0.0",
+        "This option was confusingly named. Please use DNS_SKIP_LOCAL_RESOLUTION instead.",
+    ),
 ]
 
 

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -828,8 +828,17 @@ def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):
     if config.LOCALSTACK_HOST.host != LOCALHOST_HOSTNAME:
         dns_server.add_host_pointing_to_localstack(f".*{config.LOCALSTACK_HOST.host}")
 
-    if config.DNS_LOCAL_NAME_PATTERNS:
-        for skip_pattern in re.split(r"[,;\s]+", config.DNS_LOCAL_NAME_PATTERNS):
+    # support both DNS_SKIP_LOCAL_RESOLUTION and DNS_LOCAL_NAME_PATTERNS
+    # until the next major version change
+    # TODO(srw): remove the usage of DNS_LOCAL_NAME_PATTERNS
+    skip_local_resolution = " ".join(
+        [
+            config.DNS_SKIP_LOCAL_RESOLUTION,
+            config.DNS_LOCAL_NAME_PATTERNS,
+        ]
+    ).strip()
+    if skip_local_resolution:
+        for skip_pattern in re.split(r"[,;\s]+", skip_local_resolution):
             dns_server.add_skip(skip_pattern)
 
     dns_server.start()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Sometimes we may wish to skip resolving a DNS name with the LocalStack DNS server. For example, when using [transparent endpoint injection](https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/) some AWS URLs need to resolve to addresses on the public internet in order to e.g. fetch something from an S3 bucket.

We currently support this feature with the configuration variable `DNS_LOCAL_NAME_PATTERNS`, but this name sounds like it does the opposite -> "local name patterns" sounds like it will either:

* add a name to be resolved locally, or
* resolve a specific name to the local address.

This is not the case.

<!-- What notable changes does this PR make? -->
## Changes

We cannot remove this configuration variable since it is a breaking change, and we have not introduced a deprecation phase. This PR starts the deprecation phase of `DNS_LOCAL_NAME_PATTERNS`, and instead lets the user configure `DNS_SKIP_LOCAL_RESOLUTION`. Currently during this deprecation phase, we accept both variables, however in the future `DNS_LOCAL_NAME_PATTERNS` will not be used to configure DNS resolution.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

