### PR TITLE
Refine get in touch readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,11 @@ We are thankful for all the contributions and feedback we receive.
 
 ## Get in touch
 
-To get in touch with LocalStack team for bugs/feature requests, support questions or general discussions, please use:
+Get in touch with the LocalStack Team to
+report 🐞 [issues](https://github.com/localstack/localstack/issues/new/choose),
+upvote 👍 [feature requests](https://github.com/localstack/localstack/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+),
+🙋🏽 ask [support questions](https://docs.localstack.cloud/getting-started/help-and-support/),
+or 🗣️ discuss local cloud development:
 
 - [LocalStack Slack Community](https://localstack.cloud/contact/)
 - [LocalStack Discussion Page](https://discuss.localstack.cloud/)


### PR DESCRIPTION
## Motivation

It would be great to explicitly motivate users to upvote top [feature requests](https://github.com/localstack/localstack/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+) (currently including issues).
Active voice could sound a little more inviting than a noun-heavy phrase.

## Changes

* Refine call for action to get in touch
* Add visual icons (using different skin tones)
* Add link to top [feature requests](https://github.com/localstack/localstack/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+)

## Discussion

Should we filter out issues in the sorted [feature requests](https://github.com/localstack/localstack/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+) view and only show "feature requests" and "enhancements"?
