### PR TITLE
s3: add SourceBucketLocation for CrossLocationLoggingProhibitions exception

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -786,6 +786,7 @@ class CrossLocationLoggingProhibitted(ServiceException):
     sender_fault: bool = False
     status_code: int = 403
     TargetBucketLocation: Optional[BucketRegion]
+    SourceBucketLocation: Optional[BucketRegion]
 
 
 class InvalidTargetBucketForLogging(ServiceException):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -886,6 +886,9 @@
         "members": {
           "TargetBucketLocation": {
             "shape": "BucketRegion"
+          },
+          "SourceBucketLocation": {
+            "shape": "BucketRegion"
           }
         },
         "error": {

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,14 +150,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,10 +150,14 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1653,9 +1653,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 TargetBucket=target_bucket_name,
             )
 
-        if target_bucket.region_name != moto_bucket.region_name:
+        source_bucket_region = moto_bucket.region_name
+        if target_bucket.region_name != source_bucket_region:
             raise CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
+                TargetBucketLocation=target_bucket.region_name,
+            ) if source_bucket_region != AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
+                "Cross S3 location logging not allowed. ",
+                SourceBucketLocation=source_bucket_region,
                 TargetBucketLocation=target_bucket.region_name,
             )
 

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1658,7 +1658,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             raise CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
                 TargetBucketLocation=target_bucket.region_name,
-            ) if source_bucket_region != AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
+            ) if source_bucket_region == AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
                 SourceBucketLocation=source_bucket_region,
                 TargetBucketLocation=target_bucket.region_name,

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -199,6 +199,7 @@ from localstack.aws.api.s3 import (
 )
 from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
 from localstack.services.edge import ROUTER
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.codec import AwsChunkedDecoder
 from localstack.services.s3.constants import (
@@ -3283,9 +3284,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 TargetBucket=target_bucket_name,
             )
 
-        if target_s3_bucket.bucket_region != s3_bucket.bucket_region:
+        source_bucket_region = s3_bucket.bucket_region
+        if target_s3_bucket.bucket_region != source_bucket_region:
             raise CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
+                TargetBucketLocation=target_s3_bucket.bucket_region,
+            ) if source_bucket_region != AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
+                "Cross S3 location logging not allowed. ",
+                SourceBucketLocation=source_bucket_region,
                 TargetBucketLocation=target_s3_bucket.bucket_region,
             )
 

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -198,8 +198,8 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
 )
 from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
-from localstack.services.edge import ROUTER
 from localstack.constants import AWS_REGION_US_EAST_1
+from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.codec import AwsChunkedDecoder
 from localstack.services.s3.constants import (
@@ -3289,7 +3289,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             raise CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
                 TargetBucketLocation=target_s3_bucket.bucket_region,
-            ) if source_bucket_region != AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
+            ) if source_bucket_region == AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
                 "Cross S3 location logging not allowed. ",
                 SourceBucketLocation=source_bucket_region,
                 TargetBucketLocation=target_s3_bucket.bucket_region,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -9256,6 +9256,7 @@ class TestS3BucketLogging:
         s3_create_bucket_with_client,
         snapshot,
     ):
+        # The aim of the test is to check the behavior of the CrossLocationLoggingProhibitions exception for us-east-1 and regions other than us-east-1.
         snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
         region_1 = "us-east-1"
         region_2 = "us-east-2"

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -9256,7 +9256,8 @@ class TestS3BucketLogging:
         s3_create_bucket_with_client,
         snapshot,
     ):
-        # The aim of the test is to check the behavior of the CrossLocationLoggingProhibitions exception for us-east-1 and regions other than us-east-1.
+        # The aim of the test is to check the behavior of the CrossLocationLoggingProhibitions
+        # exception for us-east-1 and regions other than us-east-1.
         snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
         region_1 = "us-east-1"
         region_2 = "us-east-2"

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -9247,6 +9247,57 @@ class TestS3BucketLogging:
         snapshot.match("put-bucket-logging-non-existent-bucket", e.value.response)
         assert e.value.response["Error"]["TargetBucket"] == nonexistent_target_bucket
 
+    @markers.aws.validated
+    def test_put_bucket_logging_cross_locations(
+        self,
+        aws_client,
+        aws_client_factory,
+        s3_create_bucket,
+        s3_create_bucket_with_client,
+        snapshot,
+    ):
+        snapshot.add_transformer(snapshot.transform.key_value("TargetBucket"))
+        region_1 = "us-east-1"
+        region_2 = "us-east-2"
+        region_3 = "us-west-2"
+
+        snapshot.add_transformer(RegexTransformer(region_1, "<region_1>"))
+        snapshot.add_transformer(RegexTransformer(region_2, "<region_2>"))
+        snapshot.add_transformer(RegexTransformer(region_3, "<region_3>"))
+
+        bucket_name_region_1 = f"bucket-{short_uid()}"
+        client = aws_client_factory(region_name=region_1).s3
+        s3_create_bucket_with_client(client, Bucket=bucket_name_region_1)
+
+        bucket_name_region_2 = s3_create_bucket(
+            CreateBucketConfiguration={"LocationConstraint": region_2}
+        )
+        target_bucket = s3_create_bucket(CreateBucketConfiguration={"LocationConstraint": region_3})
+
+        with pytest.raises(ClientError) as e:
+            bucket_logging_status = {
+                "LoggingEnabled": {
+                    "TargetBucket": target_bucket,
+                    "TargetPrefix": "log",
+                },
+            }
+            client.put_bucket_logging(
+                Bucket=bucket_name_region_1, BucketLoggingStatus=bucket_logging_status
+            )
+        snapshot.match("put-bucket-logging-cross-us-east-1", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            bucket_logging_status = {
+                "LoggingEnabled": {
+                    "TargetBucket": target_bucket,
+                    "TargetPrefix": "log",
+                },
+            }
+            aws_client.s3.put_bucket_logging(
+                Bucket=bucket_name_region_2, BucketLoggingStatus=bucket_logging_status
+            )
+        snapshot.match("put-bucket-logging-different-regions", e.value.response)
+
 
 class TestS3BucketReplication:
     @markers.aws.validated

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -7407,7 +7407,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging_wrong_target": {
-    "recorded-date": "03-08-2023, 04:26:14",
+    "recorded-date": "27-11-2023, 16:26:34",
     "recorded-content": {
       "put-bucket-logging-different-regions": {
         "Error": {

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10656,5 +10656,33 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3BucketLogging::test_put_bucket_logging_cross_locations": {
+    "recorded-date": "27-11-2023, 16:40:53",
+    "recorded-content": {
+      "put-bucket-logging-cross-us-east-1": {
+        "Error": {
+          "Code": "CrossLocationLoggingProhibitted",
+          "Message": "Cross S3 location logging not allowed. ",
+          "TargetBucketLocation": "<region_3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "put-bucket-logging-different-regions": {
+        "Error": {
+          "Code": "CrossLocationLoggingProhibitted",
+          "Message": "Cross S3 location logging not allowed. ",
+          "SourceBucketLocation": "<region_2>",
+          "TargetBucketLocation": "<region_3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While fixing a test case: `test_put_bucket_logging_wrong_target` for multiple accounts and regions in #9713, found AWS parity issues with parameters of `CrossLocationLoggingProhibitted` exception. 

<!-- What notable changes does this PR make? -->
## Changes
This PR: 
- updates the exception `CrossLocationLoggingProhibitted` with `SourceBucketLocation`.
- update the raised exceptions in the `PutBucketLogging` handler. 
- validates the change with `test_put_bucket_logging_cross_locations` test case. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

