### PR TITLE
add APIGW PutIntegration IntegrationType validation

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2360,3 +2360,26 @@ class TestApiGatewayGatewayResponse:
             snapshot.match(
                 f"update-gateway-replace-invalid-parameter-{index}-none", e.value.response
             )
+
+
+class TestApigatewayIntegration:
+    @markers.aws.validated
+    def test_put_integration_wrong_type(
+        self, aws_client, apigw_create_rest_api, aws_client_factory, snapshot
+    ):
+        apigw_client = aws_client_factory(config=Config(parameter_validation=False)).apigateway
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}",
+            description="APIGW test PutIntegration Types",
+        )
+        api_id = response["id"]
+
+        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
+
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        with pytest.raises(ClientError) as e:
+            apigw_client.put_integration(
+                restApiId=api_id, resourceId=root_id, httpMethod="GET", type="HTTPS_PROXY"
+            )
+        snapshot.match("put-integration-wrong-type", e.value.response)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -3156,5 +3156,20 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_wrong_type": {
+    "recorded-date": "28-11-2023, 20:15:11",
+    "recorded-content": {
+      "put-integration-wrong-type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'HTTPS_PROXY' at 'putIntegrationInput.type' failed to satisfy constraint: Member must satisfy enum value set: [HTTP, MOCK, AWS_PROXY, HTTP_PROXY, AWS]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had a support case where the user was having issue with the `HTTPS_PROXY` integration type. After some investigation, it looked like it didn't exist in AWS either. We need validation early so that it would fail when setting up infrastructure and not when actually calling the `execute-api` endpoint.

<!-- What notable changes does this PR make? -->
## Changes
Add validation for `IntegrationType` in `PutIntegration`, and write a small snapshot test. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

