### PR TITLE
CFn: render ext providers with correct plugin namespace

### DIFF
--- a/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack/services/cloudformation/scaffolding/__main__.py
@@ -335,7 +335,7 @@ class TemplateRenderer:
             case FileType.plugin:
                 kwargs["service"] = resource_name.python_compatible_service_name.lower()
                 kwargs["lower_resource"] = resource_name.resource.lower()
-                kwargs["pro"] = False
+                kwargs["pro"] = self.pro
             case FileType.integration_test:
                 kwargs["black_box_template_path"] = str(
                     template_path(resource_name, FileType.minimal_template, tests_output_path)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While activating the pro resource providers in https://github.com/localstack/localstack/pull/9601 I neglected to read the `pro` flag from the command line arguments when rendering the plugin file. This means that we will get conflicting plugin namespaces which has an undefined load order. To get around this, we chose to add a new namespace for the pro plugins, and load the plugins in priority order (pro first). This feature has not worked correctly!

In the companion PR in the pro repo, I migrate the current plugins to this new namespace.

cc @Morijarti 

<!-- What notable changes does this PR make? -->
## Changes

* Read the `--pro` flag from the environment when rendering the plugin file


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

