### PR TITLE
add raw-metrics endpoint for v2

### DIFF
--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -329,9 +329,17 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 )
 
     def get_raw_metrics(self, request: Request):
-        # TODO this needs to be read from the database
-        # FIXME this is just a placeholder for now
-        return {"metrics": []}
+        """this feature was introduced with https://github.com/localstack/localstack/pull/3535
+        # in the meantime, it required a valid aws-header so that the account-id/region could be extracted
+        # with the new implementation, we want to return all data, but add the account-id/region as additional attributes
+
+        # TODO endpoint should be refactored or deprecated at some point
+        #   - result should be paginated
+        #   - include aggregated metrics (but we would also need to change/adapt the shape of "metrics" that we return)
+        :returns: json {"metrics": [{"ns": "namespace", "n": "metric_name", "v": value, "t": timestamp,
+        "d": [<dimensions-key-pair-values>],"account": account, "region": region}]}
+        """
+        return {"metrics": self.cloudwatch_database.get_all_metric_data() or []}
 
     @handler("PutMetricAlarm", expand=False)
     def put_metric_alarm(self, context: RequestContext, request: PutMetricAlarmInput) -> None:

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -522,7 +522,7 @@ class TestCloudwatch:
         retry(assert_results, retries=retries, sleep_before=sleep_before)
 
     @markers.aws.only_localstack
-    @pytest.mark.skipif(condition=is_new_provider, reason="not supported by the new provider")
+    # this feature was a customer request and added with https://github.com/localstack/localstack/pull/3535
     def test_raw_metric_data(self, aws_client):
         """
         tests internal endpoint at "/_aws/cloudwatch/metrics/raw"
@@ -531,6 +531,7 @@ class TestCloudwatch:
         aws_client.cloudwatch.put_metric_data(
             Namespace=namespace1, MetricData=[dict(MetricName="someMetric", Value=23)]
         )
+        # the new v2 provider doesn't need the headers, will return results for all accounts/regions
         headers = mock_aws_request_headers(
             "cloudwatch", aws_access_key_id=TEST_AWS_ACCESS_KEY_ID, region_name=TEST_AWS_REGION_NAME
         )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Adds the raw-metrics endpoint for the cloudwatch v2 provider, which was introduced in #3535 (customer request). 

<!-- What notable changes does this PR make? -->
## Changes
* in v1 the endpoint currently requires aws headers, which seems a bit odd
  * for v2 removed this requirement, instead we also return the account-id and region for each datapoint
  * it currently returns all the single-metric data (like it did before)  


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes
-->
## TODO

In a future iteration we should decide if we want to keep this endpoint, and/or collect data about how many people are actually using it. 
Considering that a AWS header is currently required to access the endpoint, I don't think it is actually used (it defeats the actual purpose). 

In case we keep the endpoint:
- [ ] add paging (there may be a huge amount of data)
- [ ] add aggregated metric data (for v1/v2 currently only single metric data is returned)



