### PR TITLE
improve S3 aws-chunked detection

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -630,7 +630,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         body = request.get("Body")
         # check if chunked request
         headers = context.request.headers
-        is_aws_chunked = headers.get("x-amz-content-sha256", "").startswith("STREAMING-")
+        is_aws_chunked = headers.get("x-amz-content-sha256", "").startswith(
+            "STREAMING-"
+        ) or "aws-chunked" in headers.get("content-encoding", "")
         if is_aws_chunked:
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
             body = AwsChunkedDecoder(body, decoded_content_length, s3_object=s3_object)
@@ -1876,7 +1878,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
         body = request.get("Body")
         headers = context.request.headers
-        is_aws_chunked = headers.get("x-amz-content-sha256", "").startswith("STREAMING-")
+        is_aws_chunked = headers.get("x-amz-content-sha256", "").startswith(
+            "STREAMING-"
+        ) or "aws-chunked" in headers.get("content-encoding", "")
         # check if chunked request
         if is_aws_chunked:
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2841,6 +2841,10 @@ class TestS3:
         assert completed_object["Body"].read() == to_bytes(body)
 
     @markers.aws.only_localstack
+    @pytest.mark.skipif(
+        reason="Not implemented in other providers than v3, moto fails at decoding",
+        condition=LEGACY_V2_S3_PROVIDER,
+    )
     def test_put_object_chunked_newlines_no_sig(self, s3_bucket, aws_client):
         object_key = "data"
         body = "test;test;test\r\ntest1;test1;test1\r\n"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This might be a fix to #9989, I could not reproduce the issue yet, but I suspect this could be one of the reason: we did not detect the payload was of `aws-chunked` format. We once set the detection to only be about the `Content-Encoding`, but it introduced a regression for some client SDKs, I think it was .NET. See #8712
So we can combine both detection to be sure. 

<!-- What notable changes does this PR make? -->
## Changes
Added a test with a similar format as the reported issue, with no signing of the chunked payload. 
Improved the detection to check both the content encoding of the request and the special header AWS uses to indicate it's an `aws-chunked` payload even when the content-encoding is not set. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

