### PR TITLE
refactor http router for better werkzeug compatibility

### DIFF
--- a/localstack/http/resource.py
+++ b/localstack/http/resource.py
@@ -45,7 +45,7 @@ def resource(path: str, host: Optional[str] = None, **kwargs):
             def on_post(request: Request, resource_id: str) -> Response:
                 return Response(f"POST called on {resource_id}")
 
-    This class can then be added to a router via ``router.add_route_endpoints(MyResource())``.
+    This class can then be added to a router via ``router.add(MyResource())``.
 
     Note that, if an on_get method is present in the resource but on_head is not, then HEAD requests are automatically
     routed to ``on_get``. This replicates Werkzeug's behavior https://werkzeug.palletsprojects.com/en/2.2.x/routing/.

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -509,6 +509,14 @@ class RuleGroup(RuleFactory):
 
 
 class _EndpointRule(RuleFactory, Generic[E]):
+    """
+    Generates default werkzeug ``Rule`` object with the given attributes. Additionally, it makes sure that
+    the generated rule always has a default host value, if the map has host matching enabled. Specifically,
+    it adds the well-known placeholder ``<__host__>``, which is later stripped out of the request arguments
+    when dispatching to the endpoint. This ensures compatibility of rule definitions across routers that
+    have host matching enabled or not.
+    """
+
     def __init__(
         self,
         path: str,
@@ -540,6 +548,19 @@ class _EndpointRule(RuleFactory, Generic[E]):
 
 
 class _EndpointFunction(RuleFactory):
+    """
+    Internal rule factory that generates router Rules from ``@route`` annotated functions, or anything else
+    that can be interpreted as a ``_RouteEndpoint``. It extracts the rule attributes from the
+    ``_RuleAttributes`` attribute defined by ``_RouteEndpoint``. Example::
+
+        @route("/my_api", methods=["GET"])
+        def do_get(request: Request, _args):
+            # should be inherited
+            return Response(f"{request.path}/do-get")
+
+        router.add(do_get)  # <- will use an _EndpointFunction RuleFactory.
+    """
+
     def __init__(self, fn: _RouteEndpoint):
         self.fn = fn
 

--- a/localstack/services/lambda_/invocation/executor_endpoint.py
+++ b/localstack/services/lambda_/invocation/executor_endpoint.py
@@ -140,8 +140,7 @@ class ExecutorEndpoint:
             ) from e
 
     def shutdown(self) -> None:
-        for rule in self.rules:
-            self.router.remove_rule(rule)
+        self.router.remove(self.rules)
         self.startup_future.cancel()
         if self.invocation_future:
             self.invocation_future.cancel()

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -504,8 +504,7 @@ class EndpointProxy:
         )
 
     def unregister(self):
-        for rule in self.routing_rules:
-            ROUTER.remove_rule(rule)
+        ROUTER.remove(self.routing_rules)
         self.routing_rules.clear()
 
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -758,8 +758,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         self._start_cloudwatch_metrics_reporting()
 
     def on_before_stop(self):
-        for rule in self._router_rules:
-            ROUTER.remove_rule(rule)
+        ROUTER.remove(self._router_rules)
 
         self._queue_update_worker.stop()
         self._message_move_task_manager.close()

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -5,10 +5,10 @@ import pytest
 import requests
 import werkzeug
 from werkzeug.exceptions import MethodNotAllowed, NotFound
-from werkzeug.routing import RequestRedirect
+from werkzeug.routing import RequestRedirect, Submount
 
 from localstack.http import Request, Response, Router
-from localstack.http.router import E, RequestArguments, route
+from localstack.http.router import E, RequestArguments, RuleAdapter, WithHost, route
 from localstack.utils.common import get_free_tcp_port
 
 
@@ -303,13 +303,13 @@ class TestRouter:
         assert router.dispatch(Request("GET", "/")).data == b"index"
         assert router.dispatch(Request("GET", "/users/12")).data == b"users"
 
-        router.remove_rule(rule1)
+        router.remove(rule1)
 
         assert router.dispatch(Request("GET", "/")).data == b"index"
         with pytest.raises(NotFound):
             assert router.dispatch(Request("GET", "/users/12"))
 
-        router.remove_rule(rule0)
+        router.remove(rule0)
         with pytest.raises(NotFound):
             assert router.dispatch(Request("GET", "/"))
         with pytest.raises(NotFound):
@@ -352,10 +352,10 @@ class TestRouter:
             return Response(b"index")
 
         rule = router.add("/", index)
-        router.remove_rule(rule)
+        router.remove(rule)
 
         with pytest.raises(KeyError) as e:
