### PR TITLE
add cli option to restart localstack container

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -57,7 +57,9 @@ class LocalStackCliGroup(click.Group):
             if ctx and ctx.params.get("debug"):
                 click.echo(traceback.format_exc())
             from localstack.utils.container_utils.container_client import (
-                ContainerException, DockerNotAvailable)
+                ContainerException,
+                DockerNotAvailable,
+            )
 
             if isinstance(e, DockerNotAvailable):
                 raise CLIError(
@@ -315,10 +317,8 @@ class DockerStatus(TypedDict, total=False):
 
 def _print_docker_status(format_: str) -> None:
     from localstack.utils import docker_utils
-    from localstack.utils.bootstrap import (get_docker_image_details,
-                                            get_server_version)
-    from localstack.utils.container_networking import (get_main_container_ip,
-                                                       get_main_container_name)
+    from localstack.utils.bootstrap import get_docker_image_details, get_server_version
+    from localstack.utils.container_networking import get_main_container_ip, get_main_container_name
 
     img = get_docker_image_details()
     cont_name = config.MAIN_CONTAINER_NAME
@@ -589,7 +589,7 @@ def cmd_restart() -> None:
     except requests.ConnectionError:
         if config.DEBUG:
             console.print_exception()
-        raise CLIError(f"could not restart the LocalStack container")
+        raise CLIError("could not restart the LocalStack container")
 
 
 @localstack.command(
@@ -791,8 +791,7 @@ def update_images(image_list: List[str]) -> None:
     from rich.markup import escape
     from rich.progress import MofNCompleteColumn, Progress
 
-    from localstack.utils.container_utils.container_client import \
-        ContainerException
+    from localstack.utils.container_utils.container_client import ContainerException
     from localstack.utils.docker_utils import DOCKER_CLIENT
 
     updated_count = 0

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -572,6 +572,33 @@ def cmd_stop() -> None:
         )
 
 
+@localstack.command(name="restart", short_help="Restart LocalStack")
+@publish_invocation
+def cmd_restart() -> None:
+    """
+    Restarts the current LocalStack runtime.
+
+    This command restarts the currently running LocalStack docker container.
+    By default, this command looks for a container named `localstack-main` (which is the default
+    container name used by the `localstack start` command).
+    If your LocalStack container has a different name, set the config variable
+    `MAIN_CONTAINER_NAME`.
+    """
+    from localstack.utils.docker_utils import DOCKER_CLIENT
+
+    from ..utils.container_utils.container_client import NoSuchContainer
+
+    container_name = config.MAIN_CONTAINER_NAME
+
+    try:
+        DOCKER_CLIENT.restart_container(container_name)
+        console.print("container restarted: %s" % container_name)
+    except NoSuchContainer:
+        raise CLIError(
+            f'Expected a running LocalStack container named "{container_name}", but found none'
+        )
+
+
 @localstack.command(
     name="logs",
     short_help="Show LocalStack logs",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -138,6 +138,16 @@ class TestCliContainerLifecycle:
         result = runner.invoke(cli, ["logs", "--tail", "20"])
         assert constants.READY_MARKER_OUTPUT in result.output.splitlines()
 
+    def test_restart(self, runner, container_client):
+        result = runner.invoke(cli, ["restart"])
+        assert result.exit_code != 0
+
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "60"])
+
+        result = runner.invoke(cli, ["restart"])
+        assert constants.READY_MARKER_OUTPUT in result.output.splitlines()
+
     def test_status_services(self, runner):
         result = runner.invoke(cli, ["status", "services"])
         assert result.exit_code != 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -146,7 +146,8 @@ class TestCliContainerLifecycle:
         runner.invoke(cli, ["wait", "-t", "60"])
 
         result = runner.invoke(cli, ["restart"])
-        assert constants.READY_MARKER_OUTPUT in result.output.splitlines()
+        assert result.exit_code == 0
+        assert "restarted" in result.output
 
     def test_status_services(self, runner):
         result = runner.invoke(cli, ["status", "services"])


### PR DESCRIPTION
## Motivation

This PR exposes a CLI option to restart the LocalStack runtime, which is often required for development/testing/running demos. 
