### PR TITLE
snapshot test for return values on condition check failure

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from time import sleep
 from typing import Dict
 
+import botocore.exceptions
 import pytest
 from boto3.dynamodb.types import STRING
 from botocore.exceptions import ClientError
@@ -1923,3 +1924,31 @@ class TestDynamoDB:
             sleep=sleep_secs,
             sleep_before=2,
         )
+
+    @markers.aws.validated
+    def test_return_values_on_conditions_check_failure(
+        self, dynamodb_create_table_with_parameters, snapshot, aws_client
+    ):
+        table_name = f"table-{short_uid()}"
+        dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+        item = {
+            PARTITION_KEY: {"S": "456"},
+            "price": {"N": "650"},
+            "product": {"S": "sporting goods"},
+        }
+        aws_client.dynamodb.put_item(TableName=table_name, Item=item)
+        try:
+            aws_client.dynamodb.delete_item(
+                TableName=table_name,
+                Key={PARTITION_KEY: {"S": "456"}},
+                ConditionExpression="price between :lo and :hi",
+                ExpressionAttributeValues={":lo": {"N": "500"}, ":hi": {"N": "600"}},
+                ReturnValuesOnConditionCheckFailure="ALL_OLD",
+            )
+        except botocore.exceptions.ClientError as error:
+            snapshot.match("items", error.response)  # noqa

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1926,6 +1926,7 @@ class TestDynamoDB:
         )
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..message"])
     def test_return_values_on_conditions_check_failure(
         self, dynamodb_create_table_with_parameters, snapshot, aws_client
     ):

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -824,5 +824,31 @@
         ]
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_on_conditions_check_failure": {
+    "recorded-date": "03-01-2024, 17:52:20",
+    "recorded-content": {
+      "items": {
+        "Error": {
+          "Code": "ConditionalCheckFailedException",
+          "Message": "The conditional request failed"
+        },
+        "Item": {
+          "id": {
+            "S": "456"
+          },
+          "price": {
+            "N": "650"
+          },
+          "product": {
+            "S": "sporting goods"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -56,6 +56,9 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_in_put_item": {
     "last_validated_date": "2023-08-23T14:32:21+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_return_values_on_conditions_check_failure": {
+    "last_validated_date": "2024-01-03T17:52:19+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_get_items": {
     "last_validated_date": "2023-08-23T14:33:37+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR arises from #9040.

When an operation (e.g., `PutItem` or `DeleteItem`) fails on DDB due to a conditional check, we can ask to receive back the items that failed the check with the `ReturnValuesOnConditionCheckFailure` set to `ALL_OLD`.
This feature was implemented in DynamoDBLocal version 2.2.0, released in December 2023, so we can now support it out of the box. This PR simply adds a snapshot test to verify the behavior.

<!-- What notable changes does this PR make? -->
## Changes
- Adding a snapshot test to verify we return a set of items when `ReturnValuesOnConditionCheckFailure` is set to `ALL_OLD`.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

