### PR TITLE
CW v2 Tests and small improvements 

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -295,7 +295,6 @@ class CloudwatchDatabase:
             return {
                 "id": query.get("Id"),
                 "datapoints": cleaned_datapoints,
-                "label": f"{metric.get('MetricName')} {stat}",
             }
 
     def list_metrics(

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -193,8 +193,8 @@ class CloudwatchDatabase:
             metric = metric_stat.get("Metric")
             period = metric_stat.get("Period")
             stat = metric_stat.get("Stat")
-            # dimensions = metric.get("Dimensions", [])
-            # unit = metric_stat.get("Unit")
+            dimensions = metric.get("Dimensions", [])
+            unit = metric_stat.get("Unit")
 
             # prepare SQL query
             order_by = "timestamp ASC" if scan_by == ScanBy.TimestampAscending else "timestamp DESC"
@@ -208,15 +208,15 @@ class CloudwatchDatabase:
                 metric.get("MetricName"),
             )
             #
-            # dimension_filter = ""
-            # for dimension in dimensions:
-            #     dimension_filter += "AND dimensions LIKE ? "
-            #     data = data + (f"%{dimension.get('Name')}={dimension.get('Value')}%",)
-            #
-            # unit_filter = ""
-            # if unit:
-            #     unit_filter = f"AND unit LIKE ? "
-            #     data = data + (unit,)
+            dimension_filter = ""
+            for dimension in dimensions:
+                dimension_filter += "AND dimensions LIKE ? "
+                data = data + (f"%{dimension.get('Name')}={dimension.get('Value')}%",)
+
+            unit_filter = ""
+            if unit:
+                unit_filter = "AND unit LIKE ? "
+                data = data + (unit,)
 
             sql_query = f"""
             SELECT
@@ -235,6 +235,8 @@ class CloudwatchDatabase:
             WHERE account_id = ? AND region = ?
             AND namespace = ? AND metric_name = ?
             AND timestamp >= ? AND timestamp < ?
+            {dimension_filter}
+            {unit_filter}
             ORDER BY {order_by}
             """
 

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -118,7 +118,9 @@ class CloudwatchDatabase:
                 for insert in inserts:
                     for _ in range(insert.get("TimesToInsert")):
                         cur.execute(
-                            self._get_insert_single_metric_query(),
+                            f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
+                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
                                 account_id,
                                 region,
@@ -136,7 +138,9 @@ class CloudwatchDatabase:
 
                 if statistic_values := metric.get("StatisticValues"):
                     cur.execute(
-                        self._get_insert_aggregated_metric_query(),
+                        f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
+                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                         (
                             account_id,
                             region,
@@ -393,13 +397,3 @@ class CloudwatchDatabase:
         self, timestamp: datetime
     ):  # TODO verify if this is the standard format, might need to convert
         return int(timestamp.timestamp())
-
-    def _get_insert_single_metric_query(self) -> str:
-        return f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
-                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"""
-
-    def _get_insert_aggregated_metric_query(self) -> str:
-        return f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
-                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -169,8 +169,6 @@ class CloudwatchDatabase:
         scan_by: str,
     ):
         # TODO exclude null values, check if dimensions must be null though if missing
-        # TODO test default order
-        # TODO add filters for dimensions
         # TODO add filters for unit
 
         with sqlite3.connect(self.METRICS_DB) as conn:
@@ -184,9 +182,9 @@ class CloudwatchDatabase:
 
             # prepare SQL query
             order_by = (
-                "timestamp DESC"
-                if scan_by and scan_by == ScanBy.TimestampDescending
-                else "timestamp ASC"
+                "timestamp ASC"
+                if scan_by == ScanBy.TimestampAscending
+                else "timestamp DESC"
             )
 
             start_time_unix = self._convert_timestamp_to_unix(start_time)

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -226,9 +226,24 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 or f'{query["MetricStat"]["Metric"]["MetricName"]} {query["MetricStat"]["Stat"]}'
             )
 
-            # Paginate
+            timestamps = query_result.get("timestamps", {})
+            values = query_result.get("values", {})
+
+            if scan_by == "TimestampAscending":
+                timestamps = timestamps[::-1]
+                values = values[::-1]
+
+            # # Paginate
+            # timestamp_value_dicts = [
+            #     {
+            #         "Timestamp": timestamp,
+            #         "Value": value,
+            #     }
+            #     for timestamp, value in zip(timestamps, values)
+            # ]
+            #
             # aliases_list = PaginatedList(query_result.get("datapoints", {}).items())
-            # page, nxt = aliases_list.get_page(
+            # timestamp_page, nxt = aliases_list.get_page(
             #     lambda metric_result: "",
             #     next_token=next_token,
             #     page_size=limit,
@@ -237,8 +252,8 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 "Id": query.get("Id"),
                 "Label": label,
                 "StatusCode": "Complete",
-                "Timestamps": query_result.get("timestamps"),
-                "Values": query_result.get("values"),
+                "Timestamps": timestamps,
+                "Values": values,
             }
             results.append(MetricDataResult(**metric_data_result))
 

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -533,7 +533,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         extended_statistics: ExtendedStatistics = None,
         unit: StandardUnit = None,
     ) -> GetMetricStatisticsOutput:
-        stat_datapoints = []
+        stat_datapoints = {}
         for stat in statistics:
             query_result = self.cloudwatch_database.get_metric_data_stat(
                 account_id=context.account_id,
@@ -555,10 +555,11 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 ),
             )
 
-            datapoints = query_result.get("datapoints", {})
-            for timestamp, datapoint_result in datapoints.items():
+            timestamps = query_result.get("timestamps", [])
+            values = query_result.get("values", [])
+            for i, timestamp in enumerate(timestamps):
                 stat_datapoints.setdefault(timestamp, {})
-                stat_datapoints[timestamp][stat] = datapoint_result
+                stat_datapoints[timestamp][stat] = values[i]
 
         datapoints = []
         for timestamp, stats in stat_datapoints.items():

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -229,10 +229,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             timestamps = query_result.get("timestamps", {})
             values = query_result.get("values", {})
 
-            if scan_by == "TimestampAscending":
-                timestamps = timestamps[::-1]
-                values = values[::-1]
-
             # Paginate
             timestamp_value_dicts = [
                 {

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -91,6 +91,7 @@ LOG = logging.getLogger(__name__)
 
 
 class ValidationError(CommonServiceException):
+    # TODO: check this error against AWS (doesn't exist in the API)
     def __init__(self, message: str):
         super().__init__("ValidationError", message, 400, True)
 

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -251,6 +251,11 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 formatted_result["Timestamps"].append(int(timestamp))
                 formatted_result["Values"].append(datapoint_result)
 
+            # temporal fix while we still use python dicts for stats
+            if scan_by == "TimestampAscending":
+                formatted_result["Timestamps"].reverse()
+                formatted_result["Values"].reverse()
+
             formatted_results.append(MetricDataResult(**formatted_result))
 
         return GetMetricDataOutput(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1848,7 +1848,9 @@ class TestCloudwatch:
     def test_put_metric_uses_utc(self, aws_client):
         namespace = f"n-sp-{short_uid()}"
         metric_name = f"m-{short_uid()}"
-        now_local = datetime.now()
+        now_local = datetime.now(timezone(timedelta(hours=-5), "America/Cancun")).replace(
+            tzinfo=None
+        )  # Remove the tz info to avoid boto converting it to UTC
         now_utc = datetime.utcnow()
         aws_client.cloudwatch.put_metric_data(
             Namespace=namespace,
@@ -1963,12 +1965,12 @@ class TestCloudwatch:
             )
 
             default_ordering_datapoints = default_ordering["MetricDataResults"][0]["Timestamps"]
-            assending_ordering_datapoints = ascending_ordering["MetricDataResults"][0]["Timestamps"]
+            ascending_ordering_datapoints = ascending_ordering["MetricDataResults"][0]["Timestamps"]
             descening_ordering_datapoints = descening_ordering["MetricDataResults"][0]["Timestamps"]
 
             # The default ordering is TimestampDescending
             assert default_ordering_datapoints == descening_ordering_datapoints
-            assert default_ordering_datapoints == assending_ordering_datapoints[::-1]
+            assert default_ordering_datapoints == ascending_ordering_datapoints[::-1]
 
         retry(assert_ordering, retries=10, sleep=1.0)
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -528,6 +528,7 @@ class TestCloudwatch:
         retry(assert_results, retries=retries, sleep_before=sleep_before)
 
     @markers.aws.only_localstack
+    @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
     def test_raw_metric_data(self, aws_client):
         """
         tests internal endpoint at "/_aws/cloudwatch/metrics/raw"
@@ -604,6 +605,7 @@ class TestCloudwatch:
         assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
 
     @markers.aws.validated
+    @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
     def test_put_composite_alarm_describe_alarms_converts_date_format_correctly(
         self, aws_client, cleanups
     ):
@@ -1277,6 +1279,7 @@ class TestCloudwatch:
         assert response["MetricAlarms"][0]["ActionsEnabled"]
 
     @markers.aws.validated
+    @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
     def test_aws_sqs_metrics_created(self, sqs_create_queue, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
         sqs_url = sqs_create_queue()

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -519,7 +519,9 @@ class TestCloudwatch:
             assert len(response["MetricDataResults"][0]["Values"]) > 0
             snapshot.match("get_metric_data", response)
 
-        retry(assert_results, retries=10, sleep_before=1)
+        retries = 10 if is_aws_cloud() else 1
+        sleep_before = 2 if is_aws_cloud() else 0
+        retry(assert_results, retries=retries, sleep_before=sleep_before)
 
     @markers.aws.only_localstack
     def test_raw_metric_data(self, aws_client):

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1970,9 +1970,7 @@ class TestCloudwatch:
         retry(assert_ordering, retries=10, sleep=1.0)
 
     @markers.aws.validated
-    # @pytest.mark.skip(
-    #     reason="it's not supported by moto"
-    # )
+    @pytest.mark.skip(reason="it's not supported by moto or new provider")
     def test_handle_different_units(self, aws_client, snapshot):
         namespace = f"n-sp-{short_uid()}"
         metric_name = "m-test"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -33,9 +33,7 @@ def is_new_provider():
 
 class TestCloudwatch:
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths= ["$..Datapoints..Unit"] , condition=is_new_provider
-    )
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Datapoints..Unit"], condition=is_new_provider)
     def test_put_metric_data_values_list(self, snapshot, aws_client):
         metric_name = "test-metric"
         namespace = f"ns-{short_uid()}"
@@ -391,8 +389,7 @@ class TestCloudwatch:
         "stat",
         ["Sum", "SampleCount", "Minimum", "Maximum", "Average"],
     )
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"])
+    @markers.snapshot.skip_snapshot_verify(paths=["$..MetricDataResults..Label"])
     def test_get_metric_data_stats(self, aws_client, snapshot, stat):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -449,8 +446,7 @@ class TestCloudwatch:
         retry(assert_results, retries=10, sleep_before=sleep_before)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"])
+    @markers.snapshot.skip_snapshot_verify(paths=["$..MetricDataResults..Label"])
     def test_get_metric_data_with_dimensions(self, aws_client, snapshot):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -1714,22 +1710,23 @@ class TestCloudwatch:
         )
         # get_metric_data
         stats = ["Average", "Sum", "Minimum", "Maximum"]
