### PR TITLE
Cfn: Fix nested stack name generation

### DIFF
--- a/localstack/services/cloudformation/resource_providers/aws_cloudformation_stack.py
+++ b/localstack/services/cloudformation/resource_providers/aws_cloudformation_stack.py
@@ -62,7 +62,7 @@ class CloudFormationStackProvider(ResourceProvider[CloudFormationStackProperties
         if not request.custom_context.get(REPEATED_INVOCATION):
             if not model.get("StackName"):
                 model["StackName"] = util.generate_default_name(
-                    request.stack_id, request.logical_resource_id
+                    request.stack_name, request.logical_resource_id
                 )
 
             create_params = util.select_attributes(

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.py
@@ -285,3 +285,9 @@ def test_nested_stacks_conditions(deploy_cfn_template, s3_create_bucket, aws_cli
 
     assert stack.outputs["ProdBucket"] == f"{nested_bucket_name}-prod"
     assert aws_client.s3.head_bucket(Bucket=stack.outputs["ProdBucket"])
+
+    # Ensure that nested stack names are correctly generated
+    nested_stack = aws_client.cloudformation.describe_stacks(
+        StackName=stack.outputs["NestedStackArn"]
+    )
+    assert ":" not in nested_stack["Stacks"][0]["StackName"]

--- a/tests/aws/templates/nested-stack-conditions.yaml
+++ b/tests/aws/templates/nested-stack-conditions.yaml
@@ -23,3 +23,5 @@ Resources:
 Outputs:
   ProdBucket:
     Value: !GetAtt Bucket.Outputs.ProdBucket
+  NestedStackArn:
+    Value: !Ref Bucket


### PR DESCRIPTION
## Summary

This PR fixes a bug where the internal name generation used request ARN instead of name which caused invalid Cfn stack names to be generated leading to CDK deployment errors which were caught by Lambda provider input validation:

```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreateFunction operation: 1 validation error detected: Value 'arn:aws:cloudformation:us-eas-LogRetentionaae0aa3c5b4d-25486f2c' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?
```

## Tests

Amended an existing test to assert that stack name does not contain invalid chars (`:` which is found in ARNs). Revalidated test against AWS.

## Related

https://github.com/localstack/localstack/pull/9449