### PR TITLE
add more tests for cw v2

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -247,6 +247,9 @@ class CloudwatchDatabase:
                 dimension_filter += "AND dimensions LIKE ? "
                 data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
 
+            if not dimensions:
+                dimension_filter = "AND dimensions = '' "
+
             unit_filter = ""
             if unit:
                 if unit == "NULL_VALUE":
@@ -254,6 +257,7 @@ class CloudwatchDatabase:
                 else:
                     unit_filter = "AND unit = ? "
                     data += (unit,)
+
 
             sql_query = f"""
             SELECT

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -258,7 +258,6 @@ class CloudwatchDatabase:
                     unit_filter = "AND unit = ? "
                     data += (unit,)
 
-
             sql_query = f"""
             SELECT
                 {STAT_TO_SQLITE_AGGREGATION_FUNC[stat]},

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -248,7 +248,7 @@ class CloudwatchDatabase:
                 data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
 
             if not dimensions:
-                dimension_filter = "AND dimensions = '' "
+                dimension_filter = "AND dimensions is null "
 
             unit_filter = ""
             if unit:

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1372,7 +1372,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn"], condition=is_old_provider()
+        paths=["$..DashboardArn"], condition=is_old_provider
     )  # ARN has a typo in moto
     def test_dashboard_lifecycle(self, aws_client, snapshot):
         dashboard_name = f"test-{short_uid()}"
@@ -2181,14 +2181,6 @@ class TestCloudwatch:
         )
         snapshot.match("lambda-alarm-invocations", invocation_res)
 
-
-def _get_lambda_logs(logs_client: "CloudWatchLogsClient", fn_name: str):
-    log_events = logs_client.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")["events"]
-    filtered_logs = [event for event in log_events if event["message"].startswith("{")]
-    assert len(filtered_logs) >= 1
-    filtered_logs.sort(key=lambda e: e["timestamp"], reverse=True)
-    return filtered_logs[0]["message"]
-
     @markers.aws.validated
     def test_get_metric_with_no_results(self, snapshot, aws_client):
         utc_now = datetime.now(tz=timezone.utc)
@@ -2233,6 +2225,14 @@ def _get_lambda_logs(logs_client: "CloudWatchLogsClient", fn_name: str):
             snapshot.match("result", data)
 
         retry(validate, sleep_before=(2 if is_aws_cloud() else 0))
+
+
+def _get_lambda_logs(logs_client: "CloudWatchLogsClient", fn_name: str):
+    log_events = logs_client.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")["events"]
+    filtered_logs = [event for event in log_events if event["message"].startswith("{")]
+    assert len(filtered_logs) >= 1
+    filtered_logs.sort(key=lambda e: e["timestamp"], reverse=True)
+    return filtered_logs[0]["message"]
 
 
 def _check_alarm_triggered(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1372,7 +1372,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn"], condition=is_old_provider
+        paths=["$..DashboardArn"], condition=is_old_provider()
     )  # ARN has a typo in moto
     def test_dashboard_lifecycle(self, aws_client, snapshot):
         dashboard_name = f"test-{short_uid()}"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1873,8 +1873,8 @@
       }
     }
   },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
-    "recorded-date": "19-12-2023, 16:29:18",
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
+    "recorded-date": "19-12-2023, 16:57:15",
     "recorded-content": {
       "result": {
         "Messages": [],
@@ -1894,14 +1894,14 @@
       }
     }
   },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
-    "recorded-date": "19-12-2023, 16:57:15",
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
+    "recorded-date": "09-01-2024, 20:13:11",
     "recorded-content": {
-      "result": {
+      "get_metric_with_null_dimensions": {
         "Messages": [],
         "MetricDataResults": [
           {
-            "Id": "result",
+            "Id": "<id:1>",
             "Label": "<label:1>",
             "StatusCode": "Complete",
             "Timestamps": "timestamp",

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1893,5 +1893,26 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
+    "recorded-date": "19-12-2023, 16:57:15",
+    "recorded-content": {
+      "result": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result",
+            "Label": "<label:1>",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1874,7 +1874,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
-    "recorded-date": "19-12-2023, 16:57:15",
+    "recorded-date": "10-01-2024, 15:29:50",
     "recorded-content": {
       "result": {
         "Messages": [],

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1872,5 +1872,26 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
+    "recorded-date": "19-12-2023, 16:29:18",
+    "recorded-content": {
+      "result": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "result",
+            "Label": "<label:1>",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_no_results": {
+    "last_validated_date": "2024-01-10T15:29:50+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
     "last_validated_date": "2024-01-09T20:13:11+00:00"
   },

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
+    "last_validated_date": "2024-01-09T20:13:11+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
     "last_validated_date": "2024-01-05T16:15:39+00:00"
   },


### PR DESCRIPTION
## Motivation
This PR addresses an essential aspect by introducing tests that specifically target unique and critical scenarios within Cloudwatch. The motivation behind this effort is to enhance the robustness and reliability of our codebase, ensuring comprehensive test coverage for cases that are both distinctive and significant.

## Changes / Testing
- Implemented a test case for scenarios where the query lacks dimensions, but the data contains them.
- Adjusted the database helper to ensure the success of the first test.
- Added a test to cover scenarios where the query results in no data.

