### PR TITLE
feat: DynamoDB TTL

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -816,6 +816,9 @@ DYNAMODB_SHARE_DB = int(os.environ.get("DYNAMODB_SHARE_DB") or 0)
 # the port on which to expose dynamodblocal
 DYNAMODB_LOCAL_PORT = int(os.environ.get("DYNAMODB_LOCAL_PORT") or 0)
 
+# Enables the automatic removal of stale KV pais based on TTL
+DYNAMODB_REMOVE_EXPIRED_ITEMS = is_env_true("DYNAMODB_REMOVE_EXPIRED_ITEMS")
+
 # Used to toggle PurgeInProgress exceptions when calling purge within 60 seconds
 SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
 
@@ -1107,6 +1110,7 @@ CONFIG_ENV_VARS = [
     "DYNAMODB_LOCAL_PORT",
     "DYNAMODB_SHARE_DB",
     "DYNAMODB_READ_ERROR_PROBABILITY",
+    "DYNAMODB_REMOVE_EXPIRED_ITEMS",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
     "EAGER_SERVICE_LOADING",
     "ENABLE_CONFIG_UPDATES",

--- a/localstack/services/dynamodb/models.py
+++ b/localstack/services/dynamodb/models.py
@@ -1,4 +1,9 @@
-from localstack.aws.api.dynamodb import RegionName, ReplicaDescription, TableName
+from localstack.aws.api.dynamodb import (
+    RegionName,
+    ReplicaDescription,
+    TableName,
+    TimeToLiveSpecification,
+)
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -29,7 +34,7 @@ class DynamoDBStore(BaseStore):
     table_properties: dict[str, dict] = LocalAttribute(default=dict)
 
     # maps table names to TTL specifications
-    ttl_specifications: dict[str, dict] = LocalAttribute(default=dict)
+    ttl_specifications: dict[str, TimeToLiveSpecification] = LocalAttribute(default=dict)
 
     # maps backups
     backups: dict[str, dict] = LocalAttribute(default=dict)

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -4,12 +4,14 @@ import logging
 import os
 import random
 import re
+import threading
 import time
 import traceback
 from binascii import crc32
 from contextlib import contextmanager
+from datetime import datetime
 from operator import itemgetter
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 import werkzeug
@@ -105,7 +107,7 @@ from localstack.constants import (
     AWS_REGION_US_EAST_1,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
-from localstack.http import Response
+from localstack.http import Request, Response, route
 from localstack.services.dynamodb.models import DynamoDBStore, dynamodb_stores
 from localstack.services.dynamodb.server import DynamodbServer
 from localstack.services.dynamodb.utils import (
@@ -132,8 +134,9 @@ from localstack.utils.aws.request_context import (
 from localstack.utils.collections import select_attributes, select_from_typed_dict
 from localstack.utils.common import short_uid, to_bytes
 from localstack.utils.json import BytesEncoder, canonical_json
+from localstack.utils.scheduler import Scheduler
 from localstack.utils.strings import long_uid, to_str
-from localstack.utils.threads import start_worker_thread
+from localstack.utils.threads import FuncThread, start_thread, start_worker_thread
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -356,15 +359,121 @@ def modify_context_region(context: RequestContext, region: str):
         context.request.headers["Authorization"] = original_authorization
 
 
+class DynamoDBDeveloperEndpoints:
+    """
+    Developer endpoints for DynamoDB
+    DELETE /_aws/dynamodb/expired - delete expired items from tables with TTL enabled; return the number of expired
+        items deleted
+    """
+
+    @route("/_aws/dynamodb/expired", methods=["DELETE"])
+    def delete_expired_messages(self, _: Request):
+        no_expired_items = delete_expired_items()
+        return {"ExpiredItems": no_expired_items}
+
+
+def delete_expired_items() -> int:
+    """
+    This utility function iterates over all stores, looks for tables with TTL enabled,
+    scan such tables and delete expired items.
+    """
+    no_expired_items = 0
+
+    for account_id, account_bundle in dynamodb_stores.items():
+        for region_name, state in account_bundle.items():
+            ttl_specs = state.ttl_specifications
+            for table_name, ttl_spec in ttl_specs.items():
+                if ttl_spec.get("Enabled", False):
+                    attribute_name = ttl_spec.get("AttributeName")
+                    client = connect_to(region_name=region_name).dynamodb
+                    current_time = int(datetime.now().timestamp())
+                    try:
+                        result = client.scan(
+                            TableName=table_name,
+                            FilterExpression=f"{attribute_name} <= :threshold",
+                            ExpressionAttributeValues={":threshold": {"N": str(current_time)}},
+                        )
+                        items_to_delete = result.get("Items", [])
+                        no_expired_items += len(items_to_delete)
+                        table_description = client.describe_table(TableName=table_name)
+                        partition_key = _get_partition_key(table_description)
+                        keys_to_delete = [
+                            {partition_key: item.get(partition_key)} for item in items_to_delete
+                        ]
+                        delete_requests = [
+                            {"DeleteRequest": {"Key": key}} for key in keys_to_delete
+                        ]
+                        client.batch_write_item(RequestItems={table_name: delete_requests})
+                    except Exception as e:
+                        LOG.warning(
+                            "An error occurred when deleting expired items from table %s: %s",
+                            table_name,
+                            e,
+                        )
+    return no_expired_items
+
+
+def _get_partition_key(table_description: DescribeTableOutput) -> str:
+    key_schema = table_description.get("Table", {}).get("KeySchema", [])
+    for key in key_schema:
+        if key["KeyType"] == "HASH":
+            return key["AttributeName"]
+
+
+class ExpiredItemsWorker:
+    """A worker that periodically computes and deletes expired items from DynamoDB tables"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.scheduler = Scheduler()
+        self.thread: Optional[FuncThread] = None
+        self.mutex = threading.RLock()
+
+    def start(self):
+        with self.mutex:
+            if self.thread:
+                return
+
+            self.scheduler = Scheduler()
+            self.scheduler.schedule(
+                delete_expired_items, period=60 * 60
+            )  # the background process seems slow on AWS
+
+            def _run(*_args):
+                self.scheduler.run()
+
+            self.thread = start_thread(_run, name="ddb-remove-expired-items")
+
+    def stop(self):
+        with self.mutex:
+            if self.scheduler:
+                self.scheduler.close()
+
+            if self.thread:
+                self.thread.stop()
+
+            self.thread = None
+            self.scheduler = None
+
+
 class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     server: DynamodbServer
     """The instance of the server managing the instance of DynamoDB local"""
 
     def __init__(self):
         self.server = self._new_dynamodb_server()
+        self._expired_items_worker = ExpiredItemsWorker()
+        self._router_rules = []
 
     def on_before_start(self):
         self.server.start_dynamodb()
+        self._expired_items_worker.start()
+        self._router_rules = ROUTER.add(DynamoDBDeveloperEndpoints())
+
+    def on_before_stop(self):
+        self._expired_items_worker.stop()
+        for rule in self._router_rules:
+            ROUTER.remove_rule(rule)
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(dynamodb_stores)

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -465,7 +465,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
     def on_before_start(self):
         self.server.start_dynamodb()
-        self._expired_items_worker.start()
+        if config.DYNAMODB_REMOVE_EXPIRED_ITEMS:
+            self._expired_items_worker.start()
         self._router_rules = ROUTER.add(DynamoDBDeveloperEndpoints())
 
     def on_before_stop(self):

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -378,40 +378,36 @@ def delete_expired_items() -> int:
     scan such tables and delete expired items.
     """
     no_expired_items = 0
-
-    for account_id, account_bundle in dynamodb_stores.items():
-        for region_name, state in account_bundle.items():
-            ttl_specs = state.ttl_specifications
-            for table_name, ttl_spec in ttl_specs.items():
-                if ttl_spec.get("Enabled", False):
-                    attribute_name = ttl_spec.get("AttributeName")
-                    client = connect_to(region_name=region_name).dynamodb
-                    current_time = int(datetime.now().timestamp())
-                    try:
-                        result = client.scan(
-                            TableName=table_name,
-                            FilterExpression=f"{attribute_name} <= :threshold",
-                            ExpressionAttributeValues={":threshold": {"N": str(current_time)}},
-                        )
-                        items_to_delete = result.get("Items", [])
-                        no_expired_items += len(items_to_delete)
-                        table_description = client.describe_table(TableName=table_name)
-                        partition_key = _get_partition_key(table_description)
-                        keys_to_delete = [
-                            {partition_key: item.get(partition_key)} for item in items_to_delete
-                        ]
-                        delete_requests = [
-                            {"DeleteRequest": {"Key": key}} for key in keys_to_delete
-                        ]
-                        for i in range(0, len(delete_requests), 25):
-                            batch = delete_requests[i : i + 25]
-                            client.batch_write_item(RequestItems={table_name: batch})
-                    except Exception as e:
-                        LOG.warning(
-                            "An error occurred when deleting expired items from table %s: %s",
-                            table_name,
-                            e,
-                        )
+    for account_id, region_name, state in dynamodb_stores.iter_stores():
+        ttl_specs = state.ttl_specifications
+        client = connect_to(region_name=region_name).dynamodb
+        for table_name, ttl_spec in ttl_specs.items():
+            if ttl_spec.get("Enabled", False):
+                attribute_name = ttl_spec.get("AttributeName")
+                current_time = int(datetime.now().timestamp())
+                try:
+                    result = client.scan(
+                        TableName=table_name,
+                        FilterExpression=f"{attribute_name} <= :threshold",
+                        ExpressionAttributeValues={":threshold": {"N": str(current_time)}},
+                    )
+                    items_to_delete = result.get("Items", [])
+                    no_expired_items += len(items_to_delete)
+                    table_description = client.describe_table(TableName=table_name)
+                    partition_key = _get_partition_key(table_description)
+                    keys_to_delete = [
+                        {partition_key: item.get(partition_key)} for item in items_to_delete
+                    ]
+                    delete_requests = [{"DeleteRequest": {"Key": key}} for key in keys_to_delete]
+                    for i in range(0, len(delete_requests), 25):
+                        batch = delete_requests[i : i + 25]
+                        client.batch_write_item(RequestItems={table_name: batch})
+                except Exception as e:
+                    LOG.warning(
+                        "An error occurred when deleting expired items from table %s: %s",
+                        table_name,
+                        e,
+                    )
     return no_expired_items
 
 

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -380,7 +380,7 @@ def delete_expired_items() -> int:
     no_expired_items = 0
     for account_id, region_name, state in dynamodb_stores.iter_stores():
         ttl_specs = state.ttl_specifications
-        client = connect_to(region_name=region_name).dynamodb
+        client = connect_to(aws_access_key_id=account_id, region_name=region_name).dynamodb
         for table_name, ttl_spec in ttl_specs.items():
             if ttl_spec.get("Enabled", False):
                 attribute_name = ttl_spec.get("AttributeName")

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -403,7 +403,9 @@ def delete_expired_items() -> int:
                         delete_requests = [
                             {"DeleteRequest": {"Key": key}} for key in keys_to_delete
                         ]
-                        client.batch_write_item(RequestItems={table_name: delete_requests})
+                        for i in range(0, len(delete_requests), 25):
+                            batch = delete_requests[i : i + 25]
+                            client.batch_write_item(RequestItems={table_name: batch})
                     except Exception as e:
                         LOG.warning(
                             "An error occurred when deleting expired items from table %s: %s",

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1,14 +1,17 @@
 import json
 import re
+import time
 from datetime import datetime
 from time import sleep
 from typing import Dict
 
 import botocore.exceptions
 import pytest
+import requests
 from boto3.dynamodb.types import STRING
 from botocore.exceptions import ClientError
 
+from localstack import config
 from localstack.aws.api.dynamodb import PointInTimeRecoverySpecification
 from localstack.constants import AWS_REGION_US_EAST_1, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
@@ -103,8 +106,39 @@ class TestDynamoDB:
         assert len(result["Items"]) == num_items
 
     @markers.aws.only_localstack
+    def test_time_to_live_deletion(self, aws_client, ddb_test_table):
+        table_name = ddb_test_table
+        aws_client.dynamodb.update_time_to_live(
+            TableName=table_name,
+            TimeToLiveSpecification={"Enabled": True, "AttributeName": "expiringAt"},
+        )
+        aws_client.dynamodb.describe_time_to_live(TableName=table_name)
+
+        exp = int(time.time()) - 10  # expired
+        items = [
+            {PARTITION_KEY: {"S": "expired"}, "expiringAt": {"N": str(exp)}},
+            {PARTITION_KEY: {"S": "not-expired"}, "expiringAt": {"N": str(exp + 120)}},
+        ]
+        for item in items:
+            aws_client.dynamodb.put_item(TableName=table_name, Item=item)
+
+        url = f"{config.internal_service_url()}/_aws/dynamodb/expired"
+        response = requests.delete(url)
+        assert response.status_code == 200
+        assert response.json() == {"ExpiredItems": 1}
+
+        result = aws_client.dynamodb.get_item(
+            TableName=table_name, Key={PARTITION_KEY: {"S": "not-expired"}}
+        )
+        assert result.get("Item")
+        result = aws_client.dynamodb.get_item(
+            TableName=table_name, Key={PARTITION_KEY: {"S": "expired"}}
+        )
+        assert not result.get("Item")
+
+    @markers.aws.only_localstack
     def test_time_to_live(self, aws_client, ddb_test_table):
-        # check response for inexistent table
+        # check response for nonexistent table
         response = testutil.send_describe_dynamodb_ttl_request("test")
         assert json.loads(response._content)["__type"] == "ResourceNotFoundException"
         assert response.status_code == 400


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR implements the Time to Live feature in DynamoDB, as reported in #10022.


<!-- What notable changes does this PR make? -->
## Changes
- We added a `ExpiredItemsWorker` class in the DDB provider that schedules a thread removing the stale keys across all the tables that define an enabled TTL specification. It uses a `Scheduler` under the hood and runs every hour. We could make the period interval parameterized.
- We added the `DELETE /_aws/dynamodb/expired` endpoint that programmatically triggers the stale items' deletion.

### Misc
- to implement the deletion, we scan every table with the `Scan` operation, collecting the stale items.
- we use `BatchItemWrite` to delete the collected stale items from the DBs. The call should consume write throughput, while TTL does not.
- an alternative would be to mark the expired element, instead of deleting them, and exclude them from all the relevant operations.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

