### PR TITLE
Remove thread-local region, access key and account ID

### DIFF
--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -3,17 +3,11 @@ import base64
 import binascii
 import logging
 import re
-import threading
-import warnings
 
 from localstack import config
-from localstack.constants import DEFAULT_AWS_ACCOUNT_ID, TEST_AWS_ACCESS_KEY_ID
+from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 
 LOG = logging.getLogger(__name__)
-
-# TODO: Remove this
-# Thread local storage for keeping current request & account related info
-REQUEST_CTX_TLS = threading.local()
 
 # Account id offset for id extraction
 # generated from int.from_bytes(base64.b32decode(b"QAAAAAAA"), byteorder="big") (user id 000000000000)
@@ -21,62 +15,6 @@ ACCOUNT_OFFSET = 549755813888
 
 # Basically the base32 alphabet, for better access as constant here
 AWS_ACCESS_KEY_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-
-#
-# Access Key IDs
-#
-
-
-# WARNING: This function is deprecated and must not be used.
-def _get_aws_access_key_id() -> str:
-    """Return the AWS access key ID for current context."""
-    return getattr(REQUEST_CTX_TLS, "access_key_id", TEST_AWS_ACCESS_KEY_ID)
-
-
-# WARNING: This function is deprecated and must not be used.
-def _set_aws_access_key_id(access_key_id: str):
-    REQUEST_CTX_TLS.access_key_id = access_key_id
-
-
-# WARNING: This function is deprecated and must not be used.
-def _reset_aws_access_key_id() -> None:
-    try:
-        del REQUEST_CTX_TLS.access_key_id
-    except AttributeError:
-        pass
-
-
-#
-# Account IDs
-#
-
-
-# WARNING: This function is deprecated and must not be used.
-def _get_aws_account_id() -> str:
-    """Return the AWS account ID for the current context."""
-    warnings.warn("_get_aws_account_id() is deprecated and must not be used", DeprecationWarning)
-
-    try:
-        return REQUEST_CTX_TLS.account_id
-    except AttributeError:
-        LOG.debug(
-            "No Account ID in thread-local storage for thread %s",
-            threading.current_thread().ident,
-        )
-        return DEFAULT_AWS_ACCOUNT_ID
-
-
-# WARNING: This function is deprecated and must not be used.
-def _set_aws_account_id(account_id: str) -> None:
-    REQUEST_CTX_TLS.account_id = account_id
-
-
-# WARNING: This function is deprecated and must not be used.
-def _reset_aws_account_id() -> None:
-    try:
-        del REQUEST_CTX_TLS.account_id
-    except AttributeError:
-        pass
 
 
 def extract_account_id_from_access_key_id(access_key_id: str) -> str:

--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -4,35 +4,42 @@ import binascii
 import logging
 import re
 import threading
+import warnings
 
 from localstack import config
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID, TEST_AWS_ACCESS_KEY_ID
 
 LOG = logging.getLogger(__name__)
 
+# TODO: Remove this
 # Thread local storage for keeping current request & account related info
 REQUEST_CTX_TLS = threading.local()
 
 # Account id offset for id extraction
 # generated from int.from_bytes(base64.b32decode(b"QAAAAAAA"), byteorder="big") (user id 000000000000)
 ACCOUNT_OFFSET = 549755813888
+
 # Basically the base32 alphabet, for better access as constant here
 AWS_ACCESS_KEY_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
 #
 # Access Key IDs
 #
 
 
-def get_aws_access_key_id() -> str:
+# WARNING: This function is deprecated and must not be used.
+def _get_aws_access_key_id() -> str:
     """Return the AWS access key ID for current context."""
     return getattr(REQUEST_CTX_TLS, "access_key_id", TEST_AWS_ACCESS_KEY_ID)
 
 
-def set_aws_access_key_id(access_key_id: str):
+# WARNING: This function is deprecated and must not be used.
+def _set_aws_access_key_id(access_key_id: str):
     REQUEST_CTX_TLS.access_key_id = access_key_id
 
 
