### PR TITLE
fix: fix failing dashboard lifecycle test for multi-account and region

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -951,7 +951,7 @@ class TestCloudwatch:
                     "height": 6,
                     "properties": {
                         "metrics": [["AWS/EC2", "CPUUtilization", "InstanceId", "i-12345678"]],
-                        "region": "us-east-1",
+                        "region": TEST_AWS_REGION_NAME,
                         "view": "timeSeries",
                         "stacked": False,
                     },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `cloudwatch` tests should still create the consequent resources in corresponding accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR fixes all the failing tests `tests.aws.services.cloudwatch.test_cloudwatch.TestCloudwatch.test_dashboard_lifecycle` by replacing the static value of region `us-east-1` with `TEST_AWS_REGION_NAME`. 

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). 

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

