### PR TITLE
Add support for partial ARNs for EventSourceMappings and fix AWS::Lambda::Version state check

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -30,7 +30,10 @@ from localstack.services.lambda_.runtimes import (
     ALL_RUNTIMES,
     SNAP_START_SUPPORTED_RUNTIMES,
 )
-from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active
+from localstack.testing.aws.lambda_utils import (
+    _await_dynamodb_table_active,
+    _await_event_source_mapping_enabled,
+)
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer import SortingTransformer
@@ -4325,9 +4328,64 @@ class TestLambdaEventSourceMappings:
         # lambda_client.delete_event_source_mapping(UUID=uuid)
 
     @markers.aws.validated
+    def test_function_name_variations(
+        self,
+        create_lambda_function,
+        snapshot,
+        sqs_create_queue,
+        cleanups,
+        lambda_su_role,
+        aws_client,
+    ):
+        function_name = f"lambda_func-{short_uid()}"
+
+        queue_url = sqs_create_queue()
+        queue_arn = aws_client.sqs.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+            role=lambda_su_role,
+        )
+
+        # create version & alias pointing to the version
+        v1 = aws_client.lambda_.publish_version(FunctionName=function_name)
+        alias = aws_client.lambda_.create_alias(
+            FunctionName=function_name, FunctionVersion=v1["Version"], Name="myalias"
+        )
+        fn = aws_client.lambda_.get_function(FunctionName=function_name)
+
+        def _create_esm(snapshot_scope: str, tested_name: str):
+            result = aws_client.lambda_.create_event_source_mapping(
+                FunctionName=tested_name,
+                EventSourceArn=queue_arn,
+            )
+            cleanups.append(
+                lambda: aws_client.lambda_.delete_event_source_mapping(UUID=result["UUID"])
+            )
+            snapshot.match(f"{snapshot_scope}_create_esm", result)
+            _await_event_source_mapping_enabled(aws_client.lambda_, result["UUID"])
+            aws_client.lambda_.delete_event_source_mapping(UUID=result["UUID"])
+
+        _create_esm("name_only", function_name)
+        _create_esm("partial_arn_latest", f"{function_name}:$LATEST")
+        _create_esm("partial_arn_version", f"{function_name}:{v1['Version']}")
+        _create_esm("partial_arn_alias", f"{function_name}:{alias['Name']}")
+        _create_esm("full_arn_latest", fn["Configuration"]["FunctionArn"])
+        _create_esm("full_arn_version", v1["FunctionArn"])
+        _create_esm("full_arn_alias", alias["AliasArn"])
+
+    # def test_multiple_esm_conflict(self):
+    # E           botocore.errorfactory.ResourceConflictException: An error occurred (ResourceConflictException) when calling the CreateEventSourceMapping operation: An event source mapping with SQS arn (" ...") and function (" ...") already exists. Please update or delete the existing mapping with UUID b0d2651a-52ea-4e9f-80f9-fa7f9fdf4d64
+
+    @markers.aws.validated
     def test_create_event_source_validation(
         self, create_lambda_function, lambda_su_role, dynamodb_create_table, snapshot, aws_client
     ):
+        """missing required field for DynamoDb stream event source mapping"""
         function_name = f"function-{short_uid()}"
         create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON_ECHO,

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4378,9 +4378,6 @@ class TestLambdaEventSourceMappings:
         _create_esm("full_arn_version", v1["FunctionArn"])
         _create_esm("full_arn_alias", alias["AliasArn"])
 
-    # def test_multiple_esm_conflict(self):
-    # E           botocore.errorfactory.ResourceConflictException: An error occurred (ResourceConflictException) when calling the CreateEventSourceMapping operation: An event source mapping with SQS arn (" ...") and function (" ...") already exists. Please update or delete the existing mapping with UUID b0d2651a-52ea-4e9f-80f9-fa7f9fdf4d64
-
     @markers.aws.validated
     def test_create_event_source_validation(
         self, create_lambda_function, lambda_su_role, dynamodb_create_table, snapshot, aws_client

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13520,5 +13520,115 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_function_name_variations": {
+    "recorded-date": "15-12-2023, 10:58:47",
+    "recorded-content": {
+      "name_only_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "partial_arn_latest_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "partial_arn_version_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:1",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "partial_arn_alias_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:myalias",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:4>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "full_arn_latest_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:5>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "full_arn_version_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:1",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:6>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "full_arn_alias_create_esm": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:myalias",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:7>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation

Investigation started due to a bug report that turned out to not actually be a bug (Select/ Join intrinsic functions).

At its core it was trying to create an `AWS::Lambda::EventSourceMapping` resource targeting a partial ARN like `<function_name>:live` which we didn't properly handle in the underlying `CreateEventSourceMapping` handler in the lambda API provider.

## Changes

- Adds a test which creates event source mappings with different structures for the `FunctionName` parameter.
- Add support for partial ARNs and other edge cases in `CreateEventSourceMapping`
- Fix `create` handler for `AWS::Lambda::Version` to properly wait for the function version to be active (cc @Morijarti ). This was causing flakes and is a regression introduced in the migration from the old to the new CFn providers.


