### PR TITLE
use mounts instead of volumes docker api

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -11,7 +11,7 @@ import tempfile
 from abc import ABCMeta, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Protocol, Tuple, Union, get_args
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Protocol, Tuple, Union, get_args
 
 from localstack import config
 from localstack.utils.collections import HashableList, ensure_list
@@ -682,7 +682,7 @@ class ContainerClient(metaclass=ABCMeta):
         """Returns a blocking generator you can iterate over to retrieve log output as it happens."""
 
     @abstractmethod
-    def inspect_container(self, container_name_or_id: str) -> Dict[str, Union[Dict, str]]:
+    def inspect_container(self, container_name_or_id: str) -> Dict[str, Any]:
         """Get detailed attributes of a container.
 
         :return: Dict containing docker attributes as returned by the daemon

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -357,6 +357,17 @@ class VolumeBind:
 
         return ":".join(args)
 
+    def to_mount_str(self) -> str:
+        """
+        Returns a string that can be used as input value for the ``--mount`` CLI flag representing the bind mount.
+
+        :return: a ``--mount`` value
+        """
+        readonly = "true" if self.read_only else "false"
+        return (
+            f"type=bind,source={self.host_dir},destination={self.container_dir},readonly={readonly}"
+        )
+
     @classmethod
     def parse(cls, param: str) -> "VolumeBind":
         parts = param.split(":")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -190,8 +190,12 @@ class TestCliContainerLifecycle:
 
         # check that mounts were created correctly
         inspect = container_client.inspect_container(config.MAIN_CONTAINER_NAME)
-        binds = inspect["HostConfig"]["Binds"]
-        assert f"{volume_dir}:{constants.DEFAULT_VOLUME_DIR}" in binds
+        mounts = inspect["HostConfig"]["Mounts"]
+        assert {
+            "Type": "bind",
+            "Source": volume_dir,
+            "Target": constants.DEFAULT_VOLUME_DIR,
+        } in mounts
 
     def test_container_starts_non_root(self, runner, monkeypatch, container_client):
         user = "localstack"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -193,7 +193,7 @@ class TestCliContainerLifecycle:
         mounts = inspect["HostConfig"]["Mounts"]
         assert {
             "Type": "bind",
-            "Source": volume_dir,
+            "Source": str(volume_dir),
             "Target": constants.DEFAULT_VOLUME_DIR,
         } in mounts
 

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -506,6 +506,14 @@ class TestDockerClient:
         docker_client.start_container(c.container_id)
         assert tmpdir.join("foo.log").isfile(), "foo.log was not created in mounted dir"
 
+        inspect = docker_client.inspect_container(c.container_id)
+        mounts = inspect["HostConfig"]["Mounts"]
+        assert {
+            "Type": "bind",
+            "Source": str(tmpdir),
+            "Target": "/tmp/mypath",
+        } in mounts
+
     @pytest.mark.skipif(
         condition=in_docker(), reason="cannot test volume mounts from host when in docker"
     )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I tried to mount a volume bind with a colon in the name, which fails both for the CLI and SDK docker client. The reason is explained here https://github.com/docker/docker-py/issues/2041

This can be fixed by using the more flexible `mounts` api parameter. 

> mounts is more modern and a better choice 99% of the time.
-- https://github.com/docker/docker-py/issues/2041#issuecomment-393359696

> In general, --mount is more explicit and verbose. The biggest difference is that the -v syntax combines all the options together in one field, while the --mount syntax separates them
-- https://docs.docker.com/storage/bind-mounts/#choose-the--v-or---mount-flag

This PR changes both the docker SDK and CMD client to use `mounts` instead of `volumes`/`bind` for mounting volumes.
There is a significant impact though: the `-v` flag would create a source directory on the host if it didn't exist, whereas `--mount` would fail. To make sure we don't break code, we explicitly create the directories now, however they will be created as the user that owns the python process (typically the user), rather than the docker process (typically root).

Open to discuss the implications and how we could mitigate them.

<!-- What notable changes does this PR make? -->
## Changes

* Rework the `VolumeBind` mapping to map to `mounts` instead of `volumes`
* If a volume source didn't exist on the host before spawning a container, the owner of the created directory is now the user running localstack and no longer the user running docker (which would typically be `root`)

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

