### PR TITLE
fix: handle BucketAlreadyOwnedByYou exception when uploading lambda in scenario test cases 

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,14 +150,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,10 +150,14 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/testing/scenario/cdk_lambda_helper.py
+++ b/localstack/testing/scenario/cdk_lambda_helper.py
@@ -146,6 +146,8 @@ def _upload_to_s3(s3_client: "S3Client", bucket_name: str, key_name: str, file: 
     try:
         create_s3_bucket(bucket_name, s3_client)
     except ClientError as exc:
+        # when creating an already existing bucket, regions differ in their behavior:
+        # us-east-1 will silently pass (idempotent)
+        # any other region will return a `BucketAlreadyOwnedByYou` exception.
         if exc.response["Error"]["Code"] != "BucketAlreadyOwnedByYou":
             raise exc
-    s3_client.upload_file(Filename=file, Bucket=bucket_name, Key=key_name)

--- a/localstack/testing/scenario/cdk_lambda_helper.py
+++ b/localstack/testing/scenario/cdk_lambda_helper.py
@@ -151,3 +151,4 @@ def _upload_to_s3(s3_client: "S3Client", bucket_name: str, key_name: str, file: 
         # any other region will return a `BucketAlreadyOwnedByYou` exception.
         if exc.response["Error"]["Code"] != "BucketAlreadyOwnedByYou":
             raise exc
+    s3_client.upload_file(Filename=file, Bucket=bucket_name, Key=key_name)

--- a/localstack/testing/scenario/cdk_lambda_helper.py
+++ b/localstack/testing/scenario/cdk_lambda_helper.py
@@ -5,7 +5,9 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from localstack.constants import AWS_REGION_US_EAST_1
+from botocore.exceptions import ClientError
+
+from localstack.utils.aws.resources import create_s3_bucket
 from localstack.utils.run import LOG, run
 
 if TYPE_CHECKING:
@@ -141,9 +143,9 @@ def _zip_lambda_resources(
 
 
 def _upload_to_s3(s3_client: "S3Client", bucket_name: str, key_name: str, file: str):
-    options = {"Bucket": bucket_name}
-    region_name = s3_client.meta.region_name
-    if region_name != AWS_REGION_US_EAST_1:
-        options["CreateBucketConfiguration"] = {"LocationConstraint": region_name}
-    s3_client.create_bucket(**options)
+    try:
+        create_s3_bucket(bucket_name, s3_client)
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "BucketAlreadyOwnedByYou":
+            raise exc
     s3_client.upload_file(Filename=file, Bucket=bucket_name, Key=key_name)

--- a/tests/aws/scenario/note_taking/functions/createNote.js
+++ b/tests/aws/scenario/note_taking/functions/createNote.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: process.env.AWS_REGION,
+        region: process.env.AWS_REGION || "us-east-1",
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/createNote.js
+++ b/tests/aws/scenario/note_taking/functions/createNote.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: 'us-east-1', // Change the region as per your setup
+        region: process.env.AWS_REGION,
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/deleteNote.js
+++ b/tests/aws/scenario/note_taking/functions/deleteNote.js
@@ -18,7 +18,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: 'us-east-1', // Change the region as per your setup
+        region: process.env.AWS_REGION,
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/deleteNote.js
+++ b/tests/aws/scenario/note_taking/functions/deleteNote.js
@@ -18,7 +18,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: process.env.AWS_REGION,
+        region: process.env.AWS_REGION || "us-east-1",
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/getNote.js
+++ b/tests/aws/scenario/note_taking/functions/getNote.js
@@ -18,7 +18,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: 'us-east-1', // Change the region as per your setup
+        region: process.env.AWS_REGION,
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/getNote.js
+++ b/tests/aws/scenario/note_taking/functions/getNote.js
@@ -18,7 +18,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: process.env.AWS_REGION,
+        region: process.env.AWS_REGION || "us-east-1",
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/listNotes.js
+++ b/tests/aws/scenario/note_taking/functions/listNotes.js
@@ -13,7 +13,7 @@ exports.handler = async () => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: process.env.AWS_REGION,
+        region: process.env.AWS_REGION || "us-east-1",
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/listNotes.js
+++ b/tests/aws/scenario/note_taking/functions/listNotes.js
@@ -13,7 +13,7 @@ exports.handler = async () => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: 'us-east-1', // Change the region as per your setup
+        region: process.env.AWS_REGION,
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/updateNote.js
+++ b/tests/aws/scenario/note_taking/functions/updateNote.js
@@ -27,7 +27,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: 'us-east-1', // Change the region as per your setup
+        region: process.env.AWS_REGION,
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {

--- a/tests/aws/scenario/note_taking/functions/updateNote.js
+++ b/tests/aws/scenario/note_taking/functions/updateNote.js
@@ -27,7 +27,7 @@ exports.handler = async (event) => {
     if (process.env.AWS_ENDPOINT_URL) {
       const localStackConfig = {
         endpoint: process.env.AWS_ENDPOINT_URL,
-        region: process.env.AWS_REGION,
+        region: process.env.AWS_REGION || "us-east-1",
       };
       client = new  DynamoDBClient(localStackConfig);
     } else {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, scenario tests should still create the consequent resources in corresponding accounts and region. When we try to upload lambas using non-default region value in scenario tests it throws `BucketAlreadyOwnedByYou` exception. 

<!-- What notable changes does this PR make? -->
## Changes
This PR: 
- handles this exception and doesn't try to recreate the bucket if the existing bucket has the same owner for non-default region in `_upload_to_s3` helper function. 
- replaces static region value `us-east-1` from environment variables. 

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). This PR fixes: 

`tests.aws.scenario.note_taking.test_note_taking.TestNoteTakingScenario.test_validate_infra_setup`
`tests.aws.scenario.note_taking.test_note_taking.TestNoteTakingScenario.test_notes_rest_api`

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

