### PR TITLE
Fix AWS parity for SQS list queues with empty response

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -771,6 +771,9 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             #  NextToken response element directly outside of the AWS CLI.
             urls = urls[:max_results]
 
+        if len(urls) == 0:
+            return ListQueuesResult()
+
         return ListQueuesResult(QueueUrls=urls)
 
     def change_message_visibility(

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -130,6 +130,10 @@ class TestSqsProvider:
         for url in queue_urls:
             assert url in result["QueueUrls"]
 
+        # list queues with empty result
+        result = aws_client.sqs.list_queues(QueueNamePrefix="nonexisting-queue-")
+        assert "QueueUrls" not in result
+
     @markers.aws.validated
     def test_create_queue_and_get_attributes(self, sqs_queue, aws_client):
         result = aws_client.sqs.get_queue_attributes(

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -850,7 +850,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_list_queues": {
-    "recorded-date": "14-11-2023, 11:57:28",
+    "recorded-date": "08-12-2023, 17:13:26",
     "recorded-content": {}
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_set_content_based_deduplication_strategy": {


### PR DESCRIPTION
## Motivation

Related discussion in https://github.com/localstack/localstack/pull/9710#discussion_r1419321271

> For empty lists, AWS often omits the field entirely, independent of the protocol. I noticed this behavior recently while parity testing different SDK versions (which use different protocols) in the Lambda multiruntime tests.
> I moved my Notion testing page to the SQS service to demonstrate the behavior for the listQueues operation (see [here](https://www.notion.so/localstack/SQS-SDK-parity-testing-164bfb9dbdd541928fd2b2abc275bac7?pvs=4)).

This behavior is independent of the protocol (both query + json).

## Changes

* Add AWS-validated test scenario with queue prefix matching that returns an empty result
* Omit the `QueueUrls` in the API response for empty results.
