### PR TITLE
fix CLI issue with outdated click version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages=find:
 
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
-    click>=7.0
+    click>=7.1
     cachetools>=5.0
     cryptography
     dill==0.3.6


### PR DESCRIPTION
## Motivation
We just discovered an issue in the CLI which can be triggered if you have an already existing, somewhat older environment and only upgrade the LocalStack packages.
The following script can be used to reproduce the issue:
```bash
cd /tmp
python3 -m venv .venv
source .venv/bin/activate
python3 -m pip install click==7.0.0
python3 -m pip install localstack
localstack
```
This results in the following error:
```
Traceback (most recent call last):
  File "/tmp/.venv/bin/localstack", line 23, in <module>
    main()
  File "/tmp/.venv/bin/localstack", line 19, in main
    main.main()
  File "/tmp/.venv/lib/python3.11/site-packages/localstack/cli/main.py", line 17, in main
    cli()
  File "/tmp/.venv/lib/python3.11/site-packages/localstack/cli/plugin.py", line 15, in __call__
    self.group(*args, **kwargs)
  File "/tmp/.venv/lib/python3.11/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.venv/lib/python3.11/site-packages/click/core.py", line 716, in main
    with self.make_context(prog_name, args, **extra) as ctx:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.venv/lib/python3.11/site-packages/click/core.py", line 639, in make_context
    ctx = Context(self, info_name=info_name, parent=parent, **extra)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Context.__init__() got an unexpected keyword argument 'show_default'
```

## Changes
- This PR upgrades the minimum Click version to `7.1`.

## Testing
These changes are really hard to test automatically, without introducing an explicit pipeline step.
I tested this locally by using the newly set minimum version in the script mentioned above:
```bash
cd /tmp
python3 -m venv .venv
source .venv/bin/activate
python3 -m pip install click==7.1
python3 -m pip install localstack
localstack
```
This set of commands works as expected.