### PR TITLE
[SFN] Enhancements for Intrinsic Function StringSplit

### DIFF
--- a/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
+++ b/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
@@ -67,5 +67,5 @@ class StringSplit(StatesFunction):
         pattern = "|".join(patterns)
 
         parts = re.split(pattern, string)
-        parts_clean = list(filter(lambda sub: bool(sub), parts))
+        parts_clean = list(filter(bool, parts))
         env.stack.append(parts_clean)

--- a/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
+++ b/localstack/services/stepfunctions/asl/component/intrinsic/function/statesfunction/string_operations/string_split.py
@@ -67,4 +67,5 @@ class StringSplit(StatesFunction):
         pattern = "|".join(patterns)
 
         parts = re.split(pattern, string)
-        env.stack.append(parts)
+        parts_clean = list(filter(lambda sub: bool(sub), parts))
+        env.stack.append(parts_clean)

--- a/tests/aws/services/stepfunctions/templates/intrinsicfunctions/intrinsic_functions_templates.py
+++ b/tests/aws/services/stepfunctions/templates/intrinsicfunctions/intrinsic_functions_templates.py
@@ -42,6 +42,9 @@ class IntrinsicFunctionTemplate(TemplateLoader):
     STRING_SPLIT: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/string_operations/string_split.json5"
     )
+    STRING_SPLIT_CONTEXT_OBJECT: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/string_operations/string_split_context_object.json5"
+    )
 
     # Encode and Decode.
     BASE_64_ENCODE: Final[str] = os.path.join(

--- a/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/string_operations/string_split_context_object.json5
+++ b/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/string_operations/string_split_context_object.json5
@@ -6,10 +6,7 @@
       "Type": "Pass",
       "End": true,
       "Parameters": {
-        "FunctionName": "SomeFunction",
-        "Payload": {
-          "FunctionResult.$": "States.StringSplit($$.Execution.Input.FunctionInput, ',')"
-        }
+        "FunctionResult.$": "States.StringSplit($$.Execution.Input.FunctionInput, ',')"
       }
     }
   }

