### PR TITLE
Test lambda provisioned concurrency scheduling

### DIFF
--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -2535,8 +2535,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             "UnreservedConcurrentExecutions"
         ]
         if (
-            provisioned_concurrent_executions
-            > unreserved_concurrent_executions - config.LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY
+            unreserved_concurrent_executions - provisioned_concurrent_executions
+            < config.LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY
         ):
             raise InvalidParameterValueException(
                 f"Specified ConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below"
@@ -3507,8 +3507,16 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             "UnreservedConcurrentExecutions"
         ]
 
+        # The existing reserved concurrent executions for the same function are already deduced in
+        # unreserved_concurrent_executions but must not count because the new one will replace the existing one.
+        # Joel tested this behavior manually against AWS (2023-11-28).
+        existing_reserved_concurrent_executions = (
+            fn.reserved_concurrent_executions if fn.reserved_concurrent_executions else 0
+        )
         if (
-            unreserved_concurrent_executions - reserved_concurrent_executions
+            unreserved_concurrent_executions
+            - reserved_concurrent_executions
+            + existing_reserved_concurrent_executions
         ) < config.LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY:
             raise InvalidParameterValueException(
                 f"Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [{config.LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY}]."

--- a/tests/aws/services/lambda_/functions/lambda_invocation_type.py
+++ b/tests/aws/services/lambda_/functions/lambda_invocation_type.py
@@ -1,7 +1,10 @@
 import os
+import time
 
 
 def handler(event, context):
+    if event.get("wait"):
+        time.sleep(event["wait"])
     init_type = os.environ["AWS_LAMBDA_INITIALIZATION_TYPE"]
     print(f"{init_type=}")
     return init_type

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3474,5 +3474,21 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_mixed_architecture": {
     "recorded-date": "20-11-2023, 23:14:17",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_provisioned_concurrency_scheduling": {
+    "recorded-date": "28-11-2023, 16:48:42",
+    "recorded-content": {
+      "get_provisioned_postwait": {
+        "AllocatedProvisionedConcurrentExecutions": 1,
+        "AvailableProvisionedConcurrentExecutions": 1,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "READY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation

Lambda provisioned concurrency misses a test for synchronous invokes with spillover from provisioned concurrency into on-demand instances. Related to the issue report https://github.com/localstack/localstack/issues/9658 (which is not a bug but highlights some testing deficit).

Why not:

* The synchronous test `test_provisioned_concurrency` already covers the prefer-provisioned-concurrency scenario but misses spillover
* The asynchronous test `test_reserved_concurrency_async_queue` covers a very similar scenario using async events

## Changes

* Add a dedicated test for synchronous invokes with spillover from provisioned-concurrency into on-demand concurrency.
* Enable a previously skipped concurrency type assertion (now implemented)
* Fix reserved concurrency update exception when a reserved concurrency config already exists for the same function
* Add concurrency quota checks for all relevant concurrency tests

