### PR TITLE
Fix Lambda CloudWatch metric recording upon invocation error

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -896,7 +896,7 @@ LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY = int(
 )
 # SEMI-PUBLIC: not actively communicated
 LAMBDA_LIMITS_TOTAL_CODE_SIZE = int(os.environ.get("LAMBDA_LIMITS_TOTAL_CODE_SIZE", 80_530_636_800))
-# SEMI-PUBLIC: not actively communicated
+# PUBLIC: documented after AWS changed validation around 2023-11
 LAMBDA_LIMITS_CODE_SIZE_ZIPPED = int(os.environ.get("LAMBDA_LIMITS_CODE_SIZE_ZIPPED", 52_428_800))
 # SEMI-PUBLIC: not actively communicated
 LAMBDA_LIMITS_CODE_SIZE_UNZIPPED = int(

--- a/localstack/services/lambda_/runtimes.py
+++ b/localstack/services/lambda_/runtimes.py
@@ -18,6 +18,8 @@ from localstack.aws.api.lambda_ import Runtime
 # 6. Review special tests including:
 # a) [ext] tests.aws.services.lambda_.test_lambda_endpoint_injection
 # 7. Before merging, run the ext integration tests to cover transparent endpoint injection testing.
+# 8. Add the new runtime to the K8 image build: https://github.com/localstack/lambda-cve-mitigation
+# 9. Inform the web team to update the resource browser (consider offering an endpoint in the future)
 
 # Mapping from a) AWS Lambda runtime identifier => b) official AWS image on Amazon ECR Public
 # a) AWS Lambda runtimes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
@@ -1,8 +1,6 @@
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
-import pytest
-
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.snapshot import is_aws
 from localstack.utils.strings import short_uid
@@ -56,7 +54,6 @@ class TestCloudWatchLambdaMetrics:
         )
         snapshot.match("get-metric-data", result)
 
-    @pytest.mark.skipif(not is_aws(), reason="'Errors' metrics not reported by LS")
     @markers.aws.validated
     def test_lambda_invoke_error(self, aws_client, create_lambda_function, snapshot):
         """


### PR DESCRIPTION
## Motivation

Lambda records a CloudWatch (CW) error metric upon every failed Lambda invocation but LocalStack does not record the error metric anymore since the Lambda invocation loop rework. @steffyP recently added a test for this behavior in https://github.com/localstack/localstack/pull/9653 discovered in a Pro sample.

> Errors – The number of invocations that result in a function error. Function errors include exceptions that your code throws and exceptions that the Lambda runtime throws. The runtime returns errors for issues such as timeouts and configuration errors. To calculate the error rate, divide the value of Errors by the value of Invocations. Note that the timestamp on an error metric reflects when the function was invoked, not when the error occurred.

see [AWS CW metrics](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html)

## Changes

* Fix the regression and submit a CloudWatch metric upon failed Lambda invocation
* Update some Lambda docs (nit)

## Discussion

* Exceptions that are not caught in `localstack.services.lambda_.invocation.version_manager.LambdaVersionManager.invoke` (i.e., all exceptions except `StatusErrorException`) won't be recorded as errors. For example, exceptions from the Lambda control plane (e.g., `TooManyRequestsException`) should be recorded in other metrics (e.g., `Throttles`).

## Background

looks like a bug introduced in the Lambda invocation loop rework: https://github.com/localstack/localstack/pull/8970/files#diff-056f8f1dc9188bf87729941f6be9805c0caf16189dafa882f16fb259676f79daL727

similar to the `record_invocation` case here:

https://github.com/localstack/localstack/pull/8970/files#diff-056f8f1dc9188bf87729941f6be9805c0caf16189dafa882f16fb259676f79daR220

This should be fixed in the `version_manager.py::invoke`