### PR TITLE
Upgrade and pin DynamoDB Local version to 2.2.0 and update snapshot

### DIFF
--- a/localstack/services/dynamodb/packages.py
+++ b/localstack/services/dynamodb/packages.py
@@ -35,6 +35,9 @@ class DynamoDBLocalPackage(Package):
         return DynamoDBLocalPackageInstaller(version)
 
     def get_versions(self) -> List[str]:
+        """
+        https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html
+        """
         return ["2.1.0", "2.2.0"]
 
 

--- a/localstack/services/dynamodb/packages.py
+++ b/localstack/services/dynamodb/packages.py
@@ -23,7 +23,12 @@ DDB_AGENT_JAR_URL = f"{DDB_PATCH_URL_PREFIX}/target/ddb-local-loader-0.1.jar"
 
 LIBSQLITE_AARCH64_URL = f"{MAVEN_REPO_URL}/io/github/ganadist/sqlite4java/libsqlite4java-osx-aarch64/1.0.392/libsqlite4java-osx-aarch64-1.0.392.dylib"
 # Downloading from maven central instead of AWS since AWS doesn't give us a way to pin the version
-DYNAMODB_JAR_URL = "https://repo1.maven.org/maven2/com/amazonaws/DynamoDBLocal/%version%/DynamoDBLocal-%version%.jar"
+DYNAMODB_JAR_URL = (
+    f"{MAVEN_REPO_URL}/com/amazonaws/DynamoDBLocal/%version%/DynamoDBLocal-%version%.jar"
+)
+DYNAMODB_JAR_URL_LATEST = (
+    "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip"
+)
 JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA.jar"
 
 
@@ -38,7 +43,7 @@ class DynamoDBLocalPackage(Package):
         """
         https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html
         """
-        return ["2.1.0", "2.2.0"]
+        return ["2.1.0", "2.2.0", "latest"]
 
 
 class DynamoDBLocalPackageInstaller(PackageInstaller):
@@ -49,7 +54,10 @@ class DynamoDBLocalPackageInstaller(PackageInstaller):
         # download and extract archive
         tmp_archive = os.path.join(config.dirs.cache, "localstack.ddb.zip")
         install_dir = self._get_install_dir(target)
-        download_url = DYNAMODB_JAR_URL.replace("%version%", self.version)
+        if self.version == "latest":
+            download_url = DYNAMODB_JAR_URL_LATEST
+        else:
+            download_url = DYNAMODB_JAR_URL.replace("%version%", self.version)
         download_and_extract_with_retry(download_url, tmp_archive, install_dir)
 
         # download additional libs for Mac M1 (for local dev mode)

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -800,7 +800,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
-    "recorded-date": "27-02-2023, 17:42:01",
+    "recorded-date": "19-12-2023, 08:08:47",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -981,6 +981,7 @@
             }
           ],
           "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {


### PR DESCRIPTION
## Motivation

We've started seeing repeatable failures in CI due to a snapshot mismatch for `tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source`.

```
=================================== FAILURES ===================================
__________ TestCfnLambdaIntegrations.test_cfn_lambda_dynamodb_source ___________
>> match key: describe_table_result
	(+)  /Table/DeletionProtectionEnabled ( False )

```

My investigation pointed towards a new update of DynamoDB local as the culprit ([AWS recently released a 2.2.0 version with support for Table delete protection](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html))


## Changes

- Download DynamoDB Local artifact from maven instead of AWS so that we can pin the downloaded version to avoid PRs like this in the future and can upgrade in more controlled matter. (e.g. driven by issues detected by snapshot updates against AWS).
- Add `2.1.0`, `2.2.0` and a `latest` (previous default) to the package
- Set default version to the new `2.2.0` version
- Updated snapshot of affected test

## TODO

- [ ] dependencies are not bundled in the jar file, so we'd need to bundle them separately if we want to continue with this solution  in the future