### PR TITLE
fix unit-handling for get-metric-statistics

### DIFF
--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -17,6 +17,7 @@ from localstack.aws.api.cloudwatch import (
     DashboardName,
     DashboardNamePrefix,
     DashboardNames,
+    Datapoint,
     DeleteDashboardsOutput,
     DescribeAlarmsOutput,
     DimensionFilters,
@@ -566,46 +567,64 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         unit: StandardUnit = None,
     ) -> GetMetricStatisticsOutput:
         stat_datapoints = {}
-        for stat in statistics:
-            query_result = self.cloudwatch_database.get_metric_data_stat(
+
+        units = (
+            [unit]
+            if unit
+            else self.cloudwatch_database.get_units_for_metric_data_stat(
                 account_id=context.account_id,
                 region=context.region,
                 start_time=start_time,
                 end_time=end_time,
-                scan_by="TimestampDescending",
-                query=MetricDataQuery(
-                    MetricStat=MetricStat(
-                        Metric={
-                            "MetricName": metric_name,
-                            "Namespace": namespace,
-                            "Dimensions": dimensions or [],
-                        },
-                        Period=period,
-                        Stat=stat,
-                        Unit=unit,
+                metric_name=metric_name,
+                namespace=namespace,
+            )
+        )
+
+        for stat in statistics:
+            for selected_unit in units:
+                query_result = self.cloudwatch_database.get_metric_data_stat(
+                    account_id=context.account_id,
+                    region=context.region,
+                    start_time=start_time,
+                    end_time=end_time,
+                    scan_by="TimestampDescending",
+                    query=MetricDataQuery(
+                        MetricStat=MetricStat(
+                            Metric={
+                                "MetricName": metric_name,
+                                "Namespace": namespace,
+                                "Dimensions": dimensions or [],
+                            },
+                            Period=period,
+                            Stat=stat,
+                            Unit=selected_unit,
+                        )
+                    ),
+                )
+
+                timestamps = query_result.get("timestamps", [])
+                values = query_result.get("values", [])
+                for i, timestamp in enumerate(timestamps):
+                    stat_datapoints.setdefault(selected_unit, {})
+                    stat_datapoints[selected_unit].setdefault(timestamp, {})
+                    stat_datapoints[selected_unit][timestamp][stat] = values[i]
+                    stat_datapoints[selected_unit][timestamp]["Unit"] = selected_unit
+
+        datapoints: list[Datapoint] = []
+        for selected_unit, results in stat_datapoints.items():
+            for timestamp, stats in results.items():
+                datapoints.append(
+                    Datapoint(
+                        Timestamp=timestamp,
+                        SampleCount=stats.get("SampleCount"),
+                        Average=stats.get("Average"),
+                        Sum=stats.get("Sum"),
+                        Minimum=stats.get("Minimum"),
+                        Maximum=stats.get("Maximum"),
+                        Unit="None" if selected_unit == "NULL_VALUE" else selected_unit,
                     )
-                ),
-            )
-
-            timestamps = query_result.get("timestamps", [])
-            values = query_result.get("values", [])
-            for i, timestamp in enumerate(timestamps):
-                stat_datapoints.setdefault(timestamp, {})
-                stat_datapoints[timestamp][stat] = values[i]
-
-        datapoints = []
-        for timestamp, stats in stat_datapoints.items():
-            datapoints.append(
-                {
-                    "Timestamp": timestamp,
-                    "SampleCount": stats.get("SampleCount"),
-                    "Average": stats.get("Average"),
-                    "Sum": stats.get("Sum"),
-                    "Minimum": stats.get("Minimum"),
-                    "Maximum": stats.get("Maximum"),
-                    "Unit": unit,
-                }
-            )
+                )
 
         return GetMetricStatisticsOutput(Datapoints=datapoints, Label=metric_name)
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -31,10 +31,6 @@ def is_old_provider():
     return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") != "v2" and not is_aws_cloud()
 
 
-def is_new_provider():
-    return os.environ.get("PROVIDER_OVERRIDE_CLOUDWATCH") == "v2"
-
-
 class TestCloudwatch:
     @markers.aws.validated
     def test_put_metric_data_values_list(self, snapshot, aws_client):

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1606,12 +1606,17 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
-    "recorded-date": "07-12-2023, 14:03:11",
+    "recorded-date": "05-01-2024, 16:15:39",
     "recorded-content": {
       "get_metric_statistics_with_different_units": {
         "Datapoints": [
           {
-            "Average": 1.0,
+            "Average": 10.0,
+            "Timestamp": "timestamp",
+            "Unit": "None"
+          },
+          {
+            "Average": 5.0,
             "Timestamp": "timestamp",
             "Unit": "Count"
           },

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -20,6 +20,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
+    "last_validated_date": "2024-01-05T16:15:39+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_insight_rule": {
     "last_validated_date": "2023-10-26T08:07:59+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes two issues revealed by tests that concern the returned unit for `get-metric-statistics`:
 1) the unit is returned, even if was not part of the query
 2) if no unit is provided for the query, but there are several units that match, the result is aggregated on `unit`

<!-- What notable changes does this PR make? -->
## Changes
* add a query-helper to retrieve the unique units that will match a query
* run the statistic for each unit, aggregate the returned result
* enhanced the test `get_metric_statistics_with_different_units` by adding also metric-data that does not have a `unit`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

