### PR TITLE
fix cloudwatch alarm evaluation for SampleCount

### DIFF
--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -5,7 +5,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List, Optional
 
-from localstack.aws.api.cloudwatch import MetricAlarm, MetricDataQuery, StateValue
+from localstack.aws.api.cloudwatch import MetricAlarm, MetricDataQuery, MetricStat, StateValue
 from localstack.aws.connect import connect_to
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.scheduler import Scheduler
@@ -142,15 +142,15 @@ def generate_metric_query(alarm_details: MetricAlarm) -> MetricDataQuery:
         metric["Namespace"] = alarm_details["Namespace"]
     if alarm_details.get("Dimensions"):
         metric["Dimensions"] = alarm_details["Dimensions"]
-    return {
-        "Id": alarm_details["AlarmName"],
-        "MetricStat": {
-            "Metric": metric,
-            "Period": alarm_details["Period"],
-            "Stat": alarm_details["Statistic"].capitalize(),
-        },
+    return MetricDataQuery(
+        Id=alarm_details["AlarmName"],
+        MetricStat=MetricStat(
+            Metric=metric,
+            Period=alarm_details["Period"],
+            Stat=alarm_details["Statistic"],
+        )
         # TODO other fields might be required in the future
-    }
+    )
 
 
 def is_threshold_exceeded(metric_values: List[float], alarm_details: MetricAlarm) -> bool:

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 from xml.sax.saxutils import escape
 
 from moto.cloudwatch import cloudwatch_backends
@@ -38,6 +37,7 @@ from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_account_id_from_arn
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
 from localstack.utils.patch import patch
+from localstack.utils.strings import camel_to_snake_case
 from localstack.utils.sync import poll_condition
 from localstack.utils.tagging import TaggingService
 from localstack.utils.threads import start_worker_thread
@@ -143,12 +143,6 @@ def put_metric_alarm(
     )
 
 
