### PR TITLE
Refactor: EventBridge: move clean_up fixture to localstack/testing/fixtures be able to use in localstack-ext

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -2096,7 +2096,7 @@ def hosted_zone(aws_client):
 
 
 @pytest.fixture
-def clean_up(aws_client):
+def events_clean_up(aws_client):
     def _events_clean_up(
         bus_name=None,
         rule_name=None,

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -32,19 +32,27 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
-from localstack.testing.aws.cloudformation_utils import load_template_file, render_template
+from localstack.testing.aws.cloudformation_utils import (
+    load_template_file,
+    render_template,
+)
 from localstack.testing.aws.util import get_lambda_logs, is_aws_cloud
 from localstack.utils import testutil
 from localstack.utils.aws.client import SigningHttpClient
 from localstack.utils.aws.resources import create_dynamodb_table
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import ensure_list
-from localstack.utils.functions import run_safe
+from localstack.utils.functions import call_safe, run_safe
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.json import CustomEncoder, json_safe
 from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
-from localstack.utils.sync import ShortCircuitWaitException, poll_condition, retry, wait_until
+from localstack.utils.sync import (
+    ShortCircuitWaitException,
+    poll_condition,
+    retry,
+    wait_until,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -2085,3 +2093,43 @@ def hosted_zone(aws_client):
 
     for zone_id in zone_ids[::-1]:
         aws_client.route53.delete_hosted_zone(Id=zone_id)
+
+
+@pytest.fixture
+def clean_up(aws_client):
+    def _events_clean_up(
+        bus_name=None,
+        rule_name=None,
+        target_ids=None,
+        queue_url=None,
+        log_group_name=None,
+    ):
+        events_client = aws_client.events
+        kwargs = {"EventBusName": bus_name} if bus_name else {}
+        if target_ids:
+            target_ids = target_ids if isinstance(target_ids, list) else [target_ids]
+            call_safe(
+                events_client.remove_targets,
+                kwargs=dict(Rule=rule_name, Ids=target_ids, Force=True, **kwargs),
+            )
+        if rule_name:
+            call_safe(events_client.delete_rule, kwargs=dict(Name=rule_name, Force=True, **kwargs))
+        if bus_name:
+            call_safe(events_client.delete_event_bus, kwargs=dict(Name=bus_name))
+        if queue_url:
+            sqs_client = aws_client.sqs
+            call_safe(sqs_client.delete_queue, kwargs=dict(QueueUrl=queue_url))
+        if log_group_name:
+            logs_client = aws_client.logs
+
+            def _delete_log_group():
+                log_streams = logs_client.describe_log_streams(logGroupName=log_group_name)
+                for log_stream in log_streams["logStreams"]:
+                    logs_client.delete_log_stream(
+                        logGroupName=log_group_name, logStreamName=log_stream["logStreamName"]
+                    )
+                logs_client.delete_log_group(logGroupName=log_group_name)
+
+            call_safe(_delete_log_group)
+
+    yield _events_clean_up

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 
-from localstack.utils.functions import call_safe
 from localstack.utils.strings import short_uid
 
 
@@ -74,43 +73,3 @@ def events_create_event_bus(aws_client):
 
     for event_bus in event_buses:
         aws_client.events.delete_event_bus(Name=event_bus)
-
-
-@pytest.fixture
-def clean_up(aws_client):
-    def _clean_up(
-        bus_name=None,
-        rule_name=None,
-        target_ids=None,
-        queue_url=None,
-        log_group_name=None,
-    ):
-        events_client = aws_client.events
-        kwargs = {"EventBusName": bus_name} if bus_name else {}
-        if target_ids:
-            target_ids = target_ids if isinstance(target_ids, list) else [target_ids]
-            call_safe(
-                events_client.remove_targets,
-                kwargs=dict(Rule=rule_name, Ids=target_ids, Force=True, **kwargs),
-            )
-        if rule_name:
-            call_safe(events_client.delete_rule, kwargs=dict(Name=rule_name, Force=True, **kwargs))
-        if bus_name:
-            call_safe(events_client.delete_event_bus, kwargs=dict(Name=bus_name))
-        if queue_url:
-            sqs_client = aws_client.sqs
-            call_safe(sqs_client.delete_queue, kwargs=dict(QueueUrl=queue_url))
-        if log_group_name:
-            logs_client = aws_client.logs
-
-            def _delete_log_group():
-                log_streams = logs_client.describe_log_streams(logGroupName=log_group_name)
-                for log_stream in log_streams["logStreams"]:
-                    logs_client.delete_log_stream(
-                        logGroupName=log_group_name, logStreamName=log_stream["logStreamName"]
-                    )
-                logs_client.delete_log_group(logGroupName=log_group_name)
-
-            call_safe(_delete_log_group)
-
-    yield _clean_up


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the fixture that is used by the EventBrdige tests to clean up the created items, is not accessible from localstack-ext. 

<!-- What notable changes does this PR make? -->
## Changes
To avoid code duplication, the fixture is moved to `localstack/testing/fixtures`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

