### PR TITLE
added util function for time

### DIFF
--- a/localstack/utils/time.py
+++ b/localstack/utils/time.py
@@ -29,6 +29,14 @@ def timestamp_millis(time=None) -> str:
     return microsecond_time[:-4] + microsecond_time[-1]
 
 
+def iso1806_to_epoch(t: str) -> float:
+    return datetime.fromisoformat(t).timestamp()
+
+
+def epoch_to_iso1806(ts: int) -> str:
+    return datetime.utcfromtimestamp(ts).isoformat()
+
+
 def epoch_timestamp() -> float:
     return time.time()
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds util functions for time operations used in https://github.com/localstack/localstack-ext/pull/2392.

<!-- What notable changes does this PR make? -->
## Changes
Added two new functions
- `iso1806_to_epoch`: to get epoch from iso1806 time string
- `epoch_to_iso1806`: to get iso1806 time string from epoch time


## Testing

Tests for validating this is added in - https://github.com/localstack/localstack-ext/pull/2392.


