### PR TITLE
Enable test for Fn::GetAZs and extend feature

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -613,7 +613,7 @@ def _resolve_refs_recursively(
                 or region_name
             )
             azs = []
-            for az in ("a", "b", "c", "d"):
+            for az in ("a", "b", "c", "d", "e", "f"):
                 azs.append("%s%s" % (region, az))
 
             return azs

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -235,20 +235,23 @@ class TestIntrinsicFunctions:
         assert deployed.outputs["Address"] == "10.0.0.0/24"
 
     @markers.aws.validated
-    @pytest.mark.skip(reason="function not currently supported")
-    def test_get_azs_function(self, deploy_cfn_template):
+    def test_get_azs_function(self, deploy_cfn_template, snapshot):
+        """
+        TODO parametrize this test.
+        For that we need to be able to parametrize the client region. The docs show the we should be
+        able to put any region in the parameters but it doesn't work. It only accepts the same region from the client config
+        if you put anything else it just returns an empty list.
+        """
+
         template_path = os.path.join(
             os.path.dirname(__file__), "../../templates/functions_get_azs.yml"
         )
-        region = "us-east-1"  # TODO parametrize
 
         deployed = deploy_cfn_template(
             template_path=template_path,
-            parameters={"Region": region},
         )
 
-        zone = "us-east-1a"  # TODO parametrize
-        assert zone in deployed.outputs["Zones"]
+        snapshot.match("azs", deployed.outputs["Zones"].split(";"))
 
     @markers.aws.validated
     def test_sub_not_ready(self, deploy_cfn_template):

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -599,5 +599,18 @@
         "Timestamp": "timestamp"
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
+    "recorded-date": "27-11-2023, 13:14:35",
+    "recorded-content": {
+      "azs": [
+        "<region>a",
+        "<region>b",
+        "<region>c",
+        "<region>d",
+        "<region>e",
+        "<region>f"
+      ]
+    }
   }
 }

--- a/tests/aws/templates/functions_get_azs.yml
+++ b/tests/aws/templates/functions_get_azs.yml
@@ -1,7 +1,3 @@
-Parameters:
-  Region:
-    Type: String
-
 Resources:
   SsmParameter:
     Type: AWS::SSM::Parameter
@@ -10,7 +6,7 @@ Resources:
       Value:
         Fn::Join:
           - ";"
-          - Fn::GetAZs: !Ref Region
+          - Fn::GetAZs: !Ref "AWS::Region"
 Outputs:
   Zones:
     Value:


### PR DESCRIPTION
## Motivation
This CFn function was requested in #9534 but it seems that @viren-nadkarni  already developed the feature while working on the Multi-Region support.

## Changes
I extended the amount of AZs the function returns to match the amount AWS returns for `us-east-1`


## Testing
I un-skipped the preexisting test of this feature and added a snapshot

