### PR TITLE
Fix for double-slash uri request

### DIFF
--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -27,6 +27,9 @@ class ApiInvocationContext:
     data: InvocationPayload
     headers: Dict[str, str]
 
+    # raw URI (including query string) retired from werkzeug "RAW_URI" environment variable
+    raw_uri: str
+
     # invocation context
     context: Dict[str, Any]
     # authentication info for this invocation

--- a/localstack/utils/strings.py
+++ b/localstack/utils/strings.py
@@ -186,3 +186,11 @@ def base64_decode(data: Union[str, bytes]) -> bytes:
 
 def get_random_hex(length: int) -> str:
     return "".join(random.choices(string.hexdigits[:16], k=length)).lower()
+
+
+def remove_leading_extra_slashes(input: str) -> str:
+    """
+    Remove leading extra slashes from the given input string.
+    Example: '///foo/bar' -> '/foo/bar'
+    """
+    return re.sub(r"^/+", "/", input)

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -193,6 +193,8 @@ class TestRouter:
         assert router.dispatch(Request(path="/my//path")).json == {"path": "my//path"}
         assert router.dispatch(Request(path="/my//path/")).json == {"path": "my//path/"}
         assert router.dispatch(Request(path="/my/path foobar")).json == {"path": "my/path foobar"}
+        assert router.dispatch(Request(path="//foobar")).json == {"path": "foobar"}
+        assert router.dispatch(Request(path="//foobar/")).json == {"path": "foobar/"}
 
     def test_path_converter_with_args(self):
         router = Router()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The RAW_URI can contain a path with a double slash for example, for the request ` https://28e9f096.execute-api.localhost.localstack.cloud:4566//hello`, RAW_URI will be `//hello`. 

This will cause an issue parsing the url using the function `urlparse`. With this fix, we replace `//` with `/` to proceed with the parsing.

<!-- What notable changes does this PR make? -->
## Changes

Normalizes the RAW_URI by replacing the `//` with `/`. It does it in two places, on the `http` package and on the apigateway `router_asf`.


## Testing

Unit tests for the specific parsing function.

