### PR TITLE
Fix: Route53 populating VPC fields

### DIFF
--- a/localstack/services/route53/provider.py
+++ b/localstack/services/route53/provider.py
@@ -39,7 +39,7 @@ class Route53Provider(Route53Api, ServiceLifecycleHook):
         response = call_moto(context)
 
         # moto does not populate the VPC struct of the response if creating a private hosted zone
-        if hosted_zone_config.get("PrivateZone", False):
+        if hosted_zone_config and hosted_zone_config.get("PrivateZone", False):
             response["VPC"]["VPCId"] = response["VPC"]["VPCId"] or vpc["VPCId"]
             response["VPC"]["VPCRegion"] = response["VPC"]["VPCRegion"] or vpc["VPCRegion"]
 

--- a/localstack/services/route53/provider.py
+++ b/localstack/services/route53/provider.py
@@ -6,21 +6,45 @@ from moto.route53.models import route53_backends
 
 from localstack.aws.api import RequestContext
 from localstack.aws.api.route53 import (
+    VPC,
     ChangeInfo,
     ChangeStatus,
+    CreateHostedZoneResponse,
     DeleteHealthCheckResponse,
+    DNSName,
     GetChangeResponse,
     GetHealthCheckResponse,
     HealthCheck,
     HealthCheckId,
+    HostedZoneConfig,
+    Nonce,
     NoSuchHealthCheck,
     ResourceId,
     Route53Api,
 )
+from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 
 
 class Route53Provider(Route53Api, ServiceLifecycleHook):
+    def create_hosted_zone(
+        self,
+        context: RequestContext,
+        name: DNSName,
+        caller_reference: Nonce,
+        vpc: VPC = None,
+        hosted_zone_config: HostedZoneConfig = None,
+        delegation_set_id: ResourceId = None,
+    ) -> CreateHostedZoneResponse:
+        response = call_moto(context)
+
+        # moto does not populate the VPC struct of the response if creating a private hosted zone
+        if hosted_zone_config.get("PrivateZone", False):
+            response["VPC"]["VPCId"] = response["VPC"]["VPCId"] or vpc["VPCId"]
+            response["VPC"]["VPCRegion"] = response["VPC"]["VPCRegion"] or vpc["VPCRegion"]
+
+        return response
+
     def get_change(self, context: RequestContext, id: ResourceId) -> GetChangeResponse:
         change_info = ChangeInfo(Id=id, Status=ChangeStatus.INSYNC, SubmittedAt=datetime.now())
         return GetChangeResponse(ChangeInfo=change_info)

--- a/localstack/services/route53/provider.py
+++ b/localstack/services/route53/provider.py
@@ -39,9 +39,14 @@ class Route53Provider(Route53Api, ServiceLifecycleHook):
         response = call_moto(context)
 
         # moto does not populate the VPC struct of the response if creating a private hosted zone
-        if hosted_zone_config and hosted_zone_config.get("PrivateZone", False):
-            response["VPC"]["VPCId"] = response["VPC"]["VPCId"] or vpc["VPCId"]
-            response["VPC"]["VPCRegion"] = response["VPC"]["VPCRegion"] or vpc["VPCRegion"]
+        if (
+            hosted_zone_config
+            and hosted_zone_config.get("PrivateZone", False)
+            and "VPC" in response
+            and vpc
+        ):
+            response["VPC"]["VPCId"] = response["VPC"]["VPCId"] or vpc.get("VPCId", "")
+            response["VPC"]["VPCRegion"] = response["VPC"]["VPCRegion"] or vpc.get("VPCRegion", "")
 
         return response
 

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -76,9 +76,9 @@ class TestRoute53:
         snapshot.match("get_hosted_zone", response)
 
     @markers.aws.unknown
-    def test_associate_vpc_with_hosted_zone(self, cleanups, aws_client):
+    def test_associate_vpc_with_hosted_zone(self, cleanups, hosted_zone, aws_client):
         name = "zone123"
