### PR TITLE
Add list to dictionary transformation function in provider_utils For CFn

### DIFF
--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -41,6 +41,15 @@ def keys_lower(model: dict) -> dict:
     return {k.lower(): v for k, v in model.items()}
 
 
+def transform_list_to_dict(param, key_attr_name="Key", value_attr_name="Value"):
+    result = {}
+    for entry in param:
+        key = entry[key_attr_name]
+        value = entry[value_attr_name]
+        result[key] = value
+    return result
+
+
 def remove_none_values(obj):
     """Remove None values (recursively) in the given object."""
     if isinstance(obj, dict):


### PR DESCRIPTION
## Motivation
Often CFn will provide tags in a form of list of dictionaries instead of a single dictionary.
GenericModel solved by returning a function for transformation, instead of actually calling it.

Do to changes in resource providers, we are calling function directly and as such this method is required to reduce amount of duplicate code

## Changes
Implemented transform_list_to_dict method

