### PR TITLE
enable Fn::Transform to use CFn macros

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Optional, TypedDict
 

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Optional, TypedDict
 

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -4,7 +4,7 @@ import logging
 from localstack.services.cloudformation.engine import yaml_parser
 from localstack.services.cloudformation.engine.transformers import (
     apply_global_transformations,
-    apply_snipped_transformations,
+    apply_intrinsic_transformations,
 )
 from localstack.utils.json import clone_safe
 
@@ -42,7 +42,7 @@ def transform_template(
 
     # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
     #  transforms below, as some utils - incl samtransformer - expect them to be resolved already)
-    proccesed_template = apply_snipped_transformations(
+    proccesed_template = apply_intrinsic_transformations(
         account_id,
         region_name,
         proccesed_template,

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -1,25 +1,14 @@
 import json
 import logging
-import os
 
-import boto3
-from samtranslator.translator.transform import transform as transform_sam
-
-from localstack.aws.api import CommonServiceException
-from localstack.aws.connect import connect_to
 from localstack.services.cloudformation.engine import yaml_parser
-from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.services.cloudformation.engine.transformers import (
-    apply_transform_intrinsic_functions,
+    apply_global_transformations,
+    apply_snipped_transformations,
 )
-from localstack.services.cloudformation.stores import get_cloudformation_store
 from localstack.utils.json import clone_safe
-from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
-SERVERLESS_TRANSFORM = "AWS::Serverless-2016-10-31"
-EXTENSIONS_TRANSFORM = "AWS::LanguageExtensions"
-SECRETSMANAGER_TRANSFORM = "AWS::SecretsManager-2020-07-23"
 
 
 def parse_template(template: str) -> dict:
@@ -43,21 +32,20 @@ def transform_template(
     account_id: str,
     region_name: str,
     template: dict,
-    parameters: list,
     stack_name: str,
     resources: dict,
     mappings: dict,
     conditions: dict[str, bool],
     resolved_parameters: dict,
 ) -> dict:
-    result = dict(template)
+    proccesed_template = dict(template)
 
     # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
     #  transforms below, as some utils - incl samtransformer - expect them to be resolved already)
-    result = apply_transform_intrinsic_functions(
+    proccesed_template = apply_snipped_transformations(
         account_id,
         region_name,
-        result,
+        proccesed_template,
         stack_name,
         resources,
         mappings,
@@ -66,152 +54,15 @@ def transform_template(
     )
 
     # apply global transforms
-    transformations = format_transforms(result.get("Transform", []))
-    for transformation in transformations:
-        if not isinstance(transformation["Name"], str):
-            # TODO this should be done during template validation
-            raise CommonServiceException(
-                code="ValidationError",
-                status_code=400,
-                message="Key Name of transform definition must be a string.",
-                sender_fault=True,
-            )
-        elif transformation["Name"] == SERVERLESS_TRANSFORM:
-            result = apply_serverless_transformation(account_id, region_name, result, parameters)
-        elif transformation["Name"] == EXTENSIONS_TRANSFORM:
-            continue
-        elif transformation["Name"] == SECRETSMANAGER_TRANSFORM:
-            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-secretsmanager.html
-            LOG.warning("%s is not yet supported. Ignoring.", SECRETSMANAGER_TRANSFORM)
-        else:
-            result = execute_macro(
-                account_id,
-                region_name,
-                parsed_template=result,
-                macro=transformation,
-                stack_parameters=parameters,
-            )
-
-    return result
-
-
-def execute_macro(
-    account_id: str, region_name: str, parsed_template: dict, macro: dict, stack_parameters: list
-) -> str:
-    macro_definition = get_cloudformation_store(account_id, region_name).macros.get(macro["Name"])
-    if not macro_definition:
-        raise FailedTransformationException(macro["Name"], "2DO")
-
-    # TODO: needs to consider ResolvedValue for SSM parameters as well
-    formatted_stack_parameters = {
-        param["ParameterKey"]: param["ParameterValue"] for param in stack_parameters
-    }
-
-    formatted_transform_parameters = macro.get("Parameters", {})
-    for k, v in formatted_transform_parameters.items():
-        if isinstance(v, dict) and "Ref" in v:
-            formatted_transform_parameters[k] = formatted_stack_parameters[v["Ref"]]
-
-    transformation_id = f"{account_id}::{macro['Name']}"
-    event = {
-        "region": region_name,
-        "accountId": account_id,
-        "fragment": parsed_template,
-        "transformId": transformation_id,
-        "params": formatted_transform_parameters,
-        "requestId": long_uid(),
-        "templateParameterValues": formatted_stack_parameters,
-    }
-
-    client = connect_to(aws_access_key_id=account_id, region_name=region_name).lambda_
-    invocation = client.invoke(
-        FunctionName=macro_definition["FunctionName"], Payload=json.dumps(event)
+    proccesed_template = apply_global_transformations(
+        account_id,
+        region_name,
+        proccesed_template,
+        stack_name,
+        resources,
+        mappings,
+        conditions,
+        resolved_parameters,
     )
-    if invocation.get("StatusCode") != 200 or invocation.get("FunctionError") == "Unhandled":
-        raise FailedTransformationException(
-            transformation=macro["Name"],
-            message=f"Received malformed response from transform {transformation_id}. Rollback requested by user.",
-        )
-    result = json.loads(invocation["Payload"].read())
 
-    if result.get("status") != "success":
-        error_message = result.get("errorMessage")
-        message = (
-            f"Transform {transformation_id} failed with: {error_message}. Rollback requested by user."
-            if error_message
-            else f"Transform {transformation_id} failed without an error message.. Rollback requested by user."
-        )
-        raise FailedTransformationException(transformation=macro["Name"], message=message)
-
-    if not isinstance(result.get("fragment"), dict):
-        raise FailedTransformationException(
-            transformation=macro["Name"],
-            message="Template format error: unsupported structure.. Rollback requested by user.",
-        )
-
-    return result.get("fragment")
-
-
-def apply_serverless_transformation(
-    account_id: str, region_name: str, parsed_template: dict, parameters: list
-):
-    """only returns string when parsing SAM template, otherwise None"""
-    # TODO: we might also want to override the access key ID to account ID
-    region_before = os.environ.get("AWS_DEFAULT_REGION")
-    if boto3.session.Session().region_name is None:
-        os.environ["AWS_DEFAULT_REGION"] = region_name
-    loader = create_policy_loader()
-
-    formatted_stack_parameters = {}
-    for param in parameters:
-        if "ResolvedValue" in param:
-            formatted_stack_parameters[param["ParameterKey"]] = param["ResolvedValue"]
-        else:
-            formatted_stack_parameters[param["ParameterKey"]] = param["ParameterValue"]
-
-    try:
-        transformed = transform_sam(parsed_template, formatted_stack_parameters, loader)
-        return transformed
-    except Exception as e:
-        raise FailedTransformationException(transformation=SERVERLESS_TRANSFORM, message=str(e))
-    finally:
-        # Note: we need to fix boto3 region, otherwise AWS SAM transformer fails
-        os.environ.pop("AWS_DEFAULT_REGION", None)
-        if region_before is not None:
-            os.environ["AWS_DEFAULT_REGION"] = region_before
-
-
-def format_transforms(transforms: list | dict | str) -> list[dict]:
-    """
-    The value of the Transform attribute can be:
-     - a list name of the transformations to apply
-     - an object like {Name: transformation, Parameters:{}}
-     - a transformation name
-     - a list of objects defining a transformation
-     so the objective of this function is to normalize the list of transformations to apply.
-    """
-    formatted_transformations = []
-    if isinstance(transforms, str):
-        formatted_transformations.append({"Name": transforms})
-
-    if isinstance(transforms, dict):
-        formatted_transformations.append(transforms)
-
-    if isinstance(transforms, list):
-        for transformation in transforms:
-            if isinstance(transformation, str):
-                formatted_transformations.append({"Name": transformation})
-            if isinstance(transformation, dict):
-                formatted_transformations.append(transformation)
-
-    return formatted_transformations
-
-
-class FailedTransformationException(Exception):
-    transformation: str
-    msg: str
-
-    def __init__(self, transformation: str, message: str = ""):
-        self.transformation = transformation
-        self.message = message
-        super().__init__(self.message)
+    return proccesed_template

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -1,11 +1,25 @@
+import json
 import logging
+import os
 from typing import Dict, Type, Union
 
+import boto3
+from samtranslator.translator.transform import transform as transform_sam
+
+from localstack.aws.api import CommonServiceException
 from localstack.aws.connect import connect_to
+from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
+from localstack.services.cloudformation.engine.template_deployer import resolve_refs_recursively
+from localstack.services.cloudformation.stores import get_cloudformation_store
 from localstack.utils import testutil
 from localstack.utils.objects import recurse_object
+from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
+
+SERVERLESS_TRANSFORM = "AWS::Serverless-2016-10-31"
+EXTENSIONS_TRANSFORM = "AWS::LanguageExtensions"
+SECRETSMANAGER_TRANSFORM = "AWS::SecretsManager-2020-07-23"
 
 TransformResult = Union[dict, str]
 
@@ -39,7 +53,7 @@ class AwsIncludeTransformer(Transformer):
 transformers: Dict[str, Type] = {"AWS::Include": AwsIncludeTransformer}
 
 
-def apply_transform_intrinsic_functions(
+def apply_snipped_transformations(
     account_id: str,
     region_name: str,
     template: dict,
@@ -50,27 +64,205 @@ def apply_transform_intrinsic_functions(
     stack_parameters: dict,
 ) -> dict:
     """Resolve constructs using the 'Fn::Transform' intrinsic function."""
-    from localstack.services.cloudformation.engine.template_deployer import resolve_refs_recursively
 
     def _visit(obj, **_):
         if isinstance(obj, dict) and obj.keys() == {"Fn::Transform"}:
             transform = obj["Fn::Transform"]
             transform_name = transform.get("Name")
             transformer_class = transformers.get(transform_name)
+            macro_store = get_cloudformation_store(account_id, region_name).macros
+            parameters = transform.get("Parameters") or {}
+            parameters = resolve_refs_recursively(
+                account_id,
+                region_name,
+                stack_name,
+                resources,
+                mappings,
+                conditions,
+                stack_parameters,
+                parameters,
+            )
             if transformer_class:
                 transformer = transformer_class()
-                parameters = transform.get("Parameters") or {}
-                parameters = resolve_refs_recursively(
-                    account_id,
-                    region_name,
-                    stack_name,
-                    resources,
-                    mappings,
-                    conditions,
-                    stack_parameters,
-                    parameters,
-                )
                 return transformer.transform(account_id, region_name, parameters)
+
+            elif transform_name in macro_store:
+                return execute_macro(
+                    account_id, region_name, template, transform, stack_parameters, parameters, True
+                )
+            else:
+                LOG.warning("Unsupported transform function: %s", transform_name)
         return obj
 
     return recurse_object(template, _visit)
+
+
+def apply_global_transformations(
+    account_id: str,
+    region_name: str,
+    template: dict,
+    stack_name: str,
+    resources: dict,
+    mappings: dict,
+    conditions: dict[str, bool],
+    stack_parameters: dict,
+) -> dict:
+    processed_template = dict(template)
+    transformations = format_template_transformations_into_list(
+        processed_template.get("Transform", [])
+    )
+    for transformation in transformations:
+        transformation_parameters = resolve_refs_recursively(
+            account_id,
+            region_name,
+            stack_name,
+            resources,
+            mappings,
+            conditions,
+            stack_parameters,
+            transformation.get("Parameters", {}),
+        )
+
+        if not isinstance(transformation["Name"], str):
+            # TODO this should be done during template validation
+            raise CommonServiceException(
+                code="ValidationError",
+                status_code=400,
+                message="Key Name of transform definition must be a string.",
+                sender_fault=True,
+            )
+        elif transformation["Name"] == SERVERLESS_TRANSFORM:
+            processed_template = apply_serverless_transformation(
+                account_id, region_name, processed_template, stack_parameters
+            )
+        elif transformation["Name"] == EXTENSIONS_TRANSFORM:
+            continue
+        elif transformation["Name"] == SECRETSMANAGER_TRANSFORM:
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-secretsmanager.html
+            LOG.warning("%s is not yet supported. Ignoring.", SECRETSMANAGER_TRANSFORM)
+        else:
+            processed_template = execute_macro(
+                account_id,
+                region_name,
+                parsed_template=template,
+                macro=transformation,
+                stack_parameters=stack_parameters,
+                transformation_parameters=transformation_parameters,
+            )
+
+    return processed_template
+
+
+def format_template_transformations_into_list(transforms: list | dict | str) -> list[dict]:
+    """
+    The value of the Transform attribute can be:
+     - a transformation name
+     - an object like {Name: transformation, Parameters:{}}
+     - a list a list of names of the transformations to apply
+     - a list of objects defining a transformation
+     so the objective of this function is to normalize the list of transformations to apply into a list of transformation objects
+    """
+    formatted_transformations = []
+    if isinstance(transforms, str):
+        formatted_transformations.append({"Name": transforms})
+
+    if isinstance(transforms, dict):
+        formatted_transformations.append(transforms)
+
+    if isinstance(transforms, list):
+        for transformation in transforms:
+            if isinstance(transformation, str):
+                formatted_transformations.append({"Name": transformation})
+            if isinstance(transformation, dict):
+                formatted_transformations.append(transformation)
+
+    return formatted_transformations
+
+
+def execute_macro(
+    account_id: str,
+    region_name: str,
+    parsed_template: dict,
+    macro: dict,
+    stack_parameters: dict,
+    transformation_parameters: dict,
+    is_intrinsic=False,
+) -> str:
+    macro_definition = get_cloudformation_store(account_id, region_name).macros.get(macro["Name"])
+    if not macro_definition:
+        raise FailedTransformationException(macro["Name"], "2DO")
+
+    formatted_stack_parameters = {}
+    for key, value in stack_parameters.items():
+        formatted_stack_parameters[key] = value.get("ParameterValue")
+
+    transformation_id = f"{account_id}::{macro['Name']}"
+    event = {
+        "region": region_name,
+        "accountId": account_id,
+        "fragment": parsed_template,
+        "transformId": transformation_id,
+        "params": transformation_parameters,
+        "requestId": long_uid(),
+        "templateParameterValues": formatted_stack_parameters,
+    }
+
+    client = connect_to(aws_access_key_id=account_id, region_name=region_name).lambda_
+    invocation = client.invoke(
+        FunctionName=macro_definition["FunctionName"], Payload=json.dumps(event)
+    )
+    if invocation.get("StatusCode") != 200 or invocation.get("FunctionError") == "Unhandled":
+        raise FailedTransformationException(
+            transformation=macro["Name"],
+            message=f"Received malformed response from transform {transformation_id}. Rollback requested by user.",
+        )
+    result = json.loads(invocation["Payload"].read())
+
+    if result.get("status") != "success":
+        error_message = result.get("errorMessage")
+        message = (
+            f"Transform {transformation_id} failed with: {error_message}. Rollback requested by user."
+            if error_message
+            else f"Transform {transformation_id} failed without an error message.. Rollback requested by user."
+        )
+        raise FailedTransformationException(transformation=macro["Name"], message=message)
+
+    if not isinstance(result.get("fragment"), dict) and not is_intrinsic:
+        raise FailedTransformationException(
+            transformation=macro["Name"],
+            message="Template format error: unsupported structure.. Rollback requested by user.",
+        )
+
+    return result.get("fragment")
+
+
+def apply_serverless_transformation(
+    account_id: str, region_name: str, parsed_template: dict, template_parameters: dict
+):
+    """only returns string when parsing SAM template, otherwise None"""
+    # TODO: we might also want to override the access key ID to account ID
+    region_before = os.environ.get("AWS_DEFAULT_REGION")
+    if boto3.session.Session().region_name is None:
+        os.environ["AWS_DEFAULT_REGION"] = region_name
+    loader = create_policy_loader()
+
+    try:
+        transformed = transform_sam(parsed_template, template_parameters, loader)
+        return transformed
+    except Exception as e:
+        raise FailedTransformationException(transformation=SERVERLESS_TRANSFORM, message=str(e))
+    finally:
+        # Note: we need to fix boto3 region, otherwise AWS SAM transformer fails
+        os.environ.pop("AWS_DEFAULT_REGION", None)
+        if region_before is not None:
+            os.environ["AWS_DEFAULT_REGION"] = region_before
+
+
+class FailedTransformationException(Exception):
+    transformation: str
+    msg: str
+
+    def __init__(self, transformation: str, message: str = ""):
+        self.transformation = transformation
+        self.message = message
+        super().__init__(self.message)

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -252,7 +252,9 @@ def apply_serverless_transformation(
     if boto3.session.Session().region_name is None:
         os.environ["AWS_DEFAULT_REGION"] = region_name
     loader = create_policy_loader()
-    simplified_parameters = {k: v["ParameterValue"] for k, v in template_parameters.items()}
+    simplified_parameters = {
+        k: v.get("ResolvedValue") or v["ParameterValue"] for k, v in template_parameters.items()
+    }
 
     try:
         transformed = transform_sam(parsed_template, simplified_parameters, loader)

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -252,9 +252,10 @@ def apply_serverless_transformation(
     if boto3.session.Session().region_name is None:
         os.environ["AWS_DEFAULT_REGION"] = region_name
     loader = create_policy_loader()
+    simplified_parameters = {k: v["ParameterValue"] for k, v in template_parameters.items()}
 
     try:
-        transformed = transform_sam(parsed_template, template_parameters, loader)
+        transformed = transform_sam(parsed_template, simplified_parameters, loader)
         return transformed
     except Exception as e:
         raise FailedTransformationException(transformation=SERVERLESS_TRANSFORM, message=str(e))

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -239,7 +239,7 @@ def execute_macro(
     if not isinstance(result.get("fragment"), dict) and not is_intrinsic:
         raise FailedTransformationException(
             transformation=macro["Name"],
-            message="Template format error: unsupported structure.. Rollback requested by user.",
+            message="Template format error: unsupported structure. Rollback requested by user.",
         )
 
     return result.get("fragment")

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -232,7 +232,7 @@ def execute_macro(
         message = (
             f"Transform {transformation_id} failed with: {error_message}. Rollback requested by user."
             if error_message
-            else f"Transform {transformation_id} failed without an error message.. Rollback requested by user."
+            else f"Transform {transformation_id} failed without an error message. Rollback requested by user."
         )
         raise FailedTransformationException(transformation=macro["Name"], message=message)
 

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Dict, Type, Union
+from typing import Dict, Optional, Type, Union
 
 import boto3
 from samtranslator.translator.transform import transform as transform_sam
@@ -53,7 +53,7 @@ class AwsIncludeTransformer(Transformer):
 transformers: Dict[str, Type] = {"AWS::Include": AwsIncludeTransformer}
 
 
-def apply_snipped_transformations(
+def apply_intrinsic_transformations(
     account_id: str,
     region_name: str,
     template: dict,
@@ -197,7 +197,9 @@ def execute_macro(
 ) -> str:
     macro_definition = get_cloudformation_store(account_id, region_name).macros.get(macro["Name"])
     if not macro_definition:
-        raise FailedTransformationException(macro["Name"], "2DO")
+        raise FailedTransformationException(
+            macro["Name"], f"Transformation {macro['Name']} is not supported."
+        )
 
     formatted_stack_parameters = {}
     for key, value in stack_parameters.items():
@@ -245,7 +247,7 @@ def execute_macro(
 
 def apply_serverless_transformation(
     account_id: str, region_name: str, parsed_template: dict, template_parameters: dict
-):
+) -> Optional[str]:
     """only returns string when parsing SAM template, otherwise None"""
     # TODO: we might also want to override the access key ID to account ID
     region_before = os.environ.get("AWS_DEFAULT_REGION")

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -98,7 +98,9 @@ def apply_intrinsic_transformations(
                 )
                 return result
             else:
-                LOG.warning("Unsupported transform function: %s", transform_name)
+                LOG.warning(
+                    "Unsupported transform function '%s' used in %s", transform_name, stack_name
+                )
         return obj
 
     return recurse_object(template, _visit)

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -232,7 +232,7 @@ def execute_macro(
     if result.get("status") != "success":
         error_message = result.get("errorMessage")
         message = (
-            f"Transform {transformation_id} failed with: {error_message}.. Rollback requested by user."
+            f"Transform {transformation_id} failed with: {error_message}. Rollback requested by user."
             if error_message
             else f"Transform {transformation_id} failed without an error message.. Rollback requested by user."
         )

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -241,7 +241,7 @@ def execute_macro(
     if not isinstance(result.get("fragment"), dict) and not is_intrinsic:
         raise FailedTransformationException(
             transformation=macro["Name"],
-            message="Template format error: unsupported structure. Rollback requested by user.",
+            message="Template format error: unsupported structure.. Rollback requested by user.",
         )
 
     return result.get("fragment")

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -232,9 +232,9 @@ def execute_macro(
     if result.get("status") != "success":
         error_message = result.get("errorMessage")
         message = (
-            f"Transform {transformation_id} failed with: {error_message}. Rollback requested by user."
+            f"Transform {transformation_id} failed with: {error_message}.. Rollback requested by user."
             if error_message
-            else f"Transform {transformation_id} failed without an error message. Rollback requested by user."
+            else f"Transform {transformation_id} failed without an error message.. Rollback requested by user."
         )
         raise FailedTransformationException(transformation=macro["Name"], message=message)
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -469,13 +469,13 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return stack_not_found_error(stack_name)
 
-        # Fix this some day
-        if template_stage == TemplateStage.Processed:
-            template_body = (
-                json.dumps(stack.template)
-                if "Transform" in stack.template_body
-                else stack.template_body
-            )
+        if template_stage == TemplateStage.Processed and "Transform" in stack.template_body:
+            copy_template = clone(stack.template_original)
+            copy_template.pop("ChangeSetName", None)
+            copy_template.pop("StackName", None)
+            for resource in copy_template.get("Resources", {}).values():
+                resource.pop("LogicalResourceId", None)
+            template_body = json.dumps(copy_template)
         else:
             template_body = stack.template_body
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -471,7 +471,11 @@ class CloudformationProvider(CloudformationApi):
 
         # Fix this some day
         if template_stage == TemplateStage.Processed:
-            template_body = json.dumps(stack.template_original)
+            template_body = (
+                json.dumps(stack.template)
+                if "Transform" in stack.template_body
+                else stack.template_body
+            )
         else:
             template_body = stack.template_body
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -469,8 +469,14 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return stack_not_found_error(stack_name)
 
+        # Fix this some day
+        if template_stage == TemplateStage.Processed:
+            template_body = json.dumps(stack.template_original)
+        else:
+            template_body = stack.template_body
+
         return GetTemplateOutput(
-            TemplateBody=stack.template_body,
+            TemplateBody=template_body,
             StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
         )
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -89,10 +89,10 @@ from localstack.services.cloudformation.engine.entities import (
 )
 from localstack.services.cloudformation.engine.parameters import strip_parameter_type
 from localstack.services.cloudformation.engine.template_deployer import NoStackUpdates
-from localstack.services.cloudformation.engine.template_preparer import (
+from localstack.services.cloudformation.engine.template_utils import resolve_stack_conditions
+from localstack.services.cloudformation.engine.transformers import (
     FailedTransformationException,
 )
-from localstack.services.cloudformation.engine.template_utils import resolve_stack_conditions
 from localstack.services.cloudformation.stores import (
     cloudformation_stores,
     find_change_set,
@@ -238,7 +238,6 @@ class CloudformationProvider(CloudformationApi):
                 context.account_id,
                 context.region,
                 template,
-                list(resolved_parameters.values()),
                 stack.stack_name,
                 stack.resources,
                 stack.mappings,
@@ -351,7 +350,6 @@ class CloudformationProvider(CloudformationApi):
                 context.account_id,
                 context.region,
                 template,
-                list(resolved_parameters.values()),
                 stack.stack_name,
                 stack.resources,
                 stack.mappings,
@@ -644,8 +642,6 @@ class CloudformationProvider(CloudformationApi):
             old_parameters=old_parameters,
         )
 
-        parameters = list(resolved_parameters.values())
-
         # TODO: remove this when fixing Stack.resources and transformation order
         #   currently we need to create a stack with existing resources + parameters so that resolve refs recursively in here will work.
         #   The correct way to do it would be at a later stage anyway just like a normal intrinsic function
@@ -659,7 +655,6 @@ class CloudformationProvider(CloudformationApi):
             context.account_id,
             context.region,
             template,
-            parameters,
             stack_name=temp_stack.stack_name,
             resources=temp_stack.resources,
             mappings=temp_stack.mappings,

--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -207,3 +207,28 @@ def singleton_factory(factory: Callable[[], _T]) -> Callable[[], _T]:
     _singleton_factory.clear = instance.clear
 
     return _singleton_factory
+
+
+def get_value_from_path(data, path):
+    keys = path.split(".")
+    try:
+        result = functools.reduce(dict.__getitem__, keys, data)
+        return result
+    except KeyError:
+        # Handle the case where the path is not valid for the given dictionary
+        return None
+
+
+def set_value_at_path(data, path, new_value):
+    keys = path.split(".")
+    last_key = keys[-1]
+
+    # Traverse the dictionary to the second-to-last level
+    nested_dict = functools.reduce(dict.__getitem__, keys[:-1], data)
+
+    try:
+        # Set the new value
+        nested_dict[last_key] = new_value
+    except KeyError:
+        # Handle the case where the path is not valid for the given dictionary
+        raise ValueError(f"Invalid path: {path}")

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -609,13 +609,6 @@ class TestMacros:
         "template_to_transform",
         ["transformation_snippet_topic.yml", "transformation_snippet_topic.json"],
     )
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..TemplateBody.ChangeSetName",
-            "$..TemplateBody.Resources.Topic.LogicalResourceId",
-            "$..TemplateBody.StackName",
-        ]
-    )
     def test_snipped_scope(
         self,
         deploy_cfn_template,

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -668,12 +668,6 @@ class TestMacros:
         )
         snapshot.add_transformer(snapshot.transform.regex(topic_name, "topic-name"))
 
-        # TODO: fix this. For some reason LS always returns a str instead of a dict
-        # if template_to_transform.endswith(".json") and isinstance(original_template["TemplateBody"], str):
-        #     original_template["TemplateBody"] = json.loads(original_template["TemplateBody"])
-        # if not is_aws_cloud():
-        #     processed_template["TemplateBody"] = json.loads(processed_template["TemplateBody"])
-
         snapshot.match("original_template", original_template)
         snapshot.match("processed_template", processed_template)
 
@@ -713,6 +707,7 @@ class TestMacros:
         assert "test-" in resulting_value
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="Fn::Transform does not support array of transformations")
     def test_scope_order_and_parameters(
         self, deploy_cfn_template, create_lambda_function, snapshot, aws_client
     ):

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -676,7 +676,6 @@ class TestMacros:
             handler_file=macro_function_path,
             runtime=Runtime.python3_10,
             client=aws_client.lambda_,
-            timeout=1,
         )
 
         macro_name = "GenerateRandom"

--- a/tests/aws/templates/macros/return_random_string.py
+++ b/tests/aws/templates/macros/return_random_string.py
@@ -1,0 +1,14 @@
+import random
+import string
+
+
+def handler(event, context):
+    parameters = event["templateParameterValues"]
+    fragment = f"{parameters['Input']}-{random_string(5)}"
+    resp = {"requestId": event["requestId"], "status": "success", "fragment": fragment}
+
+    return resp
+
+
+def random_string(length):
+    return "".join(random.choice(string.ascii_lowercase) for i in range(length))

--- a/tests/aws/templates/transformation_resource_att.yml
+++ b/tests/aws/templates/transformation_resource_att.yml
@@ -1,0 +1,20 @@
+Parameters:
+  Input:
+    Type: String
+
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value:
+        Fn::Transform:
+          Name: GenerateRandom
+          Parameters:
+            Prefix: !Ref Input
+Outputs:
+  Parameter:
+    Value:
+      Fn::GetAtt:
+        - Parameter
+        - Value


### PR DESCRIPTION
## Motivation
This feature was proposed in issue #9535 but @whummer has already implemented support for the Fn::Transform intrinsic function in LocalStack. This pull request builds upon that implementation by enhancing the functionality. Specifically, it enables the Fn::Transform intrinsic function to incorporate user-defined CloudFormation macros.


## Changes
- Enable Fn::Intrinsic function to use user's macros.
- Refactoring to standarize the usage of snipped and global transformations


## Testing
- Added a test where the macro returns a string and CFn applies to a resource value.
- Un-skipped some tests regarding snipped transformations.


## TODO
Figure out a way to handle both a Fn::Instrinsic which contains a list of transformations and a Fn::Intrinsic that returns a single att.