-        response = aws_client.route53.create_hosted_zone(
+        response = hosted_zone(
             Name=name,
             HostedZoneConfig={"PrivateZone": True, "Comment": "test"},
         )

--- a/tests/aws/services/route53/test_route53.py
+++ b/tests/aws/services/route53/test_route53.py
@@ -49,12 +49,37 @@ class TestRoute53:
             aws_client.route53.delete_health_check(HealthCheckId=health_check_id)
         assert "NoSuchHealthCheck" in str(ctx.value)
 
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..HostedZone.CallerReference"])
+    def test_create_private_hosted_zone(self, region, aws_client, cleanups, snapshot, hosted_zone):
+        vpc = aws_client.ec2.create_vpc(CidrBlock="10.113.0.0/24")
+        cleanups.append(lambda: aws_client.ec2.delete_vpc(VpcId=vpc["Vpc"]["VpcId"]))
+        vpc_id = vpc["Vpc"]["VpcId"]
+        snapshot.add_transformer(snapshot.transform.key_value("VPCId"))
+
+        name = f"zone-{short_uid()}.com"
+        response = hosted_zone(
+            Name=name,
+            HostedZoneConfig={
+                "PrivateZone": True,
+                "Comment": "test",
+            },
+            VPC={
+                "VPCId": vpc_id,
+                "VPCRegion": region,
+            },
+        )
+        snapshot.match("create-hosted-zone-response", response)
+        zone_id = response["HostedZone"]["Id"]
+
+        response = aws_client.route53.get_hosted_zone(Id=zone_id)
+        snapshot.match("get_hosted_zone", response)
+
     @markers.aws.unknown
     def test_associate_vpc_with_hosted_zone(self, cleanups, aws_client):
         name = "zone123"
         response = aws_client.route53.create_hosted_zone(
             Name=name,
-            CallerReference="ref123",
             HostedZoneConfig={"PrivateZone": True, "Comment": "test"},
         )
         zone_id = response["HostedZone"]["Id"]

--- a/tests/aws/services/route53/test_route53.snapshot.json
+++ b/tests/aws/services/route53/test_route53.snapshot.json
@@ -45,5 +45,58 @@
         }
       }
     }
+  },
+  "tests/aws/services/route53/test_route53.py::TestRoute53::test_create_private_hosted_zone": {
+    "recorded-date": "15-12-2023, 15:20:07",
+    "recorded-content": {
+      "create-hosted-zone-response": {
+        "ChangeInfo": {
+          "Id": "/change/<change-id>",
+          "Status": "<status:1>",
+          "SubmittedAt": "datetime"
+        },
+        "HostedZone": {
+          "CallerReference": "<caller-reference:1>",
+          "Config": {
+            "Comment": "test",
+            "PrivateZone": true
+          },
+          "Id": "/hostedzone/<zone-id:1>",
+          "Name": "<zone_name:1>",
+          "ResourceRecordSetCount": 2
+        },
+        "Location": "https://route53.amazonaws.com/2013-04-01/hostedzone/<zone-id:1>",
+        "VPC": {
+          "VPCId": "<v-p-c-id:1>",
+          "VPCRegion": "<region>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_hosted_zone": {
+        "HostedZone": {
+          "CallerReference": "<caller-reference:1>",
+          "Config": {
+            "Comment": "test",
+            "PrivateZone": true
+          },
+          "Id": "/hostedzone/<zone-id:1>",
+          "Name": "<zone_name:1>",
+          "ResourceRecordSetCount": 2
+        },
+        "VPCs": [
+          {
+            "VPCId": "<v-p-c-id:1>",
+            "VPCRegion": "<region>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While investigating https://github.com/localstack/localstack/issues/9486 I discovered that `moto` does not populate the VPC information for private hosted zones. This PR both addresses this missing information and adds an AWS validated test for private hosted zones.

*Note*: the existing test `test_associate_vpc_with_hosted_zone` will not work on AWS since creating a private zone without specifying VPC parameters fails with a client error from `boto3`. Rather than updating that test, which tests additional things, I created a new test that focuses purely on the create response.


<!-- What notable changes does this PR make? -->
## Changes

* Update `route53::create_hosted_zone` response to populate the VPC parameters if missing and when creating a private zone
* Add AWS validated test to capture responses
* Update `test_associate_vpc_with_hosted_zone` to use hosted zone fixture to ensure proper teardown

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

