### PR TITLE
Extract container logs on bootstrap test failure

### DIFF
--- a/tests/bootstrap/test_localstack_container_server.py
+++ b/tests/bootstrap/test_localstack_container_server.py
@@ -19,6 +19,10 @@ class TestLocalstackContainerServer:
 
             response = requests.get("http://localhost:4566/_localstack/health")
             assert response.ok, "expected health check to return OK: %s" % response.text
+        except Exception:
+            # get the container logs so we actually know what went wrong
+            print(server.container.get_logs())
+            raise
         finally:
             server.shutdown()
 


### PR DESCRIPTION

## Motivation

Hunting failings tests here is quite awful because the CI doesn't actually show you what went wrong in the started container.

## Changes

- If the container can't start, at least print the logs so that we see them in CI. Also locally this is quite helpful since the container is by default immediately removed.

## TODO

Might want to go through the rest of the bootstrap tests and do similar things there