--- a/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/string_operations/string_split_context_object.json5
+++ b/tests/aws/services/stepfunctions/templates/intrinsicfunctions/statemachines/string_operations/string_split_context_object.json5
@@ -1,0 +1,16 @@
+{
+  "Comment": "STRING_SPLIT_CONTEXT_OBJECT",
+  "StartAt": "State_0",
+  "States": {
+    "State_0": {
+      "Type": "Pass",
+      "End": true,
+      "Parameters": {
+        "FunctionName": "SomeFunction",
+        "Payload": {
+          "FunctionResult.$": "States.StringSplit($$.Execution.Input.FunctionInput, ',')"
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py
@@ -14,6 +14,10 @@ class TestStringOperations:
         self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
     ):
         input_values = [
+            {"fst": " ", "snd": ","},
+            {"fst": " , ", "snd": ","},
+            {"fst": ", , ,", "snd": ","},
+            {"fst": ",,,,", "snd": ","},
             {"fst": "1,2,3,4,5", "snd": ","},
             {"fst": "This.is+a,test=string", "snd": ".+,="},
         ]
@@ -23,5 +27,28 @@ class TestStringOperations:
             create_state_machine,
             sfn_snapshot,
             IFT.STRING_SPLIT,
+            input_values,
+        )
+
+    @markers.aws.validated
+    def test_string_split_context_object(
+        self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
+    ):
+        input_values = [
+            (
+                "Value1,Value2,Value3\n"
+                "Value4,Value5,Value6\n"
+                ",,,\n"
+                "true,1,'HelloWorld'\n"
+                "Null,None,\n"
+                "   \n"
+            )
+        ]
+        create_and_test_on_inputs(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            IFT.STRING_SPLIT_CONTEXT_OBJECT,
             input_values,
         )

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
@@ -483,7 +483,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split_context_object": {
-    "recorded-date": "28-11-2023, 10:04:41",
+    "recorded-date": "28-11-2023, 10:25:42",
     "recorded-content": {
       "exec_hist_resp_0": {
         "events": [
@@ -523,21 +523,18 @@
             "stateExitedEventDetails": {
               "name": "State_0",
               "output": {
-                "FunctionName": "SomeFunction",
-                "Payload": {
-                  "FunctionResult": [
-                    "Value1",
-                    "Value2",
-                    "Value3\nValue4",
-                    "Value5",
-                    "Value6\n",
-                    "\ntrue",
-                    "1",
-                    "'HelloWorld'\nNull",
-                    "None",
-                    "\n   \n"
-                  ]
-                }
+                "FunctionResult": [
+                  "Value1",
+                  "Value2",
+                  "Value3\nValue4",
+                  "Value5",
+                  "Value6\n",
+                  "\ntrue",
+                  "1",
+                  "'HelloWorld'\nNull",
+                  "None",
+                  "\n   \n"
+                ]
               },
               "outputDetails": {
                 "truncated": false
@@ -549,21 +546,18 @@
           {
             "executionSucceededEventDetails": {
               "output": {
-                "FunctionName": "SomeFunction",
-                "Payload": {
-                  "FunctionResult": [
-                    "Value1",
-                    "Value2",
-                    "Value3\nValue4",
-                    "Value5",
-                    "Value6\n",
-                    "\ntrue",
-                    "1",
-                    "'HelloWorld'\nNull",
-                    "None",
-                    "\n   \n"
-                  ]
-                }
+                "FunctionResult": [
+                  "Value1",
+                  "Value2",
+                  "Value3\nValue4",
+                  "Value5",
+                  "Value6\n",
+                  "\ntrue",
+                  "1",
+                  "'HelloWorld'\nNull",
+                  "None",
+                  "\n   \n"
+                ]
               },
               "outputDetails": {
                 "truncated": false

--- a/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.snapshot.json
@@ -1,8 +1,316 @@
 {
   "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split": {
-    "recorded-date": "09-02-2023, 10:36:01",
+    "recorded-date": "28-11-2023, 10:19:26",
     "recorded-content": {
       "exec_hist_resp_0": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": " ",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": " ",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": [
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": [
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_1": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": " , ",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": " , ",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": [
+                  " ",
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": [
+                  " ",
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_2": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": ", , ,",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": ", , ,",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": [
+                  " ",
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": [
+                  " ",
+                  " "
+                ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_3": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": ",,,,",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": {
+                  "fst": ",,,,",
+                  "snd": ","
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionResult": []
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionResult": []
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_hist_resp_4": {
         "events": [
           {
             "executionStartedEventDetails": {
@@ -87,7 +395,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "exec_hist_resp_1": {
+      "exec_hist_resp_5": {
         "events": [
           {
             "executionStartedEventDetails": {
@@ -156,6 +464,106 @@
                   "test",
                   "string"
                 ]
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/intrinsic_functions/test_string_operations.py::TestStringOperations::test_string_split_context_object": {
+    "recorded-date": "28-11-2023, 10:04:41",
+    "recorded-content": {
+      "exec_hist_resp_0": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionInput": "Value1,Value2,Value3\nValue4,Value5,Value6\n,,,\ntrue,1,'HelloWorld'\nNull,None,\n   \n"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionInput": "Value1,Value2,Value3\nValue4,Value5,Value6\n,,,\ntrue,1,'HelloWorld'\nNull,None,\n   \n"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_0"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_0",
+              "output": {
+                "FunctionName": "SomeFunction",
+                "Payload": {
+                  "FunctionResult": [
+                    "Value1",
+                    "Value2",
+                    "Value3\nValue4",
+                    "Value5",
+                    "Value6\n",
+                    "\ntrue",
+                    "1",
+                    "'HelloWorld'\nNull",
+                    "None",
+                    "\n   \n"
+                  ]
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "FunctionName": "SomeFunction",
+                "Payload": {
+                  "FunctionResult": [
+                    "Value1",
+                    "Value2",
+                    "Value3\nValue4",
+                    "Value5",
+                    "Value6\n",
+                    "\ntrue",
+                    "1",
+                    "'HelloWorld'\nNull",
+                    "None",
+                    "\n   \n"
+                  ]
+                }
               },
               "outputDetails": {
                 "truncated": false


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
For the current implementation of the SFN interpreter, the Intrinsic Functions States.StringSplit does not filter for non-empty strings after computing the parts. This PR addresses such behaviour by filtering for empty string results.
Closes: #9742 

<!-- What notable changes does this PR make? -->
## Changes
Added empty string filtering after computing the split parts in the implementation for States.StringSplit, and a number of relevant test cases

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

