### PR TITLE
add subrange operation for ports

### DIFF
--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -322,6 +322,30 @@ class PortRange:
         )
         self._ports_lock = threading.RLock()
 
+    def subrange(self, start: int = None, end: int = None) -> "PortRange":
+        """
+        Creates a new PortRange object from this range which is a sub-range of this port range. The new
+        object will use the same port cache and locks of this port range, so you can constrain port
+        reservations of an existing port range but have reservations synced between them.
+
+        :param start: the start of the subrange
+        :param end: the end of the subrange
+        :raises ValueError: if start or end are outside the current port range
+        :return: a new PortRange object synced to this one
+        """
+        start = start if start is not None else self.start
+        end = end if end is not None else self.end
+
+        if start < self.start:
+            raise ValueError(f"start not in range ({start} < {self.start})")
+        if end > self.end:
+            raise ValueError(f"end not in range ({end} < {self.end})")
+
+        port_range = PortRange(start, end)
+        port_range._ports_cache = self._ports_cache
+        port_range._ports_lock = self._ports_lock
+        return port_range
+
     def as_range(self) -> range:
         """
         Returns a ``range(start, end+1)`` object representing this port range.

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -96,6 +96,27 @@ def test_get_free_tcp_port_range():
         assert port_can_be_bound(port)
 
 
+def test_subrange():
+    r = PortRange(50000, 60000)
+    r.mark_reserved(50000)
+    r.mark_reserved(50001)
+    r.mark_reserved(50002)
+    r.mark_reserved(50003)
+
+    sr = r.subrange(end=50005)
+    assert sr.as_range() == range(50000, 50006)
+
+    assert sr.is_port_reserved(50000)
+    assert sr.is_port_reserved(50001)
+    assert sr.is_port_reserved(50002)
+    assert sr.is_port_reserved(50003)
+    assert not sr.is_port_reserved(50004)
+    assert not sr.is_port_reserved(50005)
+
+    sr.mark_reserved(50005)
+    assert r.is_port_reserved(50005)
+
+
 def test_get_free_tcp_port_range_fails_if_reserved(monkeypatch):
     mock = MagicMock()
     mock.return_value = True


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Sometimes we want to only consider a subrange of a `PortRange`, while also sharing the port cache and port reservation status. This PR adds functionality for that. The need came up when constraining the dynamic port range to ports that are also valid container ports (different on some systems).

<!-- What notable changes does this PR make? -->
## Changes

* add `PortRange.subrange` command that creates a new `PortRange` that is synced with the original object

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

