### PR TITLE
fix s3 presign tests for multi account support

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -145,15 +145,15 @@ except Exception:
     MAX_POOL_CONNECTIONS = 150
 
 # Fallback Account ID if not available in the client request
-DEFAULT_AWS_ACCOUNT_ID = "000000000000"
+DEFAULT_AWS_ACCOUNT_ID = "111111111111"
 
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
 TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "111111111111"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "111111111111"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "eu-central-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -145,15 +145,15 @@ except Exception:
     MAX_POOL_CONNECTIONS = 150
 
 # Fallback Account ID if not available in the client request
-DEFAULT_AWS_ACCOUNT_ID = "111111111111"
+DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
 TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "111111111111"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "111111111111"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "eu-central-1"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_presign.js
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_presign.js
@@ -13,13 +13,13 @@ exports.handler = async (event, context, callback) => {
     let s3;
     if (process.env.AWS_ENDPOINT_URL) {
         const CREDENTIALS = {
-            secretAccessKey: 'test',
-            accessKeyId: 'test',
+            secretAccessKey: process.env.SECRET_KEY,
+            accessKeyId: process.env.ACCESS_KEY,
         };
 
         s3 = new S3Client({
             endpoint: "http://s3.localhost.localstack.cloud:4566",
-            region: 'us-east-1',
+            region: process.env.AWS_REGION,
             credentials: CREDENTIALS,
         });
     } else {

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_sdk_v2.js
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_sdk_v2.js
@@ -7,12 +7,12 @@ exports.handler = async (event, context, callback) => {
     let s3;
     if (process.env.AWS_ENDPOINT_URL) {
         const CREDENTIALS = {
-            secretAccessKey: 'test',
-            accessKeyId: 'test',
+            secretAccessKey: process.env.SECRET_KEY,
+            accessKeyId: process.env.ACCESS_KEY,
         };
         s3 = new AWS.S3({
             endpoint: "http://s3.localhost.localstack.cloud:4566",
-            region: 'us-east-1',
+            region: process.env.AWS_REGION,
             signatureVersion: 'v4', // Required for the presigned URL functionality with extra headers
             credentials: CREDENTIALS
           });


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds support for multi account to tests

- `test_presigned_url_v4_x_amz_in_qs`
- `test_presigned_url_v4_signed_headers_in_qs`
- `test_s3_copy_md5`

<!-- What notable changes does this PR make? -->
## Changes
- Updated lambda functions to use correct access key and secret keys (passed from env)
- Created custom s3 client to use `s3_v4` for presign url generation

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (TEST_AWS_ACCOUNT_ID=111111111111, TEST_AWS_ACCESS_KEY_ID=111111111111, TEST_AWS_REGION=us-west-1). The affected tests are:

- `tests.aws.services.s3.test_s3.TestS3PresignedUrl.test_presigned_url_v4_x_amz_in_qs`
- `tests.aws.services.s3.test_s3.TestS3PresignedUrl.test_presigned_url_v4_signed_headers_in_qs`
- `tests.aws.services.s3.test_s3.TestS3PresignedUrl.test_s3_copy_md5`

## TODO

What's left to do:

- [x] Run `-ext` test against this branch : ✅ 
- [ ] Run tests with incorrect account id

