### PR TITLE
fix: support for non-homogeneous lists

### DIFF
--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -218,9 +218,10 @@ class SnapshotSession:
                 original[k] = v = v.read().decode(
                     "utf-8"
                 )  # TODO: patch boto client so this doesn't break any further read() calls
-            if isinstance(v, list) and v and isinstance(v[0], dict):
+            if isinstance(v, list) and v:
                 for item in v:
-                    self._transform_dict_to_parseable_values(item)
+                    if isinstance(item, dict):
+                        self._transform_dict_to_parseable_values(item)
             if isinstance(v, Dict):
                 self._transform_dict_to_parseable_values(v)
 

--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -195,9 +195,10 @@ class KeyValueBasedTransformer:
                             f"Replacing value for key '{k}' with '{self.replacement}'. (Original value: {str(v)})"
                         )
                         input_data[k] = self.replacement
-            elif isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
+            elif isinstance(v, list) and len(v) > 0:
                 for i in range(0, len(v)):
-                    v[i] = self.transform(v[i], ctx=ctx)
+                    if isinstance(v[i], dict):
+                        v[i] = self.transform(v[i], ctx=ctx)
             elif isinstance(v, dict):
                 input_data[k] = self.transform(v, ctx=ctx)
 

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -141,8 +141,8 @@ class TestSnapshotManager:
 
     def test_non_homogeneous_list(self):
         sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
-        sm.recorded_state = {"key_a": [{"a": 1}, "String", 1]}
-        sm.match("key_a", [{"a": 1}, "String", 1])
+        sm.recorded_state = {"key1": [{"key2": "value1"}, "value2", 3]}
+        sm.match("key1", [{"key2": "value1"}, "value2", 3])
         sm._assert_all()
 
 

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -139,6 +139,12 @@ class TestSnapshotManager:
         skip_path_escaped = ["$..aab", "$..b.'a.aa'"]
         sm._assert_all(skip_verification_paths=skip_path_escaped)
 
+    def test_non_homogeneous_list(self):
+        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm.recorded_state = {"key_a": [{"a": 1}, "String", 1]}
+        sm.match("key_a", [{"a": 1}, "String", 1])
+        sm._assert_all()
+
 
 def test_json_diff_format():
     path = ["Records", 1]


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR addresses an issue in the snapshot tests mechanism, specifically when dealing with dictionaries containing lists with non-homogeneous elements. An example scenario is shown below:

```python
d = {"key1": [{"key2": "value1"}, "value2", 3]}
snapshot.map("test_generic", d)
```

<!-- What notable changes does this PR make? -->
## Changes
The proposed changes address the issue by altering the approach to parsing dictionaries containing lists. Instead of assuming the data type based on the first element of the list, this update ensures that the data type of each element in the list is checked and handled appropriately.


## Testing

- added test case for testing out the supported element