-def convert_camel_to_snake_upper_case(input: str) -> str:
-    # currently we only need to handle "SampleCount" camel case
-    input = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", input)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", input).upper()
-
-
 def create_message_response_update_state(alarm, old_state):
     response = {
         "AWSAccountId": extract_account_id_from_arn(alarm.alarm_arn),
@@ -191,9 +185,7 @@ def create_message_response_update_state(alarm, old_state):
 
     if alarm.statistic:
         details["StatisticType"] = "Statistic"
-        details["Statistic"] = convert_camel_to_snake_upper_case(
-            alarm.statistic
-        )  # AWS returns uppercase
+        details["Statistic"] = camel_to_snake_case(alarm.statistic).upper()  # AWS returns uppercase
     elif alarm.extended_statistic:
         details["StatisticType"] = "ExtendedStatistic"
         details["ExtendedStatistic"] = alarm.extended_statistic

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -455,7 +455,7 @@ class TestCloudwatch:
             "EvaluateLowSampleCountPercentile": "",
             "Dimensions": [{"value": "i-0317828c84edbe100", "name": "InstanceId"}],
             "StatisticType": "Statistic",
-            "Statistic": "Average",
+            "Statistic": "AVERAGE",
         }
         # subscribe to SQS
         subscription_alarm = aws_client.sns.subscribe(
@@ -484,7 +484,7 @@ class TestCloudwatch:
             Threshold=expected_trigger["Threshold"],
             Dimensions=[{"Name": "InstanceId", "Value": "i-0317828c84edbe100"}],
             Unit=expected_trigger["Unit"],
-            Statistic=expected_trigger["Statistic"],
+            Statistic=expected_trigger["Statistic"].capitalize(),
             OKActions=[topic_arn_ok],
             AlarmActions=[topic_arn_alarm],
             EvaluationPeriods=expected_trigger["EvaluationPeriods"],

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -455,7 +455,7 @@ class TestCloudwatch:
             "EvaluateLowSampleCountPercentile": "",
             "Dimensions": [{"value": "i-0317828c84edbe100", "name": "InstanceId"}],
             "StatisticType": "Statistic",
-            "Statistic": "AVERAGE",
+            "Statistic": "Average",
         }
         # subscribe to SQS
         subscription_alarm = aws_client.sns.subscribe(
@@ -484,7 +484,7 @@ class TestCloudwatch:
             Threshold=expected_trigger["Threshold"],
             Dimensions=[{"Name": "InstanceId", "Value": "i-0317828c84edbe100"}],
             Unit=expected_trigger["Unit"],
-            Statistic=expected_trigger["Statistic"].capitalize(),
+            Statistic=expected_trigger["Statistic"],
             OKActions=[topic_arn_ok],
             AlarmActions=[topic_arn_alarm],
             EvaluationPeriods=expected_trigger["EvaluationPeriods"],

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
@@ -1,12 +1,16 @@
+import json
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.snapshot import is_aws
+from localstack.utils.aws.arns import extract_resource_from_arn
 from localstack.utils.strings import short_uid
+from tests.aws.services.cloudwatch.test_cloudwatch import get_sqs_policy
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudwatch import CloudWatchClient
+    from mypy_boto3_sqs import SQSClient
 from localstack.utils.sync import retry
 
 TEST_SUCCESSFUL_LAMBDA = """
@@ -157,3 +161,113 @@ class TestSqsApproximateMetrics:
         assert "ApproximateNumberOfMessagesNotVisible" in metric_names
         assert "ApproximateNumberOfMessagesDelayed" in metric_names
         return res
+
+
+class TestSQSMetrics:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..MetricAlarms..StateReason",
+            "$..MetricAlarms..StateReasonData.evaluatedDatapoints",
+            "$..MetricAlarms..StateReasonData.startDate",
+            "$..MetricAlarms..StateTransitionedTimestamp",
+            "$..NewStateReason",
+        ]
+    )
+    def test_alarm_number_of_messages_sent(
+        self, aws_client, sns_create_topic, sqs_create_queue, cleanups, snapshot
+    ):
+        snapshot.add_transformer(snapshot.transform.cloudwatch_api())
+        # transform the date, that is part of the StateReason
+        #  eg. "Threshold Crossed: 1 datapoint [1.0 (03/01/24 11:36:00)] was greater than the threshold (0.0).",
+        snapshot.add_transformer(
+            # regex to transform date-pattern, e.g. (03/01/24 11:36:00)
+            snapshot.transform.regex(
+                r"\(\d{2}\/\d{2}\/\d{2}\ \d{2}:\d{2}:\d{2}\)", "(MM/DD/YY HH:MM:SS)"
+            )
+        )
+        # sns topic -> will be notified by alarm
+        sns_topic_alarm = sns_create_topic()
+        topic_arn_alarm = sns_topic_alarm["TopicArn"]
+        snapshot.add_transformer(
+            snapshot.transform.regex(extract_resource_from_arn(topic_arn_alarm), "<topic-name>")
+        )
+
+        # sqs queue will subscribe to sns topic
+        # -> so we can check the alarm action was triggered
+        sqs_url_alarm_triggered_check = sqs_create_queue()
+        sqs_arn_alarm_triggered = aws_client.sqs.get_queue_attributes(
+            QueueUrl=sqs_url_alarm_triggered_check, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+        # set policy - required for AWS:
+        aws_client.sqs.set_queue_attributes(
+            QueueUrl=sqs_url_alarm_triggered_check,
+            Attributes={"Policy": get_sqs_policy(sqs_arn_alarm_triggered, topic_arn_alarm)},
+        )
+        # add subscription
+        subscription = aws_client.sns.subscribe(
+            TopicArn=topic_arn_alarm, Protocol="sqs", Endpoint=sqs_arn_alarm_triggered
+        )
+        cleanups.append(
+            lambda: aws_client.sns.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+        )
+        queue_name = f"queue-to-watch-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(queue_name, "<replaced-queue-name>"))
+
+        alarm_name = f"check_sqs_messages_{short_uid()}"
+        aws_client.cloudwatch.put_metric_alarm(
+            AlarmName=alarm_name,
+            AlarmDescription="test messages sent",
+            MetricName="NumberOfMessagesSent",
+            Namespace="AWS/SQS",
+            ActionsEnabled=True,
+            Period=60,
+            Threshold=0,
+            Dimensions=[{"Name": "QueueName", "Value": queue_name}],
+            Statistic="SampleCount",
+            OKActions=[],
+            AlarmActions=[topic_arn_alarm],
+            EvaluationPeriods=1,
+            ComparisonOperator="GreaterThanThreshold",
+            TreatMissingData="missing",
+        )
+        cleanups.append(lambda: aws_client.cloudwatch.delete_alarms(AlarmNames=[alarm_name]))
+
+        # create the sqs test queue, where we will manually send a message to
+        # and will set an alarm specific for that queue
+        # it should automatically report the metric "NumberOfMessagesSent"
+        sqs_test_queue_url = sqs_create_queue(QueueName=queue_name)
+        aws_client.sqs.send_message(QueueUrl=sqs_test_queue_url, MessageBody="new message")
+
+        retry(
+            self._verify_alarm_triggered,
+            retries=60,
+            sleep=3 if is_aws() else 1,
+            cloudwatch_client=aws_client.cloudwatch,
+            sqs_client=aws_client.sqs,
+            alarm_name=alarm_name,
+            sqs_queue_url=sqs_url_alarm_triggered_check,
+            identifier="NumberOfMessagesSent",
+            snapshot=snapshot,
+        )
+
+    def _verify_alarm_triggered(
+        self,
+        cloudwatch_client: "CloudWatchClient",
+        sqs_client: "SQSClient",
+        alarm_name: str,
+        sqs_queue_url: str,
+        identifier: str,
+        snapshot,
+    ):
+        response = cloudwatch_client.describe_alarms(AlarmNames=[alarm_name])
+        assert response["MetricAlarms"][0]["StateValue"] == "ALARM"
+        snapshot.match(f"{identifier}-describe", response)
+
+        result = sqs_client.receive_message(QueueUrl=sqs_queue_url, VisibilityTimeout=0)
+        msg = result["Messages"][0]
+        body = json.loads(msg["Body"])
+        message = json.loads(body["Message"])
+        sqs_client.delete_message(QueueUrl=sqs_queue_url, ReceiptHandle=msg["ReceiptHandle"])
+        assert message["NewStateValue"] == "ALARM"
+        snapshot.match(f"{identifier}-sqs-msg", message)

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.snapshot.json
@@ -90,5 +90,103 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch_metrics.py::TestSQSMetrics::test_alarm_number_of_messages_sent": {
+    "recorded-date": "03-01-2024, 11:59:08",
+    "recorded-content": {
+      "NumberOfMessagesSent-describe": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:aws:sns:<region>:111111111111:<topic-name>"
+            ],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "test messages sent",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "QueueName",
+                "Value": "<replaced-queue-name>"
+              }
+            ],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "NumberOfMessagesSent",
+            "Namespace": "<namespace:1>",
+            "OKActions": [],
+            "Period": 60,
+            "StateReason": "Threshold Crossed: 1 datapoint [1.0 (MM/DD/YY HH:MM:SS)] was greater than the threshold (0.0).",
+            "StateReasonData": {
+              "version": "1.0",
+              "queryDate": "date",
+              "startDate": "date",
+              "statistic": "SampleCount",
+              "period": 60,
+              "recentDatapoints": [
+                1.0
+              ],
+              "threshold": 0.0,
+              "evaluatedDatapoints": [
+                {
+                  "timestamp": "date",
+                  "sampleCount": 1.0,
+                  "value": 1.0
+                }
+              ]
+            },
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "ALARM",
+            "Statistic": "SampleCount",
+            "Threshold": 0.0,
+            "TreatMissingData": "missing"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "NumberOfMessagesSent-sqs-msg": {
+        "AWSAccountId": "111111111111",
+        "AlarmActions": [
+          "arn:aws:sns:<region>:111111111111:<topic-name>"
+        ],
+        "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+        "AlarmConfigurationUpdatedTimestamp": "date",
+        "AlarmDescription": "test messages sent",
+        "AlarmName": "<alarm-name:1>",
+        "InsufficientDataActions": [],
+        "NewStateReason": "Threshold Crossed: 1 datapoint [1.0 (MM/DD/YY HH:MM:SS)] was greater than the threshold (0.0).",
+        "NewStateValue": "ALARM",
+        "OKActions": [],
+        "OldStateValue": "INSUFFICIENT_DATA",
+        "Region": "<region-name-full:1>",
+        "StateChangeTime": "date",
+        "Trigger": {
+          "ComparisonOperator": "GreaterThanThreshold",
+          "Dimensions": [
+            {
+              "name": "QueueName",
+              "value": "<replaced-queue-name>"
+            }
+          ],
+          "EvaluateLowSampleCountPercentile": "",
+          "EvaluationPeriods": 1,
+          "MetricName": "NumberOfMessagesSent",
+          "Namespace": "<namespace:1>",
+          "Period": 60,
+          "Statistic": "SAMPLE_COUNT",
+          "StatisticType": "Statistic",
+          "Threshold": 0.0,
+          "TreatMissingData": "missing",
+          "Unit": null
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.validation.json
@@ -7,5 +7,8 @@
   },
   "tests/aws/services/cloudwatch/test_cloudwatch_metrics.py::TestSqsApproximateMetrics::test_sqs_approximate_metrics": {
     "last_validated_date": "2024-01-02T11:33:18+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch_metrics.py::TestSQSMetrics::test_alarm_number_of_messages_sent": {
+    "last_validated_date": "2024-01-03T12:05:01+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fix for https://github.com/localstack/localstack/issues/8934: the alarm did not trigger for `SampleCount` statistics, and was throwing errors. 
The issue was caused by casing-mismatch - the metric query was send to moto using the statistic `Samplecount` but it's expecting an exact match. 

<!-- What notable changes does this PR make? -->
## Changes
* fixed the casing issue
* added a snapshot test for the reported scenario (it relies on metrics automatically reported by SQS when a message is send)
* some cleanup and fixes revealed by snapshot test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

