### PR TITLE
Fix missing "Pulling container image" message from CLI startup

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -1165,10 +1165,10 @@ def start_infra_in_docker(console, cli_params: Dict[str, Any] = None):
     # create and prepare container
     container_config = ContainerConfiguration(get_docker_image_to_start())
     container = Container(container_config)
+    ensure_container_image(console, container)
 
     configure_container(container)
     container.configure(ContainerConfigurators.cli_params(cli_params or {}))
-    ensure_container_image(console, container)
 
     status = console.status("Starting LocalStack container")
     status.start()
@@ -1249,9 +1249,9 @@ def start_infra_in_docker_detached(console, cli_params: Dict[str, Any] = None):
     console.log("configuring container")
     container_config = ContainerConfiguration(get_docker_image_to_start())
     container = Container(container_config)
+    ensure_container_image(console, container)
     configure_container(container)
     container.configure(ContainerConfigurators.cli_params(cli_params or {}))
-    ensure_container_image(console, container)
 
     container_config.detach = True
 

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -18,7 +18,6 @@ from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 
-
 # port range instance used to reserve Docker container ports
 PORT_START = 0
 PORT_END = 65536
@@ -251,8 +250,12 @@ def _get_ports_check_docker_image() -> str:
         # explicit configuration takes precedence
         return config.PORTS_CHECK_DOCKER_IMAGE
     if not config.is_in_docker:
-        # use default image for host mode
-        return DOCKER_IMAGE_NAME
+        # local import to prevent circular imports
+        from localstack.utils.bootstrap import get_docker_image_to_start
+
+        # Use whatever image the user is trying to run LocalStack with, since they either have
+        # it already, or need it by definition to start LocalStack.
+        return get_docker_image_to_start()
     try:
         # inspect the running container to determine the image
         container = DOCKER_CLIENT.inspect_container(get_current_container_id())

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -16,6 +16,7 @@ from localstack.constants import LOCALHOST_HOSTNAME, LOCALHOST_IP, MODULE_MAIN_P
 from localstack.utils import bootstrap
 from localstack.utils.bootstrap import in_ci
 from localstack.utils.common import poll_condition
+from localstack.utils.container_utils.container_client import ContainerClient, NoSuchImage
 from localstack.utils.files import mkdir
 from localstack.utils.net import get_free_udp_port, send_dns_query
 from localstack.utils.run import run, to_str
@@ -53,6 +54,22 @@ def container_client():
     )
 
 
+@pytest.fixture
+def backup_and_remove_image(container_client: ContainerClient):
+    """
+    To test whether the image is pulled correctly, we must remove the image.
+    However we do not want to do this and remove the current image, so "back it
+    up" - i.e. tag it with another tag, and restore it afterwards.
+    """
+
+    source_image_name = "localstack/localstack:latest"
+    tagged_image_name = "localstack/localstack:backup"
+    container_client.tag_image(source_image_name, tagged_image_name)
+    container_client.remove_image(source_image_name, force=True)
+    yield
+    container_client.tag_image(tagged_image_name, source_image_name)
+
+
 @pytest.mark.skipif(condition=in_docker(), reason="cannot run CLI tests in docker")
 class TestCliContainerLifecycle:
     def test_start_wait_stop(self, runner, container_client):
@@ -77,6 +94,16 @@ class TestCliContainerLifecycle:
 
         with pytest.raises(requests.ConnectionError):
             requests.get(config.external_service_url() + "/_localstack/health")
+
+    @pytest.mark.usefixtures("backup_and_remove_image")
+    def test_pulling_image_message(self, runner, container_client: ContainerClient):
+        with pytest.raises(NoSuchImage):
+            container_client.inspect_image("localstack/localstack:latest", pull=False)
+
+        result = runner.invoke(cli, ["start", "-d"])
+
+        assert result.exit_code == 0, result.output
+        assert "Pulling container image" in result.output, result.output
 
     def test_start_already_running(self, runner, container_client):
         runner.invoke(cli, ["start", "-d"])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -103,7 +103,12 @@ class TestCliContainerLifecycle:
         result = runner.invoke(cli, ["start", "-d"])
 
         assert result.exit_code == 0, result.output
-        assert "Pulling container image" in result.output, result.output
+
+        # we cannot check for "Pulling container image" which would be more accurate
+        # since it is printed in a temporary status line and may not be present in
+        # the output if the docker pull is fast enough, but we can check for the
+        # presence of another message which is present when pulling the image.
+        assert "download complete" in result.output
 
     def test_start_already_running(self, runner, container_client):
         runner.invoke(cli, ["start", "-d"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When starting LocalStack in Docker mode with the CLI, if the Docker image is not present we used to print "Pulling container image" to indicate that the Docker image was being pulled.

Since #9049, we instead start the DNS server first. To do this, we check if we can publish port 53 to the host, implemented via `container_ports_can_be_bound`. This in turn tries to run a docker image with the publish flag `-p 53`:

https://github.com/localstack/localstack/blob/c3348f842a875a9f7ba025ecaebb5f4bbdaac896/localstack/utils/docker_utils.py#L150-L156

We use the LocalStack docker image to check for port publishing, so we end up pulling the Docker image (silently) first before calling `ensure_container_image` which prints the "Pulling container image" message.

Possibly related: https://github.com/localstack/localstack/issues/9727


<!-- What notable changes does this PR make? -->
## Changes

* Ensure we have the container image present before testing for port bindability
* Add a CLI test to capture the behaviour

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

