### PR TITLE
fix cloudwatch resource providers

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
@@ -74,5 +74,46 @@
         }
       ]
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_cloudwatch.py::test_alarm_no_statistic": {
+    "recorded-date": "27-11-2023, 10:08:09",
+    "recorded-content": {}
+  },
+  "tests/aws/services/cloudformation/resources/test_cloudwatch.py::test_alarm_ext_statistic": {
+    "recorded-date": "27-11-2023, 10:09:46",
+    "recorded-content": {
+      "simple_alarm": [
+        {
+          "AlarmName": "<alarm-name:1>",
+          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+          "AlarmDescription": "uses extended statistic",
+          "AlarmConfigurationUpdatedTimestamp": "timestamp",
+          "ActionsEnabled": true,
+          "OKActions": [],
+          "AlarmActions": [],
+          "InsufficientDataActions": [],
+          "StateValue": "INSUFFICIENT_DATA",
+          "StateReason": "Unchecked: Initial alarm creation",
+          "StateUpdatedTimestamp": "timestamp",
+          "MetricName": "Duration",
+          "Namespace": "<namespace:1>",
+          "ExtendedStatistic": "p99",
+          "Dimensions": [
+            {
+              "Name": "FunctionName",
+              "Value": "my-function"
+            }
+          ],
+          "Period": 300,
+          "Unit": "Count",
+          "EvaluationPeriods": 3,
+          "DatapointsToAlarm": 3,
+          "Threshold": 10.0,
+          "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+          "TreatMissingData": "ignore",
+          "StateTransitionedTimestamp": "timestamp"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_cloudwatch.snapshot.json
@@ -7,5 +7,72 @@
         "AlarmName": "<resource:1>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_cloudwatch.py::test_composite_alarm_creation": {
+    "recorded-date": "27-11-2023, 09:26:48",
+    "recorded-content": {
+      "composite_alarm": [
+        {
+          "ActionsEnabled": true,
+          "AlarmActions": [
+            "arn:aws:sns:<region>:111111111111:stack-fd398c48-SNS-7rt9W1qlY3qk"
+          ],
+          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+          "AlarmConfigurationUpdatedTimestamp": "timestamp",
+          "AlarmDescription": "Indicates that the system resource usage is high while no known deployment is in progress",
+          "AlarmName": "<alarm-name:1>",
+          "AlarmRule": "(ALARM(<SubscriptionArn:2>) OR ALARM(<alarm-name:2>))",
+          "InsufficientDataActions": [],
+          "OKActions": [],
+          "StateReason": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1> was created and its alarm rule evaluates to OK",
+          "StateReasonData": {
+            "triggeringAlarms": [
+              {
+                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<SubscriptionArn:2>",
+                "state": {
+                  "value": "INSUFFICIENT_DATA",
+                  "timestamp": "date"
+                }
+              },
+              {
+                "arn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:2>",
+                "state": {
+                  "value": "INSUFFICIENT_DATA",
+                  "timestamp": "date"
+                }
+              }
+            ]
+          },
+          "StateUpdatedTimestamp": "timestamp",
+          "StateValue": "OK",
+          "StateTransitionedTimestamp": "timestamp"
+        }
+      ],
+      "metric_alarm": [
+        {
+          "AlarmName": "<alarm-name:2>",
+          "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:2>",
+          "AlarmDescription": "Memory usage is high",
+          "AlarmConfigurationUpdatedTimestamp": "timestamp",
+          "ActionsEnabled": true,
+          "OKActions": [],
+          "AlarmActions": [],
+          "InsufficientDataActions": [],
+          "StateValue": "INSUFFICIENT_DATA",
+          "StateReason": "Unchecked: Initial alarm creation",
+          "StateUpdatedTimestamp": "timestamp",
+          "MetricName": "MemoryUsage",
+          "Namespace": "<namespace:1>",
+          "Statistic": "Average",
+          "Dimensions": [],
+          "Period": 60,
+          "EvaluationPeriods": 1,
+          "Threshold": 65.0,
+          "ComparisonOperator": "GreaterThanThreshold",
+          "TreatMissingData": "breaching",
+          "StateTransitionedTimestamp": "timestamp"
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/templates/cfn_cw_composite_alarm.yml
+++ b/tests/aws/templates/cfn_cw_composite_alarm.yml
@@ -1,0 +1,50 @@
+Resources:
+  SNS:
+    Type: AWS::SNS::Topic
+  HighResourceUsage:
+    Type: AWS::CloudWatch::CompositeAlarm
+    Properties:
+      AlarmName: HighResourceUsage
+      AlarmRule: (ALARM(HighCPUUsage) OR ALARM(HighMemoryUsage))
+      AlarmActions:
+      - Ref: SNS
+      AlarmDescription: Indicates that the system resource usage is high while no known deployment is in progress
+    DependsOn:
+    - HighCPUUsage
+    - HighMemoryUsage
+  HighCPUUsage:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: CPU usage is high
+      AlarmName: HighCPUUsage
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: CPUUsage
+      Namespace: CustomNamespace
+      Period: 60
+      Statistic: Average
+      Threshold: 70
+      TreatMissingData: notBreaching
+  HighMemoryUsage:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Memory usage is high
+      AlarmName: HighMemoryUsage
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: MemoryUsage
+      Namespace: CustomNamespace
+      Period: 60
+      Statistic: Average
+      Threshold: 65
+      TreatMissingData: breaching
+
+Outputs:
+  CompositeAlarmName:
+    Description: Composite Alarm
+    Value:
+      Ref: HighResourceUsage
+  MetricAlarmName:
+    Description: Memory Alarm
+    Value:
+      Ref: HighMemoryUsage

--- a/tests/aws/templates/cfn_cw_simple_alarm.yml
+++ b/tests/aws/templates/cfn_cw_simple_alarm.yml
@@ -1,0 +1,24 @@
+Resources:
+  MetricAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "uses extended statistic"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 3
+      Dimensions:
+        - Name: FunctionName
+          Value: "my-function"
+      EvaluationPeriods: 3
+      ExtendedStatistic: p99
+      MetricName: Duration
+      Namespace: AWS/Lambda
+      Period: 300
+      Threshold: 10
+      TreatMissingData: ignore
+      Unit: Count
+
+Outputs:
+    MetricAlarmName:
+        Description: Memory Alarm
+        Value:
+          Ref: MetricAlarm


### PR DESCRIPTION
## Motivation
The cloudwatch resource providers were found to be unusable. After researching it seems that the pipeline never failed for the migration PR due to the lack of tests.

## Changes
- Resource Providers for AWS::Cloudwatch::MetricAlarm and AWS::Cloudwatch::CompositeAlarm now considers more parameters and also considers that not all parameters are mandatory.


## Testing
- snapshoted test that validates the creation and  the deletion of  the resources
- snaphoted test for an alarm with no statistic

CC: @thrau @Morijarti 


