### PR TITLE
fix APIGW import integration method for AWS integration type

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1157,9 +1157,18 @@ def import_api_from_openapi_spec(
             integration_type = (
                 i_type.upper() if (i_type := method_integration.get("type")) else None
             )
-            # TODO: validate more cases like this
-            # if the integration is AWS_PROXY with lambda, the only accepted integration method is POST
-            integration_method = method_name if integration_type != "AWS_PROXY" else "POST"
+
+            match integration_type:
+                case "AWS_PROXY":
+                    # if the integration is AWS_PROXY with lambda, the only accepted integration method is POST
+                    integration_method = "POST"
+                case "AWS":
+                    integration_method = (
+                        method_integration.get("httpMethod") or method_name
+                    ).upper()
+                case _:
+                    integration_method = method_name
+
             connection_type = (
                 ConnectionType.INTERNET
                 if integration_type in (IntegrationType.HTTP, IntegrationType.HTTP_PROXY)

--- a/tests/aws/files/openapi-http-method-integration.json
+++ b/tests/aws/files/openapi-http-method-integration.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test-http-method",
+    "description": "Test httpMethod for AWS integration",
+    "version": "2022-04-12T15:36:55Z"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws",
+          "httpMethod": "POST",
+          "uri": "${lambda_invocation_arn}",
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "requestParameters": {
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          },
+          "requestTemplates": {
+            "application/json": "#set($allParams = $input.params())\n{\n  \"params\" : {\n    #foreach($type in $allParams.keySet())\n      #set($params = $allParams.get($type))\n      \"$type\" : {\n        #foreach($paramName in $params.keySet())\n          \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\n          #if($foreach.hasNext),#end\n        #end\n      }\n      #if($foreach.hasNext),#end\n    #end\n  }\n}\n"
+          },
+          "passthroughBehavior": "when_no_templates",
+          "contentHandling": "CONVERT_TO_TEXT"
+        }
+      },
+      "options": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            },
+            "description": "200 response",
+            "headers": {
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "responses": {
+            "default": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'"
+              },
+              "statusCode": "200"
+            }
+          },
+          "type": "mock"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Empty": {
+        "title": "Empty Schema",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4586,5 +4586,193 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_http_method_integration": {
+    "recorded-date": "05-12-2023, 22:27:16",
+    "recorded-content": {
+      "resources": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/",
+            "resourceMethods": {
+              "GET": {},
+              "OPTIONS": {}
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-root-get": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:1>",
+          "contentHandling": "CONVERT_TO_TEXT",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_TEMPLATES",
+          "requestParameters": {
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          },
+          "requestTemplates": {
+            "application/json": "#set($allParams = $input.params())\n{\n  \"params\" : {\n    #foreach($type in $allParams.keySet())\n      #set($params = $allParams.get($type))\n      \"$type\" : {\n        #foreach($paramName in $params.keySet())\n          \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\n          #if($foreach.hasNext),#end\n        #end\n      }\n      #if($foreach.hasNext),#end\n    #end\n  }\n}\n"
+          },
+          "timeoutInMillis": 29000,
+          "type": "AWS",
+          "uri": "<uri:1>"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-root-get": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-root-get": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<id:1>",
+        "contentHandling": "CONVERT_TO_TEXT",
+        "httpMethod": "POST",
+        "integrationResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_TEMPLATES",
+        "requestParameters": {
+          "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+        },
+        "requestTemplates": {
+          "application/json": "#set($allParams = $input.params())\n{\n  \"params\" : {\n    #foreach($type in $allParams.keySet())\n      #set($params = $allParams.get($type))\n      \"$type\" : {\n        #foreach($paramName in $params.keySet())\n          \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\n          #if($foreach.hasNext),#end\n        #end\n      }\n      #if($foreach.hasNext),#end\n    #end\n  }\n}\n"
+        },
+        "timeoutInMillis": 29000,
+        "type": "AWS",
+        "uri": "<uri:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-root-get": {
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-root-options": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "OPTIONS",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "<id:1>",
+          "integrationResponses": {
+            "200": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type'"
+              },
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "requestTemplates": {
+            "application/json": {
+              "statusCode": 200
+            }
+          },
+          "timeoutInMillis": 29000,
+          "type": "MOCK"
+        },
+        "methodResponses": {
+          "200": {
+            "responseModels": {
+              "application/json": "Empty"
+            },
+            "responseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": false
+            },
+            "statusCode": "200"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "method-response-root-options": {
+        "responseModels": {
+          "application/json": "Empty"
+        },
+        "responseParameters": {
+          "method.response.header.Access-Control-Allow-Headers": false
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-root-options": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<id:1>",
+        "integrationResponses": {
+          "200": {
+            "responseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": "'Content-Type'"
+            },
+            "statusCode": "200"
+          }
+        },
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "requestTemplates": {
+          "application/json": {
+            "statusCode": 200
+          }
+        },
+        "timeoutInMillis": 29000,
+        "type": "MOCK",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "integration-response-root-options": {
+        "responseParameters": {
+          "method.response.header.Access-Control-Allow-Headers": "'Content-Type'"
+        },
+        "statusCode": "200",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9804, we would not take into account the `httpMethod` when importing integration of `AWS` type.

<!-- What notable changes does this PR make? -->
## Changes
- create a test to validate the use case
- update the helper to take the `httpMethod` field, and ignore it for different type of integration

Note: test failure is unrelated

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

