### PR TITLE
fix AWS::SQS::Queue update missing QueueArn and QueueUrl

### DIFF
--- a/localstack/services/sqs/resource_providers/aws_sqs_queue.py
+++ b/localstack/services/sqs/resource_providers/aws_sqs_queue.py
@@ -189,14 +189,12 @@ class SQSQueueProvider(ResourceProvider[SQSQueueProperties]):
             model["QueueUrl"] = sqs.create_queue(QueueName=request.desired_state.get("QueueName"))[
                 "QueueUrl"
             ]
-        elif "QueueUrl" not in model:
+        else:
             model["QueueUrl"] = sqs.get_queue_url(QueueName=model["QueueName"])["QueueUrl"]
 
-        if "Arn" not in model:
-            model["Arn"] = sqs.get_queue_attributes(
-                QueueUrl=model["QueueUrl"], AttributeNames=["QueueArn"]
-            )["Attributes"]["QueueArn"]
-
+        model["Arn"] = sqs.get_queue_attributes(
+            QueueUrl=model["QueueUrl"], AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
         return ProgressEvent(OperationStatus.SUCCESS, resource_model=model)
 
     def _compile_sqs_queue_attributes(self, properties: SQSQueueProperties) -> dict[str, str]:

--- a/localstack/services/sqs/resource_providers/aws_sqs_queue.py
+++ b/localstack/services/sqs/resource_providers/aws_sqs_queue.py
@@ -190,6 +190,7 @@ class SQSQueueProvider(ResourceProvider[SQSQueueProperties]):
                 "QueueUrl"
             ]
         else:
+            # TODO: write test with CDK re-deploy updating the queue with no changes to validate this fix
             model["QueueUrl"] = sqs.get_queue_url(QueueName=model["QueueName"])["QueueUrl"]
 
         model["Arn"] = sqs.get_queue_attributes(

--- a/localstack/services/sqs/resource_providers/aws_sqs_queue.py
+++ b/localstack/services/sqs/resource_providers/aws_sqs_queue.py
@@ -189,9 +189,14 @@ class SQSQueueProvider(ResourceProvider[SQSQueueProperties]):
             model["QueueUrl"] = sqs.create_queue(QueueName=request.desired_state.get("QueueName"))[
                 "QueueUrl"
             ]
+        elif "QueueUrl" not in model:
+            model["QueueUrl"] = sqs.get_queue_url(QueueName=model["QueueName"])["QueueUrl"]
+
+        if "Arn" not in model:
             model["Arn"] = sqs.get_queue_attributes(
                 QueueUrl=model["QueueUrl"], AttributeNames=["QueueArn"]
             )["Attributes"]["QueueArn"]
+
         return ProgressEvent(OperationStatus.SUCCESS, resource_model=model)
 
     def _compile_sqs_queue_attributes(self, properties: SQSQueueProperties) -> dict[str, str]:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
During a support case, it appeared we were not supporting updating SNS subscriptions with an SQS queue. The resolving of the queue was failing in CFN, multiple resources were waiting on it: SQS Queue Policy and SNS Subscriptions.
They were dependent on it with the following:
```json
"Resource": {
  "Fn::GetAtt": [
    "testqueuequeuefifo81DD86F9",
    "Arn"
  ]
}
```

<!-- What notable changes does this PR make? -->
## Changes
After looking into `AWS::SQS:Queue`, it seems the update called was returning the `desired_state` only, but this was lacking the `Arn` field, so the resolving failed. I don't know if this is the right way of fixing this, and I have no idea how to test it. \cc @dominikschubert could you maybe suggest something?

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

