### PR TITLE
[SFN] Fix optimised integrations clients leading to timeouts and retries 

### DIFF
--- a/localstack/services/stepfunctions/asl/utils/boto_client.py
+++ b/localstack/services/stepfunctions/asl/utils/boto_client.py
@@ -2,6 +2,7 @@ from botocore.client import BaseClient
 from botocore.config import Config
 
 from localstack.aws.connect import connect_to
+from localstack.services.stepfunctions.asl.component.common.timeouts.timeout import TimeoutSeconds
 
 
 def boto_client_for(region: str, account: str, service: str) -> BaseClient:
@@ -9,5 +10,10 @@ def boto_client_for(region: str, account: str, service: str) -> BaseClient:
         aws_access_key_id=account,
         region_name=region,
         service_name=service,
-        config=Config(parameter_validation=False),
+        config=Config(
+            parameter_validation=False,
+            retries={"max_attempts": 0, "total_max_attempts": 1},
+            connect_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,
+            read_timeout=TimeoutSeconds.DEFAULT_TIMEOUT_SECONDS,
+        ),
     )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Invocations of service integrations in SFN v2 currently trigger the default behaviour of boto for connection and read timeouts, as well as the retry strategy. This could potentially disrupt the State Machine's behaviour related to timeout and retry declarations.
Closes #9731 

<!-- What notable changes does this PR make? -->
## Changes
This pull request deactivates the mentioned boto behaviour to guarantee that timeout issues are passed upstream to the interpreter as intended.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

