### PR TITLE
Add option to capture raw snapshots when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ gen/
 
 # hypothesis pytest plugin
 .hypothesis
+
+# RAW snapshots
+*.raw.snapshot.json

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -11,13 +11,13 @@ from localstack.testing.snapshots.transformer_utility import (
 
 class TestSnapshotManager:
     def test_simple_diff_nochange(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.recorded_state = {"key_a": {"a": 3}}
         sm.match("key_a", {"a": 3})
         sm._assert_all()
 
     def test_simple_diff_change(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.recorded_state = {"key_a": {"a": 3}}
         sm.match("key_a", {"a": 5})
         with pytest.raises(Exception) as ctx:
@@ -25,7 +25,7 @@ class TestSnapshotManager:
         ctx.match("Parity snapshot failed")
 
     def test_multiple_assertmatch_with_same_key_fail(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.recorded_state = {"key_a": {"a": 3}}
         sm.match("key_a", {"a": 3})
         with pytest.raises(Exception) as ctx:
@@ -33,7 +33,7 @@ class TestSnapshotManager:
         ctx.match("used multiple times in the same test scope")
 
     def test_context_replacement(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.add_transformer(
             KeyValueBasedTransformer(lambda k, v: v if k == "aaa" else None, replacement="A")
         )
@@ -42,7 +42,7 @@ class TestSnapshotManager:
         sm._assert_all()
 
     def test_context_replacement_no_change(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.add_transformer(TransformerUtility.key_value("name"))
         sm.recorded_state = {"key_a": {"name": ""}}
         sm.match("key_a", {"name": ""})
@@ -50,7 +50,7 @@ class TestSnapshotManager:
 
     def test_match_order_reference_replacement(self):
         """tests if the reference-replacement works as expected, e.g., using alphabetical order of keys"""
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
 
         sm.add_transformer(KeyValueBasedTransformer(_resource_name_transformer, "resource"))
 
@@ -95,14 +95,14 @@ class TestSnapshotManager:
 
     def test_reference_replacement_skip_outer_keys(self):
         """Test if the reference replacement properly skips the snapshot keys on the outermost level"""
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.add_transformer(TransformerUtility.key_value("name"))
         sm.recorded_state = {"key_a": {"name": "<name:1>"}}
         sm.match("key_a", {"name": "key"})
         sm._assert_all()
 
     def test_replacement_key_value(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.add_transformer(
             KeyValueBasedTransformer(
                 # returns last two characters of value -> only this should be replaced
@@ -118,7 +118,7 @@ class TestSnapshotManager:
         sm._assert_all()
 
     def test_dot_in_skip_verification_path(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.recorded_state = {
             "key_a": {"aaa": "hello", "aab": "this is a test", "b": {"a.aa": "another test"}}
         }
@@ -140,7 +140,7 @@ class TestSnapshotManager:
         sm._assert_all(skip_verification_paths=skip_path_escaped)
 
     def test_non_homogeneous_list(self):
-        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
         sm.recorded_state = {"key1": [{"key2": "value1"}, "value2", 3]}
         sm.match("key1", [{"key2": "value1"}, "value2", 3])
         sm._assert_all()


### PR DESCRIPTION

## Motivation

A useful util for debugging snapshots. RAW snapshots are the RAW untransformed recorded content . In contrast to normal snapshots these should not be committed (see gitignore) and should only be used for debugging & exploration purposes.


## Changes

- Introduces **RAW snapshot mode**: Set `SNAPSHOT_RAW=1` or use the CLI argument `--snapshot-raw` to enable this mode. When enabled it will save a separate JSON file next to the normal snapshots with the "raw", i.e. untransformed recorded contents.


## Testing

Set `SNAPSHOT_RAW=1` and execute a snapshot test
