### PR TITLE
Fix lambda function name validation for CreateFunction

### DIFF
--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -139,6 +139,7 @@ from localstack.services.lambda_ import hooks as lambda_hooks
 from localstack.services.lambda_.api_utils import (
     ARCHITECTURES,
     STATEMENT_ID_REGEX,
+    function_locators_from_arn,
 )
 from localstack.services.lambda_.event_source_listeners.event_source_listener import (
     EventSourceListener,
@@ -762,7 +763,44 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: {VALID_RUNTIMES} or be a valid ARN",
                 Type="User",
             )
-        function_name = request["FunctionName"]
+        request_function_name = request["FunctionName"]
+        # Validate FunctionName:
+        # a) Function name: just function name (max 64 chars)
+        # b) Function ARN: unqualified arn (min 1, max 64 chars)
+        # c) Partial ARN: ACCOUNT_ID:function:FUNCTION_NAME
+        function_name, qualifier, account, region = function_locators_from_arn(
+            request_function_name
+        )
+        if (
+            function_name and qualifier is None and account is None and region is None
+        ):  # just function name
+            pass
+        elif function_name and account and qualifier is None and region is None:  # partial arn
+            if account != context.account_id:
+                raise AccessDeniedException(None)
+        elif function_name and account and region and qualifier is None:  # unqualified arn
+            if len(request_function_name) > 140:
+                raise ValidationException(
+                    f"1 validation error detected: Value '{request_function_name}' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
+                )
+            if region != context.region:
+                raise ResourceNotFoundException(
+                    f"Functions from '{region}' are not reachable in this region ('{context.region}')",
+                    Type="User",
+                )
+            if account != context.account_id:
+                raise AccessDeniedException(None)
+        else:
+            pattern = r"(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?"
+            raise ValidationException(
+                f"1 validation error detected: Value '{request_function_name}' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: {pattern}"
+            )
+        if len(function_name) > 64:
+            raise InvalidParameterValueException(
+                f"1 validation error detected: Value '{function_name}' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 64",
+                Type="User",
+            )
+
         if runtime in DEPRECATED_RUNTIMES:
             LOG.warning(
                 f"The Lambda runtime {runtime} is deprecated. "

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13371,5 +13371,154 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
+    "recorded-date": "08-12-2023, 12:27:16",
+    "recorded-content": {
+      "create-function-arn-response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "create-function-partial-arn-response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:2>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:2>",
+          "FunctionName": "<function-name:2>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invalid_function_name_exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'invalid:function:name' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "long_function_name_exc": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 64"
+        },
+        "Type": "User",
+        "message": "1 validation error detected: Value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 64",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "long_function_arn_exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:function:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "function_arn_other_region_exc": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Functions from 'ap-southeast-1' are not reachable in this region ('<region>')"
+        },
+        "Message": "Functions from 'ap-southeast-1' are not reachable in this region ('<region>')",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "function_arn_other_account_exc": {
+        "Error": {
+          "Code": "AccessDeniedException",
+          "Message": null
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -223,6 +223,7 @@ class TestLambdaRuntimesCommon:
     @markers.aws.validated
     # Only works for >=al2 runtimes, except for any provided runtimes
     # Source: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
+    # TODO: update runtime filters (should not skip >=al2 runtimes); resolved after fixing ARM build
     @markers.multiruntime(
         scenario="introspection",
         runtimes=list(


### PR DESCRIPTION
## Motivation

The `FunctionName` in the Lambda `CreateFunction` operation is currently not validated and cannot handle function ARNs.
The [AWS API reference](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-FunctionName) describes that the operation can accept the following options for `FunctionName`:

* Function name – my-function.
* Function ARN – arn:aws:lambda:us-west-2:123456789012:function:my-function.
* Partial ARN – 123456789012:function:my-function.

This issue came up in a support case where a function ARN crashed in the `event_manager.py` because it tried to create an SQS queue with an invalid name (containing `:`).

## Changes

* Add AWS-validated tests for exceptions and valid function ARNs
* Fix validation of `FunctionName` for the Lambda `CreateFunction` operation

## Testing

* `tests.aws.services.lambda_.test_lambda_api.TestLambdaFunction.test_function_arns`

## Notes

* Other operations in the Lambda API also do not cover all validation implemented for `CreateFunction` now. However, they often use `api_utils.get_name_and_qualifier`, which supports function ARNs and handles some validations (i.e., qualified and region). If we want to improve server-side validations consistently, we need better boto-spec-based validation abstractions as suggested by @thrau [here](https://github.com/localstack/localstack/pull/7675#discussion_r1107777058).
* The `FunctionName` cannot be updated, so we don't need to consider renaming.