### PR TITLE
Bump Postgresql CI dependency

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -177,7 +177,8 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.*-0ubuntu0* postgresql-client postgresql-plpython3
+          # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.10-0ubuntu0* postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true


### PR DESCRIPTION
## Motivation

Ubuntu repos regularly update the Postgres package to the newest minor version. It was bumped to 14.10 yesterday: https://launchpad.net/ubuntu/+source/postgresql-14 and the previous version was removed. This broke the CI setup step.

Failing step: https://github.com/localstack/localstack/actions/runs/7125312627/job/19401028988?pr=9816

## Implementation

This PR bumps the pin to the currently available version.

Unfortunately, we can't remove the pin because it is required to prevent install of the version from the PGDG repos:

```
The following packages have unmet dependencies:
 postgresql-plpython3-14 : Depends: postgresql-14 (= 14.10-0ubuntu0.22.04.1) but 14.10-1.pgdg22.04+1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

Link to passing step: https://github.com/localstack/localstack/actions/runs/7126359173/job/19404085596?pr=9818#step:9:111