### PR TITLE
Add flag to disable kinesis-mock persistence

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -769,6 +769,7 @@ LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 
 # limit in which to kinesis-mock will start throwing exceptions
 KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
+KINESIS_PERSISTENCE = is_env_not_false("KINESIS_PERSISTENCE")
 
 # limit in which to kinesis-mock will start throwing exceptions
 KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = (
@@ -1106,6 +1107,7 @@ CONFIG_ENV_VARS = [
     "KINESIS_MOCK_PERSIST_INTERVAL",
     "KINESIS_MOCK_LOG_LEVEL",
     "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT",
+    "KINESIS_PERSISTENCE",
     "LAMBDA_DISABLE_AWS_ENDPOINT_URL",
     "LAMBDA_DOCKER_DNS",
     "LAMBDA_DOCKER_FLAGS",

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -84,7 +84,7 @@ class KinesisMockServer(Server):
         for param in latency_params:
             env_vars[param] = self._latency
 
-        if self._data_dir:
+        if self._data_dir and config.KINESIS_PERSISTENCE:
             env_vars["SHOULD_PERSIST_DATA"] = "true"
             # FIXME use relative path to current working directory until
             #  https://github.com/etspaceman/kinesis-mock/issues/554 is resolved


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With recent kinesis performance tests, we have seen a significant performance degradation up to an out-of-memory error of kinesis-mock, especially when pushing over 50 entries with the maximum payload of 1024KB to a stream.
This behavior is way worse when the persistence is enabled when starting kinesis-mock. For now, to fix it for users not needing persistence, we need a flag to disable it.

In the future, we need to spend some work on increasing the performance and memory usage of the persistence of our kinesis implementation.

<!-- What notable changes does this PR make? -->
## Changes
- Add flag to disable the persistence mechanism for kinesis, which is currently active regardless of cloud pods or persistence being used on the localstack level.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

