### PR TITLE
Track date of last passed validation run of tests targeting AWS

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -74,6 +74,6 @@ jobs:
           pip install pytest pytest-tinybird
       - name: Run CLI tests
         env:
-          PYTEST_ADDOPTS: "${{ env.TINYBIRD_PYTEST_ARGS }}-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:tests.fixtures -s"
+          PYTEST_ADDOPTS: "${{ env.TINYBIRD_PYTEST_ARGS }}-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:localstack.testing.pytest.validation_tracking -p no:tests.fixtures -s"
         run: |
           python -m pytest tests/cli/

--- a/localstack/testing/pytest/validation_tracking.py
+++ b/localstack/testing/pytest/validation_tracking.py
@@ -1,0 +1,74 @@
+"""
+When a test (in tests/aws) is executed against AWS, we want to track the date of the last successful run.
+
+Keeping a record of how long ago a test was validated last,
+we can periodically re-validate ALL AWS-targeting tests (and therefore not only just snapshot-using tests).
+"""
+
+import datetime
+import json
+import os
+from typing import Optional
+
+import pluggy
+import pytest
+
+from localstack.testing.aws.util import is_aws_cloud
+
+
+def find_snapshot_for_item(item: pytest.Item) -> Optional[dict]:
+    base_path = os.path.join(item.fspath.dirname, item.fspath.purebasename)
+    snapshot_path = f"{base_path}.snapshot.json"
+
+    if not os.path.exists(snapshot_path):
+        return None
+
+    with open(snapshot_path, "r") as fd:
+        file_content = json.load(fd)
+        return file_content.get(item.nodeid)
+
+
+def record_passed_validation(item: pytest.Item, timestamp: Optional[datetime.datetime] = None):
+    base_path = os.path.join(item.fspath.dirname, item.fspath.purebasename)
+    with open(f"{base_path}.validation.json", "w+") as fd:
+        # read existing state from file
+        try:
+            content = json.load(fd)
+        except json.JSONDecodeError:  # expected on first try (empty file)
+            content = {}
+
+        # update for this pytest node
+        if not timestamp:
+            timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        content[item.nodeid] = {"last_validated_date": timestamp.isoformat(timespec="seconds")}
+
+        # save updates
+        fd.seek(0)
+        json.dump(content, fd, indent=2)
+
+
+# TODO: we should skip if we're updating snapshots
+# make sure this is *AFTER* snapshot comparison => tryfirst=True
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_call(item: pytest.Item):
+    outcome: pluggy.Result = yield
+
+    # we only want to track passed runs against AWS
+    if not is_aws_cloud() or outcome.excinfo:
+        return
+
+    record_passed_validation(item)
+
+
+# this is a sort of utility used for retroactively creating validation files in accordance with existing snapshot files
+# it takes the recorded date from a snapshot and sets it to the last validated date
+# @pytest.hookimpl(trylast=True)
+# def pytest_collection_modifyitems(session, config, items: list[pytest.Item]):
+#     for item in items:
+#         snapshot_entry = find_snapshot_for_item(item)
+#         if not snapshot_entry:
+#             continue
+#
+#         snapshot_update_timestamp = datetime.datetime.strptime(snapshot_entry["recorded-date"], "%d-%m-%Y, %H:%M:%S").astimezone(tz=datetime.timezone.utc)
+#
+#         record_passed_validation(item, snapshot_update_timestamp)

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from json import JSONDecodeError
 from pathlib import Path
 from re import Pattern
@@ -111,7 +111,9 @@ class SnapshotSession:
                     content = fd.read()
                     full_state = json.loads(content or "{}")
                     recorded = {
-                        "recorded-date": datetime.now().strftime("%d-%m-%Y, %H:%M:%S"),
+                        "recorded-date": datetime.now(tz=timezone.utc).strftime(
+                            "%d-%m-%Y, %H:%M:%S"
+                        ),
                         "recorded-content": self.observed_state,
                     }
                     full_state[self.scope_key] = recorded
@@ -131,7 +133,9 @@ class SnapshotSession:
                     content = fd.read()
                     full_state = json.loads(content or "{}")
                     recorded = {
-                        "recorded-date": datetime.now().strftime("%d-%m-%Y, %H:%M:%S"),
+                        "recorded-date": datetime.now(tz=timezone.utc).strftime(
+                            "%d-%m-%Y, %H:%M:%S"
+                        ),
                         "recorded-content": raw_state,
                     }
                     full_state[self.scope_key] = recorded

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ pytest_plugins = [
     "localstack.testing.pytest.marking",
     "localstack.testing.pytest.marker_report",
     "localstack.testing.pytest.in_memory_localstack",
+    "localstack.testing.pytest.validation_tracking",
 ]
 
 


### PR DESCRIPTION
## Motivation

When creating tests we validate that they are passing successfully against AWS. This can change over time and so we need a way to have a sensible way to periodically re-evaluate this validation status.  In the future we can do this e.g. on a schedule where we re-validate any tests that haven't been validated in the last x (e.g. 12) months.

Earlier this year we started a similar effort on keeping snapshots up to date to avoid recurring issues where changes on AWS' side cause undetected issues. We can probably re-target the tools used there to instead track the validation date, since the snapshot update date can actually just stay the same until it really needs to be changed.

In the past a few of our team expressed interest in having this data available, so there you go :)

## Changes

- Add new pytest plugin which creates a new entry in a `*.validation.json` companion file that is updated when a test is ran against AWS and executes successfully.
- Add filtering option to select tests that have a validation date older than a user-provided date.
- Added a  small (commented-out) util that I'll use in a follow-up PR to set the validation date for existing snapshot tests to the snapshot's updated date.

## Testing

```
pytest ... --validation-date-limit-days=10
pytest ... --validation-date-limit-timestamp="2023-12-01T00:00:00"
```

## Future work
- Linting that makes sure if something is marked `@markers.aws.validated` that is also has a validation file/date (and the other way around as well.
- A follow-up PR will populate an initial set of validation files by assuming the snapshot date as the last validated date.

