### PR TITLE
fix S3 service name parsing consuming the stream

### DIFF
--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -30,6 +30,12 @@ class ServiceNameParser(Handler):
     """
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        # Some early handlers can already determine the AWS service the request is directed to (the S3 CORS handler for
+        # example). If it is already set, we can skip the parsing of the request. It is very important for S3, because
+        # parsing the request will consume the data stream and prevent streaming.
+        if context.service:
+            return
+
         service = determine_aws_service_name(context.request)
 
         if not service:

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -401,7 +401,12 @@ def determine_aws_service_name(request: Request, services: ServiceCatalog = None
             candidates.update(query_candidates)
 
     except RequestEntityTooLarge:
-        LOG.debug("Failed to parse the form while determining AWS service name")
+        # Some requests can be form-urlencoded but also contain binary data, which will fail the form parsing (S3 can
+        # do this). In that case, skip this step and continue to try to determine the service name.
+        LOG.debug(
+            "Failed to parse the form while determining AWS service name",
+            exc_info=LOG.isEnabledFor(logging.DEBUG),
+        )
         pass
 
     # 6. resolve service spec conflicts

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -402,12 +402,12 @@ def determine_aws_service_name(request: Request, services: ServiceCatalog = None
 
     except RequestEntityTooLarge:
         # Some requests can be form-urlencoded but also contain binary data, which will fail the form parsing (S3 can
-        # do this). In that case, skip this step and continue to try to determine the service name.
+        # do this). In that case, skip this step and continue to try to determine the service name. The exception is
+        # RequestEntityTooLarge even if the error is due to failed decoding.
         LOG.debug(
-            "Failed to parse the form while determining AWS service name",
+            "Failed to determine AWS service from request body because the form could not be parsed",
             exc_info=LOG.isEnabledFor(logging.DEBUG),
         )
-        pass
 
     # 6. resolve service spec conflicts
     resolved_conflict = resolve_conflicts(candidates, request)

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -3,6 +3,7 @@ import os
 from typing import NamedTuple, Optional, Set
 
 import botocore
+from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.http import parse_dict_header
 
 import localstack
@@ -374,29 +375,34 @@ def determine_aws_service_name(request: Request, services: ServiceCatalog = None
         return None
 
     # 5. check the query / form-data
-    values = request.values
-    if "Action" in values:
-        # query / ec2 protocol requests always have an action and a version (the action is more significant)
-        query_candidates = [
-            service
-            for service in services.by_operation(values["Action"])
-            if services.get(service).protocol in ("ec2", "query")
-        ]
+    try:
+        values = request.values
+        if "Action" in values:
+            # query / ec2 protocol requests always have an action and a version (the action is more significant)
+            query_candidates = [
+                service
+                for service in services.by_operation(values["Action"])
+                if services.get(service).protocol in ("ec2", "query")
+            ]
 
-        if len(query_candidates) == 1:
-            return query_candidates[0]
+            if len(query_candidates) == 1:
+                return query_candidates[0]
 
-        if "Version" in values:
-            for service in list(query_candidates):
-                service_model = services.get(service)
-                if values["Version"] != service_model.api_version:
-                    # the combination of Version and Action is not unique, add matches to the candidates
-                    query_candidates.remove(service)
+            if "Version" in values:
+                for service in list(query_candidates):
+                    service_model = services.get(service)
+                    if values["Version"] != service_model.api_version:
+                        # the combination of Version and Action is not unique, add matches to the candidates
+                        query_candidates.remove(service)
 
-        if len(query_candidates) == 1:
-            return query_candidates[0]
+            if len(query_candidates) == 1:
+                return query_candidates[0]
 
-        candidates.update(query_candidates)
+            candidates.update(query_candidates)
+
+    except RequestEntityTooLarge:
+        LOG.debug("Failed to parse the form while determining AWS service name")
+        pass
 
     # 6. resolve service spec conflicts
     resolved_conflict = resolve_conflicts(candidates, request)

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -5542,6 +5542,28 @@ class TestS3:
         response = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
         snapshot.match("list-obj-after-empty", response)
 
+    @markers.aws.only_localstack
+    def test_s3_raw_request_routing(self, s3_bucket, aws_client):
+        """
+        When sending a PutObject request to S3 with a very raw request not having any indication that the request is
+        directed to S3 (no signing, no specific S3 endpoint) and encoded as a form, the request will go through the
+        ServiceNameParser handler.
+        This parser will try to parse the form data (which in our case is binary data), and will fail with a decoding
+        error. It also consumes the stream, and leaves S3 with no data to save.
+        This test verifies that this scenario works by skipping the service name thanks to the early S3 CORS handler.
+        """
+        default_endpoint = f"http://{get_localstack_host().host_and_port()}"
+        object_key = "test-routing-key"
+        key_url = f"{default_endpoint}/{s3_bucket}/{object_key}"
+        data = os.urandom(445529)
+        resp = requests.put(
+            key_url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+        )
+        assert resp.ok
+
+        get_object = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key)
+        assert get_object["Body"].read() == data
+
 
 class TestS3MultiAccounts:
     @pytest.fixture

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -5564,6 +5564,12 @@ class TestS3:
         get_object = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key)
         assert get_object["Body"].read() == data
 
+        fake_key_url = f"{default_endpoint}/fake-bucket-{short_uid()}/{object_key}"
+        resp = requests.put(
+            fake_key_url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+        )
+        assert b"NoSuchBucket" in resp.content
+
 
 class TestS3MultiAccounts:
     @pytest.fixture

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -5543,6 +5543,10 @@ class TestS3:
         snapshot.match("list-obj-after-empty", response)
 
     @markers.aws.only_localstack
+    @pytest.mark.xfail(
+        condition=LEGACY_V2_S3_PROVIDER,
+        reason="Moto parsing fails on the form",
+    )
     def test_s3_raw_request_routing(self, s3_bucket, aws_client):
         """
         When sending a PutObject request to S3 with a very raw request not having any indication that the request is


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9867, we have an issue when using S3 pre-signed URL from a browser encoding the request as `application/x-www-form-urlencoded` and targeting a default LocalStack endpoint and not the S3 specific one. The `ServiceNameParser` will try to determine the AWS service, and as S3 is the "fallback" service, it will go through the whole service detection, which includes accessing `request.values`. This will:
- consume the stream
- if you send binary data, as the request is form encoded, Werkzeug will try to parse the form and fail decoding it as `utf-8`. 
```python
Traceback (most recent call last):
  File "/Users/benjaminsimon/Projects/localstack/localstack-ext/.venv/lib/python3.11/site-packages/werkzeug/formparser.py", line 284, in _parse_urlencoded
    stream.read().decode(),
    ^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa6 in position 0: invalid start byte
```
<!-- What notable changes does this PR make? -->
## Changes
When targeting S3, we have an early handler trying to determine if the request is targeting S3 by checking the bucket name and verifies that it exists. This will allow to actually skip the service name parsing, as we already set the service in the context there.

We also need to have the form parsing around a `try...exception` block in case the bucket does not exist, because the S3 CORS handler will not mark it as an S3 request, and the decoding of the form will fail. We will just swallow the exception and pass so that the service name parser tries the next step. This does not matter that it consumes the stream, because it will lead in an exception anyway. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