+
         def _get_metric_data():
             return aws_client.cloudwatch.get_metric_data(
-            MetricDataQueries=[
-                {
-                    "Id": "result_" + stat,
-                    "MetricStat": {
-                        "Metric": {"Namespace": namespace1, "MetricName": "metric1"},
-                        "Period": 60,
-                        "Stat": stat,
-                    },
-                }
-                for stat in stats
-            ],
-            StartTime=utc_now - timedelta(seconds=60),
-            EndTime=utc_now + timedelta(seconds=60),
-        )
+                MetricDataQueries=[
+                    {
+                        "Id": "result_" + stat,
+                        "MetricStat": {
+                            "Metric": {"Namespace": namespace1, "MetricName": "metric1"},
+                            "Period": 60,
+                            "Stat": stat,
+                        },
+                    }
+                    for stat in stats
+                ],
+                StartTime=utc_now - timedelta(seconds=60),
+                EndTime=utc_now + timedelta(seconds=60),
+            )
 
         def _match_results():
             response = _get_metric_data()

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -389,7 +389,9 @@ class TestCloudwatch:
         "stat",
         ["Sum", "SampleCount", "Minimum", "Maximum", "Average"],
     )
-    @markers.snapshot.skip_snapshot_verify(paths=["$..MetricDataResults..Label"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..MetricDataResults..Label"], condition=is_new_provider
+    )
     def test_get_metric_data_stats(self, aws_client, snapshot, stat):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -446,7 +448,9 @@ class TestCloudwatch:
         retry(assert_results, retries=10, sleep_before=sleep_before)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..MetricDataResults..Label"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..MetricDataResults..Label"], condition=is_new_provider
