### PR TITLE
add reset feature to CW v2

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -317,13 +317,13 @@ class CloudwatchDatabase:
             return {"metrics": metrics_result}
 
     def clear_tables(self):
-        # TODO clear tables for reset calls on cloudwatch
-        pass
-
-    def shutdown(self):
-        # TODO delete tmpdir/database if we do not have persistence enabled?
-        # anything else we should consider?
-        ...
+        with sqlite3.connect(self.METRICS_DB) as conn:
+            cur = conn.cursor()
+            cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
+            cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
+            conn.commit()
+            cur.execute("VACUUM")
+            conn.commit()
 
     def _get_ordered_dimensions_with_separator(self, dims: Optional[List[Dict]]):
         if not dims:

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -164,7 +164,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
 
     def on_before_stop(self):
         self.shutdown_alarm_scheduler()
-        self.cloudwatch_database.shutdown()
 
     def start_alarm_scheduler(self):
         if not self.alarm_scheduler:


### PR DESCRIPTION
## Motivation
This adds the ability to reset the Cloudwatch v2 state cleaning the database  metrics tables.  
Related to localstack/localstack#9347

## Changes
 - removed unused functions in the cloudwatch_database_helper.py and their calls
 - the shutdown function in the helper implements the query to reset their metrics tables and the index Autoincrement.
 
