### PR TITLE
Implement basic status filter for StepFunctions list-executions

### DIFF
--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -890,6 +890,7 @@ class TestSnfApi:
 
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
 
+    @markers.snapshot.skip_snapshot_verify(paths=["$..redriveCount"])
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..redriveCount", "$..redriveStatus", "$..redriveStatusReason"]

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 import yaml
+from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 
 from localstack.aws.api.lambda_ import Runtime
@@ -14,6 +15,7 @@ from tests.aws.services.stepfunctions.utils import (
     await_execution_started,
     await_execution_success,
     await_execution_terminated,
+    await_list_execution_status,
     await_state_machine_listed,
     await_state_machine_not_listed,
 )
@@ -1003,3 +1005,55 @@ class TestSnfApi:
         sfn_snapshot.match(
             "exception", {"exception_typename": exc.typename, "exception_value": exc.value}
         )
+
+    @markers.aws.validated
+    def test_state_machine_status_filter(
+        self, create_iam_role_for_sfn, create_state_machine, sfn_snapshot, aws_client
+    ):
+        snf_role_arn = create_iam_role_for_sfn()
+        sfn_snapshot.add_transformer(RegexTransformer(snf_role_arn, "snf_role_arn"))
+
+        sm_name: str = f"statemachine_{short_uid()}"
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+        definition_str = json.dumps(definition)
+
+        creation_resp = create_state_machine(
+            name=sm_name, definition=definition_str, roleArn=snf_role_arn
+        )
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_create_arn(creation_resp, 0))
+        sfn_snapshot.match("creation_resp", creation_resp)
+        state_machine_arn = creation_resp["stateMachineArn"]
+
+        list_response = aws_client.stepfunctions.list_executions(
+            stateMachineArn=state_machine_arn, statusFilter="SUCCEEDED"
+        )
+        sfn_snapshot.match("list_before_execution", list_response)
+
+        exec_resp = aws_client.stepfunctions.start_execution(stateMachineArn=state_machine_arn)
+        sfn_snapshot.add_transformer(sfn_snapshot.transform.sfn_sm_exec_arn(exec_resp, 0))
+        sfn_snapshot.match("exec_resp", exec_resp)
+        execution_arn = exec_resp["executionArn"]
+
+        await_list_execution_status(
+            stepfunctions_client=aws_client.stepfunctions,
+            state_machine_arn=state_machine_arn,
+            execution_arn=execution_arn,
+            status="SUCCEEDED",
+        )
+
+        list_response = aws_client.stepfunctions.list_executions(
+            stateMachineArn=state_machine_arn, statusFilter="SUCCEEDED"
+        )
+        sfn_snapshot.match("list_succeeded_when_complete", list_response)
+
+        list_response = aws_client.stepfunctions.list_executions(
+            stateMachineArn=state_machine_arn, statusFilter="RUNNING"
+        )
+        sfn_snapshot.match("list_running_when_complete", list_response)
+
+        with pytest.raises(
+            ClientError, match="Value 'succeeded' at 'statusFilter' failed to satisfy constraint"
+        ):
+            aws_client.stepfunctions.list_executions(
+                stateMachineArn=state_machine_arn, statusFilter="succeeded"
+            )

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1616,7 +1616,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
-    "recorded-date": "20-12-2023, 16:18:45",
+    "recorded-date": "14-03-2024, 18:37:36",
     "recorded-content": {
       "creation_resp": {
         "creationDate": "datetime",
@@ -1646,6 +1646,7 @@
           {
             "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
             "name": "<ExecArnPart_0idx>",
+            "redriveCount": 0,
             "startDate": "datetime",
             "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
             "status": "SUCCEEDED",

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1614,5 +1614,56 @@
         "exception_value": "An error occurred (InvalidArn) when calling the DescribeExecution operation: Invalid Arn: 'Invalid ARN prefix: invalid_state_machine_arn'"
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
+    "recorded-date": "20-12-2023, 16:18:45",
+    "recorded-content": {
+      "creation_resp": {
+        "creationDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_before_execution": {
+        "executions": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "exec_resp": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_succeeded_when_complete": {
+        "executions": [
+          {
+            "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+            "name": "<ExecArnPart_0idx>",
+            "startDate": "datetime",
+            "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+            "status": "SUCCEEDED",
+            "stopDate": "datetime"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_running_when_complete": {
+        "executions": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -1616,7 +1616,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
-    "recorded-date": "14-03-2024, 18:37:36",
+    "recorded-date": "14-03-2024, 21:58:24",
     "recorded-content": {
       "creation_resp": {
         "creationDate": "datetime",
@@ -1663,6 +1663,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "list_executions_filter_exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'succeeded' at 'statusFilter' failed to satisfy constraint: Member must satisfy enum value set: [SUCCEEDED, TIMED_OUT, PENDING_REDRIVE, ABORTED, FAILED, RUNNING]"
+        },
+        "message": "1 validation error detected: Value 'succeeded' at 'statusFilter' failed to satisfy constraint: Member must satisfy enum value set: [SUCCEEDED, TIMED_OUT, PENDING_REDRIVE, ABORTED, FAILED, RUNNING]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -90,7 +90,7 @@
     "last_validated_date": "2023-06-22T11:52:39+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
-    "last_validated_date": "2024-03-14T18:37:36+00:00"
+    "last_validated_date": "2024-03-14T21:59:25+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_stop_execution": {
     "last_validated_date": "2023-06-22T11:53:24+00:00"

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -89,6 +89,9 @@
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_start_execution": {
     "last_validated_date": "2023-06-22T11:52:39+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter": {
+    "last_validated_date": "2024-03-14T18:37:36+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_stop_execution": {
     "last_validated_date": "2023-06-22T11:53:24+00:00"
   }


### PR DESCRIPTION
## Motivation

v2 stepfunctions provider `list-executions` should support `statusFilter`  ... not yet implmented


## Changes
* added basic statusFilter to  localstack/services/stepfunctions/provider.py
* new test `tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter`

## Testing

basic coverage `tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_state_machine_status_filter`


