### PR TITLE
fix: serverless failing multi-account/region tests

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,14 +150,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -150,10 +150,14 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+# TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+# TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+# TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+# TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "000000000001"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -32,7 +32,7 @@ class TestServerless:
     @pytest.fixture(scope="class")
     def setup_and_teardown(self, aws_client, delenv):
         if not is_aws_cloud():
-            delenv("AWS_PROFILE")
+            delenv("AWS_PROFILE", raising=False)
         base_dir = get_base_dir()
         if not os.path.exists(os.path.join(base_dir, "node_modules")):
             # install dependencies

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -43,8 +43,11 @@ class TestServerless:
         existing_api_ids = [api["id"] for api in apis]
 
         # deploy serverless app
-        run(["npm", "run", "deploy", "--", f"--region={TEST_AWS_REGION_NAME}"], cwd=base_dir,
-            env_vars={"AWS_ACCESS_KEY_ID": TEST_AWS_ACCOUNT_ID})
+        run(
+            ["npm", "run", "deploy", "--", f"--region={TEST_AWS_REGION_NAME}"],
+            cwd=base_dir,
+            env_vars={"AWS_ACCESS_KEY_ID": TEST_AWS_ACCOUNT_ID},
+        )
 
         yield existing_api_ids
 

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -120,7 +120,7 @@ class TestServerless:
 
         # assert that stream consumer is properly connected and Lambda gets invoked
         def assert_invocations():
-            events = get_lambda_log_events(function_name2)
+            events = get_lambda_log_events(function_name2, logs_client=aws_client.logs)
             assert len(events) == 1
 
         kinesis_client.put_record(StreamName=stream_name, Data=b"test123", PartitionKey="key1")
@@ -144,11 +144,13 @@ class TestServerless:
         assert 1 == len(events)
         event_source_arn = events[0]["EventSourceArn"]
 
-        assert event_source_arn == arns.sqs_queue_arn(
+        queue_arn = arns.sqs_queue_arn(
             queue_name, account_id=TEST_AWS_ACCOUNT_ID, region_name=TEST_AWS_REGION_NAME
         )
+
+        assert event_source_arn == queue_arn
         result = sqs_client.get_queue_attributes(
-            QueueUrl=arns.sqs_queue_url_for_arn(queue_name),
+            QueueUrl=arns.sqs_queue_url_for_arn(queue_arn),
             AttributeNames=[
                 "RedrivePolicy",
             ],

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_AWS_ACCESS_KEY_ID
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
 from localstack.utils.common import retry, run
@@ -20,7 +21,18 @@ LOG = logging.getLogger(__name__)
 
 class TestServerless:
     @pytest.fixture(scope="class")
-    def setup_and_teardown(self, aws_client):
+    def delenv(self):
+        # Workaround for the inability to use the standard `monkeypatch` fixture in `class` scope
+        from _pytest.monkeypatch import MonkeyPatch
+
+        mkypatch = MonkeyPatch()
+        yield mkypatch.delenv
+        mkypatch.undo()
+
+    @pytest.fixture(scope="class")
+    def setup_and_teardown(self, aws_client, delenv):
+        if not is_aws_cloud():
+            delenv("AWS_PROFILE")
         base_dir = get_base_dir()
         if not os.path.exists(os.path.join(base_dir, "node_modules")):
             # install dependencies
@@ -31,7 +43,8 @@ class TestServerless:
         existing_api_ids = [api["id"] for api in apis]
 
         # deploy serverless app
-        run(["npm", "run", "deploy", "--", f"--region={TEST_AWS_REGION_NAME}"], cwd=base_dir)
+        run(["npm", "run", "deploy", "--", f"--region={TEST_AWS_REGION_NAME}"], cwd=base_dir,
+            env_vars={"AWS_ACCESS_KEY_ID": TEST_AWS_ACCOUNT_ID})
 
         yield existing_api_ids
 

--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
+from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME, TEST_AWS_ACCESS_KEY_ID
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
@@ -46,7 +46,7 @@ class TestServerless:
         run(
             ["npm", "run", "deploy", "--", f"--region={TEST_AWS_REGION_NAME}"],
             cwd=base_dir,
-            env_vars={"AWS_ACCESS_KEY_ID": TEST_AWS_ACCOUNT_ID},
+            env_vars={"AWS_ACCESS_KEY_ID": TEST_AWS_ACCESS_KEY_ID},
         )
 
         yield existing_api_ids


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `serverless` tests should still create the consequent resources in these accounts and region. When we try to deploy the serverless setup using non-default region value in tests it throws `IndexError` or `AssertionError` since the setup wasn't getting deployed in the correct account.

<!-- What notable changes does this PR make? -->
## Changes
This PR: 
- passes `AWS_ACCESS_KEY_ID` as an environment variable to [`serverless-localstack`](https://github.com/localstack/serverless-localstack). 
- deletes(later undos), the `AWS_PROFILE` env variable. 
- replaces queue name with queue arn while fetching queue url in method `sqs_queue_url_for_arn`.
- passes `logs_client` in `get_lambda_log_events`. 

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). This PR fixes: 

`tests.aws.test_serverless.TestServerless.test_event_rules_deployed`
`tests.aws.test_serverless.TestServerless.test_dynamodb_stream_handler_deployed`
`tests.aws.test_serverless.TestServerless.test_kinesis_stream_handler_deployed`
`tests.aws.test_serverless.TestServerless.test_queue_handler_deployed`
`tests.aws.test_serverless.TestServerless.test_lambda_with_configs_deployed`
`tests.aws.test_serverless.TestServerless.test_apigateway_deployed`

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

