### PR TITLE
fix SQS send batch message validation for message size

### DIFF
--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -1380,5 +1380,31 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_message_size": {
+    "recorded-date": "03-01-2024, 01:58:35",
+    "recorded-content": {
+      "send-message-batch-result": {
+        "Failed": [
+          {
+            "Code": "InvalidParameterValue",
+            "Id": "<uuid:1>",
+            "Message": "One or more parameters cannot be validated. Reason: Message must be shorter than 1024 bytes.",
+            "SenderFault": true
+          }
+        ],
+        "Successful": [
+          {
+            "Id": "<uuid:2>",
+            "MD5OfMessageBody": "c9a34cfc85d982698c6ac89f76071abd",
+            "MessageId": "<uuid:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -89,6 +89,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters": {
     "last_validated_date": "2023-11-14T11:00:14+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_message_size": {
+    "last_validated_date": "2024-01-03T01:58:49+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_missing_deduplication_id_for_fifo_queue": {
     "last_validated_date": "2023-11-14T10:58:55+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR fixes #8570, where a user noted that the `MaximumMessageSize` constraint is not handled correctly for `BatchSendMessage` commands in SQS. 

<!-- What notable changes does this PR make? -->
## Changes

* message size is now checked for each individual message in a batch
* batch errors are now populated using `ServiceException` parameters rather than generic `Exception` properties

Limitations:
* Because of the way error serialization works in SQS (query vs json rest protocol), we currently serialize the exception code as `InvalidParameterValueException` instead of `InvalidParameterValue`. The message is also slightly different from what AWS returns. fixing this limitation in a generic way is IMO not worth it at the moment, but happy to reconsider if this is a blocker for users.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

