### PR TITLE
fix sqs multi-protocol handling and upgrade botocore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Install the latest version of awslocal globally
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install --upgrade awscli==1.30.5 awscli-local requests
+    pip3 install --upgrade awscli awscli-local requests
 
 
 

--- a/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack/aws/api/cloudwatch/__init__.py
@@ -133,6 +133,7 @@ class HistoryItemType(str):
 class MetricStreamOutputFormat(str):
     json = "json"
     opentelemetry0_7 = "opentelemetry0.7"
+    opentelemetry1_0 = "opentelemetry1.0"
 
 
 class RecentlyActive(str):

--- a/localstack/aws/api/config/__init__.py
+++ b/localstack/aws/api/config/__init__.py
@@ -31,6 +31,7 @@ DeliveryS3Bucket = str
 DeliveryS3KeyPrefix = str
 DescribeConformancePackComplianceLimit = int
 DescribePendingAggregationRequestsLimit = int
+Description = str
 EmptiableStringWithCharLimit256 = str
 ErrorMessage = str
 EvaluationContextIdentifier = str
@@ -252,6 +253,11 @@ class RecorderStatus(str):
     Pending = "Pending"
     Success = "Success"
     Failure = "Failure"
+
+
+class RecordingFrequency(str):
+    CONTINUOUS = "CONTINUOUS"
+    DAILY = "DAILY"
 
 
 class RecordingStrategyType(str):
@@ -1183,6 +1189,7 @@ class AggregationAuthorization(TypedDict, total=False):
 
 AggregationAuthorizationList = List[AggregationAuthorization]
 AutoRemediationAttemptSeconds = int
+ConfigurationItemDeliveryTime = datetime
 SupplementaryConfiguration = Dict[SupplementaryConfigurationName, SupplementaryConfigurationValue]
 ResourceCreationTime = datetime
 ConfigurationItemCaptureTime = datetime
@@ -1203,6 +1210,8 @@ class BaseConfigurationItem(TypedDict, total=False):
     resourceCreationTime: Optional[ResourceCreationTime]
     configuration: Optional[Configuration]
     supplementaryConfiguration: Optional[SupplementaryConfiguration]
+    recordingFrequency: Optional[RecordingFrequency]
+    configurationItemDeliveryTime: Optional[ConfigurationItemDeliveryTime]
 
 
 BaseConfigurationItems = List[BaseConfigurationItem]
@@ -1422,9 +1431,26 @@ class ConfigurationItem(TypedDict, total=False):
     relationships: Optional[RelationshipList]
     configuration: Optional[Configuration]
     supplementaryConfiguration: Optional[SupplementaryConfiguration]
+    recordingFrequency: Optional[RecordingFrequency]
+    configurationItemDeliveryTime: Optional[ConfigurationItemDeliveryTime]
 
 
 ConfigurationItemList = List[ConfigurationItem]
+RecordingModeResourceTypesList = List[ResourceType]
+
+
+class RecordingModeOverride(TypedDict, total=False):
+    description: Optional[Description]
+    resourceTypes: RecordingModeResourceTypesList
+    recordingFrequency: RecordingFrequency
+
+
+RecordingModeOverrides = List[RecordingModeOverride]
+
+
+class RecordingMode(TypedDict, total=False):
+    recordingFrequency: RecordingFrequency
+    recordingModeOverrides: Optional[RecordingModeOverrides]
 
 
 class RecordingStrategy(TypedDict, total=False):
@@ -1450,6 +1476,7 @@ class ConfigurationRecorder(TypedDict, total=False):
     name: Optional[RecorderName]
     roleARN: Optional[String]
     recordingGroup: Optional[RecordingGroup]
+    recordingMode: Optional[RecordingMode]
 
 
 ConfigurationRecorderList = List[ConfigurationRecorder]

--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -41,6 +41,7 @@ CoolOffPeriodResponseHours = int
 CopySnapshotRequestPSU = str
 CoreCount = int
 CoreNetworkArn = str
+CpuManufacturerName = str
 CurrentGenerationFlag = bool
 CustomerGatewayId = str
 DITMaxResults = int
@@ -327,6 +328,7 @@ class AcceleratorManufacturer(str):
     amd = "amd"
     nvidia = "nvidia"
     xilinx = "xilinx"
+    habana = "habana"
 
 
 class AcceleratorName(str):
@@ -339,6 +341,9 @@ class AcceleratorName(str):
     t4 = "t4"
     vu9p = "vu9p"
     v100 = "v100"
+    a10g = "a10g"
+    h100 = "h100"
+    t4g = "t4g"
 
 
 class AcceleratorType(str):
@@ -1976,6 +1981,15 @@ class InstanceType(str):
     r7i_24xlarge = "r7i.24xlarge"
     r7i_48xlarge = "r7i.48xlarge"
     dl2q_24xlarge = "dl2q.24xlarge"
+    mac2_m2_metal = "mac2-m2.metal"
+    i4i_12xlarge = "i4i.12xlarge"
+    i4i_24xlarge = "i4i.24xlarge"
+    c7i_metal_24xl = "c7i.metal-24xl"
+    c7i_metal_48xl = "c7i.metal-48xl"
+    m7i_metal_24xl = "m7i.metal-24xl"
+    m7i_metal_48xl = "m7i.metal-48xl"
+    r7i_metal_24xl = "r7i.metal-24xl"
+    r7i_metal_48xl = "r7i.metal-48xl"
 
 
 class InstanceTypeHypervisor(str):
@@ -2730,6 +2744,11 @@ class SSEType(str):
     none = "none"
 
 
+class SecurityGroupReferencingSupportValue(str):
+    enable = "enable"
+    disable = "disable"
+
+
 class SelfServicePortal(str):
     enabled = "enabled"
     disabled = "disabled"
@@ -3440,6 +3459,7 @@ class AcceptTransitGatewayVpcAttachmentRequest(ServiceRequest):
 
 class TransitGatewayVpcAttachmentOptions(TypedDict, total=False):
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     Ipv6Support: Optional[Ipv6SupportValue]
     ApplianceModeSupport: Optional[ApplianceModeSupportValue]
 
@@ -3948,6 +3968,7 @@ class AdvertiseByoipCidrRequest(ServiceRequest):
     Cidr: String
     Asn: Optional[String]
     DryRun: Optional[Boolean]
+    NetworkBorderGroup: Optional[String]
 
 
 class AsnAssociation(TypedDict, total=False):
@@ -3966,6 +3987,7 @@ class ByoipCidr(TypedDict, total=False):
     AsnAssociations: Optional[AsnAssociationSet]
     StatusMessage: Optional[String]
     State: Optional[ByoipCidrState]
+    NetworkBorderGroup: Optional[String]
 
 
 class AdvertiseByoipCidrResult(TypedDict, total=False):
@@ -8227,6 +8249,7 @@ class TransitGatewayRequestOptions(TypedDict, total=False):
     DefaultRouteTablePropagation: Optional[DefaultRouteTablePropagationValue]
     VpnEcmpSupport: Optional[VpnEcmpSupportValue]
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     MulticastSupport: Optional[MulticastSupportValue]
     TransitGatewayCidrBlocks: Optional[TransitGatewayCidrBlockStringList]
 
@@ -8248,6 +8271,7 @@ class TransitGatewayOptions(TypedDict, total=False):
     PropagationDefaultRouteTableId: Optional[String]
     VpnEcmpSupport: Optional[VpnEcmpSupportValue]
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     MulticastSupport: Optional[MulticastSupportValue]
 
 
@@ -8343,6 +8367,7 @@ class CreateTransitGatewayRouteTableResult(TypedDict, total=False):
 
 class CreateTransitGatewayVpcAttachmentRequestOptions(TypedDict, total=False):
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     Ipv6Support: Optional[Ipv6SupportValue]
     ApplianceModeSupport: Optional[ApplianceModeSupportValue]
 
@@ -11355,6 +11380,7 @@ class ProcessorInfo(TypedDict, total=False):
     SupportedArchitectures: Optional[ArchitectureTypeList]
     SustainedClockSpeedInGhz: Optional[ProcessorSustainedClockSpeed]
     SupportedFeatures: Optional[SupportedAdditionalProcessorFeatureList]
+    Manufacturer: Optional[CpuManufacturerName]
 
 
 VirtualizationTypeList = List[VirtualizationType]
@@ -12718,6 +12744,7 @@ class SecurityGroupReference(TypedDict, total=False):
     GroupId: Optional[String]
     ReferencingVpcId: Optional[String]
     VpcPeeringConnectionId: Optional[String]
+    TransitGatewayId: Optional[String]
 
 
 SecurityGroupReferences = List[SecurityGroupReference]
@@ -16688,6 +16715,7 @@ class ModifyTransitGatewayOptions(TypedDict, total=False):
     RemoveTransitGatewayCidrBlocks: Optional[TransitGatewayCidrBlockStringList]
     VpnEcmpSupport: Optional[VpnEcmpSupportValue]
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     AutoAcceptSharedAttachments: Optional[AutoAcceptSharedAttachmentsValue]
     DefaultRouteTableAssociation: Optional[DefaultRouteTableAssociationValue]
     AssociationDefaultRouteTableId: Optional[TransitGatewayRouteTableId]
@@ -16721,6 +16749,7 @@ class ModifyTransitGatewayResult(TypedDict, total=False):
 
 class ModifyTransitGatewayVpcAttachmentRequestOptions(TypedDict, total=False):
     DnsSupport: Optional[DnsSupportValue]
+    SecurityGroupReferencingSupport: Optional[SecurityGroupReferencingSupportValue]
     Ipv6Support: Optional[Ipv6SupportValue]
     ApplianceModeSupport: Optional[ApplianceModeSupportValue]
 
@@ -17137,6 +17166,7 @@ class ProvisionByoipCidrRequest(ServiceRequest):
     DryRun: Optional[Boolean]
     PoolTagSpecifications: Optional[TagSpecificationList]
     MultiRegion: Optional[Boolean]
+    NetworkBorderGroup: Optional[String]
 
 
 class ProvisionByoipCidrResult(TypedDict, total=False):
@@ -18157,7 +18187,12 @@ class Ec2Api:
 
     @handler("AdvertiseByoipCidr")
     def advertise_byoip_cidr(
-        self, context: RequestContext, cidr: String, asn: String = None, dry_run: Boolean = None
+        self,
+        context: RequestContext,
+        cidr: String,
+        asn: String = None,
+        dry_run: Boolean = None,
+        network_border_group: String = None,
     ) -> AdvertiseByoipCidrResult:
         raise NotImplementedError
 
@@ -24169,6 +24204,7 @@ class Ec2Api:
         dry_run: Boolean = None,
         pool_tag_specifications: TagSpecificationList = None,
         multi_region: Boolean = None,
+        network_border_group: String = None,
     ) -> ProvisionByoipCidrResult:
         raise NotImplementedError
 

--- a/localstack/aws/api/firehose/__init__.py
+++ b/localstack/aws/api/firehose/__init__.py
@@ -71,6 +71,8 @@ RedshiftRetryDurationInSeconds = int
 RetryDurationInSeconds = int
 RoleARN = str
 SizeInMBs = int
+SplunkBufferingIntervalInSeconds = int
+SplunkBufferingSizeInMBs = int
 SplunkRetryDurationInSeconds = int
 TagKey = str
 TagValue = str
@@ -264,6 +266,12 @@ class InvalidArgumentException(ServiceException):
 
 class InvalidKMSResourceException(ServiceException):
     code: str = "InvalidKMSResourceException"
+    sender_fault: bool = False
+    status_code: int = 400
+
+
+class InvalidSourceException(ServiceException):
+    code: str = "InvalidSourceException"
     sender_fault: bool = False
     status_code: int = 400
 
@@ -559,6 +567,11 @@ class HttpEndpointDestinationConfiguration(TypedDict, total=False):
     S3Configuration: S3DestinationConfiguration
 
 
+class SplunkBufferingHints(TypedDict, total=False):
+    IntervalInSeconds: Optional[SplunkBufferingIntervalInSeconds]
+    SizeInMBs: Optional[SplunkBufferingSizeInMBs]
+
+
 class SplunkRetryOptions(TypedDict, total=False):
     DurationInSeconds: Optional[SplunkRetryDurationInSeconds]
 
@@ -573,6 +586,7 @@ class SplunkDestinationConfiguration(TypedDict, total=False):
     S3Configuration: S3DestinationConfiguration
     ProcessingConfiguration: Optional[ProcessingConfiguration]
     CloudWatchLoggingOptions: Optional[CloudWatchLoggingOptions]
+    BufferingHints: Optional[SplunkBufferingHints]
 
 
 class ElasticsearchRetryOptions(TypedDict, total=False):
@@ -793,6 +807,7 @@ class SplunkDestinationDescription(TypedDict, total=False):
     S3DestinationDescription: Optional[S3DestinationDescription]
     ProcessingConfiguration: Optional[ProcessingConfiguration]
     CloudWatchLoggingOptions: Optional[CloudWatchLoggingOptions]
+    BufferingHints: Optional[SplunkBufferingHints]
 
 
 class ElasticsearchDestinationDescription(TypedDict, total=False):
@@ -1050,6 +1065,7 @@ class SplunkDestinationUpdate(TypedDict, total=False):
     S3Update: Optional[S3DestinationUpdate]
     ProcessingConfiguration: Optional[ProcessingConfiguration]
     CloudWatchLoggingOptions: Optional[CloudWatchLoggingOptions]
+    BufferingHints: Optional[SplunkBufferingHints]
 
 
 class StartDeliveryStreamEncryptionInput(ServiceRequest):

--- a/localstack/aws/api/kinesis/__init__.py
+++ b/localstack/aws/api/kinesis/__init__.py
@@ -21,7 +21,9 @@ NextToken = str
 OnDemandStreamCountLimitObject = int
 OnDemandStreamCountObject = int
 PartitionKey = str
+Policy = str
 PositiveIntegerObject = int
+ResourceARN = str
 RetentionPeriodHours = int
 SequenceNumber = str
 ShardCountObject = int
@@ -248,6 +250,10 @@ class DecreaseStreamRetentionPeriodInput(ServiceRequest):
     StreamARN: Optional[StreamARN]
 
 
+class DeleteResourcePolicyInput(ServiceRequest):
+    ResourceARN: ResourceARN
+
+
 class DeleteStreamInput(ServiceRequest):
     StreamName: Optional[StreamName]
     EnforceConsumerDeletion: Optional[BooleanObject]
@@ -401,6 +407,14 @@ class GetRecordsOutput(TypedDict, total=False):
     ChildShards: Optional[ChildShardList]
 
 
+class GetResourcePolicyInput(ServiceRequest):
+    ResourceARN: ResourceARN
+
+
+class GetResourcePolicyOutput(TypedDict, total=False):
+    Policy: Policy
+
+
 class GetShardIteratorInput(ServiceRequest):
     StreamName: Optional[StreamName]
     ShardId: ShardId
@@ -551,6 +565,11 @@ class PutRecordsOutput(TypedDict, total=False):
     EncryptionType: Optional[EncryptionType]
 
 
+class PutResourcePolicyInput(ServiceRequest):
+    ResourceARN: ResourceARN
+    Policy: Policy
+
+
 class RegisterStreamConsumerInput(ServiceRequest):
     StreamARN: StreamARN
     ConsumerName: ConsumerName
@@ -679,6 +698,10 @@ class KinesisApi:
     ) -> None:
         raise NotImplementedError
 
+    @handler("DeleteResourcePolicy")
+    def delete_resource_policy(self, context: RequestContext, resource_arn: ResourceARN) -> None:
+        raise NotImplementedError
+
     @handler("DeleteStream")
     def delete_stream(
         self,
@@ -761,6 +784,12 @@ class KinesisApi:
         limit: GetRecordsInputLimit = None,
         stream_arn: StreamARN = None,
     ) -> GetRecordsOutput:
+        raise NotImplementedError
+
+    @handler("GetResourcePolicy")
+    def get_resource_policy(
+        self, context: RequestContext, resource_arn: ResourceARN
+    ) -> GetResourcePolicyOutput:
         raise NotImplementedError
 
     @handler("GetShardIterator")
@@ -864,6 +893,12 @@ class KinesisApi:
         stream_name: StreamName = None,
         stream_arn: StreamARN = None,
     ) -> PutRecordsOutput:
+        raise NotImplementedError
+
+    @handler("PutResourcePolicy")
+    def put_resource_policy(
+        self, context: RequestContext, resource_arn: ResourceARN, policy: Policy
+    ) -> None:
         raise NotImplementedError
 
     @handler("RegisterStreamConsumer")

--- a/localstack/aws/api/logs/__init__.py
+++ b/localstack/aws/api/logs/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TypedDict
+from typing import Dict, Iterator, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
@@ -6,7 +6,10 @@ AccessPolicy = str
 AccountId = str
 AccountPolicyDocument = str
 AmazonResourceName = str
+AnomalyDetectorArn = str
+AnomalyId = str
 Arn = str
+Boolean = bool
 ClientToken = str
 DataProtectionPolicyDocument = str
 Days = int
@@ -18,10 +21,13 @@ DeliverySourceName = str
 Descending = bool
 DescribeLimit = int
 DescribeQueriesMaxResults = int
+Description = str
 DestinationArn = str
 DestinationName = str
+DetectorName = str
 DimensionsKey = str
 DimensionsValue = str
+DynamicTokenPosition = int
 EncryptionKey = str
 EventId = str
 EventMessage = str
@@ -37,9 +43,15 @@ FilterName = str
 FilterPattern = str
 ForceUpdate = bool
 IncludeLinkedAccounts = bool
+Integer = int
 Interleaved = bool
+IsSampled = bool
 KmsKeyId = str
+ListAnomaliesLimit = int
+ListLogAnomalyDetectorsLimit = int
+LogEvent = str
 LogEventIndex = int
+LogGroupArn = str
 LogGroupIdentifier = str
 LogGroupName = str
 LogGroupNamePattern = str
@@ -52,28 +64,45 @@ MetricName = str
 MetricNamespace = str
 MetricValue = str
 NextToken = str
+PatternId = str
+PatternRegex = str
+PatternString = str
 Percentage = int
 PolicyDocument = str
 PolicyName = str
+Priority = str
 QueryCharOffset = int
 QueryDefinitionName = str
 QueryDefinitionString = str
 QueryId = str
 QueryListMaxResults = int
 QueryString = str
+RequestId = str
 ResourceIdentifier = str
 RoleArn = str
 SequenceToken = str
 Service = str
+SessionId = str
 StartFromHead = bool
 StatsValue = float
 Success = bool
 TagKey = str
 TagValue = str
 TargetArn = str
+Time = str
 Token = str
+TokenString = str
 Unmask = bool
 Value = str
+
+
+class AnomalyDetectorStatus(str):
+    INITIALIZING = "INITIALIZING"
+    TRAINING = "TRAINING"
+    ANALYZING = "ANALYZING"
+    FAILED = "FAILED"
+    DELETED = "DELETED"
+    PAUSED = "PAUSED"
 
 
 class DataProtectionStatus(str):
@@ -94,6 +123,15 @@ class Distribution(str):
     ByLogStream = "ByLogStream"
 
 
+class EvaluationFrequency(str):
+    ONE_MIN = "ONE_MIN"
+    FIVE_MIN = "FIVE_MIN"
+    TEN_MIN = "TEN_MIN"
+    FIFTEEN_MIN = "FIFTEEN_MIN"
+    THIRTY_MIN = "THIRTY_MIN"
+    ONE_HOUR = "ONE_HOUR"
+
+
 class ExportTaskStatusCode(str):
     CANCELLED = "CANCELLED"
     COMPLETED = "COMPLETED"
@@ -105,6 +143,11 @@ class ExportTaskStatusCode(str):
 
 class InheritedProperty(str):
     ACCOUNT_DATA_PROTECTION = "ACCOUNT_DATA_PROTECTION"
+
+
+class LogGroupClass(str):
+    STANDARD = "STANDARD"
+    INFREQUENT_ACCESS = "INFREQUENT_ACCESS"
 
 
 class OrderBy(str):
@@ -166,6 +209,28 @@ class StandardUnit(str):
     Terabits_Second = "Terabits/Second"
     Count_Second = "Count/Second"
     None_ = "None"
+
+
+class State(str):
+    Active = "Active"
+    Suppressed = "Suppressed"
+    Baseline = "Baseline"
+
+
+class SuppressionState(str):
+    SUPPRESSED = "SUPPRESSED"
+    UNSUPPRESSED = "UNSUPPRESSED"
+
+
+class SuppressionType(str):
+    LIMITED = "LIMITED"
+    INFINITE = "INFINITE"
+
+
+class SuppressionUnit(str):
+    SECONDS = "SECONDS"
+    MINUTES = "MINUTES"
+    HOURS = "HOURS"
 
 
 class AccessDeniedException(ServiceException):
@@ -259,6 +324,18 @@ class ServiceUnavailableException(ServiceException):
     status_code: int = 400
 
 
+class SessionStreamingException(ServiceException):
+    code: str = "SessionStreamingException"
+    sender_fault: bool = False
+    status_code: int = 400
+
+
+class SessionTimeoutException(ServiceException):
+    code: str = "SessionTimeoutException"
+    sender_fault: bool = False
+    status_code: int = 400
+
+
 class ThrottlingException(ServiceException):
     code: str = "ThrottlingException"
     sender_fault: bool = False
@@ -298,6 +375,65 @@ class AccountPolicy(TypedDict, total=False):
 
 
 AccountPolicies = List[AccountPolicy]
+EpochMillis = int
+LogGroupArnList = List[LogGroupArn]
+TokenValue = int
+Enumerations = Dict[TokenString, TokenValue]
+
+
+class PatternToken(TypedDict, total=False):
+    dynamicTokenPosition: Optional[DynamicTokenPosition]
+    isDynamic: Optional[Boolean]
+    tokenString: Optional[TokenString]
+    enumerations: Optional[Enumerations]
+
+
+PatternTokens = List[PatternToken]
+LogSamples = List[LogEvent]
+Count = int
+Histogram = Dict[Time, Count]
+
+
+class Anomaly(TypedDict, total=False):
+    anomalyId: AnomalyId
+    patternId: PatternId
+    anomalyDetectorArn: AnomalyDetectorArn
+    patternString: PatternString
+    patternRegex: Optional[PatternRegex]
+    priority: Optional[Priority]
+    firstSeen: EpochMillis
+    lastSeen: EpochMillis
+    description: Description
+    active: Boolean
+    state: State
+    histogram: Histogram
+    logSamples: LogSamples
+    patternTokens: PatternTokens
+    logGroupArnList: LogGroupArnList
+    suppressed: Optional[Boolean]
+    suppressedDate: Optional[EpochMillis]
+    suppressedUntil: Optional[EpochMillis]
+    isPatternLevelSuppression: Optional[Boolean]
+
+
+Anomalies = List[Anomaly]
+AnomalyVisibilityTime = int
+
+
+class AnomalyDetector(TypedDict, total=False):
+    anomalyDetectorArn: Optional[AnomalyDetectorArn]
+    detectorName: Optional[DetectorName]
+    logGroupArnList: Optional[LogGroupArnList]
+    evaluationFrequency: Optional[EvaluationFrequency]
+    filterPattern: Optional[FilterPattern]
+    anomalyDetectorStatus: Optional[AnomalyDetectorStatus]
+    kmsKeyId: Optional[KmsKeyId]
+    creationTimeStamp: Optional[EpochMillis]
+    lastModifiedTimeStamp: Optional[EpochMillis]
+    anomalyVisibilityTime: Optional[AnomalyVisibilityTime]
+
+
+AnomalyDetectors = List[AnomalyDetector]
 
 
 class AssociateKmsKeyRequest(ServiceRequest):
@@ -351,10 +487,25 @@ class CreateExportTaskResponse(TypedDict, total=False):
     taskId: Optional[ExportTaskId]
 
 
+class CreateLogAnomalyDetectorRequest(ServiceRequest):
+    logGroupArnList: LogGroupArnList
+    detectorName: Optional[DetectorName]
+    evaluationFrequency: Optional[EvaluationFrequency]
+    filterPattern: Optional[FilterPattern]
+    kmsKeyId: Optional[KmsKeyId]
+    anomalyVisibilityTime: Optional[AnomalyVisibilityTime]
+    tags: Optional[Tags]
+
+
+class CreateLogAnomalyDetectorResponse(TypedDict, total=False):
+    anomalyDetectorArn: Optional[AnomalyDetectorArn]
+
+
 class CreateLogGroupRequest(ServiceRequest):
     logGroupName: LogGroupName
     kmsKeyId: Optional[KmsKeyId]
     tags: Optional[Tags]
+    logGroupClass: Optional[LogGroupClass]
 
 
 class CreateLogStreamRequest(ServiceRequest):
@@ -389,6 +540,10 @@ class DeleteDeliverySourceRequest(ServiceRequest):
 
 class DeleteDestinationRequest(ServiceRequest):
     destinationName: DestinationName
+
+
+class DeleteLogAnomalyDetectorRequest(ServiceRequest):
+    anomalyDetectorArn: AnomalyDetectorArn
 
 
 class DeleteLogGroupRequest(ServiceRequest):
@@ -568,6 +723,7 @@ class DescribeLogGroupsRequest(ServiceRequest):
     nextToken: Optional[NextToken]
     limit: Optional[DescribeLimit]
     includeLinkedAccounts: Optional[IncludeLinkedAccounts]
+    logGroupClass: Optional[LogGroupClass]
 
 
 InheritedProperties = List[InheritedProperty]
@@ -584,6 +740,7 @@ class LogGroup(TypedDict, total=False):
     kmsKeyId: Optional[KmsKeyId]
     dataProtectionStatus: Optional[DataProtectionStatus]
     inheritedProperties: Optional[InheritedProperties]
+    logGroupClass: Optional[LogGroupClass]
 
 
 LogGroups = List[LogGroup]
@@ -850,6 +1007,22 @@ class GetDeliverySourceResponse(TypedDict, total=False):
     deliverySource: Optional[DeliverySource]
 
 
+class GetLogAnomalyDetectorRequest(ServiceRequest):
+    anomalyDetectorArn: AnomalyDetectorArn
+
+
+class GetLogAnomalyDetectorResponse(TypedDict, total=False):
+    detectorName: Optional[DetectorName]
+    logGroupArnList: Optional[LogGroupArnList]
+    evaluationFrequency: Optional[EvaluationFrequency]
+    filterPattern: Optional[FilterPattern]
+    anomalyDetectorStatus: Optional[AnomalyDetectorStatus]
+    kmsKeyId: Optional[KmsKeyId]
+    creationTimeStamp: Optional[EpochMillis]
+    lastModifiedTimeStamp: Optional[EpochMillis]
+    anomalyVisibilityTime: Optional[AnomalyVisibilityTime]
+
+
 class GetLogEventsRequest(ServiceRequest):
     logGroupName: Optional[LogGroupName]
     logGroupIdentifier: Optional[LogGroupIdentifier]
@@ -941,6 +1114,29 @@ class InputLogEvent(TypedDict, total=False):
 InputLogEvents = List[InputLogEvent]
 
 
+class ListAnomaliesRequest(ServiceRequest):
+    anomalyDetectorArn: Optional[AnomalyDetectorArn]
+    suppressionState: Optional[SuppressionState]
+    limit: Optional[ListAnomaliesLimit]
+    nextToken: Optional[NextToken]
+
+
+class ListAnomaliesResponse(TypedDict, total=False):
+    anomalies: Optional[Anomalies]
+    nextToken: Optional[NextToken]
+
+
+class ListLogAnomalyDetectorsRequest(ServiceRequest):
+    filterLogGroupArn: Optional[LogGroupArn]
+    limit: Optional[ListLogAnomalyDetectorsLimit]
+    nextToken: Optional[NextToken]
+
+
+class ListLogAnomalyDetectorsResponse(TypedDict, total=False):
+    anomalyDetectors: Optional[AnomalyDetectors]
+    nextToken: Optional[NextToken]
+
+
 class ListTagsForResourceRequest(ServiceRequest):
     resourceArn: AmazonResourceName
 
@@ -955,6 +1151,36 @@ class ListTagsLogGroupRequest(ServiceRequest):
 
 class ListTagsLogGroupResponse(TypedDict, total=False):
     tags: Optional[Tags]
+
+
+class LiveTailSessionLogEvent(TypedDict, total=False):
+    logStreamName: Optional[LogStreamName]
+    logGroupIdentifier: Optional[LogGroupIdentifier]
+    message: Optional[EventMessage]
+    timestamp: Optional[Timestamp]
+    ingestionTime: Optional[Timestamp]
+
+
+class LiveTailSessionMetadata(TypedDict, total=False):
+    sampled: Optional[IsSampled]
+
+
+LiveTailSessionResults = List[LiveTailSessionLogEvent]
+StartLiveTailLogGroupIdentifiers = List[LogGroupIdentifier]
+
+
+class LiveTailSessionStart(TypedDict, total=False):
+    requestId: Optional[RequestId]
+    sessionId: Optional[SessionId]
+    logGroupIdentifiers: Optional[StartLiveTailLogGroupIdentifiers]
+    logStreamNames: Optional[InputLogStreamNames]
+    logStreamNamePrefixes: Optional[InputLogStreamNames]
+    logEventFilterPattern: Optional[FilterPattern]
+
+
+class LiveTailSessionUpdate(TypedDict, total=False):
+    sessionMetadata: Optional[LiveTailSessionMetadata]
+    sessionResults: Optional[LiveTailSessionResults]
 
 
 LogGroupIdentifiers = List[LogGroupIdentifier]
@@ -1099,6 +1325,24 @@ class PutSubscriptionFilterRequest(ServiceRequest):
     distribution: Optional[Distribution]
 
 
+class StartLiveTailRequest(ServiceRequest):
+    logGroupIdentifiers: StartLiveTailLogGroupIdentifiers
+    logStreamNames: Optional[InputLogStreamNames]
+    logStreamNamePrefixes: Optional[InputLogStreamNames]
+    logEventFilterPattern: Optional[FilterPattern]
+
+
+class StartLiveTailResponseStream(TypedDict, total=False):
+    sessionStart: Optional[LiveTailSessionStart]
+    sessionUpdate: Optional[LiveTailSessionUpdate]
+    SessionTimeoutException: Optional[SessionTimeoutException]
+    SessionStreamingException: Optional[SessionStreamingException]
+
+
+class StartLiveTailResponse(TypedDict, total=False):
+    responseStream: Iterator[StartLiveTailResponseStream]
+
+
 class StartQueryRequest(ServiceRequest):
     logGroupName: Optional[LogGroupName]
     logGroupNames: Optional[LogGroupNames]
@@ -1119,6 +1363,11 @@ class StopQueryRequest(ServiceRequest):
 
 class StopQueryResponse(TypedDict, total=False):
     success: Optional[Success]
+
+
+class SuppressionPeriod(TypedDict, total=False):
+    value: Optional[Integer]
+    suppressionUnit: Optional[SuppressionUnit]
 
 
 TagKeyList = List[TagKey]
@@ -1157,6 +1406,22 @@ class UntagResourceRequest(ServiceRequest):
     tagKeys: TagKeyList
 
 
+class UpdateAnomalyRequest(ServiceRequest):
+    anomalyId: Optional[AnomalyId]
+    patternId: Optional[PatternId]
+    anomalyDetectorArn: AnomalyDetectorArn
+    suppressionType: Optional[SuppressionType]
+    suppressionPeriod: Optional[SuppressionPeriod]
+
+
+class UpdateLogAnomalyDetectorRequest(ServiceRequest):
+    anomalyDetectorArn: AnomalyDetectorArn
+    evaluationFrequency: Optional[EvaluationFrequency]
+    filterPattern: Optional[FilterPattern]
+    anomalyVisibilityTime: Optional[AnomalyVisibilityTime]
+    enabled: Boolean
+
+
 class LogsApi:
     service = "logs"
     version = "2014-03-28"
@@ -1191,6 +1456,20 @@ class LogsApi:
     ) -> CreateExportTaskResponse:
         raise NotImplementedError
 
+    @handler("CreateLogAnomalyDetector")
+    def create_log_anomaly_detector(
+        self,
+        context: RequestContext,
+        log_group_arn_list: LogGroupArnList,
+        detector_name: DetectorName = None,
+        evaluation_frequency: EvaluationFrequency = None,
+        filter_pattern: FilterPattern = None,
+        kms_key_id: KmsKeyId = None,
+        anomaly_visibility_time: AnomalyVisibilityTime = None,
+        tags: Tags = None,
+    ) -> CreateLogAnomalyDetectorResponse:
+        raise NotImplementedError
+
     @handler("CreateLogGroup")
     def create_log_group(
         self,
@@ -1198,6 +1477,7 @@ class LogsApi:
         log_group_name: LogGroupName,
         kms_key_id: KmsKeyId = None,
         tags: Tags = None,
+        log_group_class: LogGroupClass = None,
     ) -> None:
         raise NotImplementedError
 
@@ -1242,6 +1522,12 @@ class LogsApi:
     @handler("DeleteDestination")
     def delete_destination(
         self, context: RequestContext, destination_name: DestinationName
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteLogAnomalyDetector")
+    def delete_log_anomaly_detector(
+        self, context: RequestContext, anomaly_detector_arn: AnomalyDetectorArn
     ) -> None:
         raise NotImplementedError
 
@@ -1344,6 +1630,7 @@ class LogsApi:
         next_token: NextToken = None,
         limit: DescribeLimit = None,
         include_linked_accounts: IncludeLinkedAccounts = None,
+        log_group_class: LogGroupClass = None,
     ) -> DescribeLogGroupsResponse:
         raise NotImplementedError
 
@@ -1467,6 +1754,12 @@ class LogsApi:
     ) -> GetDeliverySourceResponse:
         raise NotImplementedError
 
+    @handler("GetLogAnomalyDetector")
+    def get_log_anomaly_detector(
+        self, context: RequestContext, anomaly_detector_arn: AnomalyDetectorArn
+    ) -> GetLogAnomalyDetectorResponse:
+        raise NotImplementedError
+
     @handler("GetLogEvents")
     def get_log_events(
         self,
@@ -1503,6 +1796,27 @@ class LogsApi:
     def get_query_results(
         self, context: RequestContext, query_id: QueryId
     ) -> GetQueryResultsResponse:
+        raise NotImplementedError
+
+    @handler("ListAnomalies")
+    def list_anomalies(
+        self,
+        context: RequestContext,
+        anomaly_detector_arn: AnomalyDetectorArn = None,
+        suppression_state: SuppressionState = None,
+        limit: ListAnomaliesLimit = None,
+        next_token: NextToken = None,
+    ) -> ListAnomaliesResponse:
+        raise NotImplementedError
+
+    @handler("ListLogAnomalyDetectors")
+    def list_log_anomaly_detectors(
+        self,
+        context: RequestContext,
+        filter_log_group_arn: LogGroupArn = None,
+        limit: ListLogAnomalyDetectorsLimit = None,
+        next_token: NextToken = None,
+    ) -> ListLogAnomalyDetectorsResponse:
         raise NotImplementedError
 
     @handler("ListTagsForResource")
@@ -1651,6 +1965,17 @@ class LogsApi:
     ) -> None:
         raise NotImplementedError
 
+    @handler("StartLiveTail")
+    def start_live_tail(
+        self,
+        context: RequestContext,
+        log_group_identifiers: StartLiveTailLogGroupIdentifiers,
+        log_stream_names: InputLogStreamNames = None,
+        log_stream_name_prefixes: InputLogStreamNames = None,
+        log_event_filter_pattern: FilterPattern = None,
+    ) -> StartLiveTailResponse:
+        raise NotImplementedError
+
     @handler("StartQuery")
     def start_query(
         self,
@@ -1699,5 +2024,29 @@ class LogsApi:
     @handler("UntagResource")
     def untag_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName, tag_keys: TagKeyList
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("UpdateAnomaly")
+    def update_anomaly(
+        self,
+        context: RequestContext,
+        anomaly_detector_arn: AnomalyDetectorArn,
+        anomaly_id: AnomalyId = None,
+        pattern_id: PatternId = None,
+        suppression_type: SuppressionType = None,
+        suppression_period: SuppressionPeriod = None,
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("UpdateLogAnomalyDetector")
+    def update_log_anomaly_detector(
+        self,
+        context: RequestContext,
+        anomaly_detector_arn: AnomalyDetectorArn,
+        enabled: Boolean,
+        evaluation_frequency: EvaluationFrequency = None,
+        filter_pattern: FilterPattern = None,
+        anomaly_visibility_time: AnomalyVisibilityTime = None,
     ) -> None:
         raise NotImplementedError

--- a/localstack/aws/api/opensearch/__init__.py
+++ b/localstack/aws/api/opensearch/__init__.py
@@ -16,6 +16,8 @@ CommitMessage = str
 ConnectionAlias = str
 ConnectionId = str
 ConnectionStatusMessage = str
+DataSourceDescription = str
+DataSourceName = str
 DeploymentType = str
 DescribePackagesFilterValue = str
 Description = str
@@ -605,6 +607,25 @@ class AccessPoliciesStatus(TypedDict, total=False):
     Status: OptionStatus
 
 
+class S3GlueDataCatalog(TypedDict, total=False):
+    RoleArn: Optional[RoleArn]
+
+
+class DataSourceType(TypedDict, total=False):
+    S3GlueDataCatalog: Optional[S3GlueDataCatalog]
+
+
+class AddDataSourceRequest(ServiceRequest):
+    DomainName: DomainName
+    Name: DataSourceName
+    DataSourceType: DataSourceType
+    Description: Optional[DataSourceDescription]
+
+
+class AddDataSourceResponse(TypedDict, total=False):
+    Message: Optional[String]
+
+
 class Tag(TypedDict, total=False):
     Key: TagKey
     Value: TagValue
@@ -1144,6 +1165,24 @@ class CreateVpcEndpointResponse(TypedDict, total=False):
     VpcEndpoint: VpcEndpoint
 
 
+class DataSourceDetails(TypedDict, total=False):
+    DataSourceType: Optional[DataSourceType]
+    Name: Optional[DataSourceName]
+    Description: Optional[DataSourceDescription]
+
+
+DataSourceList = List[DataSourceDetails]
+
+
+class DeleteDataSourceRequest(ServiceRequest):
+    DomainName: DomainName
+    Name: DataSourceName
+
+
+class DeleteDataSourceResponse(TypedDict, total=False):
+    Message: Optional[String]
+
+
 class DeleteDomainRequest(ServiceRequest):
     DomainName: DomainName
 
@@ -1644,6 +1683,17 @@ class GetCompatibleVersionsResponse(TypedDict, total=False):
     CompatibleVersions: Optional[CompatibleVersionsList]
 
 
+class GetDataSourceRequest(ServiceRequest):
+    DomainName: DomainName
+    Name: DataSourceName
+
+
+class GetDataSourceResponse(TypedDict, total=False):
+    DataSourceType: Optional[DataSourceType]
+    Name: Optional[DataSourceName]
+    Description: Optional[DataSourceDescription]
+
+
 class GetDomainMaintenanceStatusRequest(ServiceRequest):
     DomainName: DomainName
     MaintenanceId: RequestId
@@ -1740,6 +1790,14 @@ class InstanceTypeDetails(TypedDict, total=False):
 
 
 InstanceTypeDetailsList = List[InstanceTypeDetails]
+
+
+class ListDataSourcesRequest(ServiceRequest):
+    DomainName: DomainName
+
+
+class ListDataSourcesResponse(TypedDict, total=False):
+    DataSources: Optional[DataSourceList]
 
 
 class ListDomainMaintenancesRequest(ServiceRequest):
@@ -1928,6 +1986,17 @@ class StartServiceSoftwareUpdateResponse(TypedDict, total=False):
     ServiceSoftwareOptions: Optional[ServiceSoftwareOptions]
 
 
+class UpdateDataSourceRequest(ServiceRequest):
+    DomainName: DomainName
+    Name: DataSourceName
+    DataSourceType: DataSourceType
+    Description: Optional[DataSourceDescription]
+
+
+class UpdateDataSourceResponse(TypedDict, total=False):
+    Message: Optional[String]
+
+
 class UpdateDomainConfigRequest(ServiceRequest):
     DomainName: DomainName
     ClusterConfig: Optional[ClusterConfig]
@@ -2014,6 +2083,17 @@ class OpensearchApi:
     ) -> AcceptInboundConnectionResponse:
         raise NotImplementedError
 
+    @handler("AddDataSource")
+    def add_data_source(
+        self,
+        context: RequestContext,
+        domain_name: DomainName,
+        name: DataSourceName,
+        data_source_type: DataSourceType,
+        description: DataSourceDescription = None,
+    ) -> AddDataSourceResponse:
+        raise NotImplementedError
+
     @handler("AddTags")
     def add_tags(self, context: RequestContext, arn: ARN, tag_list: TagList) -> None:
         raise NotImplementedError
@@ -2093,6 +2173,12 @@ class OpensearchApi:
         vpc_options: VPCOptions,
         client_token: ClientToken = None,
     ) -> CreateVpcEndpointResponse:
+        raise NotImplementedError
+
+    @handler("DeleteDataSource")
+    def delete_data_source(
+        self, context: RequestContext, domain_name: DomainName, name: DataSourceName
+    ) -> DeleteDataSourceResponse:
         raise NotImplementedError
 
     @handler("DeleteDomain")
@@ -2259,6 +2345,12 @@ class OpensearchApi:
     ) -> GetCompatibleVersionsResponse:
         raise NotImplementedError
 
+    @handler("GetDataSource")
+    def get_data_source(
+        self, context: RequestContext, domain_name: DomainName, name: DataSourceName
+    ) -> GetDataSourceResponse:
+        raise NotImplementedError
+
     @handler("GetDomainMaintenanceStatus")
     def get_domain_maintenance_status(
         self, context: RequestContext, domain_name: DomainName, maintenance_id: RequestId
@@ -2289,6 +2381,12 @@ class OpensearchApi:
     def get_upgrade_status(
         self, context: RequestContext, domain_name: DomainName
     ) -> GetUpgradeStatusResponse:
+        raise NotImplementedError
+
+    @handler("ListDataSources")
+    def list_data_sources(
+        self, context: RequestContext, domain_name: DomainName
+    ) -> ListDataSourcesResponse:
         raise NotImplementedError
 
     @handler("ListDomainMaintenances")
@@ -2424,6 +2522,17 @@ class OpensearchApi:
         schedule_at: ScheduleAt = None,
         desired_start_time: Long = None,
     ) -> StartServiceSoftwareUpdateResponse:
+        raise NotImplementedError
+
+    @handler("UpdateDataSource")
+    def update_data_source(
+        self,
+        context: RequestContext,
+        domain_name: DomainName,
+        name: DataSourceName,
+        data_source_type: DataSourceType,
+        description: DataSourceDescription = None,
+    ) -> UpdateDataSourceResponse:
         raise NotImplementedError
 
     @handler("UpdateDomainConfig")

--- a/localstack/aws/api/redshift/__init__.py
+++ b/localstack/aws/api/redshift/__init__.py
@@ -1101,6 +1101,7 @@ class AssociateDataShareConsumerMessage(ServiceRequest):
     AssociateEntireAccount: Optional[BooleanOptional]
     ConsumerArn: Optional[String]
     ConsumerRegion: Optional[String]
+    AllowWrites: Optional[BooleanOptional]
 
 
 class ClusterAssociatedToSchedule(TypedDict, total=False):
@@ -1186,6 +1187,7 @@ class AuthorizeClusterSecurityGroupIngressResult(TypedDict, total=False):
 class AuthorizeDataShareMessage(ServiceRequest):
     DataShareArn: String
     ConsumerIdentifier: String
+    AllowWrites: Optional[BooleanOptional]
 
 
 VpcIdentifierList = List[String]
@@ -2033,6 +2035,8 @@ class DataShareAssociation(TypedDict, total=False):
     ConsumerRegion: Optional[String]
     CreatedDate: Optional[TStamp]
     StatusChangeDate: Optional[TStamp]
+    ProducerAllowedWrites: Optional[BooleanOptional]
+    ConsumerAcceptedWrites: Optional[BooleanOptional]
 
 
 DataShareAssociationList = List[DataShareAssociation]
@@ -3395,6 +3399,7 @@ class RedshiftApi:
         associate_entire_account: BooleanOptional = None,
         consumer_arn: String = None,
         consumer_region: String = None,
+        allow_writes: BooleanOptional = None,
     ) -> DataShare:
         raise NotImplementedError
 
@@ -3411,7 +3416,11 @@ class RedshiftApi:
 
     @handler("AuthorizeDataShare")
     def authorize_data_share(
-        self, context: RequestContext, data_share_arn: String, consumer_identifier: String
+        self,
+        context: RequestContext,
+        data_share_arn: String,
+        consumer_identifier: String,
+        allow_writes: BooleanOptional = None,
     ) -> DataShare:
         raise NotImplementedError
 

--- a/localstack/aws/api/route53/__init__.py
+++ b/localstack/aws/api/route53/__init__.py
@@ -152,6 +152,7 @@ class CloudWatchRegion(str):
     us_isob_east_1 = "us-isob-east-1"
     ap_southeast_4 = "ap-southeast-4"
     il_central_1 = "il-central-1"
+    ca_west_1 = "ca-west-1"
 
 
 class ComparisonOperator(str):
@@ -257,6 +258,7 @@ class ResourceRecordSetRegion(str):
     eu_south_2 = "eu-south-2"
     ap_southeast_4 = "ap-southeast-4"
     il_central_1 = "il-central-1"
+    ca_west_1 = "ca-west-1"
 
 
 class ReusableDelegationSetLimitType(str):
@@ -311,6 +313,7 @@ class VPCRegion(str):
     eu_south_2 = "eu-south-2"
     ap_southeast_4 = "ap-southeast-4"
     il_central_1 = "il-central-1"
+    ca_west_1 = "ca-west-1"
 
 
 class CidrBlockInUseException(ServiceException):

--- a/localstack/aws/api/route53resolver/__init__.py
+++ b/localstack/aws/api/route53resolver/__init__.py
@@ -137,6 +137,12 @@ class OutpostResolverStatus(str):
     FAILED_DELETION = "FAILED_DELETION"
 
 
+class Protocol(str):
+    DoH = "DoH"
+    Do53 = "Do53"
+    DoH_FIPS = "DoH-FIPS"
+
+
 class ResolverAutodefinedReverseStatus(str):
     ENABLING = "ENABLING"
     ENABLED = "ENABLED"
@@ -393,6 +399,7 @@ class AssociateResolverEndpointIpAddressRequest(ServiceRequest):
     IpAddress: IpAddressUpdate
 
 
+ProtocolList = List[Protocol]
 SecurityGroupIds = List[ResourceId]
 
 
@@ -409,9 +416,10 @@ class ResolverEndpoint(TypedDict, total=False):
     StatusMessage: Optional[StatusMessage]
     CreationTime: Optional[Rfc3339TimeString]
     ModificationTime: Optional[Rfc3339TimeString]
-    ResolverEndpointType: Optional[ResolverEndpointType]
     OutpostArn: Optional[OutpostArn]
     PreferredInstanceType: Optional[OutpostInstanceType]
+    ResolverEndpointType: Optional[ResolverEndpointType]
+    Protocols: Optional[ProtocolList]
 
 
 class AssociateResolverEndpointIpAddressResponse(TypedDict, total=False):
@@ -577,10 +585,11 @@ class CreateResolverEndpointRequest(ServiceRequest):
     SecurityGroupIds: SecurityGroupIds
     Direction: ResolverEndpointDirection
     IpAddresses: IpAddressesRequest
-    Tags: Optional[TagList]
-    ResolverEndpointType: Optional[ResolverEndpointType]
     OutpostArn: Optional[OutpostArn]
     PreferredInstanceType: Optional[OutpostInstanceType]
+    Tags: Optional[TagList]
+    ResolverEndpointType: Optional[ResolverEndpointType]
+    Protocols: Optional[ProtocolList]
 
 
 class CreateResolverEndpointResponse(TypedDict, total=False):
@@ -615,6 +624,7 @@ class TargetAddress(TypedDict, total=False):
     Ip: Optional[Ip]
     Port: Optional[Port]
     Ipv6: Optional[Ipv6]
+    Protocol: Optional[Protocol]
 
 
 TargetList = List[TargetAddress]
@@ -624,7 +634,7 @@ class CreateResolverRuleRequest(ServiceRequest):
     CreatorRequestId: CreatorRequestId
     Name: Optional[Name]
     RuleType: RuleTypeOption
-    DomainName: DomainName
+    DomainName: Optional[DomainName]
     TargetIps: Optional[TargetList]
     ResolverEndpointId: Optional[ResourceId]
     Tags: Optional[TagList]
@@ -1309,6 +1319,7 @@ class UpdateResolverEndpointRequest(ServiceRequest):
     Name: Optional[Name]
     ResolverEndpointType: Optional[ResolverEndpointType]
     UpdateIpAddresses: Optional[UpdateIpAddresses]
+    Protocols: Optional[ProtocolList]
 
 
 class UpdateResolverEndpointResponse(TypedDict, total=False):
@@ -1426,10 +1437,11 @@ class Route53ResolverApi:
         direction: ResolverEndpointDirection,
         ip_addresses: IpAddressesRequest,
         name: Name = None,
-        tags: TagList = None,
-        resolver_endpoint_type: ResolverEndpointType = None,
         outpost_arn: OutpostArn = None,
         preferred_instance_type: OutpostInstanceType = None,
+        tags: TagList = None,
+        resolver_endpoint_type: ResolverEndpointType = None,
+        protocols: ProtocolList = None,
     ) -> CreateResolverEndpointResponse:
         raise NotImplementedError
 
@@ -1450,8 +1462,8 @@ class Route53ResolverApi:
         context: RequestContext,
         creator_request_id: CreatorRequestId,
         rule_type: RuleTypeOption,
-        domain_name: DomainName,
         name: Name = None,
+        domain_name: DomainName = None,
         target_ips: TargetList = None,
         resolver_endpoint_id: ResourceId = None,
         tags: TagList = None,
@@ -1902,6 +1914,7 @@ class Route53ResolverApi:
         name: Name = None,
         resolver_endpoint_type: ResolverEndpointType = None,
         update_ip_addresses: UpdateIpAddresses = None,
+        protocols: ProtocolList = None,
     ) -> UpdateResolverEndpointResponse:
         raise NotImplementedError
 

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -5,6 +5,8 @@ from localstack.aws.api import RequestContext, ServiceException, ServiceRequest,
 
 AbortRuleId = str
 AcceptRanges = str
+AccessKeyIdValue = str
+AccessPointAlias = bool
 AccessPointArn = str
 AccountId = str
 AllowQuotedRecordDelimiter = bool
@@ -13,6 +15,7 @@ AllowedMethod = str
 AllowedOrigin = str
 AnalyticsId = str
 BucketKeyEnabled = bool
+BucketLocationName = str
 BucketName = str
 BypassGovernanceRetention = bool
 CacheControl = str
@@ -45,6 +48,7 @@ DeleteMarker = bool
 DeleteMarkerVersionId = str
 Delimiter = str
 Description = str
+DirectoryBucketToken = str
 DisplayName = str
 ETag = str
 EmailAddress = str
@@ -84,10 +88,12 @@ KeyMarker = str
 KeyPrefixEquals = str
 LambdaFunctionArn = str
 Location = str
+LocationNameAsString = str
 LocationPrefix = str
 MFA = str
 Marker = str
 MaxAgeSeconds = int
+MaxDirectoryBuckets = int
 MaxKeys = int
 MaxParts = int
 MaxUploads = int
@@ -121,6 +127,7 @@ QuoteCharacter = str
 QuoteEscapeCharacter = str
 Range = str
 RecordDelimiter = str
+Region = str
 ReplaceKeyPrefixWith = str
 ReplaceKeyWith = str
 ReplicaKmsKeyID = str
@@ -139,6 +146,7 @@ SSECustomerKey = str
 SSECustomerKeyMD5 = str
 SSEKMSEncryptionContext = str
 SSEKMSKeyId = str
+SessionCredentialValue = str
 Setting = bool
 SkipValidation = bool
 StartAfter = str
@@ -206,6 +214,7 @@ class BucketLocationConstraint(str):
     ap_northeast_2 = "ap-northeast-2"
     ap_northeast_3 = "ap-northeast-3"
     ap_south_1 = "ap-south-1"
+    ap_south_2 = "ap-south-2"
     ap_southeast_1 = "ap-southeast-1"
     ap_southeast_2 = "ap-southeast-2"
     ap_southeast_3 = "ap-southeast-3"
@@ -216,6 +225,7 @@ class BucketLocationConstraint(str):
     eu_central_1 = "eu-central-1"
     eu_north_1 = "eu-north-1"
     eu_south_1 = "eu-south-1"
+    eu_south_2 = "eu-south-2"
     eu_west_1 = "eu-west-1"
     eu_west_2 = "eu-west-2"
     eu_west_3 = "eu-west-3"
@@ -226,14 +236,16 @@ class BucketLocationConstraint(str):
     us_gov_west_1 = "us-gov-west-1"
     us_west_1 = "us-west-1"
     us_west_2 = "us-west-2"
-    ap_south_2 = "ap-south-2"
-    eu_south_2 = "eu-south-2"
 
 
 class BucketLogsPermission(str):
     FULL_CONTROL = "FULL_CONTROL"
     READ = "READ"
     WRITE = "WRITE"
+
+
+class BucketType(str):
+    Directory = "Directory"
 
 
 class BucketVersioningStatus(str):
@@ -256,6 +268,10 @@ class CompressionType(str):
     NONE = "NONE"
     GZIP = "GZIP"
     BZIP2 = "BZIP2"
+
+
+class DataRedundancy(str):
+    SingleAvailabilityZone = "SingleAvailabilityZone"
 
 
 class DeleteMarkerReplicationStatus(str):
@@ -373,6 +389,10 @@ class JSONType(str):
     LINES = "LINES"
 
 
+class LocationType(str):
+    AvailabilityZone = "AvailabilityZone"
+
+
 class MFADelete(str):
     Enabled = "Enabled"
     Disabled = "Disabled"
@@ -447,6 +467,7 @@ class ObjectStorageClass(str):
     OUTPOSTS = "OUTPOSTS"
     GLACIER_IR = "GLACIER_IR"
     SNOW = "SNOW"
+    EXPRESS_ONEZONE = "EXPRESS_ONEZONE"
 
 
 class ObjectVersionStorageClass(str):
@@ -459,6 +480,11 @@ class OptionalObjectAttributes(str):
 
 class OwnerOverride(str):
     Destination = "Destination"
+
+
+class PartitionDateSource(str):
+    EventTime = "EventTime"
+    DeliveryTime = "DeliveryTime"
 
 
 class Payer(str):
@@ -525,6 +551,11 @@ class ServerSideEncryption(str):
     aws_kms_dsse = "aws:kms:dsse"
 
 
+class SessionMode(str):
+    ReadOnly = "ReadOnly"
+    ReadWrite = "ReadWrite"
+
+
 class SseKmsEncryptedObjectsStatus(str):
     Enabled = "Enabled"
     Disabled = "Disabled"
@@ -541,6 +572,7 @@ class StorageClass(str):
     OUTPOSTS = "OUTPOSTS"
     GLACIER_IR = "GLACIER_IR"
     SNOW = "SNOW"
+    EXPRESS_ONEZONE = "EXPRESS_ONEZONE"
 
 
 class StorageClassAnalysisSchemaVersion(str):
@@ -576,7 +608,7 @@ class Type(str):
 class BucketAlreadyExists(ServiceException):
     code: str = "BucketAlreadyExists"
     sender_fault: bool = False
-    status_code: int = 400
+    status_code: int = 409
 
 
 class BucketAlreadyOwnedByYou(ServiceException):
@@ -620,13 +652,13 @@ class NoSuchUpload(ServiceException):
 class ObjectAlreadyInActiveTierError(ServiceException):
     code: str = "ObjectAlreadyInActiveTierError"
     sender_fault: bool = False
-    status_code: int = 400
+    status_code: int = 403
 
 
 class ObjectNotInActiveTierError(ServiceException):
     code: str = "ObjectNotInActiveTierError"
     sender_fault: bool = False
-    status_code: int = 400
+    status_code: int = 403
 
 
 class NoSuchLifecycleConfiguration(ServiceException):
@@ -1006,6 +1038,11 @@ class Bucket(TypedDict, total=False):
     CreationDate: Optional[CreationDate]
 
 
+class BucketInfo(TypedDict, total=False):
+    DataRedundancy: Optional[DataRedundancy]
+    Type: Optional[BucketType]
+
+
 class NoncurrentVersionExpiration(TypedDict, total=False):
     NoncurrentDays: Optional[Days]
     NewerNoncurrentVersions: Optional[VersionCount]
@@ -1072,6 +1109,19 @@ class BucketLifecycleConfiguration(TypedDict, total=False):
     Rules: LifecycleRules
 
 
+class PartitionedPrefix(TypedDict, total=False):
+    PartitionDateSource: Optional[PartitionDateSource]
+
+
+class SimplePrefix(TypedDict, total=False):
+    pass
+
+
+class TargetObjectKeyFormat(TypedDict, total=False):
+    SimplePrefix: Optional[SimplePrefix]
+    PartitionedPrefix: Optional[PartitionedPrefix]
+
+
 class TargetGrant(TypedDict, total=False):
     Grantee: Optional[Grantee]
     Permission: Optional[BucketLogsPermission]
@@ -1084,6 +1134,7 @@ class LoggingEnabled(TypedDict, total=False):
     TargetBucket: TargetBucket
     TargetGrants: Optional[TargetGrants]
     TargetPrefix: TargetPrefix
+    TargetObjectKeyFormat: Optional[TargetObjectKeyFormat]
 
 
 class BucketLoggingStatus(TypedDict, total=False):
@@ -1303,8 +1354,15 @@ class CopyPartResult(TypedDict, total=False):
     ChecksumSHA256: Optional[ChecksumSHA256]
 
 
+class LocationInfo(TypedDict, total=False):
+    Type: Optional[LocationType]
+    Name: Optional[LocationNameAsString]
+
+
 class CreateBucketConfiguration(TypedDict, total=False):
     LocationConstraint: Optional[BucketLocationConstraint]
+    Location: Optional[LocationInfo]
+    Bucket: Optional[BucketInfo]
 
 
 class CreateBucketOutput(TypedDict, total=False):
@@ -1371,6 +1429,25 @@ class CreateMultipartUploadRequest(ServiceRequest):
     ObjectLockLegalHoldStatus: Optional[ObjectLockLegalHoldStatus]
     ExpectedBucketOwner: Optional[AccountId]
     ChecksumAlgorithm: Optional[ChecksumAlgorithm]
+
+
+SessionExpiration = datetime
+
+
+class SessionCredentials(TypedDict, total=False):
+    AccessKeyId: AccessKeyIdValue
+    SecretAccessKey: SessionCredentialValue
+    SessionToken: SessionCredentialValue
+    Expiration: SessionExpiration
+
+
+class CreateSessionOutput(TypedDict, total=False):
+    Credentials: SessionCredentials
+
+
+class CreateSessionRequest(ServiceRequest):
+    SessionMode: Optional[SessionMode]
+    Bucket: BucketName
 
 
 class DefaultRetention(TypedDict, total=False):
@@ -2236,6 +2313,11 @@ class GlacierJobParameters(TypedDict, total=False):
     Tier: Tier
 
 
+class HeadBucketOutput(TypedDict, total=False):
+    BucketRegion: Optional[BucketRegion]
+    BucketContentType: Optional[BucketContentType]
+
+
 class HeadBucketRequest(ServiceRequest):
     Bucket: BucketName
     ExpectedBucketOwner: Optional[AccountId]
@@ -2407,6 +2489,16 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
 class ListBucketsOutput(TypedDict, total=False):
     Owner: Optional[Owner]
     Buckets: Optional[Buckets]
+
+
+class ListDirectoryBucketsOutput(TypedDict, total=False):
+    Buckets: Optional[Buckets]
+    ContinuationToken: Optional[DirectoryBucketToken]
+
+
+class ListDirectoryBucketsRequest(ServiceRequest):
+    ContinuationToken: Optional[DirectoryBucketToken]
+    MaxDirectoryBuckets: Optional[MaxDirectoryBuckets]
 
 
 class MultipartUpload(TypedDict, total=False):
@@ -3231,11 +3323,6 @@ class WriteGetObjectResponseRequest(ServiceRequest):
     BucketKeyEnabled: Optional[BucketKeyEnabled]
 
 
-class HeadBucketOutput(TypedDict, total=False):
-    BucketRegion: Optional[BucketRegion]
-    BucketContentType: Optional[BucketContentType]
-
-
 class PostObjectRequest(ServiceRequest):
     Body: Optional[IO[Body]]
     Bucket: BucketName
@@ -3400,6 +3487,12 @@ class S3Api:
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
     ) -> CreateMultipartUploadOutput:
+        raise NotImplementedError
+
+    @handler("CreateSession")
+    def create_session(
+        self, context: RequestContext, bucket: BucketName, session_mode: SessionMode = None
+    ) -> CreateSessionOutput:
         raise NotImplementedError
 
     @handler("DeleteBucket")
@@ -3871,6 +3964,15 @@ class S3Api:
         self,
         context: RequestContext,
     ) -> ListBucketsOutput:
+        raise NotImplementedError
+
+    @handler("ListDirectoryBuckets")
+    def list_directory_buckets(
+        self,
+        context: RequestContext,
+        continuation_token: DirectoryBucketToken = None,
+        max_directory_buckets: MaxDirectoryBuckets = None,
+    ) -> ListDirectoryBucketsOutput:
         raise NotImplementedError
 
     @handler("ListMultipartUploads")

--- a/localstack/aws/api/s3control/__init__.py
+++ b/localstack/aws/api/s3control/__init__.py
@@ -3,6 +3,13 @@ from typing import Dict, List, Optional, TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
+AccessGrantArn = str
+AccessGrantId = str
+AccessGrantsInstanceArn = str
+AccessGrantsInstanceId = str
+AccessGrantsLocationArn = str
+AccessGrantsLocationId = str
+AccessKeyId = str
 AccessPointName = str
 AccountId = str
 Alias = str
@@ -19,6 +26,7 @@ ConfirmationRequired = bool
 ContinuationToken = str
 Days = int
 DaysAfterInitiation = int
+DurationSeconds = int
 ExceptionMessage = str
 ExpiredObjectDeleteMarker = bool
 FunctionArnString = str
@@ -27,8 +35,11 @@ GrantRead = str
 GrantReadACP = str
 GrantWrite = str
 GrantWriteACP = str
+GranteeIdentifier = str
 IAMRoleArn = str
 ID = str
+IdentityCenterApplicationArn = str
+IdentityCenterArn = str
 IsEnabled = bool
 IsPublic = bool
 JobArn = str
@@ -62,7 +73,9 @@ ObjectLambdaAccessPointName = str
 ObjectLambdaPolicy = str
 ObjectLambdaSupportingAccessPointArn = str
 ObjectLockEnabledForBucket = bool
+Organization = str
 Policy = str
+PolicyDocument = str
 Prefix = str
 Priority = int
 PublicAccessBlockEnabled = bool
@@ -76,9 +89,13 @@ S3BucketArnString = str
 S3ExpirationInDays = int
 S3KeyArnString = str
 S3ObjectVersionId = str
+S3Prefix = str
 S3RegionalBucketArn = str
+S3RegionalOrS3ExpressBucketArnString = str
 S3ResourceArn = str
 SSEKMSKeyId = str
+SecretAccessKey = str
+SessionToken = str
 Setting = bool
 StorageLensArn = str
 StorageLensGroupArn = str
@@ -148,6 +165,12 @@ class Format(str):
 
 class GeneratedManifestFormat(str):
     S3InventoryReport_CSV_20211130 = "S3InventoryReport_CSV_20211130"
+
+
+class GranteeType(str):
+    DIRECTORY_USER = "DIRECTORY_USER"
+    DIRECTORY_GROUP = "DIRECTORY_GROUP"
+    IAM = "IAM"
 
 
 class JobManifestFieldName(str):
@@ -255,6 +278,17 @@ class OwnerOverride(str):
     Destination = "Destination"
 
 
+class Permission(str):
+    READ = "READ"
+    WRITE = "WRITE"
+    READWRITE = "READWRITE"
+
+
+class Privilege(str):
+    Minimal = "Minimal"
+    Default = "Default"
+
+
 class ReplicaModificationsStatus(str):
     Enabled = "Enabled"
     Disabled = "Disabled"
@@ -348,6 +382,10 @@ class S3Permission(str):
     WRITE = "WRITE"
     READ_ACP = "READ_ACP"
     WRITE_ACP = "WRITE_ACP"
+
+
+class S3PrefixType(str):
+    Object = "Object"
 
 
 class S3SSEAlgorithm(str):
@@ -458,6 +496,54 @@ class AccessControlTranslation(TypedDict, total=False):
     Owner: OwnerOverride
 
 
+CreationTimestamp = datetime
+
+
+class ListAccessGrantsInstanceEntry(TypedDict, total=False):
+    AccessGrantsInstanceId: Optional[AccessGrantsInstanceId]
+    AccessGrantsInstanceArn: Optional[AccessGrantsInstanceArn]
+    CreatedAt: Optional[CreationTimestamp]
+    IdentityCenterArn: Optional[IdentityCenterArn]
+
+
+AccessGrantsInstancesList = List[ListAccessGrantsInstanceEntry]
+
+
+class AccessGrantsLocationConfiguration(TypedDict, total=False):
+    S3SubPrefix: Optional[S3Prefix]
+
+
+class Grantee(TypedDict, total=False):
+    GranteeType: Optional[GranteeType]
+    GranteeIdentifier: Optional[GranteeIdentifier]
+
+
+class ListAccessGrantEntry(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantId: Optional[AccessGrantId]
+    AccessGrantArn: Optional[AccessGrantArn]
+    Grantee: Optional[Grantee]
+    Permission: Optional[Permission]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationConfiguration: Optional[AccessGrantsLocationConfiguration]
+    GrantScope: Optional[S3Prefix]
+    ApplicationArn: Optional[IdentityCenterApplicationArn]
+
+
+AccessGrantsList = List[ListAccessGrantEntry]
+
+
+class ListAccessGrantsLocationsEntry(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationArn: Optional[AccessGrantsLocationArn]
+    LocationScope: Optional[S3Prefix]
+    IAMRoleArn: Optional[IAMRoleArn]
+
+
+AccessGrantsLocationsList = List[ListAccessGrantsLocationsEntry]
+
+
 class VpcConfiguration(TypedDict, total=False):
     VpcId: VpcId
 
@@ -532,6 +618,11 @@ class AccountLevel(TypedDict, total=False):
     AdvancedDataProtectionMetrics: Optional[AdvancedDataProtectionMetrics]
     DetailedStatusCodesMetrics: Optional[DetailedStatusCodesMetrics]
     StorageLensGroupLevel: Optional[StorageLensGroupLevel]
+
+
+class AssociateAccessGrantsIdentityCenterRequest(ServiceRequest):
+    AccountId: AccountId
+    IdentityCenterArn: IdentityCenterArn
 
 
 AsyncCreationTimestamp = datetime
@@ -618,6 +709,65 @@ class CloudWatchMetrics(TypedDict, total=False):
     IsEnabled: IsEnabled
 
 
+class Tag(TypedDict, total=False):
+    Key: TagKeyString
+    Value: TagValueString
+
+
+TagList = List[Tag]
+
+
+class CreateAccessGrantRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantsLocationId: AccessGrantsLocationId
+    AccessGrantsLocationConfiguration: Optional[AccessGrantsLocationConfiguration]
+    Grantee: Grantee
+    Permission: Permission
+    ApplicationArn: Optional[IdentityCenterApplicationArn]
+    S3PrefixType: Optional[S3PrefixType]
+    Tags: Optional[TagList]
+
+
+class CreateAccessGrantResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantId: Optional[AccessGrantId]
+    AccessGrantArn: Optional[AccessGrantArn]
+    Grantee: Optional[Grantee]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationConfiguration: Optional[AccessGrantsLocationConfiguration]
+    Permission: Optional[Permission]
+    ApplicationArn: Optional[IdentityCenterApplicationArn]
+    GrantScope: Optional[S3Prefix]
+
+
+class CreateAccessGrantsInstanceRequest(ServiceRequest):
+    AccountId: AccountId
+    IdentityCenterArn: Optional[IdentityCenterArn]
+    Tags: Optional[TagList]
+
+
+class CreateAccessGrantsInstanceResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantsInstanceId: Optional[AccessGrantsInstanceId]
+    AccessGrantsInstanceArn: Optional[AccessGrantsInstanceArn]
+    IdentityCenterArn: Optional[IdentityCenterArn]
+
+
+class CreateAccessGrantsLocationRequest(ServiceRequest):
+    AccountId: AccountId
+    LocationScope: S3Prefix
+    IAMRoleArn: IAMRoleArn
+    Tags: Optional[TagList]
+
+
+class CreateAccessGrantsLocationResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationArn: Optional[AccessGrantsLocationArn]
+    LocationScope: Optional[S3Prefix]
+    IAMRoleArn: Optional[IAMRoleArn]
+
+
 class ObjectLambdaContentTransformation(TypedDict, total=False):
     AwsLambda: Optional[AwsLambdaTransformation]
 
@@ -695,6 +845,18 @@ class CreateBucketResult(TypedDict, total=False):
     BucketArn: Optional[S3RegionalBucketArn]
 
 
+StorageClassList = List[S3StorageClass]
+ObjectSizeLessThanBytes = int
+ObjectSizeGreaterThanBytes = int
+NonEmptyMaxLength1024StringList = List[NonEmptyMaxLength1024String]
+
+
+class KeyNameConstraint(TypedDict, total=False):
+    MatchAnyPrefix: Optional[NonEmptyMaxLength1024StringList]
+    MatchAnySuffix: Optional[NonEmptyMaxLength1024StringList]
+    MatchAnySubstring: Optional[NonEmptyMaxLength1024StringList]
+
+
 ReplicationStatusFilterList = List[ReplicationStatus]
 ObjectCreationTime = datetime
 
@@ -704,6 +866,10 @@ class JobManifestGeneratorFilter(TypedDict, total=False):
     CreatedAfter: Optional[ObjectCreationTime]
     CreatedBefore: Optional[ObjectCreationTime]
     ObjectReplicationStatuses: Optional[ReplicationStatusFilterList]
+    KeyNameConstraint: Optional[KeyNameConstraint]
+    ObjectSizeGreaterThanBytes: Optional[ObjectSizeGreaterThanBytes]
+    ObjectSizeLessThanBytes: Optional[ObjectSizeLessThanBytes]
+    MatchAnyStorageClass: Optional[StorageClassList]
 
 
 class SSEKMSEncryption(TypedDict, total=False):
@@ -864,7 +1030,7 @@ class S3ObjectMetadata(TypedDict, total=False):
 
 
 class S3CopyObjectOperation(TypedDict, total=False):
-    TargetResource: Optional[S3BucketArnString]
+    TargetResource: Optional[S3RegionalOrS3ExpressBucketArnString]
     CannedAccessControlList: Optional[S3CannedAccessControlList]
     AccessControlGrants: Optional[S3GrantList]
     MetadataDirective: Optional[S3MetadataDirective]
@@ -884,8 +1050,13 @@ class S3CopyObjectOperation(TypedDict, total=False):
     ChecksumAlgorithm: Optional[S3ChecksumAlgorithm]
 
 
+UserArguments = Dict[NonEmptyMaxLength64String, MaxLength1024String]
+
+
 class LambdaInvokeOperation(TypedDict, total=False):
     FunctionArn: Optional[FunctionArnString]
+    InvocationSchemaVersion: Optional[NonEmptyMaxLength64String]
+    UserArguments: Optional[UserArguments]
 
 
 class JobOperation(TypedDict, total=False):
@@ -928,12 +1099,6 @@ class CreateMultiRegionAccessPointResult(TypedDict, total=False):
     RequestTokenARN: Optional[AsyncRequestTokenARN]
 
 
-class Tag(TypedDict, total=False):
-    Key: TagKeyString
-    Value: TagValueString
-
-
-TagList = List[Tag]
 ObjectSizeValue = int
 
 
@@ -991,8 +1156,35 @@ class CreateStorageLensGroupRequest(ServiceRequest):
 
 
 CreationDate = datetime
-CreationTimestamp = datetime
+Expiration = datetime
+
+
+class Credentials(TypedDict, total=False):
+    AccessKeyId: Optional[AccessKeyId]
+    SecretAccessKey: Optional[SecretAccessKey]
+    SessionToken: Optional[SessionToken]
+    Expiration: Optional[Expiration]
+
+
 Date = datetime
+
+
+class DeleteAccessGrantRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantId: AccessGrantId
+
+
+class DeleteAccessGrantsInstanceRequest(ServiceRequest):
+    AccountId: AccountId
+
+
+class DeleteAccessGrantsInstanceResourcePolicyRequest(ServiceRequest):
+    AccountId: AccountId
+
+
+class DeleteAccessGrantsLocationRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantsLocationId: AccessGrantsLocationId
 
 
 class DeleteAccessPointForObjectLambdaRequest(ServiceRequest):
@@ -1189,6 +1381,10 @@ class Destination(TypedDict, total=False):
     StorageClass: Optional[ReplicationStorageClass]
 
 
+class DissociateAccessGrantsIdentityCenterRequest(ServiceRequest):
+    AccountId: AccountId
+
+
 Endpoints = Dict[NonEmptyMaxLength64String, NonEmptyMaxLength1024String]
 
 
@@ -1206,6 +1402,67 @@ class Exclude(TypedDict, total=False):
 
 class ExistingObjectReplication(TypedDict, total=False):
     Status: ExistingObjectReplicationStatus
+
+
+class GetAccessGrantRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantId: AccessGrantId
+
+
+class GetAccessGrantResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantId: Optional[AccessGrantId]
+    AccessGrantArn: Optional[AccessGrantArn]
+    Grantee: Optional[Grantee]
+    Permission: Optional[Permission]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationConfiguration: Optional[AccessGrantsLocationConfiguration]
+    GrantScope: Optional[S3Prefix]
+    ApplicationArn: Optional[IdentityCenterApplicationArn]
+
+
+class GetAccessGrantsInstanceForPrefixRequest(ServiceRequest):
+    AccountId: AccountId
+    S3Prefix: S3Prefix
+
+
+class GetAccessGrantsInstanceForPrefixResult(TypedDict, total=False):
+    AccessGrantsInstanceArn: Optional[AccessGrantsInstanceArn]
+    AccessGrantsInstanceId: Optional[AccessGrantsInstanceId]
+
+
+class GetAccessGrantsInstanceRequest(ServiceRequest):
+    AccountId: AccountId
+
+
+class GetAccessGrantsInstanceResourcePolicyRequest(ServiceRequest):
+    AccountId: AccountId
+
+
+class GetAccessGrantsInstanceResourcePolicyResult(TypedDict, total=False):
+    Policy: Optional[PolicyDocument]
+    Organization: Optional[Organization]
+    CreatedAt: Optional[CreationTimestamp]
+
+
+class GetAccessGrantsInstanceResult(TypedDict, total=False):
+    AccessGrantsInstanceArn: Optional[AccessGrantsInstanceArn]
+    AccessGrantsInstanceId: Optional[AccessGrantsInstanceId]
+    IdentityCenterArn: Optional[IdentityCenterArn]
+    CreatedAt: Optional[CreationTimestamp]
+
+
+class GetAccessGrantsLocationRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantsLocationId: AccessGrantsLocationId
+
+
+class GetAccessGrantsLocationResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationArn: Optional[AccessGrantsLocationArn]
+    LocationScope: Optional[S3Prefix]
+    IAMRoleArn: Optional[IAMRoleArn]
 
 
 class GetAccessPointConfigurationForObjectLambdaRequest(ServiceRequest):
@@ -1312,8 +1569,6 @@ class Transition(TypedDict, total=False):
 
 
 TransitionList = List[Transition]
-ObjectSizeLessThanBytes = int
-ObjectSizeGreaterThanBytes = int
 
 
 class LifecycleRuleAndOperator(TypedDict, total=False):
@@ -1446,6 +1701,20 @@ class GetBucketVersioningRequest(ServiceRequest):
 class GetBucketVersioningResult(TypedDict, total=False):
     Status: Optional[BucketVersioningStatus]
     MFADelete: Optional[MFADeleteStatus]
+
+
+class GetDataAccessRequest(ServiceRequest):
+    AccountId: AccountId
+    Target: S3Prefix
+    Permission: Permission
+    DurationSeconds: Optional[DurationSeconds]
+    Privilege: Optional[Privilege]
+    TargetType: Optional[S3PrefixType]
+
+
+class GetDataAccessResult(TypedDict, total=False):
+    Credentials: Optional[Credentials]
+    MatchedGrantTarget: Optional[S3Prefix]
 
 
 class GetJobTaggingRequest(ServiceRequest):
@@ -1639,6 +1908,45 @@ class LifecycleConfiguration(TypedDict, total=False):
     Rules: Optional[LifecycleRules]
 
 
+class ListAccessGrantsInstancesRequest(ServiceRequest):
+    AccountId: AccountId
+    NextToken: Optional[ContinuationToken]
+    MaxResults: Optional[MaxResults]
+
+
+class ListAccessGrantsInstancesResult(TypedDict, total=False):
+    NextToken: Optional[ContinuationToken]
+    AccessGrantsInstancesList: Optional[AccessGrantsInstancesList]
+
+
+class ListAccessGrantsLocationsRequest(ServiceRequest):
+    AccountId: AccountId
+    NextToken: Optional[ContinuationToken]
+    MaxResults: Optional[MaxResults]
+    LocationScope: Optional[S3Prefix]
+
+
+class ListAccessGrantsLocationsResult(TypedDict, total=False):
+    NextToken: Optional[ContinuationToken]
+    AccessGrantsLocationsList: Optional[AccessGrantsLocationsList]
+
+
+class ListAccessGrantsRequest(ServiceRequest):
+    AccountId: AccountId
+    NextToken: Optional[ContinuationToken]
+    MaxResults: Optional[MaxResults]
+    GranteeType: Optional[GranteeType]
+    GranteeIdentifier: Optional[GranteeIdentifier]
+    Permission: Optional[Permission]
+    GrantScope: Optional[S3Prefix]
+    ApplicationArn: Optional[IdentityCenterApplicationArn]
+
+
+class ListAccessGrantsResult(TypedDict, total=False):
+    NextToken: Optional[ContinuationToken]
+    AccessGrantsList: Optional[AccessGrantsList]
+
+
 class ListAccessPointsForObjectLambdaRequest(ServiceRequest):
     AccountId: AccountId
     NextToken: Optional[NonEmptyMaxLength1024String]
@@ -1766,6 +2074,18 @@ class ListTagsForResourceRequest(ServiceRequest):
 
 class ListTagsForResourceResult(TypedDict, total=False):
     Tags: Optional[TagList]
+
+
+class PutAccessGrantsInstanceResourcePolicyRequest(ServiceRequest):
+    AccountId: AccountId
+    Policy: PolicyDocument
+    Organization: Optional[Organization]
+
+
+class PutAccessGrantsInstanceResourcePolicyResult(TypedDict, total=False):
+    Policy: Optional[PolicyDocument]
+    Organization: Optional[Organization]
+    CreatedAt: Optional[CreationTimestamp]
 
 
 class PutAccessPointConfigurationForObjectLambdaRequest(ServiceRequest):
@@ -1902,6 +2222,20 @@ class UntagResourceResult(TypedDict, total=False):
     pass
 
 
+class UpdateAccessGrantsLocationRequest(ServiceRequest):
+    AccountId: AccountId
+    AccessGrantsLocationId: AccessGrantsLocationId
+    IAMRoleArn: IAMRoleArn
+
+
+class UpdateAccessGrantsLocationResult(TypedDict, total=False):
+    CreatedAt: Optional[CreationTimestamp]
+    AccessGrantsLocationId: Optional[AccessGrantsLocationId]
+    AccessGrantsLocationArn: Optional[AccessGrantsLocationArn]
+    LocationScope: Optional[S3Prefix]
+    IAMRoleArn: Optional[IAMRoleArn]
+
+
 class UpdateJobPriorityRequest(ServiceRequest):
     AccountId: AccountId
     JobId: JobId
@@ -1935,6 +2269,48 @@ class UpdateStorageLensGroupRequest(ServiceRequest):
 class S3ControlApi:
     service = "s3control"
     version = "2018-08-20"
+
+    @handler("AssociateAccessGrantsIdentityCenter")
+    def associate_access_grants_identity_center(
+        self, context: RequestContext, account_id: AccountId, identity_center_arn: IdentityCenterArn
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("CreateAccessGrant")
+    def create_access_grant(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        access_grants_location_id: AccessGrantsLocationId,
+        grantee: Grantee,
+        permission: Permission,
+        access_grants_location_configuration: AccessGrantsLocationConfiguration = None,
+        application_arn: IdentityCenterApplicationArn = None,
+        s3_prefix_type: S3PrefixType = None,
+        tags: TagList = None,
+    ) -> CreateAccessGrantResult:
+        raise NotImplementedError
+
+    @handler("CreateAccessGrantsInstance")
+    def create_access_grants_instance(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        identity_center_arn: IdentityCenterArn = None,
+        tags: TagList = None,
+    ) -> CreateAccessGrantsInstanceResult:
+        raise NotImplementedError
+
+    @handler("CreateAccessGrantsLocation")
+    def create_access_grants_location(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        location_scope: S3Prefix,
+        iam_role_arn: IAMRoleArn,
+        tags: TagList = None,
+    ) -> CreateAccessGrantsLocationResult:
+        raise NotImplementedError
 
     @handler("CreateAccessPoint")
     def create_access_point(
@@ -2011,6 +2387,31 @@ class S3ControlApi:
         account_id: AccountId,
         storage_lens_group: StorageLensGroup,
         tags: TagList = None,
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteAccessGrant")
+    def delete_access_grant(
+        self, context: RequestContext, account_id: AccountId, access_grant_id: AccessGrantId
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteAccessGrantsInstance")
+    def delete_access_grants_instance(self, context: RequestContext, account_id: AccountId) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteAccessGrantsInstanceResourcePolicy")
+    def delete_access_grants_instance_resource_policy(
+        self, context: RequestContext, account_id: AccountId
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteAccessGrantsLocation")
+    def delete_access_grants_location(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        access_grants_location_id: AccessGrantsLocationId,
     ) -> None:
         raise NotImplementedError
 
@@ -2121,6 +2522,45 @@ class S3ControlApi:
     ) -> DescribeMultiRegionAccessPointOperationResult:
         raise NotImplementedError
 
+    @handler("DissociateAccessGrantsIdentityCenter")
+    def dissociate_access_grants_identity_center(
+        self, context: RequestContext, account_id: AccountId
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("GetAccessGrant")
+    def get_access_grant(
+        self, context: RequestContext, account_id: AccountId, access_grant_id: AccessGrantId
+    ) -> GetAccessGrantResult:
+        raise NotImplementedError
+
+    @handler("GetAccessGrantsInstance")
+    def get_access_grants_instance(
+        self, context: RequestContext, account_id: AccountId
+    ) -> GetAccessGrantsInstanceResult:
+        raise NotImplementedError
+
+    @handler("GetAccessGrantsInstanceForPrefix")
+    def get_access_grants_instance_for_prefix(
+        self, context: RequestContext, account_id: AccountId, s3_prefix: S3Prefix
+    ) -> GetAccessGrantsInstanceForPrefixResult:
+        raise NotImplementedError
+
+    @handler("GetAccessGrantsInstanceResourcePolicy")
+    def get_access_grants_instance_resource_policy(
+        self, context: RequestContext, account_id: AccountId
+    ) -> GetAccessGrantsInstanceResourcePolicyResult:
+        raise NotImplementedError
+
+    @handler("GetAccessGrantsLocation")
+    def get_access_grants_location(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        access_grants_location_id: AccessGrantsLocationId,
+    ) -> GetAccessGrantsLocationResult:
+        raise NotImplementedError
+
     @handler("GetAccessPoint")
     def get_access_point(
         self, context: RequestContext, account_id: AccountId, name: AccessPointName
@@ -2199,6 +2639,19 @@ class S3ControlApi:
     ) -> GetBucketVersioningResult:
         raise NotImplementedError
 
+    @handler("GetDataAccess")
+    def get_data_access(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        target: S3Prefix,
+        permission: Permission,
+        duration_seconds: DurationSeconds = None,
+        privilege: Privilege = None,
+        target_type: S3PrefixType = None,
+    ) -> GetDataAccessResult:
+        raise NotImplementedError
+
     @handler("GetJobTagging")
     def get_job_tagging(
         self, context: RequestContext, account_id: AccountId, job_id: JobId
@@ -2251,6 +2704,42 @@ class S3ControlApi:
     def get_storage_lens_group(
         self, context: RequestContext, name: StorageLensGroupName, account_id: AccountId
     ) -> GetStorageLensGroupResult:
+        raise NotImplementedError
+
+    @handler("ListAccessGrants")
+    def list_access_grants(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        next_token: ContinuationToken = None,
+        max_results: MaxResults = None,
+        grantee_type: GranteeType = None,
+        grantee_identifier: GranteeIdentifier = None,
+        permission: Permission = None,
+        grant_scope: S3Prefix = None,
+        application_arn: IdentityCenterApplicationArn = None,
+    ) -> ListAccessGrantsResult:
+        raise NotImplementedError
+
+    @handler("ListAccessGrantsInstances")
+    def list_access_grants_instances(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        next_token: ContinuationToken = None,
+        max_results: MaxResults = None,
+    ) -> ListAccessGrantsInstancesResult:
+        raise NotImplementedError
+
+    @handler("ListAccessGrantsLocations")
+    def list_access_grants_locations(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        next_token: ContinuationToken = None,
+        max_results: MaxResults = None,
+        location_scope: S3Prefix = None,
+    ) -> ListAccessGrantsLocationsResult:
         raise NotImplementedError
 
     @handler("ListAccessPoints")
@@ -2322,6 +2811,16 @@ class S3ControlApi:
     def list_tags_for_resource(
         self, context: RequestContext, account_id: AccountId, resource_arn: S3ResourceArn
     ) -> ListTagsForResourceResult:
+        raise NotImplementedError
+
+    @handler("PutAccessGrantsInstanceResourcePolicy")
+    def put_access_grants_instance_resource_policy(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        policy: PolicyDocument,
+        organization: Organization = None,
+    ) -> PutAccessGrantsInstanceResourcePolicyResult:
         raise NotImplementedError
 
     @handler("PutAccessPointConfigurationForObjectLambda")
@@ -2472,6 +2971,16 @@ class S3ControlApi:
         resource_arn: S3ResourceArn,
         tag_keys: TagKeyList,
     ) -> UntagResourceResult:
+        raise NotImplementedError
+
+    @handler("UpdateAccessGrantsLocation")
+    def update_access_grants_location(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        access_grants_location_id: AccessGrantsLocationId,
+        iam_role_arn: IAMRoleArn,
+    ) -> UpdateAccessGrantsLocationResult:
         raise NotImplementedError
 
     @handler("UpdateJobPriority")

--- a/localstack/aws/api/secretsmanager/__init__.py
+++ b/localstack/aws/api/secretsmanager/__init__.py
@@ -7,6 +7,7 @@ BooleanType = bool
 ClientRequestTokenType = str
 DescriptionType = str
 DurationType = str
+ErrorCode = str
 ErrorMessage = str
 ExcludeCharactersType = str
 ExcludeLowercaseType = bool
@@ -16,6 +17,7 @@ ExcludeUppercaseType = bool
 FilterValueStringType = str
 IncludeSpaceType = bool
 KmsKeyIdType = str
+MaxResultsBatchType = int
 MaxResultsType = int
 NameType = str
 NextTokenType = str
@@ -131,6 +133,15 @@ class ResourceNotFoundException(ServiceException):
     status_code: int = 400
 
 
+class APIErrorType(TypedDict, total=False):
+    SecretId: Optional[SecretIdType]
+    ErrorCode: Optional[ErrorCode]
+    Message: Optional[ErrorMessage]
+
+
+APIErrorListType = List[APIErrorType]
+
+
 class ReplicaRegionType(TypedDict, total=False):
     Region: Optional[RegionType]
     KmsKeyId: Optional[KmsKeyIdType]
@@ -138,6 +149,47 @@ class ReplicaRegionType(TypedDict, total=False):
 
 AddReplicaRegionListType = List[ReplicaRegionType]
 AutomaticallyRotateAfterDaysType = int
+FilterValuesStringList = List[FilterValueStringType]
+
+
+class Filter(TypedDict, total=False):
+    Key: Optional[FilterNameStringType]
+    Values: Optional[FilterValuesStringList]
+
+
+FiltersListType = List[Filter]
+SecretIdListType = List[SecretIdType]
+
+
+class BatchGetSecretValueRequest(ServiceRequest):
+    SecretIdList: Optional[SecretIdListType]
+    Filters: Optional[FiltersListType]
+    MaxResults: Optional[MaxResultsBatchType]
+    NextToken: Optional[NextTokenType]
+
+
+CreatedDateType = datetime
+SecretVersionStagesType = List[SecretVersionStageType]
+SecretBinaryType = bytes
+
+
+class SecretValueEntry(TypedDict, total=False):
+    ARN: Optional[SecretARNType]
+    Name: Optional[SecretNameType]
+    VersionId: Optional[SecretVersionIdType]
+    SecretBinary: Optional[SecretBinaryType]
+    SecretString: Optional[SecretStringType]
+    VersionStages: Optional[SecretVersionStagesType]
+    CreatedDate: Optional[CreatedDateType]
+
+
+SecretValuesType = List[SecretValueEntry]
+
+
+class BatchGetSecretValueResponse(TypedDict, total=False):
+    SecretValues: Optional[SecretValuesType]
+    NextToken: Optional[NextTokenType]
+    Errors: Optional[APIErrorListType]
 
 
 class CancelRotateSecretRequest(ServiceRequest):
@@ -156,7 +208,6 @@ class Tag(TypedDict, total=False):
 
 
 TagListType = List[Tag]
-SecretBinaryType = bytes
 
 
 class CreateSecretRequest(ServiceRequest):
@@ -190,9 +241,6 @@ class CreateSecretResponse(TypedDict, total=False):
     Name: Optional[SecretNameType]
     VersionId: Optional[SecretVersionIdType]
     ReplicationStatus: Optional[ReplicationStatusListType]
-
-
-CreatedDateType = datetime
 
 
 class DeleteResourcePolicyRequest(ServiceRequest):
@@ -230,7 +278,6 @@ class DescribeSecretRequest(ServiceRequest):
 
 
 TimestampType = datetime
-SecretVersionStagesType = List[SecretVersionStageType]
 SecretVersionsToStagesMapType = Dict[SecretVersionIdType, SecretVersionStagesType]
 NextRotationDateType = datetime
 LastChangedDateType = datetime
@@ -264,15 +311,6 @@ class DescribeSecretResponse(TypedDict, total=False):
     ReplicationStatus: Optional[ReplicationStatusListType]
 
 
-FilterValuesStringList = List[FilterValueStringType]
-
-
-class Filter(TypedDict, total=False):
-    Key: Optional[FilterNameStringType]
-    Values: Optional[FilterValuesStringList]
-
-
-FiltersListType = List[Filter]
 PasswordLengthType = int
 
 
@@ -523,6 +561,17 @@ class ValidateResourcePolicyResponse(TypedDict, total=False):
 class SecretsmanagerApi:
     service = "secretsmanager"
     version = "2017-10-17"
+
+    @handler("BatchGetSecretValue")
+    def batch_get_secret_value(
+        self,
+        context: RequestContext,
+        secret_id_list: SecretIdListType = None,
+        filters: FiltersListType = None,
+        max_results: MaxResultsBatchType = None,
+        next_token: NextTokenType = None,
+    ) -> BatchGetSecretValueResponse:
+        raise NotImplementedError
 
     @handler("CancelRotateSecret")
     def cancel_rotate_secret(

--- a/localstack/aws/api/sqs/__init__.py
+++ b/localstack/aws/api/sqs/__init__.py
@@ -4,9 +4,8 @@ from localstack.aws.api import RequestContext, ServiceException, ServiceRequest,
 
 Boolean = bool
 BoxedInteger = int
-ExceptionMessage = str
+Integer = int
 MessageAttributeName = str
-NullableInteger = int
 String = str
 TagKey = str
 TagValue = str
@@ -55,26 +54,20 @@ class QueueAttributeName(str):
 
 
 class BatchEntryIdsNotDistinct(ServiceException):
-    code: str = "BatchEntryIdsNotDistinct"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class BatchRequestTooLong(ServiceException):
-    code: str = "BatchRequestTooLong"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.BatchRequestTooLong"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class EmptyBatchRequest(ServiceException):
-    code: str = "EmptyBatchRequest"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class InvalidAddress(ServiceException):
-    code: str = "InvalidAddress"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.EmptyBatchRequest"
+    sender_fault: bool = True
     status_code: int = 400
 
 
@@ -84,15 +77,9 @@ class InvalidAttributeName(ServiceException):
     status_code: int = 400
 
 
-class InvalidAttributeValue(ServiceException):
-    code: str = "InvalidAttributeValue"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
 class InvalidBatchEntryId(ServiceException):
-    code: str = "InvalidBatchEntryId"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.InvalidBatchEntryId"
+    sender_fault: bool = True
     status_code: int = 400
 
 
@@ -108,87 +95,39 @@ class InvalidMessageContents(ServiceException):
     status_code: int = 400
 
 
-class InvalidSecurity(ServiceException):
-    code: str = "InvalidSecurity"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsAccessDenied(ServiceException):
-    code: str = "KmsAccessDenied"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsDisabled(ServiceException):
-    code: str = "KmsDisabled"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsInvalidKeyUsage(ServiceException):
-    code: str = "KmsInvalidKeyUsage"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsInvalidState(ServiceException):
-    code: str = "KmsInvalidState"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsNotFound(ServiceException):
-    code: str = "KmsNotFound"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsOptInRequired(ServiceException):
-    code: str = "KmsOptInRequired"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
-class KmsThrottled(ServiceException):
-    code: str = "KmsThrottled"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
 class MessageNotInflight(ServiceException):
-    code: str = "MessageNotInflight"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.MessageNotInflight"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class OverLimit(ServiceException):
     code: str = "OverLimit"
-    sender_fault: bool = False
-    status_code: int = 400
+    sender_fault: bool = True
+    status_code: int = 403
 
 
 class PurgeQueueInProgress(ServiceException):
-    code: str = "PurgeQueueInProgress"
-    sender_fault: bool = False
-    status_code: int = 400
+    code: str = "AWS.SimpleQueueService.PurgeQueueInProgress"
+    sender_fault: bool = True
+    status_code: int = 403
 
 
 class QueueDeletedRecently(ServiceException):
-    code: str = "QueueDeletedRecently"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.QueueDeletedRecently"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class QueueDoesNotExist(ServiceException):
-    code: str = "QueueDoesNotExist"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.NonExistentQueue"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class QueueNameExists(ServiceException):
-    code: str = "QueueNameExists"
-    sender_fault: bool = False
+    code: str = "QueueAlreadyExists"
+    sender_fault: bool = True
     status_code: int = 400
 
 
@@ -198,27 +137,21 @@ class ReceiptHandleIsInvalid(ServiceException):
     status_code: int = 400
 
 
-class RequestThrottled(ServiceException):
-    code: str = "RequestThrottled"
-    sender_fault: bool = False
-    status_code: int = 400
-
-
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
-    sender_fault: bool = False
-    status_code: int = 400
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class TooManyEntriesInBatchRequest(ServiceException):
-    code: str = "TooManyEntriesInBatchRequest"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
+    sender_fault: bool = True
     status_code: int = 400
 
 
 class UnsupportedOperation(ServiceException):
-    code: str = "UnsupportedOperation"
-    sender_fault: bool = False
+    code: str = "AWS.SimpleQueueService.UnsupportedOperation"
+    sender_fault: bool = True
     status_code: int = 400
 
 
@@ -262,7 +195,7 @@ class CancelMessageMoveTaskResult(TypedDict, total=False):
 class ChangeMessageVisibilityBatchRequestEntry(TypedDict, total=False):
     Id: String
     ReceiptHandle: String
-    VisibilityTimeout: Optional[NullableInteger]
+    VisibilityTimeout: Optional[Integer]
 
 
 ChangeMessageVisibilityBatchRequestEntryList = List[ChangeMessageVisibilityBatchRequestEntry]
@@ -288,7 +221,7 @@ class ChangeMessageVisibilityBatchResult(TypedDict, total=False):
 class ChangeMessageVisibilityRequest(ServiceRequest):
     QueueUrl: String
     ReceiptHandle: String
-    VisibilityTimeout: NullableInteger
+    VisibilityTimeout: Integer
 
 
 TagMap = Dict[TagKey, TagValue]
@@ -373,10 +306,7 @@ class ListDeadLetterSourceQueuesResult(TypedDict, total=False):
 
 class ListMessageMoveTasksRequest(ServiceRequest):
     SourceArn: String
-    MaxResults: Optional[NullableInteger]
-
-
-NullableLong = int
+    MaxResults: Optional[Integer]
 
 
 class ListMessageMoveTasksResultEntry(TypedDict, total=False):
@@ -384,9 +314,9 @@ class ListMessageMoveTasksResultEntry(TypedDict, total=False):
     Status: Optional[String]
     SourceArn: Optional[String]
     DestinationArn: Optional[String]
-    MaxNumberOfMessagesPerSecond: Optional[NullableInteger]
+    MaxNumberOfMessagesPerSecond: Optional[Integer]
     ApproximateNumberOfMessagesMoved: Optional[Long]
-    ApproximateNumberOfMessagesToMove: Optional[NullableLong]
+    ApproximateNumberOfMessagesToMove: Optional[Long]
     FailureReason: Optional[String]
     StartedTimestamp: Optional[Long]
 
@@ -467,9 +397,9 @@ class ReceiveMessageRequest(ServiceRequest):
     QueueUrl: String
     AttributeNames: Optional[AttributeNameList]
     MessageAttributeNames: Optional[MessageAttributeNameList]
-    MaxNumberOfMessages: Optional[NullableInteger]
-    VisibilityTimeout: Optional[NullableInteger]
-    WaitTimeSeconds: Optional[NullableInteger]
+    MaxNumberOfMessages: Optional[Integer]
+    VisibilityTimeout: Optional[Integer]
+    WaitTimeSeconds: Optional[Integer]
     ReceiveRequestAttemptId: Optional[String]
 
 
@@ -485,7 +415,7 @@ class RemovePermissionRequest(ServiceRequest):
 class SendMessageBatchRequestEntry(TypedDict, total=False):
     Id: String
     MessageBody: String
-    DelaySeconds: Optional[NullableInteger]
+    DelaySeconds: Optional[Integer]
     MessageAttributes: Optional[MessageBodyAttributeMap]
     MessageSystemAttributes: Optional[MessageBodySystemAttributeMap]
     MessageDeduplicationId: Optional[String]
@@ -520,7 +450,7 @@ class SendMessageBatchResult(TypedDict, total=False):
 class SendMessageRequest(ServiceRequest):
     QueueUrl: String
     MessageBody: String
-    DelaySeconds: Optional[NullableInteger]
+    DelaySeconds: Optional[Integer]
     MessageAttributes: Optional[MessageBodyAttributeMap]
     MessageSystemAttributes: Optional[MessageBodySystemAttributeMap]
     MessageDeduplicationId: Optional[String]
@@ -543,7 +473,7 @@ class SetQueueAttributesRequest(ServiceRequest):
 class StartMessageMoveTaskRequest(ServiceRequest):
     SourceArn: String
     DestinationArn: Optional[String]
-    MaxNumberOfMessagesPerSecond: Optional[NullableInteger]
+    MaxNumberOfMessagesPerSecond: Optional[Integer]
 
 
 class StartMessageMoveTaskResult(TypedDict, total=False):
@@ -590,7 +520,7 @@ class SqsApi:
         context: RequestContext,
         queue_url: String,
         receipt_handle: String,
-        visibility_timeout: NullableInteger,
+        visibility_timeout: Integer,
     ) -> None:
         raise NotImplementedError
 
@@ -656,7 +586,7 @@ class SqsApi:
 
     @handler("ListMessageMoveTasks")
     def list_message_move_tasks(
-        self, context: RequestContext, source_arn: String, max_results: NullableInteger = None
+        self, context: RequestContext, source_arn: String, max_results: Integer = None
     ) -> ListMessageMoveTasksResult:
         raise NotImplementedError
 
@@ -685,9 +615,9 @@ class SqsApi:
         queue_url: String,
         attribute_names: AttributeNameList = None,
         message_attribute_names: MessageAttributeNameList = None,
-        max_number_of_messages: NullableInteger = None,
-        visibility_timeout: NullableInteger = None,
-        wait_time_seconds: NullableInteger = None,
+        max_number_of_messages: Integer = None,
+        visibility_timeout: Integer = None,
+        wait_time_seconds: Integer = None,
         receive_request_attempt_id: String = None,
     ) -> ReceiveMessageResult:
         raise NotImplementedError
@@ -702,7 +632,7 @@ class SqsApi:
         context: RequestContext,
         queue_url: String,
         message_body: String,
-        delay_seconds: NullableInteger = None,
+        delay_seconds: Integer = None,
         message_attributes: MessageBodyAttributeMap = None,
         message_system_attributes: MessageBodySystemAttributeMap = None,
         message_deduplication_id: String = None,
@@ -728,7 +658,7 @@ class SqsApi:
         context: RequestContext,
         source_arn: String,
         destination_arn: String = None,
-        max_number_of_messages_per_second: NullableInteger = None,
+        max_number_of_messages_per_second: Integer = None,
     ) -> StartMessageMoveTaskResult:
         raise NotImplementedError
 

--- a/localstack/aws/api/stepfunctions/__init__.py
+++ b/localstack/aws/api/stepfunctions/__init__.py
@@ -11,6 +11,12 @@ ConnectorParameters = str
 Definition = str
 Enabled = bool
 ErrorMessage = str
+HTTPBody = str
+HTTPHeaders = str
+HTTPMethod = str
+HTTPProtocol = str
+HTTPStatusCode = str
+HTTPStatusMessage = str
 Identity = str
 IncludeExecutionData = bool
 IncludeExecutionDataGetExecutionHistory = bool
@@ -23,17 +29,20 @@ PageSize = int
 PageToken = str
 Publish = bool
 RedriveCount = int
+RevealSecrets = bool
 ReverseOrder = bool
 RevisionId = str
 SensitiveCause = str
 SensitiveData = str
 SensitiveDataJobInput = str
 SensitiveError = str
+StateName = str
 TagKey = str
 TagValue = str
 TaskToken = str
 ToleratedFailurePercentage = float
 TraceHeader = str
+URL = str
 UnsignedInteger = int
 VersionDescription = str
 VersionWeight = int
@@ -125,6 +134,12 @@ class HistoryEventType(str):
     MapRunRedriven = "MapRunRedriven"
 
 
+class InspectionLevel(str):
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+    TRACE = "TRACE"
+
+
 class LogLevel(str):
     ALL = "ALL"
     ERROR = "ERROR"
@@ -153,6 +168,13 @@ class SyncExecutionStatus(str):
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
     TIMED_OUT = "TIMED_OUT"
+
+
+class TestExecutionStatus(str):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    RETRIABLE = "RETRIABLE"
+    CAUGHT_ERROR = "CAUGHT_ERROR"
 
 
 class ValidationExceptionReason(str):
@@ -907,6 +929,33 @@ class GetExecutionHistoryOutput(TypedDict, total=False):
     nextToken: Optional[PageToken]
 
 
+class InspectionDataResponse(TypedDict, total=False):
+    protocol: Optional[HTTPProtocol]
+    statusCode: Optional[HTTPStatusCode]
+    statusMessage: Optional[HTTPStatusMessage]
+    headers: Optional[HTTPHeaders]
+    body: Optional[HTTPBody]
+
+
+class InspectionDataRequest(TypedDict, total=False):
+    protocol: Optional[HTTPProtocol]
+    method: Optional[HTTPMethod]
+    url: Optional[URL]
+    headers: Optional[HTTPHeaders]
+    body: Optional[HTTPBody]
+
+
+class InspectionData(TypedDict, total=False):
+    input: Optional[SensitiveData]
+    afterInputPath: Optional[SensitiveData]
+    afterParameters: Optional[SensitiveData]
+    result: Optional[SensitiveData]
+    afterResultSelector: Optional[SensitiveData]
+    afterResultPath: Optional[SensitiveData]
+    request: Optional[InspectionDataRequest]
+    response: Optional[InspectionDataResponse]
+
+
 class ListActivitiesInput(ServiceRequest):
     maxResults: Optional[PageSize]
     nextToken: Optional[PageToken]
@@ -1125,6 +1174,23 @@ class TagResourceInput(ServiceRequest):
 
 class TagResourceOutput(TypedDict, total=False):
     pass
+
+
+class TestStateInput(ServiceRequest):
+    definition: Definition
+    roleArn: Arn
+    input: Optional[SensitiveData]
+    inspectionLevel: Optional[InspectionLevel]
+    revealSecrets: Optional[RevealSecrets]
+
+
+class TestStateOutput(TypedDict, total=False):
+    output: Optional[SensitiveData]
+    error: Optional[SensitiveError]
+    cause: Optional[SensitiveCause]
+    inspectionData: Optional[InspectionData]
+    nextState: Optional[StateName]
+    status: Optional[TestExecutionStatus]
 
 
 class UntagResourceInput(ServiceRequest):
@@ -1410,6 +1476,18 @@ class StepfunctionsApi:
     def tag_resource(
         self, context: RequestContext, resource_arn: Arn, tags: TagList
     ) -> TagResourceOutput:
+        raise NotImplementedError
+
+    @handler("TestState")
+    def test_state(
+        self,
+        context: RequestContext,
+        definition: Definition,
+        role_arn: Arn,
+        input: SensitiveData = None,
+        inspection_level: InspectionLevel = None,
+        reveal_secrets: RevealSecrets = None,
+    ) -> TestStateOutput:
         raise NotImplementedError
 
     @handler("UntagResource")

--- a/localstack/aws/api/transcribe/__init__.py
+++ b/localstack/aws/api/transcribe/__init__.py
@@ -17,6 +17,7 @@ MaxResults = int
 MaxSpeakers = int
 MediaSampleRateHertz = int
 MedicalMediaSampleRateHertz = int
+MedicalScribeChannelId = int
 ModelName = str
 NextToken = str
 NonEmptyString = str
@@ -103,6 +104,70 @@ class LanguageCode(str):
     en_NZ = "en-NZ"
     vi_VN = "vi-VN"
     sv_SE = "sv-SE"
+    ab_GE = "ab-GE"
+    ast_ES = "ast-ES"
+    az_AZ = "az-AZ"
+    ba_RU = "ba-RU"
+    be_BY = "be-BY"
+    bg_BG = "bg-BG"
+    bn_IN = "bn-IN"
+    bs_BA = "bs-BA"
+    ca_ES = "ca-ES"
+    ckb_IQ = "ckb-IQ"
+    ckb_IR = "ckb-IR"
+    cs_CZ = "cs-CZ"
+    cy_WL = "cy-WL"
+    el_GR = "el-GR"
+    et_ET = "et-ET"
+    eu_ES = "eu-ES"
+    fi_FI = "fi-FI"
+    gl_ES = "gl-ES"
+    gu_IN = "gu-IN"
+    ha_NG = "ha-NG"
+    hr_HR = "hr-HR"
+    hu_HU = "hu-HU"
+    hy_AM = "hy-AM"
+    is_IS = "is-IS"
+    ka_GE = "ka-GE"
+    kab_DZ = "kab-DZ"
+    kk_KZ = "kk-KZ"
+    kn_IN = "kn-IN"
+    ky_KG = "ky-KG"
+    lg_IN = "lg-IN"
+    lt_LT = "lt-LT"
+    lv_LV = "lv-LV"
+    mhr_RU = "mhr-RU"
+    mi_NZ = "mi-NZ"
+    mk_MK = "mk-MK"
+    ml_IN = "ml-IN"
+    mn_MN = "mn-MN"
+    mr_IN = "mr-IN"
+    mt_MT = "mt-MT"
+    no_NO = "no-NO"
+    or_IN = "or-IN"
+    pa_IN = "pa-IN"
+    pl_PL = "pl-PL"
+    ps_AF = "ps-AF"
+    ro_RO = "ro-RO"
+    rw_RW = "rw-RW"
+    si_LK = "si-LK"
+    sk_SK = "sk-SK"
+    sl_SI = "sl-SI"
+    so_SO = "so-SO"
+    sr_RS = "sr-RS"
+    su_ID = "su-ID"
+    sw_BI = "sw-BI"
+    sw_KE = "sw-KE"
+    sw_RW = "sw-RW"
+    sw_TZ = "sw-TZ"
+    sw_UG = "sw-UG"
+    tl_PH = "tl-PH"
+    tt_RU = "tt-RU"
+    ug_CN = "ug-CN"
+    uk_UA = "uk-UA"
+    uz_UZ = "uz-UZ"
+    wo_SN = "wo-SN"
+    zu_ZA = "zu-ZA"
 
 
 class MediaFormat(str):
@@ -118,6 +183,22 @@ class MediaFormat(str):
 
 class MedicalContentIdentificationType(str):
     PHI = "PHI"
+
+
+class MedicalScribeJobStatus(str):
+    QUEUED = "QUEUED"
+    IN_PROGRESS = "IN_PROGRESS"
+    FAILED = "FAILED"
+    COMPLETED = "COMPLETED"
+
+
+class MedicalScribeLanguageCode(str):
+    en_US = "en-US"
+
+
+class MedicalScribeParticipantRole(str):
+    PATIENT = "PATIENT"
+    CLINICIAN = "CLINICIAN"
 
 
 class ModelStatus(str):
@@ -256,6 +337,10 @@ class ChannelDefinition(TypedDict, total=False):
 ChannelDefinitions = List[ChannelDefinition]
 
 
+class Summarization(TypedDict, total=False):
+    GenerateAbstractiveSummary: Boolean
+
+
 class LanguageIdSettings(TypedDict, total=False):
     VocabularyName: Optional[VocabularyName]
     VocabularyFilterName: Optional[VocabularyFilterName]
@@ -281,6 +366,7 @@ class CallAnalyticsJobSettings(TypedDict, total=False):
     ContentRedaction: Optional[ContentRedaction]
     LanguageOptions: Optional[LanguageOptions]
     LanguageIdSettings: Optional[LanguageIdSettingsMap]
+    Summarization: Optional[Summarization]
 
 
 DateTime = datetime
@@ -506,6 +592,10 @@ class DeleteLanguageModelRequest(ServiceRequest):
     ModelName: ModelName
 
 
+class DeleteMedicalScribeJobRequest(ServiceRequest):
+    MedicalScribeJobName: TranscriptionJobName
+
+
 class DeleteMedicalTranscriptionJobRequest(ServiceRequest):
     MedicalTranscriptionJobName: TranscriptionJobName
 
@@ -560,6 +650,52 @@ class GetCallAnalyticsJobRequest(ServiceRequest):
 
 class GetCallAnalyticsJobResponse(TypedDict, total=False):
     CallAnalyticsJob: Optional[CallAnalyticsJob]
+
+
+class GetMedicalScribeJobRequest(ServiceRequest):
+    MedicalScribeJobName: TranscriptionJobName
+
+
+class MedicalScribeChannelDefinition(TypedDict, total=False):
+    ChannelId: MedicalScribeChannelId
+    ParticipantRole: MedicalScribeParticipantRole
+
+
+MedicalScribeChannelDefinitions = List[MedicalScribeChannelDefinition]
+
+
+class MedicalScribeSettings(TypedDict, total=False):
+    ShowSpeakerLabels: Optional[Boolean]
+    MaxSpeakerLabels: Optional[MaxSpeakers]
+    ChannelIdentification: Optional[Boolean]
+    VocabularyName: Optional[VocabularyName]
+    VocabularyFilterName: Optional[VocabularyFilterName]
+    VocabularyFilterMethod: Optional[VocabularyFilterMethod]
+
+
+class MedicalScribeOutput(TypedDict, total=False):
+    TranscriptFileUri: Uri
+    ClinicalDocumentUri: Uri
+
+
+class MedicalScribeJob(TypedDict, total=False):
+    MedicalScribeJobName: Optional[TranscriptionJobName]
+    MedicalScribeJobStatus: Optional[MedicalScribeJobStatus]
+    LanguageCode: Optional[MedicalScribeLanguageCode]
+    Media: Optional[Media]
+    MedicalScribeOutput: Optional[MedicalScribeOutput]
+    StartTime: Optional[DateTime]
+    CreationTime: Optional[DateTime]
+    CompletionTime: Optional[DateTime]
+    FailureReason: Optional[FailureReason]
+    Settings: Optional[MedicalScribeSettings]
+    DataAccessRoleArn: Optional[DataAccessRoleArn]
+    ChannelDefinitions: Optional[MedicalScribeChannelDefinitions]
+    Tags: Optional[TagList]
+
+
+class GetMedicalScribeJobResponse(TypedDict, total=False):
+    MedicalScribeJob: Optional[MedicalScribeJob]
 
 
 class GetMedicalTranscriptionJobRequest(ServiceRequest):
@@ -761,6 +897,32 @@ class ListLanguageModelsResponse(TypedDict, total=False):
     Models: Optional[Models]
 
 
+class ListMedicalScribeJobsRequest(ServiceRequest):
+    Status: Optional[MedicalScribeJobStatus]
+    JobNameContains: Optional[TranscriptionJobName]
+    NextToken: Optional[NextToken]
+    MaxResults: Optional[MaxResults]
+
+
+class MedicalScribeJobSummary(TypedDict, total=False):
+    MedicalScribeJobName: Optional[TranscriptionJobName]
+    CreationTime: Optional[DateTime]
+    StartTime: Optional[DateTime]
+    CompletionTime: Optional[DateTime]
+    LanguageCode: Optional[MedicalScribeLanguageCode]
+    MedicalScribeJobStatus: Optional[MedicalScribeJobStatus]
+    FailureReason: Optional[FailureReason]
+
+
+MedicalScribeJobSummaries = List[MedicalScribeJobSummary]
+
+
+class ListMedicalScribeJobsResponse(TypedDict, total=False):
+    Status: Optional[MedicalScribeJobStatus]
+    NextToken: Optional[NextToken]
+    MedicalScribeJobSummaries: Optional[MedicalScribeJobSummaries]
+
+
 class ListMedicalTranscriptionJobsRequest(ServiceRequest):
     Status: Optional[TranscriptionJobStatus]
     JobNameContains: Optional[TranscriptionJobName]
@@ -902,6 +1064,22 @@ class StartCallAnalyticsJobRequest(ServiceRequest):
 
 class StartCallAnalyticsJobResponse(TypedDict, total=False):
     CallAnalyticsJob: Optional[CallAnalyticsJob]
+
+
+class StartMedicalScribeJobRequest(ServiceRequest):
+    MedicalScribeJobName: TranscriptionJobName
+    Media: Media
+    OutputBucketName: OutputBucketName
+    OutputEncryptionKMSKeyId: Optional[KMSKeyId]
+    KMSEncryptionContext: Optional[KMSEncryptionContextMap]
+    DataAccessRoleArn: DataAccessRoleArn
+    Settings: MedicalScribeSettings
+    ChannelDefinitions: Optional[MedicalScribeChannelDefinitions]
+    Tags: Optional[TagList]
+
+
+class StartMedicalScribeJobResponse(TypedDict, total=False):
+    MedicalScribeJob: Optional[MedicalScribeJob]
 
 
 class StartMedicalTranscriptionJobRequest(ServiceRequest):
@@ -1108,6 +1286,12 @@ class TranscribeApi:
     def delete_language_model(self, context: RequestContext, model_name: ModelName) -> None:
         raise NotImplementedError
 
+    @handler("DeleteMedicalScribeJob")
+    def delete_medical_scribe_job(
+        self, context: RequestContext, medical_scribe_job_name: TranscriptionJobName
+    ) -> None:
+        raise NotImplementedError
+
     @handler("DeleteMedicalTranscriptionJob")
     def delete_medical_transcription_job(
         self, context: RequestContext, medical_transcription_job_name: TranscriptionJobName
@@ -1152,6 +1336,12 @@ class TranscribeApi:
     def get_call_analytics_job(
         self, context: RequestContext, call_analytics_job_name: CallAnalyticsJobName
     ) -> GetCallAnalyticsJobResponse:
+        raise NotImplementedError
+
+    @handler("GetMedicalScribeJob")
+    def get_medical_scribe_job(
+        self, context: RequestContext, medical_scribe_job_name: TranscriptionJobName
+    ) -> GetMedicalScribeJobResponse:
         raise NotImplementedError
 
     @handler("GetMedicalTranscriptionJob")
@@ -1210,6 +1400,17 @@ class TranscribeApi:
         next_token: NextToken = None,
         max_results: MaxResults = None,
     ) -> ListLanguageModelsResponse:
+        raise NotImplementedError
+
+    @handler("ListMedicalScribeJobs")
+    def list_medical_scribe_jobs(
+        self,
+        context: RequestContext,
+        status: MedicalScribeJobStatus = None,
+        job_name_contains: TranscriptionJobName = None,
+        next_token: NextToken = None,
+        max_results: MaxResults = None,
+    ) -> ListMedicalScribeJobsResponse:
         raise NotImplementedError
 
     @handler("ListMedicalTranscriptionJobs")
@@ -1284,6 +1485,22 @@ class TranscribeApi:
         settings: CallAnalyticsJobSettings = None,
         channel_definitions: ChannelDefinitions = None,
     ) -> StartCallAnalyticsJobResponse:
+        raise NotImplementedError
+
+    @handler("StartMedicalScribeJob")
+    def start_medical_scribe_job(
+        self,
+        context: RequestContext,
+        medical_scribe_job_name: TranscriptionJobName,
+        media: Media,
+        output_bucket_name: OutputBucketName,
+        data_access_role_arn: DataAccessRoleArn,
+        settings: MedicalScribeSettings,
+        output_encryption_kms_key_id: KMSKeyId = None,
+        kms_encryption_context: KMSEncryptionContextMap = None,
+        channel_definitions: MedicalScribeChannelDefinitions = None,
+        tags: TagList = None,
+    ) -> StartMedicalScribeJobResponse:
         raise NotImplementedError
 
     @handler("StartMedicalTranscriptionJob", expand=False)

--- a/localstack/aws/data/sqs-json/2012-11-05/README.md
+++ b/localstack/aws/data/sqs-json/2012-11-05/README.md
@@ -1,8 +1,8 @@
 This spec preserves the SQS query protocol spec, which was part of botocore until the protocol was switched to json with `botocore==1.31.81`.
 This switch removed a lot of spec data which is necessary for the proper parsing and serialization, which is why we have to preserve them on our own.
 
-- The spec content was preserved from this state: https://github.com/boto/botocore/blob/4ff08259b6325b9b8d25127672b88d7c963e6f71/botocore/data/sqs/2012-11-05/service-2.json
-- This was the last commit before the protocol switched to json (with https://github.com/boto/botocore/commit/143e3925dac58976b5e83864a3ed9a2dea1db91b).
+- The spec content was preserved from this state: https://github.com/boto/botocore/blob/143e3925dac58976b5e83864a3ed9a2dea1db91b/botocore/data/sqs/2012-11-05/service-2.json
+- This was the last commit before the protocol switched back (again) to query (with https://github.com/boto/botocore/commit/143e3925dac58976b5e83864a3ed9a2dea1db91b).
 - The file is licensed with Apache License 2.0.
 - Modifications:
   - Removal of documentation strings with the following regex: `(,)?\n\s+"documentation":".*"`

--- a/localstack/aws/data/sqs-json/2012-11-05/service-2.json
+++ b/localstack/aws/data/sqs-json/2012-11-05/service-2.json
@@ -2,14 +2,17 @@
   "version":"2.0",
   "metadata":{
     "apiVersion":"2012-11-05",
+    "awsQueryCompatible":{
+    },
     "endpointPrefix":"sqs",
-    "protocol":"query",
+    "jsonVersion":"1.0",
+    "protocol":"json",
     "serviceAbbreviation":"Amazon SQS",
     "serviceFullName":"Amazon Simple Queue Service",
     "serviceId":"SQS",
     "signatureVersion":"v4",
-    "uid":"sqs-2012-11-05",
-    "xmlNamespace":"http://queue.amazonaws.com/doc/2012-11-05/"
+    "targetPrefix":"AmazonSQS",
+    "uid":"sqs-2012-11-05"
   },
   "operations":{
     "AddPermission":{
@@ -20,7 +23,12 @@
       },
       "input":{"shape":"AddPermissionRequest"},
       "errors":[
-        {"shape":"OverLimit"}
+        {"shape":"OverLimit"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
       ]
     },
     "CancelMessageMoveTask":{
@@ -30,12 +38,12 @@
         "requestUri":"/"
       },
       "input":{"shape":"CancelMessageMoveTaskRequest"},
-      "output":{
-        "shape":"CancelMessageMoveTaskResult",
-        "resultWrapper":"CancelMessageMoveTaskResult"
-      },
+      "output":{"shape":"CancelMessageMoveTaskResult"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
         {"shape":"UnsupportedOperation"}
       ]
     },
@@ -48,7 +56,12 @@
       "input":{"shape":"ChangeMessageVisibilityRequest"},
       "errors":[
         {"shape":"MessageNotInflight"},
-        {"shape":"ReceiptHandleIsInvalid"}
+        {"shape":"ReceiptHandleIsInvalid"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"}
       ]
     },
     "ChangeMessageVisibilityBatch":{
@@ -58,15 +71,17 @@
         "requestUri":"/"
       },
       "input":{"shape":"ChangeMessageVisibilityBatchRequest"},
-      "output":{
-        "shape":"ChangeMessageVisibilityBatchResult",
-        "resultWrapper":"ChangeMessageVisibilityBatchResult"
-      },
+      "output":{"shape":"ChangeMessageVisibilityBatchResult"},
       "errors":[
         {"shape":"TooManyEntriesInBatchRequest"},
         {"shape":"EmptyBatchRequest"},
         {"shape":"BatchEntryIdsNotDistinct"},
-        {"shape":"InvalidBatchEntryId"}
+        {"shape":"InvalidBatchEntryId"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"}
       ]
     },
     "CreateQueue":{
@@ -76,13 +91,16 @@
         "requestUri":"/"
       },
       "input":{"shape":"CreateQueueRequest"},
-      "output":{
-        "shape":"CreateQueueResult",
-        "resultWrapper":"CreateQueueResult"
-      },
+      "output":{"shape":"CreateQueueResult"},
       "errors":[
         {"shape":"QueueDeletedRecently"},
-        {"shape":"QueueNameExists"}
+        {"shape":"QueueNameExists"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidAttributeName"},
+        {"shape":"InvalidAttributeValue"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidSecurity"}
       ]
     },
     "DeleteMessage":{
@@ -94,7 +112,12 @@
       "input":{"shape":"DeleteMessageRequest"},
       "errors":[
         {"shape":"InvalidIdFormat"},
-        {"shape":"ReceiptHandleIsInvalid"}
+        {"shape":"ReceiptHandleIsInvalid"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"InvalidAddress"}
       ]
     },
     "DeleteMessageBatch":{
@@ -104,15 +127,17 @@
         "requestUri":"/"
       },
       "input":{"shape":"DeleteMessageBatchRequest"},
-      "output":{
-        "shape":"DeleteMessageBatchResult",
-        "resultWrapper":"DeleteMessageBatchResult"
-      },
+      "output":{"shape":"DeleteMessageBatchResult"},
       "errors":[
         {"shape":"TooManyEntriesInBatchRequest"},
         {"shape":"EmptyBatchRequest"},
         {"shape":"BatchEntryIdsNotDistinct"},
-        {"shape":"InvalidBatchEntryId"}
+        {"shape":"InvalidBatchEntryId"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"}
       ]
     },
     "DeleteQueue":{
@@ -121,7 +146,14 @@
         "method":"POST",
         "requestUri":"/"
       },
-      "input":{"shape":"DeleteQueueRequest"}
+      "input":{"shape":"DeleteQueueRequest"},
+      "errors":[
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidAddress"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidSecurity"}
+      ]
     },
     "GetQueueAttributes":{
       "name":"GetQueueAttributes",
@@ -130,12 +162,14 @@
         "requestUri":"/"
       },
       "input":{"shape":"GetQueueAttributesRequest"},
-      "output":{
-        "shape":"GetQueueAttributesResult",
-        "resultWrapper":"GetQueueAttributesResult"
-      },
+      "output":{"shape":"GetQueueAttributesResult"},
       "errors":[
-        {"shape":"InvalidAttributeName"}
+        {"shape":"InvalidAttributeName"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"InvalidAddress"}
       ]
     },
     "GetQueueUrl":{
@@ -145,12 +179,13 @@
         "requestUri":"/"
       },
       "input":{"shape":"GetQueueUrlRequest"},
-      "output":{
-        "shape":"GetQueueUrlResult",
-        "resultWrapper":"GetQueueUrlResult"
-      },
+      "output":{"shape":"GetQueueUrlResult"},
       "errors":[
-        {"shape":"QueueDoesNotExist"}
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
       ]
     },
     "ListDeadLetterSourceQueues":{
@@ -160,12 +195,13 @@
         "requestUri":"/"
       },
       "input":{"shape":"ListDeadLetterSourceQueuesRequest"},
-      "output":{
-        "shape":"ListDeadLetterSourceQueuesResult",
-        "resultWrapper":"ListDeadLetterSourceQueuesResult"
-      },
+      "output":{"shape":"ListDeadLetterSourceQueuesResult"},
       "errors":[
-        {"shape":"QueueDoesNotExist"}
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"InvalidAddress"},
+        {"shape":"UnsupportedOperation"}
       ]
     },
     "ListMessageMoveTasks":{
@@ -175,12 +211,12 @@
         "requestUri":"/"
       },
       "input":{"shape":"ListMessageMoveTasksRequest"},
-      "output":{
-        "shape":"ListMessageMoveTasksResult",
-        "resultWrapper":"ListMessageMoveTasksResult"
-      },
+      "output":{"shape":"ListMessageMoveTasksResult"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
         {"shape":"UnsupportedOperation"}
       ]
     },
@@ -191,10 +227,14 @@
         "requestUri":"/"
       },
       "input":{"shape":"ListQueueTagsRequest"},
-      "output":{
-        "shape":"ListQueueTagsResult",
-        "resultWrapper":"ListQueueTagsResult"
-      }
+      "output":{"shape":"ListQueueTagsResult"},
+      "errors":[
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"}
+      ]
     },
     "ListQueues":{
       "name":"ListQueues",
@@ -203,10 +243,13 @@
         "requestUri":"/"
       },
       "input":{"shape":"ListQueuesRequest"},
-      "output":{
-        "shape":"ListQueuesResult",
-        "resultWrapper":"ListQueuesResult"
-      }
+      "output":{"shape":"ListQueuesResult"},
+      "errors":[
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"InvalidAddress"},
+        {"shape":"UnsupportedOperation"}
+      ]
     },
     "PurgeQueue":{
       "name":"PurgeQueue",
@@ -217,7 +260,11 @@
       "input":{"shape":"PurgeQueueRequest"},
       "errors":[
         {"shape":"QueueDoesNotExist"},
-        {"shape":"PurgeQueueInProgress"}
+        {"shape":"PurgeQueueInProgress"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
       ]
     },
     "ReceiveMessage":{
@@ -227,12 +274,21 @@
         "requestUri":"/"
       },
       "input":{"shape":"ReceiveMessageRequest"},
-      "output":{
-        "shape":"ReceiveMessageResult",
-        "resultWrapper":"ReceiveMessageResult"
-      },
+      "output":{"shape":"ReceiveMessageResult"},
       "errors":[
-        {"shape":"OverLimit"}
+        {"shape":"UnsupportedOperation"},
+        {"shape":"OverLimit"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"KmsDisabled"},
+        {"shape":"KmsInvalidState"},
+        {"shape":"KmsNotFound"},
+        {"shape":"KmsOptInRequired"},
+        {"shape":"KmsThrottled"},
+        {"shape":"KmsAccessDenied"},
+        {"shape":"KmsInvalidKeyUsage"},
+        {"shape":"InvalidAddress"}
       ]
     },
     "RemovePermission":{
@@ -241,7 +297,14 @@
         "method":"POST",
         "requestUri":"/"
       },
-      "input":{"shape":"RemovePermissionRequest"}
+      "input":{"shape":"RemovePermissionRequest"},
+      "errors":[
+        {"shape":"InvalidAddress"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
+      ]
     },
     "SendMessage":{
       "name":"SendMessage",
@@ -250,13 +313,21 @@
         "requestUri":"/"
       },
       "input":{"shape":"SendMessageRequest"},
-      "output":{
-        "shape":"SendMessageResult",
-        "resultWrapper":"SendMessageResult"
-      },
+      "output":{"shape":"SendMessageResult"},
       "errors":[
         {"shape":"InvalidMessageContents"},
-        {"shape":"UnsupportedOperation"}
+        {"shape":"UnsupportedOperation"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"KmsDisabled"},
+        {"shape":"KmsInvalidState"},
+        {"shape":"KmsNotFound"},
+        {"shape":"KmsOptInRequired"},
+        {"shape":"KmsThrottled"},
+        {"shape":"KmsAccessDenied"},
+        {"shape":"KmsInvalidKeyUsage"},
+        {"shape":"InvalidAddress"}
       ]
     },
     "SendMessageBatch":{
@@ -266,17 +337,25 @@
         "requestUri":"/"
       },
       "input":{"shape":"SendMessageBatchRequest"},
-      "output":{
-        "shape":"SendMessageBatchResult",
-        "resultWrapper":"SendMessageBatchResult"
-      },
+      "output":{"shape":"SendMessageBatchResult"},
       "errors":[
         {"shape":"TooManyEntriesInBatchRequest"},
         {"shape":"EmptyBatchRequest"},
         {"shape":"BatchEntryIdsNotDistinct"},
         {"shape":"BatchRequestTooLong"},
         {"shape":"InvalidBatchEntryId"},
-        {"shape":"UnsupportedOperation"}
+        {"shape":"UnsupportedOperation"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"KmsDisabled"},
+        {"shape":"KmsInvalidState"},
+        {"shape":"KmsNotFound"},
+        {"shape":"KmsOptInRequired"},
+        {"shape":"KmsThrottled"},
+        {"shape":"KmsAccessDenied"},
+        {"shape":"KmsInvalidKeyUsage"},
+        {"shape":"InvalidAddress"}
       ]
     },
     "SetQueueAttributes":{
@@ -287,7 +366,14 @@
       },
       "input":{"shape":"SetQueueAttributesRequest"},
       "errors":[
-        {"shape":"InvalidAttributeName"}
+        {"shape":"InvalidAttributeName"},
+        {"shape":"InvalidAttributeValue"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"UnsupportedOperation"},
+        {"shape":"OverLimit"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"}
       ]
     },
     "StartMessageMoveTask":{
@@ -297,12 +383,12 @@
         "requestUri":"/"
       },
       "input":{"shape":"StartMessageMoveTaskRequest"},
-      "output":{
-        "shape":"StartMessageMoveTaskResult",
-        "resultWrapper":"StartMessageMoveTaskResult"
-      },
+      "output":{"shape":"StartMessageMoveTaskResult"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"RequestThrottled"},
+        {"shape":"InvalidAddress"},
+        {"shape":"InvalidSecurity"},
         {"shape":"UnsupportedOperation"}
       ]
     },
@@ -312,7 +398,14 @@
         "method":"POST",
         "requestUri":"/"
       },
-      "input":{"shape":"TagQueueRequest"}
+      "input":{"shape":"TagQueueRequest"},
+      "errors":[
+        {"shape":"InvalidAddress"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
+      ]
     },
     "UntagQueue":{
       "name":"UntagQueue",
@@ -320,24 +413,25 @@
         "method":"POST",
         "requestUri":"/"
       },
-      "input":{"shape":"UntagQueueRequest"}
+      "input":{"shape":"UntagQueueRequest"},
+      "errors":[
+        {"shape":"InvalidAddress"},
+        {"shape":"RequestThrottled"},
+        {"shape":"QueueDoesNotExist"},
+        {"shape":"InvalidSecurity"},
+        {"shape":"UnsupportedOperation"}
+      ]
     }
   },
   "shapes":{
     "AWSAccountIdList":{
       "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"AWSAccountId"
-      },
+      "member":{"shape":"String"},
       "flattened":true
     },
     "ActionNameList":{
       "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"ActionName"
-      },
+      "member":{"shape":"String"},
       "flattened":true
     },
     "AddPermissionRequest":{
@@ -365,31 +459,20 @@
     },
     "AttributeNameList":{
       "type":"list",
-      "member":{
-        "shape":"QueueAttributeName",
-        "locationName":"AttributeName"
-      },
+      "member":{"shape":"QueueAttributeName"},
       "flattened":true
     },
     "BatchEntryIdsNotDistinct":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.BatchEntryIdsNotDistinct",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "BatchRequestTooLong":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.BatchRequestTooLong",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -417,19 +500,13 @@
     },
     "BatchResultErrorEntryList":{
       "type":"list",
-      "member":{
-        "shape":"BatchResultErrorEntry",
-        "locationName":"BatchResultErrorEntry"
-      },
+      "member":{"shape":"BatchResultErrorEntry"},
       "flattened":true
     },
     "Binary":{"type":"blob"},
     "BinaryList":{
       "type":"list",
-      "member":{
-        "shape":"Binary",
-        "locationName":"BinaryListValue"
-      }
+      "member":{"shape":"Binary"}
     },
     "Boolean":{"type":"boolean"},
     "BoxedInteger":{
@@ -482,16 +559,13 @@
           "shape":"String"
         },
         "VisibilityTimeout":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         }
       }
     },
     "ChangeMessageVisibilityBatchRequestEntryList":{
       "type":"list",
-      "member":{
-        "shape":"ChangeMessageVisibilityBatchRequestEntry",
-        "locationName":"ChangeMessageVisibilityBatchRequestEntry"
-      },
+      "member":{"shape":"ChangeMessageVisibilityBatchRequestEntry"},
       "flattened":true
     },
     "ChangeMessageVisibilityBatchResult":{
@@ -520,10 +594,7 @@
     },
     "ChangeMessageVisibilityBatchResultEntryList":{
       "type":"list",
-      "member":{
-        "shape":"ChangeMessageVisibilityBatchResultEntry",
-        "locationName":"ChangeMessageVisibilityBatchResultEntry"
-      },
+      "member":{"shape":"ChangeMessageVisibilityBatchResultEntry"},
       "flattened":true
     },
     "ChangeMessageVisibilityRequest":{
@@ -541,7 +612,7 @@
           "shape":"String"
         },
         "VisibilityTimeout":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         }
       }
     },
@@ -553,12 +624,10 @@
           "shape":"String"
         },
         "Attributes":{
-          "shape":"QueueAttributeMap",
-          "locationName":"Attribute"
+          "shape":"QueueAttributeMap"
         },
         "tags":{
-          "shape":"TagMap",
-          "locationName":"Tag"
+          "shape":"TagMap"
         }
       }
     },
@@ -602,10 +671,7 @@
     },
     "DeleteMessageBatchRequestEntryList":{
       "type":"list",
-      "member":{
-        "shape":"DeleteMessageBatchRequestEntry",
-        "locationName":"DeleteMessageBatchRequestEntry"
-      },
+      "member":{"shape":"DeleteMessageBatchRequestEntry"},
       "flattened":true
     },
     "DeleteMessageBatchResult":{
@@ -634,10 +700,7 @@
     },
     "DeleteMessageBatchResultEntryList":{
       "type":"list",
-      "member":{
-        "shape":"DeleteMessageBatchResultEntry",
-        "locationName":"DeleteMessageBatchResultEntry"
-      },
+      "member":{"shape":"DeleteMessageBatchResultEntry"},
       "flattened":true
     },
     "DeleteMessageRequest":{
@@ -667,14 +730,11 @@
     "EmptyBatchRequest":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.EmptyBatchRequest",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
+    "ExceptionMessage":{"type":"string"},
     "GetQueueAttributesRequest":{
       "type":"structure",
       "required":["QueueUrl"],
@@ -691,8 +751,7 @@
       "type":"structure",
       "members":{
         "Attributes":{
-          "shape":"QueueAttributeMap",
-          "locationName":"Attribute"
+          "shape":"QueueAttributeMap"
         }
       }
     },
@@ -716,21 +775,31 @@
         }
       }
     },
-    "Integer":{"type":"integer"},
+    "InvalidAddress":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
     "InvalidAttributeName":{
       "type":"structure",
       "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "InvalidAttributeValue":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "InvalidBatchEntryId":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.InvalidBatchEntryId",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -738,11 +807,70 @@
       "type":"structure",
       "members":{
       },
+      "deprecated":true,
+      "deprecatedMessage":"exception has been included in ReceiptHandleIsInvalid",
       "exception":true
     },
     "InvalidMessageContents":{
       "type":"structure",
       "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "InvalidSecurity":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsAccessDenied":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsDisabled":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsInvalidKeyUsage":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsInvalidState":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsNotFound":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsOptInRequired":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "KmsThrottled":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -781,7 +909,7 @@
           "shape":"String"
         },
         "MaxResults":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         }
       }
     },
@@ -789,7 +917,8 @@
       "type":"structure",
       "members":{
         "Results":{
-          "shape":"ListMessageMoveTasksResultEntryList"
+          "shape":"ListMessageMoveTasksResultEntryList",
+          "flattened":true
         }
       }
     },
@@ -809,13 +938,13 @@
           "shape":"String"
         },
         "MaxNumberOfMessagesPerSecond":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "ApproximateNumberOfMessagesMoved":{
           "shape":"Long"
         },
         "ApproximateNumberOfMessagesToMove":{
-          "shape":"Long"
+          "shape":"NullableLong"
         },
         "FailureReason":{
           "shape":"String"
@@ -827,10 +956,7 @@
     },
     "ListMessageMoveTasksResultEntryList":{
       "type":"list",
-      "member":{
-        "shape":"ListMessageMoveTasksResultEntry",
-        "locationName":"ListMessageMoveTasksResultEntry"
-      },
+      "member":{"shape":"ListMessageMoveTasksResultEntry"},
       "flattened":true
     },
     "ListQueueTagsRequest":{
@@ -846,8 +972,7 @@
       "type":"structure",
       "members":{
         "Tags":{
-          "shape":"TagMap",
-          "locationName":"Tag"
+          "shape":"TagMap"
         }
       }
     },
@@ -893,25 +1018,20 @@
           "shape":"String"
         },
         "Attributes":{
-          "shape":"MessageSystemAttributeMap",
-          "locationName":"Attribute"
+          "shape":"MessageSystemAttributeMap"
         },
         "MD5OfMessageAttributes":{
           "shape":"String"
         },
         "MessageAttributes":{
-          "shape":"MessageBodyAttributeMap",
-          "locationName":"MessageAttribute"
+          "shape":"MessageBodyAttributeMap"
         }
       }
     },
     "MessageAttributeName":{"type":"string"},
     "MessageAttributeNameList":{
       "type":"list",
-      "member":{
-        "shape":"MessageAttributeName",
-        "locationName":"MessageAttributeName"
-      },
+      "member":{"shape":"MessageAttributeName"},
       "flattened":true
     },
     "MessageAttributeValue":{
@@ -926,13 +1046,11 @@
         },
         "StringListValues":{
           "shape":"StringList",
-          "flattened":true,
-          "locationName":"StringListValue"
+          "flattened":true
         },
         "BinaryListValues":{
           "shape":"BinaryList",
-          "flattened":true,
-          "locationName":"BinaryListValue"
+          "flattened":true
         },
         "DataType":{
           "shape":"String"
@@ -941,59 +1059,32 @@
     },
     "MessageBodyAttributeMap":{
       "type":"map",
-      "key":{
-        "shape":"String",
-        "locationName":"Name"
-      },
-      "value":{
-        "shape":"MessageAttributeValue",
-        "locationName":"Value"
-      },
+      "key":{"shape":"String"},
+      "value":{"shape":"MessageAttributeValue"},
       "flattened":true
     },
     "MessageBodySystemAttributeMap":{
       "type":"map",
-      "key":{
-        "shape":"MessageSystemAttributeNameForSends",
-        "locationName":"Name"
-      },
-      "value":{
-        "shape":"MessageSystemAttributeValue",
-        "locationName":"Value"
-      },
+      "key":{"shape":"MessageSystemAttributeNameForSends"},
+      "value":{"shape":"MessageSystemAttributeValue"},
       "flattened":true
     },
     "MessageList":{
       "type":"list",
-      "member":{
-        "shape":"Message",
-        "locationName":"Message"
-      },
+      "member":{"shape":"Message"},
       "flattened":true
     },
     "MessageNotInflight":{
       "type":"structure",
       "members":{
       },
-      "error":{
-        "code":"AWS.SimpleQueueService.MessageNotInflight",
-        "httpStatusCode":400,
-        "senderFault":true
-      },
       "exception":true
     },
     "MessageSystemAttributeMap":{
       "type":"map",
-      "key":{
-        "shape":"MessageSystemAttributeName",
-        "locationName":"Name"
-      },
-      "value":{
-        "shape":"String",
-        "locationName":"Value"
-      },
-      "flattened":true,
-      "locationName":"Attribute"
+      "key":{"shape":"MessageSystemAttributeName"},
+      "value":{"shape":"String"},
+      "flattened":true
     },
     "MessageSystemAttributeName":{
       "type":"string",
@@ -1025,38 +1116,30 @@
         },
         "StringListValues":{
           "shape":"StringList",
-          "flattened":true,
-          "locationName":"StringListValue"
+          "flattened":true
         },
         "BinaryListValues":{
           "shape":"BinaryList",
-          "flattened":true,
-          "locationName":"BinaryListValue"
+          "flattened":true
         },
         "DataType":{
           "shape":"String"
         }
       }
     },
+    "NullableInteger":{"type":"integer"},
+    "NullableLong":{"type":"long"},
     "OverLimit":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"OverLimit",
-        "httpStatusCode":403,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "PurgeQueueInProgress":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.PurgeQueueInProgress",
-        "httpStatusCode":403,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -1071,16 +1154,9 @@
     },
     "QueueAttributeMap":{
       "type":"map",
-      "key":{
-        "shape":"QueueAttributeName",
-        "locationName":"Name"
-      },
-      "value":{
-        "shape":"String",
-        "locationName":"Value"
-      },
-      "flattened":true,
-      "locationName":"Attribute"
+      "key":{"shape":"QueueAttributeName"},
+      "value":{"shape":"String"},
+      "flattened":true
     },
     "QueueAttributeName":{
       "type":"string",
@@ -1112,47 +1188,33 @@
     "QueueDeletedRecently":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.QueueDeletedRecently",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "QueueDoesNotExist":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.NonExistentQueue",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "QueueNameExists":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"QueueAlreadyExists",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "QueueUrlList":{
       "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"QueueUrl"
-      },
+      "member":{"shape":"String"},
       "flattened":true
     },
     "ReceiptHandleIsInvalid":{
       "type":"structure",
       "members":{
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -1170,13 +1232,13 @@
           "shape":"MessageAttributeNameList"
         },
         "MaxNumberOfMessages":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "VisibilityTimeout":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "WaitTimeSeconds":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "ReceiveRequestAttemptId":{
           "shape":"String"
@@ -1206,14 +1268,17 @@
         }
       }
     },
+    "RequestThrottled":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
     "ResourceNotFoundException":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"ResourceNotFoundException",
-        "httpStatusCode":404,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
@@ -1246,15 +1311,13 @@
           "shape":"String"
         },
         "DelaySeconds":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "MessageAttributes":{
-          "shape":"MessageBodyAttributeMap",
-          "locationName":"MessageAttribute"
+          "shape":"MessageBodyAttributeMap"
         },
         "MessageSystemAttributes":{
-          "shape":"MessageBodySystemAttributeMap",
-          "locationName":"MessageSystemAttribute"
+          "shape":"MessageBodySystemAttributeMap"
         },
         "MessageDeduplicationId":{
           "shape":"String"
@@ -1266,10 +1329,7 @@
     },
     "SendMessageBatchRequestEntryList":{
       "type":"list",
-      "member":{
-        "shape":"SendMessageBatchRequestEntry",
-        "locationName":"SendMessageBatchRequestEntry"
-      },
+      "member":{"shape":"SendMessageBatchRequestEntry"},
       "flattened":true
     },
     "SendMessageBatchResult":{
@@ -1317,10 +1377,7 @@
     },
     "SendMessageBatchResultEntryList":{
       "type":"list",
-      "member":{
-        "shape":"SendMessageBatchResultEntry",
-        "locationName":"SendMessageBatchResultEntry"
-      },
+      "member":{"shape":"SendMessageBatchResultEntry"},
       "flattened":true
     },
     "SendMessageRequest":{
@@ -1337,15 +1394,13 @@
           "shape":"String"
         },
         "DelaySeconds":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         },
         "MessageAttributes":{
-          "shape":"MessageBodyAttributeMap",
-          "locationName":"MessageAttribute"
+          "shape":"MessageBodyAttributeMap"
         },
         "MessageSystemAttributes":{
-          "shape":"MessageBodySystemAttributeMap",
-          "locationName":"MessageSystemAttribute"
+          "shape":"MessageBodySystemAttributeMap"
         },
         "MessageDeduplicationId":{
           "shape":"String"
@@ -1386,8 +1441,7 @@
           "shape":"String"
         },
         "Attributes":{
-          "shape":"QueueAttributeMap",
-          "locationName":"Attribute"
+          "shape":"QueueAttributeMap"
         }
       }
     },
@@ -1402,7 +1456,7 @@
           "shape":"String"
         },
         "MaxNumberOfMessagesPerSecond":{
-          "shape":"Integer"
+          "shape":"NullableInteger"
         }
       }
     },
@@ -1417,32 +1471,19 @@
     "String":{"type":"string"},
     "StringList":{
       "type":"list",
-      "member":{
-        "shape":"String",
-        "locationName":"StringListValue"
-      }
+      "member":{"shape":"String"}
     },
     "TagKey":{"type":"string"},
     "TagKeyList":{
       "type":"list",
-      "member":{
-        "shape":"TagKey",
-        "locationName":"TagKey"
-      },
+      "member":{"shape":"TagKey"},
       "flattened":true
     },
     "TagMap":{
       "type":"map",
-      "key":{
-        "shape":"TagKey",
-        "locationName":"Key"
-      },
-      "value":{
-        "shape":"TagValue",
-        "locationName":"Value"
-      },
-      "flattened":true,
-      "locationName":"Tag"
+      "key":{"shape":"TagKey"},
+      "value":{"shape":"TagValue"},
+      "flattened":true
     },
     "TagQueueRequest":{
       "type":"structure",
@@ -1464,22 +1505,14 @@
     "TooManyEntriesInBatchRequest":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },
     "UnsupportedOperation":{
       "type":"structure",
       "members":{
-      },
-      "error":{
-        "code":"AWS.SimpleQueueService.UnsupportedOperation",
-        "httpStatusCode":400,
-        "senderFault":true
+        "message":{"shape":"ExceptionMessage"}
       },
       "exception":true
     },

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -34,14 +34,12 @@ class ServiceNameParser(Handler):
         if context.service:
             return
 
-        service = determine_aws_service_model(context.request)
+        service_model = determine_aws_service_model(context.request)
 
-        if not service:
+        if not service_model:
             return
 
-        context.service = service
-        headers = context.request.headers
-        headers["x-localstack-tgt-api"] = service  # TODO: probably no longer needed
+        context.service = service_model
 
 
 class ServiceRequestParser(Handler):

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -2,7 +2,6 @@
 import logging
 import traceback
 from collections import defaultdict
-from functools import lru_cache
 from typing import Any, Dict, Union
 
 from botocore.model import OperationModel, ServiceModel
@@ -17,9 +16,8 @@ from ..chain import CompositeResponseHandler, ExceptionHandler, Handler, Handler
 from ..client import parse_response, parse_service_exception
 from ..protocol.parser import RequestParser, create_parser
 from ..protocol.serializer import create_serializer
-from ..protocol.service_router import determine_aws_service_name
+from ..protocol.service_router import determine_aws_service_model
 from ..skeleton import Skeleton, create_skeleton
-from ..spec import load_service
 
 LOG = logging.getLogger(__name__)
 
@@ -36,18 +34,14 @@ class ServiceNameParser(Handler):
         if context.service:
             return
 
-        service = determine_aws_service_name(context.request)
+        service = determine_aws_service_model(context.request)
 
         if not service:
             return
 
-        context.service = self.get_service_model(service)
+        context.service = service
         headers = context.request.headers
         headers["x-localstack-tgt-api"] = service  # TODO: probably no longer needed
-
-    @lru_cache()
-    def get_service_model(self, service: str) -> ServiceModel:
-        return load_service(service)
 
 
 class ServiceRequestParser(Handler):
@@ -69,17 +63,8 @@ class ServiceRequestParser(Handler):
 
         return self.parse_and_enrich(context)
 
-    def get_parser(self, service: ServiceModel):
-        name = service.service_name
-
-        if name in self.parsers:
-            return self.parsers[name]
-
-        self.parsers[name] = create_parser(service)
-        return self.parsers[name]
-
     def parse_and_enrich(self, context: RequestContext):
-        parser = self.get_parser(context.service)
+        parser = create_parser(context.service)
         operation, instance = parser.parse(context.request)
 
         # enrich context

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -1120,6 +1120,7 @@ class SQSQueryRequestParser(QueryRequestParser):
         return primary_name
 
 
+@functools.cache
 def create_parser(service: ServiceModel) -> RequestParser:
     """
     Creates the right parser for the given service model.
@@ -1133,8 +1134,8 @@ def create_parser(service: ServiceModel) -> RequestParser:
     # within the parser implementations, the service-specific parser implementations (basically the implicit /
     # informally more specific protocol implementation) has precedence over the more general protocol-specific parsers.
     service_specific_parsers = {
-        "s3": S3RequestParser,
-        "sqs-query": SQSQueryRequestParser,
+        "s3": {"rest-xml": S3RequestParser},
+        "sqs": {"query": SQSQueryRequestParser},
     }
     protocol_specific_parsers = {
         "query": QueryRequestParser,
@@ -1144,9 +1145,12 @@ def create_parser(service: ServiceModel) -> RequestParser:
         "ec2": EC2RequestParser,
     }
 
-    # Try to select a service-specific parser implementation
-    if service.service_name in service_specific_parsers:
-        return service_specific_parsers[service.service_name](service)
+    # Try to select a service- and protocol-specific parser implementation
+    if (
+        service.service_name in service_specific_parsers
+        and service.protocol in service_specific_parsers[service.service_name]
+    ):
+        return service_specific_parsers[service.service_name][service.protocol](service)
     else:
         # Otherwise, pick the protocol-specific parser for the protocol of the service
         return protocol_specific_parsers[service.protocol](service)

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1604,33 +1604,12 @@ class SqsQueryResponseSerializer(QueryResponseSerializer):
     - These double-escapes are corrected by replacing such strings with their original.
     """
 
-    # those are deleted from the JSON specs, but need to be kept for legacy reason (sent in 'x-amzn-query-error')
-    QUERY_PREFIXED_ERRORS = {
-        "BatchEntryIdsNotDistinct",
-        "BatchRequestTooLong",
-        "EmptyBatchRequest",
-        "InvalidBatchEntryId",
-        "MessageNotInflight",
-        "PurgeQueueInProgress",
-        "QueueDeletedRecently",
-        "TooManyEntriesInBatchRequest",
-        "UnsupportedOperation",
-    }
-
     # Some error code changed between JSON and query, and we need to have a way to map it for legacy reason
     JSON_TO_QUERY_ERROR_CODES = {
         "InvalidParameterValueException": "InvalidParameterValue",
         "MissingRequiredParameterException": "MissingParameter",
         "AccessDeniedException": "AccessDenied",
-        "QueueDoesNotExist": "AWS.SimpleQueueService.NonExistentQueue",
-        "QueueNameExists": "QueueAlreadyExists",
     }
-
-    SENDER_FAULT_ERRORS = (
-        QUERY_PREFIXED_ERRORS
-        | JSON_TO_QUERY_ERROR_CODES.keys()
-        | {"OverLimit", "ResourceNotFoundException"}
-    )
 
     def _default_serialize(self, xmlnode: ETree.Element, params: str, _, name: str, __) -> None:
         """
@@ -1668,40 +1647,28 @@ class SqsQueryResponseSerializer(QueryResponseSerializer):
 
         if error.code in self.JSON_TO_QUERY_ERROR_CODES:
             error_code = self.JSON_TO_QUERY_ERROR_CODES[error.code]
-        elif error.code in self.QUERY_PREFIXED_ERRORS:
-            error_code = f"AWS.SimpleQueueService.{error.code}"
         else:
             error_code = error.code
         code_tag.text = error_code
         message = self._get_error_message(error)
         if message:
             self._default_serialize(error_tag, message, None, "Message", mime_type)
-        if error.code in self.SENDER_FAULT_ERRORS or error.sender_fault:
+        if error.sender_fault:
             # The sender fault is either not set or "Sender"
             self._default_serialize(error_tag, "Sender", None, "Type", mime_type)
 
 
-class SqsResponseSerializer(JSONResponseSerializer):
-    # those are deleted from the JSON specs, but need to be kept for legacy reason (sent in 'x-amzn-query-error')
-    QUERY_PREFIXED_ERRORS = {
-        "BatchEntryIdsNotDistinct",
-        "BatchRequestTooLong",
-        "EmptyBatchRequest",
-        "InvalidBatchEntryId",
-        "MessageNotInflight",
-        "PurgeQueueInProgress",
-        "QueueDeletedRecently",
-        "TooManyEntriesInBatchRequest",
-        "UnsupportedOperation",
-    }
-
+class SqsJsonResponseSerializer(JSONResponseSerializer):
     # Some error code changed between JSON and query, and we need to have a way to map it for legacy reason
     JSON_TO_QUERY_ERROR_CODES = {
         "InvalidParameterValueException": "InvalidParameterValue",
         "MissingRequiredParameterException": "MissingParameter",
         "AccessDeniedException": "AccessDenied",
-        "QueueDoesNotExist": "AWS.SimpleQueueService.NonExistentQueue",
-        "QueueNameExists": "QueueAlreadyExists",
+    }
+
+    QUERY_TO_JSON_ERROR_CODES = {
+        "NonExistentQueue": "QueueDoesNotExist",
+        "QueueAlreadyExists": "QueueNameExists",
     }
 
     def _serialize_error(
@@ -1722,16 +1689,18 @@ class SqsResponseSerializer(JSONResponseSerializer):
         # AWS: "com.amazon.coral.service#InvalidParameterValueException"
         # or AWS: "com.amazonaws.sqs#BatchRequestTooLong"
         # LocalStack: "InvalidParameterValue"
-        super()._serialize_error(error, response, shape, operation_model, mime_type, request_id)
+
         # We need to add a prefix to certain errors, as they have been deleted in the specs. These will not change
         if error.code in self.JSON_TO_QUERY_ERROR_CODES:
             code = self.JSON_TO_QUERY_ERROR_CODES[error.code]
-        elif error.code in self.QUERY_PREFIXED_ERRORS:
-            code = f"AWS.SimpleQueueService.{error.code}"
         else:
             code = error.code
-
         response.headers["x-amzn-query-error"] = f"{code};Sender"
+
+        error.code = error.code.removeprefix("AWS.SimpleQueueService.")
+        if error.code in self.QUERY_TO_JSON_ERROR_CODES:
+            error.code = self.QUERY_TO_JSON_ERROR_CODES[error.code]
+        super()._serialize_error(error, response, shape, operation_model, mime_type, request_id)
 
 
 def gen_amzn_requestid():
@@ -1763,7 +1732,7 @@ def create_serializer(service: ServiceModel) -> ResponseSerializer:
     # Therefore, the service-specific serializer implementations (basically the implicit / informally more specific
     # protocol implementation) has precedence over the more general protocol-specific serializers.
     service_specific_serializers = {
-        "sqs": {"json": SqsResponseSerializer, "query": SqsQueryResponseSerializer},
+        "sqs": {"json": SqsJsonResponseSerializer, "query": SqsQueryResponseSerializer},
         "s3": {"rest-xml": S3ResponseSerializer},
     }
     protocol_specific_serializers = {
@@ -1801,7 +1770,7 @@ def aws_response_serializer(service_model_name: str, operation: str):
 
             return ListQueuesResult(QueueUrls=...)  # <- object from the SQS API will be serialized
 
-    :param service_model_name: the AWS service model name (e.g., "sqs", "lambda", "sqs-query")
+    :param service_model_name: the AWS service model name (e.g., "sqs", "lambda", "sqs-json")
     :param operation: the operation name (e.g., "ReceiveMessage", "ListFunctions")
     :returns: a decorator
     """

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -9,7 +9,12 @@ from werkzeug.http import parse_dict_header
 
 import localstack
 from localstack import config
-from localstack.aws.spec import ServiceCatalog, build_service_index_cache, load_service_index_cache
+from localstack.aws.spec import (
+    ServiceCatalog,
+    ServiceModelIdentifier,
+    build_service_index_cache,
+    load_service_index_cache,
+)
 from localstack.constants import LOCALHOST_HOSTNAME, PATH_USER_REQUEST
 from localstack.http import Request
 from localstack.services.s3.utils import uses_host_addressing
@@ -73,43 +78,43 @@ def _extract_service_indicators(request: Request) -> _ServiceIndicators:
 signing_name_path_prefix_rules = {
     # custom rules based on URI path prefixes that are not easily generalizable
     "apigateway": {
-        "/v2": "apigatewayv2",
+        "/v2": ServiceModelIdentifier("apigatewayv2"),
     },
     "appconfig": {
-        "/configuration": "appconfigdata",
+        "/configuration": ServiceModelIdentifier("appconfigdata"),
     },
     "execute-api": {
-        "/@connections": "apigatewaymanagementapi",
-        "/participant": "connectparticipant",
-        "*": "iot",
+        "/@connections": ServiceModelIdentifier("apigatewaymanagementapi"),
+        "/participant": ServiceModelIdentifier("connectparticipant"),
+        "*": ServiceModelIdentifier("iot"),
     },
     "ses": {
-        "/v2": "sesv2",
-        "/v1": "pinpoint-email",
+        "/v2": ServiceModelIdentifier("sesv2"),
+        "/v1": ServiceModelIdentifier("pinpoint-email"),
     },
     "greengrass": {
-        "/greengrass/v2/": "greengrassv2",
+        "/greengrass/v2/": ServiceModelIdentifier("greengrassv2"),
     },
     "cloudsearch": {
-        "/2013-01-01": "cloudsearchdomain",
+        "/2013-01-01": ServiceModelIdentifier("cloudsearchdomain"),
     },
-    "s3": {"/v20180820": "s3control"},
+    "s3": {"/v20180820": ServiceModelIdentifier("s3control")},
     "iot1click": {
-        "/projects": "iot1click-projects",
-        "/devices": "iot1click-devices",
+        "/projects": ServiceModelIdentifier("iot1click-projects"),
+        "/devices": ServiceModelIdentifier("iot1click-devices"),
     },
     "es": {
-        "/2015-01-01": "es",
-        "/2021-01-01": "opensearch",
+        "/2015-01-01": ServiceModelIdentifier("es"),
+        "/2021-01-01": ServiceModelIdentifier("opensearch"),
     },
     "sagemaker": {
-        "/endpoints": "sagemaker-runtime",
-        "/human-loops": "sagemaker-a2i-runtime",
+        "/endpoints": ServiceModelIdentifier("sagemaker-runtime"),
+        "/human-loops": ServiceModelIdentifier("sagemaker-a2i-runtime"),
     },
 }
 
 
-def custom_signing_name_rules(signing_name: str, path: str) -> Optional[str]:
+def custom_signing_name_rules(signing_name: str, path: str) -> Optional[ServiceModelIdentifier]:
     """
     Rules which are based on the signing name (in the auth header) and the request path.
     """
@@ -119,43 +124,43 @@ def custom_signing_name_rules(signing_name: str, path: str) -> Optional[str]:
         if signing_name == "servicecatalog":
             if path == "/":
                 # servicecatalog uses the protocol json (only uses root-path URIs, i.e. only /)
-                return "servicecatalog"
+                return ServiceModelIdentifier("servicecatalog")
             else:
                 # servicecatalog-appregistry uses rest-json (only uses non-root-path request URIs)
-                return "servicecatalog-appregistry"
+                return ServiceModelIdentifier("servicecatalog-appregistry")
         return
 
-    for prefix, name in rules.items():
+    for prefix, service_model_identifier in rules.items():
         if path.startswith(prefix):
-            return name
+            return service_model_identifier
 
-    return rules.get("*", signing_name)
+    return rules.get("*", ServiceModelIdentifier(signing_name))
 
 
-def custom_host_addressing_rules(host: str) -> Optional[str]:
+def custom_host_addressing_rules(host: str) -> Optional[ServiceModelIdentifier]:
     """
     Rules based on the host header of the request.
     """
     if ".execute-api." in host:
-        return "apigateway"
+        return ServiceModelIdentifier("apigateway")
 
     if ".lambda-url." in host:
-        return "lambda"
+        return ServiceModelIdentifier("lambda")
 
 
-def custom_path_addressing_rules(path: str) -> Optional[str]:
+def custom_path_addressing_rules(path: str) -> Optional[ServiceModelIdentifier]:
     """
     Rules which are only based on the request path.
     """
 
     if is_sqs_queue_url(path):
-        return "sqs"
+        return ServiceModelIdentifier("sqs")
 
     if path.startswith("/2015-03-31/functions/"):
-        return "lambda"
+        return ServiceModelIdentifier("lambda")
 
 
-def legacy_rules(request: Request) -> Optional[str]:
+def legacy_rules(request: Request) -> Optional[ServiceModelIdentifier]:
     """
     *Legacy* rules which migrate routing logic which will become obsolete with the ASF Gateway.
     All rules which are implemented here should be migrated to the new router once these services are migrated to ASF.
@@ -172,23 +177,18 @@ def legacy_rules(request: Request) -> Optional[str]:
     if ("/%s/" % PATH_USER_REQUEST) in request.path or (
         host.endswith(LOCALHOST_HOSTNAME) and "execute-api" in host
     ):
-        return "apigateway"
+        return ServiceModelIdentifier("apigateway")
 
     if ".lambda-url." in host:
-        return "lambda"
+        return ServiceModelIdentifier("lambda")
 
     # DynamoDB shell URLs
     if path.startswith("/shell") or path.startswith("/dynamodb/shell"):
-        return "dynamodb"
+        return ServiceModelIdentifier("dynamodb")
 
     # TODO Remove once fallback to S3 is disabled (after S3 ASF and Cors rework)
     # necessary for correct handling of cors for internal endpoints
-    if (
-        path == "/health"
-        or path.startswith("/_localstack")
-        or path.startswith("/_pods")
-        or path.startswith("/_aws")
-    ):
+    if path.startswith("/_localstack") or path.startswith("/_pods") or path.startswith("/_aws"):
         return None
 
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.
@@ -196,20 +196,20 @@ def legacy_rules(request: Request) -> Optional[str]:
     stripped = path.strip("/")
     if method in ["GET", "HEAD"] and stripped:
         # assume that this is an S3 GET request with URL path `/<bucket>/<key ...>`
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
     # detect S3 URLs
     if stripped and "/" not in stripped:
         if method == "PUT":
             # assume that this is an S3 PUT bucket request with URL path `/<bucket>`
-            return "s3"
+            return ServiceModelIdentifier("s3")
         if method == "POST" and "key" in request.values:
             # assume that this is an S3 POST request with form parameters or multipart form in the body
-            return "s3"
+            return ServiceModelIdentifier("s3")
 
     # detect S3 requests sent from aws-cli using --no-sign-request option
     if "aws-cli/" in str(request.user_agent):
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
     # detect S3 pre-signed URLs (v2 and v4)
     values = request.values
@@ -226,28 +226,28 @@ def legacy_rules(request: Request) -> Optional[str]:
             "X-Amz-Signature",
         ]
     ):
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
     # S3 delete object requests
     if method == "POST" and "delete" in values:
         data_bytes = to_bytes(request.data)
         if b"<Delete" in data_bytes and b"<Key>" in data_bytes:
-            return "s3"
+            return ServiceModelIdentifier("s3")
 
     # Put Object API can have multiple keys
     if stripped.count("/") >= 1 and method == "PUT":
         # assume that this is an S3 PUT bucket object request with URL path `/<bucket>/object`
         # or `/<bucket>/object/object1/+`
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
     # detect S3 requests with "AWS id:key" Auth headers
     auth_header = request.headers.get("Authorization") or ""
     if auth_header.startswith("AWS "):
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
     if uses_host_addressing(request.headers):
         # Note: This needs to be the last rule (and therefore is not in the host rules), since it is incredibly greedy
-        return "s3"
+        return ServiceModelIdentifier("s3")
 
 
 @singleton_factory
@@ -277,17 +277,19 @@ def get_service_catalog() -> ServiceCatalog:
         return ServiceCatalog()
 
 
-def resolve_conflicts(candidates: Set[ServiceModel], request: Request):
+def resolve_conflicts(
+    candidates: Set[ServiceModelIdentifier], request: Request
+) -> ServiceModelIdentifier:
     """
     Some service definitions are overlapping to a point where they are _not_ distinguishable at all
     (f.e. ``DescribeEndpints`` in timestream-query and timestream-write).
     These conflicts need to be resolved manually.
     """
-    service_name_candidates = {service.service_name for service in candidates}
+    service_name_candidates = {service.name for service in candidates}
     if service_name_candidates == {"timestream-query", "timestream-write"}:
-        return "timestream-query"
+        return ServiceModelIdentifier("timestream-query")
     if service_name_candidates == {"docdb", "neptune", "rds"}:
-        return "rds"
+        return ServiceModelIdentifier("rds")
     if service_name_candidates == {"sqs"}:
         # SQS now have 2 different specs for `query` and `json` protocol. From our current implementation with the
         # parser and serializer, we need to have 2 different service names for them, but they share one provider
@@ -297,7 +299,11 @@ def resolve_conflicts(candidates: Set[ServiceModel], request: Request):
         # can safely route them to the `sqs-json` JSON parser/serializer. If not present, route the request to the
         # default sqs protocol (`query`).
         content_type = request.headers.get("Content-Type")
-        return "sqs-json" if content_type == "application/x-amz-json-1.0" else "sqs"
+        return (
+            ServiceModelIdentifier("sqs", "json")
+            if content_type == "application/x-amz-json-1.0"
+            else ServiceModelIdentifier("sqs")
+        )
 
 
 def determine_aws_service_model(
@@ -318,12 +324,12 @@ def determine_aws_service_model(
         signing_name_candidates = services.by_signing_name(signing_name)
         if len(signing_name_candidates) == 1:
             # a unique signing-name -> service name mapping is the case for ~75% of service operations
-            return signing_name_candidates[0]
+            return services.get(*signing_name_candidates[0])
 
         # try to find a match with the custom signing name rules
         custom_match = custom_signing_name_rules(signing_name, path)
         if custom_match:
-            return services.get(custom_match)
+            return services.get(*custom_match)
 
         # still ambiguous - add the services to the list of candidates
         candidates.update(signing_name_candidates)
@@ -333,30 +339,33 @@ def determine_aws_service_model(
         target_candidates = services.by_target_prefix(target_prefix)
         if len(target_candidates) == 1:
             # a unique target prefix
-            return target_candidates[0]
+            return services.get(*target_candidates[0])
 
         # still ambiguous - add the services to the list of candidates
         candidates.update(target_candidates)
 
         # exclude services where the operation is not contained in the service spec
-        for service in list(candidates):
+        for service_identifier in list(candidates):
+            service = services.get(*service_identifier)
             if operation not in service.operation_names:
-                candidates.remove(service)
+                candidates.remove(service_identifier)
     else:
         # exclude services which have a target prefix (the current request does not have one)
-        for service in list(candidates):
+        for service_identifier in list(candidates):
+            service = services.get(*service_identifier)
             if service.metadata.get("targetPrefix") is not None:
-                candidates.remove(service)
+                candidates.remove(service_identifier)
 
     if len(candidates) == 1:
-        return candidates.pop()
+        service_identifier = candidates.pop()
+        return services.get(*service_identifier)
 
     # 3. check the path if it is set and not a trivial root path
     if path and path != "/":
         # try to find a match with the custom path rules
         custom_path_match = custom_path_addressing_rules(path)
         if custom_path_match:
-            return services.get(custom_path_match)
+            return services.get(*custom_path_match)
 
     # 4. check the host (custom host addressing rules)
     if host:
@@ -365,12 +374,12 @@ def determine_aws_service_model(
             # this prevents a virtual host addressed bucket to be wrongly recognized
             if host.startswith(f"{prefix}.") and ".s3." not in host:
                 if len(services_per_prefix) == 1:
-                    return services_per_prefix[0]
+                    return services.get(*services_per_prefix[0])
                 candidates.update(services_per_prefix)
 
         custom_host_match = custom_host_addressing_rules(host)
         if custom_host_match:
-            return services.get(custom_host_match)
+            return services.get(*custom_host_match)
 
     if request.shallow:
         # from here on we would need access to the request body, which doesn't exist for shallow requests like
@@ -389,16 +398,17 @@ def determine_aws_service_model(
             ]
 
             if len(query_candidates) == 1:
-                return query_candidates[0]
+                return services.get(*query_candidates[0])
 
             if "Version" in values:
-                for service_model in list(query_candidates):
+                for service_identifier in list(query_candidates):
+                    service_model = services.get(*service_identifier)
                     if values["Version"] != service_model.api_version:
                         # the combination of Version and Action is not unique, add matches to the candidates
-                        query_candidates.remove(service_model)
+                        query_candidates.remove(service_identifier)
 
             if len(query_candidates) == 1:
-                return query_candidates[0]
+                return services.get(*query_candidates[0])
 
             candidates.update(query_candidates)
 
@@ -414,15 +424,15 @@ def determine_aws_service_model(
     # 6. resolve service spec conflicts
     resolved_conflict = resolve_conflicts(candidates, request)
     if resolved_conflict:
-        return services.get(resolved_conflict)
+        return services.get(*resolved_conflict)
 
     # 7. check the legacy rules in the end
     legacy_match = legacy_rules(request)
     if legacy_match:
-        return services.get(legacy_match)
+        return services.get(*legacy_match)
 
     if signing_name:
-        return services.get(signing_name)
+        return services.get(name=signing_name)
     if candidates:
-        return candidates.pop()
+        return services.get(*candidates.pop())
     return None

--- a/localstack/aws/spec.py
+++ b/localstack/aws/spec.py
@@ -70,9 +70,9 @@ def load_service(service: ServiceName, version: str = None, model_type="service-
     For example: load_service("sqs", "2012-11-05")
     """
     service_description = loader.load_service_model(service, model_type, version)
-    # if the service name is sqs-query, we just loaded our internalized SQS query spec,
+    # if the service name is sqs-json, we just loaded our internalized SQS query spec,
     # the service name needs to be set to standard sqs
-    if service == "sqs-query":
+    if service == "sqs-json":
         service = "sqs"
     return ServiceModel(service_description, service)
 

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -87,10 +87,7 @@ class HealthResource:
         if reload:
             self.service_manager.check_all()
         services = {
-            service: state.value
-            for service, state in self.service_manager.get_states().items()
-            # TODO remove this as soon as the sqs-query service is gone
-            if service != "sqs-query"
+            service: state.value for service, state in self.service_manager.get_states().items()
         }
 
         # build state dict from internal state and merge into it the service states

--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -23,6 +23,7 @@ from localstack.aws.api.logs import (
     KmsKeyId,
     ListTagsForResourceResponse,
     ListTagsLogGroupResponse,
+    LogGroupClass,
     LogGroupName,
     LogsApi,
     LogStreamName,
@@ -139,6 +140,7 @@ class LogsProvider(LogsApi, ServiceLifecycleHook):
         log_group_name: LogGroupName,
         kms_key_id: KmsKeyId = None,
         tags: Tags = None,
+        log_group_class: LogGroupClass = None,
     ) -> None:
         call_moto(context)
         if tags:

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -142,7 +142,6 @@ class Service:
         provider: ServiceProvider,
         dispatch_table_factory: Callable[[ServiceProvider], DispatchTable] = None,
         service_lifecycle_hook: ServiceLifecycleHook = None,
-        custom_service_name: Optional[str] = None,
     ) -> "Service":
         """
         Factory method for creating services for providers. This method hides a bunch of legacy code and
@@ -152,7 +151,6 @@ class Service:
         :param dispatch_table_factory: a `MotoFallbackDispatcher` or something similar that uses the provider to
             create a dispatch table. this one's a bit clumsy.
         :param service_lifecycle_hook: if left empty, the factory checks whether the provider is a ServiceLifecycleHook.
-        :param custom_service_name: allows defining a custom name for this service (instead of the one in the provider).
         :return: a service instance
         """
         # determine the service_lifecycle_hook
@@ -162,10 +160,9 @@ class Service:
 
         # determine the delegate for injecting into the skeleton
         delegate = dispatch_table_factory(provider) if dispatch_table_factory else provider
-        service_name = custom_service_name or provider.service
         service = Service(
-            name=service_name,
-            skeleton=Skeleton(load_service(service_name), delegate),
+            name=provider.service,
+            skeleton=Skeleton(load_service(provider.service), delegate),
             lifecycle_hook=service_lifecycle_hook,
         )
         service._provider = provider

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -298,41 +298,16 @@ def sns():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-sqs_provider = None
-
-
-def get_sqs_provider():
-    """
-    Creates the SQS provider instance (and registers the query API routes) in a singleton fashion, such that the
-    same instance of the provider can be used by multiple services (i.e. the `sqs` as well as the `sqs-query` service).
-
-    TODO it would be great if we could find a better solution to use a single provider for multiple services
-    """
-    global sqs_provider
-
-    if not sqs_provider:
-        from localstack.services import edge
-        from localstack.services.sqs import query_api
-        from localstack.services.sqs.provider import SqsProvider
-
-        query_api.register(edge.ROUTER)
-
-        sqs_provider = SqsProvider()
-    return sqs_provider
-
-
 @aws_provider()
 def sqs():
-    return Service.for_provider(get_sqs_provider())
+    from localstack.services import edge
+    from localstack.services.sqs import query_api
+    from localstack.services.sqs.provider import SqsProvider
 
+    query_api.register(edge.ROUTER)
 
-@aws_provider("sqs-query")
-def sqs_query():
-    sqs_query_service = Service.for_provider(
-        get_sqs_provider(),
-        custom_service_name="sqs-query",
-    )
-    return sqs_query_service
+    provider = SqsProvider()
+    return Service.for_provider(provider)
 
 
 @aws_provider()

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -63,6 +63,7 @@ from localstack.aws.api.route53resolver import (
     OutpostArn,
     OutpostInstanceType,
     Priority,
+    ProtocolList,
     ResolverEndpointDirection,
     ResolverEndpointType,
     ResolverQueryLogConfig,
@@ -544,10 +545,11 @@ class Route53ResolverProvider(Route53ResolverApi):
         direction: ResolverEndpointDirection,
         ip_addresses: IpAddressesRequest,
         name: Name = None,
-        tags: TagList = None,
-        resolver_endpoint_type: ResolverEndpointType = None,
         outpost_arn: OutpostArn = None,
         preferred_instance_type: OutpostInstanceType = None,
+        tags: TagList = None,
+        resolver_endpoint_type: ResolverEndpointType = None,
+        protocols: ProtocolList = None,
     ) -> CreateResolverEndpointResponse:
         create_resolver_endpoint_resp = call_moto(context)
         create_resolver_endpoint_resp["ResolverEndpoint"][

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -791,7 +791,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             arn["account"],
             arn["region"],
             arn["resource"],
-            is_query=context.service.service_name == "sqs-query",
+            is_query=context.service.protocol == "query",
         )
 
     def _resolve_queue(
@@ -811,7 +811,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         :raises QueueDoesNotExist: if the queue does not exist
         """
         account_id, region_name, name = resolve_queue_location(context, queue_name, queue_url)
-        is_query = context.service.service_name == "sqs-query"
+        is_query = context.service.protocol == "query"
         return self._require_queue(
             account_id, region_name or context.region, name, is_query=is_query
         )
@@ -885,7 +885,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             queue_owner_aws_account_id or context.account_id,
             context.region,
             queue_name,
-            is_query=context.service.service_name == "sqs-query",
+            is_query=context.service.protocol == "query",
         )
 
         return GetQueueUrlResult(QueueUrl=queue.url(context))

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -31,7 +31,7 @@ from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
 
-service = load_service("sqs-query")
+service = load_service("sqs")
 parser = create_parser(service)
 serializer = create_serializer(service)
 
@@ -212,7 +212,7 @@ def try_call_sqs(request: Request, region: str) -> Tuple[Dict, OperationModel]:
         region_name=region,
         aws_access_key_id=account_id or INTERNAL_AWS_ACCESS_KEY_ID,
         aws_secret_access_key=INTERNAL_AWS_SECRET_ACCESS_KEY,
-    ).sqs_query
+    ).sqs
 
     try:
         # using the layer below boto3.client("sqs").<operation>(...) to make the call

--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -217,7 +217,7 @@ class TypedServiceClientFactory(abc.ABC):
     sesv2: Union["SESV2Client", "MetadataRequestInjector[SESV2Client]"]
     sns: Union["SNSClient", "MetadataRequestInjector[SNSClient]"]
     sqs: Union["SQSClient", "MetadataRequestInjector[SQSClient]"]
-    sqs_query: Union["SQSClient", "MetadataRequestInjector[SQSClient]"]
+    sqs_json: Union["SQSClient", "MetadataRequestInjector[SQSClient]"]
     ssm: Union["SSMClient", "MetadataRequestInjector[SSMClient]"]
     sso_admin: Union["SSOAdminClient", "MetadataRequestInjector[SSOAdminClient]"]
     stepfunctions: Union["SFNClient", "MetadataRequestInjector[SFNClient]"]

--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -217,6 +217,7 @@ class TypedServiceClientFactory(abc.ABC):
     sesv2: Union["SESV2Client", "MetadataRequestInjector[SESV2Client]"]
     sns: Union["SNSClient", "MetadataRequestInjector[SNSClient]"]
     sqs: Union["SQSClient", "MetadataRequestInjector[SQSClient]"]
+    sqs_query: Union["SQSClient", "MetadataRequestInjector[SQSClient]"]
     ssm: Union["SSMClient", "MetadataRequestInjector[SSMClient]"]
     sso_admin: Union["SSOAdminClient", "MetadataRequestInjector[SSOAdminClient]"]
     stepfunctions: Union["SFNClient", "MetadataRequestInjector[SFNClient]"]

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -49,7 +49,6 @@ API_DEPENDENCIES = {
     "cloudformation": ["s3", "sts"],
     "lambda": ["s3", "sqs", "sts"],
     "firehose": ["kinesis"],
-    "sqs": ["sqs-query"],
     "transcribe": ["s3"],
 }
 # composites define an abstract name like "serverless" that maps to a set of services

--- a/localstack/utils/coverage_docs.py
+++ b/localstack/utils/coverage_docs.py
@@ -10,10 +10,6 @@ def get_coverage_link_for_service(service_name: str, action_name: str) -> str:
 
     available_services = SERVICE_PLUGINS.list_available()
 
-    # TODO we could maybe find a better way of handling this service alias (or maybe we can phase it out at some point)
-    if service_name == "sqs-query":
-        service_name = "sqs"
-
     if service_name not in available_services:
         return MESSAGE_TEMPLATE % ("", service_name, "")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ localstack =
 base-runtime =
     awscrt>=0.13.14
     boto3>=1.26.121
-    botocore>=1.32.2,<1.32.6
+    botocore>=1.34.12
     cbor2>=5.2.0
     dnspython>=1.16.0
     # TODO tag incompatibility introduced in 7.0.0 with https://github.com/docker/docker-py/pull/3191

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
@@ -239,7 +239,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "recorded-date": "10-11-2023, 19:17:37",
+    "recorded-date": "07-12-2023, 12:55:26",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -249,7 +249,6 @@
         }
       },
       "send_message_batch": {
-        "Failed": [],
         "Successful": [
           {
             "Id": "message-1",

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -341,6 +341,7 @@ class TestS3:
         snapshot.match("get-copied-object", response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..AccessPointAlias"])
     def test_region_header_exists(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = s3_create_bucket(
@@ -3688,7 +3689,7 @@ class TestS3:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..x-amz-access-point-alias", "$..x-amz-id-2"],
+        paths=["$..x-amz-access-point-alias", "$..x-amz-id-2", "$..AccessPointAlias"],
     )
     def test_create_bucket_head_bucket(self, aws_client_factory, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1,8 +1,10 @@
 {
   "tests/aws/services/s3/test_s3.py::TestS3::test_region_header_exists": {
-    "recorded-date": "03-08-2023, 04:13:15",
+    "recorded-date": "06-12-2023, 16:47:40",
     "recorded-content": {
       "head_bucket": {
+        "AccessPointAlias": false,
+        "BucketRegion": "eu-west-1",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1793,7 +1795,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
-    "recorded-date": "06-11-2023, 16:32:57",
+    "recorded-date": "06-12-2023, 16:45:33",
     "recorded-content": {
       "create_bucket": {
         "Location": "/<bucket-name:1>",
@@ -1810,6 +1812,8 @@
         }
       },
       "head_bucket": {
+        "AccessPointAlias": false,
+        "BucketRegion": "<x-amz-bucket-region:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1823,6 +1827,8 @@
         "x-amz-request-id": "x-amz-request-id"
       },
       "head_bucket_2": {
+        "AccessPointAlias": false,
+        "BucketRegion": "<x-amz-bucket-region:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -1917,7 +1917,7 @@ class TestSNSSubscriptionSQSFifo:
 
         aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
 
-        response = aws_client.sqs.receive_message(
+        response = aws_client.sqs_json.receive_message(
             QueueUrl=queue_url,
             WaitTimeSeconds=10,
             AttributeNames=["All"],
@@ -1929,7 +1929,7 @@ class TestSNSSubscriptionSQSFifo:
         )
         # republish the message, to check deduplication
         aws_client.sns.publish(TopicArn=topic_arn, Message=message, **kwargs)
-        response = aws_client.sqs.receive_message(
+        response = aws_client.sqs_json.receive_message(
             QueueUrl=queue_url,
             WaitTimeSeconds=1,
             AttributeNames=["All"],
@@ -2691,8 +2691,7 @@ class TestSNSFilter:
             QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
         )
         snapshot.match("messages-3", response_3)
-        assert "Messages" in response_3
-        assert response_3["Messages"] == []
+        assert "Messages" not in response_3 or response_3["Messages"] == []
 
     @markers.aws.validated
     def test_exists_filter_policy(
@@ -3016,8 +3015,7 @@ class TestSNSFilter:
         )
         snapshot.match("recv-init", response)
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
         # publish messages that satisfies the filter policy, assert that messages are received
         messages = [
@@ -3057,8 +3055,7 @@ class TestSNSFilter:
             QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
         )
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
         # publish message that does not satisfy the filter policy as it's not even JSON, or not a JSON object
         message = "Regular string message"
@@ -3075,8 +3072,7 @@ class TestSNSFilter:
             QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=2
         )
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
     @markers.aws.validated
     def test_filter_policy_for_batch(
@@ -3227,8 +3223,7 @@ class TestSNSFilter:
         )
         snapshot.match("recv-init", response)
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
         def _verify_and_snapshot_sqs_messages(msg_to_send: list[dict], snapshot_prefix: str):
             for i, _message in enumerate(msg_to_send):
@@ -3267,8 +3262,7 @@ class TestSNSFilter:
             QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
         )
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
         # assert with more nesting
         deep_nested_filter_policy = json.dumps(
@@ -3306,8 +3300,7 @@ class TestSNSFilter:
             QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=5 if is_aws_cloud() else 2
         )
         # assert there are no messages in the queue
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
 
 class TestSNSPlatformEndpoint:
@@ -4001,8 +3994,7 @@ class TestSNSSubscriptionHttp:
 
         response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=2)
         # AWS doesn't send to the DLQ if the UnsubscribeConfirmation fails to be delivered
-        assert "Messages" in response
-        assert response["Messages"] == []
+        assert "Messages" not in response or response["Messages"] == []
 
 
 class TestSNSSubscriptionFirehose:

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -1997,7 +1997,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[True]": {
-    "recorded-date": "09-11-2023, 21:12:03",
+    "recorded-date": "07-12-2023, 10:13:37",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2031,7 +2031,6 @@
         }
       },
       "dedup-messages": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2040,7 +2039,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_message_to_fifo_sqs[False]": {
-    "recorded-date": "09-11-2023, 21:12:07",
+    "recorded-date": "07-12-2023, 10:13:41",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -2074,7 +2073,6 @@
         }
       },
       "dedup-messages": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2568,7 +2566,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[True]": {
-    "recorded-date": "09-11-2023, 21:10:27",
+    "recorded-date": "07-12-2023, 10:10:22",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -2765,7 +2763,6 @@
         }
       },
       "duplicate-messages": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -2774,7 +2771,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_batch_messages_from_fifo_topic_to_fifo_queue[False]": {
-    "recorded-date": "09-11-2023, 21:10:33",
+    "recorded-date": "07-12-2023, 10:10:29",
     "recorded-content": {
       "topic-attrs": {
         "Attributes": {
@@ -2971,7 +2968,6 @@
         }
       },
       "duplicate-messages": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3074,7 +3070,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionSQSFifo::test_publish_to_fifo_topic_deduplication_on_topic_level": {
-    "recorded-date": "09-11-2023, 21:07:36",
+    "recorded-date": "07-12-2023, 10:12:08",
     "recorded-content": {
       "messages": {
         "Messages": [
@@ -3108,7 +3104,6 @@
         }
       },
       "dedup-messages": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3195,7 +3190,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
-    "recorded-date": "09-11-2023, 21:05:40",
+    "recorded-date": "07-12-2023, 10:17:45",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -3228,7 +3223,6 @@
         }
       },
       "messages-0": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3321,7 +3315,6 @@
         }
       },
       "messages-3": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3330,7 +3323,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_exists_filter_policy": {
-    "recorded-date": "09-11-2023, 21:04:02",
+    "recorded-date": "07-12-2023, 10:17:55",
     "recorded-content": {
       "subscription-attributes-policy-1": {
         "Attributes": {
@@ -3358,7 +3351,6 @@
         }
       },
       "messages-0": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3520,7 +3512,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_set_subscription_filter_policy_scope": {
-    "recorded-date": "25-08-2023, 00:15:12",
+    "recorded-date": "07-12-2023, 10:17:58",
     "recorded-content": {
       "sub-attrs-default": {
         "Attributes": {
@@ -3593,7 +3585,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_sub_filter_policy_nested_property": {
-    "recorded-date": "25-08-2023, 00:15:14",
+    "recorded-date": "07-12-2023, 10:18:00",
     "recorded-content": {
       "sub-filter-policy-nested-error": {
         "Error": {
@@ -3636,7 +3628,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_sub_filter_policy_nested_property_constraints": {
-    "recorded-date": "25-08-2023, 00:18:18",
+    "recorded-date": "07-12-2023, 10:18:03",
     "recorded-content": {
       "sub-filter-policy-nested-error-too-many-combinations": {
         "Error": {
@@ -3674,10 +3666,9 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[True]": {
-    "recorded-date": "09-11-2023, 20:58:29",
+    "recorded-date": "07-12-2023, 10:18:17",
     "recorded-content": {
       "recv-init": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3722,10 +3713,9 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[False]": {
-    "recorded-date": "09-11-2023, 20:58:42",
+    "recorded-date": "07-12-2023, 10:18:31",
     "recorded-content": {
       "recv-init": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3782,7 +3772,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_for_batch": {
-    "recorded-date": "09-11-2023, 21:01:32",
+    "recorded-date": "07-12-2023, 10:18:50",
     "recorded-content": {
       "subscription-attributes-with-filter": {
         "Attributes": {
@@ -3832,14 +3822,12 @@
         }
       },
       "messages-no-filter-before-publish": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "messages-with-filter-before-publish": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3936,7 +3924,6 @@
         }
       },
       "messages-with-filter-after-publish-filtered": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4607,10 +4594,9 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_dot_attribute": {
-    "recorded-date": "09-11-2023, 18:50:59",
+    "recorded-date": "07-12-2023, 10:19:19",
     "recorded-content": {
       "recv-init": {
-        "Messages": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -5,7 +5,7 @@ import threading
 import time
 from queue import Empty, Queue
 from threading import Timer
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import pytest
 import requests
@@ -35,6 +35,9 @@ from localstack.utils.common import poll_condition, retry, short_uid, to_str
 from localstack.utils.urls import localstack_host
 from tests.aws.services.lambda_.functions import lambda_integration
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs import SQSClient
 
 TEST_POLICY = """
 {
@@ -75,10 +78,15 @@ def sqs_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.sqs_api())
 
 
+@pytest.fixture(params=["sqs", "sqs_json"])
+def aws_sqs_client(aws_client, request: str) -> "SQSClient":
+    yield getattr(aws_client, request.param)
+
+
 class TestSqsProvider:
     @markers.aws.only_localstack
     def test_get_queue_url_contains_localstack_host(
-        self, sqs_create_queue, monkeypatch, aws_client, aws_client_factory
+        self, sqs_create_queue, monkeypatch, aws_sqs_client
     ):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
 
@@ -86,7 +94,7 @@ class TestSqsProvider:
 
         sqs_create_queue(QueueName=queue_name)
 
-        queue_url = aws_client.sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        queue_url = aws_sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
 
         host_definition = localstack_host()
         # our current queue pattern looks like this, but may change going forward, or may be configurable
@@ -138,8 +146,8 @@ class TestSqsProvider:
         assert "QueueUrls" not in result
 
     @markers.aws.validated
-    def test_create_queue_and_get_attributes(self, sqs_queue, aws_client):
-        result = aws_client.sqs.get_queue_attributes(
+    def test_create_queue_and_get_attributes(self, sqs_queue, aws_sqs_client):
+        result = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["QueueArn", "CreatedTimestamp", "VisibilityTimeout"]
         )
         assert "Attributes" in result
@@ -151,12 +159,12 @@ class TestSqsProvider:
         assert int(attrs["VisibilityTimeout"]) == 30, "visibility timeout is not the default value"
 
     @markers.aws.validated
-    def test_create_queue_recently_deleted(self, sqs_create_queue, monkeypatch, aws_client):
+    def test_create_queue_recently_deleted(self, sqs_create_queue, monkeypatch, aws_sqs_client):
         monkeypatch.setattr(config, "SQS_DELAY_RECENTLY_DELETED", True)
 
         name = f"test-queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=name)
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        aws_sqs_client.delete_queue(QueueUrl=queue_url)
 
         with pytest.raises(ClientError) as e:
             sqs_create_queue(QueueName=name)
@@ -167,7 +175,9 @@ class TestSqsProvider:
         )
 
     @markers.aws.only_localstack
-    def test_create_queue_recently_deleted_cache(self, sqs_create_queue, monkeypatch, aws_client):
+    def test_create_queue_recently_deleted_cache(
+        self, sqs_create_queue, monkeypatch, aws_sqs_client
+    ):
         # this is a white-box test for the QueueDeletedRecently timeout behavior
         from localstack.services.sqs import constants
 
@@ -176,7 +186,7 @@ class TestSqsProvider:
 
         name = f"test-queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=name)
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        aws_sqs_client.delete_queue(QueueUrl=queue_url)
 
         with pytest.raises(ClientError) as e:
             sqs_create_queue(QueueName=name)
@@ -194,25 +204,25 @@ class TestSqsProvider:
 
     @markers.aws.only_localstack
     def test_create_queue_recently_deleted_can_be_disabled(
-        self, sqs_create_queue, monkeypatch, aws_client
+        self, sqs_create_queue, monkeypatch, aws_sqs_client
     ):
         monkeypatch.setattr(config, "SQS_DELAY_RECENTLY_DELETED", False)
 
         name = f"test-queue-{short_uid()}"
 
         queue_url = sqs_create_queue(QueueName=name)
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        aws_sqs_client.delete_queue(QueueUrl=queue_url)
         assert queue_url == sqs_create_queue(QueueName=name)
 
     @markers.aws.validated
-    def test_send_receive_message(self, sqs_queue, aws_client):
-        send_result = aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="message")
+    def test_send_receive_message(self, sqs_queue, aws_sqs_client):
+        send_result = aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="message")
 
         assert send_result["MessageId"]
         assert send_result["MD5OfMessageBody"] == "78e731027d8fd50ed642340b7c9a63b3"
         # TODO: other attributes
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=sqs_queue)
+        receive_result = aws_sqs_client.receive_message(QueueUrl=sqs_queue)
 
         assert len(receive_result["Messages"]) == 1
         message = receive_result["Messages"][0]
@@ -223,23 +233,24 @@ class TestSqsProvider:
         assert message["MD5OfBody"] == send_result["MD5OfMessageBody"]
 
     @markers.aws.validated
-    def test_send_receive_max_number_of_messages(self, sqs_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_receive_max_number_of_messages(self, sqs_queue, snapshot, aws_sqs_client):
         queue_url = sqs_queue
-        send_result = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message")
+        send_result = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message")
         assert send_result["MessageId"]
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.receive_message(
+            aws_sqs_client.receive_message(
                 QueueUrl=queue_url, MaxNumberOfMessages=MAX_NUMBER_OF_MESSAGES + 1
             )
 
         snapshot.match("send_max_number_of_messages", e.value.response)
 
     @markers.aws.validated
-    def test_receive_message_attributes_timestamp_types(self, sqs_queue, aws_client):
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="message")
+    def test_receive_message_attributes_timestamp_types(self, sqs_queue, aws_sqs_client):
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="message")
 
-        r0 = aws_client.sqs.receive_message(
+        r0 = aws_sqs_client.receive_message(
             QueueUrl=sqs_queue, VisibilityTimeout=0, AttributeNames=["All"]
         )
         attrs = r0["Messages"][0]["Attributes"]
@@ -258,24 +269,23 @@ class TestSqsProvider:
         aws_client.sqs.send_message(QueueUrl=queue0, MessageBody="message")
 
         result = aws_client.sqs.receive_message(QueueUrl=queue1)
-        assert "Messages" in result
-        assert result["Messages"] == []
+        assert "Messages" not in result or result["Messages"] == []
 
         result = aws_client.sqs.receive_message(QueueUrl=queue0)
         assert len(result["Messages"]) == 1
         assert result["Messages"][0]["Body"] == "message"
 
     @markers.aws.validated
-    def test_send_receive_message_encoded_content(self, sqs_create_queue, aws_client):
+    def test_send_receive_message_encoded_content(self, sqs_create_queue, aws_sqs_client):
         queue = sqs_create_queue()
-        aws_client.sqs.send_message(QueueUrl=queue, MessageBody='"&quot;&quot;\r')
-        result = aws_client.sqs.receive_message(QueueUrl=queue)
+        aws_sqs_client.send_message(QueueUrl=queue, MessageBody='"&quot;&quot;\r')
+        result = aws_sqs_client.receive_message(QueueUrl=queue)
         assert len(result["Messages"]) == 1
         assert result["Messages"][0]["Body"] == '"&quot;&quot;\r'
 
     @markers.aws.validated
-    def test_send_message_batch(self, sqs_queue, aws_client):
-        aws_client.sqs.send_message_batch(
+    def test_send_message_batch(self, sqs_queue, aws_sqs_client):
+        aws_sqs_client.send_message_batch(
             QueueUrl=sqs_queue,
             Entries=[
                 {"Id": "1", "MessageBody": "message-0"},
@@ -283,9 +293,9 @@ class TestSqsProvider:
             ],
         )
 
-        response0 = aws_client.sqs.receive_message(QueueUrl=sqs_queue)
-        response1 = aws_client.sqs.receive_message(QueueUrl=sqs_queue)
-        response2 = aws_client.sqs.receive_message(QueueUrl=sqs_queue)
+        response0 = aws_sqs_client.receive_message(QueueUrl=sqs_queue)
+        response1 = aws_sqs_client.receive_message(QueueUrl=sqs_queue)
+        response2 = aws_sqs_client.receive_message(QueueUrl=sqs_queue)
 
         assert len(response0.get("Messages", [])) == 1
         assert len(response1.get("Messages", [])) == 1
@@ -298,23 +308,23 @@ class TestSqsProvider:
         assert message1["Body"] == "message-1"
 
     @markers.aws.validated
-    def test_send_batch_receive_multiple(self, sqs_queue, aws_client):
+    def test_send_batch_receive_multiple(self, sqs_queue, aws_sqs_client):
         # send a batch, then a single message, then receive them
         # Important: AWS does not guarantee the order of messages, be it within the batch or between sends
         message_count = 3
-        aws_client.sqs.send_message_batch(
+        aws_sqs_client.send_message_batch(
             QueueUrl=sqs_queue,
             Entries=[
                 {"Id": "1", "MessageBody": "message-0"},
                 {"Id": "2", "MessageBody": "message-1"},
             ],
         )
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="message-2")
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="message-2")
         i = 0
         result_recv = {"Messages": []}
         while len(result_recv["Messages"]) < message_count and i < message_count:
             result_recv["Messages"] = result_recv["Messages"] + (
-                aws_client.sqs.receive_message(
+                aws_sqs_client.receive_message(
                     QueueUrl=sqs_queue, MaxNumberOfMessages=message_count
                 ).get("Messages")
             )
@@ -325,22 +335,23 @@ class TestSqsProvider:
         )
 
     @markers.aws.validated
-    def test_send_message_batch_with_empty_list(self, sqs_create_queue, aws_client):
+    def test_send_message_batch_with_empty_list(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         try:
-            aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=[])
+            aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=[])
         except ClientError as e:
             assert "EmptyBatchRequest" in e.response["Error"]["Code"]
             assert e.response["ResponseMetadata"]["HTTPStatusCode"] in [400, 404]
 
     @markers.aws.validated
-    def test_send_oversized_message(self, sqs_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_oversized_message(self, sqs_queue, snapshot, aws_sqs_client):
         with pytest.raises(ClientError) as e:
             message_attributes = {"k": {"DataType": "String", "StringValue": "x"}}
             message_attributes_size = len("k") + len("String") + len("x")
             message_body = "a" * (DEFAULT_MAXIMUM_MESSAGE_SIZE - message_attributes_size + 1)
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=sqs_queue,
                 MessageBody=message_body,
                 MessageAttributes=message_attributes,
@@ -349,22 +360,25 @@ class TestSqsProvider:
         snapshot.match("send_oversized_message", e.value.response)
 
     @markers.aws.validated
-    def test_send_message_with_updated_maximum_message_size(self, sqs_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_message_with_updated_maximum_message_size(
+        self, sqs_queue, snapshot, aws_sqs_client
+    ):
         new_max_message_size = 1024
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=sqs_queue,
             Attributes={"MaximumMessageSize": str(new_max_message_size)},
         )
 
         # check base case still works
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="a" * new_max_message_size)
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="a" * new_max_message_size)
 
         # check error case
         with pytest.raises(ClientError) as e:
             message_attributes = {"k": {"DataType": "String", "StringValue": "x"}}
             message_attributes_size = len("k") + len("String") + len("x")
             message_body = "a" * (new_max_message_size - message_attributes_size + 1)
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=sqs_queue,
                 MessageBody=message_body,
                 MessageAttributes=message_attributes,
@@ -373,14 +387,15 @@ class TestSqsProvider:
         snapshot.match("send_oversized_message", e.value.response)
 
     @markers.aws.validated
-    def test_send_message_batch_with_oversized_contents(self, sqs_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_message_batch_with_oversized_contents(self, sqs_queue, snapshot, aws_sqs_client):
         # Send two messages, one of max message size and a second with
         # message body of size 1
         with pytest.raises(ClientError) as e:
             message_attributes = {"k": {"DataType": "String", "StringValue": "x"}}
             message_attributes_size = len("k") + len("String") + len("x")
             message_body = "a" * (DEFAULT_MAXIMUM_MESSAGE_SIZE - message_attributes_size)
-            aws_client.sqs.send_message_batch(
+            aws_sqs_client.send_message_batch(
                 QueueUrl=sqs_queue,
                 Entries=[
                     {
@@ -396,10 +411,10 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size(
-        self, sqs_queue, snapshot, aws_client
+        self, sqs_queue, snapshot, aws_sqs_client
     ):
         new_max_message_size = 2048
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=sqs_queue,
             Attributes={"MaximumMessageSize": str(new_max_message_size)},
         )
@@ -408,7 +423,7 @@ class TestSqsProvider:
         message_attributes = {"k": {"DataType": "String", "StringValue": "x"}}
         message_attributes_size = len("k") + len("String") + len("x")
         message_body = "a" * (new_max_message_size - message_attributes_size)
-        response = aws_client.sqs.send_message_batch(
+        response = aws_sqs_client.send_message_batch(
             QueueUrl=sqs_queue,
             Entries=[
                 {"Id": "1", "MessageBody": message_body, "MessageAttributes": message_attributes},
@@ -419,77 +434,77 @@ class TestSqsProvider:
         snapshot.match("send_oversized_message_batch", response)
 
     @markers.aws.validated
-    def test_tag_untag_queue(self, sqs_create_queue, aws_client, snapshot):
+    def test_tag_untag_queue(self, sqs_create_queue, aws_sqs_client, snapshot):
         queue_url = sqs_create_queue()
 
         # tag queue
         tags = {"tag1": "value1", "tag2": "value2", "tag3": ""}
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
         # check queue tags
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         snapshot.match("get-tag-1", response)
         assert response["Tags"] == tags
 
         # remove tag1 and tag3
-        aws_client.sqs.untag_queue(QueueUrl=queue_url, TagKeys=["tag1", "tag3"])
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        aws_sqs_client.untag_queue(QueueUrl=queue_url, TagKeys=["tag1", "tag3"])
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         snapshot.match("get-tag-2", response)
         assert response["Tags"] == {"tag2": "value2"}
 
         # remove tag2
-        aws_client.sqs.untag_queue(QueueUrl=queue_url, TagKeys=["tag2"])
+        aws_sqs_client.untag_queue(QueueUrl=queue_url, TagKeys=["tag2"])
 
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         snapshot.match("get-tag-after-untag", response)
-        assert response["Tags"] == {}
+        assert "Tags" not in response or response["Tags"] == {}
 
     @markers.aws.validated
-    def test_tags_case_sensitive(self, sqs_create_queue, aws_client):
+    def test_tags_case_sensitive(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         # tag queue
         tags = {"MyTag": "value1", "mytag": "value2"}
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         assert response["Tags"] == tags
 
     @markers.aws.validated
-    def test_untag_queue_ignores_non_existing_tag(self, sqs_create_queue, aws_client):
+    def test_untag_queue_ignores_non_existing_tag(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         # tag queue
         tags = {"tag1": "value1", "tag2": "value2"}
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
         # remove tags
-        aws_client.sqs.untag_queue(QueueUrl=queue_url, TagKeys=["tag1", "tag3"])
+        aws_sqs_client.untag_queue(QueueUrl=queue_url, TagKeys=["tag1", "tag3"])
 
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         assert response["Tags"] == {"tag2": "value2"}
 
     @markers.aws.validated
-    def test_tag_queue_overwrites_existing_tag(self, sqs_create_queue, aws_client):
+    def test_tag_queue_overwrites_existing_tag(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         # tag queue
         tags = {"tag1": "value1", "tag2": "value2"}
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
         # overwrite tags
         tags = {"tag1": "VALUE1", "tag3": "value3"}
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
 
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         assert response["Tags"] == {"tag1": "VALUE1", "tag2": "value2", "tag3": "value3"}
 
     @markers.aws.validated
-    def test_create_queue_with_tags(self, sqs_create_queue, aws_client):
+    def test_create_queue_with_tags(self, sqs_create_queue, aws_sqs_client):
         tags = {"tag1": "value1", "tag2": "value2"}
         queue_url = sqs_create_queue(tags=tags)
 
-        response = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        response = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         assert response["Tags"] == tags
 
     @markers.aws.validated
@@ -513,7 +528,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_receive_message_wait_time_seconds_and_max_number_of_messages_does_not_block(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         """
         this test makes sure that `WaitTimeSeconds` does not block when messages are in the queue, even when
@@ -521,14 +536,14 @@ class TestSqsProvider:
         """
         queue_url = sqs_create_queue()
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar2")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar2")
 
         # wait for the two messages to be in the queue
-        assert poll_condition(lambda: get_qsize(aws_client.sqs, queue_url) == 2, timeout=10)
+        assert poll_condition(lambda: get_qsize(aws_sqs_client, queue_url) == 2, timeout=10)
 
         then = time.time()
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=3, WaitTimeSeconds=5
         )
         took = time.time() - then
@@ -539,19 +554,21 @@ class TestSqsProvider:
         ), f"unexpected number of messages in {response}"
 
     @markers.aws.validated
-    def test_wait_time_seconds_waits_correctly(self, sqs_queue, aws_client):
+    def test_wait_time_seconds_waits_correctly(self, sqs_queue, aws_sqs_client):
         def _send_message():
-            aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="foobared")
+            aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foobared")
 
         Timer(1, _send_message).start()  # send message asynchronously after 1 second
-        response = aws_client.sqs.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=10)
+        response = aws_sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=10)
 
         assert (
             len(response.get("Messages", [])) == 1
         ), f"unexpected number of messages in response {response}"
 
     @markers.aws.validated
-    def test_wait_time_seconds_queue_attribute_waits_correctly(self, sqs_create_queue, aws_client):
+    def test_wait_time_seconds_queue_attribute_waits_correctly(
+        self, sqs_create_queue, aws_sqs_client
+    ):
         queue_url = sqs_create_queue(
             Attributes={
                 "ReceiveMessageWaitTimeSeconds": "10",
@@ -559,10 +576,10 @@ class TestSqsProvider:
         )
 
         def _send_message():
-            aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobared")
+            aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobared")
 
         Timer(1, _send_message).start()  # send message asynchronously after 1 second
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url)
 
         assert (
             len(response.get("Messages", [])) == 1
@@ -587,10 +604,11 @@ class TestSqsProvider:
         assert sqs_create_queue(QueueName=queue_name, Attributes=attributes) == queue_url
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_create_fifo_queue_with_different_attributes_raises_error(
         self,
         sqs_create_queue,
-        aws_client,
+        aws_sqs_client,
         snapshot,
     ):
         queue_name = f"queue-{short_uid()}.fifo"
@@ -606,24 +624,25 @@ class TestSqsProvider:
         snapshot.match("queue-already-exists", e.value.response)
 
     @markers.aws.validated
-    def test_send_message_with_delay_0_works_for_fifo(self, sqs_create_queue, aws_client):
+    def test_send_message_with_delay_0_works_for_fifo(self, sqs_create_queue, aws_sqs_client):
         # see issue https://github.com/localstack/localstack/issues/6612
         queue_name = f"queue-{short_uid()}.fifo"
         attributes = {"FifoQueue": "true"}
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
-        message_sent_hash = aws_client.sqs.send_message(
+        message_sent_hash = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             DelaySeconds=0,
             MessageBody="Hello World!",
             MessageGroupId="test",
             MessageDeduplicationId="42",
         )["MD5OfMessageBody"]
-        message_received_hash = aws_client.sqs.receive_message(
+        message_received_hash = aws_sqs_client.receive_message(
             QueueUrl=queue_url, VisibilityTimeout=0
         )["Messages"][0]["MD5OfBody"]
         assert message_sent_hash == message_received_hash
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_message_deduplication_id_too_long(self, sqs_create_queue, aws_client, snapshot):
         # see issue https://github.com/localstack/localstack/issues/6612
         queue_name = f"queue-{short_uid()}.fifo"
@@ -647,6 +666,7 @@ class TestSqsProvider:
         snapshot.match("error-response", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_message_group_id_too_long(self, sqs_create_queue, aws_client, snapshot):
         # see issue https://github.com/localstack/localstack/issues/6612
         queue_name = f"queue-{short_uid()}.fifo"
@@ -670,8 +690,9 @@ class TestSqsProvider:
         snapshot.match("error-response", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_create_queue_with_different_attributes_raises_exception(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         queue_name = f"queue-{short_uid()}"
 
@@ -702,7 +723,7 @@ class TestSqsProvider:
         snapshot.match("create_queue_01", e.value.response)
 
         # update the attribute of the queue
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes={"DelaySeconds": "2"})
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes={"DelaySeconds": "2"})
 
         # try again
         assert queue_url == sqs_create_queue(
@@ -726,19 +747,19 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_create_queue_after_internal_attributes_changes_works(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         queue_name = f"queue-{short_uid()}"
 
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar-1", DelaySeconds=1)
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar-2")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar-1", DelaySeconds=1)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar-2")
 
         assert queue_url == sqs_create_queue(QueueName=queue_name)
 
     @markers.aws.validated
-    def test_create_and_update_queue_attributes(self, sqs_create_queue, snapshot, aws_client):
+    def test_create_and_update_queue_attributes(self, sqs_create_queue, snapshot, aws_sqs_client):
         queue_url = sqs_create_queue(
             Attributes={
                 "MessageRetentionPeriod": "604800",  # Unsupported by ElasticMq, should be saved in memory
@@ -747,10 +768,10 @@ class TestSqsProvider:
             }
         )
 
-        response = aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
+        response = aws_sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
         snapshot.match("get_queue_attributes", response)
 
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=queue_url,
             Attributes={
                 "MaximumMessageSize": "2048",
@@ -759,18 +780,18 @@ class TestSqsProvider:
             },
         )
 
-        response = aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
+        response = aws_sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
         snapshot.match("get_updated_queue_attributes", response)
 
     @markers.aws.validated
     @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5938")
     def test_create_queue_with_default_arguments_works_with_modified_attributes(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=queue_url,
             Attributes={
                 "VisibilityTimeout": "2",
@@ -803,7 +824,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5938")
-    def test_create_queue_after_modified_attributes(self, sqs_create_queue, aws_client):
+    def test_create_queue_after_modified_attributes(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(
             QueueName=queue_name,
@@ -813,7 +834,7 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=queue_url,
             Attributes={
                 "VisibilityTimeout": "2",
@@ -845,17 +866,17 @@ class TestSqsProvider:
         assert queue_url == sqs_create_queue(QueueName=queue_name)
 
     @markers.aws.validated
-    def test_create_queue_after_send(self, sqs_create_queue, aws_client):
+    def test_create_queue_after_send(self, sqs_create_queue, aws_sqs_client):
         # checks that intrinsic queue attributes like "ApproxMessages" does not hinder queue creation
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="bared")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="baz")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="bared")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="baz")
 
         def _qsize(_url):
-            response = aws_client.sqs.get_queue_attributes(
+            response = aws_sqs_client.get_queue_attributes(
                 QueueUrl=_url, AttributeNames=["ApproximateNumberOfMessages"]
             )
             return int(response["Attributes"]["ApproximateNumberOfMessages"])
@@ -866,26 +887,25 @@ class TestSqsProvider:
         assert queue_url == sqs_create_queue(QueueName=queue_name)
 
     @markers.aws.validated
-    def test_send_delay_and_wait_time(self, sqs_queue, aws_client):
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="foobar", DelaySeconds=1)
+    def test_send_delay_and_wait_time(self, sqs_queue, aws_sqs_client):
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foobar", DelaySeconds=1)
 
-        result = aws_client.sqs.receive_message(QueueUrl=sqs_queue)
-        assert "Messages" in result
-        assert result["Messages"] == []
+        result = aws_sqs_client.receive_message(QueueUrl=sqs_queue)
+        assert "Messages" not in result or result["Messages"] == []
 
-        result = aws_client.sqs.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=2)
+        result = aws_sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=2)
         assert "Messages" in result
         assert len(result["Messages"]) == 1
 
     @markers.aws.only_localstack
-    def test_approximate_number_of_messages_delayed(self, sqs_queue, aws_client):
+    def test_approximate_number_of_messages_delayed(self, sqs_queue, aws_sqs_client):
         # this test does not work against AWS in the same way, because AWS only has eventual consistency guarantees
         # for the tested attributes that can take up to a minute to update.
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="ed")
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="foo", DelaySeconds=2)
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="bar", DelaySeconds=2)
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="ed")
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo", DelaySeconds=2)
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="bar", DelaySeconds=2)
 
-        result = aws_client.sqs.get_queue_attributes(
+        result = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue,
             AttributeNames=[
                 "ApproximateNumberOfMessages",
@@ -900,7 +920,7 @@ class TestSqsProvider:
         }
 
         def _assert():
-            _result = aws_client.sqs.get_queue_attributes(
+            _result = aws_sqs_client.get_queue_attributes(
                 QueueUrl=sqs_queue,
                 AttributeNames=[
                     "ApproximateNumberOfMessages",
@@ -917,23 +937,22 @@ class TestSqsProvider:
         retry(_assert)
 
     @markers.aws.validated
-    def test_receive_after_visibility_timeout(self, sqs_create_queue, aws_client):
+    def test_receive_after_visibility_timeout(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "1"})
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar")
 
         # receive the message
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert "Messages" in result
         message_receipt_0 = result["Messages"][0]
 
         # message should be within the visibility timeout
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        assert "Messages" in result
-        assert result["Messages"] == []
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        assert "Messages" not in result or result["Messages"] == []
 
         # visibility timeout should have expired
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
         assert "Messages" in result
         message_receipt_1 = result["Messages"][0]
 
@@ -942,16 +961,16 @@ class TestSqsProvider:
         ), "receipt handles should be different"
 
     @markers.aws.validated
-    def test_receive_terminate_visibility_timeout(self, sqs_queue, aws_client):
+    def test_receive_terminate_visibility_timeout(self, sqs_queue, aws_sqs_client):
         queue_url = sqs_queue
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="foobar")
 
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
         assert "Messages" in result
         message_receipt_0 = result["Messages"][0]
 
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert "Messages" in result
         message_receipt_1 = result["Messages"][0]
 
@@ -960,84 +979,83 @@ class TestSqsProvider:
         ), "receipt handles should be different"
 
         # TODO: check if this is correct (whether receive with VisibilityTimeout = 0 is permanent)
-        result = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        assert "Messages" in result
-        assert result["Messages"] == []
+        result = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        assert "Messages" not in result or result["Messages"] == []
 
     @markers.aws.validated
-    def test_extend_message_visibility_timeout_set_in_queue(self, sqs_create_queue, aws_client):
+    def test_extend_message_visibility_timeout_set_in_queue(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "2"})
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
         receipt = response["Messages"][0]["ReceiptHandle"]
 
         # update even if time expires
         for _ in range(4):
             time.sleep(1)
             # we've waited a total of four seconds, although the visibility timeout is 2, so we are extending it
-            aws_client.sqs.change_message_visibility(
+            aws_sqs_client.change_message_visibility(
                 QueueUrl=queue_url, ReceiptHandle=receipt, VisibilityTimeout=2
             )
-            assert aws_client.sqs.receive_message(QueueUrl=queue_url).get("Messages", []) == []
+            assert aws_sqs_client.receive_message(QueueUrl=queue_url).get("Messages", []) == []
 
-        messages = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)["Messages"]
+        messages = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)["Messages"]
         assert messages[0]["Body"] == "test"
         assert len(messages) == 1
 
     @markers.aws.validated
     def test_change_message_visibility_after_visibility_timeout_expiration(
-        self, snapshot, sqs_create_queue, aws_client
+        self, snapshot, sqs_create_queue, aws_sqs_client
     ):
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "1"})
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url)
         receipt = response["Messages"][0]["ReceiptHandle"]
         time.sleep(2)
         # VisibiltyTimeout was 1 and has now expired
-        response = aws_client.sqs.change_message_visibility(
+        response = aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url, ReceiptHandle=receipt, VisibilityTimeout=2
         )
         snapshot.match("visibility_timeout_expired", response)
 
     @markers.aws.validated
     def test_receive_message_with_visibility_timeout_updates_timeout(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         queue_url = sqs_create_queue()
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
 
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
         )
         assert len(response["Messages"]) == 1
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
         assert len(response["Messages"]) == 1
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert response.get("Messages", []) == []
 
     @markers.aws.validated
-    def test_terminate_visibility_timeout_after_receive(self, sqs_create_queue, aws_client):
+    def test_terminate_visibility_timeout_after_receive(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
 
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
         )
         receipt_1 = response["Messages"][0]["ReceiptHandle"]
         assert len(response["Messages"]) == 1
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
         assert len(response["Messages"]) == 1
 
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url, ReceiptHandle=receipt_1, VisibilityTimeout=0
         )
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert len(response["Messages"]) == 1
 
     @markers.aws.validated
@@ -1139,7 +1157,7 @@ class TestSqsProvider:
     @markers.aws.needs_fixing
     @pytest.mark.skip("Needs AWS fixing and is now failing against LocalStack")
     def test_delete_message_batch_from_lambda(
-        self, sqs_create_queue, create_lambda_function, aws_client
+        self, sqs_create_queue, create_lambda_function, aws_sqs_client, aws_client
     ):
         # issue 3671 - not recreatable
         # TODO: lambda creation does not work when testing against AWS
@@ -1155,38 +1173,40 @@ class TestSqsProvider:
         batch = []
         for i in range(4):
             batch.append({"Id": str(i), "MessageBody": str(i)})
-        aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=batch)
+        aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=batch)
 
         aws_client.lambda_.invoke(
             FunctionName=lambda_name, Payload=json.dumps(delete_batch_payload), LogType="Tail"
         )
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert "Messages" in receive_result
         assert receive_result["Messages"] == []
 
     @markers.aws.validated
-    def test_invalid_receipt_handle_should_return_error_message(self, sqs_create_queue, aws_client):
+    def test_invalid_receipt_handle_should_return_error_message(
+        self, sqs_create_queue, aws_sqs_client
+    ):
         # issue 3619
         queue_url = sqs_create_queue()
         with pytest.raises(Exception) as e:
-            aws_client.sqs.change_message_visibility(
+            aws_sqs_client.change_message_visibility(
                 QueueUrl=queue_url, ReceiptHandle="INVALID", VisibilityTimeout=60
             )
         e.match("ReceiptHandleIsInvalid")
 
     @markers.aws.validated
-    def test_message_with_attributes_should_be_enqueued(self, sqs_create_queue, aws_client):
+    def test_message_with_attributes_should_be_enqueued(self, sqs_create_queue, aws_sqs_client):
         # issue 3737
         queue_url = sqs_create_queue()
 
         message_body = "test"
         timestamp_attribute = {"DataType": "Number", "StringValue": "1614717034367"}
         message_attributes = {"timestamp": timestamp_attribute}
-        response_send = aws_client.sqs.send_message(
+        response_send = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=message_body, MessageAttributes=message_attributes
         )
-        response_receive = aws_client.sqs.receive_message(
+        response_receive = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MessageAttributeNames=["All"]
         )
         message = response_receive["Messages"][0]
@@ -1194,7 +1214,7 @@ class TestSqsProvider:
         assert message["MessageAttributes"] == message_attributes
 
     @markers.aws.validated
-    def test_batch_send_with_invalid_char_should_succeed(self, sqs_create_queue, aws_client):
+    def test_batch_send_with_invalid_char_should_succeed(self, sqs_create_queue, aws_sqs_client):
         # issue 4135
         queue_url = sqs_create_queue()
 
@@ -1203,7 +1223,7 @@ class TestSqsProvider:
             batch.append({"Id": str(i), "MessageBody": str(i)})
         batch.append({"Id": "9", "MessageBody": "\x01"})
 
-        result_send = aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=batch)
+        result_send = aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=batch)
 
         # check the one failed message
         assert len(result_send["Failed"]) == 1
@@ -1215,7 +1235,7 @@ class TestSqsProvider:
         messages = []
 
         def collect_messages():
-            response = aws_client.sqs.receive_message(
+            response = aws_sqs_client.receive_message(
                 QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=1
             )
             messages.extend(response.get("Messages", []))
@@ -1229,7 +1249,7 @@ class TestSqsProvider:
         assert bodies == {"0", "1", "2", "3", "4", "5", "6", "7", "8"}
 
     @markers.aws.only_localstack
-    def test_external_endpoint(self, monkeypatch, sqs_create_queue, aws_client):
+    def test_external_endpoint(self, monkeypatch, sqs_create_queue, aws_sqs_client):
         external_host = "external-host"
         external_port = 12345
 
@@ -1243,9 +1263,9 @@ class TestSqsProvider:
         assert f"{external_host}:{external_port}" in queue_url
 
         message_body = "external_host_test"
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_body)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_body)
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert receive_result["Messages"][0]["Body"] == message_body
 
     @markers.aws.only_localstack
@@ -1361,7 +1381,7 @@ class TestSqsProvider:
         assert message["Body"] == "message-2"
 
     @markers.aws.validated
-    def test_fifo_messages_in_order_after_timeout(self, sqs_create_queue, aws_client):
+    def test_fifo_messages_in_order_after_timeout(self, sqs_create_queue, aws_sqs_client):
         # issue 4287
         queue_name = f"queue-{short_uid()}.fifo"
         timeout = 1
@@ -1369,7 +1389,7 @@ class TestSqsProvider:
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
 
         for i in range(3):
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url,
                 MessageBody=f"message-{i}",
                 MessageGroupId="1",
@@ -1377,7 +1397,7 @@ class TestSqsProvider:
             )
 
         def receive_and_check_order():
-            result_receive = aws_client.sqs.receive_message(
+            result_receive = aws_sqs_client.receive_message(
                 QueueUrl=queue_url, MaxNumberOfMessages=10
             )
             for j in range(3):
@@ -1388,7 +1408,7 @@ class TestSqsProvider:
         receive_and_check_order()
 
     @markers.aws.validated
-    def test_fifo_receive_message_group_id_ordering(self, sqs_create_queue, aws_client):
+    def test_fifo_receive_message_group_id_ordering(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
             Attributes={
@@ -1398,22 +1418,22 @@ class TestSqsProvider:
         )
 
         # add message to group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
         # we interleave one message in group 2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
         # and then continue with group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="group-1"
         )
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10)
 
         # even though we sent a message from group 2 in between messages of group 1, the messages arrive in
         # order of the message groups
@@ -1424,7 +1444,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_fifo_receive_message_visibility_timeout_shared_in_group(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         timeout = 1
         queue_url = sqs_create_queue(
@@ -1436,33 +1456,33 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m4", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="group-3"
         )
 
         # we receive 2 messages of the 3 in the first message group
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
         assert response["Messages"][0]["Body"] == "g1-m1"
         assert response["Messages"][1]["Body"] == "g1-m2"
 
         # the entire group 1 is affected by the visibility timeout, so the next receive returns a message
         # of group 2
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
         assert response["Messages"][0]["Body"] == "g2-m1"
 
         # let the visibility timeout expire
@@ -1470,7 +1490,7 @@ class TestSqsProvider:
 
         # now we try to fetch all messages from the queue. since there are no guarantees about the ordering of
         # message groups themselves, multiple orderings are valid now
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=10, VisibilityTimeout=0
         )
         ordering = [message["Body"] for message in response["Messages"]]
@@ -1481,7 +1501,9 @@ class TestSqsProvider:
         )
 
     @markers.aws.validated
-    def test_fifo_receive_message_with_zero_visibility_timeout(self, sqs_create_queue, aws_client):
+    def test_fifo_receive_message_with_zero_visibility_timeout(
+        self, sqs_create_queue, aws_sqs_client
+    ):
         # this test shows that receiving messages from a fifo queue with visibility timeout = 0 terminates the
         # group's visibility correctly.
         queue_url = sqs_create_queue(
@@ -1492,28 +1514,28 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
         # interleave g2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
         # interleave g2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m2", MessageGroupId="group-2"
         )
         # interleave g3
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="group-3"
         )
         # send another message to g1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
 
         # we receive messages from the first two groups with a visibility timeout of 0, ordering is preserved
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=3, VisibilityTimeout=0
         )
         assert response["Messages"][0]["Body"] == "g1-m1"
@@ -1522,7 +1544,7 @@ class TestSqsProvider:
 
         # now we try to fetch all messages from the queue. since there are no guarantees about the ordering of
         # message groups themselves, multiple orderings are valid now
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=10, VisibilityTimeout=0
         )
         ordering = [message["Body"] for message in response["Messages"]]
@@ -1530,7 +1552,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_fifo_message_group_visibility_after_terminate_visibility_timeout(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         """
         This test demonstrates that
@@ -1547,31 +1569,31 @@ class TestSqsProvider:
         }
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
         assert len(response["Messages"]) == 2
         assert response["Messages"][0]["Body"] == "g1-m1"
         assert response["Messages"][1]["Body"] == "g1-m2"
 
         # both messages from group 1 have a visibility timeout of 30
         # we now terminate the visibility timeout of message 1
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url,
             ReceiptHandle=response["Messages"][0]["ReceiptHandle"],
             VisibilityTimeout=0,
         )
 
         # when we now try to receive 3 messages, we get messages from both groups, but only the visible ones
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=3, WaitTimeSeconds=2
         )
         assert response["Messages"][0]["Body"] == "g2-m1"
@@ -1580,7 +1602,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_fifo_message_group_visibility_after_change_message_visibility(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         """
         This test demonstrates that
@@ -1597,24 +1619,24 @@ class TestSqsProvider:
         }
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
         assert len(response["Messages"]) == 2
         assert response["Messages"][0]["Body"] == "g1-m1"
         assert response["Messages"][1]["Body"] == "g1-m2"
 
         # both messages from group 1 have a visibility timeout of 30
         # we now change the visibility timeout of message 1 to 1
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url,
             ReceiptHandle=response["Messages"][0]["ReceiptHandle"],
             VisibilityTimeout=1,
@@ -1625,7 +1647,7 @@ class TestSqsProvider:
 
         # when we now try to receive 3 messages, we get messages from both groups, but only the visible ones
         # g1-m2 still has a visibility timeout of 30
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=3,
         )
@@ -1634,7 +1656,7 @@ class TestSqsProvider:
         assert len(response["Messages"]) == 2
 
     @markers.aws.validated
-    def test_fifo_message_group_visibility_after_delete(self, sqs_create_queue, aws_client):
+    def test_fifo_message_group_visibility_after_delete(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
             Attributes={
@@ -1643,51 +1665,51 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
         # we interleave a message from group 2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
         # continue with group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
         # we interleave another a message from group 2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m2", MessageGroupId="group-2"
         )
         # continue with group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m4", MessageGroupId="group-1"
         )
         # add group 3
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="group-3"
         )
 
         # we receive two messages from group 1
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
         assert response["Messages"][0]["Body"] == "g1-m1"
         assert response["Messages"][1]["Body"] == "g1-m2"
 
         # we delete all in-flight messages we received from group 1, which will make that group visible again
-        aws_client.sqs.delete_message(
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
         )
-        aws_client.sqs.delete_message(
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=response["Messages"][1]["ReceiptHandle"]
         )
 
         # draining the queue should include the message from group 1 we didn't delete earlier
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=10,
         )
@@ -1700,7 +1722,9 @@ class TestSqsProvider:
         )
 
     @markers.aws.validated
-    def test_fifo_message_group_visibility_after_partial_delete(self, sqs_create_queue, aws_client):
+    def test_fifo_message_group_visibility_after_partial_delete(
+        self, sqs_create_queue, aws_sqs_client
+    ):
         # this is almost the same test case as the one above, only that it doesn't fully delete the messages
         # it received so the message group remains in-flight.
         queue_url = sqs_create_queue(
@@ -1711,48 +1735,48 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="group-1"
         )
         # we interleave a message from group 2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="group-2"
         )
         # continue with group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
         # we interleave another a message from group 2
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g2-m2", MessageGroupId="group-2"
         )
         # continue with group 1
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="group-1"
         )
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g1-m4", MessageGroupId="group-1"
         )
         # add group 3
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="group-3"
         )
 
         # we receive two messages from group 1 (note that group 2 is not in there)
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=2)
         assert response["Messages"][0]["Body"] == "g1-m1"
         assert response["Messages"][1]["Body"] == "g1-m2"
 
         # we delete only one in-flight messages we received from group 1
-        aws_client.sqs.delete_message(
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
         )
 
         # draining the queue should now not the message from group 1, since it's not yet visible
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=10,
         )
@@ -1760,8 +1784,9 @@ class TestSqsProvider:
         assert ordering == ["g2-m1", "g2-m2", "g3-m1"]
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_fifo_queue_send_message_with_delay_seconds_fails(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
@@ -1769,14 +1794,16 @@ class TestSqsProvider:
         )
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url, MessageBody="message-1", MessageGroupId="1", DelaySeconds=2
             )
 
         snapshot.match("send_message", e.value.response)
 
     @markers.aws.validated
-    def test_fifo_queue_send_message_with_delay_on_queue_works(self, sqs_create_queue, aws_client):
+    def test_fifo_queue_send_message_with_delay_on_queue_works(
+        self, sqs_create_queue, aws_sqs_client
+    ):
         delay_seconds = 2
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
@@ -1787,16 +1814,16 @@ class TestSqsProvider:
             },
         )
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-1", MessageGroupId="1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-2", MessageGroupId="1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-3", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-1", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-2", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-3", MessageGroupId="1")
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert response.get("Messages", []) == []
 
         time.sleep(delay_seconds + 1)
 
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=3)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=3)
         messages = response["Messages"]
         assert len(messages) == 3
 
@@ -1805,7 +1832,7 @@ class TestSqsProvider:
         assert messages[2]["Body"] == "message-3"
 
     @markers.aws.validated
-    def test_fifo_message_attributes(self, sqs_create_queue, snapshot, aws_client):
+    def test_fifo_message_attributes(self, sqs_create_queue, snapshot, aws_sqs_client):
         snapshot.add_transformer(snapshot.transform.sqs_api())
 
         queue_url = sqs_create_queue(
@@ -1819,7 +1846,7 @@ class TestSqsProvider:
             },
         )
 
-        response = aws_client.sqs.send_message(
+        response = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="message-body-1",
             MessageGroupId="group-1",
@@ -1827,18 +1854,18 @@ class TestSqsProvider:
         )
         snapshot.match("send_message", response)
 
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, AttributeNames=["All"], WaitTimeSeconds=10
         )
         snapshot.match("receive_message_0", response)
         # makes sure that attributes are mutated correctly
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, AttributeNames=["All"], WaitTimeSeconds=10
         )
         snapshot.match("receive_message_1", response)
 
     @markers.aws.validated
-    def test_fifo_approx_number_of_messages(self, sqs_create_queue, aws_client):
+    def test_fifo_approx_number_of_messages(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
             Attributes={
@@ -1847,39 +1874,39 @@ class TestSqsProvider:
             },
         )
 
-        assert get_qsize(aws_client.sqs, queue_url) == 0
+        assert get_qsize(aws_sqs_client, queue_url) == 0
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="1")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="2")
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="3")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g1-m2", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g1-m3", MessageGroupId="1")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g2-m1", MessageGroupId="2")
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g3-m1", MessageGroupId="3")
 
-        assert get_qsize(aws_client.sqs, queue_url) == 5
+        assert get_qsize(aws_sqs_client, queue_url) == 5
 
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=4, WaitTimeSeconds=1
         )
 
         if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
             time.sleep(5)
 
-        assert get_qsize(aws_client.sqs, queue_url) == 1
+        assert get_qsize(aws_sqs_client, queue_url) == 1
 
         for message in response["Messages"]:
-            aws_client.sqs.delete_message(
+            aws_sqs_client.delete_message(
                 QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
             )
 
         if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
             time.sleep(5)
 
-        assert get_qsize(aws_client.sqs, queue_url) == 1
+        assert get_qsize(aws_sqs_client, queue_url) == 1
 
     @markers.aws.validated
     @pytest.mark.xfail(reason="not implemented in localstack at the moment")
     def test_fifo_delete_message_with_expired_receipt_handle(
-        self, sqs_create_queue, aws_client, snapshot
+        self, sqs_create_queue, aws_sqs_client, snapshot
     ):
         timeout = 1
         queue_url = sqs_create_queue(
@@ -1890,8 +1917,8 @@ class TestSqsProvider:
                 "ContentBasedDeduplication": "true",
             },
         )
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="1")
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="g1-m1", MessageGroupId="1")
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url)
         receipt_handle = response["Messages"][0]["ReceiptHandle"]
 
         snapshot.match("response", response)
@@ -1900,13 +1927,13 @@ class TestSqsProvider:
         time.sleep(timeout + 1)
         # try to remove the message with the old receipt handle
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+            aws_sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
         snapshot.match("error", e.value.response)
 
     @markers.aws.validated
     def test_fifo_set_content_based_deduplication_strategy(
-        self, sqs_create_queue, aws_client, snapshot
+        self, sqs_create_queue, aws_sqs_client, snapshot
     ):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
@@ -1919,89 +1946,87 @@ class TestSqsProvider:
 
         snapshot.match(
             "before-update",
-            aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"]),
+            aws_sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"]),
         )
 
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=queue_url, Attributes={"ContentBasedDeduplication": "false"}
         )
 
         snapshot.match(
             "after-update",
-            aws_client.sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"]),
+            aws_sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"]),
         )
 
     @markers.aws.validated
-    def test_list_queue_tags(self, sqs_create_queue, aws_client):
+    def test_list_queue_tags(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         tags = {"testTag1": "test1", "testTag2": "test2"}
 
-        aws_client.sqs.tag_queue(QueueUrl=queue_url, Tags=tags)
-        tag_list = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        aws_sqs_client.tag_queue(QueueUrl=queue_url, Tags=tags)
+        tag_list = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
         assert tags == tag_list["Tags"]
 
     @markers.aws.validated
-    def test_queue_list_nonexistent_tags(self, sqs_create_queue, aws_client):
+    def test_queue_list_nonexistent_tags(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        tag_list = aws_client.sqs.list_queue_tags(QueueUrl=queue_url)
+        tag_list = aws_sqs_client.list_queue_tags(QueueUrl=queue_url)
 
         assert "Tags" not in tag_list["ResponseMetadata"].keys()
 
     @markers.aws.validated
-    def test_publish_get_delete_message(self, sqs_create_queue, aws_client):
+    def test_publish_get_delete_message(self, sqs_create_queue, aws_sqs_client):
         # visibility part handled by test_receive_terminate_visibility_timeout
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         message_body = "test message"
-        result_send = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_body)
+        result_send = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_body)
 
-        result_recv = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_recv = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert result_recv["Messages"][0]["MessageId"] == result_send["MessageId"]
 
-        aws_client.sqs.delete_message(
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=result_recv["Messages"][0]["ReceiptHandle"]
         )
-        result_recv = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        assert "Messages" in result_recv
-        assert result_recv["Messages"] == []
+        result_recv = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        assert "Messages" not in result_recv or result_recv["Messages"] == []
 
     @markers.aws.validated
     def test_delete_message_deletes_with_change_visibility_timeout(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         # Old name: test_delete_message_deletes_visibility_agnostic
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        message_id = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")[
+        message_id = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")[
             "MessageId"
         ]
-        result_recv = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        result_follow_up = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_recv = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        result_follow_up = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert result_recv["Messages"][0]["MessageId"] == message_id
-        assert "Messages" in result_follow_up
-        assert result_follow_up["Messages"] == []
+        assert "Messages" not in result_follow_up or result_follow_up["Messages"] == []
 
         receipt_handle = result_recv["Messages"][0]["ReceiptHandle"]
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url, ReceiptHandle=receipt_handle, VisibilityTimeout=0
         )
 
         # check if the new timeout enables instant re-receiving, to ensure the message was deleted
-        result_recv = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_recv = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert result_recv["Messages"][0]["MessageId"] == message_id
 
         receipt_handle = result_recv["Messages"][0]["ReceiptHandle"]
-        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
-        result_follow_up = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        assert "Messages" in result_follow_up
-        assert result_follow_up["Messages"] == []
+        aws_sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+        result_follow_up = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        assert "Messages" not in result_follow_up or result_follow_up["Messages"] == []
 
     @markers.aws.validated
-    def test_too_many_entries_in_batch_request(self, sqs_create_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_too_many_entries_in_batch_request(self, sqs_create_queue, snapshot, aws_sqs_client):
         message_count = 20
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -2014,11 +2039,12 @@ class TestSqsProvider:
         ]
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
+            aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
         snapshot.match("test_too_many_entries_in_batch_request", e.value.response)
 
     @markers.aws.validated
-    def test_invalid_batch_id(self, sqs_create_queue, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_invalid_batch_id(self, sqs_create_queue, snapshot, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         message_batch = [
@@ -2028,12 +2054,13 @@ class TestSqsProvider:
             }
         ]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
+            aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
         snapshot.match("test_invalid_batch_id", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_batch_missing_deduplication_id_for_fifo_queue(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
@@ -2056,7 +2083,7 @@ class TestSqsProvider:
             },
         ]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
+            aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
         snapshot.match("test_missing_deduplication_id_for_fifo_queue", e.value.response)
 
     @markers.aws.validated
@@ -2076,8 +2103,9 @@ class TestSqsProvider:
         snapshot.match("send-message-batch-result", response)
 
     @markers.parity.aws_validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_send_batch_missing_message_group_id_for_fifo_queue(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         queue_url = sqs_create_queue(
             QueueName=f"queue-{short_uid()}.fifo",
@@ -2100,11 +2128,11 @@ class TestSqsProvider:
             },
         ]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
+            aws_sqs_client.send_message_batch(QueueUrl=queue_url, Entries=message_batch)
         snapshot.match("test_missing_message_group_id_for_fifo_queue", e.value.response)
 
     @markers.aws.validated
-    def test_publish_get_delete_message_batch(self, sqs_create_queue, aws_client):
+    def test_publish_get_delete_message_batch(self, sqs_create_queue, aws_sqs_client):
         message_count = 10
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -2117,7 +2145,7 @@ class TestSqsProvider:
             for i in range(message_count)
         ]
 
-        result_send_batch = aws_client.sqs.send_message_batch(
+        result_send_batch = aws_sqs_client.send_message_batch(
             QueueUrl=queue_url, Entries=message_batch
         )
         successful = result_send_batch["Successful"]
@@ -2126,7 +2154,7 @@ class TestSqsProvider:
         result_recv = []
         i = 0
         while len(result_recv) < message_count and i < message_count:
-            result = aws_client.sqs.receive_message(
+            result = aws_sqs_client.receive_message(
                 QueueUrl=queue_url, MaxNumberOfMessages=message_count
             )["Messages"]
             if result:
@@ -2147,19 +2175,18 @@ class TestSqsProvider:
             {"Id": message["MessageId"], "ReceiptHandle": message["ReceiptHandle"]}
             for message in result_recv
         ]
-        aws_client.sqs.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
-        confirmation = aws_client.sqs.receive_message(
+        aws_sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
+        confirmation = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=message_count
         )
-        assert "Messages" in confirmation
-        assert confirmation["Messages"] == []
+        assert "Messages" not in confirmation or confirmation["Messages"] == []
 
     @markers.aws.validated
     @pytest.mark.parametrize(
         argnames="invalid_message_id", argvalues=["", "testLongId" * 10, "invalid:id"]
     )
     def test_delete_message_batch_invalid_msg_id(
-        self, invalid_message_id, sqs_create_queue, snapshot, aws_client
+        self, invalid_message_id, sqs_create_queue, snapshot, aws_sqs_client
     ):
         self._add_error_detail_transformer(snapshot)
 
@@ -2168,12 +2195,12 @@ class TestSqsProvider:
 
         delete_entries = [{"Id": invalid_message_id, "ReceiptHandle": "testHandle1"}]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
+            aws_sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
         snapshot.match("error_response", e.value.response)
 
     @markers.aws.validated
     def test_delete_message_batch_with_too_large_batch(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         self._add_error_detail_transformer(snapshot)
 
@@ -2188,13 +2215,13 @@ class TestSqsProvider:
             for i in range(MAX_NUMBER_OF_MESSAGES)
         ]
 
-        result_send_batch = aws_client.sqs.send_message_batch(
+        result_send_batch = aws_sqs_client.send_message_batch(
             QueueUrl=queue_url, Entries=message_batch
         )
         successful = result_send_batch["Successful"]
         assert len(successful) == len(message_batch)
 
-        result_send_batch = aws_client.sqs.send_message_batch(
+        result_send_batch = aws_sqs_client.send_message_batch(
             QueueUrl=queue_url, Entries=message_batch
         )
         successful = result_send_batch["Successful"]
@@ -2205,7 +2232,7 @@ class TestSqsProvider:
 
         def _receive_all_messages():
             result_recv.extend(
-                aws_client.sqs.receive_message(
+                aws_sqs_client.receive_message(
                     QueueUrl=queue_url,
                     MaxNumberOfMessages=min(MAX_NUMBER_OF_MESSAGES, target_size - len(result_recv)),
                 )["Messages"]
@@ -2219,12 +2246,12 @@ class TestSqsProvider:
             for i, msg in enumerate(result_recv)
         ]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
+            aws_sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=delete_entries)
         snapshot.match("error_response", e.value.response)
 
     @markers.aws.validated
     def test_change_message_visibility_batch_with_too_large_batch(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         self._add_error_detail_transformer(snapshot)
 
@@ -2239,13 +2266,13 @@ class TestSqsProvider:
             for i in range(MAX_NUMBER_OF_MESSAGES)
         ]
 
-        result_send_batch = aws_client.sqs.send_message_batch(
+        result_send_batch = aws_sqs_client.send_message_batch(
             QueueUrl=queue_url, Entries=message_batch
         )
         successful = result_send_batch["Successful"]
         assert len(successful) == len(message_batch)
 
-        result_send_batch = aws_client.sqs.send_message_batch(
+        result_send_batch = aws_sqs_client.send_message_batch(
             QueueUrl=queue_url, Entries=message_batch
         )
         successful = result_send_batch["Successful"]
@@ -2256,7 +2283,7 @@ class TestSqsProvider:
 
         def _receive_all_messages():
             result_recv.extend(
-                aws_client.sqs.receive_message(
+                aws_sqs_client.receive_message(
                     QueueUrl=queue_url,
                     MaxNumberOfMessages=min(MAX_NUMBER_OF_MESSAGES, target_size - len(result_recv)),
                 )["Messages"]
@@ -2270,13 +2297,13 @@ class TestSqsProvider:
             for i, msg in enumerate(result_recv)
         ]
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.change_message_visibility_batch(
+            aws_sqs_client.change_message_visibility_batch(
                 QueueUrl=queue_url, Entries=change_visibility_entries
             )
         snapshot.match("error_response", e.value.response)
 
     @markers.aws.validated
-    def test_create_and_send_to_fifo_queue(self, sqs_create_queue, aws_client):
+    def test_create_and_send_to_fifo_queue(self, sqs_create_queue, aws_sqs_client):
         # Old name: test_create_fifo_queue
         queue_name = f"queue-{short_uid()}.fifo"
         attributes = {"FifoQueue": "true"}
@@ -2285,14 +2312,14 @@ class TestSqsProvider:
         # it should preserve .fifo in the queue name
         assert queue_name in queue_url
 
-        message_id = aws_client.sqs.send_message(
+        message_id = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="test",
             MessageDeduplicationId=f"dedup-{short_uid()}",
             MessageGroupId="test_group",
         )["MessageId"]
 
-        result_recv = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_recv = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert result_recv["Messages"][0]["MessageId"] == message_id
 
     @markers.aws.validated
@@ -2314,7 +2341,7 @@ class TestSqsProvider:
     @pytest.mark.xfail
     @markers.aws.validated
     def test_redrive_policy_attribute_validity(
-        self, sqs_create_queue, sqs_get_queue_arn, aws_client
+        self, sqs_create_queue, sqs_get_queue_arn, aws_sqs_client
     ):
         dl_queue_name = f"dl-queue-{short_uid()}"
         dl_queue_url = sqs_create_queue(QueueName=dl_queue_name)
@@ -2325,14 +2352,14 @@ class TestSqsProvider:
         invalid_max_receive_count = "invalid"
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=queue_url,
                 Attributes={"RedrivePolicy": json.dumps({"deadLetterTargetArn": dl_target_arn})},
             )
         e.match("InvalidParameterValue")
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=queue_url,
                 Attributes={
                     "RedrivePolicy": json.dumps({"maxReceiveCount": valid_max_receive_count})
@@ -2346,7 +2373,7 @@ class TestSqsProvider:
         }
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=queue_url,
                 Attributes={"RedrivePolicy": json.dumps(_invalid_redrive_policy)},
             )
@@ -2357,7 +2384,7 @@ class TestSqsProvider:
             "maxReceiveCount": valid_max_receive_count,
         }
 
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=queue_url, Attributes={"RedrivePolicy": json.dumps(_valid_redrive_policy)}
         )
 
@@ -2376,55 +2403,55 @@ class TestSqsProvider:
         snapshot.match("error_response", e.value.response)
 
     @markers.aws.validated
-    def test_set_queue_policy(self, sqs_create_queue, aws_client):
+    def test_set_queue_policy(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
         attributes = {"Policy": TEST_POLICY}
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
 
         # accessing the policy generally and specifically
-        attributes = aws_client.sqs.get_queue_attributes(
+        attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["All"]
         )["Attributes"]
         policy = json.loads(attributes["Policy"])
         assert "sqs:SendMessage" == policy["Statement"][0]["Action"]
-        attributes = aws_client.sqs.get_queue_attributes(
+        attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["Policy"]
         )["Attributes"]
         policy = json.loads(attributes["Policy"])
         assert "sqs:SendMessage" == policy["Statement"][0]["Action"]
 
     @markers.aws.validated
-    def test_set_empty_queue_policy(self, sqs_create_queue, aws_client):
+    def test_set_empty_queue_policy(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
         attributes = {"Policy": ""}
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
 
-        attributes = aws_client.sqs.get_queue_attributes(
+        attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["All"]
         )["Attributes"]
         assert "Policy" not in attributes.keys()
 
         # check if this behaviour holds on existing Policies as well
         attributes = {"Policy": TEST_POLICY}
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
-        attributes = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["All"]
         )["Attributes"]
         assert "sqs:SendMessage" in attributes["Policy"]
 
         attributes = {"Policy": ""}
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
-        attributes = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["All"]
         )["Attributes"]
         assert "Policy" not in attributes.keys()
 
     @markers.aws.validated
-    def test_send_message_with_attributes(self, sqs_create_queue, aws_client):
+    def test_send_message_with_attributes(self, sqs_create_queue, aws_sqs_client):
         # Old name: test_send_message_attributes
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -2433,11 +2460,11 @@ class TestSqsProvider:
             "attr1": {"StringValue": "test1", "DataType": "String"},
             "attr2": {"StringValue": "test2", "DataType": "String"},
         }
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="test", MessageAttributes=attributes
         )
 
-        result_receive = aws_client.sqs.receive_message(
+        result_receive = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MessageAttributeNames=["All"]
         )
         messages = result_receive["Messages"]
@@ -2447,7 +2474,7 @@ class TestSqsProvider:
         assert messages[0]["MD5OfMessageAttributes"] == result_send["MD5OfMessageAttributes"]
 
     @markers.aws.validated
-    def test_send_message_with_binary_attributes(self, sqs_create_queue, snapshot, aws_client):
+    def test_send_message_with_binary_attributes(self, sqs_create_queue, snapshot, aws_sqs_client):
         # Old name: test_send_message_attributes
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -2458,11 +2485,11 @@ class TestSqsProvider:
                 "DataType": "Binary",
             },
         }
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="test", MessageAttributes=attributes
         )
 
-        result_receive = aws_client.sqs.receive_message(
+        result_receive = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MessageAttributeNames=["All"]
         )
         messages = result_receive["Messages"]
@@ -2473,29 +2500,30 @@ class TestSqsProvider:
         assert messages[0]["MD5OfMessageAttributes"] == result_send["MD5OfMessageAttributes"]
 
     @markers.aws.validated
-    def test_sent_message_retains_attributes_after_receive(self, sqs_create_queue, aws_client):
+    def test_sent_message_retains_attributes_after_receive(self, sqs_create_queue, aws_sqs_client):
         # Old name: test_send_message_retains_attributes
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
         attributes = {"attr1": {"StringValue": "test1", "DataType": "String"}}
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="test", MessageAttributes=attributes
         )
 
         # receive should not interfere with message attributes
-        aws_client.sqs.receive_message(
+        aws_sqs_client.receive_message(
             QueueUrl=queue_url, VisibilityTimeout=0, MessageAttributeNames=["All"]
         )
-        receive_result = aws_client.sqs.receive_message(
+        receive_result = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MessageAttributeNames=["All"]
         )
         assert receive_result["Messages"][0]["MessageAttributes"] == attributes
 
     @markers.aws.validated
-    def test_send_message_with_empty_string_attribute(self, sqs_queue, aws_client, snapshot):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_send_message_with_empty_string_attribute(self, sqs_queue, aws_sqs_client, snapshot):
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=sqs_queue,
                 MessageBody="test",
                 MessageAttributes={"ErrorDetails": {"StringValue": "", "DataType": "String"}},
@@ -2503,19 +2531,19 @@ class TestSqsProvider:
         snapshot.match("empty-string-attr", e.value.response)
 
     @markers.aws.validated
-    def test_send_message_with_invalid_string_attributes(self, sqs_create_queue, aws_client):
+    def test_send_message_with_invalid_string_attributes(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
         # base line against to detect general failure
         valid_attribute = {"attr.1øßä": {"StringValue": "Valida", "DataType": "String"}}
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="test", MessageAttributes=valid_attribute
         )
 
         def send_invalid(attribute):
             with pytest.raises(Exception) as e:
-                aws_client.sqs.send_message(
+                aws_sqs_client.send_message(
                     QueueUrl=queue_url, MessageBody="test", MessageAttributes=attribute
                 )
             e.match("Invalid")
@@ -2571,14 +2599,14 @@ class TestSqsProvider:
 
     @pytest.mark.xfail
     @markers.aws.unknown
-    def test_send_message_with_invalid_fifo_parameters(self, sqs_create_queue, aws_client):
+    def test_send_message_with_invalid_fifo_parameters(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(
             QueueName=fifo_queue_name,
             Attributes={"FifoQueue": "true"},
         )
         with pytest.raises(Exception) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url,
                 MessageBody="test",
                 MessageDeduplicationId=f"Invalid-{chr(8)}",
@@ -2587,7 +2615,7 @@ class TestSqsProvider:
         e.match("InvalidParameterValue")
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url,
                 MessageBody="test",
                 MessageDeduplicationId="1",
@@ -2596,13 +2624,13 @@ class TestSqsProvider:
         e.match("InvalidParameterValue")
 
     @markers.aws.validated
-    def test_send_message_with_invalid_payload_characters(self, sqs_create_queue, aws_client):
+    def test_send_message_with_invalid_payload_characters(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         invalid_message_body = f"Invalid-{chr(0)}-{chr(8)}-{chr(19)}-{chr(65535)}"
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=invalid_message_body)
+            aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=invalid_message_body)
         e.match("InvalidMessageContents")
 
     @markers.aws.validated
@@ -2625,7 +2653,7 @@ class TestSqsProvider:
         assert queue_url
 
     @markers.aws.validated
-    def test_dead_letter_queue_list_sources(self, sqs_create_queue, aws_client):
+    def test_dead_letter_queue_list_sources(self, sqs_create_queue, aws_sqs_client):
         dl_queue_url = sqs_create_queue()
         url_parts = dl_queue_url.split("/")
         region = TEST_AWS_REGION_NAME
@@ -2642,14 +2670,14 @@ class TestSqsProvider:
         assert queue_url_1
         assert queue_url_2
 
-        source_urls = aws_client.sqs.list_dead_letter_source_queues(QueueUrl=dl_queue_url)
+        source_urls = aws_sqs_client.list_dead_letter_source_queues(QueueUrl=dl_queue_url)
         assert len(source_urls) == 2
         assert queue_url_1 in source_urls["queueUrls"]
         assert queue_url_2 in source_urls["queueUrls"]
 
     @markers.aws.validated
     def test_dead_letter_queue_with_fifo_and_content_based_deduplication(
-        self, sqs_create_queue, sqs_get_queue_arn, aws_client
+        self, sqs_create_queue, sqs_get_queue_arn, aws_sqs_client
     ):
         dlq_url = sqs_create_queue(
             QueueName=f"test-dlq-{short_uid()}.fifo",
@@ -2671,19 +2699,19 @@ class TestSqsProvider:
             },
         )
 
-        response = aws_client.sqs.send_message(
+        response = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="foobar", MessageGroupId="1"
         )
         message_id = response["MessageId"]
 
         # receive the messages twice, which is the maximum allowed
-        aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
-        aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
+        aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
+        aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
         # after this receive call the message should be in the DLQ
-        aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
+        aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
 
         # check the DLQ
-        response = aws_client.sqs.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        response = aws_sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
         assert (
             len(response["Messages"]) == 1
         ), f"invalid number of messages in DLQ response {response}"
@@ -2692,7 +2720,7 @@ class TestSqsProvider:
         assert message["Body"] == "foobar"
 
     @markers.aws.validated
-    def test_dead_letter_queue_max_receive_count(self, sqs_create_queue, aws_client):
+    def test_dead_letter_queue_max_receive_count(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         dead_letter_queue_name = f"dl-queue-{short_uid()}"
         dl_queue_url = sqs_create_queue(
@@ -2712,23 +2740,23 @@ class TestSqsProvider:
             QueueName=queue_name,
             Attributes={"RedrivePolicy": json.dumps(policy), "VisibilityTimeout": "0"},
         )
-        result_send = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
+        result_send = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
 
-        result_recv1_messages = aws_client.sqs.receive_message(QueueUrl=queue_url)["Messages"]
-        result_recv2_messages = aws_client.sqs.receive_message(QueueUrl=queue_url)["Messages"]
+        result_recv1_messages = aws_sqs_client.receive_message(QueueUrl=queue_url).get("Messages")
+        result_recv2_messages = aws_sqs_client.receive_message(QueueUrl=queue_url).get("Messages")
         # only one request received a message
         assert result_recv1_messages != result_recv2_messages
 
         assert poll_condition(
-            lambda: aws_client.sqs.receive_message(QueueUrl=dl_queue_url)["Messages"], 5.0, 1.0
+            lambda: aws_sqs_client.receive_message(QueueUrl=dl_queue_url)["Messages"], 5.0, 1.0
         )
         assert (
-            aws_client.sqs.receive_message(QueueUrl=dl_queue_url)["Messages"][0]["MessageId"]
+            aws_sqs_client.receive_message(QueueUrl=dl_queue_url)["Messages"][0]["MessageId"]
             == result_send["MessageId"]
         )
 
     @markers.aws.needs_fixing
-    def test_dead_letter_queue_chain(self, sqs_create_queue, aws_client):
+    def test_dead_letter_queue_chain(self, sqs_create_queue, aws_sqs_client):
         # test a chain of 3 queues, with DLQ flow q1 -> q2 -> q3
 
         # create queues
@@ -2749,34 +2777,34 @@ class TestSqsProvider:
                 ),
                 "maxReceiveCount": 1,
             }
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=queue_urls[idx],
                 Attributes={"RedrivePolicy": json.dumps(policy), "VisibilityTimeout": "0"},
             )
 
         def _retry_receive(q_url):
             def _receive():
-                _result = aws_client.sqs.receive_message(QueueUrl=q_url)
+                _result = aws_sqs_client.receive_message(QueueUrl=q_url)
                 assert _result.get("Messages")
                 return _result
 
             return retry(_receive, sleep=1, retries=5)
 
         # send message
-        result = aws_client.sqs.send_message(QueueUrl=queue_urls[0], MessageBody="test")
+        result = aws_sqs_client.send_message(QueueUrl=queue_urls[0], MessageBody="test")
         # retrieve message from q1
         result = _retry_receive(queue_urls[0])
         assert len(result.get("Messages")) == 1
         # Wait for VisibilityTimeout to expire
         time.sleep(1.1)
         # retrieve message from q1 again -> no message, should go to DLQ q2
-        result = aws_client.sqs.receive_message(QueueUrl=queue_urls[0])
+        result = aws_sqs_client.receive_message(QueueUrl=queue_urls[0])
         assert not result.get("Messages")
         # retrieve message from q2
         result = _retry_receive(queue_urls[1])
         assert len(result.get("Messages")) == 1
         # retrieve message from q2 again -> no message, should go to DLQ q3
-        result = aws_client.sqs.receive_message(QueueUrl=queue_urls[1])
+        result = aws_sqs_client.receive_message(QueueUrl=queue_urls[1])
         assert not result.get("Messages")
         # retrieve message from q3
         result = _retry_receive(queue_urls[2])
@@ -2785,13 +2813,13 @@ class TestSqsProvider:
     # TODO: check if test_set_queue_attribute_at_creation == test_create_queue_with_attributes
 
     @markers.aws.validated
-    def test_get_specific_queue_attribute_response(self, sqs_create_queue, aws_client):
+    def test_get_specific_queue_attribute_response(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         dead_letter_queue_name = f"dead_letter_queue-{short_uid()}"
 
         dl_queue_url = sqs_create_queue(QueueName=dead_letter_queue_name)
         region = TEST_AWS_REGION_NAME
-        dl_result = aws_client.sqs.get_queue_attributes(
+        dl_result = aws_sqs_client.get_queue_attributes(
             QueueUrl=dl_queue_url, AttributeNames=["QueueArn"]
         )
 
@@ -2811,11 +2839,11 @@ class TestSqsProvider:
 
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
         url_parts = queue_url.split("/")
-        get_two_attributes = aws_client.sqs.get_queue_attributes(
+        get_two_attributes = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url,
             AttributeNames=["MessageRetentionPeriod", "RedrivePolicy"],
         )
-        get_single_attribute = aws_client.sqs.get_queue_attributes(
+        get_single_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url,
             AttributeNames=["QueueArn"],
         )
@@ -2832,12 +2860,12 @@ class TestSqsProvider:
 
     @pytest.mark.xfail
     @markers.aws.validated
-    def test_set_unsupported_attribute_fifo(self, sqs_create_queue, aws_client, snapshot):
+    def test_set_unsupported_attribute_fifo(self, sqs_create_queue, aws_sqs_client, snapshot):
         # TODO: behaviour diverges from AWS
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=queue_url, Attributes={"FifoQueue": "true"}
             )
         snapshot.match("invalid-attr-name-1", e.value.response)
@@ -2846,18 +2874,18 @@ class TestSqsProvider:
         fifo_queue_url = sqs_create_queue(
             QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"}
         )
-        aws_client.sqs.set_queue_attributes(
+        aws_sqs_client.set_queue_attributes(
             QueueUrl=fifo_queue_url, Attributes={"FifoQueue": "true"}
         )
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.set_queue_attributes(
+            aws_sqs_client.set_queue_attributes(
                 QueueUrl=fifo_queue_url, Attributes={"FifoQueue": "false"}
             )
         snapshot.match("invalid-attr-name-2", e.value.response)
 
     @markers.aws.validated
     def test_fifo_queue_send_multiple_messages_multiple_single_receives(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(
@@ -2868,7 +2896,7 @@ class TestSqsProvider:
         group_id = f"fifo_group-{short_uid()}"
         sent_messages = []
         for i in range(message_count):
-            result = aws_client.sqs.send_message(
+            result = aws_sqs_client.send_message(
                 QueueUrl=queue_url,
                 MessageBody=f"message{i}",
                 MessageDeduplicationId=f"deduplication{i}",
@@ -2877,18 +2905,18 @@ class TestSqsProvider:
             sent_messages.append(result)
 
         for i in range(message_count):
-            result = aws_client.sqs.receive_message(QueueUrl=queue_url)
+            result = aws_sqs_client.receive_message(QueueUrl=queue_url)
             message = result["Messages"][0]
             assert message["Body"] == f"message{i}"
             assert message["MD5OfBody"] == sent_messages[i]["MD5OfMessageBody"]
             assert message["MessageId"] == sent_messages[i]["MessageId"]
-            aws_client.sqs.delete_message(
+            aws_sqs_client.delete_message(
                 QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
             )
 
     @markers.aws.validated
     def test_fifo_content_based_message_deduplication_arrives_once(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         # created for https://github.com/localstack/localstack/issues/6327
         queue_url = sqs_create_queue(
@@ -2898,18 +2926,18 @@ class TestSqsProvider:
         item = '{"foo": "bar"}'
         group = "group-1"
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=item, MessageGroupId=group)
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=item, MessageGroupId=group)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=item, MessageGroupId=group)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=item, MessageGroupId=group)
 
         # first receive has the item
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=2
         )
         assert len(response["Messages"]) == 1
         assert response["Messages"][0]["Body"] == item
 
         # second doesn't since the message has the same content
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=1
         )
         assert response.get("Messages", []) == []
@@ -2919,7 +2947,7 @@ class TestSqsProvider:
     def test_fifo_deduplication_arrives_once_after_delete(
         self,
         sqs_create_queue,
-        aws_client,
+        aws_sqs_client,
         content_based_deduplication,
         snapshot,
     ):
@@ -2935,28 +2963,28 @@ class TestSqsProvider:
         kwargs = {}
         if not content_based_deduplication:
             kwargs["MessageDeduplicationId"] = "dedup1"
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=item, MessageGroupId=group, **kwargs
         )
 
         # first receive has the item
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=3)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=3)
         snapshot.match("get-messages", response)
         assert len(response["Messages"]) == 1
         assert response["Messages"][0]["Body"] == item
         # delete the item, we want to check that we don't receive a duplicate even after deletion
         # see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
-        aws_client.sqs.delete_message(
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
         )
 
         # republish the same message
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=item, MessageGroupId=group, **kwargs
         )
 
         # second doesn't receive anything the deduplication id is the same
-        response = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        response = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert response.get("Messages", []) == []
         snapshot.match("get-messages-duplicate", response)
 
@@ -2965,7 +2993,7 @@ class TestSqsProvider:
     def test_fifo_deduplication_not_on_message_group_id(
         self,
         sqs_create_queue,
-        aws_client,
+        aws_sqs_client,
         content_based_deduplication,
         snapshot,
     ):
@@ -2981,16 +3009,16 @@ class TestSqsProvider:
         if not content_based_deduplication:
             kwargs["MessageDeduplicationId"] = "dedup1"
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=item, MessageGroupId="group-1", **kwargs
         )
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=item, MessageGroupId="group-2", **kwargs
         )
 
         # first receive has the item
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=2
         )
         assert len(response["Messages"]) == 1
@@ -2998,7 +3026,7 @@ class TestSqsProvider:
         snapshot.match("get-messages", response)
 
         # second doesn't since the message has the same content
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=1
         )
         assert response.get("Messages", []) == []
@@ -3043,7 +3071,7 @@ class TestSqsProvider:
         assert b"<ListQueuesResponse" in response.content
 
     @markers.aws.validated
-    def test_system_attributes_have_no_effect_on_attr_md5(self, sqs_create_queue, aws_client):
+    def test_system_attributes_have_no_effect_on_attr_md5(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         msg_attrs_provider = {"timestamp": {"StringValue": "1493147359900", "DataType": "Number"}}
@@ -3053,10 +3081,10 @@ class TestSqsProvider:
                 "DataType": "String",
             }
         }
-        response_send = aws_client.sqs.send_message(
+        response_send = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody="test", MessageAttributes=msg_attrs_provider
         )
-        response_send_system_attr = aws_client.sqs.send_message(
+        response_send_system_attr = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="test",
             MessageAttributes=msg_attrs_provider,
@@ -3093,7 +3121,7 @@ class TestSqsProvider:
         assert result_receive1["Messages"][0]["Body"] == result_receive2["Messages"][0]["Body"]
 
     @markers.aws.validated
-    def test_sequence_number(self, sqs_create_queue, aws_client):
+    def test_sequence_number(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         fifo_queue_url = sqs_create_queue(
             QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"}
@@ -3102,7 +3130,7 @@ class TestSqsProvider:
         dedup_id = f"fifo_dedup-{short_uid()}"
         group_id = f"fifo_group-{short_uid()}"
 
-        send_result_fifo = aws_client.sqs.send_message(
+        send_result_fifo = aws_sqs_client.send_message(
             QueueUrl=fifo_queue_url,
             MessageBody=message_content,
             MessageGroupId=group_id,
@@ -3112,29 +3140,29 @@ class TestSqsProvider:
 
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
-        send_result = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_content)
+        send_result = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_content)
         assert "SequenceNumber" not in send_result
 
     @markers.aws.validated
-    def test_fifo_sequence_number_increases(self, sqs_create_queue, aws_client):
+    def test_fifo_sequence_number_increases(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         fifo_queue_url = sqs_create_queue(
             QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"}
         )
 
-        send_result_1 = aws_client.sqs.send_message(
+        send_result_1 = aws_sqs_client.send_message(
             QueueUrl=fifo_queue_url,
             MessageBody="message-1",
             MessageGroupId="group",
             MessageDeduplicationId="m1",
         )
-        send_result_2 = aws_client.sqs.send_message(
+        send_result_2 = aws_sqs_client.send_message(
             QueueUrl=fifo_queue_url,
             MessageBody="message-2",
             MessageGroupId="group",
             MessageDeduplicationId="m2",
         )
-        send_result_3 = aws_client.sqs.send_message(
+        send_result_3 = aws_sqs_client.send_message(
             QueueUrl=fifo_queue_url,
             MessageBody="message-3",
             MessageGroupId="group",
@@ -3147,7 +3175,7 @@ class TestSqsProvider:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
     def test_posting_to_fifo_requires_deduplicationid_group_id(
-        self, sqs_create_queue, aws_client, snapshot
+        self, sqs_create_queue, aws_sqs_client, snapshot, aws_client
     ):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"})
@@ -3156,13 +3184,13 @@ class TestSqsProvider:
         group_id = f"fifo_group-{short_uid()}"
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url, MessageBody=message_content, MessageGroupId=group_id
             )
         snapshot.match("invalid-parameter-value", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url, MessageBody=message_content, MessageDeduplicationId=dedup_id
             )
         snapshot.match("missing-parameter", e.value.response)
@@ -3172,24 +3200,24 @@ class TestSqsProvider:
         # validate that the `query` protocol does not do that
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs_query.send_message(
+            aws_client.sqs.send_message(
                 QueueUrl=queue_url, MessageBody=message_content, MessageGroupId=group_id
             )
         snapshot.match("invalid-parameter-value-query", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs_query.send_message(
+            aws_client.sqs.send_message(
                 QueueUrl=queue_url, MessageBody=message_content, MessageDeduplicationId=dedup_id
             )
         snapshot.match("missing-parameter-query", e.value.response)
 
     @markers.aws.validated
-    def test_posting_to_queue_via_queue_name(self, sqs_create_queue, aws_client):
+    def test_posting_to_queue_via_queue_name(self, sqs_create_queue, aws_sqs_client):
         # TODO: behaviour diverges from AWS
         queue_name = f"queue-{short_uid()}"
         sqs_create_queue(QueueName=queue_name)
 
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_name, MessageBody="Using name instead of URL"
         )
         assert result_send["MD5OfMessageBody"] == "86a83f96652a1bfad3891e7d523750cb"
@@ -3197,7 +3225,7 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_invalid_string_attributes_cause_invalid_parameter_value_error(
-        self, sqs_create_queue, aws_client
+        self, sqs_create_queue, aws_sqs_client
     ):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -3207,35 +3235,34 @@ class TestSqsProvider:
         }
 
         with pytest.raises(Exception) as e:
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url, MessageBody="test", MessageAttributes=invalid_attribute
             )
         e.match("InvalidParameterValue")
 
     @markers.aws.validated
-    def test_change_message_visibility_not_permanent(self, sqs_create_queue, aws_client):
+    def test_change_message_visibility_not_permanent(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
-        result_receive = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        result_receive = aws_sqs_client.receive_message(QueueUrl=queue_url)
         receipt_handle = result_receive.get("Messages")[0]["ReceiptHandle"]
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=queue_url, ReceiptHandle=receipt_handle, VisibilityTimeout=0
         )
-        result_recv_1 = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        result_recv_2 = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_recv_1 = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        result_recv_2 = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert (
             result_recv_1.get("Messages")[0]["MessageId"]
             == result_receive.get("Messages")[0]["MessageId"]
         )
-        assert "Messages" in result_recv_2
-        assert result_recv_2["Messages"] == []
+        assert "Messages" not in result_recv_2 or result_recv_2["Messages"] == []
 
     @pytest.mark.skip
     @markers.aws.unknown
     def test_dead_letter_queue_execution_lambda_mapping_preserves_id(
-        self, sqs_create_queue, create_lambda_function, aws_client
+        self, sqs_create_queue, create_lambda_function, aws_sqs_client
     ):
         # TODO: lambda triggered dead letter delivery does not preserve the message id
         # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
@@ -3266,62 +3293,61 @@ class TestSqsProvider:
         queue_arn = "arn:aws:sqs:{}:{}:{}".format(
             region, url_parts[len(url_parts) - 2], url_parts[-1]
         )
-        aws_client.lambda_.create_event_source_mapping(
+        aws_sqs_client.lambda_.create_event_source_mapping(
             EventSourceArn=queue_arn, FunctionName=lambda_name
         )
 
         # add message to SQS, which will trigger the Lambda, resulting in an error
         payload = {lambda_integration.MSG_BODY_RAISE_ERROR_FLAG: 1}
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_url, MessageBody=json.dumps(payload)
         )
 
         assert poll_condition(
             lambda: "Messages"
-            in aws_client.sqs.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0),
+            in aws_sqs_client.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0),
             5.0,
             1.0,
         )
-        result_recv = aws_client.sqs.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0)
+        result_recv = aws_sqs_client.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0)
         assert result_recv["Messages"][0]["MessageId"] == result_send["MessageId"]
 
     @markers.aws.validated
-    def test_message_with_carriage_return(self, sqs_create_queue, aws_client):
+    def test_message_with_carriage_return(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         message_content = "{\r\n" + '"machineID" : "d357006e26ff47439e1ef894225d4307"' + "}"
-        result_send = aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_content)
-        result_receive = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_send = aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_content)
+        result_receive = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert result_send["MD5OfMessageBody"] == result_receive["Messages"][0]["MD5OfBody"]
         assert message_content == result_receive["Messages"][0]["Body"]
 
     @markers.aws.validated
-    def test_purge_queue(self, sqs_create_queue, aws_client):
+    def test_purge_queue(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         for i in range(3):
             message_content = f"test-0-{i}"
-            aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_content)
-        approx_nr_of_messages = aws_client.sqs.get_queue_attributes(
+            aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_content)
+        approx_nr_of_messages = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
         )
         assert int(approx_nr_of_messages["Attributes"]["ApproximateNumberOfMessages"]) > 1
 
-        aws_client.sqs.purge_queue(QueueUrl=queue_url)
+        aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        assert "Messages" in receive_result
-        assert receive_result["Messages"] == []
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        assert "Messages" not in receive_result or receive_result["Messages"] == []
 
         # test that adding messages after purge works
         for i in range(3):
             message_content = f"test-1-{i}"
-            aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=message_content)
+            aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_content)
 
         messages = []
 
         def _collect():
-            result = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+            result = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
             messages.extend(result.get("Messages", []))
             return len(messages) == 3
 
@@ -3329,68 +3355,66 @@ class TestSqsProvider:
         assert {m["Body"] for m in messages} == {"test-1-0", "test-1-1", "test-1-2"}
 
     @markers.aws.validated
-    def test_purge_queue_deletes_inflight_messages(self, sqs_create_queue, aws_client):
+    def test_purge_queue_deletes_inflight_messages(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         for i in range(10):
-            aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+            aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
 
-        response = aws_client.sqs.receive_message(
+        response = aws_sqs_client.receive_message(
             QueueUrl=queue_url, VisibilityTimeout=3, WaitTimeSeconds=5, MaxNumberOfMessages=5
         )
         assert "Messages" in response
 
-        aws_client.sqs.purge_queue(QueueUrl=queue_url)
+        aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
         # wait for visibility timeout to expire
         time.sleep(3)
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
-        assert "Messages" in receive_result
-        assert receive_result["Messages"] == []
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert "Messages" not in receive_result or receive_result["Messages"] == []
 
     @markers.aws.validated
-    def test_purge_queue_deletes_delayed_messages(self, sqs_create_queue, aws_client):
+    def test_purge_queue_deletes_delayed_messages(self, sqs_create_queue, aws_sqs_client):
         queue_url = sqs_create_queue()
 
         for i in range(5):
-            aws_client.sqs.send_message(
+            aws_sqs_client.send_message(
                 QueueUrl=queue_url, MessageBody=f"message-{i}", DelaySeconds=2
             )
 
-        aws_client.sqs.purge_queue(QueueUrl=queue_url)
+        aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
         # wait for delay to expire
         time.sleep(2)
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
-        assert "Messages" in receive_result
-        assert receive_result["Messages"] == []
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert "Messages" not in receive_result or receive_result["Messages"] == []
 
     @markers.aws.validated
-    def test_purge_queue_clears_fifo_deduplication_cache(self, sqs_create_queue, aws_client):
+    def test_purge_queue_clears_fifo_deduplication_cache(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"test-queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"})
         dedup_id = f"fifo_dedup-{short_uid()}"
         group_id = f"fifo_group-{short_uid()}"
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="message-1",
             MessageGroupId=group_id,
             MessageDeduplicationId=dedup_id,
         )
 
-        aws_client.sqs.purge_queue(QueueUrl=queue_url)
+        aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="message-2",
             MessageGroupId=group_id,
             MessageDeduplicationId=dedup_id,
         )
 
-        receive_result = aws_client.sqs.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
 
         assert len(receive_result["Messages"]) == 1
         message = receive_result["Messages"][0]
@@ -3398,40 +3422,36 @@ class TestSqsProvider:
         assert message["Body"] == "message-2"
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$.purge-error-code-query.Error.Detail"])
-    def test_successive_purge_calls_fail(self, sqs_create_queue, monkeypatch, snapshot, aws_client):
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_successive_purge_calls_fail(
+        self, sqs_create_queue, monkeypatch, snapshot, aws_sqs_client, aws_client
+    ):
         monkeypatch.setattr(config, "SQS_DELAY_PURGE_RETRY", True)
         queue_name = f"test-queue-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(queue_name, "<queue-name>"))
 
         queue_url = sqs_create_queue(QueueName=queue_name)
 
-        aws_client.sqs.purge_queue(QueueUrl=queue_url)
+        aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.purge_queue(QueueUrl=queue_url)
+            aws_sqs_client.purge_queue(QueueUrl=queue_url)
 
         snapshot.match("purge_queue_error", e.value.response)
 
-        # PurgeQueueInProgress has had its status code removed from the specs, validate that we still return it
-        with pytest.raises(ClientError) as e:
-            aws_client.sqs_query.purge_queue(QueueUrl=queue_url)
-
-        snapshot.match("purge-error-code-query", e.value.response)
-
     @markers.aws.validated
-    def test_remove_message_with_old_receipt_handle(self, sqs_create_queue, aws_client):
+    def test_remove_message_with_old_receipt_handle(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
-        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="test")
-        result_receive = aws_client.sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=1)
+        aws_sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        result_receive = aws_sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=1)
         time.sleep(2)
         receipt_handle = result_receive["Messages"][0]["ReceiptHandle"]
-        aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
+        aws_sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
         # This is more suited to the check than receiving because it simply
         # returns the number of elements in the queue, without further logic
-        approx_nr_of_messages = aws_client.sqs.get_queue_attributes(
+        approx_nr_of_messages = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
         )
         assert int(approx_nr_of_messages["Attributes"]["ApproximateNumberOfMessages"]) == 0
@@ -3549,7 +3569,7 @@ class TestSqsProvider:
         reason="this is an AWS behaviour test that requires 5 minutes to run. Only execute manually"
     )
     @markers.aws.unknown
-    def test_deduplication_interval(self, sqs_create_queue, aws_client):
+    def test_deduplication_interval(self, sqs_create_queue, aws_sqs_client):
         # TODO: AWS behaviour here "seems" inconsistent -> current code might need adaption
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(QueueName=fifo_queue_name, Attributes={"FifoQueue": "true"})
@@ -3558,24 +3578,24 @@ class TestSqsProvider:
         message_content_half_time = f"{message_content}-half_time"
         dedup_id = f"fifo_dedup-{short_uid()}"
         group_id = f"fifo_group-{short_uid()}"
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody=message_content,
             MessageGroupId=group_id,
             MessageDeduplicationId=dedup_id,
         )
         time.sleep(3)
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody=message_content_duplicate,
             MessageGroupId=group_id,
             MessageDeduplicationId=dedup_id,
         )
-        result_receive = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        aws_client.sqs.delete_message(
+        result_receive = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=result_receive["Messages"][0]["ReceiptHandle"]
         )
-        result_receive_duplicate = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_receive_duplicate = aws_sqs_client.receive_message(QueueUrl=queue_url)
 
         assert result_send.get("MessageId") == result_receive.get("Messages")[0].get("MessageId")
         assert result_send.get("MD5OfMessageBody") == result_receive.get("Messages")[0].get(
@@ -3584,7 +3604,7 @@ class TestSqsProvider:
         assert "Messages" in result_receive_duplicate
         assert result_receive_duplicate["Messages"] == []
 
-        result_send = aws_client.sqs.send_message(
+        result_send = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody=message_content,
             MessageGroupId=group_id,
@@ -3595,7 +3615,7 @@ class TestSqsProvider:
         # We give it a bit of leeway to avoid timing issues
         # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
         time.sleep(2)
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody=message_content_half_time,
             MessageGroupId=group_id,
@@ -3603,17 +3623,17 @@ class TestSqsProvider:
         )
         time.sleep(6 * 60)
 
-        result_send_duplicate = aws_client.sqs.send_message(
+        result_send_duplicate = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody=message_content_duplicate,
             MessageGroupId=group_id,
             MessageDeduplicationId=dedup_id,
         )
-        result_receive = aws_client.sqs.receive_message(QueueUrl=queue_url)
-        aws_client.sqs.delete_message(
+        result_receive = aws_sqs_client.receive_message(QueueUrl=queue_url)
+        aws_sqs_client.delete_message(
             QueueUrl=queue_url, ReceiptHandle=result_receive["Messages"][0]["ReceiptHandle"]
         )
-        result_receive_duplicate = aws_client.sqs.receive_message(QueueUrl=queue_url)
+        result_receive_duplicate = aws_sqs_client.receive_message(QueueUrl=queue_url)
 
         assert result_send.get("MessageId") == result_receive.get("Messages")[0].get("MessageId")
         assert result_send.get("MD5OfMessageBody") == result_receive.get("Messages")[0].get(
@@ -3627,7 +3647,7 @@ class TestSqsProvider:
         )[0].get("MD5OfBody")
 
     @markers.aws.validated
-    def test_sse_queue_attributes(self, sqs_create_queue, snapshot, aws_client):
+    def test_sse_queue_attributes(self, sqs_create_queue, snapshot, aws_sqs_client):
         # KMS server-side encryption (SSE)
         queue_url = sqs_create_queue()
         attributes = {
@@ -3635,8 +3655,8 @@ class TestSqsProvider:
             "KmsDataKeyReusePeriodSeconds": "6000",
             "SqsManagedSseEnabled": "false",
         }
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
-        response = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        response = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url,
             AttributeNames=[
                 "KmsMasterKeyId",
@@ -3651,8 +3671,8 @@ class TestSqsProvider:
         attributes = {
             "SqsManagedSseEnabled": "true",
         }
-        aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
-        response = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        response = aws_sqs_client.get_queue_attributes(
             QueueUrl=queue_url,
             AttributeNames=[
                 "KmsMasterKeyId",
@@ -3664,7 +3684,9 @@ class TestSqsProvider:
 
     @pytest.mark.xfail(reason="validation currently not implemented in localstack")
     @markers.aws.validated
-    def test_sse_kms_and_sqs_are_mutually_exclusive(self, sqs_create_queue, snapshot, aws_client):
+    def test_sse_kms_and_sqs_are_mutually_exclusive(
+        self, sqs_create_queue, snapshot, aws_sqs_client
+    ):
         queue_url = sqs_create_queue()
         attributes = {
             "KmsMasterKeyId": "testKeyId",
@@ -3672,7 +3694,7 @@ class TestSqsProvider:
         }
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+            aws_sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
 
         snapshot.match("error", e.value)
 
@@ -3685,7 +3707,7 @@ class TestSqsProvider:
         ]
     )
     def test_receive_message_message_attribute_names_filters(
-        self, sqs_create_queue, snapshot, aws_client
+        self, sqs_create_queue, snapshot, aws_sqs_client
     ):
         """
         Receive message allows a list of filters to be passed with MessageAttributeNames. See:
@@ -3693,7 +3715,7 @@ class TestSqsProvider:
         """
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
 
-        response = aws_client.sqs.send_message(
+        response = aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="msg",
             MessageAttributes={
@@ -3705,7 +3727,7 @@ class TestSqsProvider:
         assert snapshot.match("send_message_response", response)
 
         def receive_message(message_attribute_names):
-            return aws_client.sqs.receive_message(
+            return aws_sqs_client.receive_message(
                 QueueUrl=queue_url,
                 WaitTimeSeconds=5,
                 MessageAttributeNames=message_attribute_names,
@@ -3752,13 +3774,15 @@ class TestSqsProvider:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SenderId"])
-    def test_receive_message_attribute_names_filters(self, sqs_create_queue, snapshot, aws_client):
+    def test_receive_message_attribute_names_filters(
+        self, sqs_create_queue, snapshot, aws_sqs_client
+    ):
         # TODO -> senderId in LS == account ID, but on AWS it looks quite different: [A-Z]{21}:<email>
         # account id is replaced with higher priority
 
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
 
-        aws_client.sqs.send_message(
+        aws_sqs_client.send_message(
             QueueUrl=queue_url,
             MessageBody="msg",
             MessageAttributes={
@@ -3767,7 +3791,7 @@ class TestSqsProvider:
         )
 
         def receive_message(attribute_names, message_attribute_names=None):
-            return aws_client.sqs.receive_message(
+            return aws_sqs_client.receive_message(
                 QueueUrl=queue_url,
                 WaitTimeSeconds=5,
                 AttributeNames=attribute_names,
@@ -3788,23 +3812,23 @@ class TestSqsProvider:
 
     @markers.aws.validated
     def test_change_visibility_on_deleted_message_raises_invalid_parameter_value(
-        self, sqs_queue, aws_client
+        self, sqs_queue, aws_sqs_client
     ):
         # prepare the fixture
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="foo")
-        response = aws_client.sqs.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo")
+        response = aws_sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
         handle = response["Messages"][0]["ReceiptHandle"]
 
         # check that it works as expected
-        aws_client.sqs.change_message_visibility(
+        aws_sqs_client.change_message_visibility(
             QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=42
         )
 
         # delete the message, the handle becomes invalid
-        aws_client.sqs.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        aws_sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.change_message_visibility(
+            aws_sqs_client.change_message_visibility(
                 QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=42
             )
 
@@ -3817,24 +3841,24 @@ class TestSqsProvider:
         )
 
     @markers.aws.validated
-    def test_delete_message_with_illegal_receipt_handle(self, sqs_queue, aws_client):
+    def test_delete_message_with_illegal_receipt_handle(self, sqs_queue, aws_sqs_client):
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.delete_message(QueueUrl=sqs_queue, ReceiptHandle="garbage")
+            aws_sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle="garbage")
 
         err = e.value.response["Error"]
         assert err["Code"] == "ReceiptHandleIsInvalid"
         assert err["Message"] == 'The input receipt handle "garbage" is not a valid receipt handle.'
 
     @markers.aws.validated
-    def test_delete_message_with_deleted_receipt_handle(self, sqs_queue, aws_client):
-        aws_client.sqs.send_message(QueueUrl=sqs_queue, MessageBody="foo")
-        response = aws_client.sqs.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
+    def test_delete_message_with_deleted_receipt_handle(self, sqs_queue, aws_sqs_client):
+        aws_sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo")
+        response = aws_sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
         handle = response["Messages"][0]["ReceiptHandle"]
 
         # does not raise errors even after successive calls
-        aws_client.sqs.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
-        aws_client.sqs.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
-        aws_client.sqs.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        aws_sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        aws_sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        aws_sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
 
     # TODO: test message attributes and message system attributes
 
@@ -3849,8 +3873,9 @@ class TestSqsProvider:
         snapshot.add_transformer(GenericTransformer(_remove_error_details))
 
     @markers.aws.validated
-    def test_sqs_permission_lifecycle(self, sqs_queue, aws_client, snapshot, account_id):
-        add_permission_response = aws_client.sqs.add_permission(
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
+    def test_sqs_permission_lifecycle(self, sqs_queue, aws_sqs_client, snapshot, account_id):
+        add_permission_response = aws_sqs_client.add_permission(
             QueueUrl=sqs_queue,
             AWSAccountIds=[account_id, "668614515564"],
             Actions=["ReceiveMessage"],
@@ -3858,7 +3883,7 @@ class TestSqsProvider:
         )
         snapshot.match("add-permission-response", add_permission_response)
 
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         # the order of the Principal.AWS field does not seem to set. Manually sort it by the hard-coded one, to not have
@@ -3871,24 +3896,24 @@ class TestSqsProvider:
         get_queue_policy_attribute["Attributes"]["Policy"] = json.dumps(get_policy)
 
         snapshot.match("get-queue-policy-attribute", get_queue_policy_attribute)
-        remove_permission_response = aws_client.sqs.remove_permission(
+        remove_permission_response = aws_sqs_client.remove_permission(
             QueueUrl=sqs_queue,
             Label="crossaccountpermission",
         )
         snapshot.match("remove-permission-response", remove_permission_response)
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         snapshot.match("get-queue-policy-attribute-after-removal", get_queue_policy_attribute)
 
         # test two permissions with the same label
-        aws_client.sqs.add_permission(
+        aws_sqs_client.add_permission(
             QueueUrl=sqs_queue,
             AWSAccountIds=[account_id],
             Actions=["ReceiveMessage"],
             Label="crossaccountpermission",
         )
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         snapshot.match(
@@ -3896,7 +3921,7 @@ class TestSqsProvider:
         )
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.add_permission(
+            aws_sqs_client.add_permission(
                 QueueUrl=sqs_queue,
                 AWSAccountIds=["668614515564"],
                 Actions=["ReceiveMessage"],
@@ -3904,36 +3929,36 @@ class TestSqsProvider:
             )
         snapshot.match("get-queue-policy-attribute-second-account-same-label", e.value.response)
 
-        aws_client.sqs.add_permission(
+        aws_sqs_client.add_permission(
             QueueUrl=sqs_queue,
             AWSAccountIds=[account_id],
             Actions=["ReceiveMessage"],
             Label="crossaccountpermission2",
         )
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         snapshot.match(
             "get-queue-policy-attribute-second-account-different-label", get_queue_policy_attribute
         )
 
-        aws_client.sqs.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission")
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission")
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         snapshot.match(
             "get-queue-policy-attribute-delete-first-permission", get_queue_policy_attribute
         )
 
-        aws_client.sqs.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission2")
-        get_queue_policy_attribute = aws_client.sqs.get_queue_attributes(
+        aws_sqs_client.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission2")
+        get_queue_policy_attribute = aws_sqs_client.get_queue_attributes(
             QueueUrl=sqs_queue, AttributeNames=["Policy"]
         )
         snapshot.match(
             "get-queue-policy-attribute-delete-second-permission", get_queue_policy_attribute
         )
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission2")
+            aws_sqs_client.remove_permission(QueueUrl=sqs_queue, Label="crossaccountpermission2")
         snapshot.match("get-queue-policy-attribute-delete-non-existent-label", e.value.response)
 
     @markers.aws.validated
@@ -3941,20 +3966,20 @@ class TestSqsProvider:
     def test_non_existent_queue(self, aws_client, sqs_create_queue, sqs_queue_exists, snapshot):
         queue_name = f"test-queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        aws_client.sqs_json.delete_queue(QueueUrl=queue_url)
         assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs.get_queue_attributes(QueueUrl=queue_url)
+            aws_client.sqs_json.get_queue_attributes(QueueUrl=queue_url)
         snapshot.match("queue-does-not-exist", e.value.response)
 
         # validate both the client exception handling in boto and GetQueueUrl
-        with pytest.raises(aws_client.sqs.exceptions.QueueDoesNotExist) as e:
-            aws_client.sqs.get_queue_url(QueueName=queue_name)
+        with pytest.raises(aws_client.sqs_json.exceptions.QueueDoesNotExist) as e:
+            aws_client.sqs_json.get_queue_url(QueueName=queue_name)
         snapshot.match("queue-does-not-exist-url", e.value.response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.sqs_query.get_queue_attributes(QueueUrl=queue_url)
+            aws_client.sqs.get_queue_attributes(QueueUrl=queue_url)
         snapshot.match("queue-does-not-exist-query", e.value.response)
 
 
@@ -4157,11 +4182,11 @@ class TestSqsQueryApi:
 
     @markers.aws.validated
     def test_get_on_deleted_queue_fails(
-        self, sqs_create_queue, sqs_http_client, sqs_queue_exists, aws_client
+        self, sqs_create_queue, sqs_http_client, sqs_queue_exists, aws_sqs_client
     ):
         queue_url = sqs_create_queue()
 
-        aws_client.sqs.delete_queue(QueueUrl=queue_url)
+        aws_sqs_client.delete_queue(QueueUrl=queue_url)
 
         assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
 
@@ -4418,7 +4443,7 @@ class TestSqsQueryApi:
         # protocol should target the root path
         sqs_client = aws_client_factory(
             endpoint_url=queue_url,
-        ).sqs
+        ).sqs_json
 
         response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
         assert (
@@ -4487,10 +4512,10 @@ class TestSQSMultiAccounts:
 
     @markers.aws.only_localstack
     def test_delete_queue_multi_account(
-        self, aws_client, secondary_aws_client, aws_http_client_factory, cleanups
+        self, aws_sqs_client, secondary_aws_client, aws_http_client_factory, cleanups
     ):
         # set up regular boto clients for creating the queues
-        client1 = aws_client.sqs
+        client1 = aws_sqs_client
         client2 = secondary_aws_client.sqs
 
         # set up the queues in the two accounts

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -1,6 +1,1819 @@
 {
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters": {
-    "recorded-date": "14-11-2023, 12:00:14",
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_max_number_of_messages[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:19",
+    "recorded-content": {
+      "send_max_number_of_messages": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value 11 for parameter MaxNumberOfMessages is invalid. Reason: Must be between 1 and 10, if provided.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_max_number_of_messages[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:20",
+    "recorded-content": {
+      "send_max_number_of_messages": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value 11 for parameter MaxNumberOfMessages is invalid. Reason: Must be between 1 and 10, if provided.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_oversized_message[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:31",
+    "recorded-content": {
+      "send_oversized_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_oversized_message[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:33",
+    "recorded-content": {
+      "send_oversized_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_updated_maximum_message_size[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:34",
+    "recorded-content": {
+      "send_oversized_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 1024 bytes.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_updated_maximum_message_size[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:35",
+    "recorded-content": {
+      "send_oversized_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 1024 bytes.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:37",
+    "recorded-content": {
+      "send_oversized_message_batch": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.BatchRequestTooLong",
+          "Detail": null,
+          "Message": "Batch requests cannot be longer than 262144 bytes. You have sent 262145 bytes.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:38",
+    "recorded-content": {
+      "send_oversized_message_batch": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.BatchRequestTooLong",
+          "Message": "Batch requests cannot be longer than 262144 bytes. You have sent 262145 bytes.",
+          "QueryErrorCode": "BatchRequestTooLong",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:39",
+    "recorded-content": {
+      "send_oversized_message_batch": {
+        "Successful": [
+          {
+            "Id": "1",
+            "MD5OfMessageAttributes": "a45daa70926828a2f0a1db3418e6feb4",
+            "MD5OfMessageBody": "f44facf5a7ee0af446ecf3e0f854441e",
+            "MessageId": "<uuid:1>"
+          },
+          {
+            "Id": "2",
+            "MD5OfMessageBody": "0cc175b9c0f1b6a831c399e269772661",
+            "MessageId": "<uuid:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:39",
+    "recorded-content": {
+      "send_oversized_message_batch": {
+        "Successful": [
+          {
+            "Id": "1",
+            "MD5OfMessageAttributes": "a45daa70926828a2f0a1db3418e6feb4",
+            "MD5OfMessageBody": "f44facf5a7ee0af446ecf3e0f854441e",
+            "MessageId": "<uuid:1>"
+          },
+          {
+            "Id": "2",
+            "MD5OfMessageBody": "0cc175b9c0f1b6a831c399e269772661",
+            "MessageId": "<uuid:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_tag_untag_queue[sqs]": {
+    "recorded-date": "06-12-2023, 13:51:41",
+    "recorded-content": {
+      "get-tag-1": {
+        "Tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-tag-2": {
+        "Tags": {
+          "tag2": "value2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-tag-after-untag": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_tag_untag_queue[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:51:43",
+    "recorded-content": {
+      "get-tag-1": {
+        "Tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-tag-2": {
+        "Tags": {
+          "tag2": "value2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-tag-after-untag": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_fifo_queue_with_different_attributes_raises_error[sqs]": {
+    "recorded-date": "06-12-2023, 13:52:04",
+    "recorded-content": {
+      "queue-already-exists": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute ContentBasedDeduplication",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_fifo_queue_with_different_attributes_raises_error[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:52:04",
+    "recorded-content": {
+      "queue-already-exists": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute ContentBasedDeduplication",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception[sqs]": {
+    "recorded-date": "06-12-2023, 13:52:09",
+    "recorded-content": {
+      "create_queue_01": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create_queue_02": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:52:11",
+    "recorded-content": {
+      "create_queue_01": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create_queue_02": {
+        "Error": {
+          "Code": "QueueAlreadyExists",
+          "Detail": null,
+          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_and_update_queue_attributes[sqs]": {
+    "recorded-date": "06-12-2023, 13:52:14",
+    "recorded-content": {
+      "get_queue_attributes": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "0",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "604800",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "10",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "20"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_updated_queue_attributes": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "420",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "2048",
+          "MessageRetentionPeriod": "604800",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "10",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "69"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_and_update_queue_attributes[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:52:15",
+    "recorded-content": {
+      "get_queue_attributes": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "0",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "604800",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "10",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "20"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_updated_queue_attributes": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "CreatedTimestamp": "timestamp",
+          "DelaySeconds": "420",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "2048",
+          "MessageRetentionPeriod": "604800",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "10",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "69"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_after_visibility_timeout_expiration[sqs]": {
+    "recorded-date": "06-12-2023, 13:52:53",
+    "recorded-content": {
+      "visibility_timeout_expired": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_after_visibility_timeout_expiration[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:52:56",
+    "recorded-content": {
+      "visibility_timeout_expired": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails[sqs]": {
+    "recorded-date": "06-12-2023, 13:53:52",
+    "recorded-content": {
+      "send_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:53:52",
+    "recorded-content": {
+      "send_message": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:04",
+    "recorded-content": {
+      "send_message": {
+        "MD5OfMessageBody": "19c9e282d65f9733bc6b35d50062c7ee",
+        "MessageId": "<uuid:1>",
+        "SequenceNumber": "<sequence-number:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_0": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_1": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:05",
+    "recorded-content": {
+      "send_message": {
+        "MD5OfMessageBody": "19c9e282d65f9733bc6b35d50062c7ee",
+        "MessageId": "<uuid:1>",
+        "SequenceNumber": "<sequence-number:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_0": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_1": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_message_with_expired_receipt_handle[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:34",
+    "recorded-content": {
+      "response": {
+        "Messages": [
+          {
+            "Body": "g1-m1",
+            "MD5OfBody": "fc4286b824b39ddf3606c9f27ff664bd",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value <receipt-handle:1> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_message_with_expired_receipt_handle[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:36",
+    "recorded-content": {
+      "response": {
+        "Messages": [
+          {
+            "Body": "g1-m1",
+            "MD5OfBody": "fc4286b824b39ddf3606c9f27ff664bd",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value <receipt-handle:1> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_set_content_based_deduplication_strategy[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:37",
+    "recorded-content": {
+      "before-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "true",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "after-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_set_content_based_deduplication_strategy[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:38",
+    "recorded-content": {
+      "before-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "true",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "after-update": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_too_many_entries_in_batch_request[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:48",
+    "recorded-content": {
+      "test_too_many_entries_in_batch_request": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Detail": null,
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_too_many_entries_in_batch_request[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:48",
+    "recorded-content": {
+      "test_too_many_entries_in_batch_request": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "QueryErrorCode": "TooManyEntriesInBatchRequest",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_batch_id[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:49",
+    "recorded-content": {
+      "test_invalid_batch_id": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Detail": null,
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_batch_id[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:50",
+    "recorded-content": {
+      "test_invalid_batch_id": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "QueryErrorCode": "InvalidBatchEntryId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_deduplication_id_for_fifo_queue[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:50",
+    "recorded-content": {
+      "test_missing_deduplication_id_for_fifo_queue": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_deduplication_id_for_fifo_queue[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:51",
+    "recorded-content": {
+      "test_missing_deduplication_id_for_fifo_queue": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_message_group_id_for_fifo_queue[sqs]": {
+    "recorded-date": "06-12-2023, 13:54:51",
+    "recorded-content": {
+      "test_missing_message_group_id_for_fifo_queue": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_message_group_id_for_fifo_queue[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:54:52",
+    "recorded-content": {
+      "test_missing_message_group_id_for_fifo_queue": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-]": {
+    "recorded-date": "06-12-2023, 13:54:56",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-testLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongId]": {
+    "recorded-date": "06-12-2023, 13:54:57",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-invalid:id]": {
+    "recorded-date": "06-12-2023, 13:54:58",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs_json-]": {
+    "recorded-date": "06-12-2023, 13:54:59",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "QueryErrorCode": "InvalidBatchEntryId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs_json-testLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongId]": {
+    "recorded-date": "06-12-2023, 13:54:59",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "QueryErrorCode": "InvalidBatchEntryId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs_json-invalid:id]": {
+    "recorded-date": "06-12-2023, 13:55:00",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
+          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
+          "QueryErrorCode": "InvalidBatchEntryId",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_with_too_large_batch[sqs]": {
+    "recorded-date": "06-12-2023, 13:55:04",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_with_too_large_batch[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:55:09",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "QueryErrorCode": "TooManyEntriesInBatchRequest",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_batch_with_too_large_batch[sqs]": {
+    "recorded-date": "06-12-2023, 13:55:14",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_batch_with_too_large_batch[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:55:19",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
+          "Message": "Maximum number of entries per request are 10. You have sent 20.",
+          "QueryErrorCode": "TooManyEntriesInBatchRequest",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_dead_letter_arn_rejected_before_lookup": {
+    "recorded-date": "06-12-2023, 13:55:25",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value {\"deadLetterTargetArn\": \"dummy\", \"maxReceiveCount\": 42} for parameter RedrivePolicy is invalid. Reason: Invalid value for deadLetterTargetArn.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes[sqs]": {
+    "recorded-date": "06-12-2023, 13:55:32",
+    "recorded-content": {
+      "binary-attrs-msg": {
+        "Messages": [
+          {
+            "Body": "test",
+            "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+            "MD5OfMessageAttributes": "8cbe4db156db8a94db8b801b7addb984",
+            "MessageAttributes": {
+              "attr1": {
+                "BinaryValue": "b'traceparent\\x1e00-774062d6c37081a5a0b9b5b88e30627c-2d2482211f6489da-01'",
+                "DataType": "Binary"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:55:33",
+    "recorded-content": {
+      "binary-attrs-msg": {
+        "Messages": [
+          {
+            "Body": "test",
+            "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+            "MD5OfMessageAttributes": "8cbe4db156db8a94db8b801b7addb984",
+            "MessageAttributes": {
+              "attr1": {
+                "BinaryValue": "b'traceparent\\x1e00-774062d6c37081a5a0b9b5b88e30627c-2d2482211f6489da-01'",
+                "DataType": "Binary"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_empty_string_attribute[sqs]": {
+    "recorded-date": "06-12-2023, 13:55:35",
+    "recorded-content": {
+      "empty-string-attr": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Message (user) attribute 'ErrorDetails' must contain a non-empty value of type 'String'.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_empty_string_attribute[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:55:35",
+    "recorded-content": {
+      "empty-string-attr": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Message (user) attribute 'ErrorDetails' must contain a non-empty value of type 'String'.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_unsupported_attribute_fifo[sqs]": {
+    "recorded-date": "06-12-2023, 13:56:04",
+    "recorded-content": {
+      "invalid-attr-name-1": {
+        "Error": {
+          "Code": "InvalidAttributeName",
+          "Detail": null,
+          "Message": "Unknown Attribute FifoQueue.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-attr-name-2": {
+        "Error": {
+          "Code": "InvalidAttributeValue",
+          "Detail": null,
+          "Message": "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_unsupported_attribute_fifo[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:56:05",
+    "recorded-content": {
+      "invalid-attr-name-1": {
+        "Error": {
+          "Code": "InvalidAttributeName",
+          "Message": "Unknown Attribute FifoQueue.",
+          "QueryErrorCode": "InvalidAttributeName",
+          "Type": "Sender"
+        },
+        "message": "Unknown Attribute FifoQueue.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-attr-name-2": {
+        "Error": {
+          "Code": "InvalidAttributeValue",
+          "Message": "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported.",
+          "QueryErrorCode": "InvalidAttributeValue",
+          "Type": "Sender"
+        },
+        "message": "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[sqs-True]": {
+    "recorded-date": "06-12-2023, 13:56:18",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[sqs-False]": {
+    "recorded-date": "06-12-2023, 13:56:21",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[sqs_json-True]": {
+    "recorded-date": "06-12-2023, 13:56:23",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[sqs_json-False]": {
+    "recorded-date": "06-12-2023, 13:56:26",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-messages-duplicate": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[sqs-True]": {
+    "recorded-date": "06-12-2023, 13:56:29",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[sqs-False]": {
+    "recorded-date": "06-12-2023, 13:56:31",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[sqs_json-True]": {
+    "recorded-date": "06-12-2023, 13:56:33",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[sqs_json-False]": {
+    "recorded-date": "06-12-2023, 13:56:35",
+    "recorded-content": {
+      "get-messages": {
+        "Messages": [
+          {
+            "Body": {
+              "foo": "bar"
+            },
+            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-dedup-messages": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_posting_to_fifo_requires_deduplicationid_group_id[sqs]": {
+    "recorded-date": "06-12-2023, 13:56:49",
+    "recorded-content": {
+      "invalid-parameter-value": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-parameter": {
+        "Error": {
+          "Code": "MissingParameter",
+          "Detail": null,
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-parameter-value-query": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-parameter-query": {
+        "Error": {
+          "Code": "MissingParameter",
+          "Detail": null,
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_posting_to_fifo_requires_deduplicationid_group_id[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:56:50",
+    "recorded-content": {
+      "invalid-parameter-value": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-parameter": {
+        "Error": {
+          "Code": "MissingParameter",
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "QueryErrorCode": "MissingRequiredParameterException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-parameter-value-query": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-parameter-query": {
+        "Error": {
+          "Code": "MissingParameter",
+          "Detail": null,
+          "Message": "The request must contain the parameter MessageGroupId.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail[sqs]": {
+    "recorded-date": "04-01-2024, 10:07:25",
+    "recorded-content": {
+      "purge_queue_error": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.PurgeQueueInProgress",
+          "Detail": null,
+          "Message": "Only one PurgeQueue operation on <queue-name> is allowed every 60 seconds.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail[sqs_json]": {
+    "recorded-date": "04-01-2024, 10:07:27",
+    "recorded-content": {
+      "purge_queue_error": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.PurgeQueueInProgress",
+          "Message": "Only one PurgeQueue operation on <queue-name> is allowed every 60 seconds.",
+          "QueryErrorCode": "PurgeQueueInProgress",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_list_queues": {
+    "recorded-date": "14-11-2023, 11:57:28",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes[sqs_json]": {
+    "recorded-date": "04-01-2024, 10:07:44",
+    "recorded-content": {
+      "sse_kms_attributes": {
+        "Attributes": {
+          "KmsDataKeyReusePeriodSeconds": "6000",
+          "KmsMasterKeyId": "testKeyId",
+          "SqsManagedSseEnabled": "false"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sse_sqs_attributes": {
+        "Attributes": {
+          "SqsManagedSseEnabled": "true"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_kms_and_sqs_are_mutually_exclusive[sqs]": {
+    "recorded-date": "06-12-2023, 13:57:48",
+    "recorded-content": {
+      "error": "An error occurred (InvalidAttributeName) when calling the SetQueueAttributes operation: You can use one type of server-side encryption (SSE) at one time. You can either enable KMS SSE or SQS SSE."
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_kms_and_sqs_are_mutually_exclusive[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:57:48",
+    "recorded-content": {
+      "error": "An error occurred (InvalidAttributeName) when calling the SetQueueAttributes operation: You can use one type of server-side encryption (SSE) at one time. You can either enable KMS SSE or SQS SSE."
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters[sqs]": {
+    "recorded-date": "06-12-2023, 13:57:51",
+    "recorded-content": {
+      "send_message_response": {
+        "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+        "MD5OfMessageBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty_filter": {
+        "Messages": [
+          {
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all_name": {
+        "Messages": [
+          {
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+            "MessageAttributes": {
+              "General": {
+                "DataType": "String",
+                "StringValue": "Kenobi"
+              },
+              "Hello": {
+                "DataType": "String",
+                "StringValue": "There"
+              },
+              "Help.Me": {
+                "DataType": "String",
+                "StringValue": "Me"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all_wildcard_asterisk": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+        "MessageAttributes": {
+          "General": {
+            "DataType": "String",
+            "StringValue": "Kenobi"
+          },
+          "Hello": {
+            "DataType": "String",
+            "StringValue": "There"
+          },
+          "Help.Me": {
+            "DataType": "String",
+            "StringValue": "Me"
+          }
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:3>"
+      },
+      "all_wildcard": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+        "MessageAttributes": {
+          "General": {
+            "DataType": "String",
+            "StringValue": "Kenobi"
+          },
+          "Hello": {
+            "DataType": "String",
+            "StringValue": "There"
+          },
+          "Help.Me": {
+            "DataType": "String",
+            "StringValue": "Me"
+          }
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:4>"
+      },
+      "only_non_existing_names": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:5>"
+      },
+      "only_existing": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MD5OfMessageAttributes": "fca026605781cb4126a1e9044df24232",
+        "MessageAttributes": {
+          "General": {
+            "DataType": "String",
+            "StringValue": "Kenobi"
+          },
+          "Hello": {
+            "DataType": "String",
+            "StringValue": "There"
+          }
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:6>"
+      },
+      "existing_and_non_existing": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MD5OfMessageAttributes": "a311262e065454b75da111d535b8dacd",
+        "MessageAttributes": {
+          "Hello": {
+            "DataType": "String",
+            "StringValue": "There"
+          }
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:7>"
+      },
+      "prefix_filter": {
+        "Body": "msg",
+        "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+        "MD5OfMessageAttributes": "83fee93c1bcd8b9a5a923ffacdc636c7",
+        "MessageAttributes": {
+          "Hello": {
+            "DataType": "String",
+            "StringValue": "There"
+          },
+          "Help.Me": {
+            "DataType": "String",
+            "StringValue": "Me"
+          }
+        },
+        "MessageId": "<uuid:1>",
+        "ReceiptHandle": "<receipt-handle:8>"
+      },
+      "illegal_name_1": {
+        "Messages": [
+          {
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:9>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "illegal_name_2": {
+        "Messages": [
+          {
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:10>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:57:53",
     "recorded-content": {
       "send_message_response": {
         "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
@@ -180,8 +1993,8 @@
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters": {
-    "recorded-date": "14-11-2023, 12:00:15",
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs]": {
+    "recorded-date": "06-12-2023, 13:57:54",
     "recorded-content": {
       "all_attributes": {
         "Messages": [
@@ -266,154 +2079,20 @@
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_and_update_queue_attributes": {
-    "recorded-date": "14-11-2023, 11:57:52",
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:57:56",
     "recorded-content": {
-      "get_queue_attributes": {
-        "Attributes": {
-          "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesDelayed": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
-          "CreatedTimestamp": "timestamp",
-          "DelaySeconds": "0",
-          "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
-          "MessageRetentionPeriod": "604800",
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "ReceiveMessageWaitTimeSeconds": "10",
-          "SqsManagedSseEnabled": "true",
-          "VisibilityTimeout": "20"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_updated_queue_attributes": {
-        "Attributes": {
-          "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesDelayed": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
-          "CreatedTimestamp": "timestamp",
-          "DelaySeconds": "420",
-          "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "2048",
-          "MessageRetentionPeriod": "604800",
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "ReceiveMessageWaitTimeSeconds": "10",
-          "SqsManagedSseEnabled": "true",
-          "VisibilityTimeout": "69"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes": {
-    "recorded-date": "14-11-2023, 12:00:11",
-    "recorded-content": {
-      "sse_kms_attributes": {
-        "Attributes": {
-          "KmsDataKeyReusePeriodSeconds": "6000",
-          "KmsMasterKeyId": "testKeyId",
-          "SqsManagedSseEnabled": "false"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "sse_sqs_attributes": {
-        "Attributes": {
-          "SqsManagedSseEnabled": "true"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_kms_and_sqs_are_mutually_exclusive": {
-    "recorded-date": "14-11-2023, 12:00:12",
-    "recorded-content": {
-      "error": "An error occurred (InvalidAttributeName) when calling the SetQueueAttributes operation: You can use one type of server-side encryption (SSE) at one time. You can either enable KMS SSE or SQS SSE."
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails": {
-    "recorded-date": "14-11-2023, 11:58:29",
-    "recorded-content": {
-      "send_message": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception": {
-    "recorded-date": "14-11-2023, 11:57:50",
-    "recorded-content": {
-      "create_queue_01": {
-        "Error": {
-          "Code": "QueueAlreadyExists",
-          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
-          "QueryErrorCode": "QueueNameExists",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "create_queue_02": {
-        "Error": {
-          "Code": "QueueAlreadyExists",
-          "Message": "A queue already exists with the same name and a different value for attribute DelaySeconds",
-          "QueryErrorCode": "QueueNameExists",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes": {
-    "recorded-date": "14-11-2023, 11:58:35",
-    "recorded-content": {
-      "send_message": {
-        "MD5OfMessageBody": "19c9e282d65f9733bc6b35d50062c7ee",
-        "MessageId": "<uuid:1>",
-        "SequenceNumber": "<sequence-number:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "receive_message_0": {
+      "all_attributes": {
         "Messages": [
           {
             "Attributes": {
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "1",
-              "MessageDeduplicationId": "dedup-1",
-              "MessageGroupId": "group-1",
               "SenderId": "<sender-id:1>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
+              "SentTimestamp": "timestamp"
             },
-            "Body": "message-body-1",
-            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
             "MessageId": "<uuid:1>",
             "ReceiptHandle": "<receipt-handle:1>"
           }
@@ -423,20 +2102,24 @@
           "HTTPStatusCode": 200
         }
       },
-      "receive_message_1": {
+      "all_system_and_message_attributes": {
         "Messages": [
           {
             "Attributes": {
               "ApproximateFirstReceiveTimestamp": "timestamp",
               "ApproximateReceiveCount": "2",
-              "MessageDeduplicationId": "dedup-1",
-              "MessageGroupId": "group-1",
               "SenderId": "<sender-id:1>",
-              "SentTimestamp": "timestamp",
-              "SequenceNumber": "<sequence-number:1>"
+              "SentTimestamp": "timestamp"
             },
-            "Body": "message-body-1",
-            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MD5OfMessageAttributes": "ae7155c6026991b6d54b11589678bf9c",
+            "MessageAttributes": {
+              "Foo": {
+                "DataType": "String",
+                "StringValue": "Bar"
+              }
+            },
             "MessageId": "<uuid:1>",
             "ReceiptHandle": "<receipt-handle:2>"
           }
@@ -445,469 +2128,45 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_dead_letter_arn_rejected_before_lookup": {
-    "recorded-date": "14-11-2023, 11:59:08",
-    "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value {\"deadLetterTargetArn\": \"dummy\", \"maxReceiveCount\": 42} for parameter RedrivePolicy is invalid. Reason: Invalid value for deadLetterTargetArn.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail": {
-    "recorded-date": "14-11-2023, 12:00:04",
-    "recorded-content": {
-      "purge_queue_error": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.PurgeQueueInProgress",
-          "Message": "Only one PurgeQueue operation on <queue-name> is allowed every 60 seconds.",
-          "QueryErrorCode": "PurgeQueueInProgress",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 403
-        }
       },
-      "purge-error-code-query": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.PurgeQueueInProgress",
-          "Detail": null,
-          "Message": "Only one PurgeQueue operation on <queue-name> is allowed every 60 seconds.",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 403
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_oversized_message": {
-    "recorded-date": "14-11-2023, 11:57:35",
-    "recorded-content": {
-      "send_oversized_message": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 262144 bytes.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_updated_maximum_message_size": {
-    "recorded-date": "14-11-2023, 11:57:36",
-    "recorded-content": {
-      "send_oversized_message": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "One or more parameters are invalid. Reason: Message must be shorter than 1024 bytes.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents": {
-    "recorded-date": "14-11-2023, 11:57:37",
-    "recorded-content": {
-      "send_oversized_message_batch": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.BatchRequestTooLong",
-          "Message": "Batch requests cannot be longer than 262144 bytes. You have sent 262145 bytes.",
-          "QueryErrorCode": "BatchRequestTooLong",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size": {
-    "recorded-date": "14-11-2023, 11:57:37",
-    "recorded-content": {
-      "send_oversized_message_batch": {
-        "Failed": [],
-        "Successful": [
-          {
-            "Id": "1",
-            "MD5OfMessageAttributes": "a45daa70926828a2f0a1db3418e6feb4",
-            "MD5OfMessageBody": "f44facf5a7ee0af446ecf3e0f854441e",
-            "MessageId": "<uuid:1>"
-          },
-          {
-            "Id": "2",
-            "MD5OfMessageBody": "0cc175b9c0f1b6a831c399e269772661",
-            "MessageId": "<uuid:2>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[]": {
-    "recorded-date": "14-11-2023, 11:58:57",
-    "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
-          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
-          "QueryErrorCode": "InvalidBatchEntryId",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[testLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongIdtestLongId]": {
-    "recorded-date": "14-11-2023, 11:58:58",
-    "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
-          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
-          "QueryErrorCode": "InvalidBatchEntryId",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[invalid:id]": {
-    "recorded-date": "14-11-2023, 11:58:59",
-    "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
-          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
-          "QueryErrorCode": "InvalidBatchEntryId",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_too_many_entries_in_batch_request": {
-    "recorded-date": "14-11-2023, 11:58:54",
-    "recorded-content": {
-      "test_too_many_entries_in_batch_request": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
-          "Message": "Maximum number of entries per request are 10. You have sent 20.",
-          "QueryErrorCode": "TooManyEntriesInBatchRequest",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_invalid_batch_id": {
-    "recorded-date": "14-11-2023, 11:58:55",
-    "recorded-content": {
-      "test_invalid_batch_id": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.InvalidBatchEntryId",
-          "Message": "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.",
-          "QueryErrorCode": "InvalidBatchEntryId",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes": {
-    "recorded-date": "14-11-2023, 11:59:11",
-    "recorded-content": {
-      "binary-attrs-msg": {
+      "single_attribute": {
         "Messages": [
           {
-            "Body": "test",
-            "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
-            "MD5OfMessageAttributes": "8cbe4db156db8a94db8b801b7addb984",
-            "MessageAttributes": {
-              "attr1": {
-                "BinaryValue": "b'traceparent\\x1e00-774062d6c37081a5a0b9b5b88e30627c-2d2482211f6489da-01'",
-                "DataType": "Binary"
-              }
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
             },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
             "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
+            "ReceiptHandle": "<receipt-handle:3>"
           }
         ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_receive_max_number_of_messages": {
-    "recorded-date": "14-11-2023, 11:57:30",
-    "recorded-content": {
-      "send_max_number_of_messages": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value 11 for parameter MaxNumberOfMessages is invalid. Reason: Must be between 1 and 10, if provided.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[True]": {
-    "recorded-date": "14-11-2023, 11:59:31",
-    "recorded-content": {
-      "get-messages": {
+      },
+      "multiple_attributes": {
         "Messages": [
           {
-            "Body": {
-              "foo": "bar"
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
             },
-            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
             "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
+            "ReceiptHandle": "<receipt-handle:4>"
           }
         ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "get-messages-duplicate": {
-        "Messages": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[False]": {
-    "recorded-date": "14-11-2023, 11:59:33",
-    "recorded-content": {
-      "get-messages": {
-        "Messages": [
-          {
-            "Body": {
-              "foo": "bar"
-            },
-            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-messages-duplicate": {
-        "Messages": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[True]": {
-    "recorded-date": "14-11-2023, 11:59:35",
-    "recorded-content": {
-      "get-messages": {
-        "Messages": [
-          {
-            "Body": {
-              "foo": "bar"
-            },
-            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-dedup-messages": {
-        "Messages": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_not_on_message_group_id[False]": {
-    "recorded-date": "14-11-2023, 11:59:37",
-    "recorded-content": {
-      "get-messages": {
-        "Messages": [
-          {
-            "Body": {
-              "foo": "bar"
-            },
-            "MD5OfBody": "94232c5b8fc9272f6f73a1e36eb68fcf",
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-dedup-messages": {
-        "Messages": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_message_with_expired_receipt_handle": {
-    "recorded-date": "14-11-2023, 11:58:50",
-    "recorded-content": {
-      "response": {
-        "Messages": [
-          {
-            "Body": "g1-m1",
-            "MD5OfBody": "fc4286b824b39ddf3606c9f27ff664bd",
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "error": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Value <receipt-handle:1> for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_cross_account_access[domain]": {
-    "recorded-date": "06-05-2023, 04:43:43",
-    "recorded-content": {}
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_cross_account_access[path]": {
-    "recorded-date": "06-05-2023, 04:43:44",
-    "recorded-content": {}
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_list_queues": {
-    "recorded-date": "08-12-2023, 17:13:26",
-    "recorded-content": {}
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_set_content_based_deduplication_strategy": {
-    "recorded-date": "14-11-2023, 11:58:51",
-    "recorded-content": {
-      "before-update": {
-        "Attributes": {
-          "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesDelayed": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
-          "ContentBasedDeduplication": "true",
-          "CreatedTimestamp": "timestamp",
-          "DeduplicationScope": "queue",
-          "DelaySeconds": "0",
-          "FifoQueue": "true",
-          "FifoThroughputLimit": "perQueue",
-          "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
-          "MessageRetentionPeriod": "345600",
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "ReceiveMessageWaitTimeSeconds": "0",
-          "SqsManagedSseEnabled": "true",
-          "VisibilityTimeout": "30"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "after-update": {
-        "Attributes": {
-          "ApproximateNumberOfMessages": "0",
-          "ApproximateNumberOfMessagesDelayed": "0",
-          "ApproximateNumberOfMessagesNotVisible": "0",
-          "ContentBasedDeduplication": "false",
-          "CreatedTimestamp": "timestamp",
-          "DeduplicationScope": "queue",
-          "DelaySeconds": "0",
-          "FifoQueue": "true",
-          "FifoThroughputLimit": "perQueue",
-          "LastModifiedTimestamp": "timestamp",
-          "MaximumMessageSize": "262144",
-          "MessageRetentionPeriod": "345600",
-          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
-          "ReceiveMessageWaitTimeSeconds": "0",
-          "SqsManagedSseEnabled": "true",
-          "VisibilityTimeout": "30"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_permission_lifecycle": {
-    "recorded-date": "14-11-2023, 12:00:19",
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_permission_lifecycle[sqs]": {
+    "recorded-date": "06-12-2023, 13:58:06",
     "recorded-content": {
       "add-permission-response": {
         "ResponseMetadata": {
@@ -948,7 +2207,163 @@
         }
       },
       "get-queue-policy-attribute-after-removal": {
-        "Attributes": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-first-account-same-label": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-second-account-same-label": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value crossaccountpermission for parameter Label is invalid. Reason: Already exists.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-queue-policy-attribute-second-account-different-label": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              },
+              {
+                "Sid": "crossaccountpermission2",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-first-permission": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission2",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "arn:aws:iam::111111111111:<resource:3>"
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-second-permission": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-delete-non-existent-label": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value crossaccountpermission2 for parameter Label is invalid. Reason: can't find label.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_permission_lifecycle[sqs_json]": {
+    "recorded-date": "06-12-2023, 13:58:09",
+    "recorded-content": {
+      "add-permission-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute": {
+        "Attributes": {
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "arn:aws:sqs:<region>:111111111111:<resource:2>/<resource:1>",
+            "Statement": [
+              {
+                "Sid": "crossaccountpermission",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": [
+                    "arn:aws:iam::668614515564:<resource:3>",
+                    "arn:aws:iam::111111111111:<resource:3>"
+                  ]
+                },
+                "Action": "SQS:ReceiveMessage",
+                "Resource": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+              }
+            ]
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-permission-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-queue-policy-attribute-after-removal": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1045,7 +2460,6 @@
         }
       },
       "get-queue-policy-attribute-delete-second-permission": {
-        "Attributes": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1065,226 +2479,19 @@
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_with_too_large_batch": {
-    "recorded-date": "14-11-2023, 11:59:02",
+  "tests/aws/services/sqs/test_sqs.py::TestSqsQueryApi::test_send_message_via_queue_url_with_json_protocol": {
+    "recorded-date": "06-12-2023, 13:59:07",
     "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
-          "Message": "Maximum number of entries per request are 10. You have sent 20.",
-          "QueryErrorCode": "TooManyEntriesInBatchRequest",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_batch_with_too_large_batch": {
-    "recorded-date": "14-11-2023, 11:59:06",
-    "recorded-content": {
-      "error_response": {
-        "Error": {
-          "Code": "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
-          "Message": "Maximum number of entries per request are 10. You have sent 20.",
-          "QueryErrorCode": "TooManyEntriesInBatchRequest",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_message_group_id_for_fifo_queue": {
-    "recorded-date": "14-11-2023, 11:58:56",
-    "recorded-content": {
-      "test_missing_message_group_id_for_fifo_queue": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "The request must contain the parameter MessageGroupId.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_deduplication_id_for_fifo_queue": {
-    "recorded-date": "14-11-2023, 11:58:55",
-    "recorded-content": {
-      "test_missing_deduplication_id_for_fifo_queue": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_tag_untag_queue": {
-    "recorded-date": "14-11-2023, 11:57:38",
-    "recorded-content": {
-      "get-tag-1": {
-        "Tags": {
-          "tag1": "value1",
-          "tag2": "value2",
-          "tag3": ""
-        },
+      "receive-json-on-queue-url": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      },
-      "get-tag-2": {
-        "Tags": {
-          "tag2": "value2"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-tag-after-untag": {
-        "Tags": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_fifo_queue_with_different_attributes_raises_error": {
-    "recorded-date": "14-11-2023, 11:57:48",
-    "recorded-content": {
-      "queue-already-exists": {
-        "Error": {
-          "Code": "QueueAlreadyExists",
-          "Message": "A queue already exists with the same name and a different value for attribute ContentBasedDeduplication",
-          "QueryErrorCode": "QueueNameExists",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_empty_string_attribute": {
-    "recorded-date": "14-11-2023, 12:04:45",
-    "recorded-content": {
-      "empty-string-attr": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "Message (user) attribute 'ErrorDetails' must contain a non-empty value of type 'String'.",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_unsupported_attribute_fifo": {
-    "recorded-date": "14-11-2023, 12:15:03",
-    "recorded-content": {
-      "invalid-attr-name-1": {
-        "Error": {
-          "Code": "InvalidAttributeName",
-          "Message": "Unknown Attribute FifoQueue.",
-          "QueryErrorCode": "InvalidAttributeName",
-          "Type": "Sender"
-        },
-        "message": "Unknown Attribute FifoQueue.",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "invalid-attr-name-2": {
-        "Error": {
-          "Code": "InvalidAttributeValue",
-          "Message": "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported.",
-          "QueryErrorCode": "InvalidAttributeValue",
-          "Type": "Sender"
-        },
-        "message": "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported.",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_posting_to_fifo_requires_deduplicationid_group_id": {
-    "recorded-date": "14-11-2023, 12:18:18",
-    "recorded-content": {
-      "invalid-parameter-value": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
-          "QueryErrorCode": "InvalidParameterValueException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "missing-parameter": {
-        "Error": {
-          "Code": "MissingParameter",
-          "Message": "The request must contain the parameter MessageGroupId.",
-          "QueryErrorCode": "MissingRequiredParameterException",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "invalid-parameter-value-query": {
-        "Error": {
-          "Code": "InvalidParameterValue",
-          "Detail": null,
-          "Message": "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "missing-parameter-query": {
-        "Error": {
-          "Code": "MissingParameter",
-          "Detail": null,
-          "Message": "The request must contain the parameter MessageGroupId.",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
         }
       }
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
-    "recorded-date": "14-11-2023, 13:04:10",
+    "recorded-date": "06-12-2023, 16:00:58",
     "recorded-content": {
       "queue-does-not-exist": {
         "Error": {
@@ -1324,37 +2531,14 @@
       }
     }
   },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsQueryApi::test_send_message_via_queue_url_with_json_protocol": {
-    "recorded-date": "14-11-2023, 21:27:28",
-    "recorded-content": {
-      "receive-json-on-queue-url": {
-        "Messages": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_change_message_visibility_after_visibility_timeout_expiration": {
-    "recorded-date": "14-11-2023, 17:51:55",
-    "recorded-content": {
-      "visibility_timeout_expired": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
-    "recorded-date": "27-12-2023, 17:52:08",
+    "recorded-date": "04-01-2024, 10:06:26",
     "recorded-content": {
       "error-response": {
         "Error": {
           "Code": "InvalidParameterValue",
+          "Detail": null,
           "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageDeduplicationId is invalid. Reason: MessageDeduplicationId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
-          "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -1365,18 +2549,43 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
-    "recorded-date": "27-12-2023, 17:49:16",
+    "recorded-date": "04-01-2024, 10:07:04",
     "recorded-content": {
       "error-response": {
         "Error": {
           "Code": "InvalidParameterValue",
+          "Detail": null,
           "Message": "Value aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for parameter MessageGroupId is invalid. Reason: MessageGroupId can only include alphanumeric and punctuation characters. 1 to 128 in length.",
-          "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes[sqs]": {
+    "recorded-date": "04-01-2024, 10:07:41",
+    "recorded-content": {
+      "sse_kms_attributes": {
+        "Attributes": {
+          "KmsDataKeyReusePeriodSeconds": "6000",
+          "KmsMasterKeyId": "testKeyId",
+          "SqsManagedSseEnabled": "false"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sse_sqs_attributes": {
+        "Attributes": {
+          "SqsManagedSseEnabled": "true"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -63,10 +63,10 @@
     "last_validated_date": "2023-12-08T16:13:26+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
-    "last_validated_date": "2023-12-27T17:52:08+00:00"
+    "last_validated_date": "2024-01-04T10:06:26+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
-    "last_validated_date": "2023-12-27T17:49:15+00:00"
+    "last_validated_date": "2024-01-04T10:07:04+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention": {
     "last_validated_date": "2023-12-28T23:48:08+00:00"
@@ -131,8 +131,20 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes": {
     "last_validated_date": "2023-11-14T11:00:11+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes[sqs]": {
+    "last_validated_date": "2024-01-04T10:07:41+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sse_queue_attributes[sqs_json]": {
+    "last_validated_date": "2024-01-04T10:07:44+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail": {
     "last_validated_date": "2023-11-14T11:00:04+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail[sqs]": {
+    "last_validated_date": "2024-01-04T10:07:25+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail[sqs_json]": {
+    "last_validated_date": "2024-01-04T10:07:26+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_tag_untag_queue": {
     "last_validated_date": "2023-11-14T10:57:38+00:00"

--- a/tests/aws/services/sqs/test_sqs_backdoor.py
+++ b/tests/aws/services/sqs/test_sqs_backdoor.py
@@ -49,7 +49,7 @@ class TestSqsDeveloperEndpoints:
         assert attributes[1]["ApproximateReceiveCount"] == "0"
 
         # do a real receive op that has a side effect
-        response = aws_client.sqs_query.receive_message(
+        response = aws_client.sqs.receive_message(
             QueueUrl=queue_url, VisibilityTimeout=0, MaxNumberOfMessages=1, AttributeNames=["All"]
         )
         assert response["Messages"][0]["Body"] == "message-1"
@@ -72,13 +72,11 @@ class TestSqsDeveloperEndpoints:
 
         queue_url = sqs_create_queue()
 
-        aws_client.sqs_query.send_message(QueueUrl=queue_url, MessageBody="message-1")
-        aws_client.sqs_query.send_message(QueueUrl=queue_url, MessageBody="message-2")
+        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-1")
+        aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-2")
 
         # use the developer endpoint as boto client URL
-        client = aws_client_factory(
-            endpoint_url="http://localhost:4566/_aws/sqs/messages"
-        ).sqs_query
+        client = aws_client_factory(endpoint_url="http://localhost:4566/_aws/sqs/messages").sqs
         # max messages is ignored
         response = client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
 
@@ -109,9 +107,7 @@ class TestSqsDeveloperEndpoints:
         aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="message-3", MessageGroupId="2")
 
         # use the developer endpoint as boto client URL
-        client = aws_client_factory(
-            endpoint_url="http://localhost:4566/_aws/sqs/messages"
-        ).sqs_query
+        client = aws_client_factory(endpoint_url="http://localhost:4566/_aws/sqs/messages").sqs
         # max messages is ignored
         response = client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
 
@@ -136,9 +132,7 @@ class TestSqsDeveloperEndpoints:
 
         queue_url = sqs_create_queue()
 
-        client = aws_client_factory(
-            endpoint_url="http://localhost:4566/_aws/sqs/messages"
-        ).sqs_query
+        client = aws_client_factory(endpoint_url="http://localhost:4566/_aws/sqs/messages").sqs
 
         with pytest.raises(ClientError) as e:
             client.send_message(QueueUrl=queue_url, MessageBody="foobar")

--- a/tests/aws/services/sqs/test_sqs_move_task.py
+++ b/tests/aws/services/sqs/test_sqs_move_task.py
@@ -105,6 +105,7 @@ def sqs_create_dlq_pipe(sqs_create_queue):
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_cancel_with_invalid_task_handle(aws_client, snapshot):
     with pytest.raises(ClientError) as e:
         aws_client.sqs.cancel_message_move_task(TaskHandle="foobared")
@@ -112,6 +113,7 @@ def test_cancel_with_invalid_task_handle(aws_client, snapshot):
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_cancel_with_invalid_source_arn_in_task_handle(aws_client, snapshot):
     source_arn = "arn:aws:sqs:us-east-1:878966065785:test-queue-doesnt-exist-123456"
     task_handle = encode_move_task_handle("10f57157-fc38-4da9-a113-4de7e12d05dd", source_arn)
@@ -122,6 +124,7 @@ def test_cancel_with_invalid_source_arn_in_task_handle(aws_client, snapshot):
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_cancel_with_invalid_task_id_in_task_handle(
     sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
 ):
@@ -136,6 +139,7 @@ def test_cancel_with_invalid_task_id_in_task_handle(
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_source_needs_redrive_policy(
     sqs_create_queue,
     sqs_get_queue_arn,
@@ -157,6 +161,7 @@ def test_source_needs_redrive_policy(
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_destination_needs_to_exist(
     sqs_create_queue,
     sqs_create_dlq_pipe,
@@ -416,6 +421,7 @@ def test_move_task_delete_destination_queue_while_running(
 
 
 @markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(paths=["$..Error.Detail"])
 def test_start_multiple_move_tasks(
     sqs_create_queue,
     sqs_create_dlq_pipe,

--- a/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
@@ -28,13 +28,13 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_source_needs_redrive_policy": {
-    "recorded-date": "03-01-2024, 19:49:15",
+    "recorded-date": "05-01-2024, 12:48:02",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "InvalidParameterValue",
+          "Detail": null,
           "Message": "Source queue must be configured as a Dead Letter Queue.",
-          "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -45,13 +45,13 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_handle": {
-    "recorded-date": "03-01-2024, 19:50:39",
+    "recorded-date": "05-01-2024, 12:45:27",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "InvalidParameterValue",
+          "Detail": null,
           "Message": "Value for parameter TaskHandle is invalid.",
-          "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -62,16 +62,15 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_source_arn_in_task_handle": {
-    "recorded-date": "03-01-2024, 19:56:40",
+    "recorded-date": "05-01-2024, 12:46:39",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "ResourceNotFoundException",
+          "Detail": null,
           "Message": "The resource that you specified for the SourceArn parameter doesn't exist.",
-          "QueryErrorCode": "ResourceNotFoundException",
           "Type": "Sender"
         },
-        "message": "The resource that you specified for the SourceArn parameter doesn't exist.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
@@ -80,16 +79,15 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_id_in_task_handle": {
-    "recorded-date": "03-01-2024, 19:57:32",
+    "recorded-date": "05-01-2024, 12:47:48",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "ResourceNotFoundException",
+          "Detail": null,
           "Message": "Task does not exist.",
-          "QueryErrorCode": "ResourceNotFoundException",
           "Type": "Sender"
         },
-        "message": "Task does not exist.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
@@ -110,16 +108,15 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_destination_needs_to_exist": {
-    "recorded-date": "03-01-2024, 20:12:56",
+    "recorded-date": "05-01-2024, 12:48:32",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "ResourceNotFoundException",
+          "Detail": null,
           "Message": "The resource that you specified for the DestinationArn parameter doesn't exist.",
-          "QueryErrorCode": "ResourceNotFoundException",
           "Type": "Sender"
         },
-        "message": "The resource that you specified for the DestinationArn parameter doesn't exist.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
@@ -198,13 +195,13 @@
     }
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_start_multiple_move_tasks": {
-    "recorded-date": "03-01-2024, 20:57:58",
+    "recorded-date": "05-01-2024, 12:50:38",
     "recorded-content": {
       "error": {
         "Error": {
           "Code": "InvalidParameterValue",
+          "Detail": null,
           "Message": "There is already a task running. Only one active task is allowed for a source queue arn at a given time.",
-          "QueryErrorCode": "InvalidParameterValueException",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sqs/test_sqs_move_task.validation.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.validation.json
@@ -3,16 +3,16 @@
     "last_validated_date": "2024-01-03T20:25:53+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_source_arn_in_task_handle": {
-    "last_validated_date": "2024-01-03T19:56:40+00:00"
+    "last_validated_date": "2024-01-05T12:46:39+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_handle": {
-    "last_validated_date": "2024-01-03T19:50:39+00:00"
+    "last_validated_date": "2024-01-05T12:45:27+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_id_in_task_handle": {
-    "last_validated_date": "2024-01-03T19:57:31+00:00"
+    "last_validated_date": "2024-01-05T12:47:48+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_destination_needs_to_exist": {
-    "last_validated_date": "2024-01-03T20:12:55+00:00"
+    "last_validated_date": "2024-01-05T12:48:32+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_cancel": {
     "last_validated_date": "2024-01-03T20:34:27+00:00"
@@ -24,9 +24,9 @@
     "last_validated_date": "2024-01-03T20:25:11+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_source_needs_redrive_policy": {
-    "last_validated_date": "2024-01-03T19:49:15+00:00"
+    "last_validated_date": "2024-01-05T12:48:02+00:00"
   },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_start_multiple_move_tasks": {
-    "last_validated_date": "2024-01-03T20:57:58+00:00"
+    "last_validated_date": "2024-01-05T12:50:37+00:00"
   }
 }

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -41,7 +41,7 @@ class TestCSRF:
         assert response.headers["Vary"] == "Origin"
         assert response.headers["Access-Control-Allow-Credentials"] == "true"
 
-    @pytest.mark.parametrize("path", ["/health", "/_localstack/health"])
+    @pytest.mark.parametrize("path", ["/_localstack/health"])
     def test_internal_route_cors_headers(self, path):
         headers = {"Origin": "https://app.localstack.cloud"}
         response = requests.get(f"{config.internal_service_url()}{path}", headers=headers)

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -45,7 +45,7 @@ def test_query_parser():
 
 def test_sqs_query_parse_tag_map_with_member_name_as_location():
     # see https://github.com/localstack/localstack/issues/4391
-    parser = create_parser(load_service("sqs-query"))
+    parser = create_parser(load_service("sqs"))
 
     # with "Tag." it works (this is the default request)
     request = HttpRequest(
@@ -116,7 +116,7 @@ def test_query_parser_uri():
 
 def test_query_parser_flattened_map():
     """Simple test with a flattened map (SQS SetQueueAttributes request)."""
-    parser = QueryRequestParser(load_service("sqs-query"))
+    parser = QueryRequestParser(load_service("sqs"))
     request = HttpRequest(
         body=to_bytes(
             "Action=SetQueueAttributes&Version=2012-11-05&"
@@ -250,7 +250,7 @@ def test_query_parser_non_flattened_list_structure_changed_name():
 
 def test_query_parser_flattened_list_structure():
     """Simple test with a flattened list of structures."""
-    parser = QueryRequestParser(load_service("sqs-query"))
+    parser = QueryRequestParser(load_service("sqs"))
     request = HttpRequest(
         body=to_bytes(
             "Action=DeleteMessageBatch&"
@@ -386,7 +386,7 @@ def test_query_parser_sqs_with_botocore():
 
 def test_query_parser_empty_required_members_sqs_with_botocore():
     _botocore_parser_integration_test(
-        service="sqs-query",
+        service="sqs",
         action="SendMessageBatch",
         QueueUrl="string",
         Entries=[],

--- a/tests/unit/aws/protocol/test_parser_validate.py
+++ b/tests/unit/aws/protocol/test_parser_validate.py
@@ -33,7 +33,7 @@ class TestExceptions:
         assert e.value.required_name == "TagList"
 
     def test_missing_required_field_query(self):
-        parser = create_parser(load_service("sqs-query"))
+        parser = create_parser(load_service("sqs"))
 
         op, params = parser.parse(
             HttpRequest(

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -112,7 +112,7 @@ def _botocore_serializer_integration_test(
 
 
 def _botocore_error_serializer_integration_test(
-    service: str,
+    service_model_name: str,
     action: str,
     exception: ServiceException,
     code: str,
@@ -127,10 +127,10 @@ def _botocore_error_serializer_integration_test(
     - Load the given service (f.e. "sqs")
     - Serialize the _error_ response with the appropriate serializer from the AWS Serivce Framework
     - Parse the serialized error response using the botocore parser
-    - Checks if the the metadata is correct (status code, requestID,...)
+    - Checks if the metadata is correct (status code, requestID,...)
     - Checks if the parsed error response content is correct
 
-    :param service: to load the correct service specification, serializer, and parser
+    :param service_model_name: to load the correct service specification, serializer, and parser
     :param action: to load the correct service specification, serializer, and parser
     :param exception: which should be serialized and tested against
     :param code: expected "code" of the exception (i.e. the AWS specific exception ID, f.e.
@@ -143,7 +143,7 @@ def _botocore_error_serializer_integration_test(
     """
 
     # Load the appropriate service
-    service = load_service(service)
+    service = load_service(service_model_name)
 
     # Use our serializer to serialize the response
     response_serializer = create_serializer(service)

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -476,7 +476,7 @@ def test_query_serializer_sqs_none_value_in_map():
 def test_query_protocol_error_serialization():
     exception = InvalidMessageContents("Exception message!")
     _botocore_error_serializer_integration_test(
-        "sqs-query", "SendMessage", exception, "InvalidMessageContents", 400, "Exception message!"
+        "sqs", "SendMessage", exception, "InvalidMessageContents", 400, "Exception message!"
     )
 
 
@@ -486,7 +486,7 @@ def test_query_protocol_error_serialization_plain():
     )
 
     # Load the SQS service
-    service = load_service("sqs-query")
+    service = load_service("sqs")
 
     # Use our serializer to serialize the response
     response_serializer = create_serializer(service)
@@ -528,7 +528,7 @@ def test_query_protocol_error_serialization_plain():
 def test_query_protocol_custom_error_serialization():
     exception = CommonServiceException("InvalidParameterValue", "Parameter x was invalid!")
     _botocore_error_serializer_integration_test(
-        "sqs-query",
+        "sqs",
         "SendMessage",
         exception,
         "InvalidParameterValue",
@@ -540,7 +540,7 @@ def test_query_protocol_custom_error_serialization():
 def test_query_protocol_error_serialization_sender_fault():
     exception = UnsupportedOperation("Operation not supported.")
     _botocore_error_serializer_integration_test(
-        "sqs-query",
+        "sqs",
         "SendMessage",
         exception,
         "AWS.SimpleQueueService.UnsupportedOperation",
@@ -1866,7 +1866,7 @@ def test_json_protocol_cbor_serialization(headers_dict):
 
 class TestAwsResponseSerializerDecorator:
     def test_query_internal_error(self):
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             raise ValueError("oh noes!")
 
@@ -1875,7 +1875,7 @@ class TestAwsResponseSerializerDecorator:
         assert b"<Code>InternalError</Code>" in response.data
 
     def test_query_service_error(self):
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             raise UnsupportedOperation("Operation not supported.")
 
@@ -1885,7 +1885,7 @@ class TestAwsResponseSerializerDecorator:
         assert b"<Message>Operation not supported.</Message>" in response.data
 
     def test_query_valid_response(self):
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             from localstack.aws.api.sqs import ListQueuesResult
 
@@ -1907,7 +1907,7 @@ class TestAwsResponseSerializerDecorator:
 
     def test_query_valid_response_content_negotiation(self):
         # this test verifies that request header values are passed correctly to perform content negotation
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             from localstack.aws.api.sqs import ListQueuesResult
 
@@ -1930,7 +1930,7 @@ class TestAwsResponseSerializerDecorator:
         }
 
     def test_return_invalid_none_type_causes_internal_error(self):
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             return None
 
@@ -1940,7 +1940,7 @@ class TestAwsResponseSerializerDecorator:
 
     def test_response_pass_through(self):
         # returning a response directly will forego the serializer
-        @aws_response_serializer("sqs-query", "ListQueues")
+        @aws_response_serializer("sqs", "ListQueues")
         def fn(request: Request):
             return Response(b"ok", status=201)
 
@@ -1959,7 +1959,7 @@ class TestAwsResponseSerializerDecorator:
 
     def test_invoke_on_bound_method(self):
         class MyHandler:
-            @aws_response_serializer("sqs-query", "ListQueues")
+            @aws_response_serializer("sqs", "ListQueues")
             def handle(self, request: Request):
                 from localstack.aws.api.sqs import ListQueuesResult
 

--- a/tests/unit/aws/test_mocking.py
+++ b/tests/unit/aws/test_mocking.py
@@ -58,4 +58,4 @@ def test_get_mocking_skeleton():
     context = create_aws_request_context("sqs", "CreateQueue", request)
     response = skeleton.invoke(context)
     # just a smoke test
-    assert b'"QueueUrl"' in response.data
+    assert b"<QueueUrl>" in response.data

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -24,6 +24,8 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
             # Exclude all operations for the following, currently _not_ supported services
             if service.service_name in [
                 "bedrock",
+                "bedrock-agent",
+                "bedrock-agent-runtime",
                 "bedrock-runtime",
                 "chime",
                 "chime-sdk-identity",
@@ -50,16 +52,20 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                 "lex-runtime",
                 "lexv2-models",
                 "lexv2-runtime",
+                "marketplace-catalog",
+                "marketplace-deployment",
                 "personalize",
                 "personalize-events",
                 "personalize-runtime",
                 "pinpoint-sms-voice",
+                "qconnect",
                 "sagemaker-edge",
                 "sagemaker-featurestore-runtime",
                 "sagemaker-metrics",
                 "sms-voice",
                 "sso",
                 "sso-oidc",
+                "wisdom",
                 "workdocs",
             ]:
                 yield pytest.param(

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -119,6 +119,7 @@ _dummy_values = {
     "integer": 0,
     "long": 0,
     "timestamp": datetime.now(),
+    "boolean": True,
 }
 
 

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -155,7 +155,7 @@ def _get_sqs_request_headers():
 
 
 def test_skeleton_e2e_sqs_send_message():
-    sqs_service = load_service("sqs-query")
+    sqs_service = load_service("sqs")
     skeleton = Skeleton(sqs_service, TestSqsApi())
     context = RequestContext()
     context.account = "test"
@@ -210,7 +210,7 @@ def test_skeleton_e2e_sqs_send_message():
     ],
 )
 def test_skeleton_e2e_sqs_send_message_not_implemented(api_class, oracle_message):
-    sqs_service = load_service("sqs-query")
+    sqs_service = load_service("sqs")
     skeleton = Skeleton(sqs_service, api_class)
     context = RequestContext()
     context.account = "test"
@@ -254,7 +254,7 @@ def test_dispatch_common_service_exception():
     table: DispatchTable = {}
     table["DeleteQueue"] = delete_queue
 
-    sqs_service = load_service("sqs-query")
+    sqs_service = load_service("sqs")
     skeleton = Skeleton(sqs_service, table)
 
     context = RequestContext()
@@ -287,7 +287,7 @@ def test_dispatch_common_service_exception():
 def test_dispatch_missing_method_returns_internal_failure():
     table: DispatchTable = {}
 
-    sqs_service = load_service("sqs-query")
+    sqs_service = load_service("sqs")
     skeleton = Skeleton(sqs_service, table)
 
     context = RequestContext()

--- a/tests/unit/aws/test_spec.py
+++ b/tests/unit/aws/test_spec.py
@@ -80,10 +80,10 @@ def test_patching_loaders():
 
 
 def test_loading_own_specs():
-    """Ensure that the internalized specifications (f.e. the sqs-query spec) can be handled by the CustomLoader."""
+    """Ensure that the internalized specifications (f.e. the sqs-json spec) can be handled by the CustomLoader."""
     loader = CustomLoader({})
     # first test that specs remain intact
-    sqs_query_description = loader.load_service_model("sqs-query", "service-2")
+    sqs_query_description = loader.load_service_model("sqs", "service-2")
     assert sqs_query_description["metadata"]["protocol"] == "query"
-    sqs_json_description = loader.load_service_model("sqs", "service-2")
+    sqs_json_description = loader.load_service_model("sqs-json", "service-2")
     assert sqs_json_description["metadata"]["protocol"] == "json"

--- a/tests/unit/utils/test_bootstrap.py
+++ b/tests/unit/utils/test_bootstrap.py
@@ -156,7 +156,7 @@ class TestGetEnabledApis:
         with temporary_env({"SERVICES": "es,lambda", "STRICT_SERVICE_LOADING": "1"}):
             result = get_enabled_apis()
 
-        assert len(result) == 7
+        assert len(result) == 6
         assert result == {
             # directly given
             "lambda",
@@ -167,8 +167,6 @@ class TestGetEnabledApis:
             "s3",
             "sqs",
             "sts",
-            # secondary dependency from sqs, which is a dependency from lambda
-            "sqs-query",
         }
 
 


### PR DESCRIPTION
## Motivation
This PR aims at cleaning up after the quick fixes with the protocol switch in SQS of `botocore` from `query` to `json` (and now back again).

These changes of the protocol are highly problematic, because this means that clients are suddenly changing the way how they talk to AWS (and in turn also with LocalStack). There's nothing we can do on our side besides implementing the new protocol (in addition to the old protocol to remain downwards-compatible with other or older clients).

Here's a timeline of what happened:
- **2023-05-04** - `botocore` switched the protocol for SQS from `query` to `json` in version [`1.29.127`](https://github.com/boto/botocore/releases/tag/1.29.127) (specifically this commit: https://github.com/boto/botocore/commit/2395012bd369f89b0bcfbbf830718866fc6ae166).
  - The changes were quickly hitting LocalStack users: https://github.com/localstack/localstack/issues/8267
- **2023-05-05** - `botocore` reverts the change with https://github.com/boto/botocore/pull/2931 in version [`1.29.128`](https://github.com/boto/botocore/releases/tag/1.29.128).
- **2023-11-09** - `botocore` again performs the switch in version [`1.31.81`](https://github.com/boto/botocore/releases/tag/1.31.81) (specifically this commit: https://github.com/boto/botocore/commit/84c784761d4cde0c0ce3b2b32382f970d23b3cc8).
- **2023-11-11** - Two days after the switch, we were ready with a somewhat hacky solution: https://github.com/localstack/localstack/pull/8268
  - https://github.com/localstack/localstack/pull/9607 - Performs a quick cleanup after the initial merge of the new protocol support.
  - https://github.com/localstack/localstack/pull/9634 - Fixes an issue in the routing
  - https://github.com/localstack/localstack/pull/9611 - Adjusts the ASF specs and the provider implementation accordingly
  - https://github.com/localstack/localstack/pull/9709 - Removes the artificial service from the list of services in the health endpoint
- **2023-11-11** - `botocore` changes the exception handling for SQS in version [`1.31.85`](https://github.com/boto/botocore/releases/tag/1.31.85) in https://github.com/boto/botocore/pull/3054.
  - These changes have been addressed with https://github.com/localstack/localstack/pull/9627.
- **2023-11-15** - `botocore` switches to gzipped specs which is not compatible with moto at the time.
  - https://github.com/localstack/localstack/commit/815d6c77245e3ebfb9d298a70fe16bd12df032f7 pins `botocore` as a first response.
- **2023-11-22** - https://github.com/localstack/localstack/pull/9624 upgrades `moto` such that it contains https://github.com/getmoto/moto/pull/7030.
- **2023-11-22** - https://github.com/localstack/localstack/pull/9667 unpins `botocore` again
- **2023-11-22** - `botocore` switches the protocol for SQS back from `json` to `query` in version [`1.32.6`](https://github.com/boto/botocore/releases/tag/1.32.6) (specifically this PR: https://github.com/boto/botocore/pull/3071)
  - https://github.com/localstack/localstack/pull/9714 pins `botocore` as a first response.

This is where we are at. With this PR we want to:
- [x] Get rid of the artificial "sqs-query" service. The term `sqs-query` should only be used in very specific sections explicitly handling the `query` spec.
- [x] Remove the pin on `botocore`, effectively switching back to `query` as the default protocol, but still support `json`.
- [x] Remove the pin of AWS CLI in the `Dockerfile` introduced with https://github.com/localstack/localstack/pull/9767.

## Changes
- The first commit cleans up after the previous efforts to adjust to the chaotic changes around the protocol changes in SQS.
  - This change centers around switching from differentiating the requests on protocol level, rather than on service level.
  - It removes the `sqs-query` service "alias", and removes all special cases handling this service alias.
  - It adjusts the `serializer` and `parser` such that they differentiate based on the protocol of the given service model (instead of only based on the service).
  - It adjusts the `service_router` such that it delivers a service model instead of only the service name (because that would be ambiguous, there are two service models for SQS).
- The second commit upgrades the ASF API stubs based on the latest `botocore` version (since they had to be hold back, see https://github.com/localstack/localstack/pull/9735).
- The third commit actually performs the upgrade / unpinning of `botocore`.
  - This means another switch from `json` back to `query` as default protocol for SQS.
  - The internalized spec for SQS is switched from `query` to `json` (the "non-default" protocol).
  - Changes the `serializer` adjustments which are necessary due to the duality of the protocols, their divergence, and the fact that we only generate a single ASF stub based on one of the specs.
  - Adjusts the SQS provider to some recent changes (empty lists / dicts are not contained anymore in certain cases, like messages or tags).
  - Fixes / updates quite a lot of tests and snapshots.
    - Also parameterizes most of the SQS tests such that they are snapshot tested against both protocols.
- The fourth commit contains some test fixes related to the new changes in the S3 specs / generated code. /cc @bentsku 