### PR TITLE
Fix: EventBus: Exists prefix not considered for rule matching

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -423,7 +423,7 @@ def filter_event_with_content_base_parameter(pattern_value: list, event_value: s
             elif element_key.lower() == "exists":
                 if element_value and event_value:
                     return True
-                elif not element_value and not event_value:
+                elif not element_value and isinstance(event_value, object):
                     return True
             elif element_key.lower() == "cidr":
                 ips = [str(ip) for ip in ipaddress.IPv4Network(element_value)]
@@ -513,6 +513,14 @@ def get_two_lists_intersection(lst1: List, lst2: List) -> List:
     return lst3
 
 
+def event_pattern_prefix_bool_filter(event_pattern_filter_value_list: List[Dict[str, Any]]) -> bool:
+    for event_pattern_filter_value in event_pattern_filter_value_list:
+        if "exists" in event_pattern_filter_value:
+            return event_pattern_filter_value.get("exists")
+        else:
+            return True
+
+
 # TODO: refactor/simplify!
 def filter_event_based_on_event_format(
     self, rule_name: str, event_bus_name: str, event: Dict[str, Any]
@@ -521,7 +529,7 @@ def filter_event_based_on_event_format(
         for key, value in event_pattern_filter.items():
             fallback = object()
             event_value = event.get(key.lower(), event.get(key, fallback))
-            if event_value is fallback:
+            if event_value is fallback and event_pattern_prefix_bool_filter(value):
                 return False
 
             # 1. check if certain values in the event do not match the expected pattern

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -489,6 +489,9 @@ def handle_prefix_filtering(event_pattern, value):
         elif isinstance(element, dict) and "anything-but" in element:
             if element.get("anything-but") != value:
                 return True
+        elif isinstance(element, dict) and "exists" in element:
+            if element.get("exists") and value:
+                return True
         elif "numeric" in element:
             return handle_numeric_conditions(element.get("numeric"), value)
         elif isinstance(element, list):

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -376,7 +376,7 @@ def _dump_events_to_files(events_with_added_uuid):
         LOG.info("Unable to dump events to tmp dir %s: %s", _get_events_tmp_dir(), e)
 
 
-def handle_numeric_conditions(conditions: List[Any], value: float):
+def handle_numeric_conditions(conditions: list[Any], value: float):
     for i in range(0, len(conditions), 2):
         if conditions[i] == "<" and not (value < conditions[i + 1]):
             return False
@@ -513,7 +513,7 @@ def get_two_lists_intersection(lst1: List, lst2: List) -> List:
     return lst3
 
 
-def event_pattern_prefix_bool_filter(event_pattern_filter_value_list: List[Dict[str, Any]]) -> bool:
+def event_pattern_prefix_bool_filter(event_pattern_filter_value_list: list[dict[str, Any]]) -> bool:
     for event_pattern_filter_value in event_pattern_filter_value_list:
         if "exists" in event_pattern_filter_value:
             return event_pattern_filter_value.get("exists")
@@ -523,9 +523,9 @@ def event_pattern_prefix_bool_filter(event_pattern_filter_value_list: List[Dict[
 
 # TODO: refactor/simplify!
 def filter_event_based_on_event_format(
-    self, rule_name: str, event_bus_name: str, event: Dict[str, Any]
+    self, rule_name: str, event_bus_name: str, event: dict[str, Any]
 ):
-    def filter_event(event_pattern_filter: Dict[str, Any], event: Dict[str, Any]):
+    def filter_event(event_pattern_filter: dict[str, Any], event: dict[str, Any]):
         for key, value in event_pattern_filter.items():
             fallback = object()
             event_value = event.get(key.lower(), event.get(key, fallback))
@@ -595,7 +595,7 @@ def filter_event_with_target_input_path(target: Dict, event: Dict) -> Dict:
     return event
 
 
-def process_events(event: Dict, targets: List[Dict]):
+def process_events(event: Dict, targets: list[Dict]):
     for target in targets:
         arn = target["Arn"]
         changed_event = filter_event_with_target_input_path(target, event)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -397,7 +397,7 @@ class TestEvents:
                 for entry_asserts in entries_asserts:
                     entries = entry_asserts[0]
                     for entry in entries:
-                        entry.setdefault("EventBusName", bus_name)
+                        entry["EventBusName"] = bus_name
                     message = self._put_entries_assert_results_sqs(
                         events_client,
                         sqs_client,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -426,7 +426,9 @@ class TestEvents:
         assert not response.get("FailedEntryCount")
 
         def get_message(queue_url):
-            resp = sqs_client.receive_message(QueueUrl=queue_url)
+            resp = sqs_client.receive_message(
+                QueueUrl=queue_url, WaitTimeSeconds=5, MaxNumberOfMessages=1
+            )
             messages = resp.get("Messages")
             if messages:
                 for message in messages:
@@ -436,7 +438,7 @@ class TestEvents:
                 assert len(messages) == 1
             return messages
 
-        messages = retry(get_message, retries=5, sleep=1, queue_url=queue_url)
+        messages = retry(get_message, retries=5, queue_url=queue_url)
 
         if should_match:
             actual_event = json.loads(messages[0]["Body"])
@@ -553,8 +555,6 @@ class TestEvents:
         )
         snapshot.match("rule-exists-true", messages)
 
-        # updating snapshot against aws: receiving message is sometimes significantly delays,
-        # increase retry sleep time to 30 seconds and retry 10 times
         messages_not_exists = put_events_with_filter_to_sqs(
             pattern=test_event_pattern_not_exists,
             entries_asserts=entries_asserts_exists_false,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -428,6 +428,10 @@ class TestEvents:
         def get_message(queue_url):
             resp = sqs_client.receive_message(QueueUrl=queue_url)
             messages = resp.get("Messages")
+            if messages:
+                for message in messages:
+                    receipt_handle = message["ReceiptHandle"]
+                    sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
             if should_match:
                 assert len(messages) == 1
             return messages

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -293,8 +293,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_to_sqs": {
-    "recorded-date": "27-12-2023, 23:10:40",
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_true_to_sqs": {
+    "recorded-date": "29-12-2023, 09:56:47",
     "recorded-content": {
       "rule-exists-true": [
         {
@@ -316,15 +316,20 @@
             }
           }
         }
-      ],
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_false_to_sqs": {
+    "recorded-date": "29-12-2023, 09:59:20",
+    "recorded-content": {
       "rule-exists-false": [
         {
-          "MessageId": "<uuid:3>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
           "Body": {
             "version": "0",
-            "id": "<uuid:4>",
+            "id": "<uuid:2>",
             "detail-type": "core.update-account-command",
             "source": "core.update-account-command",
             "account": "111111111111",

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -292,5 +292,52 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_to_sqs": {
+    "recorded-date": "27-12-2023, 23:10:40",
+    "recorded-content": {
+      "rule-exists-true": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "key": "value",
+              "payload": "baz"
+            }
+          }
+        }
+      ],
+      "rule-exists-false": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:4>",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "no-key": "no-value",
+              "payload": "baz"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -8,6 +8,12 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_to_default_eventbus_for_custom_eventbus": {
     "last_validated_date": "2022-12-22T00:50:01+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_false_to_sqs": {
+    "last_validated_date": "2023-12-29T09:59:20+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_rule_exists_true_to_sqs": {
+    "last_validated_date": "2023-12-29T09:56:47+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_rule": {
     "last_validated_date": "2023-09-29T17:26:53+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #8512 and #7305 the current behavior does not fully match the aws cli behavior regarding the EventBridge pattern `{"exists": True}`.

This rule:
```
{
	"source": ["core.update-account-command"],
	"detail-type": ["core.update-account-command"],
	"detail": {"key": [{"exists": True}]},
}
```

in combination with this message:
```
{
	"version": "0",
	"id": "<uuid:2>",
	"detail-type": "core.update-account-command",
	"source": "core.update-account-command",
	"account": "111111111111",
	"time": "date",
	"region": "<region>",
	"resources": [],
	"detail": {
	    "key":"value",
		"payload":"baz"
	}
}
```

does not match on LocalStack, but does correctly match on AWS.

The issue arises from the prefix `exists` not being considered.

Furthermore, the opposite pattern `[("exists"): False]` was also not correctly matched

This rule:
```
{
	"source": ["core.update-account-command"],
	"detail-type": ["core.update-account-command"],
	"detail": {"key": [{"exists": False}]},
}
```

in combination with this message:
```
{
	"version": "0",
	"id": "<uuid:2>",
	"detail-type": "core.update-account-command",
	"source": "core.update-account-command",
	"account": "111111111111",
	"time": "date",
	"region": "<region>",
	"resources": [],
	"detail": {
	    "no-key":"no-value",
		"payload":"baz"
	}
}
```

<!-- What notable changes does this PR make? -->
## Changes
Adding a condition to check for the prefix `exists` and use the boolean value in combination with the condition if there value to return exists for the pattern `[("exists"): True]`.

The pattern `[("exists"): False]` needs different handling, since per definition, the getter of the message event for the in the pattern defined key will always fail to the fallback object. To still send the message correctly, an additional check is put in place handling this particular instance when the return value is not presented, that is only `True` in the condition that the pattern prefix equal `"exists"` see (`provider.py` line 516).

Fixes #8512 and fixes #7305 

## Testing

Polling for sqs messages was changed to long poll due to inconsistencies when generating the snapshots against aws with messages not being received. 

