### PR TITLE
Support creation of CloudFormation stacks with the same name after deletion

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -60,6 +60,8 @@ class StackTemplate(TypedDict):
 
 # TODO: remove metadata (flatten into individual fields)
 class Stack:
+    change_sets: list["StackChangeSet"]
+
     def __init__(
         self,
         account_id: str,

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -157,9 +157,6 @@ class InternalFailure(CommonServiceException):
 
 
 class CloudformationProvider(CloudformationApi):
-    def _get_stack_by_name_or_arn(self, context: RequestContext, stack_name_or_arn: str):
-        ...
-
     def _stack_status_is_active(self, stack_status: str) -> bool:
         return stack_status not in [StackStatus.DELETE_COMPLETE]
 
@@ -173,7 +170,7 @@ class CloudformationProvider(CloudformationApi):
         # get stacks by name
         active_stack_candidates = [
             s
-            for stack_arn, s in state.stacks.items()
+            for s in state.stacks.values()
             if s.stack_name == stack_name and self._stack_status_is_active(s.status)
         ]
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -6,9 +6,11 @@ from copy import deepcopy
 
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudformation import (
+    AlreadyExistsException,
     CallAs,
     ChangeSetNameOrId,
     ChangeSetNotFoundException,
+    ChangeSetType,
     ClientRequestToken,
     CloudformationApi,
     CreateChangeSetInput,
@@ -61,6 +63,7 @@ from localstack.aws.api.cloudformation import (
     StackName,
     StackNameOrId,
     StackSetName,
+    StackStatus,
     StackStatusFilter,
     TemplateParameter,
     TemplateStage,
@@ -154,10 +157,39 @@ class InternalFailure(CommonServiceException):
 
 
 class CloudformationProvider(CloudformationApi):
+    def _get_stack_by_name_or_arn(self, context: RequestContext, stack_name_or_arn: str):
+        ...
+
+    def _stack_status_is_active(self, stack_status: str) -> bool:
+        return stack_status not in [StackStatus.DELETE_COMPLETE]
+
     @handler("CreateStack", expand=False)
     def create_stack(self, context: RequestContext, request: CreateStackInput) -> CreateStackOutput:
         # TODO: test what happens when both TemplateUrl and Body are specified
         state = get_cloudformation_store(context.account_id, context.region)
+
+        stack_name = request.get("StackName")
+
+        # get stacks by name
+        active_stack_candidates = [
+            s
+            for stack_arn, s in state.stacks.items()
+            if s.stack_name == stack_name and self._stack_status_is_active(s.status)
+        ]
+
+        # TODO: fix/implement this code path
+        #   this needs more investigation how Cloudformation handles it (e.g. normal stack create or does it create a separate changeset?)
+        # REVIEW_IN_PROGRESS is another special status
+        # in this case existing changesets are set to obsolete and the stack is created
+        # review_stack_candidates = [s for s in stack_candidates if s.status == StackStatus.REVIEW_IN_PROGRESS]
+        # if review_stack_candidates:
+        # set changesets to obsolete
+        # for cs in review_stack_candidates[0].change_sets:
+        #     cs.execution_status = ExecutionStatus.OBSOLETE
+
+        if active_stack_candidates:
+            raise AlreadyExistsException(f"Stack [{stack_name}] already exists")
+
         template_body = request.get("TemplateBody") or ""
         if len(template_body) > 51200:
             raise ValidationError(
@@ -173,15 +205,6 @@ class CloudformationProvider(CloudformationApi):
                 f"1 validation error detected: Value '{stack_name}' at 'stackName' failed to satisfy constraint:\
                 Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*"
             )
-
-        # find existing stack with same name, and remove it if this stack is in DELETED state
-        existing = ([s for s in state.stacks.values() if s.stack_name == stack_name] or [None])[0]
-        if existing:
-            if "DELETE" not in existing.status:
-                raise ValidationError(
-                    f'Stack named "{stack_name}" already exists with status "{existing.status}"'
-                )
-            state.stacks.pop(existing.stack_id)
 
         if (
             "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
@@ -359,13 +382,29 @@ class CloudformationProvider(CloudformationApi):
     def describe_stacks(
         self, context: RequestContext, stack_name: StackName = None, next_token: NextToken = None
     ) -> DescribeStacksOutput:
+        # TODO: test & implement pagination
         state = get_cloudformation_store(context.account_id, context.region)
-        stack_list = list(state.stacks.values())
-        stacks = [
-            s.describe_details()
-            for s in stack_list
-            if stack_name in [None, s.stack_name, s.stack_id]
-        ]
+
+        if stack_name:
+            if ARN_STACK_REGEX.match(stack_name):
+                # we can get the stack directly since we index the store by ARN/stackID
+                stack = state.stacks.get(stack_name)
+                stacks = [stack.describe_details()] if stack else []
+            else:
+                # otherwise we have to find the active stack with the given name
+                stack_candidates: list[Stack] = [
+                    s for stack_arn, s in state.stacks.items() if s.stack_name == stack_name
+                ]
+                active_stack_candidates = [
+                    s for s in stack_candidates if self._stack_status_is_active(s.status)
+                ]
+                stacks = [s.describe_details() for s in active_stack_candidates]
+        else:
+            # return all active stacks
+            stack_list = list(state.stacks.values())
+            stacks = [
+                s.describe_details() for s in stack_list if self._stack_status_is_active(s.status)
+            ]
 
         if stack_name and not stacks:
             raise ValidationError(f"Stack with id {stack_name} does not exist")
@@ -484,6 +523,8 @@ class CloudformationProvider(CloudformationApi):
     def create_change_set(
         self, context: RequestContext, request: CreateChangeSetInput
     ) -> CreateChangeSetOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+
         req_params = request
         change_set_type = req_params.get("ChangeSetType", "UPDATE")
         stack_name = req_params.get("StackName")
@@ -491,8 +532,6 @@ class CloudformationProvider(CloudformationApi):
         template_body = req_params.get("TemplateBody")
         # s3 or secretsmanager url
         template_url = req_params.get("TemplateURL")
-
-        stack = find_stack(context.account_id, context.region, stack_name)
 
         # validate and resolve template
         if template_body and template_url:
@@ -518,44 +557,66 @@ class CloudformationProvider(CloudformationApi):
         template["StackName"] = stack_name
         # TODO: validate with AWS what this is actually doing?
         template["ChangeSetName"] = change_set_name
-        state = get_cloudformation_store(context.account_id, context.region)
+
+        # this is intentionally not in a util yet. Let's first see how the different operations deal with these before generalizing
+        # handle ARN stack_name here (not valid for initial CREATE, since stack doesn't exist yet)
+        if ARN_STACK_REGEX.match(stack_name):
+            if not (stack := state.stacks.get(stack_name)):
+                raise ValidationError(f"Stack '{stack_name}' does not exist.")
+        else:
+            # stack name specified, so fetch the stack by name
+            stack_candidates: list[Stack] = [
+                s for stack_arn, s in state.stacks.items() if s.stack_name == stack_name
+            ]
+            active_stack_candidates = [
+                s for s in stack_candidates if self._stack_status_is_active(s.status)
+            ]
+
+            # on a CREATE an empty Stack should be generated if we didn't find an active one
+            if not active_stack_candidates and change_set_type == ChangeSetType.CREATE:
+                empty_stack_template = dict(template)
+                empty_stack_template["Resources"] = {}
+                req_params_copy = clone_stack_params(req_params)
+                stack = Stack(
+                    context.account_id,
+                    context.region,
+                    req_params_copy,
+                    empty_stack_template,
+                    template_body=template_body,
+                )
+                state.stacks[stack.stack_id] = stack
+                stack.set_stack_status("REVIEW_IN_PROGRESS")
+            else:
+                if not active_stack_candidates:
+                    raise ValidationError(f"Stack '{stack_name}' does not exist.")
+                stack = active_stack_candidates[0]
+
+        # TODO: test if rollback status is allowed as well
+        if (
+            change_set_type == ChangeSetType.CREATE
+            and stack.status != StackStatus.REVIEW_IN_PROGRESS
+        ):
+            raise ValidationError(
+                f"Stack [{stack_name}] already exists and cannot be created again with the changeSet [{change_set_name}]."
+            )
 
         old_parameters: dict[str, Parameter] = {}
-        if change_set_type == "UPDATE":
-            # add changeset to existing stack
-            if stack is None:
-                raise ValidationError(
-                    f"Stack '{stack_name}' does not exist."
-                )  # stack should exist already
-            old_parameters = {
-                k: strip_parameter_type(v) for k, v in stack.resolved_parameters.items()
-            }
-        elif change_set_type == "CREATE":
-            # create new (empty) stack
-            if stack is not None:
-                raise ValidationError(
-                    f"Stack {stack_name} already exists"
-                )  # stack should not exist yet (TODO: check proper message)
-            empty_stack_template = dict(template)
-            empty_stack_template["Resources"] = {}
-            req_params_copy = clone_stack_params(req_params)
-            stack = Stack(
-                context.account_id,
-                context.region,
-                req_params_copy,
-                empty_stack_template,
-                template_body=template_body,
-            )
-            state.stacks[stack.stack_id] = stack
-            stack.set_stack_status("REVIEW_IN_PROGRESS")
-        elif change_set_type == "IMPORT":
-            raise NotImplementedError()  # TODO: implement importing resources
-        else:
-            msg = (
-                f"1 validation error detected: Value '{change_set_type}' at 'changeSetType' failed to satisfy "
-                f"constraint: Member must satisfy enum value set: [IMPORT, UPDATE, CREATE] "
-            )
-            raise ValidationError(msg)
+        match change_set_type:
+            case ChangeSetType.UPDATE:
+                # add changeset to existing stack
+                old_parameters = {
+                    k: strip_parameter_type(v) for k, v in stack.resolved_parameters.items()
+                }
+            case ChangeSetType.IMPORT:
+                raise NotImplementedError()  # TODO: implement importing resources
+            case ChangeSetType.CREATE:
+                pass
+            case _:
+                msg = (
+                    f"1 validation error detected: Value '{change_set_type}' at 'changeSetType' failed to satisfy "
+                    f"constraint: Member must satisfy enum value set: [IMPORT, UPDATE, CREATE] "
+                )
+                raise ValidationError(msg)
 
         # resolve parameters
         new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(

--- a/localstack/services/cloudformation/stores.py
+++ b/localstack/services/cloudformation/stores.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet, StackSet
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
@@ -8,17 +8,16 @@ LOG = logging.getLogger(__name__)
 
 
 class CloudFormationStore(BaseStore):
-    # FIXME: use stack name as ID instead ?
     # maps stack ID to stack details
-    stacks: Dict[str, Stack] = LocalAttribute(default=dict)
+    stacks: dict[str, Stack] = LocalAttribute(default=dict)
 
     # maps stack set ID to stack set details
-    stack_sets: Dict[str, StackSet] = LocalAttribute(default=dict)
+    stack_sets: dict[str, StackSet] = LocalAttribute(default=dict)
 
     # maps macro ID to macros
-    macros: Dict[str, Dict] = LocalAttribute(default=dict)
+    macros: dict[str, dict] = LocalAttribute(default=dict)
 
-    # exports: Dict[str, str]
+    # exports: dict[str, str]
     @property
     def exports(self):
         exports = []
@@ -53,6 +52,7 @@ def get_cloudformation_store(account_id: str, region_name: str) -> CloudFormatio
     return cloudformation_stores[account_id][region_name]
 
 
+# TODO: rework / fix usage of this
 def find_stack(account_id: str, region_name: str, stack_name: str) -> Stack | None:
     state = get_cloudformation_store(account_id, region_name)
     return (

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -749,7 +749,7 @@ def test_autoexpand_capability_requirement(cleanups, aws_client):
     )
 
 
-# TODO: a CreateStack operation should work with an existing stack if its in REVIEW_IN_PROGRESS
+# FIXME: a CreateStack operation should work with an existing stack if its in REVIEW_IN_PROGRESS
 @pytest.mark.skip(reason="not implemented correctly yet")
 @markers.aws.validated
 def test_create_while_in_review(aws_client, snapshot, cleanups):

--- a/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
@@ -179,20 +179,12 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_name_conflicts": {
-    "recorded-date": "22-11-2023, 09:09:04",
+    "recorded-date": "22-11-2023, 10:58:04",
     "recorded-content": {
-      "overwriting_changeset": {
-        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
-        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "create_changeset_existingstack_exc": {
         "Error": {
           "Code": "ValidationError",
-          "Message": "Stack [<stack-name:1>] already exists and cannot be created again with the changeSet [<change-set-id:1>].",
+          "Message": "Stack [<stack-name:1>] already exists and cannot be created again with the changeSet [<change-set-name:1>].",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -211,7 +203,7 @@
             "EnableTerminationProtection": false,
             "NotificationARNs": [],
             "RollbackConfiguration": {},
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "StackStatus": "REVIEW_IN_PROGRESS",
             "StackStatusReason": "User Initiated",
@@ -257,7 +249,7 @@
             "EnableTerminationProtection": false,
             "NotificationARNs": [],
             "RollbackConfiguration": {},
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "StackStatus": "REVIEW_IN_PROGRESS",
             "StackStatusReason": "User Initiated",
@@ -271,37 +263,8 @@
       },
       "initial_changeset_id_desc": {
         "Capabilities": [],
-        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:4>",
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "ChangeSetName": "<change-set-name:1>",
-        "Changes": [
-          {
-            "ResourceChange": {
-              "Action": "Add",
-              "Details": [],
-              "LogicalResourceId": "SimpleParam",
-              "ResourceType": "AWS::SSM::Parameter",
-              "Scope": []
-            },
-            "Type": "Resource"
-          }
-        ],
-        "CreationTime": "datetime",
-        "ExecutionStatus": "OBSOLETE",
-        "IncludeNestedStacks": false,
-        "NotificationARNs": [],
-        "RollbackConfiguration": {},
-        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
-        "StackName": "<stack-name:1>",
-        "Status": "CREATE_COMPLETE",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "overwriting_changeset_id_desc": {
-        "Capabilities": [],
-        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
-        "ChangeSetName": "<change-set-id:1>",
         "Changes": [
           {
             "ResourceChange": {
@@ -329,7 +292,7 @@
       },
       "second_initial_changeset_id_desc": {
         "Capabilities": [],
-        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:5>",
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:4>",
         "ChangeSetName": "<change-set-name:1>",
         "Changes": [
           {
@@ -348,7 +311,7 @@
         "IncludeNestedStacks": false,
         "NotificationARNs": [],
         "RollbackConfiguration": {},
-        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
         "StackName": "<stack-name:1>",
         "Status": "CREATE_COMPLETE",
         "ResponseMetadata": {
@@ -414,6 +377,101 @@
         "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
         "StackName": "<stack-name:1>",
         "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_template_rendering_with_list": {
+    "recorded-date": "23-11-2023, 09:23:26",
+    "recorded-content": {
+      "resolved-template": {
+        "d": [
+          {
+            "userid": 1
+          },
+          1,
+          "string"
+        ]
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_create_changeset_with_stack_id": {
+    "recorded-date": "28-11-2023, 07:48:23",
+    "recorded-content": {
+      "describe_stack": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "REVIEW_IN_PROGRESS",
+            "StackStatusReason": "User Initiated",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recreate_deleted_with_id_exception": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack [arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>] already exists and cannot be created again with the changeSet [revived-stack-changeset].",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_multiple_create_changeset": {
+    "recorded-date": "28-11-2023, 07:38:49",
+    "recorded-content": {
+      "initial_changeset": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SimpleParam",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "additional_changeset": {
+        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
@@ -177,5 +177,248 @@
       "e1": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: Stack [nostack] does not exist') tblen=3>",
       "e2": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: StackName must be specified if ChangeSetName is not specified as an ARN.') tblen=3>"
     }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_name_conflicts": {
+    "recorded-date": "22-11-2023, 09:09:04",
+    "recorded-content": {
+      "overwriting_changeset": {
+        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_changeset_existingstack_exc": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack [<stack-name:1>] already exists and cannot be created again with the changeSet [<change-set-id:1>].",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "new_stack_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "REVIEW_IN_PROGRESS",
+            "StackStatusReason": "User Initiated",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_id_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "new_stack_id_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "REVIEW_IN_PROGRESS",
+            "StackStatusReason": "User Initiated",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "initial_changeset_id_desc": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:4>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SimpleParam",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "OBSOLETE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "overwriting_changeset_id_desc": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SimpleParam",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "EXECUTE_COMPLETE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_initial_changeset_id_desc": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:5>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SimpleParam",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_create_while_in_review": {
+    "recorded-date": "22-11-2023, 08:49:15",
+    "recorded-content": {
+      "create_stack_while_in_review": {
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_stack": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_change_set": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:2>",
+        "ChangeSetName": "<change-set-name:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SimpleParam",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "OBSOLETE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -662,15 +662,6 @@ Resources:
             Type: String
 """
 
-MINIMAL_TEMPLATE_UPDATED = """
-Resources:
-    SimpleParam:
-        Type: AWS::SSM::Parameter
-        Properties:
-            Value: test2
-            Type: String
-"""
-
 
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..EnableTerminationProtection", "$..LastUpdatedTime"]

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -653,6 +653,15 @@ Resources:
             Type: String
 """
 
+MINIMAL_TEMPLATE_UPDATED = """
+Resources:
+    SimpleParam:
+        Type: AWS::SSM::Parameter
+        Properties:
+            Value: test2
+            Type: String
+"""
+
 
 @markers.snapshot.skip_snapshot_verify(
     paths=["$..EnableTerminationProtection", "$..LastUpdatedTime"]

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -642,3 +642,85 @@ def test_blocked_stack_deletion(aws_client, cleanups, snapshot):
     snapshot.match("stack_post_success_delete", stack_post_success_delete)
     stack_events = cfn.describe_stack_events(StackName=stack_id)
     snapshot.match("stack_events", stack_events)
+
+
+MINIMAL_TEMPLATE = """
+Resources:
+    SimpleParam:
+        Type: AWS::SSM::Parameter
+        Properties:
+            Value: test
+            Type: String
+"""
+
+
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..EnableTerminationProtection", "$..LastUpdatedTime"]
+)
+@markers.aws.validated
+def test_name_conflicts(aws_client, snapshot, cleanups):
+    """
+    Tests behavior of creating a stack with the same name of one that was previously deleted
+
+    1. Create Stack
+    2. Delete Stack
+    3. Create Stack with same name as in 1.
+
+    Step 3 should be successful because you can re-use StackNames,
+    but only one stack for a given stack name can be `ACTIVE` at one time.
+
+    We didn't exhaustively test yet what is considered as Active by CloudFormation
+    For now the assumption is that anything != "DELETE_COMPLETED" is considered "ACTIVE"
+    """
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
+    stack_name = f"repeated-stack-{short_uid()}"
+    cleanups.append(lambda: aws_client.cloudformation.delete_stack(StackName=stack_name))
+    stack = aws_client.cloudformation.create_stack(
+        StackName=stack_name, TemplateBody=MINIMAL_TEMPLATE
+    )
+    stack_id = stack["StackId"]
+    aws_client.cloudformation.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    # only one can be active at a time
+    with pytest.raises(aws_client.cloudformation.exceptions.AlreadyExistsException) as e:
+        aws_client.cloudformation.create_stack(StackName=stack_name, TemplateBody=MINIMAL_TEMPLATE)
+    snapshot.match("create_stack_already_exists_exc", e.value.response)
+
+    created_stack_desc = aws_client.cloudformation.describe_stacks(StackName=stack_name)["Stacks"][
+        0
+    ]["StackStatus"]
+    snapshot.match("created_stack_desc", created_stack_desc)
+
+    aws_client.cloudformation.delete_stack(StackName=stack_name)
+    aws_client.cloudformation.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+
+    # describe with name fails
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        aws_client.cloudformation.describe_stacks(StackName=stack_name)
+    snapshot.match("deleted_stack_not_found_exc", e.value.response)
+
+    # describe with stack id (ARN) succeeds
+    deleted_stack_desc = aws_client.cloudformation.describe_stacks(StackName=stack_id)
+    snapshot.match("deleted_stack_desc", deleted_stack_desc)
+
+    # creating a new stack with the same name as the previously deleted one should work
+    stack = aws_client.cloudformation.create_stack(
+        StackName=stack_name, TemplateBody=MINIMAL_TEMPLATE
+    )
+    # should issue a new unique stack ID/ARN
+    new_stack_id = stack["StackId"]
+    assert stack_id != new_stack_id
+    aws_client.cloudformation.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    new_stack_desc = aws_client.cloudformation.describe_stacks(StackName=stack_name)
+    snapshot.match("new_stack_desc", new_stack_desc)
+    assert len(new_stack_desc["Stacks"]) == 1
+    assert new_stack_desc["Stacks"][0]["StackId"] == new_stack_id
+
+    # can still access both by using the ARN (stack id)
+    # and they should be different from each other
+    stack_id_desc = aws_client.cloudformation.describe_stacks(StackName=stack_id)
+    new_stack_id_desc = aws_client.cloudformation.describe_stacks(StackName=new_stack_id)
+    snapshot.match("stack_id_desc", stack_id_desc)
+    snapshot.match("new_stack_id_desc", new_stack_id_desc)

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -953,5 +953,121 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_name_conflicts": {
+    "recorded-date": "16-11-2023, 17:07:37",
+    "recorded-content": {
+      "create_stack_already_exists_exc": {
+        "Error": {
+          "Code": "AlreadyExistsException",
+          "Message": "Stack [<stack-name:1>] already exists",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "created_stack_desc": "CREATE_COMPLETE",
+      "deleted_stack_not_found_exc": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack with id <stack-name:1> does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "deleted_stack_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "new_stack_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack_id_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "new_stack_id_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -354,7 +354,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_lifecycle": {
-    "recorded-date": "11-10-2022, 13:34:32",
+    "recorded-date": "28-11-2023, 13:24:40",
     "recorded-content": {
       "creation": {
         "Capabilities": [
@@ -410,7 +410,43 @@
         "StackStatus": "UPDATE_COMPLETE",
         "Tags": []
       },
-      "deletion": true
+      "describe_deleted_by_name_exc": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack with id <stack-name:1> does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "deleted": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "ApiName",
+            "ParameterValue": "<parameter-value:2>"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
     }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_linting_error_during_creation": {


### PR DESCRIPTION
## Motivation

Tackling the issue where we couldn't  cycle between deleting and creating stacks with the same name. E.g. doing a CDK deployment, deleting the stack and then doing another deployment which will typically use the same name again.

Resolves https://github.com/localstack/localstack/issues/7699

## Changes

- Improved handling of stack ARN for `StackName` parameter in `CreateStack` and `CreateChangeSet`
- Creating multiple stacks with a single name are allowed now, as long as only one is an active state (i.e. not deleted).
  - this should work for both `CreateStack` and `CreateChangeSet` now
- Better handling of Stack in `REVIEW_IN_PROGRESS`
- Added tests covering a few scenarios involving deleted
- Fixed `test_stack_lifecycle` which was implicitly depending on a stack being in `DELETE_IN_PROGRESS` and when waiting for the deletion to be completed the test failed against AWS as well.

## TODO (not in this PR)

Some things still need to be done in the near future to improve detection of deleted stacks and in general the provider parity here.

- find a good abstraction for fetching the stack by name/arn/status after testing and fixing a few more operations
- we should cover more stack life cycle scenarios via tests but this isn't super urgent since only a few states are realistically relevant for use with LocalStack


