### PR TITLE
add SQS message retention period functionality

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -822,6 +822,9 @@ SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
 # Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
 SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 
+# Used to toggle MessageRetentionPeriod functionality in SQS queues
+SQS_ENABLE_MESSAGE_RETENTION_PERIOD = is_env_true("SQS_ENABLE_MESSAGE_RETENTION_PERIOD")
+
 # Strategy used when creating SQS queue urls. can be "off", "standard" (default), "domain", or "path"
 SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "standard"
 
@@ -1171,6 +1174,7 @@ CONFIG_ENV_VARS = [
     "SNAPSHOT_FLUSH_INTERVAL",
     "SQS_DELAY_PURGE_RETRY",
     "SQS_DELAY_RECENTLY_DELETED",
+    "SQS_ENABLE_MESSAGE_RETENTION_PERIOD",
     "SQS_ENDPOINT_STRATEGY",
     "SQS_DISABLE_CLOUDWATCH_METRICS",
     "SQS_CLOUDWATCH_METRICS_REPORT_INTERVAL",

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -356,6 +356,12 @@ class QueueUpdateWorker:
                 except Exception:
                     LOG.exception("error enqueueing delayed messages")
 
+                if config.SQS_ENABLE_MESSAGE_RETENTION_PERIOD:
+                    try:
+                        queue.remove_expired_messages()
+                    except Exception:
+                        LOG.exception("error removing expired messages")
+
     def start(self):
         with self.mutex:
             if self.thread:

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1094,40 +1094,40 @@ class TestSqsProvider:
     def test_message_retention_with_inflight(self, sqs_create_queue, aws_client, monkeypatch):
         # tests whether an inflight message is correctly removed after it expires
         monkeypatch.setattr(config, "SQS_ENABLE_MESSAGE_RETENTION_PERIOD", True)
+
         if is_aws_cloud():
             message_retention_period = 60
-            visibility_timeout = 30
-            wait_time = 10
+            wait_time = 5
         else:
-            message_retention_period = 6
-            visibility_timeout = 3
-            wait_time = 2
+            message_retention_period = 2
+            wait_time = 1
 
+        # by setting message_retention_period = visibility_timeout, we can keep the waiting logic simple
         queue_url = sqs_create_queue(
             Attributes={
                 "MessageRetentionPeriod": str(message_retention_period),
-                "VisibilityTimeout": str(visibility_timeout),
+                "VisibilityTimeout": str(message_retention_period),
             }
         )
 
         aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar1")
         aws_client.sqs.send_message(QueueUrl=queue_url, MessageBody="foobar2")
 
-        # We need to wait for a time so that once we receive the message, the visibility timeout
+        # We need to wait for a bit so that once we receive the message, the visibility timeout
         # expiration happens after the message expiration via message retention period
-        time.sleep(message_retention_period - visibility_timeout + wait_time)
+        time.sleep(wait_time)
         response = aws_client.sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
         assert response["Messages"][0]["Body"] == "foobar1"
         receipt_handle = response["Messages"][0]["ReceiptHandle"]
 
         # all messages should be removed after the retention policy timeframe has passed
-        time.sleep(visibility_timeout - wait_time / 2)
+        time.sleep(message_retention_period + 1)
 
         response = aws_client.sqs.receive_message(QueueUrl=queue_url)
         assert not response.get("Messages")
 
         # wait until the visibility timeout of the first receive message has expired, should be nonexistent
-        time.sleep(wait_time)
+        time.sleep(wait_time * 1.5)
         response = aws_client.sqs.receive_message(QueueUrl=queue_url)
         assert not response.get("Messages")
 

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -68,6 +68,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention": {
     "last_validated_date": "2023-12-28T23:48:08+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention_fifo": {
+    "last_validated_date": "2023-12-29T10:21:20+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention_with_inflight": {
     "last_validated_date": "2023-12-28T23:51:43+00:00"
   },

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -65,6 +65,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
     "last_validated_date": "2023-12-27T17:49:15+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention": {
+    "last_validated_date": "2023-12-28T23:48:08+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention_with_inflight": {
+    "last_validated_date": "2023-12-28T23:51:43+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2023-11-14T12:04:10+00:00"
   },

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -72,7 +72,7 @@
     "last_validated_date": "2023-12-29T10:21:20+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention_with_inflight": {
-    "last_validated_date": "2024-01-02T17:21:07+00:00"
+    "last_validated_date": "2024-01-02T17:32:37+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2023-11-14T12:04:10+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -72,7 +72,7 @@
     "last_validated_date": "2023-12-29T10:21:20+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_retention_with_inflight": {
-    "last_validated_date": "2023-12-28T23:51:43+00:00"
+    "last_validated_date": "2024-01-02T17:21:07+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2023-11-14T12:04:10+00:00"


### PR DESCRIPTION
## Motivation

A user noted in #3525 that we currently do not support the MessageRetentionPeriod of SQS queues. Basically, messages are deleted from queues after a period controlled by `MessageRetentionPeriod`.

From [the SQS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html)

> MessageRetentionPeriod – The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer representing seconds, from 60 (1 minute) to 1,209,600 (14 days). Default: 345,600 (4 days). When you change a queue's attributes, the change can take up to 60 seconds for most of the attributes to propagate throughout the Amazon SQS system. Changes made to the MessageRetentionPeriod attribute can take up to 15 minutes and will impact existing messages in the queue potentially causing them to be expired and deleted if the MessageRetentionPeriod is reduced below the age of existing messages.

This PR adds a basic implementation of message expiry. I integrated this into the Queue update worker mechanism which runs every second. In most cases, the invocation only peeks the first message and then aborts (because very rarely the message retention period will actually be triggered). We currently assume that message priority == created time, this way we can make assumptions about the heap property in the removal algorithm.

By default, message retention is at least 60 seconds in AWS. This makes for annoying tests, so we allow lower retention periods. I added two validated tests, but only one is run by default. Parametrizing the other one seemed to complicated.

Currently we have to hide this behind a feature flag, mainly because it would potentially break SQS persistence. See my [explanation here](https://github.com/localstack/localstack/issues/3525#issuecomment-1871255998).

## Changes

* Add a config flag `SQS_ENABLE_MESSAGE_RETENTION_PERIOD`
* Add message expiry logic into queue update worker

## Limitations

* Updating `MessageRetentionPeriod` currently has no effect
* There may be potential races when listening on the queue, if the message that expires is inflight, because it's first re-queued and then removed by the expiry logic. we could also remove all the messages from the inflight messages, but that would require additional code