### PR TITLE
pin docker dependency to <7.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ base-runtime =
     cbor2>=5.2.0
     dnspython>=1.16.0
     # TODO tag incompatibility introduced in 7.0.0 with https://github.com/docker/docker-py/pull/3191
-    docker>=6.1.1<7.0.0
+    docker>=6.1.1,<7.0.0
     jsonpatch>=1.24,<2.0
     hypercorn>=0.14.4
     pyopenssl>=23.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,8 @@ base-runtime =
     botocore>=1.32.2,<1.32.6
     cbor2>=5.2.0
     dnspython>=1.16.0
-    docker>=6.1.1
+    # TODO tag incompatibility introduced in 7.0.0 with https://github.com/docker/docker-py/pull/3191
+    docker>=6.1.1<7.0.0
     jsonpatch>=1.24,<2.0
     hypercorn>=0.14.4
     pyopenssl>=23.0.0


### PR DESCRIPTION
## Motivation
It doesn't seem to break anything here yet but it technically could lead to the same kind of issues for users of community.

Recently the docker PyPI package was updated to 7.0.0 which started breaking integration tests in -ext with the following kind of exception:
```
docker.errors.DockerException: invalid tag 'localhost.localstack.cloud:4514/r-a9dfa6f4:latest': invalid reference format` anymore.
```

## Context

Change that was included in their `7.0.0` release: https://github.com/docker/docker-py/pull/3191

## Changes

- pin `docker` dependency to `<7.0.0` to avoid the breaking change for now until we know how to circumvent this


