### PR TITLE
Fix execution storage for new stepfunctions provider

### DIFF
--- a/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack/services/stepfunctions/backend/execution.py
@@ -132,9 +132,9 @@ class Execution:
         self.exec_worker = None
         self.error = None
         self.cause = None
-        self._events_client = connect_to(
-            aws_access_key_id=self.account_id, region_name=self.region_name
-        ).events
+
+    def _get_events_client(self):
+        return connect_to(aws_access_key_id=self.account_id, region_name=self.region_name).events
 
     def to_start_output(self) -> StartExecutionOutput:
         return StartExecutionOutput(executionArn=self.exec_arn, startDate=self.start_date)
@@ -273,7 +273,7 @@ class Execution:
             ),
         )
         try:
-            self._events_client.put_events(Entries=[entry])
+            self._get_events_client().put_events(Entries=[entry])
         except Exception:
             LOG.exception(
                 f"Unable to send notification of Entry='{entry}' for Step Function execution with Arn='{self.exec_arn}' to EventBridge."


### PR DESCRIPTION
## Motivation

Pickling a boto client is currently not working and there's also no particular reason it should. Before we were saving the events client and when trying to pickle it, it was throwing an Exception when failing to pickle the SSLContext object.  With this PR we avoid this situation by just not saving the reference to the client in the stored `Execution` object.

Companion to https://github.com/localstack/localstack-ext/pull/2360

## Changes

- Replace property with internal function. The client access is cached anyway, so there's no particular performance downside.

## Testing

Needs access to the -ext repo. Run https://github.com/localstack/localstack-ext/pull/2360 with pro enabled and start an execution of any state machine (or run any integration test involving a step function). 

Manually verified this to be working by creating a state machine, executing it once, restarting, making sure the execution and state machine are still there and then starting another execution.
