### PR TITLE
fix flaky sns unit test

### DIFF
--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -634,7 +634,7 @@ class TestSns:
             "TopicArn": "arn",
             "Message": "test content",
             "Subject": "random",
-            "Timestamp": timestamp_millis(),
+            "Timestamp": timestamp,
             "UnsubscribeURL": "http://randomurl.com",
         }
 
@@ -650,7 +650,7 @@ class TestSns:
             "TopicArn": "arn",
             "Message": "test content",
             "Subject": "random",
-            "Timestamp": timestamp_millis(),
+            "Timestamp": timestamp,
             "UnsubscribeURL": "http://randomurl.com",
             "SubscribeURL": "http://randomurl.com",
             "Token": "randomtoken",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A flake showed up in the sns untit test `test_canonical_string_calculation`: https://app.circleci.com/pipelines/github/localstack/localstack/21448/workflows/caff7afc-1a8b-4ec3-87b9-45e83aa06e90/jobs/171800/tests

```
AssertionError: assert 'Message\ntes...otification\n' == 'Message\ntes...otification\n'
    Message
    test content
    MessageId
    abdcdef
    Subject
    random
    Timestamp
  - 2024-01-07T20:43:26.204Z
  ?                       ^
  + 2024-01-07T20:43:26.205Z
  ?                       ^
    TopicArn
    arn
    Type
    Notification
```

looks like tiny variations between timestamps

<!-- What notable changes does this PR make? -->
## Changes

* use the created timestamp throughout the test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

