### PR TITLE
Added SIGINT trap, improved docker workflow

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Function to perform cleanup before exiting
+cleanup() {
+    echo "Caught SIGINT, exiting..."
+    exit 1
+}
+
+# Trap the SIGINT signal and call the cleanup function
+trap cleanup SIGINT
+
 set -eo pipefail
 shopt -s nullglob
 


### PR DESCRIPTION
Now docker container will catch SIGINT from `docker stop` and similar commands and will exit right away instead of waiting docker timeout of 10s and getting SIGKILL

Haven't tested it

linking https://github.com/localstack/localstack/issues/1645

