### PR TITLE
Simplify the official docker-compose.yml

### DIFF
--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -9,6 +9,7 @@ services:
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
       - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (required for Pro)
     environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration
       - DEBUG=${DEBUG-}
       - PERSISTENCE=${PERSISTENCE-}
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # required for Pro

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack-pro  # required for Pro
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
@@ -10,9 +10,9 @@ services:
       - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (required for Pro)
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration
-      - DEBUG=${DEBUG-}
-      - PERSISTENCE=${PERSISTENCE-}
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN-}  # required for Pro
+      - DEBUG=${DEBUG:-0}
+      - PERSISTENCE=${PERSISTENCE:-0}
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -9,10 +9,11 @@ services:
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
       - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (required for Pro)
     environment:
-      # LocalStack configuration: https://docs.localstack.cloud/references/configuration
+      # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - PERSISTENCE=${PERSISTENCE:-0}
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -7,14 +7,11 @@ services:
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
-      - "127.0.0.1:53:53"                # DNS config (required for Pro)
-      - "127.0.0.1:53:53/udp"            # DNS config (required for Pro)
       - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (required for Pro)
     environment:
       - DEBUG=${DEBUG-}
       - PERSISTENCE=${PERSISTENCE-}
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # required for Pro
-      - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -12,7 +12,7 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration
       - DEBUG=${DEBUG-}
       - PERSISTENCE=${PERSISTENCE-}
-      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # required for Pro
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN-}  # required for Pro
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
-      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (required for Pro)
+      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (Pro)
     environment:
       # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration
-      - DEBUG=${DEBUG-}
+      - DEBUG=${DEBUG:-0}
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       - DEBUG=${DEBUG-}
-      - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration
       - DEBUG=${DEBUG-}
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
-      # LocalStack configuration: https://docs.localstack.cloud/references/configuration
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"


### PR DESCRIPTION
## Motivation

Our official `docker-compose-pro.yml` fails to start if port `53` is already bound on the host system. This is a common issue on macOS due to this [known Docker for Mac issue](https://docs.docker.com/desktop/release-notes/#known-issues-2) or due to enabled [internet sharing](https://github.com/docker/for-mac/issues/7008#issuecomment-1748344545). The comment `# (required for Pro)` is also misleading because publishing port `53` is only required if you wish to use the LocalStack DNS server on the system host, which requires extra configuration anyway as documented [here](https://docs.localstack.cloud/user-guide/tools/dns-server/#system-dns-configuration). For example, simply pointing the system DNS leads to `127.0.0.1` without configuring the default upstream `DNS_SERVER` leads to an infinite loop.

Further, `DOCKER_HOST` is the default configuration and therefore not required.

## Changes

* Remove the port mapping for port `53` (DNS) from the host to the LocalStack container
* Remove the environment variable `DOCKER_HOST` because that is the default
* Switch from `LOCALSTACK_API_KEY` to `LOCALSTACK_AUTH_TOKEN`
* Unify Docker compose variable [interpolations](https://docs.docker.com/compose/compose-file/12-interpolation/)
  * Do not pass empty values using `:-`
  * Require the auth token using `:?`

## Discussion

* Are there any default scenarios that require port `53` to be exposed on the host?
* Do we want to keep `PERSISTENCE=${PERSISTENCE-}` in the official `docker-compose-pro.yml`?
  * It is not strictly necessary
  * It was added to advertise the persistence feature so that users can toggle it easily

## Follow Ups

- [ ] Update the new recommended/official `docker-compose.yml` in the documentation accordingly. Especially in [getting started](https://docs.localstack.cloud/getting-started/installation/#docker-compose). https://github.com/localstack/docs/pull/963
- [ ] Document `LOCALSTACK_API_KEY` as a deprecated variable under configuration (currently not there at all!) https://github.com/localstack/docs/pull/963
- [ ] Document `DOCKER_HOST` under configuration. Possibly under [miscellaneous](https://docs.localstack.cloud/references/configuration/#miscellaneous) as a relevant configuration of an important LocalStack dependency. Other relevant configurations could be `NO_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`, and `REQUESTS_CA_BUNDLE` (already documented). https://github.com/localstack/docs/pull/963
- [ ] Update references in other localstack repositories (74 files) https://github.com/search?q=org%3Alocalstack+docker-compose.yml+language%3AYAML&type=code&l=YAML
- [ ] Update references in localstack-samples (4 files) https://github.com/search?q=org%3Alocalstack-samples+docker-compose.yml&type=code