### PR TITLE
events: add account_id while creating client in sending events to target

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -151,10 +151,14 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -151,14 +151,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
@@ -333,7 +333,7 @@ class StreamEventSourceListener(EventSourceListener):
             "streamArn": source_arn,
         }
         payload[self._FAILURE_PAYLOAD_DETAILS_FIELD_NAME] = details
-        send_event_to_target(destination, payload)
+        send_event_to_target(target_arn=destination, event=payload, source_arn=source_arn)
 
     def _monitor_stream_event_sources(self, *args):
         """

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -47,7 +47,7 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        clients = connect_to(region_name=region)
+        clients = connect_to(aws_access_key_id=event.get("account"), region_name=region)
 
     if ":lambda:" in target_arn:
         lambda_client = clients.lambda_.request_metadata(

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -39,6 +39,7 @@ def send_event_to_target(
     source_service: str = None,
 ):
     region = extract_region_from_arn(target_arn)
+    account_id = extract_account_id_from_arn(target_arn)
 
     if target is None:
         target = {}
@@ -47,7 +48,7 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        clients = connect_to(aws_access_key_id=event.get("account"), region_name=region)
+        clients = connect_to(aws_access_key_id=account_id, region_name=region)
 
     if ":lambda:" in target_arn:
         lambda_client = clients.lambda_.request_metadata(

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -38,7 +38,7 @@ def send_event_to_target(
     source_arn: str = None,
     source_service: str = None,
 ):
-    region = extract_region_from_arn(source_arn)
+    region = extract_region_from_arn(target_arn)
     account_id = extract_account_id_from_arn(source_arn)
 
     if target is None:

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -48,14 +48,16 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        client1 = connect_to(aws_access_key_id=account_id, region_name=region)
-        client2 = connect_to(region_name=region)
         try:
             from localstack_ext.config import ENFORCE_IAM
 
-            clients = client2 if ENFORCE_IAM else client1
+            clients = (
+                connect_to(region_name=region)
+                if ENFORCE_IAM
+                else connect_to(aws_access_key_id=account_id, region_name=region)
+            )
         except ImportError:
-            clients = client1
+            clients = connect_to(aws_access_key_id=account_id, region_name=region)
 
     if ":lambda:" in target_arn:
         lambda_client = clients.lambda_.request_metadata(

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -5,10 +5,10 @@ import re
 import uuid
 from typing import Dict, Optional
 
-from localstack_ext.config import ENFORCE_IAM
 from moto.events.models import events_backends
 
 from localstack.aws.connect import connect_to
+from localstack.config import is_env_true
 from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.utils import collections
 from localstack.utils.aws.arns import (
@@ -49,7 +49,7 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        if ENFORCE_IAM:
+        if is_env_true("ENFORCE_IAM"):
             clients = connect_to(region_name=region)
         else:
             clients = connect_to(aws_access_key_id=account_id, region_name=region)

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -38,8 +38,8 @@ def send_event_to_target(
     source_arn: str = None,
     source_service: str = None,
 ):
-    region = extract_region_from_arn(target_arn)
-    account_id = extract_account_id_from_arn(target_arn)
+    region = extract_region_from_arn(source_arn)
+    account_id = extract_account_id_from_arn(source_arn)
 
     if target is None:
         target = {}
@@ -48,16 +48,7 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        try:
-            from localstack_ext.config import ENFORCE_IAM
-
-            clients = (
-                connect_to(region_name=region)
-                if ENFORCE_IAM
-                else connect_to(aws_access_key_id=account_id, region_name=region)
-            )
-        except ImportError:
-            clients = connect_to(aws_access_key_id=account_id, region_name=region)
+        clients = connect_to(aws_access_key_id=account_id, region_name=region)
 
     if ":lambda:" in target_arn:
         lambda_client = clients.lambda_.request_metadata(

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -5,6 +5,7 @@ import re
 import uuid
 from typing import Dict, Optional
 
+from localstack_ext.config import ENFORCE_IAM
 from moto.events.models import events_backends
 
 from localstack.aws.connect import connect_to
@@ -48,7 +49,10 @@ def send_event_to_target(
             role_arn=role, service_principal=source_service, region_name=region
         )
     else:
-        clients = connect_to(aws_access_key_id=account_id, region_name=region)
+        if ENFORCE_IAM:
+            clients = connect_to(region_name=region)
+        else:
+            clients = connect_to(aws_access_key_id=account_id, region_name=region)
 
     if ":lambda:" in target_arn:
         lambda_client = clients.lambda_.request_metadata(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account id or `us-east-1` for region, `events` tests should still create the consequent resources in the corresponding accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR introduces the use of `account_id` field fetched from `target_arn` in order to connect with the correct client in `connect_to()` method while sending events to the target.

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). The affected tests are:

```
tests.aws.services.events.test_events.TestEvents.test_put_events_into_event_bus[standard]
tests.aws.services.events.test_events.TestEvents.test_put_events_into_event_bus[domain]
tests.aws.services.events.test_events.TestEvents.test_put_events_into_event_bus[path]
tests.aws.services.events.test_events.TestEvents.test_put_events_with_target_firehose
tests.aws.services.events.test_events.TestEvents.test_put_events_with_target_kinesis
tests.aws.services.cloudformation.resources.test_events.test_event_rule_to_logs
```

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

