### PR TITLE
remove sqs-query from health endpoint

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -87,7 +87,10 @@ class HealthResource:
         if reload:
             self.service_manager.check_all()
         services = {
-            service: state.value for service, state in self.service_manager.get_states().items()
+            service: state.value
+            for service, state in self.service_manager.get_states().items()
+            # TODO remove this as soon as the sqs-query service is gone
+            if service != "sqs-query"
         }
 
         # build state dict from internal state and merge into it the service states

--- a/tests/bootstrap/test_strict_service_loading.py
+++ b/tests/bootstrap/test_strict_service_loading.py
@@ -39,7 +39,6 @@ def test_strict_service_loading(
     assert services.pop("sqs") == "available"
     assert services.pop("s3") == "available"
     assert services.pop("sns") == "available"
-    assert services.pop("sqs-query") == "available"  # dependency of SQS
 
     assert services
     assert all(services.get(key) == "disabled" for key in services.keys())


### PR DESCRIPTION
## Motivation
This PR removes the service alias for SQS to support the old `query` protocol from the health endpoint (because it's not its own AWS service, just an alias for an existing service used to distinguish between the routing and allow loading a separate spec).

## Changes
Explicitly removes `sqs-query` from the health endpoint as a temporary workaround (until the "service alias" has been removed again).

/cc @Pive01 