### PR TITLE
Remove old basic snapshot transformer and exemptions

### DIFF
--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -17,7 +17,6 @@ from localstack.testing.snapshots.report import render_report
 from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.testing.snapshots.transformer_utility import (
     SNAPSHOT_BASIC_TRANSFORMER,
-    SNAPSHOT_BASIC_TRANSFORMER_NEW,
 )
 from localstack.utils.bootstrap import is_api_enabled
 
@@ -126,40 +125,7 @@ def _snapshot_session(request: SubRequest, account_id, region):
     sm.add_transformer(RegexTransformer(account_id, "1" * 12), priority=2)
     sm.add_transformer(RegexTransformer(region, "<region>"), priority=2)
 
-    # TODO: temporary to migrate to new default transformers.
-    #   remove this after all exemptions are gone
-    exemptions = [
-        "tests/aws/services/acm",
-        "tests/aws/services/apigateway",
-        "tests/aws/services/cloudwatch",
-        "tests/aws/services/cloudformation",
-        "tests/aws/services/dynamodb",
-        "tests/aws/services/events",
-        "tests/aws/services/iam",
-        "tests/aws/services/kinesis",
-        "tests/aws/services/kms",
-        "tests/aws/services/lambda_",
-        "tests/aws/services/logs",
-        "tests/aws/services/route53",
-        "tests/aws/services/route53resolver",
-        "tests/aws/services/s3",
-        "tests/aws/services/secretsmanager",
-        "tests/aws/services/ses",
-        "tests/aws/services/sns",
-        "tests/aws/services/stepfunctions",
-        "tests/aws/services/sqs",
-        "tests/aws/services/transcribe",
-        "tests/aws/scenario/bookstore",
-        "tests/aws/scenario/note_taking",
-        "tests/aws/scenario/lambda_destination",
-        "tests/aws/scenario/loan_broker",
-        "localstack_ext",
-        "localstack-ext",
-    ]
-    if any([e in request.fspath.dirname for e in exemptions]):
-        sm.add_transformer(SNAPSHOT_BASIC_TRANSFORMER, priority=2)
-    else:
-        sm.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=2)
+    sm.add_transformer(SNAPSHOT_BASIC_TRANSFORMER, priority=2)
 
     yield sm
 

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -1,14 +1,12 @@
 import json
 import logging
 import re
-from datetime import datetime
 from json import JSONDecodeError
 from typing import Optional, Pattern
 
 from localstack.aws.api.secretsmanager import CreateSecretResponse
 from localstack.aws.api.stepfunctions import CreateStateMachineOutput, LongArn, StartExecutionOutput
 from localstack.testing.snapshots.transformer import (
-    PATTERN_ISO8601,
     JsonpathTransformer,
     KeyValueBasedTransformer,
     RegexTransformer,
@@ -748,19 +746,6 @@ def _change_set_id_transformer(key: str, val: str) -> str:
 
 # TODO maybe move to a different place?
 # Basic Transformation - added automatically to each snapshot (in the fixture)
-SNAPSHOT_BASIC_TRANSFORMER_NEW = [
-    ResponseMetaDataTransformer(),
-    KeyValueBasedTransformer(
-        lambda k, v: (
-            v
-            if (isinstance(v, str) and k.lower().endswith("id") and re.match(PATTERN_UUID, v))
-            else None
-        ),
-        "uuid",
-    ),
-    TimestampTransformer(),
-]
-
 SNAPSHOT_BASIC_TRANSFORMER = [
     ResponseMetaDataTransformer(),
     KeyValueBasedTransformer(
@@ -771,19 +756,5 @@ SNAPSHOT_BASIC_TRANSFORMER = [
         ),
         "uuid",
     ),
-    RegexTransformer(PATTERN_ISO8601, "date"),
-    KeyValueBasedTransformer(
-        lambda k, v: (v if isinstance(v, datetime) else None), "datetime", replace_reference=False
-    ),
-    KeyValueBasedTransformer(
-        lambda k, v: str(v)
-        if (
-            re.compile(r"^.*timestamp.*$", flags=re.IGNORECASE).match(k)
-            or k in ("creationTime", "ingestionTime")
-        )
-        and not PATTERN_ISO8601.match(str(v))
-        else None,
-        "timestamp",
-        replace_reference=False,
-    ),
+    TimestampTransformer(),
 ]


### PR DESCRIPTION

## Motivation

Follow-up to https://github.com/localstack/localstack/pull/9772 which introduced an exemption list with paths that are still using the old transformer. This PR can't be merged yet since it will have a lot of CI failures. It should stay open until other PRs have regenerated/fixed the issues in the specific services. Until then it can be rebased and re-run to get an overview of all currently detected issues.

## Changes

- Remove old basis snapshot transformer list & exemption paths