-            router.remove_rule(rule)
+            router.remove(rule)
         e.match("no such rule")
 
     def test_router_route_decorator(self):
@@ -444,6 +444,66 @@ class TestRouter:
 
         assert router.dispatch(Request("GET", "/my_api")).data == b"/my_api/do-get"
         assert router.dispatch(Request("HEAD", "/my_api")).data == b"/my_api/do-get"
+
+    def test_submount_rule_adapter(self):
+        @route("/my_api", methods=["GET"])
+        def do_get(request: Request, _args):
+            # should be inherited
+            return Response(f"{request.path}/do-get")
+
+        def hello(request: Request, _args):
+            return Response("hello world")
+
+        router = Router()
+
+        # base endpoints
+        endpoints = RuleAdapter([do_get, RuleAdapter("/hello", hello)])
+
+        router.add([endpoints, Submount("/foo", [endpoints])])
+
+        assert router.dispatch(Request("GET", "/foo/my_api")).data == b"/foo/my_api/do-get"
+        assert router.dispatch(Request("GET", "/my_api")).data == b"/my_api/do-get"
+
+        assert router.dispatch(Request("GET", "/foo/hello")).data == b"hello world"
+        assert router.dispatch(Request("GET", "/hello")).data == b"hello world"
+
+    def test_with_host_and_submount(self):
+        @route("/my_api", methods=["GET"])
+        def do_get(request: Request, _args):
+            response = Response()
+            response.set_json({"path": request.path, "host": request.host})
+            return response
+
+        router = Router()
+
+        router.add(
+            [
+                WithHost(
+                    "foo.localhost.localstack.cloud:4566",
+                    [RuleAdapter(do_get)],
+                ),
+                Submount(
+                    "/foo",
+                    [RuleAdapter(do_get)],
+                ),
+            ]
+        )
+
+        request = Request("GET", "/foo/my_api")
+        assert router.dispatch(request).json == {
+            "host": "127.0.0.1",
+            "path": "/foo/my_api",
+        }
+
+        request = Request("GET", "/my_api", server=("foo.localhost.localstack.cloud", 4566))
+        assert router.dispatch(request).json == {
+            "path": "/my_api",
+            "host": "foo.localhost.localstack.cloud:4566",
+        }
+
+        request = Request("GET", "/my_api", server=("localhost.localstack.cloud", 4566))
+        with pytest.raises(NotFound):
+            router.dispatch(request)
 
 
 class TestWsgiIntegration:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Werkzeug has clever utilities such as `Submount` which allows you to streamline the creation of routers:

```python
url_map = Map([
    Rule('/', endpoint='index'),
    Submount('/blog', [
        Rule('/', endpoint='blog/index'),
        Rule('/entry/<entry_slug>', endpoint='blog/show')
    ])
])
```

Our `@route`, `@resource`, or endpoint concepts have not been compatible with these, because the werkzeug `Rule` objects are created within `Router.add`, instead of an encapsulating `RuleFactory`, which is werkzeug's mechanism of building higher-level routing utilities.

This PR moves all the code that generates `Rule` objects out of `Router.add`, and instead encapsulates them into `RuleFactory` classes. This makes them naturally compatible with werkzeug.

For instance, now you can do something like:

```python
@route("/v1/hello", methods=["GET"])
def hello(request: Request, _args):
    return "hello"

@route("/v1/world", methods=["GET"])
def world(request: Request, _args):
    return "world"

def main():
    router = Router()

    api = RuleAdapter([
        hello,
        world,
    ])
    
    router.add([
        WithHost("myextension.localhost.localstack.cloud:4566", [api]),
        Submount("/_ext/myextension", [api]),
    ])
```

Where you'll be able to call:
* `localhost:4566/_ext/myextension/v1/hello`
* `myextension.localhost.localstack.cloud:4566/v1/hello`

This is going to be very useful to implement higher-level patterns like in extensions. For example, for the openai mock extension https://github.com/localstack/localstack-extensions/pull/36, there are several routes that all have hardcoded routes prefixed with `/v1/...`. We wouldn't want to expose this via `localhost.localstack.cloud:4566/v1/...` because of potential collisions, but would be ok through `openai.localhost...` or `localhost.localstack.cloud:4566/openai-mock/v1/...`.
The utilities of this PR allows you to easily do that with a combination of `WithHost` and `Submount`, as in the example above.

<!-- What notable changes does this PR make? -->
## Changes

* the logic to create werkzeug `Rule` objects from endpoints and other localstack concepts is now in a `RuleAdapter` class that is compatible with werkzeug's `RuleFactory`
* Removed deprecated methods from `Router` and refactored existing code accordingly


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

