### PR TITLE
add OpenSearch analysis-kuromoji plugin

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -125,6 +125,7 @@ OPENSEARCH_DEFAULT_VERSION = "OpenSearch_2.9"
 # See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
 OPENSEARCH_PLUGIN_LIST = [
     "ingest-attachment",
+    "analysis-kuromoji",
 ]
 
 # API endpoint for analytics events


### PR DESCRIPTION
## Motivation
There have been requests to install the `analysis-kuromoji` plugin when setting up OpenSearch clusters (f.e. in [Discuss](https://discuss.localstack.cloud/t/opensearch-kuromoji-tokenizer-plugin/681)).
In fact, this plugin is [one of the plugins which is installed by default](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html), and is therefore now added.
For now, I did not add all the plugins listed there, because this would increase the package download / setup time by quite a bit. If we decide to add all these packages, we should maybe consider switching to a different distribution (which already contains all of them - maybe there is one?).

## Changes
- Adds the `analysis-kuromoji` plugin to the list of plugins installed for OpenSearch.

## Testing
- There is already a test verifying that the plugins defined in the constant are actually available after creating a domain: https://github.com/localstack/localstack/blob/124a4e288951a587f581f586f6e8b1e8ab40e438/tests/aws/services/opensearch/test_opensearch.py#L351-L358