### PR TITLE
fix S3 CORS headers casing matching

### DIFF
--- a/tests/aws/services/s3/test_s3_cors.py
+++ b/tests/aws/services/s3/test_s3_cors.py
@@ -404,7 +404,9 @@ class TestS3Cors:
         condition=lambda: config.LEGACY_V2_S3_PROVIDER,
         paths=["$..Headers.x-amz-server-side-encryption"],
     )
-    def test_cors_match_headers(self, s3_bucket, match_headers, aws_client, allow_bucket_acl):
+    def test_cors_match_headers(
+        self, s3_bucket, match_headers, aws_client, allow_bucket_acl, snapshot
+    ):
         origin = "https://localhost:4200"
         bucket_cors_config = {
             "CORSRules": [
@@ -462,11 +464,15 @@ class TestS3Cors:
                     "AllowedHeaders": [
                         "x-amz-expected-bucket-owner",
                         "x-amz-server-side-encryption-customer-algorithm",
+                        "x-AMZ-server-SIDE-encryption",
                     ],
                 }
             ]
         }
         aws_client.s3.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+
+        get_bucket_cors_casing = aws_client.s3.get_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("get-bucket-cors-casing", get_bucket_cors_casing)
 
         # test with a specific header: x-amz-request-payer, but not allowed in the config
         opt_req = requests.options(
@@ -490,6 +496,18 @@ class TestS3Cors:
             },
         )
         match_headers("opt-get-allowed", opt_req)
+        assert opt_req.ok
+
+        # test with a specific header but different casing: x-AMZ-expected-BUCKET-owner, allowed in the config
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-AMZ-expected-BUCKET-owner, x-amz-server-side-encryption",
+            },
+        )
+        match_headers("opt-get-allowed-diff-casing", opt_req)
         assert opt_req.ok
 
         # test GET with Access-Control-Request-Headers: should not happen in reality, AWS is considering it like an

--- a/tests/aws/services/s3/test_s3_cors.snapshot.json
+++ b/tests/aws/services/s3/test_s3_cors.snapshot.json
@@ -338,7 +338,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
-    "recorded-date": "31-07-2023, 12:34:42",
+    "recorded-date": "02-01-2024, 16:08:41",
     "recorded-content": {
       "opt-get": {
         "Body": "",
@@ -395,14 +395,36 @@
         },
         "StatusCode": 200
       },
+      "get-bucket-cors-casing": {
+        "CORSRules": [
+          {
+            "AllowedHeaders": [
+              "x-amz-expected-bucket-owner",
+              "x-amz-server-side-encryption-customer-algorithm",
+              "x-AMZ-server-SIDE-encryption"
+            ],
+            "AllowedMethods": [
+              "GET"
+            ],
+            "AllowedOrigins": [
+              "https://localhost:4200"
+            ],
+            "MaxAgeSeconds": 3000
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "opt-get-non-allowed": {
         "Body": {
           "Error": {
             "Code": "AccessForbidden",
-            "HostId": "<x-amz-id-2:4>",
+            "HostId": "<x-amz-id-2:5>",
             "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
             "Method": "GET",
-            "RequestId": "<x-amz-request-id:4>",
+            "RequestId": "<x-amz-request-id:5>",
             "ResourceType": "OBJECT"
           }
         },
@@ -411,8 +433,8 @@
           "Transfer-Encoding": "chunked",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:4>",
-          "x-amz-request-id": "<x-amz-request-id:4>"
+          "x-amz-id-2": "<x-amz-id-2:5>",
+          "x-amz-request-id": "<x-amz-request-id:5>"
         },
         "StatusCode": 403
       },
@@ -428,8 +450,25 @@
           "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:5>",
-          "x-amz-request-id": "<x-amz-request-id:5>"
+          "x-amz-id-2": "<x-amz-id-2:6>",
+          "x-amz-request-id": "<x-amz-request-id:6>"
+        },
+        "StatusCode": 200
+      },
+      "opt-get-allowed-diff-casing": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Headers": "x-amz-expected-bucket-owner, x-amz-server-side-encryption",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:7>",
+          "x-amz-request-id": "<x-amz-request-id:7>"
         },
         "StatusCode": 200
       },
@@ -443,8 +482,8 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:6>",
-          "x-amz-request-id": "<x-amz-request-id:6>",
+          "x-amz-id-2": "<x-amz-id-2:8>",
+          "x-amz-request-id": "<x-amz-request-id:8>",
           "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200
@@ -464,8 +503,8 @@
           "accept-ranges": "bytes",
           "date": "date",
           "server": "<server:1>",
-          "x-amz-id-2": "<x-amz-id-2:7>",
-          "x-amz-request-id": "<x-amz-request-id:7>",
+          "x-amz-id-2": "<x-amz-id-2:9>",
+          "x-amz-request-id": "<x-amz-request-id:9>",
           "x-amz-server-side-encryption": "AES256"
         },
         "StatusCode": 200

--- a/tests/aws/services/s3/test_s3_cors.validation.json
+++ b/tests/aws/services/s3/test_s3_cors.validation.json
@@ -12,7 +12,7 @@
     "last_validated_date": "2023-07-31T10:31:40+00:00"
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
-    "last_validated_date": "2023-07-31T10:34:42+00:00"
+    "last_validated_date": "2024-01-02T16:08:41+00:00"
   },
   "tests/aws/services/s3/test_s3_cors.py::TestS3Cors::test_cors_match_methods": {
     "last_validated_date": "2023-07-31T10:34:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9957, the header matching was case sensitive for the `AllowedHeaders` field for `OPTIONS` requests with the `Access-Control-Request-Headers` header.

<!-- What notable changes does this PR make? -->
## Changes
Wrote a AWS validated test to verify the behavior and fixed the matching to now be case insensitive. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

