### PR TITLE
Install websocket-client as it is no longer included with docker client

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,7 @@ test =
     pytest-rerunfailures==12.0
     pytest-tinybird>=0.2.0
     aws-cdk-lib>=2.88.0
+    websocket-client>=1.7.0
 
 # for developing localstack
 dev =


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In `docker-py` version 7.0.0 the automatic installation of `websocket-client` was removed. We require `websocket-client` in our tests as we test our websocket support there, however automatically updating docker to 7.0.0 (from 6.1.3) has removed this dependency for us.


<!-- What notable changes does this PR make? -->
## Changes

Explicitly install `websocket-client` in our `tests` extra


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

