### PR TITLE
fix kms key creation for s3 encryption

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,14 +150,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,10 +150,14 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -668,8 +668,8 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket | Any) -> None:
         raise
 
 
-def create_s3_kms_managed_key_for_region(region_name: str) -> SSEKMSKeyId:
-    kms_client = connect_to(region_name=region_name).kms
+def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
+    kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
     key = kms_client.create_key(
         Description="Default key that protects my S3 objects when no other key is defined"
     )

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -670,7 +670,6 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket | Any) -> None:
 
 def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
     kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
-    kms_client = connect_to(region_name=region_name).kms
     key = kms_client.create_key(
         Description="Default key that protects my S3 objects when no other key is defined"
     )

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -668,8 +668,10 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket | Any) -> None:
         raise
 
 
-def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
-    kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
+# def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
+def create_s3_kms_managed_key_for_region(region_name: str) -> SSEKMSKeyId:
+    # kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
+    kms_client = connect_to(region_name=region_name).kms
     key = kms_client.create_key(
         Description="Default key that protects my S3 objects when no other key is defined"
     )

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -668,9 +668,8 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket | Any) -> None:
         raise
 
 
-# def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
-def create_s3_kms_managed_key_for_region(region_name: str) -> SSEKMSKeyId:
-    # kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
+def create_s3_kms_managed_key_for_region(account_id: str, region_name: str) -> SSEKMSKeyId:
+    kms_client = connect_to(aws_access_key_id=account_id, region_name=region_name).kms
     kms_client = connect_to(region_name=region_name).kms
     key = kms_client.create_key(
         Description="Default key that protects my S3 objects when no other key is defined"

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3653,8 +3653,11 @@ def get_encryption_parameters_from_request_and_bucket(
                 # if not key is provided, AWS will use an AWS managed KMS key
                 # create it if it doesn't already exist, and save it in the store per region
                 if not store.aws_managed_kms_key_id:
+                    # managed_kms_key_id = create_s3_kms_managed_key_for_region(
+                    #     s3_bucket.bucket_account_id, s3_bucket.bucket_region
+                    # )
                     managed_kms_key_id = create_s3_kms_managed_key_for_region(
-                        s3_bucket.bucket_account_id, s3_bucket.bucket_region
+                        s3_bucket.bucket_region
                     )
                     store.aws_managed_kms_key_id = managed_kms_key_id
 

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3654,7 +3654,7 @@ def get_encryption_parameters_from_request_and_bucket(
                 # create it if it doesn't already exist, and save it in the store per region
                 if not store.aws_managed_kms_key_id:
                     managed_kms_key_id = create_s3_kms_managed_key_for_region(
-                        s3_bucket.bucket_region
+                        s3_bucket.bucket_account_id, s3_bucket.bucket_region
                     )
                     store.aws_managed_kms_key_id = managed_kms_key_id
 

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3653,11 +3653,8 @@ def get_encryption_parameters_from_request_and_bucket(
                 # if not key is provided, AWS will use an AWS managed KMS key
                 # create it if it doesn't already exist, and save it in the store per region
                 if not store.aws_managed_kms_key_id:
-                    # managed_kms_key_id = create_s3_kms_managed_key_for_region(
-                    #     s3_bucket.bucket_account_id, s3_bucket.bucket_region
-                    # )
                     managed_kms_key_id = create_s3_kms_managed_key_for_region(
-                        s3_bucket.bucket_region
+                        s3_bucket.bucket_account_id, s3_bucket.bucket_region
                     )
                     store.aws_managed_kms_key_id = managed_kms_key_id
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `test_s3_bucket_encryption_sse_kms_aws_managed_key` test should still create the consequent resources in the corresponding accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR adds `account_id` when creating kms key for s3 bucket encryption in `create_s3_kms_managed_key_for_region` and the remaining modifications involve propagating the `account_id` value to the relevant functions.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

