### PR TITLE
use batches to report SQS metrics for approximate query metrics

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -286,8 +286,10 @@ class CloudwatchPublishWorker:
 
         for account_id, region, store in sqs_stores.iter_stores():
             start = 0
-            batch_size = 1000
-            # can include up to 1000 metric queries for one put-metric-data call
+            # we can include up to 1000 metric queries for one put-metric-data call
+            #  and we currently include 3 metrics per queue
+            batch_size = 300
+
             while start < len(store.queues):
                 batch_data = []
                 # Process the current batch
@@ -314,7 +316,9 @@ class CloudwatchPublishWorker:
                         )
                     )
 
-                publish_sqs_metric_batch(account_id=account_id, region=region, data=batch_data)
+                publish_sqs_metric_batch(
+                    account_id=account_id, region=region, sqs_metric_batch_data=batch_data
+                )
                 # Update for the next batch
                 start += batch_size
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -318,33 +318,6 @@ class CloudwatchPublishWorker:
                 # Update for the next batch
                 start += batch_size
 
-    def publish_approximate_metrics_for_queue_to_cloudwatch(self, queue):
-        """Publishes the metrics for ApproximateNumberOfMessagesVisible, ApproximateNumberOfMessagesNotVisible
-        and ApproximateNumberOfMessagesDelayed to CloudWatch"""
-        # TODO ApproximateAgeOfOldestMessage is missing
-        #  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html
-        publish_sqs_metric(
-            account_id=queue.account_id,
-            region=queue.region,
-            queue_name=queue.name,
-            metric="ApproximateNumberOfMessagesVisible",
-            value=queue.approx_number_of_messages,
-        )
-        publish_sqs_metric(
-            account_id=queue.account_id,
-            region=queue.region,
-            queue_name=queue.name,
-            metric="ApproximateNumberOfMessagesNotVisible",
-            value=queue.approx_number_of_messages_not_visible,
-        )
-        publish_sqs_metric(
-            account_id=queue.account_id,
-            region=queue.region,
-            queue_name=queue.name,
-            metric="ApproximateNumberOfMessagesDelayed",
-            value=queue.approx_number_of_messages_delayed,
-        )
-
     def start(self):
         if self.thread:
             return

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -6,6 +6,7 @@ import re
 import threading
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
+from itertools import islice
 from typing import Dict, List, Optional, Tuple
 
 from moto.sqs.models import BINARY_TYPE_FIELD_INDEX, STRING_TYPE_FIELD_INDEX