-def reset_aws_access_key_id() -> None:
+# WARNING: This function is deprecated and must not be used.
+def _reset_aws_access_key_id() -> None:
     try:
         del REQUEST_CTX_TLS.access_key_id
     except AttributeError:
@@ -44,8 +51,11 @@ def reset_aws_access_key_id() -> None:
 #
 
 
-def get_aws_account_id() -> str:
+# WARNING: This function is deprecated and must not be used.
+def _get_aws_account_id() -> str:
     """Return the AWS account ID for the current context."""
+    warnings.warn("_get_aws_account_id() is deprecated and must not be used", DeprecationWarning)
+
     try:
         return REQUEST_CTX_TLS.account_id
     except AttributeError:
@@ -56,11 +66,13 @@ def get_aws_account_id() -> str:
         return DEFAULT_AWS_ACCOUNT_ID
 
 
-def set_aws_account_id(account_id: str) -> None:
+# WARNING: This function is deprecated and must not be used.
+def _set_aws_account_id(account_id: str) -> None:
     REQUEST_CTX_TLS.account_id = account_id
 
 
-def reset_aws_account_id() -> None:
+# WARNING: This function is deprecated and must not be used.
+def _reset_aws_account_id() -> None:
     try:
         del REQUEST_CTX_TLS.account_id
     except AttributeError:

--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -28,7 +28,6 @@ from localstack.constants import (
 )
 from localstack.utils.aws.aws_stack import get_local_service_url, get_s3_hostname
 from localstack.utils.aws.client_types import ServicePrincipal, TypedServiceClientFactory
-from localstack.utils.aws.request_context import get_region_from_request_context
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid
 
@@ -423,9 +422,7 @@ class ClientFactory(ABC):
         - Boto session
         - us-east-1
         """
-        return (
-            get_region_from_request_context() or self._get_session_region() or AWS_REGION_US_EAST_1
-        )
+        return self._get_session_region() or AWS_REGION_US_EAST_1
 
 
 class InternalClientFactory(ClientFactory):

--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -1,8 +1,6 @@
 import logging
 
 from localstack.aws.accounts import (
-    _set_aws_access_key_id,
-    _set_aws_account_id,
     get_account_id_from_access_key_id,
 )
 from localstack.constants import (
@@ -42,18 +40,14 @@ class AccountIdEnricher(Handler):
     """
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
-        # Obtain the access key ID and save it in the thread context
+        # Obtain the access key ID
         access_key_id = (
             extract_access_key_id_from_auth_header(context.request.headers)
             or TEST_AWS_ACCESS_KEY_ID
         )
-        _set_aws_access_key_id(access_key_id)
 
-        # Obtain the account ID and save it in the request context
+        # Obtain the account ID from access key ID
         context.account_id = get_account_id_from_access_key_id(access_key_id)
-
-        # Save the same account ID in the thread context
-        _set_aws_account_id(context.account_id)
 
         # Make Moto use the same Account ID as LocalStack
         context.request.headers.add("x-moto-account-id", context.account_id)

--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -1,9 +1,9 @@
 import logging
 
 from localstack.aws.accounts import (
+    _set_aws_access_key_id,
+    _set_aws_account_id,
     get_account_id_from_access_key_id,
-    set_aws_access_key_id,
-    set_aws_account_id,
 )
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
@@ -47,13 +47,13 @@ class AccountIdEnricher(Handler):
             extract_access_key_id_from_auth_header(context.request.headers)
             or TEST_AWS_ACCESS_KEY_ID
         )
-        set_aws_access_key_id(access_key_id)
+        _set_aws_access_key_id(access_key_id)
 
         # Obtain the account ID and save it in the request context
         context.account_id = get_account_id_from_access_key_id(access_key_id)
 
         # Save the same account ID in the thread context
-        set_aws_account_id(context.account_id)
+        _set_aws_account_id(context.account_id)
 
         # Make Moto use the same Account ID as LocalStack
         context.request.headers.add("x-moto-account-id", context.account_id)

--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -4,7 +4,6 @@ import logging
 
 from localstack.http import Response
 
