### PR TITLE
Fix secret rotation in secretsmanager

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -565,12 +565,8 @@ def backend_rotate_secret(
 
     try:
         lm_client = connect_to(region_name=self.region_name).lambda_
-        get_func_res = lm_client.get_function(FunctionName=rotation_lambda_arn)
+        lm_client.get_function(FunctionName=rotation_lambda_arn)
     except Exception:
-        # Fall through to ResourceNotFoundException.
-        pass
-    #
-    if not get_func_res:
         raise ResourceNotFoundException("Lambda does not exist or could not be accessed")
 
     secret = self.secrets[secret_id]
@@ -651,8 +647,8 @@ def backend_rotate_secret(
         except Exception:
             if pending_version:
                 raise pending_version.pop()
-            # Fall through so we'll "stuck" with a secret version in AWSPENDING state.
-            pass
+            # Fall through if there is no previously pending version so we'll "stuck" with a new
+            # secret version in AWSPENDING state.
 
     return secret.to_short_dict(version_id=new_version_id)
 

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -601,7 +601,8 @@ def backend_rotate_secret(
     secret.rotation_lambda_arn = rotation_lambda_arn
     secret.auto_rotate_after_days = rotation_rules.get(rotation_days, 0)
     if secret.auto_rotate_after_days > 0:
-        secret.next_rotation_date = int(time.time()) + (int(rotation_period) * 86400)
+        wait_interval_s = int(rotation_period) * 86400
+        secret.next_rotation_date = int(time.time()) + wait_interval_s
         secret.rotation_enabled = True
         secret.rotation_requested = True
 

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -514,6 +514,7 @@ def fake_secret_remove_version_stages_from_old_versions(fn, self, version_stages
         del self.versions[version_no_stages]
 
 
+# Moto does not support rotate_immediately as an API parameter while the AWS API does
 @patch(SecretsManagerResponse.rotate_secret, pass_target=False)
 def rotate_secret(self) -> str:
     client_request_token = self._get_param("ClientRequestToken")

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -645,8 +645,10 @@ def backend_rotate_secret(
                     ),
                 )
                 if resp.get("FunctionError"):
-                    raise Exception
-        except Exception:
+                    data = json.loads(resp.get("Payload").read())
+                    raise Exception(data.get("errorType"))
+        except Exception as e:
+            LOG.debug("An exception (%s) has occurred in %s", str(e), rotation_lambda_arn)
             if pending_version:
                 raise pending_version.pop()
             # Fall through if there is no previously pending version so we'll "stuck" with a new

--- a/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
+++ b/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
@@ -48,13 +48,15 @@ def handler(event, context):
     """
     # Client setup.
     region = os.environ["AWS_REGION"]
-    endpoint_url = (
-        os.environ.get("AWS_ENDPOINT_URL") or f"https://secretsmanager.{region}.amazonaws.com"
-    )
-    verify = urlparse(endpoint_url).scheme == "https"
-    service_client = boto3.client(
-        "secretsmanager", endpoint_url=endpoint_url, verify=verify, region_name=region
-    )
+    endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
+
+    if endpoint_url:
+        verify = urlparse(endpoint_url).scheme == "https"
+        service_client = boto3.client(
+            "secretsmanager", endpoint_url=endpoint_url, verify=verify, region_name=region
+        )
+    else:
+        service_client = boto3.client("secretsmanager", region_name=region)
 
     arn = event["SecretId"]
     token = event["ClientRequestToken"]

--- a/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
+++ b/tests/aws/services/secretsmanager/functions/lambda_rotate_secret.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from urllib.parse import urlparse
 
 import boto3
 
@@ -46,10 +47,13 @@ def handler(event, context):
 
     """
     # Client setup.
-    endpoint_url = os.environ["AWS_ENDPOINT_URL"]
     region = os.environ["AWS_REGION"]
+    endpoint_url = (
+        os.environ.get("AWS_ENDPOINT_URL") or f"https://secretsmanager.{region}.amazonaws.com"
+    )
+    verify = urlparse(endpoint_url).scheme == "https"
     service_client = boto3.client(
-        "secretsmanager", endpoint_url=endpoint_url, verify=False, region_name=region
+        "secretsmanager", endpoint_url=endpoint_url, verify=verify, region_name=region
     )
 
     arn = event["SecretId"]

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -20,6 +20,7 @@ from localstack.aws.api.secretsmanager import (
 )
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
+from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import select_from_typed_dict
@@ -348,6 +349,7 @@ class TestSecretsManager:
             Description="testing rotation of secrets",
         )
 
+        sm_snapshot.add_transformer(SortingTransformer("Versions", lambda x: x["CreatedDate"]))
         sm_snapshot.add_transformers_list(
             sm_snapshot.transform.secretsmanager_secret_id_arn(cre_res, 0)
         )
@@ -381,10 +383,6 @@ class TestSecretsManager:
 
         list_secret_versions_1 = aws_client.secretsmanager.list_secret_version_ids(
             SecretId=secret_name
-        )
-
-        list_secret_versions_1["Versions"] = sorted(
-            list_secret_versions_1["Versions"], key=lambda x: x["CreatedDate"]
         )
 
         sm_snapshot.match("list_secret_versions_rotated_1", list_secret_versions_1)

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -27,7 +27,6 @@ from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 from localstack.utils.time import today_no_time
-from tests.aws.services.secretsmanager.functions import lambda_rotate_secret
 
 LOG = logging.getLogger(__name__)
 
@@ -386,105 +385,6 @@ class TestSecretsManager:
         )
 
         sm_snapshot.match("list_secret_versions_rotated_1", list_secret_versions_1)
-
-    # TODO: validate against AWS, then check against new lambda provider
-    @pytest.mark.skipif(reason="needs lambda usage rework")
-    @markers.aws.unknown
-    def test_rotate_secret_with_lambda_2(
-        self, secret_name, create_lambda_function, create_secret, aws_client
-    ):
-        cre_res = create_secret(
-            Name=secret_name,
-            SecretString="init",
-            Description="testing rotation of secrets",
-        )
-        version_id_0 = cre_res["VersionId"]
-
-        function_name = f"rotate-func-{short_uid()}"
-        function_arn = create_lambda_function(
-            handler_file=TEST_LAMBDA_ROTATE_SECRET,
-            func_name=function_name,
-            runtime=Runtime.python3_9,
-        )["CreateFunctionResponse"]["FunctionArn"]
-
-        aws_client.lambda_.add_permission(
-            FunctionName=function_name,
-            StatementId="secretsManagerPermission",
-            Action="lambda:InvokeFunction",
-            Principal="secretsmanager.amazonaws.com",
-        )
-
-        rot_res = aws_client.secretsmanager.rotate_secret(
-            SecretId=secret_name,
-            RotationLambdaARN=function_arn,
-            RotationRules={
-                "AutomaticallyAfterDays": 1,
-            },
-            RotateImmediately=True,
-        )
-        version_id_1 = rot_res["VersionId"]
-        assert version_id_0 != version_id_1
-
-        # Assert secretsmanager promoted the creation of the new secret version by reporting resource not found
-        # exception on pending secret version.
-        sig_rnfe_1 = lambda_rotate_secret.secret_signal_resource_not_found_exception_on_create(
-            version_id_1
-        )
-        with pytest.raises(Exception):
-            get_sig_rnfe_1 = aws_client.secretsmanager.get_secret_value(SecretId=sig_rnfe_1)
-        assert get_sig_rnfe_1["Name"] == sig_rnfe_1
-        assert get_sig_rnfe_1["SecretString"] == sig_rnfe_1
-
-        des = aws_client.secretsmanager.describe_secret(SecretId=secret_name)
-        assert des["RotationEnabled"]
-        assert des["RotationRules"] == {"AutomaticallyAfterDays": 1}
-        assert des["RotationLambdaARN"] == function_arn
-
-        lst_res = aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_name)
-        versions = lst_res["Versions"]
-        assert len(versions) == 2
-
-        get_res_v0 = aws_client.secretsmanager.get_secret_value(
-            SecretId=secret_name, VersionId=version_id_0
-        )
-        assert get_res_v0["VersionId"] == version_id_0
-        assert get_res_v0["SecretString"] == "init"
-
-        get_res_v1 = aws_client.secretsmanager.get_secret_value(
-            SecretId=secret_name, VersionId=version_id_1
-        )
-        assert get_res_v1["VersionId"] == version_id_1
-        secret_string_1 = lambda_rotate_secret.secret_of_rotation_from_version_id(version_id_1)
-        assert get_res_v1["SecretString"] == secret_string_1
-
-        get_res = aws_client.secretsmanager.get_secret_value(SecretId=secret_name)
-        assert get_res["VersionId"] == version_id_1
-        assert get_res["SecretString"] == secret_string_1
-
-        rot_2_res = aws_client.secretsmanager.rotate_secret(
-            SecretId=secret_name,
-            RotationLambdaARN=function_arn,
-            RotationRules={
-                "AutomaticallyAfterDays": 1,
-            },
-            RotateImmediately=True,
-        )
-        version_id_2 = rot_2_res["VersionId"]
-        assert len({version_id_0, version_id_1, version_id_2}) == 3
-
-        # Assert secretsmanager promoted the creation of the new secret version by reporting resource not found
-        # exception on pending secret version.
-        sig_rnfe_2 = lambda_rotate_secret.secret_signal_resource_not_found_exception_on_create(
-            version_id_2
-        )
-        get_sig_rnfe_2 = aws_client.secretsmanager.get_secret_value(SecretId=sig_rnfe_2)
-        assert get_sig_rnfe_2["Name"] == sig_rnfe_2
-        assert get_sig_rnfe_2["SecretString"] == sig_rnfe_2
-
-        get_res = aws_client.secretsmanager.get_secret_value(SecretId=secret_name)
-        assert get_res["VersionId"] == version_id_2
-        secret_string_2 = lambda_rotate_secret.secret_of_rotation_from_version_id(version_id_2)
-        assert get_res["SecretString"] == secret_string_2
 
     @markers.aws.unknown
     def test_rotate_secret_invalid_lambda_arn(self, secret_name, aws_client):

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3685,5 +3685,51 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
+    "recorded-date": "19-12-2023, 13:20:04",
+    "recorded-content": {
+      "rotate_secret_immediately": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSCURRENT",
+              "AWSPENDING"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Secret rotation seemed to be completely broken.

<!-- What notable changes does this PR make? -->
## Changes
- added patch for response so immediate rotation is optional
- added logic to set/enable rotation but do not run immediately
- Lambda invokation happens via LS instead of moto using the user's previously created Lambda
- fixed AWSCURRENT and AWSPENDING tag on same secret version, which is pretty common (we were failing on it)
- calculating next rotation date now
- skipping other lambda steps in rotation if lambda returns an error 
- in progress rotation exception is delayed after lambda trigger so we can give a chance to the lambda function to fix the state, in AWS the runs are scheduled until tags are fixed
- smoke test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

