### PR TITLE
fix S3 missing XML namespace

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1465,6 +1465,8 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         "UploadPartCopyOutput": "CopyPartResult",
     }
 
+    XML_NAMESPACE = "http://s3.amazonaws.com/doc/2006-03-01/"
+
     def _serialize_response(
         self,
         parameters: dict,
@@ -1576,6 +1578,8 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         # some tools (Serverless) require a newline after the "<?xml ...>\n" preamble line, e.g., for LocationConstraint
         if root and not root.tail:
             root.tail = "\n"
+
+        root.attrib["xmlns"] = self.XML_NAMESPACE
 
     @staticmethod
     def _timestamp_iso8601(value: datetime) -> str:

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -230,6 +230,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_region_header_exists": {
     "last_validated_date": "2023-08-03T02:13:15+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure": {
+    "last_validated_date": "2024-01-03T16:46:18+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
     "last_validated_date": "2023-08-03T02:25:40+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This will fix #9930. The `Net::Amazon::S3` Perl client is making using of XML namespace to parse the responses (https://metacpan.org/module/Net::Amazon::S3::Operation::Objects::List::Response/source), but we didn't add them to S3 responses, as the current logic in the serializer is counting on the namespace being defined on the operation, but it's not in S3 specs.

<!-- What notable changes does this PR make? -->
## Changes
- manually add the S3 namespace to the root tag of the S3 response
- add additional checks to a specific S3 test checking raw XML S3 responses, to validate the behavior is in line with AWS

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