-from ..accounts import _reset_aws_access_key_id, _reset_aws_account_id
 from ..api import RequestContext
 from ..chain import HandlerChain
 from .routes import RouterHandler
@@ -15,17 +14,14 @@ LOG = logging.getLogger(__name__)
 def push_request_context(_chain: HandlerChain, context: RequestContext, _response: Response):
     from localstack.utils.aws import request_context
 
-    # TODO remove request_context.THREAD_LOCAL and accounts.REQUEST_CTX_TLS
+    # TODO remove request_context.THREAD_LOCAL
     request_context.THREAD_LOCAL.request_context = context.request
-    # resetting thread local storage to avoid leakage between requests at all cost
-    _reset_aws_access_key_id()
-    _reset_aws_account_id()
 
 
 def pop_request_context(_chain: HandlerChain, _context: RequestContext, _response: Response):
     from localstack.utils.aws import request_context
 
-    # TODO remove request_context.THREAD_LOCAL and accounts.REQUEST_CTX_TLS
+    # TODO remove request_context.THREAD_LOCAL
     request_context.THREAD_LOCAL.request_context = None
 
 

--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -4,7 +4,7 @@ import logging
 
 from localstack.http import Response
 
-from ..accounts import reset_aws_access_key_id, reset_aws_account_id
+from ..accounts import _reset_aws_access_key_id, _reset_aws_account_id
 from ..api import RequestContext
 from ..chain import HandlerChain
 from .routes import RouterHandler
