### PR TITLE
fix CopySource unquoting of special + char

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -117,7 +117,11 @@ def extract_bucket_key_version_id_from_copy_source(
     :return: parsed BucketName, ObjectKey and optionally VersionId
     """
     copy_source_parsed = urlparser.urlparse(copy_source)
-    src_bucket, src_key = urlparser.unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
+    # we need to manually replace `+` character with a space character before URL decoding, because different languages
+    # don't encode their URL the same way (%20 vs +), and Python doesn't unquote + into a space char
+    src_bucket, src_key = (
+        urlparser.unquote(copy_source_parsed.path.replace("+", " ")).lstrip("/").split("/", 1)
+    )
     src_version_id = urlparser.parse_qs(copy_source_parsed.query).get("versionId", [None])[0]
 
     return src_bucket, src_key, src_version_id

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -566,6 +566,9 @@ class TestS3:
         snapshot.match("copy-object-special-char", copy_obj)
 
     @markers.aws.validated
+    @pytest.mark.xfail(
+        condition=LEGACY_V2_S3_PROVIDER, reason="moto does not handle this edge case"
+    )
     def test_copy_object_special_character_plus_for_space(
         self, s3_bucket, aws_client, aws_http_client_factory
     ):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4977,6 +4977,7 @@ class TestS3:
         condition=LEGACY_V2_S3_PROVIDER,
         reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882",
     )
+    @pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="KMS not enabled in S3 image")
     # there is currently no server side encryption is place in LS, ETag will be different
     @markers.snapshot.skip_snapshot_verify(paths=["$..ETag"])
     def test_s3_multipart_upload_sse(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10970,10 +10970,10 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[file%2Fname]": {
-    "recorded-date": "04-01-2024, 13:38:45",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character": {
+    "recorded-date": "04-01-2024, 15:59:31",
     "recorded-content": {
-      "put-object-src-special-char": {
+      "put-object-src-special-char-file%2Fname": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -10981,7 +10981,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-file%2Fname": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
@@ -10991,13 +10991,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test@key/]": {
-    "recorded-date": "04-01-2024, 13:38:49",
-    "recorded-content": {
-      "put-object-src-special-char": {
+      },
+      "put-object-src-special-char-test@key/": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -11005,7 +11000,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-test@key/": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
@@ -11015,13 +11010,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key/]": {
-    "recorded-date": "04-01-2024, 13:38:53",
-    "recorded-content": {
-      "put-object-src-special-char": {
+      },
+      "put-object-src-special-char-test key/": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -11029,7 +11019,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-test key/": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
@@ -11039,13 +11029,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key//]": {
-    "recorded-date": "04-01-2024, 13:38:56",
-    "recorded-content": {
-      "put-object-src-special-char": {
+      },
+      "put-object-src-special-char-test key//": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -11053,7 +11038,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-test key//": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
@@ -11063,13 +11048,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[a/%F0%9F%98%80/]": {
-    "recorded-date": "04-01-2024, 13:39:00",
-    "recorded-content": {
-      "put-object-src-special-char": {
+      },
+      "put-object-src-special-char-a/%F0%9F%98%80/": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -11077,7 +11057,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-a/%F0%9F%98%80/": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
@@ -11087,13 +11067,8 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test+key]": {
-    "recorded-date": "04-01-2024, 13:39:04",
-    "recorded-content": {
-      "put-object-src-special-char": {
+      },
+      "put-object-src-special-char-test+key": {
         "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
@@ -11101,12 +11076,68 @@
           "HTTPStatusCode": 200
         }
       },
-      "copy-object-special-char": {
+      "copy-object-special-char-test+key": {
         "CopyObjectResult": {
           "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
           "LastModified": "datetime"
         },
         "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-copy-dest-special-char": {
+        "Contents": [
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "a/%F0%9F%98%80/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "file%2Fname",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test key/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test key//",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test+key",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+            "Key": "test@key/",
+            "LastModified": "datetime",
+            "Size": 4,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 6,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -10969,5 +10969,149 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[file%2Fname]": {
+    "recorded-date": "04-01-2024, 13:38:45",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test@key/]": {
+    "recorded-date": "04-01-2024, 13:38:49",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key/]": {
+    "recorded-date": "04-01-2024, 13:38:53",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key//]": {
+    "recorded-date": "04-01-2024, 13:38:56",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[a/%F0%9F%98%80/]": {
+    "recorded-date": "04-01-2024, 13:39:00",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test+key]": {
+    "recorded-date": "04-01-2024, 13:39:04",
+    "recorded-content": {
+      "put-object-src-special-char": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-special-char": {
+        "CopyObjectResult": {
+          "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -26,23 +26,8 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_kms": {
     "last_validated_date": "2023-08-03T02:13:12+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[a/%F0%9F%98%80/]": {
-    "last_validated_date": "2024-01-04T13:39:00+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[file%2Fname]": {
-    "last_validated_date": "2024-01-04T13:38:45+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key//]": {
-    "last_validated_date": "2024-01-04T13:38:56+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key/]": {
-    "last_validated_date": "2024-01-04T13:38:53+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test+key]": {
-    "last_validated_date": "2024-01-04T13:39:04+00:00"
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test@key/]": {
-    "last_validated_date": "2024-01-04T13:38:49+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character": {
+    "last_validated_date": "2024-01-04T15:59:31+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character_plus_for_space": {
     "last_validated_date": "2024-01-04T13:48:40+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -26,6 +26,27 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_kms": {
     "last_validated_date": "2023-08-03T02:13:12+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[a/%F0%9F%98%80/]": {
+    "last_validated_date": "2024-01-04T13:39:00+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[file%2Fname]": {
+    "last_validated_date": "2024-01-04T13:38:45+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key//]": {
+    "last_validated_date": "2024-01-04T13:38:56+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test key/]": {
+    "last_validated_date": "2024-01-04T13:38:53+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test+key]": {
+    "last_validated_date": "2024-01-04T13:39:04+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character[test@key/]": {
+    "last_validated_date": "2024-01-04T13:38:49+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_copy_object_special_character_plus_for_space": {
+    "last_validated_date": "2024-01-04T13:48:40+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
     "last_validated_date": "2023-11-06T15:32:57+00:00"
   },

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -90,7 +90,7 @@ class TestS3BucketCRUD:
 )
 class TestS3ObjectCRUD:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not raise exceptions",
     )
@@ -112,7 +112,7 @@ class TestS3ObjectCRUD:
         snapshot.match("delete-nonexistent-object-versionid", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not raise exceptions",
     )
@@ -145,7 +145,7 @@ class TestS3ObjectCRUD:
         snapshot.match("delete-objects", delete_objects)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not return proper headers",
     )
@@ -247,7 +247,7 @@ class TestS3ObjectCRUD:
         snapshot.match("delete-wrong-key", delete_wrong_key)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not return right values",
     )
@@ -327,7 +327,7 @@ class TestS3ObjectCRUD:
         snapshot.match("delete-objects-version-id", delete_objects_marker)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation raises the wrong exception",
     )
@@ -347,7 +347,7 @@ class TestS3ObjectCRUD:
         snapshot.match("get-obj-with-null-version", get_obj)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation deletes all versions when suspending versioning, when it should keep it",
     )
@@ -398,7 +398,7 @@ class TestS3ObjectCRUD:
         snapshot.match("get-object-current", get_object)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation has the wrong behaviour",
     )
@@ -546,7 +546,7 @@ class TestS3Multipart:
     # TODO: write a validated test for UploadPartCopy preconditions
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto does not handle the exceptions properly",
     )
@@ -672,7 +672,7 @@ class TestS3Multipart:
 
 class TestS3BucketVersioning:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation not raising exceptions",
     )
@@ -726,7 +726,7 @@ class TestS3BucketVersioning:
 
 class TestS3BucketEncryption:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have default encryption",
     )
@@ -744,7 +744,7 @@ class TestS3BucketEncryption:
         snapshot.match("get-bucket-no-encryption", bucket_versioning)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have proper validation",
     )
@@ -904,7 +904,7 @@ class TestS3BucketEncryption:
 
     @pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="KMS not enabled in S3 image")
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have S3 KMS managed key",
     )
@@ -1060,7 +1060,7 @@ class TestS3BucketObjectTagging:
         snapshot.match("get-obj-after-tags-deleted", get_object)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation do not catch exceptions",
     )
@@ -1106,7 +1106,7 @@ class TestS3BucketObjectTagging:
         snapshot.match("put-obj-wrong-format", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation missing versioning implementation",
     )
@@ -1248,7 +1248,7 @@ class TestS3BucketObjectTagging:
         snapshot.match("get-object-after-recreation", get_bucket_tags)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not raise exceptions",
     )
@@ -1335,7 +1335,7 @@ class TestS3BucketObjectTagging:
 
 class TestS3ObjectLock:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not catch exception",
     )
@@ -1405,7 +1405,7 @@ class TestS3ObjectLock:
         snapshot.match("get-lock-config-only-enabled", get_lock_config)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not catch exception",
     )
@@ -1493,7 +1493,7 @@ class TestS3ObjectLock:
         snapshot.match("get-lock-config-bucket-not-exists", e.value.response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not raise exceptions",
     )
@@ -1530,7 +1530,7 @@ class TestS3ObjectLock:
 
 class TestS3BucketOwnershipControls:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have default ownership controls",
     )
@@ -1566,7 +1566,7 @@ class TestS3BucketOwnershipControls:
         snapshot.match("get-ownership-at-creation", get_ownership_at_creation)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have default ownership controls",
     )
@@ -1613,7 +1613,7 @@ class TestS3BucketOwnershipControls:
 
 class TestS3PublicAccessBlock:
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not have default public access block",
     )
@@ -1691,7 +1691,7 @@ class TestS3BucketPolicy:
         snapshot.match("delete-bucket-policy-after-delete", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=config.LEGACY_V2_S3_PROVIDER,
         reason="Moto implementation does not raise Exception",
     )

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -120,7 +120,7 @@ class TestS3ListObjects:
         snapshot.match("list-objects", resp)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=LEGACY_V2_S3_PROVIDER,
         reason="moto does not implement the right behaviour",
     )
@@ -354,7 +354,7 @@ class TestS3ListObjectsV2:
 
 class TestS3ListObjectVersions:
     @markers.aws.validated
-    @pytest.mark.xfail(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
+    @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     def test_list_objects_versions_markers(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         aws_client.s3.put_bucket_versioning(
@@ -432,7 +432,7 @@ class TestS3ListObjectVersions:
         snapshot.match("list-objects-next-key-empty", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
+    @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     def test_list_object_versions_pagination_common_prefixes(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -560,7 +560,7 @@ class TestS3ListObjectVersions:
 
 class TestS3ListMultipartUploads:
     @markers.aws.validated
-    @pytest.mark.xfail(condition=is_v2_provider(), reason="not implemented in moto")
+    @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     def test_list_multiparts_next_marker(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformers_list(
@@ -666,7 +666,7 @@ class TestS3ListMultipartUploads:
         snapshot.match("list-multiparts-next-key-empty", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(condition=is_v2_provider, reason="not implemented in moto")
+    @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     def test_list_multiparts_with_prefix_and_delimiter(
         self, s3_bucket, snapshot, aws_client, aws_http_client_factory
     ):
@@ -767,7 +767,7 @@ class TestS3ListMultipartUploads:
         snapshot.match("list-uploads-delimiter", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=LEGACY_V2_S3_PROVIDER,
         reason="not implemented in moto",
     )
@@ -845,7 +845,7 @@ class TestS3ListMultipartUploads:
 
 
 class TestS3ListParts:
-    @pytest.mark.xfail(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
+    @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
     @markers.aws.validated
     def test_list_parts_pagination(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(
@@ -901,7 +901,7 @@ class TestS3ListParts:
         )
         snapshot.match("list-parts-wrong-part", response)
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=LEGACY_V2_S3_PROVIDER, reason="moto does not handle empty query string parameters"
     )
     @markers.aws.validated


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #9990, we had an issue when copying a file with a space in the name with Go. This issue was not present with Python however. When looking at the sample provided by the user, it appeared that Go in URL encoding space character with `+` when Python is using `%20`.
When calling `unquote` with Python, it won't replace an encoded URL `+` character with a space. We will need to manually replace it before unquote the URL to not accidentally replaced an encoded `+`. 

<!-- What notable changes does this PR make? -->
## Changes
Manually replace an encoded URL `+` when parsing the `CopySource` header. 
Added 2 different AWS tests to verify exactly the fix:
- one global with weird key encoding as we didn't have one
- one very specific test for this use case using the HTTP client because botocore will automatically encode space as `%20` so we couldn't reproduce exactly the issue. This test fails without the fix, confirming it. This specific test is `xfail` for the v2 legacy provider as moto does not handle this edge case (so not a regression from the new provider)

_fixes #9990_

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

