### PR TITLE
Fix serialization of content in raw snapshots

### DIFF
--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -19,6 +19,7 @@ from localstack.testing.snapshots.transformer import (
     Transformer,
 )
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
+from localstack.utils.json import CustomEncoder
 
 SNAPSHOT_LOGGER = logging.getLogger(__name__)
 SNAPSHOT_LOGGER.setLevel(logging.DEBUG if os.environ.get("DEBUG_SNAPSHOT") else logging.WARNING)
@@ -134,7 +135,8 @@ class SnapshotSession:
                         "recorded-content": raw_state,
                     }
                     full_state[self.scope_key] = recorded
-                    state_to_dump = json.dumps(full_state, indent=2)
+                    # need to use CustomEncoder to handle datetime objects
+                    state_to_dump = json.dumps(full_state, indent=2, cls=CustomEncoder)
                     fd.seek(0)
                     fd.truncate()
                     # add line ending to be compatible with pre-commit-hooks (end-of-file-fixer)


### PR DESCRIPTION

## Motivation

Since we're not using transformers with raw snapshots, we need to make sure datetime objects are handled properly, otherwise `json.dumps` with the default JSON encoder will fail.

## Changes

- Use `CustomEncoder` from our json utils to encode the response.