### PR TITLE
Feat/cloudwatch v2 put composite alarm

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -606,9 +606,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
-    def test_put_composite_alarm_describe_alarms_converts_date_format_correctly(
-        self, aws_client, cleanups
-    ):
+    def test_put_composite_alarm_describe_alarms(self, aws_client, cleanups):
         composite_alarm_name = f"composite-a-{short_uid()}"
         alarm_name = f"a-{short_uid()}"
         metric_name = "something"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -605,7 +605,6 @@ class TestCloudwatch:
         assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
 
     @markers.aws.validated
-    @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
     def test_put_composite_alarm_describe_alarms(self, aws_client, cleanups):
         composite_alarm_name = f"composite-a-{short_uid()}"
         alarm_name = f"a-{short_uid()}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Get the new cloudwatch v2 provider more on par with the old one with composite alarms
<!-- What notable changes does this PR make? -->
## Changes
- Adds put_composite_alarm to the new provider in the same mock fashion as in the v1 provider
- changes test name (since the test didn't do what the name implied

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

