### PR TITLE
Feat/cloudwatch v2 fix labels

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -298,10 +298,6 @@ class TestCloudwatch:
                 assert len(data_metric["Values"]) == 0
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"],
-        condition=is_new_provider,
-    )
     def test_get_metric_data_for_multiple_metrics(self, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.cloudwatch_api())
         utc_now = datetime.now(tz=timezone.utc)
@@ -389,9 +385,6 @@ class TestCloudwatch:
         "stat",
         ["Sum", "SampleCount", "Minimum", "Maximum", "Average"],
     )
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"], condition=is_new_provider
-    )
     def test_get_metric_data_stats(self, aws_client, snapshot, stat):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -448,9 +441,6 @@ class TestCloudwatch:
         retry(assert_results, retries=10, sleep_before=sleep_before)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"], condition=is_new_provider
-    )
     def test_get_metric_data_with_dimensions(self, aws_client, snapshot):
         utc_now = datetime.now(tz=timezone.utc)
         namespace = f"test/{short_uid()}"
@@ -2013,9 +2003,6 @@ class TestCloudwatch:
         retry(assert_results, retries=retries, sleep=1.0, sleep_before=sleep_before)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=["$..MetricDataResults..Label"], condition=is_new_provider
-    )
     def test_get_metric_data_with_different_units(self, aws_client, snapshot):
         namespace = f"n-sp-{short_uid()}"
         metric_name = "m-test"
@@ -2063,6 +2050,63 @@ class TestCloudwatch:
         retries = 10 if is_aws_cloud() else 1
         sleep_before = 2 if is_aws_cloud() else 0.0
         retry(assert_results, retries=retries, sleep=1.0, sleep_before=sleep_before)
+
+    @pytest.mark.parametrize(
+        "input_pairs",
+        [
+            [("Sum", 60, "Seconds"), ("Minimum", 30, "Seconds")],
+            [("Sum", 60, "Seconds"), ("Minimum", 60, "Seconds")],
+            [("Sum", 60, "Seconds"), ("Sum", 30, "Seconds")],
+            [("Sum", 60, "Seconds"), ("Minimum", 30, "Milliseconds")],
+            [("Sum", 60, "Seconds"), ("Minimum", 60, "Milliseconds")],
+            [("Sum", 60, "Seconds"), ("Sum", 30, "Milliseconds")],
+            [("Sum", 60, "Seconds"), ("Sum", 60, "Milliseconds")],
+        ],
+    )
+    @markers.aws.validated
+    def test_label_generation(self, aws_client, snapshot, input_pairs):
+        # Whenever values differ for a statistic type or period, that value is added to the label
+        utc_now = datetime.now(tz=timezone.utc)
+
+        namespace1 = f"test/{short_uid()}"
+        # put metric data
+        values = [0, 2, 7, 100]
+        aws_client.cloudwatch.put_metric_data(
+            Namespace=namespace1,
+            MetricData=[
+                {"MetricName": "metric1", "Value": val, "Unit": "Seconds"} for val in values
+            ],
+        )
+        # get_metric_data
+
+        def _get_metric_data():
+            return aws_client.cloudwatch.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        "Id": f"result_{stat}_{str(period)}_{unit}",
+                        "MetricStat": {
+                            "Metric": {"Namespace": namespace1, "MetricName": "metric1"},
+                            "Period": period,
+                            "Stat": stat,
+                            "Unit": unit,
+                        },
+                    }
+                    for (stat, period, unit) in input_pairs
+                ],
+                StartTime=utc_now - timedelta(seconds=60),
+                EndTime=utc_now + timedelta(seconds=60),
+            )
+
+        def _match_results():
+            response = _get_metric_data()
+            # keep one assert to avoid storing incorrect values
+            sum = [
+                res for res in response["MetricDataResults"] if res["Id"].startswith("result_Sum")
+            ][0]
+            assert [int(val) for val in sum["Values"]] == [109]
+            snapshot.match("label_generation", response)
+
+        retry(_match_results, retries=10, sleep=1.0)
 
 
 def _check_alarm_triggered(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2064,6 +2064,7 @@ class TestCloudwatch:
         ],
     )
     @markers.aws.validated
+    @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     def test_label_generation(self, aws_client, snapshot, input_pairs):
         # Whenever values differ for a statistic type or period, that value is added to the label
         utc_now = datetime.now(tz=timezone.utc)

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1608,5 +1608,221 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs0]": {
+    "recorded-date": "15-12-2023, 11:27:23",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 Sum 60",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Minimum_30_Seconds",
+            "Label": "metric1 Minimum 30",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              0.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs1]": {
+    "recorded-date": "15-12-2023, 11:27:25",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 Sum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Minimum_60_Seconds",
+            "Label": "metric1 Minimum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              0.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs2]": {
+    "recorded-date": "15-12-2023, 11:27:27",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 60",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Sum_30_Seconds",
+            "Label": "metric1 30",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs3]": {
+    "recorded-date": "15-12-2023, 11:27:29",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 Sum 60",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Minimum_30_Milliseconds",
+            "Label": "metric1 Minimum 30",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs4]": {
+    "recorded-date": "15-12-2023, 11:27:31",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 Sum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Minimum_60_Milliseconds",
+            "Label": "metric1 Minimum",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs5]": {
+    "recorded-date": "15-12-2023, 11:27:33",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1 60",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Sum_30_Milliseconds",
+            "Label": "metric1 30",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_label_generation[input_pairs6]": {
+    "recorded-date": "15-12-2023, 11:27:35",
+    "recorded-content": {
+      "label_generation": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result_Sum_60_Seconds",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              109.0
+            ]
+          },
+          {
+            "Id": "result_Sum_60_Milliseconds",
+            "Label": "metric1",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes the label generation in the new cloudwatch provider. It seems to be the case that for certain parameters, whenever we have multiple queries in a `get_metric_data` call that have different values for these parameters (like "sum" and "average" for Stat or "30" and "60" for Period) the values are added to the label.

<!-- What notable changes does this PR make? -->
## Changes
- fixes the label generation in the provider
- adds 7way parametrized test to make sure label generation behaves as expect

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

