### PR TITLE
Allow kinesis get_records shard iterator to have surrounding quotes

### DIFF
--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -413,6 +413,24 @@ class TestKinesis:
         assert shard_iterator != get_records_response["NextShardIterator"]
         assert new_shard_iterator != get_records_response["NextShardIterator"]
 
+    @markers.aws.validated
+    def test_get_records_shard_iterator_with_surrounding_quotes(
+        self, kinesis_create_stream, wait_for_stream_ready, aws_client
+    ):
+        stream_name = kinesis_create_stream(ShardCount=1)
+        wait_for_stream_ready(stream_name)
+
+        first_stream_shard_data = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["Shards"][0]
+        shard_id = first_stream_shard_data["ShardId"]
+
+        shard_iterator = aws_client.kinesis.get_shard_iterator(
+            StreamName=stream_name, ShardIteratorType="LATEST", ShardId=shard_id
+        )["ShardIterator"]
+
+        aws_client.kinesis.get_records(ShardIterator=f'"{shard_iterator}"')
+
 
 @pytest.fixture
 def wait_for_consumer_ready(aws_client):

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -420,16 +420,20 @@ class TestKinesis:
         stream_name = kinesis_create_stream(ShardCount=1)
         wait_for_stream_ready(stream_name)
 
+        aws_client.kinesis.put_records(
+            StreamName=stream_name, Records=[{"Data": b"Hello world", "PartitionKey": "1"}]
+        )
+
         first_stream_shard_data = aws_client.kinesis.describe_stream(StreamName=stream_name)[
             "StreamDescription"
         ]["Shards"][0]
         shard_id = first_stream_shard_data["ShardId"]
 
         shard_iterator = aws_client.kinesis.get_shard_iterator(
-            StreamName=stream_name, ShardIteratorType="LATEST", ShardId=shard_id
+            StreamName=stream_name, ShardIteratorType="TRIM_HORIZON", ShardId=shard_id
         )["ShardIterator"]
 
-        aws_client.kinesis.get_records(ShardIterator=f'"{shard_iterator}"')
+        assert aws_client.kinesis.get_records(ShardIterator=f'"{shard_iterator}"')["Records"]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Using the AWS CLI, it is easily accomplished to have surrounding double quotes around the Shard Iterator of the `get_records` request.

Even though this is not technically correct, both the CLI and AWS allow this.

This PR will add a test for the behavior on LS side

Kinesis-mock issue: etspaceman/kinesis-mock#682
Upstream PR: etspaceman/kinesis-mock#689

<!-- What notable changes does this PR make? -->
## Changes
* Add test for double quotes within shard iterator

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

