### PR TITLE
fix CFN RequestValidator parameters being optional

### DIFF
--- a/localstack/services/apigateway/resource_providers/aws_apigateway_requestvalidator.py
+++ b/localstack/services/apigateway/resource_providers/aws_apigateway_requestvalidator.py
@@ -64,8 +64,8 @@ class ApiGatewayRequestValidatorProvider(ResourceProvider[ApiGatewayRequestValid
         response = api.create_request_validator(
             name=model["Name"],
             restApiId=model["RestApiId"],
-            validateRequestBody=model["ValidateRequestBody"],
-            validateRequestParameters=model["ValidateRequestParameters"],
+            validateRequestBody=model.get("ValidateRequestBody", False),
+            validateRequestParameters=model.get("ValidateRequestParameters", False),
         )
         model["RequestValidatorId"] = response["id"]
         # FIXME error happens when other resources try to reference this one

--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -212,7 +212,13 @@ def test_cfn_with_apigateway_resources(deploy_cfn_template, aws_client, snapshot
 
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
-    paths=["$.get-resources.items..resourceMethods.ANY"]  # TODO: empty in AWS
+    paths=[
+        "$.get-resources.items..resourceMethods.ANY",  # TODO: empty in AWS
+        "$..requestParameters",  # FIXME: it seems AWS does not return empty dicts anymore, will need to fix
+        "$..responseTemplates",  # FIXME: it seems AWS does not return empty dicts anymore, will need to fix
+        "$.get-method-any..responseModels",
+        "$.get-method-any..responseParameters",
+    ]
 )
 def test_cfn_deploy_apigateway_models(deploy_cfn_template, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.apigateway_api())

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -168,7 +168,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_models": {
-    "recorded-date": "05-07-2023, 20:11:14",
+    "recorded-date": "19-12-2023, 19:04:52",
     "recorded-content": {
       "get-resources": {
         "items": [
@@ -271,13 +271,10 @@
           "cacheNamespace": "<id:2>",
           "integrationResponses": {
             "200": {
-              "responseParameters": {},
-              "responseTemplates": {},
               "statusCode": "200"
             }
           },
           "passthroughBehavior": "NEVER",
-          "requestParameters": {},
           "requestTemplates": {
             "application/json": {
               "statusCode": 200
@@ -288,15 +285,12 @@
         },
         "methodResponses": {
           "200": {
-            "responseModels": {},
-            "responseParameters": {},
             "statusCode": "200"
           }
         },
         "requestModels": {
           "application/json": "<name:3>"
         },
-        "requestParameters": {},
         "requestValidatorId": "<id:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/templates/apigateway_models.json
+++ b/tests/aws/templates/apigateway_models.json
@@ -108,8 +108,7 @@
      "Ref": "apiC8550315"
     },
     "Name": "require-valid-body",
-    "ValidateRequestBody": true,
-    "ValidateRequestParameters": false
+    "ValidateRequestBody": true
    },
    "Metadata": {
     "aws:cdk:path": "ValidatorExampleStack/request-validator/Resource"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've seen a regression from #9320 where optional parameters were accessed directly from the model in CloudFormation. Those parameters are marked as optional, and will default to `False`.
See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-requestvalidator.html

<!-- What notable changes does this PR make? -->
## Changes
Access those parameters with `.get` instead of direct attribute access, and make default to `False`.
Update a test to not specify a `False` parameter to check that it still properly create the resource and default to `False`.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

