### PR TITLE
Add support for conditions on CFn stack outputs

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1440,6 +1440,8 @@ class TemplateDeployer:
 def resolve_outputs(account_id: str, region_name: str, stack) -> list[dict]:
     result = []
     for k, details in stack.outputs.items():
+        if not evaluate_resource_condition(stack.resolved_conditions, details):
+            continue
         value = None
         try:
             resolve_refs_recursively(

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -10,7 +10,7 @@ from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing
 def test_nested_stack(deploy_cfn_template, s3_create_bucket, aws_client):
     # upload template to S3
     artifacts_bucket = f"cf-artifacts-{short_uid()}"
@@ -116,7 +116,7 @@ def test_nested_with_nested_stack(deploy_cfn_template, s3_create_bucket, aws_cli
 
 
 @markers.aws.validated
-@pytest.mark.skip(reason="not working correctly")
+@pytest.mark.skip(reason="UPDATE isn't working on nested stacks")
 def test_lifecycle_nested_stack(deploy_cfn_template, s3_create_bucket, aws_client):
     bucket_name = s3_create_bucket()
     nested_bucket_name = f"test-bucket-nested-{short_uid()}"
@@ -252,3 +252,36 @@ def test_nested_output_in_params(deploy_cfn_template, s3_create_bucket, snapshot
     topics = sns_pager.paginate().build_full_result()["Topics"]
     filtered_topics = [t["TopicArn"] for t in topics if topic_name in t["TopicArn"]]
     assert len(filtered_topics) == 1
+
+
+@markers.aws.validated
+def test_nested_stacks_conditions(deploy_cfn_template, s3_create_bucket, aws_client):
+    """
+    see: TestCloudFormationConditions.test_condition_on_outputs
+
+    equivalent to the condition test but for a nested stack
+    """
+    bucket_name = s3_create_bucket()
+    nested_bucket_name = f"test-bucket-nested-{short_uid()}"
+    key = f"test-key-{short_uid()}"
+
+    aws_client.s3.upload_file(
+        os.path.join(
+            os.path.dirname(__file__), "../../../templates/nested-stack-conditions.nested.yaml"
+        ),
+        Bucket=bucket_name,
+        Key=key,
+    )
+
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/nested-stack-conditions.yaml"
+        ),
+        template_mapping={
+            "s3_bucket_url": f"/{bucket_name}/{key}",
+            "s3_bucket_name": nested_bucket_name,
+        },
+    )
+
+    assert stack.outputs["ProdBucket"] == f"{nested_bucket_name}-prod"
+    assert aws_client.s3.head_bucket(Bucket=stack.outputs["ProdBucket"])

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -277,9 +277,9 @@ def test_nested_stacks_conditions(deploy_cfn_template, s3_create_bucket, aws_cli
         template_path=os.path.join(
             os.path.dirname(__file__), "../../../templates/nested-stack-conditions.yaml"
         ),
-        template_mapping={
-            "s3_bucket_url": f"/{bucket_name}/{key}",
-            "s3_bucket_name": nested_bucket_name,
+        parameters={
+            "S3BucketPath": f"/{bucket_name}/{key}",
+            "S3BucketName": nested_bucket_name,
         },
     )
 

--- a/tests/aws/templates/nested-stack-conditions.nested.yaml
+++ b/tests/aws/templates/nested-stack-conditions.nested.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Mode:
+    Type: String
+  BucketBaseName:
+    Type: String
+Conditions:
+  ProdMode: !Equals [ !Ref Mode, prod ]
+  TestMode: !Equals [ !Ref Mode, test ]
+Resources:
+  TestS3:
+    Type: AWS::S3::Bucket
+    Condition: TestMode
+    Properties:
+      BucketName:
+        Fn::Join:
+          - "-"
+          - - !Ref BucketBaseName
+            - test
+  ProdS3:
+    Type: AWS::S3::Bucket
+    Condition: ProdMode
+    Properties:
+      BucketName:
+        Fn::Join:
+          - "-"
+          - - !Ref BucketBaseName
+            - prod
+Outputs:
+  TestBucket:
+    Condition: TestMode
+    Value: !Ref TestS3
+  ProdBucket:
+    Condition: ProdMode
+    Value: !Ref ProdS3

--- a/tests/aws/templates/nested-stack-conditions.yaml
+++ b/tests/aws/templates/nested-stack-conditions.yaml
@@ -1,4 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  S3BucketPath:
+    Type: String
+  S3BucketName:
+    Type: String
 
 Resources:
   Bucket:
@@ -11,9 +16,9 @@ Resources:
             - Ref: AWS::Region
             - "."
             - Ref: AWS::URLSuffix
-            - {{ s3_bucket_url }}
+            - Ref: S3BucketPath
       Parameters:
-        BucketBaseName: {{ s3_bucket_name }}
+        BucketBaseName: !Ref S3BucketName
         Mode: prod
 Outputs:
   ProdBucket:

--- a/tests/aws/templates/nested-stack-conditions.yaml
+++ b/tests/aws/templates/nested-stack-conditions.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Resources:
+  Bucket:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL:
+        Fn::Join:
+          - ""
+          - - https://s3.
+            - Ref: AWS::Region
+            - "."
+            - Ref: AWS::URLSuffix
+            - {{ s3_bucket_url }}
+      Parameters:
+        BucketBaseName: {{ s3_bucket_name }}
+        Mode: prod
+Outputs:
+  ProdBucket:
+    Value: !GetAtt Bucket.Outputs.ProdBucket


### PR DESCRIPTION
## Motivation

Resolves https://github.com/localstack/localstack/issues/9628

The inital report was a bit misleading since this also fails for a normal stack deployment, i.e. it doesn't just affect nested stacks.

## Changes

- Evaluate conditions on stack outputs and if they evaluate to false, drop them.