### PR TITLE
Fix StepFunctions execution date formatting

### DIFF
--- a/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack/services/stepfunctions/asl/component/state/state.py
@@ -117,7 +117,7 @@ class CommonStateField(EvalComponent, ABC):
         )
 
         env.context_object_manager.context_object["State"] = State(
-            EnteredTime=datetime.datetime.now().isoformat(), Name=self.name
+            EnteredTime=datetime.datetime.now(tz=datetime.UTC).isoformat(), Name=self.name
         )
 
         # Filter the input onto the stack.

--- a/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack/services/stepfunctions/asl/component/state/state.py
@@ -117,7 +117,7 @@ class CommonStateField(EvalComponent, ABC):
         )
 
         env.context_object_manager.context_object["State"] = State(
-            EnteredTime=datetime.datetime.now(tz=datetime.UTC).isoformat(), Name=self.name
+            EnteredTime=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(), Name=self.name
         )
 
         # Filter the input onto the stack.

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/map_run_record.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/map_run_record.py
@@ -115,7 +115,7 @@ class MapRunRecord:
         self.max_concurrency = max_concurrency
         self.execution_counter = ExecutionCounter()
         self.item_counter = ItemCounter()
-        self.start_date = datetime.datetime.now()
+        self.start_date = datetime.datetime.now(tz=datetime.UTC)
         self.status = MapRunStatus.RUNNING
         self.stop_date = None
         self.tolerated_failure_count = 0
@@ -134,7 +134,7 @@ class MapRunRecord:
 
     def set_stop(self, status: MapRunStatus):
         self.status = status