@@ -18,8 +18,8 @@ def push_request_context(_chain: HandlerChain, context: RequestContext, _respons
     # TODO remove request_context.THREAD_LOCAL and accounts.REQUEST_CTX_TLS
     request_context.THREAD_LOCAL.request_context = context.request
     # resetting thread local storage to avoid leakage between requests at all cost
-    reset_aws_access_key_id()
-    reset_aws_account_id()
+    _reset_aws_access_key_id()
+    _reset_aws_account_id()
 
 
 def pop_request_context(_chain: HandlerChain, _context: RequestContext, _response: Response):

--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -4,9 +4,9 @@ Adapters and other utilities to use ASF together with the edge proxy.
 import logging
 
 from localstack.aws.accounts import (
+    _set_aws_access_key_id,
+    _set_aws_account_id,
     get_account_id_from_access_key_id,
-    set_aws_access_key_id,
-    set_aws_account_id,
 )
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request
@@ -24,9 +24,9 @@ def get_account_id_from_request(request: Request) -> str:
     access_key_id = (
         extract_access_key_id_from_auth_header(request.headers) or TEST_AWS_ACCESS_KEY_ID
     )
-    set_aws_access_key_id(access_key_id)
+    _set_aws_access_key_id(access_key_id)
 
     account_id = get_account_id_from_access_key_id(access_key_id)
-    set_aws_account_id(account_id)
+    _set_aws_account_id(account_id)
 
     return account_id

--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -4,29 +4,19 @@ Adapters and other utilities to use ASF together with the edge proxy.
 import logging
 
 from localstack.aws.accounts import (
-    _set_aws_access_key_id,
-    _set_aws_account_id,
     get_account_id_from_access_key_id,
 )
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
-from localstack.utils.aws.request_context import extract_region_from_headers
 
 LOG = logging.getLogger(__name__)
 
 
-def get_region(request: Request) -> str:
-    return extract_region_from_headers(request.headers)
-
-
+# TODO: consider moving this to `localstack.utils.aws.request_context`
 def get_account_id_from_request(request: Request) -> str:
     access_key_id = (
         extract_access_key_id_from_auth_header(request.headers) or TEST_AWS_ACCESS_KEY_ID
     )
-    _set_aws_access_key_id(access_key_id)
 
-    account_id = get_account_id_from_access_key_id(access_key_id)
-    _set_aws_account_id(account_id)
-
-    return account_id
+    return get_account_id_from_access_key_id(access_key_id)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import socket
-import warnings
 from functools import lru_cache
 from typing import Dict, List, Optional, Union
 
@@ -17,12 +16,6 @@ from localstack.utils.strings import is_string_or_bytes, to_str
 
 # set up logger
 LOG = logging.getLogger(__name__)
-
-# cache local region
-LOCAL_REGION = None
-
-# Used in AWS assume role function
-INITIAL_BOTO3_SESSION = None
 
 # cached value used to determine the DNS status of the S3 hostname (whether it can be resolved properly)
 CACHE_S3_HOSTNAME_DNS_STATUS = None
@@ -44,36 +37,6 @@ def get_valid_regions_for_service(service_name):
     regions.extend(boto3.Session().get_available_regions("cloudwatch", partition_name="aws-us-gov"))
     regions.extend(boto3.Session().get_available_regions("cloudwatch", partition_name="aws-cn"))
     return regions
-
-
-# WARNING: This function is deprecated and must not be used.
-def _get_region():
-    warnings.warn("_get_region() is deprecated and must not be used", DeprecationWarning)
-
-    # Note: leave import here to avoid import errors (e.g., "flask") for CLI commands
-    from localstack.utils.aws.request_context import get_region_from_request_context
-
-    region = get_region_from_request_context()
-    if region:
-        return region
-    # fall back to returning static pre-defined region
-    return get_local_region()
-
-
-# WARNING: This function is deprecated and must not be used.
-def _get_partition(region_name: str = None):
-    warnings.warn("_get_partition() is deprecated and must not be used", DeprecationWarning)
-
-    region_name = region_name or _get_region()
-    return boto3.session.Session().get_partition_for_region(region_name)
-
-
-# TODO: Deprecate and remove this
-def get_local_region():
-    global LOCAL_REGION
-    if LOCAL_REGION is None:
-        LOCAL_REGION = get_boto3_region() or ""
-    return AWS_REGION_US_EAST_1 or LOCAL_REGION
 
 
 def get_boto3_region() -> str:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import socket
+import warnings
 from functools import lru_cache
 from typing import Dict, Optional, Union
 
@@ -46,9 +47,10 @@ def get_valid_regions_for_service(service_name):
     return regions
 
 
-# NOTE: This method should not be used as it is not guaranteed to return the correct region
-# In the near future it will be deprecated and removed
-def get_region():
+# WARNING: This function is deprecated and must not be used.
+def _get_region():
+    warnings.warn("_get_region() is deprecated and must not be used", DeprecationWarning)
+
     # Note: leave import here to avoid import errors (e.g., "flask") for CLI commands
     from localstack.utils.aws.request_context import get_region_from_request_context
 
@@ -59,8 +61,11 @@ def get_region():
     return get_local_region()
 
 
-def get_partition(region_name: str = None):
-    region_name = region_name or get_region()
+# WARNING: This function is deprecated and must not be used.
+def _get_partition(region_name: str = None):
+    warnings.warn("_get_partition() is deprecated and must not be used", DeprecationWarning)
+
+    region_name = region_name or _get_region()
     return boto3.session.Session().get_partition_for_region(region_name)
 
 
@@ -132,7 +137,7 @@ def extract_region_from_auth_header(headers: Dict[str, str], use_default=True) -
     if region == auth:
         region = None
     if use_default:
-        region = region or get_region()
+        region = region or AWS_REGION_US_EAST_1
     return region
 
 

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -115,16 +115,6 @@ class RequestContextManager:
         THREAD_LOCAL.request_context = None
 
 
-def get_region_from_request_context():
-    """look up region from request context"""
-
-    request_context = get_request_context()
-    if not request_context:
-        return
-
-    return extract_region_from_headers(request_context.headers)
-
-
 def mock_request_for_region(service_name: str, account_id: str, region_name: str) -> Request:
     result = Request()
     result.headers["Authorization"] = mock_aws_request_headers(


### PR DESCRIPTION
## Motivation

This PR is the culmination of months of refactoring efforts!

We are finally deprecating and removing `aws_stack.get_region()` and `get_aws_account_id()` (and few other functions that rely on the thread-local storage).

Thanks for patiently reviewing all the PRs folks! cc: @alexrashed @baermat @bentsku @dfangl @dominikschubert @giograno @joe4dev @MEPalma @steffyP @thrau @whummer 