### PR TITLE
fix snapshot match order

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_metrics.py
@@ -262,7 +262,6 @@ class TestSQSMetrics:
     ):
         response = cloudwatch_client.describe_alarms(AlarmNames=[alarm_name])
         assert response["MetricAlarms"][0]["StateValue"] == "ALARM"
-        snapshot.match(f"{identifier}-describe", response)
 
         result = sqs_client.receive_message(QueueUrl=sqs_queue_url, VisibilityTimeout=0)
         msg = result["Messages"][0]
@@ -270,4 +269,5 @@ class TestSQSMetrics:
         message = json.loads(body["Message"])
         sqs_client.delete_message(QueueUrl=sqs_queue_url, ReceiptHandle=msg["ReceiptHandle"])
         assert message["NewStateValue"] == "ALARM"
+        snapshot.match(f"{identifier}-describe", response)
         snapshot.match(f"{identifier}-sqs-msg", message)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Fix for test `test_alarm_number_of_messages_sent` introduced with #9978. 

The `snapshot.match` must be called after the assertions, currently seeing flakes with:
```
Exception: Key NumberOfMessagesSent-describe used multiple times in the same test scope
```

The snapshots are collected in the `_verify_alarm_triggered` which is called using `retry` and have two assertions.


<!-- What notable changes does this PR make? -->
## Changes
* only call `snapshot.match` after assertions

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

