### PR TITLE
Update dynamodb snapshot to unblock pipeline

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -159,6 +159,7 @@ class DynamodbServer(Server):
             log_listener=_log_listener,
             auto_restart=True,
             name="dynamodb-local",
+            env_vars={"DDB_LOCAL_TELEMETRY": "0"},
         )
         TMP_THREADS.append(t)
         t.start()

--- a/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.snapshot.json
@@ -800,7 +800,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
-    "recorded-date": "27-02-2023, 17:42:01",
+    "recorded-date": "19-12-2023, 08:08:47",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -981,6 +981,7 @@
             }
           ],
           "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
           "ItemCount": 0,
           "KeySchema": [
             {


### PR DESCRIPTION
## Motivation

We've started seeing repeatable failures in CI due to a snapshot mismatch for `tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source`.

```
=================================== FAILURES ===================================
__________ TestCfnLambdaIntegrations.test_cfn_lambda_dynamodb_source ___________
>> match key: describe_table_result
	(+)  /Table/DeletionProtectionEnabled ( False )

```

My investigation pointed towards a new update of DynamoDB local as the culprit ([AWS recently released a 2.2.0 version with support for Table delete protection](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html))

Was running into some issues with the initial PR in https://github.com/localstack/localstack/pull/9909

I still want to tackle the problem with a more long-term solution to avoid these unpredictable dependency update but for now this should unblock the pipeline.

## Changes


- Update snapshot for `tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source`

