### PR TITLE
add extension mechanism for exceptions

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -55,6 +55,7 @@ class LocalstackAwsGateway(Gateway):
         self.exception_handlers.extend(
             [
                 handlers.log_exception,
+                handlers.serve_custom_exception_handlers,
                 handlers.handle_service_exception,
                 handlers.handle_internal_failure,
             ]

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -39,6 +39,7 @@ modify_service_response = service.ServiceResponseHandlers()
 parse_service_response = service.ServiceResponseParser()
 parse_pre_signed_url_request = presigned_url.ParsePreSignedUrlRequest()
 run_custom_finalizers = chain.CompositeFinalizer()
+serve_custom_exception_handlers = chain.CompositeExceptionHandler()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()
 set_close_connection_header = legacy.set_close_connection_header

--- a/localstack/extensions/api/aws.py
+++ b/localstack/extensions/api/aws.py
@@ -6,6 +6,7 @@ from localstack.aws.api import (
     ServiceResponse,
 )
 from localstack.aws.chain import (
+    CompositeExceptionHandler,
     CompositeHandler,
     CompositeResponseHandler,
     ExceptionHandler,
@@ -26,4 +27,5 @@ __all__ = [
     "CompositeHandler",
     "ExceptionHandler",
     "CompositeResponseHandler",
+    "CompositeExceptionHandler",
 ]

--- a/localstack/extensions/api/extension.py
+++ b/localstack/extensions/api/extension.py
@@ -1,6 +1,6 @@
 from plugin import Plugin
 
-from .aws import CompositeHandler, CompositeResponseHandler
+from .aws import CompositeExceptionHandler, CompositeHandler, CompositeResponseHandler
 from .http import RouteHandler, Router
 
 
@@ -75,6 +75,14 @@ class Extension(BaseExtension):
         Called with the custom response handlers of the LocalStack gateway. Overwrite this to add or update handlers.
 
         :param handlers: custom response handlers of the gateway
+        """
+        pass
+
+    def update_exception_handlers(self, handlers: CompositeExceptionHandler):
+        """
+        Called with the custom exception handlers of the LocalStack gateway. Overwrite this to add or update handlers.
+
+        :param handlers: custom exception handlers of the gateway
         """
         pass
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The need has come up in extensions to be able to hook in custom exception handlers into the handler chain. Specifically, @ackdav needs this for the snowflake extension.

This PR extends the handler chain with a composite exception handler that can be used in the same way as other handlers, and adds an `update_exception_handlers` method to the `Extension` interface.

<!-- What notable changes does this PR make? -->
## Changes

* the handler chain now has a composite handler for custom exception handlers
* the extension api now supports adding exception handlers into this composite


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