-        self.stop_date = datetime.datetime.now()
+        self.stop_date = datetime.datetime.now(tz=datetime.UTC)
 
     def describe(self) -> DescribeMapRunOutput:
         describe_output = DescribeMapRunOutput(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/map_run_record.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/itemprocessor/map_run_record.py
@@ -115,7 +115,7 @@ class MapRunRecord:
         self.max_concurrency = max_concurrency
         self.execution_counter = ExecutionCounter()
         self.item_counter = ItemCounter()
-        self.start_date = datetime.datetime.now(tz=datetime.UTC)
+        self.start_date = datetime.datetime.now(tz=datetime.timezone.utc)
         self.status = MapRunStatus.RUNNING
         self.stop_date = None
         self.tolerated_failure_count = 0
@@ -134,7 +134,7 @@ class MapRunRecord:
 
     def set_stop(self, status: MapRunStatus):
         self.status = status
-        self.stop_date = datetime.datetime.now(tz=datetime.UTC)
+        self.stop_date = datetime.datetime.now(tz=datetime.timezone.utc)
 
     def describe(self) -> DescribeMapRunOutput:
         describe_output = DescribeMapRunOutput(

--- a/localstack/services/stepfunctions/asl/eval/event/event_history.py
+++ b/localstack/services/stepfunctions/asl/eval/event/event_history.py
@@ -74,7 +74,7 @@ class EventHistory:
             history_event["id"] = event_id
             history_event["previousEventId"] = context.source_event_id
             history_event["type"] = hist_type_event
-            history_event["timestamp"] = timestamp or datetime.datetime.now()
+            history_event["timestamp"] = timestamp or datetime.datetime.now(tz=datetime.UTC)
             self._history_event_list.append(history_event)
             context.last_published_event_id = event_id
             if update_source_event_id:

--- a/localstack/services/stepfunctions/asl/eval/event/event_history.py
+++ b/localstack/services/stepfunctions/asl/eval/event/event_history.py
@@ -74,7 +74,9 @@ class EventHistory:
             history_event["id"] = event_id
             history_event["previousEventId"] = context.source_event_id
             history_event["type"] = hist_type_event
-            history_event["timestamp"] = timestamp or datetime.datetime.now(tz=datetime.UTC)
+            history_event["timestamp"] = timestamp or datetime.datetime.now(
+                tz=datetime.timezone.utc
+            )
             self._history_event_list.append(history_event)
             context.last_published_event_id = event_id
             if update_source_event_id:

--- a/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack/services/stepfunctions/backend/execution.py
@@ -206,7 +206,8 @@ class Execution:
         event_history: HistoryEventList = self.exec_worker.env.event_history.get_event_history()
         return GetExecutionHistoryOutput(events=event_history)
 
-    def _to_serialized_date(self, timestamp: datetime.datetime) -> str:
+    @staticmethod
+    def _to_serialized_date(timestamp: datetime.datetime) -> str:
         """See test in tests.aws.services.stepfunctions.v2.base.test_base.TestSnfBase.test_execution_dateformat"""
         return (
             f'{timestamp.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]}Z'

--- a/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack/services/stepfunctions/backend/execution.py
@@ -57,7 +57,7 @@ class BaseExecutionWorkerComm(ExecutionWorkerComm):
 
     def terminated(self) -> None:
         exit_program_state: ProgramState = self.execution.exec_worker.env.program_state()
-        self.execution.stop_date = datetime.datetime.now(tz=datetime.UTC)
+        self.execution.stop_date = datetime.datetime.now(tz=datetime.timezone.utc)
         if isinstance(exit_program_state, ProgramEnded):
             self.execution.exec_status = ExecutionStatus.SUCCEEDED
             self.execution.output = to_json_str(
@@ -208,7 +208,9 @@ class Execution:
 
     def _to_serialized_date(self, timestamp: datetime.datetime) -> str:
         """See test in tests.aws.services.stepfunctions.v2.base.test_base.TestSnfBase.test_execution_dateformat"""
-        return f'{timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]}Z'
+        return (
+            f'{timestamp.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]}Z'
+        )
 
     def start(self) -> None:
         # TODO: checks exec_worker does not exists already?

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -55,7 +55,7 @@ class StateMachineInstance:
         self.revision_id = None
         self.definition = definition
         self.role_arn = role_arn
-        self.create_date = create_date or datetime.now()
+        self.create_date = create_date or datetime.now(tz=datetime.UTC)
         self.sm_type = sm_type or StateMachineType.STANDARD
         self.logging_config = logging_config
         self.tags = tags
@@ -207,7 +207,7 @@ class StateMachineVersion(StateMachineInstance):
             arn=version_arn,
             definition=state_machine_revision.definition,
             role_arn=state_machine_revision.role_arn,
-            create_date=datetime.now(),
+            create_date=datetime.now(tz=datetime.UTC),
             sm_type=state_machine_revision.sm_type,
             logging_config=state_machine_revision.logging_config,
             tags=state_machine_revision.tags,

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import abc
+import datetime
 import json
 from collections import OrderedDict
-from datetime import datetime
 from typing import Final, Optional
 
 from localstack.aws.api.stepfunctions import (
@@ -32,7 +32,7 @@ class StateMachineInstance:
     revision_id: Optional[RevisionId]
     definition: Definition
     role_arn: Arn
-    create_date: datetime
+    create_date: datetime.datetime
     sm_type: StateMachineType
     logging_config: Optional[LoggingConfiguration]
     tags: Optional[TagList]
@@ -44,7 +44,7 @@ class StateMachineInstance:
         arn: Arn,
         definition: Definition,
         role_arn: Arn,
-        create_date: Optional[datetime] = None,
+        create_date: Optional[datetime.datetime] = None,
         sm_type: Optional[StateMachineType] = None,
         logging_config: Optional[LoggingConfiguration] = None,
         tags: Optional[TagList] = None,
@@ -55,7 +55,7 @@ class StateMachineInstance:
         self.revision_id = None
         self.definition = definition
         self.role_arn = role_arn
-        self.create_date = create_date or datetime.now(tz=datetime.timezone.utc)
+        self.create_date = create_date or datetime.datetime.now(tz=datetime.timezone.utc)
         self.sm_type = sm_type or StateMachineType.STANDARD
         self.logging_config = logging_config
         self.tags = tags
@@ -128,7 +128,7 @@ class StateMachineRevision(StateMachineInstance):
         arn: Arn,
         definition: Definition,
         role_arn: Arn,
-        create_date: Optional[datetime] = None,
+        create_date: Optional[datetime.datetime] = None,
         sm_type: Optional[StateMachineType] = None,
         logging_config: Optional[LoggingConfiguration] = None,
         tags: Optional[TagList] = None,
@@ -207,7 +207,7 @@ class StateMachineVersion(StateMachineInstance):
             arn=version_arn,
             definition=state_machine_revision.definition,
             role_arn=state_machine_revision.role_arn,
-            create_date=datetime.now(tz=datetime.timezone.utc),
+            create_date=datetime.datetime.now(tz=datetime.timezone.utc),
             sm_type=state_machine_revision.sm_type,
             logging_config=state_machine_revision.logging_config,
             tags=state_machine_revision.tags,

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -55,7 +55,7 @@ class StateMachineInstance:
         self.revision_id = None
         self.definition = definition
         self.role_arn = role_arn
-        self.create_date = create_date or datetime.now(tz=datetime.UTC)
+        self.create_date = create_date or datetime.now(tz=datetime.timezone.utc)
         self.sm_type = sm_type or StateMachineType.STANDARD
         self.logging_config = logging_config
         self.tags = tags
@@ -207,7 +207,7 @@ class StateMachineVersion(StateMachineInstance):
             arn=version_arn,
             definition=state_machine_revision.definition,
             role_arn=state_machine_revision.role_arn,
-            create_date=datetime.now(tz=datetime.UTC),
+            create_date=datetime.now(tz=datetime.timezone.utc),
             sm_type=state_machine_revision.sm_type,
             logging_config=state_machine_revision.logging_config,
             tags=state_machine_revision.tags,

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -388,7 +388,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             account_id=context.account_id,
             region_name=context.region,
             state_machine=state_machine_clone,
-            start_date=datetime.datetime.now(tz=datetime.UTC),
+            start_date=datetime.datetime.now(tz=datetime.timezone.utc),
             input_data=input_data,
             trace_header=trace_header,
         )
@@ -506,7 +506,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         cause: SensitiveCause = None,
     ) -> StopExecutionOutput:
         execution: Execution = self._get_execution(context=context, execution_arn=execution_arn)
-        stop_date = datetime.datetime.now(tz=datetime.UTC)
+        stop_date = datetime.datetime.now(tz=datetime.timezone.utc)
         execution.stop(stop_date=stop_date, cause=cause, error=error)
         return StopExecutionOutput(stopDate=stop_date)
 
@@ -547,7 +547,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                 target_revision_id = revision_id or state_machine.revision_id
                 version_arn = state_machine.versions[target_revision_id]
 
-        update_output = UpdateStateMachineOutput(updateDate=datetime.datetime.now(tz=datetime.UTC))
+        update_output = UpdateStateMachineOutput(
+            updateDate=datetime.datetime.now(tz=datetime.timezone.utc)
+        )
         if revision_id is not None:
             update_output["revisionId"] = revision_id
         if version_arn is not None:

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -108,15 +108,8 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     def get_store(context: RequestContext) -> SFNStore:
         return sfn_stores[context.account_id][context.region]
 
-    # def on_before_state_save(self):
-    #     # abort all running executions
-    #     ...
-
     def accept_state_visitor(self, visitor: StateVisitor):
-        try:
-            visitor.visit(sfn_stores)
-        except Exception as e:
-            print(e)
+        visitor.visit(sfn_stores)
 
     def _get_execution(self, context: RequestContext, execution_arn: Arn) -> Execution:
         execution: Optional[Execution] = self.get_store(context).executions.get(execution_arn)

--- a/tests/aws/services/stepfunctions/templates/base/base_templates.py
+++ b/tests/aws/services/stepfunctions/templates/base/base_templates.py
@@ -19,3 +19,6 @@ class BaseTemplate(TemplateLoader):
     QUERY_CONTEXT_OBJECT_VALUES: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/query_context_object_values.json5"
     )
+    PASS_START_TIME: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/pass_start_time_format.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/base/statemachines/pass_start_time_format.json5
+++ b/tests/aws/services/stepfunctions/templates/base/statemachines/pass_start_time_format.json5
@@ -1,0 +1,13 @@
+{
+  "Comment": "Used to check format of generated timestamp",
+  "StartAt": "Pass",
+  "States": {
+    "Pass": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "out1.$": "$$.Execution.StartTime"
+      }
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -231,9 +231,7 @@ class TestSnfBase:
 
         # check that date format conforms to AWS spec e.g. "2023-11-21T06:27:31.545Z"
         date_regex = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z"
-        context_start_time = json.loads(execution_done["output"])[
-            "out1"
-        ]  # "2023-11-21T06:27:31.545Z" => ISO 8601
+        context_start_time = json.loads(execution_done["output"])["out1"]
         assert re.match(date_regex, context_start_time)
 
         # make sure execution start time on the API side is the same as the one returned internally when accessing the context object


### PR DESCRIPTION
## Motivation

Resolves https://github.com/localstack/localstack/issues/9695

The returned string needs to look like this: "2023-11-21T06:27:31.545Z" which is not the default isoformat which we've been using previously. It also seems like AWS always returns UTC timestamps as far as I can see.


## Changes

- Changes format of serialized timestamp for execution start and end date.
- Explicitly use UTC everywhere when creating timestamps to hopefully avoid any future issues.


## TODO

What's left to do:

- [ ] cover other (de-)serializations, e.g. strptime

