### PR TITLE
Skip comment for entrypoints line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ install: install-dev entrypoints  ## Install full dependencies into venv
 
 entrypoints:              ## Run setup.py develop to build entry points
 	$(VENV_RUN); python setup.py plugins egg_info
-	# make sure that the entrypoints were correctly created and are non-empty
+	@# make sure that the entrypoints were correctly created and are non-empty
 	@test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 
 dist: entrypoints        ## Build source and built (wheel) distributions of the current version


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In https://github.com/localstack/localstack/pull/9827 we prevented printing the line with "Aborting" in it to stop showing it as it is confusing to see as `make` prints the command, however the comment above it "# make sure that the entrypoints were correctly created and are non-empty" now sounds like an instruction, so we should comment it out.


<!-- What notable changes does this PR make? -->
## Changes

Also comment out the instruction sounding comment


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

