### PR TITLE
fix type hints incompatible with python < 3.10 in aws_stack

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -98,7 +98,7 @@ def get_s3_hostname():
 
 
 def fix_account_id_in_arns(
-    response, replacement: str, colon_delimiter: str = ":", existing: str | List[str] = None
+    response, replacement: str, colon_delimiter: str = ":", existing: Union[str, List[str]] = None
 ):
     """Fix the account ID in the ARNs returned in the given Flask response or string"""
     from moto.core import DEFAULT_ACCOUNT_ID

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -2,7 +2,7 @@ import logging
 import re
 import socket
 from functools import lru_cache
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import boto3
 
@@ -98,7 +98,7 @@ def get_s3_hostname():
 
 
 def fix_account_id_in_arns(
-    response, replacement: str, colon_delimiter: str = ":", existing: str | list[str] = None
+    response, replacement: str, colon_delimiter: str = ":", existing: str | List[str] = None
 ):
     """Fix the account ID in the ARNs returned in the given Flask response or string"""
     from moto.core import DEFAULT_ACCOUNT_ID


### PR DESCRIPTION
## Motivation

Use of subscriptable types broke CLI tests in for older Python version, specifically the **cli-tests (3.8)** job.

This PR makes use of backward-compatible type hints.