### PR TITLE
cloudwatch: fix functionality of metrics for multi-accounts and region

### DIFF
--- a/localstack/services/lambda_/invocation/metrics.py
+++ b/localstack/services/lambda_/invocation/metrics.py
@@ -5,30 +5,33 @@ from localstack.utils.cloudwatch.cloudwatch_util import publish_lambda_metric
 LOG = logging.getLogger(__name__)
 
 
-def record_cw_metric_invocation(function_name: str, region_name: str, function_arn: str):
+def record_cw_metric_invocation(function_name: str, account_id: str, region_name: str):
     try:
         publish_lambda_metric(
             "Invocations",
             1,
-            {"func_name": function_name, "func_arn": function_arn},
+            {"func_name": function_name},
             region_name=region_name,
+            account_id=account_id,
         )
     except Exception as e:
         LOG.debug("Failed to send CloudWatch metric for Lambda invocation: %s", e)
 
 
-def record_cw_metric_error(function_name: str, region_name: str, function_arn: str):
+def record_cw_metric_error(function_name: str, account_id: str, region_name: str):
     try:
         publish_lambda_metric(
             "Invocations",
             1,
-            {"func_name": function_name, "func_arn": function_arn},
+            {"func_name": function_name},
             region_name=region_name,
+            account_id=account_id,
         )
         publish_lambda_metric(
             "Errors",
             1,
-            {"func_name": function_name, "func_arn": function_arn},
+            {"func_name": function_name},
+            account_id=account_id,
             region_name=region_name,
         )
     except Exception as e:

--- a/localstack/services/lambda_/invocation/metrics.py
+++ b/localstack/services/lambda_/invocation/metrics.py
@@ -17,18 +17,18 @@ def record_cw_metric_invocation(function_name: str, region_name: str, function_a
         LOG.debug("Failed to send CloudWatch metric for Lambda invocation: %s", e)
 
 
-def record_cw_metric_error(function_name: str, region_name: str):
+def record_cw_metric_error(function_name: str, region_name: str, function_arn: str):
     try:
         publish_lambda_metric(
             "Invocations",
             1,
-            {"func_name": function_name},
+            {"func_name": function_name, "func_arn": function_arn},
             region_name=region_name,
         )
         publish_lambda_metric(
             "Errors",
             1,
-            {"func_name": function_name},
+            {"func_name": function_name, "func_arn": function_arn},
             region_name=region_name,
         )
     except Exception as e:

--- a/localstack/services/lambda_/invocation/metrics.py
+++ b/localstack/services/lambda_/invocation/metrics.py
@@ -5,12 +5,12 @@ from localstack.utils.cloudwatch.cloudwatch_util import publish_lambda_metric
 LOG = logging.getLogger(__name__)
 
 
-def record_cw_metric_invocation(function_name: str, region_name: str):
+def record_cw_metric_invocation(function_name: str, region_name: str, function_arn: str):
     try:
         publish_lambda_metric(
             "Invocations",
             1,
-            {"func_name": function_name},
+            {"func_name": function_name, "func_arn": function_arn},
             region_name=region_name,
         )
     except Exception as e:

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -229,8 +229,8 @@ class LambdaVersionManager:
             start_thread(
                 lambda *args, **kwargs: record_cw_metric_error(
                     function_name=self.function.function_name,
+                    account_id=self.function_version.id.account,
                     region_name=self.function_version.id.region,
-                    function_arn=self.function_arn,
                 ),
                 name=f"record-cloudwatch-metric-error-{function_id.function_name}:{function_id.qualifier}",
             )
@@ -238,8 +238,8 @@ class LambdaVersionManager:
             start_thread(
                 lambda *args, **kwargs: record_cw_metric_invocation(
                     function_name=self.function.function_name,
+                    account_id=self.function_version.id.account,
                     region_name=self.function_version.id.region,
-                    function_arn=self.function_arn,
                 ),
                 name=f"record-cloudwatch-metric-{function_id.function_name}:{function_id.qualifier}",
             )

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -238,6 +238,7 @@ class LambdaVersionManager:
                 lambda *args, **kwargs: record_cw_metric_invocation(
                     function_name=self.function.function_name,
                     region_name=self.function_version.id.region,
+                    function_arn=self.function_arn,
                 ),
                 name=f"record-cloudwatch-metric-{function_id.function_name}:{function_id.qualifier}",
             )

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -230,6 +230,7 @@ class LambdaVersionManager:
                 lambda *args, **kwargs: record_cw_metric_error(
                     function_name=self.function.function_name,
                     region_name=self.function_version.id.region,
+                    function_arn=self.function_arn,
                 ),
                 name=f"record-cloudwatch-metric-error-{function_id.function_name}:{function_id.qualifier}",
             )

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -30,11 +30,10 @@ def dimension_lambda(kwargs):
     return [{"Name": "FunctionName", "Value": func_name}]
 
 
