### PR TITLE
fix S3 UploadPart logic when cancelling/error a request

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1880,7 +1880,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         stored_multipart = self._storage_backend.get_multipart(bucket_name, s3_multipart)
         stored_s3_part = stored_multipart.open(s3_part)
-        stored_s3_part.write(body)
+        try:
+            stored_s3_part.write(body)
+        except Exception:
+            stored_multipart.remove_part(s3_part)
+            raise
 
         if checksum_algorithm and s3_part.checksum_value != stored_s3_part.checksum:
             stored_multipart.remove_part(s3_part)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #9851, we would face an issue when cancelling/error an `UploadPart` request and retrying on the same PartNumber. 
This was due because of our ephemeral MultipartUpload object is not fully stateless, and keeps the `EphemeralS3StoredObject` in a dict to allow easier "fusion" of all underlying parts when completing (it does not have to recreate the `EphemeralS3StoredObject` on top of the `LockedSpooledTemporaryFile`). 

However, this created an issue when the request would error/cancel, because the `EphemeralS3StoredObject` kept the reference to the `S3Part` that errored (created in the provider operation which raised an Exception). When creating a new S3Part in a non-failing provider operation, the asynchronous calculation of the `ETag` due to the `aws-chunked` encoding would not set the `ETag` to the new `S3Part` but to the previously created one, hence the returned `ETag` set to `None`. 

<!-- What notable changes does this PR make? -->
## Changes
The simple fix is to simply remove the part entry for the underlying storage if the writing of that part fails. It could maybe be wrapped in a context manager which would clean up only if the operation fails, but this is simple and clear what it does.

I've also added a test to verify the fix, ran the external `soto` test suite and validated that it now works. 


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

