### PR TITLE
allow headers to be set from integration definition for HTTP integrat…

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -608,7 +608,7 @@ class HTTPIntegration(BackendIntegration):
         integration = invocation_context.integration
         path_params = invocation_context.path_params
         method = invocation_context.method
-        headers = invocation_context.headers
+        headers = helpers.create_invocation_headers(invocation_context)
         relative_path, query_string_params = extract_query_string_params(path=invocation_path)
         uri = integration.get("uri") or integration.get("integrationUri") or ""
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Unlike the lambda integration, which allows headers to be set from the integration definition, the HTTP integration passes the invocation context headers directly to the backend without applying the headers from the integration. This change addresses https://github.com/localstack/localstack/issues/10034 and allows additional headers to be sent to the backend which matches our ability to do this in the AWS cloud.


<!-- What notable changes does this PR make? -->
## Changes
Headers defined in an integration are now able to be sent along to the backend.

```
2024-01-09 10:03:04 {
2024-01-09 10:03:04     "type": "HTTP_PROXY",
2024-01-09 10:03:04     "httpMethod": "ANY",
2024-01-09 10:03:04     "uri": "http://api-proxy/{proxy}",
2024-01-09 10:03:04     "connectionType": "INTERNET",
2024-01-09 10:03:04     "requestParameters": {
2024-01-09 10:03:04         "integration.request.header.x-hello": "'hello'",
2024-01-09 10:03:04         "integration.request.path.proxy": "method.request.path.proxy"
2024-01-09 10:03:04     },
2024-01-09 10:03:04     "passthroughBehavior": "WHEN_NO_MATCH",
2024-01-09 10:03:04     "timeoutInMillis": 29000,
2024-01-09 10:03:04     "cacheNamespace": "q3jxp7vw3s",
2024-01-09 10:03:04     "cacheKeyParameters": []
2024-01-09 10:03:04 }
... print(headers)
2024-01-09 10:03:31 x-localstack-tgt-api: apigateway
2024-01-09 10:03:31 X-Forwarded-For: awslocal:4566
2024-01-09 10:03:31 x-localstack-edge: http://awslocal:4566
2024-01-09 10:03:31 x-hello: 'hello'
2024-01-09 10:03:31 
```

## Testing

* I would love to add testing but am a bit new to python so am not sure where best to add it (e.g. what to mock and all that)



