### PR TITLE
Add performance logging for tests

### DIFF
--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -1,4 +1,6 @@
+import json
 import os
+import time
 from typing import Optional
 
 import pytest
@@ -87,3 +89,17 @@ def infrastructure_setup(cdk_template_path, aws_client):
         )
 
     return _infrastructure_setup
+
+
+# HACK: global timer (the first timediff is inaccurate)
+TIMER = time.perf_counter()
+
+
+@pytest.hookimpl()
+def pytest_runtest_logfinish(nodeid: str, location: tuple):
+    global TIMER
+    now = time.perf_counter()
+    timediff = now - TIMER
+    TIMER = now
+    row = {"nodeid": nodeid, "timediff": timediff}
+    print(f"test-perf-timelog:{json.dumps(row)}")


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

After merging https://github.com/localstack/localstack/pull/9917 to mitigate async Lambda reliability issues upon high load, the pipeline got blocked by 🔴 build timeouts because test time massively increased (from ~30min to >45-60min for each runner). We need better performance logging to track performance regressions that make many tests a little bit slower but are hard to pinpoint in a single test (especially without dedicated performance tests).

[Pytest duration profiling](https://stackoverflow.com/a/55095253/6875981) is not applicable for runners that time out. Therefore, we add print the timediff directly in the live logs. Example to print all durations: `pytest --durations=0 --durations-min=0.0 -vv`

## Changes

* Add very basic timediff logging in seconds for each test

## Limitations

Ad-hoc approach: the timediff for the first test is inaccurate
