### PR TITLE
add SQS message move task feature

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -6,6 +6,7 @@ import logging
 import re
 import threading
 import time
+from datetime import datetime
 from queue import Empty, PriorityQueue, Queue
 from typing import Dict, Optional, Set
 
@@ -27,11 +28,13 @@ from localstack.services.sqs.exceptions import (
 )
 from localstack.services.sqs.utils import (
     decode_receipt_handle,
+    encode_move_task_handle,
     encode_receipt_handle,
     global_message_sequence,
     is_message_deduplication_id_required,
 )
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.utils.strings import long_uid
 from localstack.utils.time import now
 from localstack.utils.urls import localstack_host
 
@@ -183,6 +186,54 @@ class ReceiveMessageResult:
         self.successful = []
         self.receipt_handles = []
         self.dead_letter_messages = []
+
+
+class MessageMoveTaskStatus(str):
+    CREATED = "CREATED"  # not validated, for internal use
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    CANCELLING = "CANCELLING"
+    CANCELLED = "CANCELLED"
+    FAILED = "FAILED"
+
+
+class MessageMoveTask:
+    """
+    A task created by the ``StartMessageMoveTask`` operation.
+    """
+
+    # configurable fields
+    source_arn: str
+    destination_arn: str
+    max_number_of_messages_per_second: int | None = None
+
+    # dynamic fields
+    task_id: str
+    status: str = MessageMoveTaskStatus.CREATED
+    started_timestamp: datetime | None = None
+    approximate_number_of_messages_moved: int | None = None
+    approximate_number_of_messages_to_move: int | None = None
+    failure_reason: str | None = None
+
+    cancel_event: threading.Event
+
+    def __init__(
+        self, source_arn: str, destination_arn: str, max_number_of_messages_per_second: int = None
+    ):
+        self.task_id = long_uid()
+        self.source_arn = source_arn
+        self.destination_arn = destination_arn
+        self.max_number_of_messages_per_second = max_number_of_messages_per_second
+        self.cancel_event = threading.Event()
+
+    def mark_started(self):
+        self.started_timestamp = datetime.utcnow()
+        self.status = MessageMoveTaskStatus.RUNNING
+        self.cancel_event.clear()
+
+    @property
+    def task_handle(self) -> str:
+        return encode_move_task_handle(self.task_id, self.source_arn)
 
 
 class SqsQueue:
@@ -640,12 +691,12 @@ class StandardQueue(SqsQueue):
         if message_deduplication_id:
             raise InvalidParameterValueException(
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
-                f"request includes a parameter that is not valid for this queue type. "
+                f"request includes a parameter that is not valid for this queue type."
             )
         if message_group_id:
             raise InvalidParameterValueException(
                 f"Value {message_group_id} for parameter MessageGroupId is invalid. Reason: The request includes a "
-                f"parameter that is not valid for this queue type. "
+                f"parameter that is not valid for this queue type."
             )
 
         standard_message = SqsMessage(time.time(), message)
@@ -1136,6 +1187,9 @@ class SqsStore(BaseStore):
     queues: Dict[str, SqsQueue] = LocalAttribute(default=dict)
 
     deleted: Dict[str, float] = LocalAttribute(default=dict)
