### PR TITLE
Allow merging of config profiles

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -867,9 +867,9 @@ def print_version() -> None:
 
 
 def print_profile() -> None:
-    if config.LOADED_PROFILE:
+    if config.LOADED_PROFILES:
         console.print(
-            f" :bust_in_silhouette: [bold]Profile:[/bold] [blue]{config.LOADED_PROFILE}[/blue]"
+            f" :bust_in_silhouette: [bold]Profile:[/bold] [blue]{', '.join(config.LOADED_PROFILES)}[/blue]"
         )
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -249,7 +249,7 @@ def load_environment(profiles: str = None, env=os.environ) -> List[str]:
         if not os.path.exists(path):
             print(f"Profile '{profile}' specified, but file {path} not found.")
             continue
-        environment |= dotenv.dotenv_values(path)
+        environment.update(dotenv.dotenv_values(path))
 
     for k, v in environment.items():
         # we do not want to override the environment

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -230,22 +230,33 @@ def is_env_not_false(env_var_name: str) -> bool:
     return os.environ.get(env_var_name, "").lower().strip() not in FALSE_STRINGS
 
 
-def load_environment(profile: str = None) -> Optional[str]:
-    """Loads the environment variables from ~/.localstack/{profile}.env
-    :param profile: the profile to load (defaults to "default")
-    :returns str: the name of the actually loaded profile (might be the fallback)
+def load_environment(profiles: str = None, env=os.environ) -> List[str]:
+    """Loads the environment variables from ~/.localstack/{profile}.env, for each profile listed in the profiles.
+    :param env: environment to load profile to. Defaults to `os.environ`
+    :param profiles: a comma separated list of profiles to load (defaults to "default")
+    :returns str: the list of the actually loaded profiles (might be the fallback)
     """
-    if not profile:
-        profile = "default"
+    if not profiles:
+        profiles = "default"
 
-    path = os.path.join(CONFIG_DIR, f"{profile}.env")
-    if not os.path.exists(path):
-        return None
-
+    profiles = profiles.split(",")
+    environment = {}
     import dotenv
 
-    dotenv.load_dotenv(path, override=False)
-    return profile
+    for profile in profiles:
+        profile = profile.strip()
+        path = os.path.join(CONFIG_DIR, f"{profile}.env")
+        if not os.path.exists(path):
+            print(f"Profile '{profile}' specified, but file {path} not found.")
+            continue
+        environment |= dotenv.dotenv_values(path)
+
+    for k, v in environment.items():
+        # we do not want to override the environment
+        if k not in env and v is not None:
+            env[k] = v
+
+    return profiles
 
 
 def is_persistence_enabled() -> bool:
@@ -371,10 +382,10 @@ CONFIG_DIR = os.environ.get("CONFIG_DIR", os.path.expanduser("~/.localstack"))
 # keep this on top to populate environment
 try:
     # CLI specific: the actually loaded configuration profile
-    LOADED_PROFILE = load_environment(CONFIG_PROFILE)
+    LOADED_PROFILES = load_environment(CONFIG_PROFILE)
 except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
-    LOADED_PROFILE = None
+    LOADED_PROFILES = None
 
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are often utilizing config profiles for our testing setups. However, those need quite some duplication for common variables.
This PR will introduce the ability to specify multiple config profiles, which are all loaded.

## Usage
Use a comma separated list of config profiles for the `CONFIG_PROFILE` environment variable.

```
CONFIG_PROFILE=profile1,profile2
```

Identically named environment variables specified in earlier profiles will be overridden by those in later profiles.
Configuration profiles will never override environment variables already set.

If profile1.env looks like this:

```
VAR1=test1
VAR2=test2
VAR3=test3
```

and profile2.env looks like this:

```
VAR3=override3
VAR4=test4
```

the finally set variables will look like this:

```
VAR1=test1
VAR2=test2
VAR3=override3
VAR4=test4
```

<!-- What notable changes does this PR make? -->
## Changes
* Add option to add multiple config profiles
* Add tests

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

