### PR TITLE
add a call_safe_with_result function

### DIFF
--- a/localstack/utils/functions.py
+++ b/localstack/utils/functions.py
@@ -2,7 +2,7 @@
 import functools
 import inspect
 import logging
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple
 
 LOG = logging.getLogger(__name__)
 
@@ -15,6 +15,17 @@ def run_safe(_python_lambda, *args, _default=None, **kwargs):
         if print_error:
             LOG.warning("Unable to execute function: %s", e)
         return _default
+
+
+class Result(NamedTuple):
+    """Wraps the possible outcomes of a function call, that can either be a value or an exception."""
+
+    error: Optional[Exception]
+    value: Optional[Any] = None
+
+    @property
+    def has_error(self) -> bool:
+        return self.error is not None
 
 
 def call_safe(
@@ -30,6 +41,17 @@ def call_safe(
     :param exception_message: message to log on exception
     :return: whatever the func returns
     """
+    result = call_safe_with_result(func, args, kwargs, exception_message)
+    if result.has_error:
+        return None
+    return result.value
+
+
+def call_safe_with_result(
+    func: Callable, args: Tuple = None, kwargs: Dict = None, exception_message: str = None
+) -> Result:
+    """Similar as call_safe, but returns a Result object that contains the value returned by func or the raised
+    exception."""
     if exception_message is None:
         exception_message = "error calling function %s" % func.__name__
     if args is None:
@@ -38,12 +60,14 @@ def call_safe(
         kwargs = {}
 
     try:
-        return func(*args, **kwargs)
+        value = func(*args, **kwargs)
+        return Result(value=value, error=None)
     except Exception as e:
         if LOG.isEnabledFor(logging.DEBUG):
             LOG.exception(exception_message)
         else:
             LOG.warning("%s: %s", exception_message, e)
+        return Result(error=e)
 
 
 def prevent_stack_overflow(match_parameters=False):

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -1,0 +1,44 @@
+import pytest
+
+from localstack.utils.functions import Result, call_safe_with_result
+
+
+def test_call_safe_ok():
+    def _my_fun():
+        return 2 + 2
+
+    result = call_safe_with_result(_my_fun)
+    assert not result.has_error
+    assert result.value == 4
+
+
+def test_call_safe_none():
+    def _my_fun():
+        return None
+
+    result = call_safe_with_result(_my_fun)
+    assert not result.has_error
+    assert result.value is None
+
+
+def test_call_safe_error():
+    def _my_fun():
+        d = {"foo": "bar"}
+        return d["baz"]
+
+    result = call_safe_with_result(_my_fun)
+    assert result.has_error
+    assert isinstance(result.error, KeyError)
+
+
+def test_result_init():
+    with pytest.raises(TypeError):
+        Result()  # type: ignore
+
+    result_ok = Result(value=1, error=None)
+    assert not result_ok.has_error
+    assert result_ok.value == 1
+
+    result_error = Result(value=1, error=Exception())
+    assert result_error.has_error
+    assert isinstance(result_error.error, Exception)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
`call_safe` is a utility function that invokes a provided `Callable` (`func`) and returns its return value or logs an exception, if raised.
While exceptions get logged, it would be handy to programmatically know if one is actually raised (e.g., [here](https://github.com/localstack/localstack-ext/blob/master/localstack_ext/persistence/manager.py)). 
A simple solution would have been to check for a `None` return from `call_safe`, which would imply an exception.
However, this assumption does not hold if `func` returns `None` even in successful cases.

<!-- What notable changes does this PR make? -->
## Changes
- implemented a function `call_safe_with_result` function that returns a `Result` object, that can either return the value or the exception for the called `func`;
- `call_safe` now uses the `call_safe_with_result` function;
- adding a few small unit tests.



<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

