### PR TITLE
Remove error message if environment does not exist

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -247,7 +247,6 @@ def load_environment(profiles: str = None, env=os.environ) -> List[str]:
         profile = profile.strip()
         path = os.path.join(CONFIG_DIR, f"{profile}.env")
         if not os.path.exists(path):
-            print(f"Profile '{profile}' specified, but file {path} not found.")
             continue
         environment.update(dotenv.dotenv_values(path))
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Originally, with #9873 , I added an error message if a config profile cannot be found. However, this interfered with the usages of the config in CLI tools where the output might get parsed, like lpm, since it is always the case due to the default profile.

Since this error message has quite significant impact, it is best for now to remove it, and find out a better way to debug profile loading should the need arise.

I also thought about only suppressing it in the default case, but the potential impact would still outweigh the benefits in my opinion.

<!-- What notable changes does this PR make? -->
## Changes
* Remove error output printed to stdout in case profile does not exist.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

