### PR TITLE
Route53: Fix ResourceRecords Cfn mapping

### DIFF
--- a/localstack/services/route53/resource_providers/aws_route53_recordset.py
+++ b/localstack/services/route53/resource_providers/aws_route53_recordset.py
@@ -111,7 +111,8 @@ class Route53RecordSetProvider(ResourceProvider[Route53RecordSetProperties]):
             # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-aliastarget.html
             if "EvaluateTargetHealth" not in attrs["AliasTarget"]:
                 attrs["AliasTarget"]["EvaluateTargetHealth"] = False
-        else:
+
+        if "ResourceRecords" in attrs:
             # TODO: CNAME & SOA only allow 1 record type. should we check that here?
             attrs["ResourceRecords"] = [{"Value": record} for record in attrs["ResourceRecords"]]
 


### PR DESCRIPTION
## Summary 

This PR fixes a small bug that prevented a valid request from being constructed in Cfn resource provider.

```
2023-12-20T20:07:24.147 DEBUG --- [functhread84] l.s.c.e.template_deployer  : Error applying changes for CloudFormation stack "ecs-service": Parameter validation failed:
Invalid type for parameter ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0], value: , type: <class 'str'>, valid types: <class 'dict'> Traceback (most recent call last):
  File "/home/viren/repo/localstack/localstack/services/cloudformation/engine/template_deployer.py", line 1177, in _run
    self.do_apply_changes_in_loop(changes, stack)
  File "/home/viren/repo/localstack/localstack/services/cloudformation/engine/template_deployer.py", line 1251, in do_apply_changes_in_loop
    self.apply_change(change, stack=stack)
  File "/home/viren/repo/localstack/localstack/services/cloudformation/engine/template_deployer.py", line 1366, in apply_change
    progress_event = executor.deploy_loop(resource_provider_payload)  # noqa
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/repo/localstack/localstack/services/cloudformation/resource_provider.py", line 734, in deploy_loop
    event = self.execute_action(resource_provider, payload)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/repo/localstack/localstack/services/cloudformation/resource_provider.py", line 802, in execute_action
    return resource_provider.create(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/repo/localstack/localstack/services/route53/resource_providers/aws_route53_recordset.py", line 122, in create
    route53.change_resource_record_sets(
  File "/home/viren/.virtualenvs/lsvenv/lib/python3.11/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/.virtualenvs/lsvenv/lib/python3.11/site-packages/botocore/client.py", line 936, in _make_api_call
    request_dict = self._convert_to_request_dict(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/.virtualenvs/lsvenv/lib/python3.11/site-packages/botocore/client.py", line 1010, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/.virtualenvs/lsvenv/lib/python3.11/site-packages/botocore/validate.py", line 381, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0], value: , type: <class 'str'>, valid types: <class 'dict'>
```

## Related

https://github.com/localstack/localstack/pull/9788/