@@ -85,7 +86,11 @@ from localstack.services.sqs.utils import (
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.request_context import extract_region_from_headers
 from localstack.utils.bootstrap import is_api_enabled
-from localstack.utils.cloudwatch.cloudwatch_util import publish_sqs_metric
+from localstack.utils.cloudwatch.cloudwatch_util import (
+    SqsMetricBatchData,
+    publish_sqs_metric,
+    publish_sqs_metric_batch,
+)
 from localstack.utils.run import FuncThread
 from localstack.utils.scheduler import Scheduler
 from localstack.utils.strings import md5
@@ -274,9 +279,44 @@ class CloudwatchPublishWorker:
         self.thread: Optional[FuncThread] = None
 
     def publish_approximate_cloudwatch_metrics(self):
+        """Publishes the metrics for ApproximateNumberOfMessagesVisible, ApproximateNumberOfMessagesNotVisible
+        and ApproximateNumberOfMessagesDelayed to CloudWatch"""
+        # TODO ApproximateAgeOfOldestMessage is missing
+        #  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html
+
         for account_id, region, store in sqs_stores.iter_stores():
-            for queue in store.queues.values():
-                self.publish_approximate_metrics_for_queue_to_cloudwatch(queue)
+            start = 0
+            batch_size = 1000
+            # can include up to 1000 metric queries for one put-metric-data call
+            while start < len(store.queues):
+                batch_data = []
+                # Process the current batch
+                for queue in islice(store.queues.values(), start, start + batch_size):
+                    batch_data.append(
+                        SqsMetricBatchData(
+                            QueueName=queue.name,
+                            MetricName="ApproximateNumberOfMessagesVisible",
+                            Value=queue.approx_number_of_messages,
+                        )
+                    )
+                    batch_data.append(
+                        SqsMetricBatchData(
+                            QueueName=queue.name,
+                            MetricName="ApproximateNumberOfMessagesNotVisible",
+                            Value=queue.approx_number_of_messages_not_visible,
+                        )
+                    )
+                    batch_data.append(
+                        SqsMetricBatchData(
+                            QueueName=queue.name,
+                            MetricName="ApproximateNumberOfMessagesDelayed",
+                            Value=queue.approx_number_of_messages_delayed,
+                        )
+                    )
+
+                publish_sqs_metric_batch(account_id=account_id, region=region, data=batch_data)
+                # Update for the next batch
+                start += batch_size
 
     def publish_approximate_metrics_for_queue_to_cloudwatch(self, queue):
         """Publishes the metrics for ApproximateNumberOfMessagesVisible, ApproximateNumberOfMessagesNotVisible

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
@@ -123,3 +123,37 @@ class TestCloudWatchLambdaMetrics:
         )
         assert res["MetricDataResults"][0]["Values"] == expected_return
         return res
+
+
+class TestSqsApproximateMetrics:
+    @markers.aws.validated
+    def test_sqs_approximate_metrics(self, aws_client, sqs_create_queue):
+        queue_names = []
+        for _ in range(0, 10):
+            q_name = f"my-test-queue-{short_uid()}"
+            sqs_create_queue(QueueName=q_name)
+            queue_names.append(q_name)
+
+        for queue in queue_names:
+            retry(
+                lambda: self._assert_approximate_metrics_for_queue(
+                    aws_client.cloudwatch, queue_name=queue
+                ),
+                retries=70,  # should be reported every 60 seconds
+                sleep=10 if is_aws() else 1,
+            )
+
+    def _assert_approximate_metrics_for_queue(
+        self,
+        cloudwatch_client: "CloudWatchClient",
+        queue_name: str,
+    ):
+        namespace = "AWS/SQS"
+        dimension = [{"Name": "QueueName", "Value": queue_name}]
+
+        res = cloudwatch_client.list_metrics(Namespace=namespace, Dimensions=dimension)
+        metric_names = [m["MetricName"] for m in res["Metrics"]]
+        assert "ApproximateNumberOfMessagesVisible" in metric_names
+        assert "ApproximateNumberOfMessagesNotVisible" in metric_names
+        assert "ApproximateNumberOfMessagesDelayed" in metric_names
+        return res

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
@@ -139,7 +139,7 @@ class TestSqsApproximateMetrics:
                 lambda: self._assert_approximate_metrics_for_queue(
                     aws_client.cloudwatch, queue_name=queue
                 ),
-                retries=70,  # should be reported every 60 seconds
+                retries=70,  # should be reported every 60 seconds on LS
                 sleep=10 if is_aws() else 1,
             )
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.validation.json
@@ -4,5 +4,8 @@
   },
   "tests/aws/services/cloudwatch/test_cloudwatch_metrics.py::TestCloudWatchLambdaMetrics::test_lambda_invoke_successful": {
     "last_validated_date": "2023-11-15T18:46:04+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch_metrics.py::TestSqsApproximateMetrics::test_sqs_approximate_metrics": {
+    "last_validated_date": "2024-01-02T11:33:18+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Improving the sqs-metrics reporting for the "Approximate*" metrics, by collecting metric-data in batches before sending the data to cloudwatch. 
As a reminder: those are the metrics that are reported regularly (by default once every minute) for all queues.

<!-- What notable changes does this PR make? -->
## Changes
* Collect the data of all queues in slices, before sending the batch to cloudwatch (previously we would call the cloudwatch-api three times for each queue)
* Added a new helper in `cloudwatch_util.py` to handle sqs-batched data

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

