### PR TITLE
fix get_raw_path with double slash prefix path for legacy v-host S3

### DIFF
--- a/localstack/http/request.py
+++ b/localstack/http/request.py
@@ -196,7 +196,12 @@ def get_raw_path(request) -> str:
     if hasattr(request, "environ"):
         # werkzeug/flask request (already a string, and contains the query part)
         # we need to parse it, because the RAW_URI can contain a full URL if it is specified in the HTTP request
-        return urlparse(request.environ.get("RAW_URI", request.path)).path
+        raw_uri: str = request.environ.get("RAW_URI", "")
+        if raw_uri.startswith("//"):
+            # if the RAW_URI starts with double slashes, `urlparse` will fail to decode it as path only
+            # it also means that we already only have the path, so we just need to remove the query string
+            return raw_uri.split("?")[0]
+        return urlparse(raw_uri or request.path).path
 
     if hasattr(request, "scope"):
         # quart request raw_path comes as bytes, and without the query part

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10576,5 +10576,85 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_object_with_slashes_in_key[True]": {
+    "recorded-date": "24-11-2023, 11:11:00",
+    "recorded-content": {
+      "list-objects-slashes": {
+        "Contents": [
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "/bar/foo/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"3858f62230ac3c915f300c664312c63f\"",
+            "Key": "/foo",
+            "LastModified": "datetime",
+            "Size": 6,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"96948aad3fcae80c08a35c9b5958cd89\"",
+            "Key": "bar",
+            "LastModified": "datetime",
+            "Size": 6,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_object_with_slashes_in_key[False]": {
+    "recorded-date": "24-11-2023, 11:11:04",
+    "recorded-content": {
+      "list-objects-slashes": {
+        "Contents": [
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "/bar/foo/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"3858f62230ac3c915f300c664312c63f\"",
+            "Key": "/foo",
+            "LastModified": "datetime",
+            "Size": 6,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"96948aad3fcae80c08a35c9b5958cd89\"",
+            "Key": "bar",
+            "LastModified": "datetime",
+            "Size": 6,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 3,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/unit/http_/test_request.py
+++ b/tests/unit/http_/test_request.py
@@ -137,6 +137,14 @@ def test_get_raw_path_with_query():
     assert get_raw_path(request) == "/foo%2Fbar/ed"
 
 
+def test_get_raw_path_with_prefix_slashes():
+    request = Request("GET", "/foo/bar/ed", raw_path="//foo%2Fbar/ed?fizz=buzz")
+
+    assert request.path == "/foo/bar/ed"
+    assert request.environ["RAW_URI"] == "//foo%2Fbar/ed?fizz=buzz"
+    assert get_raw_path(request) == "//foo%2Fbar/ed"
+
+
 def test_get_raw_path_with_full_uri():
     # raw_path is actually raw_uri in the WSGI environment
     # it can be a full URL


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As raised by #9723, when supplying a path only starting with double slashes, `get_raw_path` does not parse it properly, it returns an empty `.path` property. 
If `RAW_URI` contains only a path, `get_raw_path` does need to call `urlparse`, we can manually strip the query string and return the path from it. 

<!-- What notable changes does this PR make? -->
## Changes
- manually return the path from `RAW_URI` if it starts with a double slashes
- add S3 tests in virtual host mode which validates the fix for the legacy provider (calling `get_raw_path` when rewriting the URL) 
- add a unit test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

