### PR TITLE
fix AWS::SNS::Topic canonicalizing bool to str for Attributes

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -8,7 +8,15 @@ from localstack.utils.common import short_uid
 
 
 @markers.aws.validated
-def test_sns_topic_fifo_with_deduplication(deploy_cfn_template, aws_client):
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "$..Attributes.DeliveryPolicy",
+        "$..Attributes.EffectiveDeliveryPolicy",
+        "$..Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
+    ]
+)
+def test_sns_topic_fifo_with_deduplication(deploy_cfn_template, aws_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.key_value("TopicArn"))
     topic_name = f"topic-{short_uid()}.fifo"
 
     deploy_cfn_template(
@@ -21,7 +29,12 @@ def test_sns_topic_fifo_with_deduplication(deploy_cfn_template, aws_client):
     topics = aws_client.sns.list_topics()["Topics"]
     topic_arns = [t["TopicArn"] for t in topics]
 
-    assert len([t for t in topic_arns if topic_name in t]) == 1
+    filtered_topics = [t for t in topic_arns if topic_name in t]
+    assert len(filtered_topics) == 1
+
+    # assert that the topic is properly created as Fifo
+    topic_attrs = aws_client.sns.get_topic_attributes(TopicArn=filtered_topics[0])
+    snapshot.match("get-topic-attrs", topic_attrs)
 
 
 @markers.aws.needs_fixing

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -1,0 +1,69 @@
+{
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_fifo_with_deduplication": {
+    "recorded-date": "27-11-2023, 21:27:29",
+    "recorded-content": {
+      "get-topic-attrs": {
+        "Attributes": {
+          "ContentBasedDeduplication": "true",
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "FifoTopic": "true",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "<topic-arn:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "<topic-arn:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This will fix #9741, it's also related to a support case I am working on. During the migration to the new cfn provider, the usage of `canonicalize_bool_to_str` had been removed. 

<!-- What notable changes does this PR make? -->
## Changes
Re-introduce using `canonicalize_bool_to_str` for the Topic Attributes, to enable creating Fifo Topic. 
Also updated the logic for creating names if not provided in case the topic is fifo.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

