### PR TITLE
Remove HEADER_LOCALSTACK_ACCOUNT_ID

### DIFF
--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -11,6 +11,7 @@ from localstack.constants import (
 )
 from localstack.http import Response
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
+from localstack.utils.aws.request_context import mock_aws_request_headers
 
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
@@ -25,13 +26,12 @@ class MissingAuthHeaderInjector(Handler):
         #  (that allows access to restricted resources by default)
         if not context.service:
             return
-        from localstack.utils.aws import aws_stack
 
         api = context.service.service_name
         headers = context.request.headers
 
         if not headers.get("Authorization"):
-            headers["Authorization"] = aws_stack.mock_aws_request_headers(
+            headers["Authorization"] = mock_aws_request_headers(
                 api, aws_access_key_id="injectedaccesskey", region_name=AWS_REGION_US_EAST_1
             )["Authorization"]
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -165,11 +165,6 @@ SECONDARY_TEST_AWS_REGION_NAME = os.getenv("SECONDARY_TEST_AWS_REGION") or "ap-s
 INTERNAL_AWS_ACCESS_KEY_ID = "__internal_call__"
 INTERNAL_AWS_SECRET_ACCESS_KEY = "__internal_call__"
 
-# This header must be set to the AWS Account ID
-# Presence of this header in an incoming request typically means that the request originated within localstack,
-# i.e. it is an internal cross-service call.
-HEADER_LOCALSTACK_ACCOUNT_ID = "x-localstack-account-id"
-
 # trace log levels (excluding/including internal API calls), configurable via $LS_LOG
 LS_LOG_TRACE = "trace"
 LS_LOG_TRACE_INTERNAL = "trace-internal"

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -42,7 +42,6 @@ from localstack.services.apigateway.templates import (
 )
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_responses import (
     LambdaResponse,
@@ -50,6 +49,7 @@ from localstack.utils.aws.aws_responses import (
     requests_response,
 )
 from localstack.utils.aws.client_types import ServicePrincipal
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.aws.templating import VtlTemplate
 from localstack.utils.collections import dict_multi_values, remove_attributes
 from localstack.utils.common import make_http_request, to_str
@@ -151,7 +151,7 @@ def get_internal_mocked_headers(
         )
     else:
         access_key_id = None
-    headers = aws_stack.mock_aws_request_headers(
+    headers = mock_aws_request_headers(
         service=service_name, aws_access_key_id=access_key_id, region_name=region_name
     )
 
@@ -589,7 +589,7 @@ class S3Integration(BackendIntegration):
             LOG.debug(msg)
             return make_error_response(msg, 404)
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             service="s3",
             aws_access_key_id=invocation_context.account_id,
             region_name=invocation_context.region_name,
@@ -715,7 +715,7 @@ class SNSIntegration(BackendIntegration):
             LOG.warning("Failed to apply template for SNS integration", e)
             raise
         region_name = uri.split(":")[3]
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             service="sns", aws_access_key_id=invocation_context.account_id, region_name=region_name
         )
         result = make_http_request(
@@ -780,7 +780,7 @@ class StepFunctionIntegration(BackendIntegration):
         result = json_safe(remove_attributes(result, ["ResponseMetadata"]))
         response = StepFunctionIntegration._create_response(
             HTTPStatus.OK.value,
-            aws_stack.mock_aws_request_headers(
+            mock_aws_request_headers(
                 "stepfunctions",
                 aws_access_key_id=invocation_context.account_id,
                 region_name=invocation_context.region_name,

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -14,7 +14,6 @@ from localstack.constants import (
     APPLICATION_AMZ_JSON_1_1,
     APPLICATION_X_WWW_FORM_URLENCODED,
     AWS_REGION_US_EAST_1,
-    HEADER_LOCALSTACK_ACCOUNT_ID,
     LOCALHOST,
 )
 from localstack.utils.strings import is_string_or_bytes, to_str
@@ -157,9 +156,8 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
             return access_id[0]
 
 
-# TODO remove the `internal` arg
 def mock_aws_request_headers(
-    service: str, aws_access_key_id: str, region_name: str, internal: bool = False
+    service: str, aws_access_key_id: str, region_name: str
 ) -> Dict[str, str]:
     """
     Returns a mock set of headers that resemble SigV4 signing method.
@@ -173,7 +171,7 @@ def mock_aws_request_headers(
     # For S3 presigned URLs, we require that the client and server use the same
     # access key ID to sign requests. So try to use the access key ID for the
     # current request if available
-    headers = {
+    return {
         "Content-Type": ctype,
         "Accept-Encoding": "identity",
         "X-Amz-Date": "20160623T103251Z",  # TODO: Use current date
@@ -183,8 +181,3 @@ def mock_aws_request_headers(
             + "SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=1234"
         ),
     }
-    if internal:
-        # TODO: This method of detecting internal calls is no longer valid
-        # We now use the `INTERNAL_REQUEST_PARAMS_HEADER` header which is set to the DTO
-        headers[HEADER_LOCALSTACK_ACCOUNT_ID] = get_aws_account_id()
-    return headers

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -1,3 +1,7 @@
+"""
+This module has utilities relating to creating/parsing AWS requests.
+"""
+
 import logging
 import re
 import threading
@@ -10,10 +14,12 @@ from requests.structures import CaseInsensitiveDict
 
 from localstack.aws.accounts import get_account_id_from_access_key_id
 from localstack.constants import (
+    APPLICATION_AMZ_JSON_1_0,
+    APPLICATION_AMZ_JSON_1_1,
+    APPLICATION_X_WWW_FORM_URLENCODED,
     AWS_REGION_US_EAST_1,
     DEFAULT_AWS_ACCOUNT_ID,
 )
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import (
     requests_error_response,
     requests_to_flask_response,
@@ -141,7 +147,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
     auth_header = headers.get("Authorization")
     auth_header = (
         auth_header
-        or aws_stack.mock_aws_request_headers(
+        or mock_aws_request_headers(
             service_name, aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID, region_name=AWS_REGION_US_EAST_1
         )["Authorization"]
     )
@@ -157,7 +163,7 @@ def configure_region_for_current_request(region_name: str, service_name: str):
 
 def mock_request_for_region(service_name: str, account_id: str, region_name: str) -> Request:
     result = Request()
-    result.headers["Authorization"] = aws_stack.mock_aws_request_headers(
+    result.headers["Authorization"] = mock_aws_request_headers(
         service_name, aws_access_key_id=account_id, region_name=region_name
     )["Authorization"]
     return result
@@ -213,3 +219,42 @@ def patch_moto_request_handling():
             # sometimes there is a race condition where the previous patch has not been applied yet
             pass
         return fn(self, *args, **kwargs)
+
+
+def mock_aws_request_headers(
+    service: str, aws_access_key_id: str, region_name: str, internal: bool = False
+) -> Dict[str, str]:
+    """
+    Returns a mock set of headers that resemble SigV4 signing method.
+    """
+    from localstack.aws.connect import (
+        INTERNAL_REQUEST_PARAMS_HEADER,
+        InternalRequestParameters,
+        dump_dto,
+    )
+
+    ctype = APPLICATION_AMZ_JSON_1_0
+    if service == "kinesis":
+        ctype = APPLICATION_AMZ_JSON_1_1
+    elif service in ["sns", "sqs", "sts", "cloudformation"]:
+        ctype = APPLICATION_X_WWW_FORM_URLENCODED
+
+    # For S3 presigned URLs, we require that the client and server use the same
+    # access key ID to sign requests. So try to use the access key ID for the
+    # current request if available
+    headers = {
+        "Content-Type": ctype,
+        "Accept-Encoding": "identity",
+        "X-Amz-Date": "20160623T103251Z",  # TODO: Use current date
+        "Authorization": (
+            "AWS4-HMAC-SHA256 "
+            + f"Credential={aws_access_key_id}/20160623/{region_name}/{service}/aws4_request, "
+            + "SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=1234"
+        ),
+    }
+
+    if internal:
+        dto = InternalRequestParameters()
+        headers[INTERNAL_REQUEST_PARAMS_HEADER] = dump_dto(dto)
+
+    return headers

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -15,6 +15,7 @@ from localstack.aws.connect import connect_externally_to, connect_to
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import arns
 from localstack.utils.aws import resources as resource_utils
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.urls import localstack_host
 
 try:
@@ -37,7 +38,6 @@ from localstack.services.lambda_.lambda_utils import (
     get_handler_file_from_name,
 )
 from localstack.utils.archives import create_zip_file_cli, create_zip_file_python
-from localstack.utils.aws import aws_stack
 from localstack.utils.collections import ensure_list
 from localstack.utils.files import (
     TMP_FILES,
@@ -496,7 +496,7 @@ def send_dynamodb_request(path, action, request_body):
     headers = {
         "Host": "dynamodb.amazonaws.com",
         "x-amz-target": "DynamoDB_20120810.{}".format(action),
-        "Authorization": aws_stack.mock_aws_request_headers(
+        "Authorization": mock_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"],
     }

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -31,8 +31,9 @@ from localstack.services.apigateway.helpers import (
 )
 from localstack.testing.pytest import markers
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns
 from localstack.utils.aws import resources as resource_util
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import select_attributes
 from localstack.utils.files import load_file
 from localstack.utils.http import safe_requests as requests
@@ -1659,9 +1660,7 @@ def test_apigateway_rust_lambda(
 
 @markers.aws.unknown
 def test_apigw_call_api_with_aws_endpoint_url(aws_client):
-    headers = aws_stack.mock_aws_request_headers(
-        "apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
-    )
+    headers = mock_aws_request_headers("apigateway", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME)
     headers["Host"] = "apigateway.us-east-2.amazonaws.com:4566"
     url = f"{config.internal_service_url()}/apikeys?includeValues=true&name=test%40example.org"
     response = requests.get(url, headers=headers)

--- a/tests/aws/services/cloudformation/resources/test_cdk.py
+++ b/tests/aws/services/cloudformation/resources/test_cdk.py
@@ -8,7 +8,7 @@ from localstack import config
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
@@ -50,7 +50,7 @@ class TestCdkInit:
         change_set_name = "cdk-deploy-change-set-a4b98b18"
         stack_name = "CDKToolkit-a4b98b18"
         try:
-            headers = aws_stack.mock_aws_request_headers(
+            headers = mock_aws_request_headers(
                 "cloudformation", TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
             )
             base_url = config.internal_service_url()

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -72,10 +72,7 @@ class TestCloudwatch:
         encoded_data = gzip.compress(bytes_data)
 
         headers = aws_stack.mock_aws_request_headers(
-            "cloudwatch",
-            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
-            region_name=TEST_AWS_REGION_NAME,
-            internal=True,
+            "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         authorization = aws_stack.mock_aws_request_headers(
             "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -13,7 +13,8 @@ from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.services.cloudwatch.provider import PATH_GET_RAW_METRICS
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import retry, short_uid, to_str
 from localstack.utils.sync import poll_condition
 
@@ -71,13 +72,13 @@ class TestCloudwatch:
         bytes_data = bytes(data, encoding="utf-8")
         encoded_data = gzip.compress(bytes_data)
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "cloudwatch",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,
             internal=True,
         )
-        authorization = aws_stack.mock_aws_request_headers(
+        authorization = mock_aws_request_headers(
             "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )["Authorization"]
 
@@ -201,7 +202,7 @@ class TestCloudwatch:
         aws_client.cloudwatch.put_metric_data(
             Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
         )
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         url = f"{config.external_service_url()}{PATH_GET_RAW_METRICS}"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -72,7 +72,10 @@ class TestCloudwatch:
         encoded_data = gzip.compress(bytes_data)
 
         headers = aws_stack.mock_aws_request_headers(
-            "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
+            "cloudwatch",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            region_name=TEST_AWS_REGION_NAME,
+            internal=True,
         )
         authorization = aws_stack.mock_aws_request_headers(
             "monitoring", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -11,7 +11,8 @@ from localstack import config, constants
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.pytest import markers
-from localstack.utils.aws import aws_stack, resources
+from localstack.utils.aws import resources
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import poll_condition, retry, select_attributes, short_uid
 from localstack.utils.kinesis import kinesis_connector
 
@@ -250,7 +251,7 @@ class TestKinesis:
         # get records with CBOR encoding
         iterator = get_shard_iterator(stream_name, aws_client.kinesis)
         url = config.internal_service_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1
@@ -284,7 +285,7 @@ class TestKinesis:
 
         # empty get records with CBOR encoding
         url = config.internal_service_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "kinesis", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Content-Type"] = constants.APPLICATION_AMZ_CBOR_1_1

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -54,7 +54,7 @@ from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.aws.resources import create_s3_bucket
 from localstack.utils.files import load_file
 from localstack.utils.run import run
@@ -2617,7 +2617,7 @@ class TestS3:
         object_key = "data"
         body = "Hello\r\n\r\n\r\n\r\n"
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -2652,7 +2652,7 @@ class TestS3:
         body = "Hello Blob"
         valid_checksum = hash_sha256(body)
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -2704,7 +2704,7 @@ class TestS3:
         body = "Hello Blob"
         precalculated_etag = hashlib.md5(body.encode()).hexdigest()
         headers = {
-            "Authorization": aws_stack.mock_aws_request_headers(
+            "Authorization": mock_aws_request_headers(
                 "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
             )["Authorization"],
             "Content-Type": "audio/mpeg",
@@ -7746,7 +7746,7 @@ class TestS3Routing:
 
         path = s3_key if use_virtual_address else f"{s3_bucket}/{s3_key}"
         url = f"{config.internal_service_url()}/{path}"
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["host"] = f"{s3_bucket}.{domain}" if use_virtual_address else domain

--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -15,7 +15,7 @@ from localstack.constants import (
     TEST_AWS_REGION_NAME,
 )
 from localstack.testing.pytest import markers
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.strings import short_uid
 
 
@@ -176,7 +176,7 @@ class TestS3Cors:
         origin = ALLOWED_CORS_ORIGINS[0]
         # we need to "sign" the request so that our service name parser recognize ListBuckets as an S3 operation
         # if the request isn't signed, AWS will redirect to https://aws.amazon.com/s3/
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "s3", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = origin

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -21,6 +21,7 @@ from localstack.aws.api.secretsmanager import (
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
@@ -1205,7 +1206,7 @@ class TestSecretsManager:
 
     @staticmethod
     def secretsmanager_http_json_headers(amz_target: str) -> dict:
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "secretsmanager",
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -26,7 +26,8 @@ from localstack.services.sqs.provider import MAX_NUMBER_OF_MESSAGES
 from localstack.services.sqs.utils import parse_queue_url
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import GenericTransformer
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import poll_condition, retry, short_uid, to_str
 from localstack.utils.urls import localstack_host
 from tests.aws.services.lambda_.functions import lambda_integration
@@ -1106,7 +1107,7 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
         sqs_create_queue(QueueName=queue_name)
 
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         payload = f"Action=GetQueueUrl&QueueName={queue_name}"
@@ -1126,7 +1127,7 @@ class TestSqsProvider:
         queue_name = f"queue-{short_uid()}"
 
         edge_url = config.internal_service_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "sqs", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         port = 12345

--- a/tests/aws/services/sts/test_sts.py
+++ b/tests/aws/services/sts/test_sts.py
@@ -8,7 +8,7 @@ from localstack import config
 from localstack.constants import APPLICATION_JSON, TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
 from localstack.testing.aws.util import create_client_with_keys
 from localstack.testing.pytest import markers
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.numbers import is_number
 from localstack.utils.strings import short_uid, to_str
 
@@ -177,7 +177,7 @@ class TestSTSIntegrations:
     def test_expiration_date_format(self):
         url = config.internal_service_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "sts", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Accept"] = APPLICATION_JSON

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -5,7 +5,7 @@ from localstack import config
 from localstack.aws.handlers import cors as cors_handler
 from localstack.aws.handlers.cors import _get_allowed_cors_origins
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.strings import short_uid, to_str
 
 
@@ -105,7 +105,7 @@ class TestCSRF:
 
     def test_disable_cors_headers(self, monkeypatch):
         """Test DISABLE_CORS_CHECKS=1 (most restrictive setting, not sending any CORS headers)"""
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         headers["Origin"] = "https://app.localstack.cloud"
@@ -133,7 +133,7 @@ class TestCSRF:
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
 
         url = config.internal_service_url()
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "sns", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )
         data = {"Action": "ListTopics", "Version": "2010-03-31"}

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -10,8 +10,8 @@ from localstack.services.dynamodb.utils import (
     SchemaExtractor,
     dynamize_value,
 )
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import dynamodb_table_arn
+from localstack.utils.aws.request_context import mock_aws_request_headers
 
 
 def test_fix_region_in_headers():
@@ -19,7 +19,7 @@ def test_fix_region_in_headers():
     # TODO: this may need to be updated once we migrate DynamoDB to ASF
 
     for region_name in ["local", "localhost"]:
-        headers = aws_stack.mock_aws_request_headers(
+        headers = mock_aws_request_headers(
             "dynamodb", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=region_name
         )
         assert TEST_AWS_REGION_NAME not in headers.get("Authorization")

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -58,10 +58,7 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
-            "dummy",
-            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
-            region_name=origin_partition,
-            internal=True,
+            "dummy", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=origin_partition
         )
     else:
         headers = {}
@@ -354,10 +351,7 @@ def test_arn_partition_rewriting_in_request_and_response(
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
-            "dummy",
-            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
-            region_name=origin_partition,
-            internal=True,
+            "dummy", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=origin_partition
         )
     else:
         headers = {"Host": f"{httpserver.host}:{httpserver.port}"}

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -13,7 +13,7 @@ from localstack.aws.handlers.partition_rewriter import ArnPartitionRewriteHandle
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request, Response
 from localstack.http.request import get_full_raw_path, get_raw_path
-from localstack.utils.aws.aws_stack import mock_aws_request_headers
+from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -58,7 +58,10 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
-            "dummy", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=origin_partition
+            "dummy",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            region_name=origin_partition,
+            internal=True,
         )
     else:
         headers = {}
@@ -351,7 +354,10 @@ def test_arn_partition_rewriting_in_request_and_response(
     # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
     if internal_call:
         headers = mock_aws_request_headers(
-            "dummy", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=origin_partition
+            "dummy",
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            region_name=origin_partition,
+            internal=True,
         )
     else:
         headers = {"Host": f"{httpserver.host}:{httpserver.port}"}


### PR DESCRIPTION
## Motivation

This PR removes the long deprecated `HEADER_LOCALSTACK_ACCOUNT_ID`. It was used by the old `aws_stack.connect_to_service()` client to pass the Account ID of origin caller. 

We have since moved to the new client `connect_to()` which is more intelligent with cross-account calls by passing the appropriate IAM credentials in the process.

## Changes

- Remove all use of `HEADER_LOCALSTACK_ACCOUNT_ID`
- Make the `mock_aws_request_headers()` use the current method of detecting internal calls
- Move the `mock_aws_request_headers()` to `localstack.utils.aws.request_context` to avoid a circular import. It also makes sense to group the AWS request related functions together - and this module already has `mock_request_for_region()`