### PR TITLE
fix sqs SendMessageBatch result for SDK compatibility

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -992,9 +992,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                         )
                     )
 
+        # some SDKs expect ``Failed`` to not be present at all
         return SendMessageBatchResult(
-            Successful=successful,
-            Failed=failed,
+            Successful=successful if successful else None,
+            Failed=failed if failed else None,
         )
 
     def _put_message(
@@ -1096,6 +1097,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             self._cloudwatch_dispatcher.dispatch_metric_received(queue, received=len(messages))
 
         # TODO: how does receiving behave if the queue was deleted in the meantime?
+        # TODO: ``Messages`` is often expected to not be set at all if it's an empty list
         return ReceiveMessageResult(Messages=messages)
 
     def list_dead_letter_source_queues(

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.py
@@ -575,9 +575,7 @@ def test_report_batch_item_failures(
     snapshot.match("first_invocation", first_invocation)
 
     # check that the DQL is empty
-    dlq_messages = aws_client.sqs.receive_message(QueueUrl=event_dlq_url)["Messages"]
-    assert dlq_messages == []
-    assert not dlq_messages
+    assert not aws_client.sqs.receive_message(QueueUrl=event_dlq_url).get("Messages")
 
     # now wait for the second invocation result which is expected to have processed message 2 and 3
     second_invocation = aws_client.sqs.receive_message(
@@ -595,7 +593,7 @@ def test_report_batch_item_failures(
     third_attempt = aws_client.sqs.receive_message(
         QueueUrl=destination_url, WaitTimeSeconds=1, MaxNumberOfMessages=1
     )
-    assert third_attempt["Messages"] == []
+    assert not third_attempt.get("Messages")
 
     # now check that message 4 was placed in the DLQ
     dlq_response = aws_client.sqs.receive_message(QueueUrl=event_dlq_url, WaitTimeSeconds=15)

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.snapshot.json
@@ -239,7 +239,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "recorded-date": "10-11-2023, 19:17:37",
+    "recorded-date": "04-01-2024, 21:45:26",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -249,7 +249,6 @@
         }
       },
       "send_message_batch": {
-        "Failed": [],
         "Successful": [
           {
             "Id": "message-1",

--- a/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_sqs.validation.json
@@ -57,7 +57,7 @@
     "last_validated_date": "2023-02-27T16:03:26+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "last_validated_date": "2023-11-10T18:17:37+00:00"
+    "last_validated_date": "2024-01-04T21:45:25+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
     "last_validated_date": "2023-02-27T16:09:08+00:00"

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -2122,6 +2122,7 @@ class TestSqsProvider:
         )
         successful = result_send_batch["Successful"]
         assert len(successful) == len(message_batch)
+        assert "Failed" not in result_send_batch
 
         result_recv = []
         i = 0
@@ -2151,8 +2152,7 @@ class TestSqsProvider:
         confirmation = aws_client.sqs.receive_message(
             QueueUrl=queue_url, MaxNumberOfMessages=message_count
         )
-        assert "Messages" in confirmation
-        assert confirmation["Messages"] == []
+        assert not confirmation.get("Messages")
 
     @markers.aws.validated
     @pytest.mark.parametrize(

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -529,7 +529,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents": {
-    "recorded-date": "14-11-2023, 11:57:37",
+    "recorded-date": "04-01-2024, 21:47:03",
     "recorded-content": {
       "send_oversized_message_batch": {
         "Error": {
@@ -546,10 +546,9 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size": {
-    "recorded-date": "14-11-2023, 11:57:37",
+    "recorded-date": "04-01-2024, 21:48:32",
     "recorded-content": {
       "send_oversized_message_batch": {
-        "Failed": [],
         "Successful": [
           {
             "Id": "1",

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -102,10 +102,10 @@
     "last_validated_date": "2023-11-14T10:58:56+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents": {
-    "last_validated_date": "2023-11-14T10:57:37+00:00"
+    "last_validated_date": "2024-01-04T21:47:03+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_batch_with_oversized_contents_with_updated_maximum_message_size": {
-    "last_validated_date": "2023-11-14T10:57:37+00:00"
+    "last_validated_date": "2024-01-04T21:48:31+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes": {
     "last_validated_date": "2023-11-14T10:59:11+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -83,6 +83,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_posting_to_fifo_requires_deduplicationid_group_id": {
     "last_validated_date": "2023-11-14T11:18:18+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_publish_get_delete_message_batch": {
+    "last_validated_date": "2024-01-04T18:51:38+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters": {
     "last_validated_date": "2023-11-14T11:00:15+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In #9832, a user noted that the Java SDK v2 method `hasFailed()` of the `SendMessageBatchResponse` would always return `true`, even though there are no failures in the batch.
This is the way they're doing it:

```java
    public final boolean hasFailed() {
        return this.failed != null && !(this.failed instanceof SdkAutoConstructList);
    }
```

Basically, the SDK expects a null value, but we're sending empty lists. I opportunistically updated an existing test to assert this accordingly, and re-validated it.

<!-- What notable changes does this PR make? -->
## Changes

* `SendMesageBatchResult` no longer returns empty lists in `Failed` or `Successful` fields

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

