### PR TITLE
fix sqs message group visibility when sending messages

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -938,7 +938,9 @@ class FifoQueue(SqsQueue):
             # put the message into the group
             message_group.push(message)
 
-            # if a message becomes visible in the queue, that message's group becomes visible also
+            # if an older message becomes visible again in the queue, that message's group becomes visible also.
+            if message.receive_count < 1:
+                return
             if message_group in self.inflight_groups:
                 self.inflight_groups.remove(message_group)
                 self.message_group_queue.put_nowait(message_group)

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes": {
     "last_validated_date": "2023-11-14T10:58:35+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_group_visibility": {
+    "last_validated_date": "2024-01-03T00:55:48+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails": {
     "last_validated_date": "2023-11-14T10:58:29+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Even after the initial implementation of FIFO message groups in #8238, users have reported odd behavior when using SQS FIFO queues related to message group visibility specifically that consumers are triggered although the message group is expected to be invisible #8724. This also affected lambdas triggered with fifo queues #7036.

This PR fixes the mechanism we were using to reset message group visibility, which was too general. It assumed that every message put into the message group reset its visibility, when really it should just be messages that were previously invisible, not new ones.

<!-- What notable changes does this PR make? -->
## Changes

* message group visibility is no longer reset when new messages are sent to the queue

Fixes
* #8724
* #7036 (tested with #7037)

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

