### PR TITLE
refactor the status cli command

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -149,6 +149,19 @@ class TestCliContainerLifecycle:
         assert result.exit_code == 0
         assert "restarted" in result.output
 
+    def test_status(self, runner):
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code != 0
+
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "60"])
+
+        result = runner.invoke(cli, ["status"])
+
+        assert "is_docker" in result.output
+        assert "session_id" in result.output
+        assert "machine_id" in result.output
+
     def test_status_services(self, runner):
         result = runner.invoke(cli, ["status", "services"])
         assert result.exit_code != 0


### PR DESCRIPTION
This PR refactors the `localstack status` command to display details from `/info` endpoint.

```bash
$ python3 -m localstack.cli.main status
┌──────────────────────┬──────────────────────────────────────┐
│ version              │ 3.0.3.dev20231227173904:c249976      │
│ edition              │ pro                                  │
│ is_license_activated │ True                                 │
│ session_id           │ 554ab315-b019-4486-92bb-190093111eaf │
│ machine_id           │ 0c49752c                             │
│ system               │ linux                                │
│ is_docker            │ True                                 │
│ server_time_utc      │ 2023-12-29T12:26:24                  │
│ uptime               │ 6                                    │
└──────────────────────┴──────────────────────────────────────┘
```