### PR TITLE
Fix parsing of StepFunction timestamps 

### DIFF
--- a/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path.py
+++ b/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding_path.py
@@ -36,6 +36,7 @@ class PayloadBindingPath(PayloadBinding):
             value = JSONPathUtils.extract_json(self.path, inp)
         except RuntimeError:
             failure_event = FailureEvent(
+                env=env,
                 error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
@@ -128,6 +128,7 @@ class ExecutionState(CommonStateField, abc.ABC):
             "State Task encountered an unhandled exception that lead to a State.Runtime error."
         )
         return FailureEvent(
+            env=env,
             error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer_csv.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer_csv.py
@@ -43,6 +43,7 @@ class ResourceOutputTransformerCSV(ResourceOutputTransformer):
         if len(set(headers)) < len(headers):
             error_name = StatesErrorName(typ=StatesErrorNameType.StatesItemReaderFailed)
             failure_event = FailureEvent(
+                env=env,
                 error_name=error_name,
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer_json.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer_json.py
@@ -33,6 +33,7 @@ class ResourceOutputTransformerJson(ResourceOutputTransformer):
         if not isinstance(json_list, list):
             error_name = StatesErrorName(typ=StatesErrorNameType.StatesItemReaderFailed)
             failure_event = FailureEvent(
+                env=env,
                 error_name=error_name,
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
@@ -90,6 +90,7 @@ class IterationWorker(abc.ABC):
                     error_name = CustomErrorName(error_name=error_name)
                 raise FailureEventException(
                     failure_event=FailureEvent(
+                        env=env,
                         error_name=error_name,
                         event_type=HistoryEventType.MapIterationFailed,
                         event_details=EventDetails(
@@ -101,6 +102,7 @@ class IterationWorker(abc.ABC):
             elif isinstance(end_program_state, ProgramStopped):
                 raise FailureEventException(
                     failure_event=FailureEvent(
+                        env=env,
                         error_name=CustomErrorName(error_name=HistoryEventType.MapIterationAborted),
                         event_type=HistoryEventType.MapIterationAborted,
                         event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branches_decl.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branches_decl.py
@@ -96,6 +96,7 @@ class BranchesDecl(EvalComponent):
             exit_error_name = exit_event_details.get("error")
             raise FailureEventException(
                 failure_event=FailureEvent(
+                    env=env,
                     error_name=CustomErrorName(error_name=exit_error_name),
                     event_type=HistoryEventType.ExecutionFailed,
                     event_details=EventDetails(executionFailedEventDetails=exit_event_details),

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -51,8 +51,9 @@ class StateTaskService(StateTask, abc.ABC):
     def _get_sfn_resource_type(self) -> str:
         return self.resource.service_name
 
-    def _get_timed_out_failure_event(self) -> FailureEvent:
+    def _get_timed_out_failure_event(self, env: Environment) -> FailureEvent:
         return FailureEvent(
+            env=env,
             error_name=StatesErrorName(typ=StatesErrorNameType.StatesTimeout),
             event_type=HistoryEventType.TaskTimedOut,
             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_api_gateway.py
@@ -254,6 +254,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
             error_name = f"ApiGateway.{ex_name}"
             cause = str(ex)
         return FailureEvent(
+            env=env,
             error_name=CustomErrorName(error_name),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -49,8 +49,9 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
             norm_ex_name += "Exception"
         return norm_ex_name
 
-    def _get_task_failure_event(self, error: str, cause: str) -> FailureEvent:
+    def _get_task_failure_event(self, env: Environment, error: str, cause: str) -> FailureEvent:
         return FailureEvent(
+            env=env,
             error_name=StatesErrorName(typ=StatesErrorNameType.StatesTaskFailed),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(
@@ -80,7 +81,7 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
                 )
 
             cause: str = f"{error_message} ({', '.join(cause_details)})"
-            failure_event = self._get_task_failure_event(error=error, cause=cause)
+            failure_event = self._get_task_failure_event(env=env, error=error, cause=cause)
             return failure_event
         return super()._from_error(env=env, ex=ex)
 

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -116,10 +116,13 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
     def _is_condition(self):
         return self.resource.condition is not None
 
-    def _get_callback_outcome_failure_event(self, ex: CallbackOutcomeFailureError) -> FailureEvent:
+    def _get_callback_outcome_failure_event(
+        self, env: Environment, ex: CallbackOutcomeFailureError
+    ) -> FailureEvent:
         callback_outcome_failure: CallbackOutcomeFailure = ex.callback_outcome_failure
         error: str = callback_outcome_failure.error
         return FailureEvent(
+            env=env,
             error_name=CustomErrorName(error_name=callback_outcome_failure.error),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(
@@ -134,7 +137,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, CallbackOutcomeFailureError):
-            return self._get_callback_outcome_failure_event(ex=ex)
+            return self._get_callback_outcome_failure_event(env=env, ex=ex)
         return super()._from_error(env=env, ex=ex)
 
     def _after_eval_execution(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_dynamodb.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_dynamodb.py
@@ -98,6 +98,7 @@ class StateTaskServiceDynamoDB(StateTaskService):
             error, cause = self._error_cause_from_client_error(ex)
             error_name = CustomErrorName(error)
             return FailureEvent(
+                env=env,
                 error_name=error_name,
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(
@@ -111,6 +112,7 @@ class StateTaskServiceDynamoDB(StateTaskService):
             )
         else:
             return FailureEvent(
+                env=env,
                 error_name=CustomErrorName(self._ERROR_NAME_AWS),
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_events.py
@@ -42,6 +42,7 @@ class StateTaskServiceEvents(StateTaskServiceCallback):
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, SfnFailedEntryCountException):
             return FailureEvent(
+                env=env,
                 error_name=self._FAILED_ENTRY_ERROR_NAME,
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_lambda.py
@@ -66,6 +66,7 @@ class StateTaskServiceLambda(StateTaskServiceCallback):
         else:
             return super()._from_error(env=env, ex=ex)
         return FailureEvent(
+            env=env,
             error_name=error_name,
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sfn.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sfn.py
@@ -62,6 +62,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
                 f"{ex.response['Error']['Message']} ({'; '.join(error_cause_details)})"
             )
             return FailureEvent(
+                env=env,
                 error_name=CustomErrorName(error_name),
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(
@@ -159,6 +160,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
                 else:
                     raise FailureEventException(
                         FailureEvent(
+                            env=env,
                             error_name=StatesErrorName(typ=StatesErrorNameType.StatesTaskFailed),
                             event_type=HistoryEventType.TaskFailed,
                             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sns.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sns.py
@@ -61,6 +61,7 @@ class StateTaskServiceSns(StateTaskServiceCallback):
             )
 
             return FailureEvent(
+                env=env,
                 error_name=CustomErrorName(error_name=error_name),
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_sqs.py
@@ -42,6 +42,7 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, ClientError):
             return FailureEvent(
+                env=env,
                 error_name=CustomErrorName(self._ERROR_NAME_CLIENT),
                 event_type=HistoryEventType.TaskFailed,
                 event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task.py
@@ -67,8 +67,9 @@ class StateTask(ExecutionState, abc.ABC):
 
         return parameters
 
-    def _get_timed_out_failure_event(self) -> FailureEvent:
+    def _get_timed_out_failure_event(self, env: Environment) -> FailureEvent:
         return FailureEvent(
+            env=env,
             error_name=StatesErrorName(typ=StatesErrorNameType.StatesTimeout),
             event_type=HistoryEventType.TaskTimedOut,
             event_details=EventDetails(
@@ -80,7 +81,7 @@ class StateTask(ExecutionState, abc.ABC):
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, TimeoutError):
-            return self._get_timed_out_failure_event()
+            return self._get_timed_out_failure_event(env)
         return super()._from_error(env=env, ex=ex)
 
     def _eval_body(self, env: Environment) -> None:

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task_lambda.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/state_task_lambda.py
@@ -42,6 +42,7 @@ class StateTaskLambda(StateTask):
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, TimeoutError):
             return FailureEvent(
+                env=env,
                 error_name=StatesErrorName(typ=StatesErrorNameType.StatesTimeout),
                 event_type=HistoryEventType.LambdaFunctionTimedOut,
                 event_details=EventDetails(
@@ -63,6 +64,7 @@ class StateTaskLambda(StateTask):
             cause = str(ex)
 
         return FailureEvent(
+            env=env,
             error_name=error_name,
             event_type=HistoryEventType.LambdaFunctionFailed,
             event_details=EventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_fail/state_fail.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_fail/state_fail.py
@@ -46,6 +46,7 @@ class StateFail(CommonStateField):
 
         error_name = CustomErrorName(error_value) if error_value else None
         failure_event = FailureEvent(
+            env=env,
             error_name=error_name,
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(taskFailedEventDetails=task_failed_event_details),

--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp.py
@@ -19,6 +19,8 @@ class Timestamp(WaitFunction):
     # the time value up to seconds and truncates milliseconds.
 
     TIMESTAMP_FORMAT: Final[str] = "%Y-%m-%dT%H:%M:%SZ"
+    # TODO: could be a bit more exact (e.g. 90 shouldn't be a valid minute)
+    TIMESTAMP_PATTERN: Final[str] = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$"
 
     def __init__(self, timestamp):
         self.timestamp: Final[datetime.datetime] = timestamp

--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp.py
@@ -27,9 +27,10 @@ class Timestamp(WaitFunction):
 
     @staticmethod
     def parse_timestamp(timestamp: str) -> datetime.datetime:
+        # TODO: need to fix this like we're doing for TimestampPath & add a test
         return datetime.datetime.strptime(timestamp, Timestamp.TIMESTAMP_FORMAT)
 
     def _get_wait_seconds(self, env: Environment) -> int:
-        delta = self.timestamp - datetime.datetime.today()
+        delta = self.timestamp - datetime.datetime.now()
         delta_sec = int(delta.total_seconds())
         return delta_sec

--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
@@ -1,6 +1,17 @@
 import datetime
 from typing import Final
 
+from localstack.aws.api.stepfunctions import ExecutionFailedEventDetails, HistoryEventType
+from localstack.services.stepfunctions.asl.component.common.error_name.failure_event import (
+    FailureEvent,
+    FailureEventException,
+)
+from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name import (
+    StatesErrorName,
+)
+from localstack.services.stepfunctions.asl.component.common.error_name.states_error_name_type import (
+    StatesErrorNameType,
+)
 from localstack.services.stepfunctions.asl.component.state.state_wait.wait_function.timestamp import (
     Timestamp,
 )
@@ -8,6 +19,7 @@ from localstack.services.stepfunctions.asl.component.state.state_wait.wait_funct
     WaitFunction,
 )
 from localstack.services.stepfunctions.asl.eval.environment import Environment
+from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 
 
@@ -22,7 +34,22 @@ class TimestampPath(WaitFunction):
     def _get_wait_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
         timestamp_str = JSONPathUtils.extract_json(self.path, inp)
-        timestamp = datetime.datetime.strptime(timestamp_str, Timestamp.TIMESTAMP_FORMAT)
+        try:
+            timestamp = datetime.datetime.strptime(timestamp_str, Timestamp.TIMESTAMP_FORMAT)
+        except Exception:
+            raise FailureEventException(
+                FailureEvent(
+                    env=env,
+                    error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
+                    event_type=HistoryEventType.ExecutionFailed,
+                    event_details=EventDetails(
+                        executionFailedEventDetails=ExecutionFailedEventDetails(
+                            error=StatesErrorNameType.StatesRuntime.to_name(),
+                            cause=f"The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: {self.path} == {timestamp_str}",
+                        )
+                    ),
+                )
+            )
         delta = timestamp - datetime.datetime.today()
         delta_sec = int(delta.total_seconds())
         return delta_sec

--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/timestamp_path.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from typing import Final
 
 from localstack.aws.api.stepfunctions import ExecutionFailedEventDetails, HistoryEventType
@@ -31,25 +32,35 @@ class TimestampPath(WaitFunction):
     def __init__(self, path: str):
         self.path: Final[str] = path
 
+    def _create_failure_event(self, env: Environment, timestamp_str: str) -> FailureEvent:
+        return FailureEvent(
+            env=env,
+            error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
+            event_type=HistoryEventType.ExecutionFailed,
+            event_details=EventDetails(
+                executionFailedEventDetails=ExecutionFailedEventDetails(
+                    error=StatesErrorNameType.StatesRuntime.to_name(),
+                    cause=f"The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: {self.path} == {timestamp_str}",
+                )
+            ),
+        )
+
     def _get_wait_seconds(self, env: Environment) -> int:
         inp = env.stack[-1]
-        timestamp_str = JSONPathUtils.extract_json(self.path, inp)
+        timestamp_str: str = JSONPathUtils.extract_json(self.path, inp)
         try:
-            timestamp = datetime.datetime.strptime(timestamp_str, Timestamp.TIMESTAMP_FORMAT)
+            if not re.match(Timestamp.TIMESTAMP_PATTERN, timestamp_str):
+                raise FailureEventException(self._create_failure_event(env, timestamp_str))
+
+            # anything lower than seconds is truncated
+            processed_timestamp = timestamp_str.rsplit(".", 2)[0]
+            # add back the "Z" suffix if we removed it
+            if not processed_timestamp.endswith("Z"):
+                processed_timestamp = f"{processed_timestamp}Z"
+            timestamp = datetime.datetime.strptime(processed_timestamp, Timestamp.TIMESTAMP_FORMAT)
         except Exception:
-            raise FailureEventException(
-                FailureEvent(
-                    env=env,
-                    error_name=StatesErrorName(typ=StatesErrorNameType.StatesRuntime),
-                    event_type=HistoryEventType.ExecutionFailed,
-                    event_details=EventDetails(
-                        executionFailedEventDetails=ExecutionFailedEventDetails(
-                            error=StatesErrorNameType.StatesRuntime.to_name(),
-                            cause=f"The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: {self.path} == {timestamp_str}",
-                        )
-                    ),
-                )
-            )
-        delta = timestamp - datetime.datetime.today()
+            raise FailureEventException(self._create_failure_event(env, timestamp_str))
+
+        delta = timestamp - datetime.datetime.now()
         delta_sec = int(delta.total_seconds())
         return delta_sec

--- a/tests/aws/services/stepfunctions/templates/base/base_templates.py
+++ b/tests/aws/services/stepfunctions/templates/base/base_templates.py
@@ -40,3 +40,6 @@ class BaseTemplate(TemplateLoader):
     PASS_START_TIME: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/pass_start_time_format.json5"
     )
+    WAIT_TIMESTAMPPATH: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/wait_timestamppath.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/base/statemachines/wait_timestamppath.json5
+++ b/tests/aws/services/stepfunctions/templates/base/statemachines/wait_timestamppath.json5
@@ -1,0 +1,11 @@
+{
+  "Comment": "WAIT_1_MIN",
+  "StartAt": "State_1",
+  "States": {
+    "State_1": {
+      "Type": "Wait",
+      "TimestampPath": "$.start_at",
+      "End": true
+    },
+  },
+}

--- a/tests/aws/services/stepfunctions/utils.py
+++ b/tests/aws/services/stepfunctions/utils.py
@@ -274,6 +274,7 @@ def launch_and_record_execution(
     sfn_snapshot.match("get_execution_history", get_execution_history)
 
 
+# TODO: make this return the execution ARN for manual assertions
 def create_and_record_execution(
     stepfunctions_client,
     create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.py
@@ -23,9 +23,8 @@ class TestSfnWait:
         "timestamp_suffix",
         [
             # valid formats
+            # TODO: re-enable
             # "Z",
-            # ".000000Z",
-            # ".00",
             # ".000000Z",
             # ".000Z",
             # invalid formats

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.py
@@ -23,8 +23,9 @@ class TestSfnWait:
         "timestamp_suffix",
         [
             # valid formats
-            # TODO: re-enable
             # "Z",
+            # ".000000Z",
+            # ".00",
             # ".000000Z",
             # ".000Z",
             # invalid formats

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
 from tests.aws.services.stepfunctions.utils import (
@@ -11,21 +12,29 @@ from tests.aws.services.stepfunctions.utils import (
 
 
 # TODO: add tests for seconds, secondspath, timestamp
+# TODO: add tests that actually validate waiting time (e.g. x minutes) BUT mark them accordingly and skip them by default!
 @markers.snapshot.skip_snapshot_verify(paths=["$..loggingConfiguration", "$..tracingConfiguration"])
 class TestSfnWait:
-    @markers.aws.unknown
-    def test_timestamp_in_past_succeeds_immediately(
-            self,
-            aws_client,
-            create_iam_role_for_sfn,
-            create_state_machine,
-            sfn_snapshot,
+    @pytest.mark.skipif(condition=not is_aws_cloud(), reason="not implemented")
+    @markers.aws.validated
+    @pytest.mark.parametrize("days", [24855, 24856])
+    def test_timestamp_too_far_in_future_boundary(
+        self, aws_client, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, days
     ):
+        """
+        seems this seems to correlate with "2147483648" as the maximum integer value for the seconds stepfunctions internally uses to represent dates
+        => 24855 days succeeds
+        => 24856 days fails
+
+        This isn't as important though since a statemachine can't run for more than a year anyway.
+        Docs for Standard workflows: "If an execution runs for more than the 1-year maximum, it will fail with a States.Timeout error and emit a ExecutionsTimedOut CloudWatch metric."
+        """
         template = BaseTemplate.load_sfn_template(BaseTemplate.WAIT_TIMESTAMPPATH)
         definition = json.dumps(template)
 
-        offset_2days = datetime.timedelta(days=2)
-        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) - offset_2days
+        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+            days=days
+        )
         timestamp = wait_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
 
         full_timestamp = f"{timestamp}.000Z"
@@ -39,50 +48,17 @@ class TestSfnWait:
             definition,
             exec_input,
         )
-
-
-    # TODO: test maximum wait time (1 year and 5 minutes)
-    @markers.aws.unknown
-    def test_timestamp_too_far_in_future_fails(
-            self,
-            aws_client,
-            create_iam_role_for_sfn,
-            create_state_machine,
-            sfn_snapshot,
-    ):
-        template = BaseTemplate.load_sfn_template(BaseTemplate.WAIT_TIMESTAMPPATH)
-        definition = json.dumps(template)
-
-        offset_toofar = datetime.timedelta(days=800)
-        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) + offset_toofar
-        timestamp = wait_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
-
-        full_timestamp = f"{timestamp}.000Z"
-        sfn_snapshot.add_transformer(sfn_snapshot.transform.regex(full_timestamp, "<timestamp>"))
-        exec_input = json.dumps({"start_at": full_timestamp})
-        create_and_record_execution(
-            aws_client.stepfunctions,
-            create_iam_role_for_sfn,
-            create_state_machine,
-            sfn_snapshot,
-            definition,
-            exec_input,
-        )
-
 
     @pytest.mark.parametrize(
         "timestamp_suffix",
         [
             # valid formats
             "Z",
-            ".0000000Z",
             ".000000Z",
-            ".000Z",
             ".00Z",
             # invalid formats
             "",
             ".000000",
-            ".000",
         ],
     )
     @markers.aws.validated
@@ -94,17 +70,20 @@ class TestSfnWait:
         sfn_snapshot,
         timestamp_suffix,
     ):
+        """
+        - Timestamp needs to be in UTC (have a Z suffix)
+        - Timestamp can be in the past (succeeds immediately)
+        - Fractional seconds are optional and there's no specific number enforced (e.g. milliseconds vs. microseconds)
+        """
         template = BaseTemplate.load_sfn_template(BaseTemplate.WAIT_TIMESTAMPPATH)
         definition = json.dumps(template)
 
-        offset_1min = datetime.timedelta(minutes=1)
-        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) + offset_1min
+        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         timestamp = wait_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
 
         full_timestamp = f"{timestamp}{timestamp_suffix}"
         sfn_snapshot.add_transformer(sfn_snapshot.transform.regex(full_timestamp, "<timestamp>"))
         exec_input = json.dumps({"start_at": full_timestamp})
-        # TODO: make this return the execution ARN for manual assertions
         create_and_record_execution(
             aws_client.stepfunctions,
             create_iam_role_for_sfn,

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.py
@@ -1,0 +1,61 @@
+import datetime
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
+from tests.aws.services.stepfunctions.utils import (
+    create_and_record_execution,
+)
+
+
+@markers.snapshot.skip_snapshot_verify(paths=["$..loggingConfiguration", "$..tracingConfiguration"])
+class TestSfnWait:
+    # TODO: timestamp in the past
+    # def test_timestamp_in_past(self):
+
+    # TODO: test maximum wait time (1 year and 5 minutes)
+    # def test_timestamp_too_far_in_future(self):
+
+    @pytest.mark.parametrize(
+        "timestamp_suffix",
+        [
+            # valid formats
+            "Z",
+            ".000000Z",
+            ".000Z",
+            # invalid formats
+            "",
+            ".000000",
+            ".000",
+        ],
+    )
+    @markers.aws.unknown
+    def test_wait_timestamppath(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+        timestamp_suffix,
+    ):
+        template = BaseTemplate.load_sfn_template(BaseTemplate.WAIT_TIMESTAMPPATH)
+        definition = json.dumps(template)
+
+        offset_1min = datetime.timedelta(minutes=1)
+        wait_timestamp = datetime.datetime.now(tz=datetime.timezone.utc) + offset_1min
+        timestamp = wait_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+
+        full_timestamp = f"{timestamp}{timestamp_suffix}"
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.regex(full_timestamp, "<timestamp>"))
+        exec_input = json.dumps({"start_at": f"{timestamp}{timestamp_suffix}"})
+        # TODO: make this return the execution ARN for manual assertions
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.py
@@ -10,6 +10,7 @@ from tests.aws.services.stepfunctions.utils import (
 )
 
 
+# TODO: add tests for seconds, secondspath, timestamp
 @markers.snapshot.skip_snapshot_verify(paths=["$..loggingConfiguration", "$..tracingConfiguration"])
 class TestSfnWait:
     # TODO: timestamp in the past
@@ -22,16 +23,17 @@ class TestSfnWait:
         "timestamp_suffix",
         [
             # valid formats
-            "Z",
-            ".000000Z",
-            ".000Z",
+            # TODO: re-enable
+            # "Z",
+            # ".000000Z",
+            # ".000Z",
             # invalid formats
             "",
             ".000000",
             ".000",
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_wait_timestamppath(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
@@ -1,6 +1,102 @@
 {
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_too_far_in_future_boundary[24855]": {
+    "recorded-date": "13-12-2023, 07:09:01",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_too_far_in_future_boundary[24856]": {
+    "recorded-date": "13-12-2023, 07:09:17",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). Wait state delay is too long.",
+              "error": "States.Runtime"
+            },
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[Z]": {
-    "recorded-date": "11-12-2023, 22:01:34",
+    "recorded-date": "13-12-2023, 07:09:32",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -72,310 +168,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000Z]": {
-    "recorded-date": "11-12-2023, 22:03:38",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "State_1"
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "State_1",
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 4,
-            "previousEventId": 3,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000Z]": {
-    "recorded-date": "11-12-2023, 22:04:41",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "State_1"
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "State_1",
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 4,
-            "previousEventId": 3,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[]": {
-    "recorded-date": "11-12-2023, 22:05:59",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "State_1"
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateEntered"
-          },
-          {
-            "executionFailedEventDetails": {
-              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
-              "error": "States.Runtime"
-            },
-            "id": 3,
-            "previousEventId": 2,
-            "timestamp": "timestamp",
-            "type": "ExecutionFailed"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000]": {
-    "recorded-date": "11-12-2023, 22:06:14",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "State_1"
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateEntered"
-          },
-          {
-            "executionFailedEventDetails": {
-              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
-              "error": "States.Runtime"
-            },
-            "id": 3,
-            "previousEventId": 2,
-            "timestamp": "timestamp",
-            "type": "ExecutionFailed"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000]": {
-    "recorded-date": "11-12-2023, 22:06:28",
-    "recorded-content": {
-      "get_execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "snf_role_arn"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "start_at": "<timestamp>"
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "State_1"
-            },
-            "timestamp": "timestamp",
-            "type": "WaitStateEntered"
-          },
-          {
-            "executionFailedEventDetails": {
-              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
-              "error": "States.Runtime"
-            },
-            "id": 3,
-            "previousEventId": 2,
-            "timestamp": "timestamp",
-            "type": "ExecutionFailed"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.0000000Z]": {
-    "recorded-date": "11-12-2023, 22:02:36",
+    "recorded-date": "13-12-2023, 07:09:46",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -447,7 +240,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.00Z]": {
-    "recorded-date": "11-12-2023, 22:05:44",
+    "recorded-date": "13-12-2023, 07:10:01",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -518,8 +311,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_in_past": {
-    "recorded-date": "11-12-2023, 22:35:58",
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[]": {
+    "recorded-date": "13-12-2023, 07:10:17",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -554,33 +347,14 @@
             "type": "WaitStateEntered"
           },
           {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
+              "error": "States.Runtime"
+            },
             "id": 3,
             "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "State_1",
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
             "timestamp": "timestamp",
-            "type": "WaitStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "start_at": "<timestamp>"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 4,
-            "previousEventId": 3,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
+            "type": "ExecutionFailed"
           }
         ],
         "ResponseMetadata": {
@@ -590,8 +364,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_too_far_in_future_fails": {
-    "recorded-date": "11-12-2023, 23:17:14",
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000]": {
+    "recorded-date": "13-12-2023, 07:10:32",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -624,6 +398,16 @@
             },
             "timestamp": "timestamp",
             "type": "WaitStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
+              "error": "States.Runtime"
+            },
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[Z]": {
-    "recorded-date": "06-12-2023, 07:58:05",
+    "recorded-date": "11-12-2023, 22:01:34",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -72,7 +72,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000Z]": {
-    "recorded-date": "06-12-2023, 07:59:06",
+    "recorded-date": "11-12-2023, 22:03:38",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -144,7 +144,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000Z]": {
-    "recorded-date": "06-12-2023, 08:00:08",
+    "recorded-date": "11-12-2023, 22:04:41",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -216,7 +216,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[]": {
-    "recorded-date": "06-12-2023, 08:00:24",
+    "recorded-date": "11-12-2023, 22:05:59",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -269,7 +269,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000]": {
-    "recorded-date": "06-12-2023, 08:00:39",
+    "recorded-date": "11-12-2023, 22:06:14",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -322,7 +322,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000]": {
-    "recorded-date": "06-12-2023, 08:00:53",
+    "recorded-date": "11-12-2023, 22:06:28",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -365,6 +365,265 @@
             "previousEventId": 2,
             "timestamp": "timestamp",
             "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.0000000Z]": {
+    "recorded-date": "11-12-2023, 22:02:36",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.00Z]": {
+    "recorded-date": "11-12-2023, 22:05:44",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_in_past": {
+    "recorded-date": "11-12-2023, 22:35:58",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_timestamp_too_far_in_future_fails": {
+    "recorded-date": "11-12-2023, 23:17:14",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_wait.snapshot.json
@@ -1,0 +1,377 @@
+{
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[Z]": {
+    "recorded-date": "06-12-2023, 07:58:05",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000Z]": {
+    "recorded-date": "06-12-2023, 07:59:06",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000Z]": {
+    "recorded-date": "06-12-2023, 08:00:08",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "State_1",
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "start_at": "<timestamp>"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 4,
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[]": {
+    "recorded-date": "06-12-2023, 08:00:24",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
+              "error": "States.Runtime"
+            },
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000000]": {
+    "recorded-date": "06-12-2023, 08:00:39",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
+              "error": "States.Runtime"
+            },
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/base/test_wait.py::TestSfnWait::test_wait_timestamppath[.000]": {
+    "recorded-date": "06-12-2023, 08:00:53",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "start_at": "<timestamp>"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "State_1"
+            },
+            "timestamp": "timestamp",
+            "type": "WaitStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "An error occurred while executing the state 'State_1' (entered at the event id #2). The TimestampPath parameter does not reference a valid ISO-8601 extended offset date-time format string: $.start_at == <timestamp>",
+              "error": "States.Runtime"
+            },
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Resolves https://github.com/localstack/localstack/issues/9722

We've been assuming that all timestamps should only include up to second precision, but StepFunctions on AWS also allows specifying milliseconds or microseconds (though they seem to be ignored anyway)

## Changes

- Added tests for multiple different timestamp formats in `TimestampPath` (both positive & negative)  

## TODO

What's left to do:

- [x] Implement `An error occurred while executing the state 'State_1' (entered at the event id #2). ` error wrapping
- [x] Add test for older timestamp
- [x] Add test for timestamp too far in future
- [x] Fix timestamp parsing for milli & microseconds (dropping them)
