### PR TITLE
fixed account id for firehose integration

### DIFF
--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -313,6 +313,7 @@ class FirehoseProvider(FirehoseApi):
                     )
                     process = kinesis_connector.listen_to_kinesis(
                         stream_name=kinesis_stream_name,
+                        account_id=context.account_id,
                         region_name=context.region,
                         listener_func=listener_function,
                         wait_until_started=True,

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -233,7 +233,8 @@ class KinesisProcessorThread(ShellCommandThread):
 
 def _start_kcl_client_process(
     stream_name: str,
-    region_name,
+    account_id: str,
+    region_name: str,
     listener_function: ListenerFunction,
     ddb_lease_table_suffix=None,
 ):
@@ -241,7 +242,10 @@ def _start_kcl_client_process(
     stream_name = arns.kinesis_stream_name(stream_name)
     # disable CBOR protocol, enforce use of plain JSON
     # TODO evaluate why?
-    env_vars = {"AWS_CBOR_DISABLE": "true"}
+    env_vars = {
+        "AWS_CBOR_DISABLE": "true",
+        "AWS_ACCESS_KEY_ID": account_id,
+    }
 
     events_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.fifo")
     TMP_FILES.append(events_file)
@@ -334,6 +338,7 @@ if __name__ == '__main__':
 
 def listen_to_kinesis(
     stream_name: str,
+    account_id: str,
     region_name: str,
     listener_func: ListenerFunction,
     ddb_lease_table_suffix: str | None = None,
@@ -345,8 +350,9 @@ def listen_to_kinesis(
     automatically started in the background.
     """
     process = _start_kcl_client_process(
-        stream_name,
-        region_name,
+        stream_name=stream_name,
+        account_id=account_id,
+        region_name=region_name,
         listener_function=listener_func,
         ddb_lease_table_suffix=ddb_lease_table_suffix,
     )

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -6,6 +6,7 @@ import requests
 from pytest_httpserver import HTTPServer
 
 from localstack import config
+from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid, to_bytes, to_str
@@ -135,7 +136,7 @@ class TestFirehoseIntegration:
     ):
         domain_name = f"test-domain-{short_uid()}"
         stream_name = f"test-stream-{short_uid()}"
-        role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"
+        role_arn = f"arn:aws:iam::{TEST_AWS_ACCOUNT_ID}:role/Firehose-Role"
         delivery_stream_name = f"test-delivery-stream-{short_uid()}"
         es_create_response = aws_client.es.create_elasticsearch_domain(DomainName=domain_name)
         cleanups.append(lambda: aws_client.es.delete_elasticsearch_domain(DomainName=domain_name))
@@ -244,7 +245,7 @@ class TestFirehoseIntegration:
     ):
         domain_name = f"test-domain-{short_uid()}"
         stream_name = f"test-stream-{short_uid()}"
-        role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"
+        role_arn = f"arn:aws:iam::{TEST_AWS_ACCOUNT_ID}:role/Firehose-Role"
         delivery_stream_name = f"test-delivery-stream-{short_uid()}"
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", opensearch_endpoint_strategy)
         try:
@@ -352,7 +353,7 @@ class TestFirehoseIntegration:
         bucket_arn = arns.s3_bucket_arn(s3_bucket)
         stream_name = f"test-stream-{short_uid()}"
         log_group_name = f"group{short_uid()}"
-        role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"
+        role_arn = f"arn:aws:iam::{TEST_AWS_ACCOUNT_ID}:role/Firehose-Role"
         delivery_stream_name = f"test-delivery-stream-{short_uid()}"
 
         kinesis_create_stream(StreamName=stream_name, ShardCount=2)

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -443,6 +443,7 @@ class TestKinesisPythonClient:
         resources.create_kinesis_stream(kinesis, stream_name, delete=True)
         process = kinesis_connector.listen_to_kinesis(
             stream_name=stream_name,
+            account_id=TEST_AWS_ACCESS_KEY_ID,
             region_name=TEST_AWS_REGION_NAME,
             listener_func=process_records,
             wait_until_started=True,

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -231,6 +231,7 @@ class TestIntegration:
         # start the KCL client process in the background
         process = kinesis_connector.listen_to_kinesis(
             stream_name,
+            account_id=TEST_AWS_ACCOUNT_ID,
             region_name=TEST_AWS_REGION_NAME,
             listener_func=process_records,
             wait_until_started=True,

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -101,9 +101,6 @@ class TestIntegration:
         tags = aws_client.firehose.list_tags_for_delivery_stream(DeliveryStreamName=stream_name)
         assert TEST_TAGS == tags["Tags"]
 
-        # create target S3 bucket
-        s3_create_bucket(Bucket=bucket_name)
-
         # put records
         aws_client.firehose.put_record(
             DeliveryStreamName=stream_name, Record={"Data": to_bytes(test_data)}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds support for multi account to tests
- `test_kinesis_firehose_elasticsearch_s3_backup`
- `test_delivery_stream_with_kinesis_as_source`
- `test_lambda_streams_batch_and_transactions`
- `test_run_kcl`
- `test_firehose_s3`
- `test_firehose_kinesis_to_s3`
- `test_lambda_streams_batch_and_transactions`
- `test_scheduled_lambda`

<!-- What notable changes does this PR make? -->
## Changes
- Passed correct account id value through env for kcl process.
- Added correct account id in IAM role

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (TEST_AWS_ACCOUNT_ID=111111111111, TEST_AWS_ACCESS_KEY_ID=111111111111, TEST_AWS_REGION=us-west-1). The affected tests are:

- `tests.aws.services.firehose.test_firehose.TestFirehoseIntegration.test_kinesis_firehose_elasticsearch_s3_backup`
- `tests.aws.services.firehose.test_firehose.TestFirehoseIntegration.test_delivery_stream_with_kinesis_as_source`
- `tests.aws.test_integration.TestIntegration.test_lambda_streams_batch_and_transactions`
- `tests.aws.services.kinesis.test_kinesis.TestKinesisPythonClient.test_run_kcl`
- `tests.aws.test_integration.TestIntegration.test_firehose_s3`
- `tests.aws.test_integration.TestIntegration.test_firehose_kinesis_to_s3`
- `tests.aws.test_integration.TestIntegration.test_lambda_streams_batch_and_transactions`
- `tests.aws.test_integration.TestIntegration.test_scheduled_lambda`
