### PR TITLE
test get-metric-data with no unit

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1657,6 +1657,35 @@
       }
     }
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data0]": {
+    "recorded-date": "15-12-2023, 08:58:39",
+    "recorded-content": {
+      "get_metric_data_with_no_unit_specified": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "m1",
+            "Label": "m-test",
+            "Messages": [
+              {
+                "Code": "MultipleUnits",
+                "Value": "Multiple units returned: '[Milliseconds, Seconds]'"
+              }
+            ],
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              60000.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs0]": {
     "recorded-date": "15-12-2023, 11:27:23",
     "recorded-content": {
@@ -1721,6 +1750,36 @@
       }
     }
   },
+
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data1]": {
+    "recorded-date": "15-12-2023, 08:58:42",
+    "recorded-content": {
+      "get_metric_data_with_no_unit_specified": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "m1",
+            "Label": "m-test",
+            "Messages": [
+              {
+                "Code": "MultipleUnits",
+                "Value": "Multiple units returned: '[Milliseconds, Seconds]'"
+              }
+            ],
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              120000.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs2]": {
     "recorded-date": "15-12-2023, 11:27:27",
     "recorded-content": {
@@ -1743,6 +1802,35 @@
             "Timestamps": "timestamp",
             "Values": [
               109.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data2]": {
+    "recorded-date": "15-12-2023, 08:58:44",
+    "recorded-content": {
+      "get_metric_data_with_no_unit_specified": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "m1",
+            "Label": "m-test",
+            "Messages": [
+              {
+                "Code": "MultipleUnits",
+                "Value": "Multiple units returned: '[Count, Milliseconds, Seconds]'"
+              }
+            ],
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              5.0
             ]
           }
         ],

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -20,6 +20,15 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data0]": {
+    "last_validated_date": "2024-01-11T11:07:38+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data1]": {
+    "last_validated_date": "2024-01-11T11:07:41+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data2]": {
+    "last_validated_date": "2024-01-11T11:07:43+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
     "last_validated_date": "2024-01-10T15:29:50+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims at checking what happens when multiple units are present in the cloudwatch database, then no unit is specified in the get-metrics-data call.
The result is that this seems to be not as described [in the docs](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/get-metric-data.html):
```
In a Get operation, if you omit Unit then all data that was collected with any unit is returned,
along with the corresponding units that were specified when the data was reported to CloudWatch.
If you specify a unit, the operation returns only data that was collected with that unit specified.
If you specify a unit that does not match the data collected, the results of the operation are null.
CloudWatch does not perform unit conversions.
```
AWS however acts differently with a given statistic: When multiple Units are present, AWS seems to simply pick the one that comes "first" in the list of allowed Units, then exclusively operates on values of that unit for calculating the statistic. This list seems to be the following (this was returned when specifying a unit not present here)
```
[Megabits, Terabits, Gigabits, Count, Bytes, Gigabytes, Gigabytes / Second, Kilobytes, Kilobits / Second,
Terabytes, Terabits/Second, Bytes/Second, Percent, Megabytes, Megabits/Second, Milliseconds, Microseconds,
Kilobytes/Second, Gigabits/Second, Megabytes/Second, Bits, Bits/Second, Count/Second, Seconds, Kilobits,
Terabytes/Second, None ].
``` 
A message is then added to the response stating that multiple units were found.

<!-- What notable changes does this PR make? -->
## Changes
Adds test for:
- 2 units, 1 value each
- 2 units, 2 values each
- as before, but with a new unit that comes "prior" to the others in the list


## TODO

What's left to do:

- [ ] Clarify how to proceed. This requires some adjustment in the query code. /cc @steffyP 


