### PR TITLE
Add image sha to startup information and more details to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -60,10 +60,11 @@ body:
         - **LocalStack**:
           You can find this information in the logs when starting localstack
 
-          LocalStack version: 2.3.2
-          LocalStack Docker image sha: sha256:f7c3a25c88a7888fafe5029069fc7d093a888abd0bdd9c4303ead58e90d8bc8a
-          LocalStack build date: 2023-10-03
-          LocalStack build git hash: 1bccf790
+          LocalStack version: 3.4.1.dev
+          LocalStack Docker image sha: sha256:f02ab8ef73f66b0ab26bb3d24a165e1066a714355f79a42bf8aa1a336d5722e7
+          LocalStack build date: 2024-05-14
+          LocalStack build git hash: ecd7dc879
+
     value: |
         - OS:
         - LocalStack:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -55,7 +55,6 @@ body:
   attributes:
     label: Environment
     description: |
-
       examples:
         - **OS**: Ubuntu 20.04
         - **LocalStack**:
@@ -65,9 +64,6 @@ body:
           LocalStack Docker image sha: sha256:f7c3a25c88a7888fafe5029069fc7d093a888abd0bdd9c4303ead58e90d8bc8a
           LocalStack build date: 2023-10-03
           LocalStack build git hash: 1bccf790
-
-          You can find this information by
-
     value: |
         - OS:
         - LocalStack:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -55,12 +55,26 @@ body:
   attributes:
     label: Environment
     description: |
+
       examples:
         - **OS**: Ubuntu 20.04
-        - **LocalStack**: latest
+        - **LocalStack**:
+          You can find this information in the logs when starting localstack
+
+          LocalStack version: 2.3.2
+          LocalStack Docker image sha: sha256:f7c3a25c88a7888fafe5029069fc7d093a888abd0bdd9c4303ead58e90d8bc8a
+          LocalStack build date: 2023-10-03
+          LocalStack build git hash: 1bccf790
+
+          You can find this information by
+
     value: |
         - OS:
         - LocalStack:
+          LocalStack version:
+          LocalStack Docker image sha:
+          LocalStack build date:
+          LocalStack build git hash:
     render: markdown
   validations:
     required: false

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -21,6 +21,7 @@ from localstack.utils.bootstrap import (
     should_eager_load_api,
 )
 from localstack.utils.container_networking import get_main_container_id
+from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cleanup_tmp_files
 from localstack.utils.net import is_port_open
 from localstack.utils.patch import patch
@@ -203,6 +204,11 @@ def print_runtime_information(in_docker=False):
         id = get_main_container_id()
         if id:
             print("LocalStack Docker container id: %s" % id[:12])
+
+        inspect_result = DOCKER_CLIENT.inspect_container(id)
+        image_sha = inspect_result.get("Image")
+        if image_sha:
+            print("LocalStack Docker image sha: %s" % image_sha)
 
     if config.LOCALSTACK_BUILD_DATE:
         print("LocalStack build date: %s" % config.LOCALSTACK_BUILD_DATE)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -20,7 +20,8 @@ from localstack.utils.bootstrap import (
     setup_logging,
     should_eager_load_api,
 )
-from localstack.utils.container_networking import get_main_container_id
+from localstack.utils.container_networking import get_main_container_name
+from localstack.utils.container_utils.container_client import ContainerException
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cleanup_tmp_files
 from localstack.utils.net import is_port_open
@@ -201,14 +202,16 @@ def print_runtime_information(in_docker=False):
     print()
     print(f"LocalStack version: {VERSION}")
     if in_docker:
-        id = get_main_container_id()
-        if id:
-            print("LocalStack Docker container id: %s" % id[:12])
-
-        inspect_result = DOCKER_CLIENT.inspect_container(id)
-        image_sha = inspect_result.get("Image")
-        if image_sha:
+        try:
+            container_name = get_main_container_name()
+            print("LocalStack Docker container name: %s" % container_name)
+            inspect_result = DOCKER_CLIENT.inspect_container(container_name)
+            container_id = inspect_result["Id"]
+            print("LocalStack Docker container id: %s" % container_id[:12])
+            image_sha = inspect_result["Image"]
             print("LocalStack Docker image sha: %s" % image_sha)
+        except ContainerException:
+            pass
 
     if config.LOCALSTACK_BUILD_DATE:
         print("LocalStack build date: %s" % config.LOCALSTACK_BUILD_DATE)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -210,8 +210,8 @@ def print_runtime_information(in_docker=False):
             print("LocalStack Docker container id: %s" % container_id[:12])
             image_sha = inspect_result["Image"]
             print("LocalStack Docker image sha: %s" % image_sha)
-        except ContainerException:
-            pass
+        except ContainerException as e:
+            print("Failed to inspect docker container: %s %s" % (e, traceback.format_exc()))
 
     if config.LOCALSTACK_BUILD_DATE:
         print("LocalStack build date: %s" % config.LOCALSTACK_BUILD_DATE)


### PR DESCRIPTION
## Motivation

Going through issues it's often quite hard to reproduce issues, especially when a bug report simply specifies that it was run with `localstack/localstack:latest`. Even with the date of the bug report this is not reliable information since the issue reporter might not have pulled a new version right before the issue was opened.
This PR intends to improve the bug report template a tiny bit by giving us better information about the version of localstack used.

## Changes

- Add another line to the startup logs of LocalStack, e.g. `LocalStack Docker image sha: sha256:f7c3a25c88a7888fafe5029069fc7d093a888abd0bdd9c4303ead58e90d8bc8a`
- Remove `latest` from the bug report template and instead refer to this startup output.


