### PR TITLE
fix lambda create event source mapping duplicates

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1292,6 +1292,24 @@ def create_lambda_function(aws_client, wait_until_lambda_ready, lambda_su_role):
 
 
 @pytest.fixture
+def create_event_source_mapping(aws_client):
+    uuids = []
+
+    def _create_event_source_mapping(*args, **kwargs):
+        response = aws_client.lambda_.create_event_source_mapping(*args, **kwargs)
+        uuids.append(response["UUID"])
+        return response
+
+    yield _create_event_source_mapping
+
+    for uuid in uuids:
+        try:
+            aws_client.lambda_.delete_event_source_mapping(UUID=uuid)
+        except Exception:
+            LOG.debug(f"Unable to delete event source mapping {uuid} in cleanup")
+
+
+@pytest.fixture
 def check_lambda_logs(aws_client):
     def _check_logs(func_name: str, expected_lines: List[str] = None) -> List[str]:
         if not expected_lines:

--- a/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py
@@ -146,10 +146,12 @@ class TestDynamoDBEventSourceMapping:
         self,
         create_lambda_function,
         lambda_su_role,
+        create_event_source_mapping,
         dynamodb_create_table,
         wait_for_dynamodb_stream_ready,
         snapshot,
         aws_client,
+        cleanups,
     ):
         function_name_1 = f"lambda_func-{short_uid()}"
         function_name_2 = f"lambda_func-{short_uid()}"
@@ -182,7 +184,7 @@ class TestDynamoDBEventSourceMapping:
             role=lambda_su_role,
         )
 