+
+    move_tasks: Dict[str, MessageMoveTask] = LocalAttribute(default=dict)
+    """Maps task IDs to their ``MoveMessageTask`` object. Task IDs can be found by decoding a task handle."""
 
     def expire_deleted(self):
         for k in list(self.deleted.keys()):

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -462,6 +462,7 @@ class TransformerUtility:
         """
         return [
             TransformerUtility.key_value("ReceiptHandle"),
+            TransformerUtility.key_value("TaskHandle"),
             TransformerUtility.key_value(
                 "SenderId"
             ),  # TODO: flaky against AWS (e.g. /Attributes/SenderId '<sender-id:1>' → '<sender-id:2>' ... (expected → actual))

--- a/tests/aws/services/sqs/test_sqs_move_task.py
+++ b/tests/aws/services/sqs/test_sqs_move_task.py
@@ -283,6 +283,12 @@ def test_move_task_with_throughput_limit(
 
 
 @markers.aws.validated
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # this is non-deterministic because of concurrency in AWS vs LocalStack
+        "$..ApproximateNumberOfMessagesMoved",
+    ]
+)
 def test_move_task_cancel(
     sqs_create_queue,
     sqs_create_dlq_pipe,
@@ -343,6 +349,15 @@ def test_move_task_cancel(
 
 
 @markers.aws.validated
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # this is non-deterministic because of concurrency in AWS vs LocalStack
+        "$..Results..ApproximateNumberOfMessagesMoved",
+        # error serialization is still an issue ('AWS.SimpleQueueService.NonExistentQueue' vs
+        # 'QueueDoesNotExist')
+        "$..Results..FailureReason",
+    ]
+)
 def test_move_task_delete_destination_queue_while_running(
     sqs_create_queue,
     sqs_create_dlq_pipe,

--- a/tests/aws/services/sqs/test_sqs_move_task.py
+++ b/tests/aws/services/sqs/test_sqs_move_task.py
@@ -1,0 +1,437 @@
+import json
+import time
+import uuid
+
+import pytest
+from botocore.exceptions import ClientError
+
+from localstack.constants import TEST_AWS_REGION_NAME
+from localstack.services.sqs.utils import decode_move_task_handle, encode_move_task_handle
+from localstack.testing.pytest import markers
+from localstack.utils.aws import arns
+from localstack.utils.sync import poll_condition, retry
+
+QueueUrl = str
+
+
+def sqs_collect_messages(
+    sqs_client, queue_url: str, expected: int, timeout: int, delete: bool = True
+):
+    collected = []
+
+    def _receive():
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            WaitTimeSeconds=min(max(1, int(timeout)), 5),
+            MaxNumberOfMessages=1,
+        )
+
+        if messages := response.get("Messages"):
+            collected.extend(messages)
+
+            if delete:
+                for m in messages:
+                    sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"])
+
+        return len(collected) >= expected
+
+    if not poll_condition(_receive, timeout=timeout):
+        raise TimeoutError(
+            f"gave up waiting for messages (expected={expected}, actual={len(collected)}"
+        )
+
+    return collected
+
+
+def get_approx_number_of_messages(
+    sqs_client,
+    queue_url: str,
+) -> int:
+    response = sqs_client.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
+    )
+    return int(response["Attributes"]["ApproximateNumberOfMessages"])
+
+
+def sqs_wait_queue_size(
+    sqs_client,
+    queue_url: str,
+    expected_num_messages: int,
+    timeout: float = None,
+) -> int:
+    def _check_num_messages():
+        return get_approx_number_of_messages(sqs_client, queue_url) >= expected_num_messages
+
+    if not poll_condition(_check_num_messages, timeout=timeout):
+        raise TimeoutError(
+            f"gave up waiting for messages (expected={expected_num_messages}, "
+            f"actual={get_approx_number_of_messages(sqs_client, queue_url)})"
+        )
+
+    return get_approx_number_of_messages(sqs_client, queue_url)
+
+
+@pytest.fixture(autouse=True)
+def sqs_snapshot_transformer(snapshot):
+    snapshot.add_transformer(snapshot.transform.sqs_api())
+
+
+@pytest.fixture()
+def sqs_create_dlq_pipe(sqs_create_queue):
+    def _factory(max_receive_count: int = 1) -> tuple[QueueUrl, QueueUrl]:
+        dl_queue_url = sqs_create_queue()
+
+        # create redrive policy
+        url_parts = dl_queue_url.split("/")
+        dl_target_arn = arns.sqs_queue_arn(
+            url_parts[-1],
+            account_id=url_parts[len(url_parts) - 2],
+            region_name=TEST_AWS_REGION_NAME,
+        )
+        queue_url = sqs_create_queue(
+            Attributes={
+                "RedrivePolicy": json.dumps(
+                    {
+                        "deadLetterTargetArn": dl_target_arn,
+                        "maxReceiveCount": max_receive_count,
+                    }
+                )
+            },
+        )
+        return queue_url, dl_queue_url
+
+    return _factory
+
+
+@markers.aws.validated
+def test_cancel_with_invalid_task_handle(aws_client, snapshot):
+    with pytest.raises(ClientError) as e:
+        aws_client.sqs.cancel_message_move_task(TaskHandle="foobared")
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
+def test_cancel_with_invalid_source_arn_in_task_handle(aws_client, snapshot):
+    source_arn = "arn:aws:sqs:us-east-1:878966065785:test-queue-doesnt-exist-123456"
+    task_handle = encode_move_task_handle("10f57157-fc38-4da9-a113-4de7e12d05dd", source_arn)
+
+    with pytest.raises(ClientError) as e:
+        aws_client.sqs.cancel_message_move_task(TaskHandle=task_handle)
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
+def test_cancel_with_invalid_task_id_in_task_handle(
+    sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
+):
+    source_queue = sqs_create_queue()
+    source_arn = sqs_get_queue_arn(source_queue)
+
+    # this is just some non-existing task_id
+    task_handle = encode_move_task_handle("10f57157-fc38-4da9-a113-4de7e12d05aa", source_arn)
+    with pytest.raises(ClientError) as e:
+        aws_client.sqs.cancel_message_move_task(TaskHandle=task_handle)
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
+def test_source_needs_redrive_policy(
+    sqs_create_queue,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    source_queue = sqs_create_queue()
+    source_arn = sqs_get_queue_arn(source_queue)
+
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    with pytest.raises(ClientError) as e:
+        sqs.start_message_move_task(SourceArn=source_arn, DestinationArn=destination_arn)
+
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
+def test_destination_needs_to_exist(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+    destination_arn += "doesntexist"
+
+    with pytest.raises(ClientError) as e:
+        sqs.start_message_move_task(SourceArn=source_arn, DestinationArn=destination_arn)
+
+    snapshot.match("error", e.value.response)
+
+
+@markers.aws.validated
+def test_basic_move_task_workflow(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    # create dlq pipe: some-queue -> dlq (source) -> destination
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    # send two messages
+    sqs.send_message(QueueUrl=queue_url, MessageBody="message-1")
+    sqs.send_message(QueueUrl=queue_url, MessageBody="message-2")
+
+    # receive each message two times to move them into the dlq
+    sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+    sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+    sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+    sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+
+    # wait until the messages arrive in the DLQ
+    assert sqs_wait_queue_size(sqs, dl_queue_url, expected_num_messages=2, timeout=10) == 2
+
+    response = aws_client.sqs.start_message_move_task(
+        SourceArn=source_arn, DestinationArn=destination_arn
+    )
+    snapshot.match("start-message-move-task-response", response)
+
+    # check task handle format
+    task_handle = response["TaskHandle"]
+    decoded_task_id, decoded_source_arn = decode_move_task_handle(task_handle)
+    assert uuid.UUID(decoded_task_id)
+    assert decoded_source_arn == source_arn
+
+    # check that messages arrived in destination queue correctly
+    messages = sqs_collect_messages(sqs, destination_queue, expected=2, timeout=10)
+    assert {message["Body"] for message in messages} == {"message-1", "message-2"}
+
+    # check move task completion (in AWS, approximate number of messages may take a while to update)
+    def _wait_for_task_completion():
+        _response = aws_client.sqs.list_message_move_tasks(SourceArn=source_arn)
+        assert int(_response["Results"][0]["ApproximateNumberOfMessagesMoved"]) == 2
+        return _response
+
+    response = retry(_wait_for_task_completion, retries=30, sleep=1)
+    snapshot.match("list-message-move-task-response", response)
+
+    # assert messages are no longer in DLQ
+    response = aws_client.sqs.receive_message(QueueUrl=dl_queue_url, WaitTimeSeconds=1)
+    assert not response.get("Messages")
+
+
+@markers.aws.validated
+def test_move_task_with_throughput_limit(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    # create dlq pipe: some-queue -> dlq (source) -> destination
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    n = 4
+
+    # send n messages and move them into the DLQ
+    for i in range(n):
+        sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+
+    assert sqs_wait_queue_size(sqs, queue_url, expected_num_messages=n, timeout=10) == n
+
+    # receive each message two times to move them into the dlq
+    for i in range(n * 2):
+        sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+
+    # wait until the messages arrive in the DLQ
+    assert sqs_wait_queue_size(sqs, dl_queue_url, expected_num_messages=n, timeout=10) == n
+
+    # start move task
+    response = aws_client.sqs.start_message_move_task(
+        SourceArn=source_arn, DestinationArn=destination_arn, MaxNumberOfMessagesPerSecond=1
+    )
+    snapshot.match("start-message-move-task-response", response)
+    started = time.time()
+    messages = sqs_collect_messages(sqs, destination_queue, n, 60)
+    assert {message["Body"] for message in messages} == {
+        "message-0",
+        "message-1",
+        "message-2",
+        "message-3",
+    }
+
+    assert time.time() - started >= 3
+
+
+@markers.aws.validated
+def test_move_task_cancel(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    # create dlq pipe: some-queue -> dlq (source) -> destination
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    n = 10
+
+    # send n messages
+    for i in range(n):
+        sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+
+    assert sqs_wait_queue_size(sqs, queue_url, expected_num_messages=n, timeout=10) == n
+
+    # receive each message two times to move them into the dlq
+    for i in range(n * 2):
+        sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+
+    # wait until the messages arrive in the DLQ
+    assert sqs_wait_queue_size(sqs, dl_queue_url, expected_num_messages=n, timeout=10) == n
+
+    # start move task
+    response = aws_client.sqs.start_message_move_task(
+        SourceArn=source_arn, DestinationArn=destination_arn, MaxNumberOfMessagesPerSecond=1
+    )
+    task_handle = response["TaskHandle"]
+
+    # wait for two messages to arrive, then cancel the task
+    messages = sqs_collect_messages(sqs, destination_queue, 2, 60)
+    assert len(messages) == 2
+
+    response = sqs.list_message_move_tasks(SourceArn=source_arn)
+    snapshot.match("list-while", response)
+
+    response = sqs.cancel_message_move_task(TaskHandle=task_handle)
+    snapshot.match("cancel", response)
+
+    # check move task completion (in AWS, approximate number of messages may take a while to update)
+    def _wait_for_task_cancellation():
+        _response = aws_client.sqs.list_message_move_tasks(SourceArn=source_arn)
+        assert _response["Results"][0]["Status"] == "CANCELLED"
+        return _response
+
+    response = retry(_wait_for_task_cancellation, retries=30, sleep=1)
+    snapshot.match("list-after", response)
+
+    # make sure that there are still messages left in the DLQ
+    assert aws_client.sqs.receive_message(QueueUrl=dl_queue_url)["Messages"]
+
+
+@markers.aws.validated
+def test_move_task_delete_destination_queue_while_running(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    # create dlq pipe: some-queue -> dlq (source) -> destination
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    n = 10
+
+    # send n messages
+    for i in range(n):
+        sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+
+    assert sqs_wait_queue_size(sqs, queue_url, expected_num_messages=n, timeout=10) == n
+
+    # receive each message two times to move them into the dlq
+    for i in range(n * 2):
+        sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+
+    # wait until the messages arrive in the DLQ
+    assert sqs_wait_queue_size(sqs, dl_queue_url, expected_num_messages=n, timeout=10) == n
+
+    # start move task
+    aws_client.sqs.start_message_move_task(
+        SourceArn=source_arn, DestinationArn=destination_arn, MaxNumberOfMessagesPerSecond=1
+    )
+
+    sqs.delete_queue(QueueUrl=destination_queue)
+
+    # check move task completion (in AWS, approximate number of messages may take a while to update)
+    def _wait_for_task_cancellation():
+        _response = aws_client.sqs.list_message_move_tasks(SourceArn=source_arn)
+        assert _response["Results"][0]["Status"] != "RUNNING"
+        return _response
+
+    # should fail
+    response = retry(_wait_for_task_cancellation, retries=30, sleep=1)
+    print(response)
+    snapshot.match("list", response)
+
+    # make sure that there are still messages left in the DLQ
+    assert aws_client.sqs.receive_message(QueueUrl=dl_queue_url)["Messages"]
+
+
+@markers.aws.validated
+def test_start_multiple_move_tasks(
+    sqs_create_queue,
+    sqs_create_dlq_pipe,
+    sqs_get_queue_arn,
+    aws_client,
+    snapshot,
+):
+    sqs = aws_client.sqs
+
+    # create dlq pipe: some-queue -> dlq (source) -> destination
+    queue_url, dl_queue_url = sqs_create_dlq_pipe(max_receive_count=1)
+    source_arn = sqs_get_queue_arn(dl_queue_url)
+    destination_queue = sqs_create_queue()
+    destination_arn = sqs_get_queue_arn(destination_queue)
+
+    n = 10
+
+    # send n messages
+    for i in range(n):
+        sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{i}")
+
+    assert sqs_wait_queue_size(sqs, queue_url, expected_num_messages=n, timeout=10) == n
+
+    # receive each message two times to move them into the dlq
+    for i in range(n * 2):
+        sqs.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
+
+    # wait until the messages arrive in the DLQ
+    assert sqs_wait_queue_size(sqs, dl_queue_url, expected_num_messages=n, timeout=10) == n
+
+    # start move task
+    aws_client.sqs.start_message_move_task(
+        SourceArn=source_arn, DestinationArn=destination_arn, MaxNumberOfMessagesPerSecond=1
+    )
+    with pytest.raises(ClientError) as e:
+        aws_client.sqs.start_message_move_task(
+            SourceArn=source_arn, DestinationArn=destination_arn, MaxNumberOfMessagesPerSecond=1
+        )
+    snapshot.match("error", e.value.response)

--- a/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
@@ -1,0 +1,217 @@
+{
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_basic_move_task_workflow": {
+    "recorded-date": "03-01-2024, 20:25:54",
+    "recorded-content": {
+      "start-message-move-task-response": {
+        "TaskHandle": "<task-handle:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-message-move-task-response": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 2,
+            "ApproximateNumberOfMessagesToMove": 2,
+            "DestinationArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+            "StartedTimestamp": "timestamp",
+            "Status": "COMPLETED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_source_needs_redrive_policy": {
+    "recorded-date": "03-01-2024, 19:49:15",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Source queue must be configured as a Dead Letter Queue.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_handle": {
+    "recorded-date": "03-01-2024, 19:50:39",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Value for parameter TaskHandle is invalid.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_source_arn_in_task_handle": {
+    "recorded-date": "03-01-2024, 19:56:40",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "The resource that you specified for the SourceArn parameter doesn't exist.",
+          "QueryErrorCode": "ResourceNotFoundException",
+          "Type": "Sender"
+        },
+        "message": "The resource that you specified for the SourceArn parameter doesn't exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_id_in_task_handle": {
+    "recorded-date": "03-01-2024, 19:57:32",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Task does not exist.",
+          "QueryErrorCode": "ResourceNotFoundException",
+          "Type": "Sender"
+        },
+        "message": "Task does not exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_with_throughput_limit": {
+    "recorded-date": "03-01-2024, 20:25:11",
+    "recorded-content": {
+      "start-message-move-task-response": {
+        "TaskHandle": "<task-handle:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_destination_needs_to_exist": {
+    "recorded-date": "03-01-2024, 20:12:56",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "The resource that you specified for the DestinationArn parameter doesn't exist.",
+          "QueryErrorCode": "ResourceNotFoundException",
+          "Type": "Sender"
+        },
+        "message": "The resource that you specified for the DestinationArn parameter doesn't exist.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_cancel": {
+    "recorded-date": "03-01-2024, 20:34:27",
+    "recorded-content": {
+      "list-while": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 0,
+            "ApproximateNumberOfMessagesToMove": 10,
+            "DestinationArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "MaxNumberOfMessagesPerSecond": 1,
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+            "StartedTimestamp": "timestamp",
+            "Status": "RUNNING",
+            "TaskHandle": "<task-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "cancel": {
+        "ApproximateNumberOfMessagesMoved": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-after": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 2,
+            "ApproximateNumberOfMessagesToMove": 10,
+            "DestinationArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "MaxNumberOfMessagesPerSecond": 1,
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+            "StartedTimestamp": "timestamp",
+            "Status": "CANCELLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_delete_destination_queue_while_running": {
+    "recorded-date": "03-01-2024, 20:47:31",
+    "recorded-content": {
+      "list": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 3,
+            "ApproximateNumberOfMessagesToMove": 10,
+            "DestinationArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "FailureReason": "AWS.SimpleQueueService.NonExistentQueue",
+            "MaxNumberOfMessagesPerSecond": 1,
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+            "StartedTimestamp": "timestamp",
+            "Status": "FAILED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_start_multiple_move_tasks": {
+    "recorded-date": "03-01-2024, 20:57:58",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "There is already a task running. Only one active task is allowed for a source queue arn at a given time.",
+          "QueryErrorCode": "InvalidParameterValueException",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/sqs/test_sqs_move_task.validation.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.validation.json
@@ -1,0 +1,32 @@
+{
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_basic_move_task_workflow": {
+    "last_validated_date": "2024-01-03T20:25:53+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_source_arn_in_task_handle": {
+    "last_validated_date": "2024-01-03T19:56:40+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_handle": {
+    "last_validated_date": "2024-01-03T19:50:39+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_cancel_with_invalid_task_id_in_task_handle": {
+    "last_validated_date": "2024-01-03T19:57:31+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_destination_needs_to_exist": {
+    "last_validated_date": "2024-01-03T20:12:55+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_cancel": {
+    "last_validated_date": "2024-01-03T20:34:27+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_delete_destination_queue_while_running": {
+    "last_validated_date": "2024-01-03T20:47:31+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_with_throughput_limit": {
+    "last_validated_date": "2024-01-03T20:25:11+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_source_needs_redrive_policy": {
+    "last_validated_date": "2024-01-03T19:49:15+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_start_multiple_move_tasks": {
+    "last_validated_date": "2024-01-03T20:57:58+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A user requested in #8471 the Amazon SQS API for "[dead-letter queue redrive](https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-sqs-dead-letter-queue-redrive-aws-sdk-cli/)" which was launched on June 8 2023. The feature consists of three operations:

1) [StartMessageMoveTask](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_StartMessageMoveTask.html), to start a new message movement task from the dead-letter queue;
2) [CancelMessageMoveTask](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CancelMessageMoveTask.html), to cancel the message movement task;
3) [ListMessageMoveTasks](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListMessageMoveTasks.html), to get 10 most recent message movement tasks for a specified source queue.


This PR adds this feature on top of our current SQS implementation, and a number of snapshot validated tests. The implementation introduces a new entity into the store, the `MessageMoveTask` which stores the basic attributes. The `MessageMoveTaskManager` implements an algorithm to execute a `MessageMoveTask` asynchronously, that uses our internal high-level queue API.

<!-- What notable changes does this PR make? -->
## Changes

* SQS now supports emulation for `StartMessageMoveTask`, `CancelMessageMoveTask`, and `ListMessageMoveTasks`
* Closes #8471

## Limitations

* Persistence for move tasks does currently not work (looks like a super fringe use case though)
* Some behavior is untested/unvalidated for the sake of getting a first version out quickly
  * What happens when messages are added to the DLQ while a move task is active? does the ApproximateMessagesToMove counter increase?
  * Multi-account access for move tasks is not clear (can you move message between queues in different accounts? if so, in which account do you have to create the move task in?)
* Error message serialization of failed move tasks are not fully correct because of the query/json protocol duality

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

