### PR TITLE
Fix: ACM: Additional domains missing from subject alternative names summaries

### DIFF
--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -89,6 +89,10 @@ def describe(describe_orig, self):
         sans.append(cert["DomainName"])
     if cert["DomainName"] not in sans_summaries:
         sans_summaries.append(cert["DomainName"])
+    additional_domains = [
+        san for san in cert["SubjectAlternativeNames"] if san not in sans_summaries
+    ]
+    sans_summaries.extend(additional_domains)
 
     if "HasAdditionalSubjectAlternativeNames" not in cert:
         cert["HasAdditionalSubjectAlternativeNames"] = False

--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -130,3 +130,41 @@ class TestACM:
         summaries = response.get("CertificateSummaryList") or []
         matching = [cert for cert in summaries if cert["CertificateArn"] == cert_arn]
         snapshot.match("list-cert", matching)
+
+    @markers.aws.unknown
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..ExtendedKeyUsages",
+            "$..IssuedAt",
+            "$..KeyUsages",
+            "$..NotAfter",
+            "$..NotBefore",
+            "$..Status",
+        ]
+    )
+    def test_create_certificate_for_multiple_alternative_domains(
+        self, acm_request_certificate, aws_client, snapshot
+    ):
+        domain_name = "test.example.com"
+        subject_alternative_names = ["test.example.com", "another.domain.com"]
+        create_response = acm_request_certificate(
+            DomainName=domain_name, SubjectAlternativeNames=subject_alternative_names
+        )
+
+        cert_arn = create_response["CertificateArn"]
+
+        def _certificate_ready():
+            response = aws_client.acm.describe_certificate(CertificateArn=cert_arn)
+            # expecting FAILED on aws due to not requesting a valid certificate
+            # expecting ISSUED as default response from moto
+            assert response["Certificate"]["Status"] in ["FAILED", "ISSUED"]
+            response = aws_client.acm.list_certificates()
+            return response
+
+        response = retry(_certificate_ready, sleep=1, retries=30)
+        summaries = response.get("CertificateSummaryList")
+        cert = next((cert for cert in summaries if cert["CertificateArn"] == cert_arn), None)
+
+        cert_id = cert_arn.split("certificate/")[-1]
+        snapshot.add_transformer(snapshot.transform.regex(cert_id, "<cert-id>"))
+        snapshot.match("list-cert-subject-alternative-names", cert)

--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -131,7 +131,7 @@ class TestACM:
         matching = [cert for cert in summaries if cert["CertificateArn"] == cert_arn]
         snapshot.match("list-cert", matching)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..ExtendedKeyUsages",

--- a/tests/aws/services/acm/test_acm.snapshot.json
+++ b/tests/aws/services/acm/test_acm.snapshot.json
@@ -137,5 +137,27 @@
         }
       ]
     }
+  },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_create_certificate_for_multiple_alternative_domains": {
+    "recorded-date": "18-12-2023, 13:01:36",
+    "recorded-content": {
+      "list-cert-subject-alternative-names": {
+        "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+        "CreatedAt": "datetime",
+        "DomainName": "test.example.com",
+        "ExtendedKeyUsages": [],
+        "HasAdditionalSubjectAlternativeNames": false,
+        "InUse": false,
+        "KeyAlgorithm": "RSA-2048",
+        "KeyUsages": [],
+        "RenewalEligibility": "INELIGIBLE",
+        "Status": "FAILED",
+        "SubjectAlternativeNameSummaries": [
+          "test.example.com",
+          "another.domain.com"
+        ],
+        "Type": "AMAZON_ISSUED"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in [issue #9768](https://github.com/localstack/localstack/issues/9768) the current behavior does not fully match the aws cli behavior regarding a certificate valid for multiple domains. 
The expected response should reflect all domains in `SubjectAlternativeNameSummaries`.   
All additional domains in `SubjectAlternativeName` returned from moto should also be present in `SubjectAlternativeNameSummaries` when calling `aws acm list-certificates`

<!-- What notable changes does this PR make? -->
## Changes
- added all additional domain to `SubjectAlternativeNameSummaries`
- updated parity snapshot to reflect the additional functionality