-        response = aws_client.lambda_.create_event_source_mapping(
+        response = create_event_source_mapping(
             FunctionName=function_name_1,
             EventSourceArn=event_source_arn,
             **kwargs,
@@ -190,7 +192,7 @@ class TestDynamoDBEventSourceMapping:
         snapshot.match("create", response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.lambda_.create_event_source_mapping(
+            create_event_source_mapping(
                 FunctionName=function_name_1,
                 EventSourceArn=event_source_arn,
                 **kwargs,
@@ -206,7 +208,7 @@ class TestDynamoDBEventSourceMapping:
             runtime=Runtime.python3_9,
             role=lambda_su_role,
         )
-        aws_client.lambda_.create_event_source_mapping(
+        create_event_source_mapping(
             FunctionName=function_name_2,
             EventSourceArn=event_source_arn,
             **kwargs,

--- a/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py
@@ -3,6 +3,7 @@ import math
 import time
 
 import pytest
+from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import InvalidParameterValueException, Runtime
 from localstack.testing.aws.lambda_utils import (
@@ -139,6 +140,77 @@ class TestDynamoDBEventSourceMapping:
         # check if the timestamp has same amount of numbers before the comma as the current timestamp
         # this will fail in november 2286, if this code is still around by then, read this comment and update to 10
         assert int(math.log10(timestamp)) == 9
+
+    @markers.aws.validated
+    def test_duplicate_event_source_mappings(
+        self,
+        create_lambda_function,
+        lambda_su_role,
+        dynamodb_create_table,
+        wait_for_dynamodb_stream_ready,
+        snapshot,
+        aws_client,
+    ):
+        function_name_1 = f"lambda_func-{short_uid()}"
+        function_name_2 = f"lambda_func-{short_uid()}"
+
+        table_name = f"test-table-{short_uid()}"
+        partition_key = "my_partition_key"
+
+        create_table_result = dynamodb_create_table(
+            table_name=table_name, partition_key=partition_key
+        )
+        # snapshot create table to get the table name registered as resource
+        snapshot.match("create-table-result", create_table_result)
+        _await_dynamodb_table_active(aws_client.dynamodb, table_name)
+        event_source_arn = aws_client.dynamodb.update_table(
+            TableName=table_name,
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_IMAGE"},
+        )["TableDescription"]["LatestStreamArn"]
+
+        # extra arguments for create_event_source_mapping calls
+        kwargs = dict(
+            StartingPosition="TRIM_HORIZON",
+            MaximumBatchingWindowInSeconds=1,
+            MaximumRetryAttempts=1,
+        )
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_1,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+
+        response = aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_1,
+            EventSourceArn=event_source_arn,
+            **kwargs,
+        )
+        snapshot.match("create", response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name_1,
+                EventSourceArn=event_source_arn,
+                **kwargs,
+            )
+
+        response = e.value.response
+        snapshot.match("error", response)
+
+        # this should work without problem since it's a new function
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_2,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+        aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_2,
+            EventSourceArn=event_source_arn,
+            **kwargs,
+        )
 
     @markers.aws.validated
     def test_disabled_dynamodb_event_source_mapping(

--- a/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1364,5 +1364,83 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
+    "recorded-date": "04-01-2024, 17:25:30",
+    "recorded-content": {
+      "create-table-result": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "my_partition_key",
+              "AttributeType": "S"
+            }
+          ],
+          "BillingModeSummary": {
+            "BillingMode": "PAY_PER_REQUEST"
+          },
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "my_partition_key",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 0,
+            "WriteCapacityUnits": 0
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<resource:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create": {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": 1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "error": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "The event source arn (\" arn:aws:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2> \") and function (\" <resource:3> \") provided mapping already exists. Please update or delete the existing mapping with UUID <uuid:2>"
+        },
+        "Type": "User",
+        "message": "The event source arn (\" arn:aws:dynamodb:<region>:111111111111:table/<resource:1>/stream/<resource:2> \") and function (\" <resource:3> \") provided mapping already exists. Please update or delete the existing mapping with UUID <uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
     "last_validated_date": "2023-02-27T17:34:59+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
+    "last_validated_date": "2024-01-04T17:25:28+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put10-None-filter0-1]": {
     "last_validated_date": "2023-02-27T17:37:56+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2023-02-27T17:34:59+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T17:25:28+00:00"
+    "last_validated_date": "2024-01-04T23:38:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put10-None-filter0-1]": {
     "last_validated_date": "2023-02-27T17:37:56+00:00"

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
@@ -4,6 +4,7 @@ import os
 import time
 
 import pytest
+from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import Runtime
 from localstack.testing.aws.lambda_utils import (
@@ -121,6 +122,63 @@ class TestKinesisSource:
         # check if the timestamp has same amount of numbers before the comma as the current timestamp
         # this will fail in november 2286, if this code is still around by then, read this comment and update to 10
         assert int(math.log10(timestamp)) == 9
+
+    @markers.aws.validated
+    def test_duplicate_event_source_mappings(
+        self,
+        create_lambda_function,
+        lambda_su_role,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        snapshot,
+        aws_client,
+    ):
+        function_name_1 = f"lambda_func-{short_uid()}"
+        function_name_2 = f"lambda_func-{short_uid()}"
+
+        stream_name = f"test-foobar-{short_uid()}"
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream_ready(stream_name=stream_name)
+        event_source_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_1,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+
+        response = aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_1,
+            EventSourceArn=event_source_arn,
+            StartingPosition="LATEST",
+        )
+        snapshot.match("create", response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name_1,
+                EventSourceArn=event_source_arn,
+                StartingPosition="LATEST",
+            )
+
+        response = e.value.response
+        snapshot.match("error", response)
+
+        # this should work without problem since it's a new function
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_2,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+        aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_2,
+            EventSourceArn=event_source_arn,
+            StartingPosition="LATEST",
+        )
 
     # TODO: is this test relevant for the new provider without patching SYNCHRONOUS_KINESIS_EVENTS?
     #   At least, it is flagged as AWS-validated.

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
@@ -128,10 +128,12 @@ class TestKinesisSource:
         self,
         create_lambda_function,
         lambda_su_role,
+        create_event_source_mapping,
         kinesis_create_stream,
         wait_for_stream_ready,
         snapshot,
         aws_client,
+        cleanups,
     ):
         function_name_1 = f"lambda_func-{short_uid()}"
         function_name_2 = f"lambda_func-{short_uid()}"
@@ -150,7 +152,7 @@ class TestKinesisSource:
             role=lambda_su_role,
         )
 
-        response = aws_client.lambda_.create_event_source_mapping(
+        response = create_event_source_mapping(
             FunctionName=function_name_1,
             EventSourceArn=event_source_arn,
             StartingPosition="LATEST",
@@ -158,7 +160,7 @@ class TestKinesisSource:
         snapshot.match("create", response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.lambda_.create_event_source_mapping(
+            create_event_source_mapping(
                 FunctionName=function_name_1,
                 EventSourceArn=event_source_arn,
                 StartingPosition="LATEST",
@@ -174,7 +176,7 @@ class TestKinesisSource:
             runtime=Runtime.python3_9,
             role=lambda_su_role,
         )
-        aws_client.lambda_.create_event_source_mapping(
+        create_event_source_mapping(
             FunctionName=function_name_2,
             EventSourceArn=event_source_arn,
             StartingPosition="LATEST",

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
@@ -1437,5 +1437,47 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
+    "recorded-date": "04-01-2024, 17:16:56",
+    "recorded-content": {
+      "create": {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:aws:kinesis:<region>:111111111111:stream/<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 0,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": -1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "LATEST",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "error": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "The event source arn (\" arn:aws:kinesis:<region>:111111111111:stream/<resource:1> \") and function (\" <resource:2> \") provided mapping already exists. Please update or delete the existing mapping with UUID <uuid:1>"
+        },
+        "Type": "User",
+        "message": "The event source arn (\" arn:aws:kinesis:<region>:111111111111:stream/<resource:1> \") and function (\" <resource:2> \") provided mapping already exists. Please update or delete the existing mapping with UUID <uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
@@ -8,6 +8,9 @@
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
     "last_validated_date": "2023-02-27T15:59:49+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
+    "last_validated_date": "2024-01-04T17:16:55+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2023-02-27T15:55:08+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-02-27T15:59:49+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T17:16:55+00:00"
+    "last_validated_date": "2024-01-04T23:37:20+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
     "last_validated_date": "2023-02-27T15:55:08+00:00"

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -1350,3 +1350,52 @@ class TestSQSEventSourceMapping:
 
         rs = aws_client.sqs.receive_message(QueueUrl=queue_url_1)
         assert rs.get("Messages") == []
+
+    @markers.aws.validated
+    def test_duplicate_event_source_mappings(
+        self,
+        create_lambda_function,
+        lambda_su_role,
+        sqs_create_queue,
+        sqs_get_queue_arn,
+        snapshot,
+        aws_client,
+    ):
+        function_name_1 = f"lambda_func-{short_uid()}"
+        function_name_2 = f"lambda_func-{short_uid()}"
+
+        event_source_arn = sqs_get_queue_arn(sqs_create_queue())
+
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_1,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+
+        response = aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_1,
+            EventSourceArn=event_source_arn,
+        )
+        snapshot.match("create", response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.lambda_.create_event_source_mapping(
+                FunctionName=function_name_1,
+                EventSourceArn=event_source_arn,
+            )
+
+        response = e.value.response
+        snapshot.match("error", response)
+
+        # this should work without problem since it's a new function
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name_2,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+        aws_client.lambda_.create_event_source_mapping(
+            FunctionName=function_name_2,
+            EventSourceArn=event_source_arn,
+        )

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -1356,6 +1356,7 @@ class TestSQSEventSourceMapping:
         self,
         create_lambda_function,
         lambda_su_role,
+        create_event_source_mapping,
         sqs_create_queue,
         sqs_get_queue_arn,
         snapshot,
@@ -1373,14 +1374,14 @@ class TestSQSEventSourceMapping:
             role=lambda_su_role,
         )
 
-        response = aws_client.lambda_.create_event_source_mapping(
+        response = create_event_source_mapping(
             FunctionName=function_name_1,
             EventSourceArn=event_source_arn,
         )
         snapshot.match("create", response)
 
         with pytest.raises(ClientError) as e:
-            aws_client.lambda_.create_event_source_mapping(
+            create_event_source_mapping(
                 FunctionName=function_name_1,
                 EventSourceArn=event_source_arn,
             )
@@ -1395,7 +1396,7 @@ class TestSQSEventSourceMapping:
             runtime=Runtime.python3_9,
             role=lambda_su_role,
         )
-        aws_client.lambda_.create_event_source_mapping(
+        create_event_source_mapping(
             FunctionName=function_name_2,
             EventSourceArn=event_source_arn,
         )

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
@@ -1547,5 +1547,37 @@
         }
       ]
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
+    "recorded-date": "04-01-2024, 17:10:43",
+    "recorded-content": {
+      "create": {
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "error": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "An event source mapping with SQS arn (\" arn:aws:sqs:<region>:111111111111:<resource:1> \") and function (\" <resource:2> \") already exists. Please update or delete the existing mapping with UUID <uuid:1>"
+        },
+        "Type": "User",
+        "message": "An event source mapping with SQS arn (\" arn:aws:sqs:<region>:111111111111:<resource:1> \") and function (\" <resource:2> \") already exists. Please update or delete the existing mapping with UUID <uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
-    "last_validated_date": "2024-01-04T17:10:41+00:00"
+    "last_validated_date": "2024-01-04T23:36:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
     "last_validated_date": "2023-02-27T16:09:20+00:00"

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_duplicate_event_source_mappings": {
+    "last_validated_date": "2024-01-04T17:10:41+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
     "last_validated_date": "2023-02-27T16:09:20+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes https://github.com/localstack/localstack/issues/9219, where a user noted that duplicate event source mappings are not handled correctly. Of course exception messages differ across services, because why make things consistent :wink: 

Tested for sqs, kinesis, and dynamodbstreams.

<!-- What notable changes does this PR make? -->
## Changes

* lambda `create_event_source_mapping` now raises a `ResourceConflictException` if a mapping with the same event source arn and function arn already exists.
* added a `create_event_source_mapping` fixture that does cleanup

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

