### PR TITLE
Prevent error message being shown with entrypoints command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: install-dev entrypoints  ## Install full dependencies into venv
 entrypoints:              ## Run setup.py develop to build entry points
 	$(VENV_RUN); python setup.py plugins egg_info
 	# make sure that the entrypoints were correctly created and are non-empty
-	test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
+	@test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 
 dist: entrypoints        ## Build source and built (wheel) distributions of the current version
 	$(VENV_RUN); pip install --upgrade twine; python setup.py sdist bdist_wheel


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When running `make entrypoints`  the following line is printed:

```bash
test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
```

This line does not indicate an error, but is `make` printing the command before running it. Some users do not check the exit code of the process, and assume that this message is an error.


<!-- What notable changes does this PR make? -->
## Changes

* Prefix the line with `@` so it is not printed before running the command. This way the error message is only printed on failure, which is more useful and less worrying for new users.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