+    )
     def test_get_metric_data_with_dimensions(self, aws_client, snapshot):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -1740,7 +1744,7 @@ class TestCloudwatch:
         retry(_match_results, retries=10, sleep=1.0)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Datapoints..Unit"])
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Datapoints..Unit"], condition=is_new_provider)
     def test_get_metric_statistics(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
         utc_now = datetime.now(tz=timezone.utc)
@@ -1915,7 +1919,7 @@ class TestCloudwatch:
                 MaxDatapoints=10,
             )
 
-            assending_ordering = aws_client.cloudwatch.get_metric_data(
+            ascending_ordering = aws_client.cloudwatch.get_metric_data(
                 MetricDataQueries=[
                     {
                         "Id": "m1",
@@ -1956,7 +1960,7 @@ class TestCloudwatch:
             )
 
             default_ordering_datapoints = default_ordering["MetricDataResults"][0]["Timestamps"]
-            assending_ordering_datapoints = assending_ordering["MetricDataResults"][0]["Timestamps"]
+            assending_ordering_datapoints = ascending_ordering["MetricDataResults"][0]["Timestamps"]
             descening_ordering_datapoints = descening_ordering["MetricDataResults"][0]["Timestamps"]
 
             # The default ordering is TimestampDescending

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -72,7 +72,7 @@ class TestCloudwatch:
         snapshot.match("get_metric_statistics", stats)
 
     @markers.aws.only_localstack
-    def test_put_metric_data_gzip(self, aws_client, snapshot):
+    def test_put_metric_data_gzip(self, aws_client):
         metric_name = "test-metric"
         namespace = "namespace"
         data = (

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -299,7 +299,8 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        # paths= ["$..MetricDataResults..Label"], condition=is_new_provider,
+        paths=["$..MetricDataResults..Label"],
+        condition=is_new_provider,
     )
     def test_get_metric_data_for_multiple_metrics(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
@@ -346,7 +347,6 @@ class TestCloudwatch:
             ],
         )
 
-        # get_metric_data
         def assert_results():
             response = aws_client.cloudwatch.get_metric_data(
                 MetricDataQueries=[
@@ -1962,8 +1962,6 @@ class TestCloudwatch:
             assert default_ordering_datapoints == assending_ordering_datapoints[::-1]
 
         retry(assert_ordering, retries=10, sleep=1.0)
-
-
 
 
 def _check_alarm_triggered(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1747,7 +1747,7 @@ class TestCloudwatch:
         retry(_match_results, retries=10, sleep=1.0)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Datapoints..Unit"], condition=is_new_provider)
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Datapoints..Unit"])
     def test_get_metric_statistics(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
         utc_now = datetime.now(tz=timezone.utc)
@@ -1801,6 +1801,7 @@ class TestCloudwatch:
         retry(assert_metrics_count, retries=10, sleep=1.0, sleep_before=1.0)
 
     @markers.aws.validated
+    @pytest.mark.skipif(condition=is_old_provider, reason="not supported by the old provider")
     def test_get_metric_data_pagination(self, aws_client):
         namespace = f"n-sp-{short_uid()}"
         metric_name = f"m-{short_uid()}"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1511,5 +1511,55 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_with_zero_and_labels": {
+    "recorded-date": "04-12-2023, 09:13:59",
+    "recorded-content": {
+      "get_metric_data_with_zero_and_labels": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Average",
+            "Label": "metric1 Average",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              19.416666666666668
+            ]
+          },
+          {
+            "Id": "result_Sum",
+            "Label": "metric1 Sum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              116.5
+            ]
+          },
+          {
+            "Id": "result_Minimum",
+            "Label": "metric1 Minimum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              0.0
+            ]
+          },
+          {
+            "Id": "result_Maximum",
+            "Label": "metric1 Maximum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              100.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1352,7 +1352,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Sum]": {
-    "recorded-date": "23-11-2023, 15:07:21",
+    "recorded-date": "04-12-2023, 12:22:53",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -1363,7 +1363,7 @@
             "StatusCode": "Complete",
             "Timestamps": "timestamp",
             "Values": [
-              11.0
+              66.0
             ]
           }
         ],
@@ -1375,7 +1375,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[SampleCount]": {
-    "recorded-date": "23-11-2023, 15:07:22",
+    "recorded-date": "04-12-2023, 12:22:55",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -1398,7 +1398,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Minimum]": {
-    "recorded-date": "23-11-2023, 15:07:24",
+    "recorded-date": "04-12-2023, 12:22:58",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -1421,7 +1421,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Maximum]": {
-    "recorded-date": "23-11-2023, 15:07:25",
+    "recorded-date": "04-12-2023, 12:23:00",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -1444,7 +1444,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Average]": {
-    "recorded-date": "23-11-2023, 15:07:26",
+    "recorded-date": "04-12-2023, 12:23:02",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -1490,16 +1490,16 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_statistics": {
-    "recorded-date": "23-11-2023, 15:15:51",
+    "recorded-date": "04-12-2023, 14:13:08",
     "recorded-content": {
       "get_metric_statistics": {
         "Datapoints": [
           {
-            "Average": 3.5,
-            "Maximum": 7.0,
+            "Average": 4.5,
+            "Maximum": 9.0,
             "Minimum": 0.0,
-            "SampleCount": 8.0,
-            "Sum": 28.0,
+            "SampleCount": 10.0,
+            "Sum": 45.0,
             "Timestamp": "timestamp",
             "Unit": "None"
           }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1563,22 +1563,45 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
-    "recorded-date": "07-12-2023, 12:45:26",
+    "recorded-date": "07-12-2023, 14:03:11",
     "recorded-content": {
       "get_metric_statistics_with_different_units": {
         "Datapoints": [
           {
             "Average": 1.0,
             "Timestamp": "timestamp",
-            "Unit": "Seconds"
+            "Unit": "Count"
           },
           {
             "Average": 1.0,
             "Timestamp": "timestamp",
-            "Unit": "Count"
+            "Unit": "Seconds"
           }
         ],
-        "Label": "m-f09fdf34",
+        "Label": "m-test",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_with_different_units": {
+    "recorded-date": "07-12-2023, 14:04:49",
+    "recorded-content": {
+      "get_metric_data_with_different_units": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "m1",
+            "Label": "m-test",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1561,5 +1561,29 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
+    "recorded-date": "07-12-2023, 12:45:26",
+    "recorded-content": {
+      "get_metric_statistics_with_different_units": {
+        "Datapoints": [
+          {
+            "Average": 1.0,
+            "Timestamp": "timestamp",
+            "Unit": "Seconds"
+          },
+          {
+            "Average": 1.0,
+            "Timestamp": "timestamp",
+            "Unit": "Count"
+          }
+        ],
+        "Label": "m-f09fdf34",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1309,5 +1309,207 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_for_multiple_metrics": {
+    "recorded-date": "23-11-2023, 14:39:07",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              50.0
+            ]
+          },
+          {
+            "Id": "result2",
+            "Label": "metric2",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              25.0
+            ]
+          },
+          {
+            "Id": "result3",
+            "Label": "metric3",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              55.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Sum]": {
+    "recorded-date": "23-11-2023, 15:07:21",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              11.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[SampleCount]": {
+    "recorded-date": "23-11-2023, 15:07:22",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              11.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Minimum]": {
+    "recorded-date": "23-11-2023, 15:07:24",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Maximum]": {
+    "recorded-date": "23-11-2023, 15:07:25",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              11.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_stats[Average]": {
+    "recorded-date": "23-11-2023, 15:07:26",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              6.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_with_dimensions": {
+    "recorded-date": "23-11-2023, 15:10:11",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result1",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              11.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_statistics": {
+    "recorded-date": "23-11-2023, 15:15:51",
+    "recorded-content": {
+      "get_metric_statistics": {
+        "Datapoints": [
+          {
+            "Average": 3.5,
+            "Maximum": 7.0,
+            "Minimum": 0.0,
+            "SampleCount": 8.0,
+            "Sum": 28.0,
+            "Timestamp": "timestamp",
+            "Unit": "None"
+          }
+        ],
+        "Label": "metric",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
<!-- What notable changes does this PR make? -->
## Changes
- [x] **Missing Tests + Test improvements**:
  - [x] add pagination tests 
  - [x] add snapshots to the existing tests
  - [x] remove the `time.sleep` from the tests and replace with `retry` or other utility
  
- [x] **put-metric-data** improvments (follow up #9475):
  - [x] verify that the default timestamp added to the metrics is UTC time (might be local timestamp?)
  - [x] Use query str instead of function call for more readable code
  - [x] add a test where we try to insert single + static values at the same time (in one put-metric-data statement (probably will throw an error, but we need to test)

- [x] **get-metric-data** improvements (follow up #9475):
     - [x] test default order (asc/desc timestamp for get-metric-data)
     - [x] handle empty filters for dimensions
     - [x] handle filters for unit, handle different units in the metrics
     - [x] ~check if we can~ simplify the logic for min/max/sum/avg the data query, by selecting everything in one query something like: `SELECT from (SELECT from simpletable ... UNION select from aggregatedtable...`) 

