### PR TITLE
add cross-account for CopyObject

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1105,15 +1105,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
         # request_payer: RequestPayer = None,  # TODO:
+        dest_bucket = request["Bucket"]
+        dest_key = request["Key"]
+        store, dest_s3_bucket = self._get_cross_account_bucket(context, dest_bucket)
 
         src_bucket, src_key, src_version_id = extract_bucket_key_version_id_from_copy_source(
             request.get("CopySource")
         )
         _, src_s3_bucket = self._get_cross_account_bucket(context, src_bucket)
-
-        dest_bucket = request["Bucket"]
-        dest_key = request["Key"]
-        store, dest_s3_bucket = self._get_cross_account_bucket(context, dest_bucket)
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, dest_s3_bucket)

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1105,19 +1105,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
         # request_payer: RequestPayer = None,  # TODO:
-        dest_bucket = request["Bucket"]
-        dest_key = request["Key"]
-        store = self.get_store(context.account_id, context.region)
-        # TODO: verify cross account CopyObject
-        if not (dest_s3_bucket := store.buckets.get(dest_bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=dest_bucket)
 
         src_bucket, src_key, src_version_id = extract_bucket_key_version_id_from_copy_source(
             request.get("CopySource")
         )
+        _, src_s3_bucket = self._get_cross_account_bucket(context, src_bucket)
 
-        if not (src_s3_bucket := store.buckets.get(src_bucket)):
-            raise NoSuchBucket("The specified bucket does not exist", BucketName=src_bucket)
+        dest_bucket = request["Bucket"]
+        dest_key = request["Key"]
+        store, dest_s3_bucket = self._get_cross_account_bucket(context, dest_bucket)
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, dest_s3_bucket)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported here: https://discuss.localstack.cloud/t/nosuchbucket-error-when-copying-file/640
The user had an issue where the bucket was created by another account, and he would then try to call `CopyObject` on it. 
I don't really have the setup for testing multi-account against AWS, but it feels like as S3 buckets are global, this should be possible and only a matter of IAM permission / ACL. 

https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html

<!-- What notable changes does this PR make? -->
## Changes
- make `CopyObject` use cross-account access while getting the S3 buckets
- add a multi account test for it

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