-def publish_lambda_metric(metric, value, kwargs, region_name: Optional[str] = None):
+def publish_lambda_metric(metric, value, kwargs, account_id: Optional[str] = None, region_name: Optional[str] = None):
     # publish metric only if CloudWatch service is available
     if not is_api_enabled("cloudwatch"):
         return
-    _, _, account_id, _ = function_locators_from_arn(kwargs.get("func_arn"))
     cw_client = connect_to(aws_access_key_id=account_id, region_name=region_name).cloudwatch
     try:
         cw_client.put_metric_data(

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -7,6 +7,7 @@ from typing import Optional, TypedDict
 from werkzeug import Response as WerkzeugResponse
 
 from localstack.aws.connect import connect_to
+from localstack.services.lambda_.api_utils import function_locators_from_arn
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.strings import to_str
 from localstack.utils.time import now_utc
@@ -33,7 +34,8 @@ def publish_lambda_metric(metric, value, kwargs, region_name: Optional[str] = No
     # publish metric only if CloudWatch service is available
     if not is_api_enabled("cloudwatch"):
         return
-    cw_client = connect_to(region_name=region_name).cloudwatch
+    _, _, account_id, _ = function_locators_from_arn(kwargs.get("func_arn"))
+    cw_client = connect_to(aws_access_key_id=account_id, region_name=region_name).cloudwatch
     try:
         cw_client.put_metric_data(
             Namespace="AWS/Lambda",

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -7,7 +7,6 @@ from typing import Optional, TypedDict
 from werkzeug import Response as WerkzeugResponse
 
 from localstack.aws.connect import connect_to
-from localstack.services.lambda_.api_utils import function_locators_from_arn
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.strings import to_str
 from localstack.utils.time import now_utc
@@ -30,7 +29,9 @@ def dimension_lambda(kwargs):
     return [{"Name": "FunctionName", "Value": func_name}]
 
 
-def publish_lambda_metric(metric, value, kwargs, account_id: Optional[str] = None, region_name: Optional[str] = None):
+def publish_lambda_metric(
+    metric, value, kwargs, account_id: Optional[str] = None, region_name: Optional[str] = None
+):
     # publish metric only if CloudWatch service is available
     if not is_api_enabled("cloudwatch"):
         return


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using values other than `000000000000` for account ID or `us-east-1` for region, `cloudwatch` tests should still create the consequent resources in these accounts and region.

<!-- What notable changes does this PR make? -->
## Changes
This PR adds `account_id` parameter to the `cloudwatch` client when publishing the lambda metric on function invoke. The remaining changes involves propagating its value to the corresponding functions.

## Testing

The tests were failing previously when executed with a non-default account ID, set through environment variables (`TEST_AWS_ACCOUNT_ID=111111111111`, `TEST_AWS_ACCESS_KEY_ID=111111111111`, `TEST_AWS_REGION=us-west-1`). This PR fixes: 

```
tests.aws.services.cloudwatch.test_cloudwatch_metrics.TestCloudWatchLambdaMetrics.test_lambda_invoke_successful
tests.aws.services.cloudwatch.test_cloudwatch_metrics.TestCloudWatchLambdaMetrics.test_lambda_invoke_error
```
<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

