### PR TITLE
improve + test thread safety for metric access

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -115,7 +115,6 @@ class CloudwatchDatabase:
             with self.DATABASE_LOCK:
                 with sqlite3.connect(self.METRICS_DB) as conn:
                     cur = conn.cursor()
-                    print(f"""---> {cur.execute("pragma lockstatus").fetchall()}""")
                     for insert in inserts:
                         times_to_insert = insert.get("TimesToInsert")
                         prepared_placeholder = ",".join(
@@ -416,16 +415,16 @@ class CloudwatchDatabase:
             with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
                 cur = conn.cursor()
                 """ shape for each data entry:
-                {
-                    "ns": r.namespace,
-                    "n": r.name,
-                    "v": r.value,
-                    "t": r.timestamp,
-                    "d": [{"n": d.name, "v": d.value} for d in r.dimensions],
-                    "account": account-id, # new for v2
-                    "region": region_name, # new for v2
-                }
-                """
+                    {
+                        "ns": r.namespace,
+                        "n": r.name,
+                        "v": r.value,
+                        "t": r.timestamp,
+                        "d": [{"n": d.name, "v": d.value} for d in r.dimensions],
+                        "account": account-id, # new for v2
+                        "region": region_name, # new for v2
+                    }
+                    """
                 query = f"SELECT namespace, metric_name, value, timestamp, dimensions, account_id, region from {self.TABLE_SINGLE_METRICS}"
                 cur.execute(query)
                 metrics_result = [

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -44,10 +44,10 @@ class CloudwatchDatabase:
             return
 
         mkdir(self.CLOUDWATCH_DATA_ROOT)
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB) as conn:
-            cur = conn.cursor()
-            common_columns = """
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB) as conn:
+                cur = conn.cursor()
+                common_columns = """
                     "id"	                INTEGER,
                     "account_id"	        TEXT,
                     "region"	            TEXT,
@@ -58,18 +58,18 @@ class CloudwatchDatabase:
                     "unit"	                TEXT,
                     "storage_resolution"	INTEGER
                 """
-            cur.execute(
-                f"""
+                cur.execute(
+                    f"""
                 CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
                     {common_columns},
                     "value"	                NUMERIC,
                     PRIMARY KEY("id")
                 );
                 """
-            )
+                )
 
-            cur.execute(
-                f"""
+                cur.execute(
+                    f"""
                 CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
                     {common_columns},
                     "sample_count"          NUMERIC,
@@ -79,15 +79,15 @@ class CloudwatchDatabase:
                     PRIMARY KEY("id")
                 );
                 """
-            )
-            # create indexes
-            cur.executescript(
-                """
+                )
+                # create indexes
+                cur.executescript(
+                    """
                 CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
                 CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
                 """
-            )
-            conn.commit()
+                )
+                conn.commit()
 
     def add_metric_data(
         self, account_id: str, region: str, namespace: str, metric_data: MetricData
@@ -134,16 +134,16 @@ class CloudwatchDatabase:
 
                         cur.execute(
                             f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
-                        ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
-                        VALUES {prepared_placeholder}""",
+                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
+                    VALUES {prepared_placeholder}""",
                             data,
                         )
 
                     if statistic_values := metric.get("StatisticValues"):
                         cur.execute(
                             f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
-                            ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
                                 account_id,
                                 region,
@@ -205,15 +205,15 @@ class CloudwatchDatabase:
             AND timestamp >= ? AND timestamp < ?
         ) AS subquery
         """
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-            cur = conn.cursor()
-            cur.execute(
-                sql_query,
-                data,
-            )
-            result_row = cur.fetchone()
-            return result_row[0].split(",") if result_row[0] else ["NULL_VALUE"]
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+                cur = conn.cursor()
+                cur.execute(
+                    sql_query,
+                    data,
+                )
+                result_row = cur.fetchone()
+                return result_row[0].split(",") if result_row[0] else ["NULL_VALUE"]
 
     def get_metric_data_stat(
         self,
@@ -280,39 +280,39 @@ class CloudwatchDatabase:
         AND timestamp >= ? AND timestamp < ?
         ORDER BY timestamp ASC
         """
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-            cur = conn.cursor()
-            timestamps = []
-            values = []
-            while start_time_unix < end_time_unix:
-                next_start_time = start_time_unix + period
-                cur.execute(
-                    sql_query,
-                    data + (start_time_unix, next_start_time),
-                )
-                result_row = cur.fetchone()
-
-                if result_row[1]:
-                    calculated_result = (
-                        result_row[0] / result_row[1] if stat == "Average" else result_row[0]
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+                cur = conn.cursor()
+                timestamps = []
+                values = []
+                while start_time_unix < end_time_unix:
+                    next_start_time = start_time_unix + period
+                    cur.execute(
+                        sql_query,
+                        data + (start_time_unix, next_start_time),
                     )
-                    timestamps.append(start_time_unix)
-                    values.append(calculated_result)
+                    result_row = cur.fetchone()
 
-                start_time_unix = next_start_time
+                    if result_row[1]:
+                        calculated_result = (
+                            result_row[0] / result_row[1] if stat == "Average" else result_row[0]
+                        )
+                        timestamps.append(start_time_unix)
+                        values.append(calculated_result)
 
-            # The while loop while always give us the timestamps in ascending order as we start with the start_time
-            # and increase it by the period until we reach the end_time
-            # If we want the timestamps in descending order we need to reverse the list
-            if scan_by is None or scan_by == ScanBy.TimestampDescending:
-                timestamps = timestamps[::-1]
-                values = values[::-1]
+                    start_time_unix = next_start_time
 
-            return {
-                "timestamps": timestamps,
-                "values": values,
-            }
+                # The while loop while always give us the timestamps in ascending order as we start with the start_time
+                # and increase it by the period until we reach the end_time
+                # If we want the timestamps in descending order we need to reverse the list
+                if scan_by is None or scan_by == ScanBy.TimestampDescending:
+                    timestamps = timestamps[::-1]
+                    values = values[::-1]
+
+                return {
+                    "timestamps": timestamps,
+                    "values": values,
+                }
 
     def list_metrics(
         self,
@@ -354,34 +354,34 @@ class CloudwatchDatabase:
             {dimension_filter}
             ORDER BY timestamp DESC
         """
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-            cur = conn.cursor()
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+                cur = conn.cursor()
 
-            cur.execute(
-                query,
-                data,
-            )
-            metrics_result = [
-                {
-                    "metric_name": r[0],
-                    "namespace": r[1],
-                    "dimensions": self._restore_dimensions_from_string(r[2]),
-                }
-                for r in cur.fetchall()
-            ]
+                cur.execute(
+                    query,
+                    data,
+                )
+                metrics_result = [
+                    {
+                        "metric_name": r[0],
+                        "namespace": r[1],
+                        "dimensions": self._restore_dimensions_from_string(r[2]),
+                    }
+                    for r in cur.fetchall()
+                ]
 
-            return {"metrics": metrics_result}
+                return {"metrics": metrics_result}
 
     def clear_tables(self):
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB) as conn:
-            cur = conn.cursor()
-            cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
-            cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
-            conn.commit()
-            cur.execute("VACUUM")
-            conn.commit()
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB) as conn:
+                cur = conn.cursor()
+                cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
+                cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
+                conn.commit()
+                cur.execute("VACUUM")
+                conn.commit()
 
     def _get_ordered_dimensions_with_separator(self, dims: Optional[List[Dict]]):
         if not dims:
@@ -411,10 +411,10 @@ class CloudwatchDatabase:
         return int(timestamp.timestamp())
 
     def get_all_metric_data(self):
-        # with self.DATABASE_LOCK:
-        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
-            cur = conn.cursor()
-            """ shape for each data entry:
+        with self.DATABASE_LOCK:
+            with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
+                cur = conn.cursor()
+                """ shape for each data entry:
                     {
                         "ns": r.namespace,
                         "n": r.name,
@@ -425,19 +425,19 @@ class CloudwatchDatabase:
                         "region": region_name, # new for v2
                     }
                     """
-            query = f"SELECT namespace, metric_name, value, timestamp, dimensions, account_id, region from {self.TABLE_SINGLE_METRICS}"
-            cur.execute(query)
-            metrics_result = [
-                {
-                    "ns": r[0],
-                    "n": r[1],
-                    "v": r[2],
-                    "t": r[3],
-                    "d": r[4],
-                    "account": r[5],
-                    "region": r[6],
-                }
-                for r in cur.fetchall()
-            ]
-            # TODO add aggregated metrics (was not handled by v1 either)
-            return metrics_result
+                query = f"SELECT namespace, metric_name, value, timestamp, dimensions, account_id, region from {self.TABLE_SINGLE_METRICS}"
+                cur.execute(query)
+                metrics_result = [
+                    {
+                        "ns": r[0],
+                        "n": r[1],
+                        "v": r[2],
+                        "t": r[3],
+                        "d": r[4],
+                        "account": r[5],
+                        "region": r[6],
+                    }
+                    for r in cur.fetchall()
+                ]
+                # TODO add aggregated metrics (was not handled by v1 either)
+                return metrics_result

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sqlite3
+import threading
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
@@ -33,94 +34,117 @@ class CloudwatchDatabase:
     METRICS_DB: str = os.path.join(CLOUDWATCH_DATA_ROOT, DB_NAME)
     TABLE_SINGLE_METRICS = "SINGLE_METRICS"
     TABLE_AGGREGATED_METRICS = "AGGREGATED_METRICS"
+    DATABASE_WRITE_LOCK: threading.RLock
 
     def __init__(self):
+        self.DATABASE_WRITE_LOCK = threading.RLock()
         if os.path.exists(self.METRICS_DB):
             LOG.debug(f"database for metrics already exists ({self.METRICS_DB})")
             return
 
         mkdir(self.CLOUDWATCH_DATA_ROOT)
-        with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
-            cur = conn.cursor()
-            common_columns = """
-                "id"	                INTEGER,
-                "account_id"	        TEXT,
-                "region"	            TEXT,
-                "metric_name"	        TEXT,
-                "namespace" 	        TEXT,
-                "timestamp"	            NUMERIC,
-                "dimensions"	        TEXT,
-                "unit"	                TEXT,
-                "storage_resolution"	INTEGER
-            """
-            cur.execute(
-                f"""
-            CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
-                {common_columns},
-                "value"	                NUMERIC,
-                PRIMARY KEY("id")
-            );
-            """
-            )
-
-            cur.execute(
-                f"""
-            CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
-                {common_columns},
-                "sample_count"          NUMERIC,
-                "sum"	                NUMERIC,
-                "min"	                NUMERIC,
-                "max"	                NUMERIC,
-                PRIMARY KEY("id")
-            );
-            """
-            )
-            # create indexes
-            cur.executescript(
+        with self.DATABASE_WRITE_LOCK:
+            with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
+                cur = conn.cursor()
+                common_columns = """
+                    "id"	                INTEGER,
+                    "account_id"	        TEXT,
+                    "region"	            TEXT,
+                    "metric_name"	        TEXT,
+                    "namespace" 	        TEXT,
+                    "timestamp"	            NUMERIC,
+                    "dimensions"	        TEXT,
+                    "unit"	                TEXT,
+                    "storage_resolution"	INTEGER
                 """
-            CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
-            CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
-            """
-            )
-            conn.commit()
+                cur.execute(
+                    f"""
+                CREATE TABLE "{self.TABLE_SINGLE_METRICS}" (
+                    {common_columns},
+                    "value"	                NUMERIC,
+                    PRIMARY KEY("id")
+                );
+                """
+                )
+
+                cur.execute(
+                    f"""
+                CREATE TABLE "{self.TABLE_AGGREGATED_METRICS}" (
+                    {common_columns},
+                    "sample_count"          NUMERIC,
+                    "sum"	                NUMERIC,
+                    "min"	                NUMERIC,
+                    "max"	                NUMERIC,
+                    PRIMARY KEY("id")
+                );
+                """
+                )
+                # create indexes
+                cur.executescript(
+                    """
+                CREATE INDEX idx_single_metrics_comp ON SINGLE_METRICS (metric_name, namespace);
+                CREATE INDEX idx_aggregated_metrics_comp ON AGGREGATED_METRICS (metric_name, namespace);
+                """
+                )
+                conn.commit()
 
     def add_metric_data(
         self, account_id: str, region: str, namespace: str, metric_data: MetricData
     ):
         # TODO consider using thread-lock here instead of increasing busy-timeout
-        with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
-            conn.execute(
-                "PRAGMA busy_timeout = 20000"
-            )  # TODO check if we need to set timeout higher, testing with 20 seconds
-            cur = conn.cursor()
+        def _get_current_unix_timestamp_utc():
+            now = datetime.utcnow().replace(tzinfo=timezone.utc)
+            return int(now.timestamp())
 
-            def _get_current_unix_timestamp_utc():
-                now = datetime.utcnow().replace(tzinfo=timezone.utc)
-                return int(now.timestamp())
+        for metric in metric_data:
+            unix_timestamp = (
+                self._convert_timestamp_to_unix(metric.get("Timestamp"))
+                if metric.get("Timestamp")
+                else _get_current_unix_timestamp_utc()
+            )
 
-            for metric in metric_data:
-                unix_timestamp = (
-                    self._convert_timestamp_to_unix(metric.get("Timestamp"))
-                    if metric.get("Timestamp")
-                    else _get_current_unix_timestamp_utc()
-                )
+            inserts = []
+            if metric.get("Value") is not None:
+                inserts.append({"Value": metric.get("Value"), "TimesToInsert": 1})
+            elif metric.get("Values"):
+                counts = metric.get("Counts", [1] * len(metric.get("Values")))
+                inserts = [
+                    {"Value": value, "TimesToInsert": int(counts[indexValue])}
+                    for indexValue, value in enumerate(metric.get("Values"))
+                ]
+            with self.DATABASE_WRITE_LOCK:
+                with sqlite3.connect(self.METRICS_DB, isolation_level="EXCLUSIVE") as conn:
+                    cur = conn.cursor()
 
-                inserts = []
-                if metric.get("Value") is not None:
-                    inserts.append({"Value": metric.get("Value"), "TimesToInsert": 1})
-                elif metric.get("Values"):
-                    counts = metric.get("Counts", [1] * len(metric.get("Values")))
-                    inserts = [
-                        {"Value": value, "TimesToInsert": int(counts[indexValue])}
-                        for indexValue, value in enumerate(metric.get("Values"))
-                    ]
+                    for insert in inserts:
+                        times_to_insert = insert.get("TimesToInsert")
+                        prepared_placeholder = ",".join(
+                            ["(?, ?, ?, ?, ?, ?, ?, ?, ?)" for _ in range(times_to_insert)]
+                        )
+                        data = (
+                            account_id,
+                            region,
+                            metric.get("MetricName"),
+                            namespace,
+                            unix_timestamp,
+                            self._get_ordered_dimensions_with_separator(metric.get("Dimensions")),
+                            metric.get("Unit"),
+                            metric.get("StorageResolution"),
+                            insert.get("Value"),
+                        ) * times_to_insert
 
-                for insert in inserts:
-                    for _ in range(insert.get("TimesToInsert")):
                         cur.execute(
                             f"""INSERT INTO {self.TABLE_SINGLE_METRICS}
                     ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "value")
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    VALUES {prepared_placeholder}""",
+                            data,
+                        )
+
+                    if statistic_values := metric.get("StatisticValues"):
+                        cur.execute(
+                            f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
+                        ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
                                 account_id,
                                 region,
@@ -132,32 +156,14 @@ class CloudwatchDatabase:
                                 ),
                                 metric.get("Unit"),
                                 metric.get("StorageResolution"),
-                                insert.get("Value"),
+                                statistic_values.get("SampleCount"),
+                                statistic_values.get("Sum"),
+                                statistic_values.get("Minimum"),
+                                statistic_values.get("Maximum"),
                             ),
                         )
 
-                if statistic_values := metric.get("StatisticValues"):
-                    cur.execute(
-                        f"""INSERT INTO {self.TABLE_AGGREGATED_METRICS}
-                    ("account_id", "region", "metric_name", "namespace", "timestamp", "dimensions", "unit", "storage_resolution", "sample_count", "sum", "min", "max")
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        (
-                            account_id,
-                            region,
-                            metric.get("MetricName"),
-                            namespace,
-                            unix_timestamp,
-                            self._get_ordered_dimensions_with_separator(metric.get("Dimensions")),
-                            metric.get("Unit"),
-                            metric.get("StorageResolution"),
-                            statistic_values.get("SampleCount"),
-                            statistic_values.get("Sum"),
-                            statistic_values.get("Minimum"),
-                            statistic_values.get("Maximum"),
-                        ),
-                    )
-
-            conn.commit()
+                conn.commit()
 
     def get_units_for_metric_data_stat(
         self,
@@ -168,42 +174,40 @@ class CloudwatchDatabase:
         metric_name: str,
         namespace: str,
     ):
-        with sqlite3.connect(self.METRICS_DB) as conn:
-            cur = conn.cursor()
+        # prepare SQL query
+        start_time_unix = self._convert_timestamp_to_unix(start_time)
+        end_time_unix = self._convert_timestamp_to_unix(end_time)
 
-            # prepare SQL query
-            start_time_unix = self._convert_timestamp_to_unix(start_time)
-            end_time_unix = self._convert_timestamp_to_unix(end_time)
+        data = (
+            account_id,
+            region,
+            namespace,
+            metric_name,
+            start_time_unix,
+            end_time_unix,
+        )
 
-            data = (
-                account_id,
-                region,
-                namespace,
-                metric_name,
-                start_time_unix,
-                end_time_unix,
-            )
-
-            sql_query = f"""
-            SELECT GROUP_CONCAT(unit) AS unit_values
-            FROM(
+        sql_query = f"""
+        SELECT GROUP_CONCAT(unit) AS unit_values
+        FROM(
+            SELECT
+                DISTINCT COALESCE(unit, 'NULL_VALUE') AS unit
+            FROM (
                 SELECT
-                    DISTINCT COALESCE(unit, 'NULL_VALUE') AS unit
-                FROM (
-                    SELECT
-                    account_id, region, metric_name, namespace, timestamp, unit
-                    FROM {self.TABLE_SINGLE_METRICS}
-                    UNION ALL
-                    SELECT
-                    account_id, region, metric_name, namespace, timestamp, unit
-                    FROM {self.TABLE_AGGREGATED_METRICS}
-                ) AS combined
-                WHERE account_id = ? AND region = ?
-                AND namespace = ? AND metric_name = ?
-                AND timestamp >= ? AND timestamp < ?
-            ) AS subquery
-            """
-
+                account_id, region, metric_name, namespace, timestamp, unit
+                FROM {self.TABLE_SINGLE_METRICS}
+                UNION ALL
+                SELECT
+                account_id, region, metric_name, namespace, timestamp, unit
+                FROM {self.TABLE_AGGREGATED_METRICS}
+            ) AS combined
+            WHERE account_id = ? AND region = ?
+            AND namespace = ? AND metric_name = ?
+            AND timestamp >= ? AND timestamp < ?
+        ) AS subquery
+        """
+        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+            cur = conn.cursor()
             cur.execute(
                 sql_query,
                 data,
@@ -220,67 +224,64 @@ class CloudwatchDatabase:
         end_time: datetime,
         scan_by: str,
     ) -> Dict[str, List]:
-        # TODO exclude null values, check if dimensions must be null though if missing
+        metric_stat = query.get("MetricStat")
+        metric = metric_stat.get("Metric")
+        period = metric_stat.get("Period")
+        stat = metric_stat.get("Stat")
+        dimensions = metric.get("Dimensions", [])
+        unit = metric_stat.get("Unit")
 
-        with sqlite3.connect(self.METRICS_DB) as conn:
-            cur = conn.cursor()
-            metric_stat = query.get("MetricStat")
-            metric = metric_stat.get("Metric")
-            period = metric_stat.get("Period")
-            stat = metric_stat.get("Stat")
-            dimensions = metric.get("Dimensions", [])
-            unit = metric_stat.get("Unit")
+        # prepare SQL query
+        start_time_unix = self._convert_timestamp_to_unix(start_time)
+        end_time_unix = self._convert_timestamp_to_unix(end_time)
 
-            # prepare SQL query
-            start_time_unix = self._convert_timestamp_to_unix(start_time)
-            end_time_unix = self._convert_timestamp_to_unix(end_time)
+        data = (
+            account_id,
+            region,
+            metric.get("Namespace"),
+            metric.get("MetricName"),
+        )
 
-            data = (
-                account_id,
-                region,
-                metric.get("Namespace"),
-                metric.get("MetricName"),
-            )
+        dimension_filter = ""
+        for dimension in dimensions:
+            dimension_filter += "AND dimensions LIKE ? "
+            data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
 
-            dimension_filter = ""
-            for dimension in dimensions:
-                dimension_filter += "AND dimensions LIKE ? "
-                data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
+        if not dimensions:
+            dimension_filter = "AND dimensions is null "
 
-            if not dimensions:
-                dimension_filter = "AND dimensions is null "
+        unit_filter = ""
+        if unit:
+            if unit == "NULL_VALUE":
+                unit_filter = "AND unit IS NULL"
+            else:
+                unit_filter = "AND unit = ? "
+                data += (unit,)
 
-            unit_filter = ""
-            if unit:
-                if unit == "NULL_VALUE":
-                    unit_filter = "AND unit IS NULL"
-                else:
-                    unit_filter = "AND unit = ? "
-                    data += (unit,)
-
-            sql_query = f"""
+        sql_query = f"""
+        SELECT
+            {STAT_TO_SQLITE_AGGREGATION_FUNC[stat]},
+            SUM(count)
+        FROM (
             SELECT
-                {STAT_TO_SQLITE_AGGREGATION_FUNC[stat]},
-                SUM(count)
-            FROM (
-                SELECT
-                value, 1 as count,
-                account_id, region, metric_name, namespace, timestamp, dimensions, unit, storage_resolution
-                FROM {self.TABLE_SINGLE_METRICS}
-                UNION ALL
-                SELECT
-                {STAT_TO_SQLITE_COL_NAME_HELPER[stat]} as value, sample_count as count,
-                account_id, region, metric_name, namespace, timestamp, dimensions, unit, storage_resolution
-                FROM {self.TABLE_AGGREGATED_METRICS}
-            ) AS combined
-            WHERE account_id = ? AND region = ?
-            AND namespace = ? AND metric_name = ?
-            {unit_filter}
-            {dimension_filter}
-            AND timestamp >= ? AND timestamp < ?
-            ORDER BY timestamp ASC
-            """
-
+            value, 1 as count,
+            account_id, region, metric_name, namespace, timestamp, dimensions, unit, storage_resolution
+            FROM {self.TABLE_SINGLE_METRICS}
+            UNION ALL
+            SELECT
+            {STAT_TO_SQLITE_COL_NAME_HELPER[stat]} as value, sample_count as count,
+            account_id, region, metric_name, namespace, timestamp, dimensions, unit, storage_resolution
+            FROM {self.TABLE_AGGREGATED_METRICS}
+        ) AS combined
+        WHERE account_id = ? AND region = ?
+        AND namespace = ? AND metric_name = ?
+        {unit_filter}
+        {dimension_filter}
+        AND timestamp >= ? AND timestamp < ?
+        ORDER BY timestamp ASC
+        """
+        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+            cur = conn.cursor()
             timestamps = []
             values = []
             while start_time_unix < end_time_unix:
@@ -320,41 +321,40 @@ class CloudwatchDatabase:
         metric_name: str,
         dimensions: list[dict[str, str]],
     ) -> dict:
-        with sqlite3.connect(self.METRICS_DB) as conn:
+        data = (account_id, region)
+
+        namespace_filter = ""
+        if namespace:
+            namespace_filter = "AND namespace = ?"
+            data = data + (namespace,)
+
+        metric_name_filter = ""
+        if metric_name:
+            metric_name_filter = "AND metric_name = ?"
+            data = data + (metric_name,)
+
+        dimension_filter = ""
+        for dimension in dimensions:
+            dimension_filter += "AND dimensions LIKE ? "
+            data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
+
+        query = f"""
+            SELECT DISTINCT metric_name, namespace, dimensions
+            FROM (
+                SELECT metric_name, namespace, dimensions, account_id, region, timestamp
+                FROM SINGLE_METRICS
+                UNION
+                SELECT metric_name, namespace, dimensions, account_id, region, timestamp
+                FROM AGGREGATED_METRICS
+            ) AS combined
+            WHERE account_id = ? AND region = ?
+            {namespace_filter}
+            {metric_name_filter}
+            {dimension_filter}
+            ORDER BY timestamp DESC
+        """
+        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
             cur = conn.cursor()
-
-            data = (account_id, region)
-
-            namespace_filter = ""
-            if namespace:
-                namespace_filter = "AND namespace = ?"
-                data = data + (namespace,)
-
-            metric_name_filter = ""
-            if metric_name:
-                metric_name_filter = "AND metric_name = ?"
-                data = data + (metric_name,)
-
-            dimension_filter = ""
-            for dimension in dimensions:
-                dimension_filter += "AND dimensions LIKE ? "
-                data = data + (f"%{dimension.get('Name')}={dimension.get('Value','')}%",)
-
-            query = f"""
-                SELECT DISTINCT metric_name, namespace, dimensions
-                FROM (
-                    SELECT metric_name, namespace, dimensions, account_id, region, timestamp
-                    FROM SINGLE_METRICS
-                    UNION
-                    SELECT metric_name, namespace, dimensions, account_id, region, timestamp
-                    FROM AGGREGATED_METRICS
-                ) AS combined
-                WHERE account_id = ? AND region = ?
-                {namespace_filter}
-                {metric_name_filter}
-                {dimension_filter}
-                ORDER BY timestamp DESC
-            """
 
             cur.execute(
                 query,
@@ -369,21 +369,17 @@ class CloudwatchDatabase:
                 for r in cur.fetchall()
             ]
 
-            cur.execute(
-                query,
-                data,
-            )
-
             return {"metrics": metrics_result}
 
     def clear_tables(self):
-        with sqlite3.connect(self.METRICS_DB) as conn:
-            cur = conn.cursor()
-            cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
-            cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
-            conn.commit()
-            cur.execute("VACUUM")
-            conn.commit()
+        with self.DATABASE_WRITE_LOCK:
+            with sqlite3.connect(self.METRICS_DB) as conn:
+                cur = conn.cursor()
+                cur.execute(f"DELETE FROM {self.TABLE_SINGLE_METRICS}")
+                cur.execute(f"DELETE FROM {self.TABLE_AGGREGATED_METRICS}")
+                conn.commit()
+                cur.execute("VACUUM")
+                conn.commit()
 
     def _get_ordered_dimensions_with_separator(self, dims: Optional[List[Dict]]):
         if not dims:
@@ -413,7 +409,7 @@ class CloudwatchDatabase:
         return int(timestamp.timestamp())
 
     def get_all_metric_data(self):
-        with sqlite3.connect(self.METRICS_DB) as conn:
+        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
             cur = conn.cursor()
             """ shape for each data entry:
             {

--- a/localstack/services/cloudwatch/cloudwatch_database_helper.py
+++ b/localstack/services/cloudwatch/cloudwatch_database_helper.py
@@ -32,6 +32,7 @@ class CloudwatchDatabase:
     DB_NAME = "metrics.db"
     CLOUDWATCH_DATA_ROOT: str = os.path.join(config.dirs.data, "cloudwatch")
     METRICS_DB: str = os.path.join(CLOUDWATCH_DATA_ROOT, DB_NAME)
+    METRICS_DB_READ_ONLY: str = f"file:{METRICS_DB}?mode=ro"
     TABLE_SINGLE_METRICS = "SINGLE_METRICS"
     TABLE_AGGREGATED_METRICS = "AGGREGATED_METRICS"
     DATABASE_WRITE_LOCK: threading.RLock
@@ -206,7 +207,7 @@ class CloudwatchDatabase:
             AND timestamp >= ? AND timestamp < ?
         ) AS subquery
         """
-        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
             cur = conn.cursor()
             cur.execute(
                 sql_query,
@@ -280,7 +281,7 @@ class CloudwatchDatabase:
         AND timestamp >= ? AND timestamp < ?
         ORDER BY timestamp ASC
         """
-        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
             cur = conn.cursor()
             timestamps = []
             values = []
@@ -353,7 +354,7 @@ class CloudwatchDatabase:
             {dimension_filter}
             ORDER BY timestamp DESC
         """
-        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
             cur = conn.cursor()
 
             cur.execute(
@@ -409,7 +410,7 @@ class CloudwatchDatabase:
         return int(timestamp.timestamp())
 
     def get_all_metric_data(self):
-        with sqlite3.connect(f"file:{self.METRICS_DB}", uri=True) as conn:
+        with sqlite3.connect(self.METRICS_DB_READ_ONLY, uri=True) as conn:
             cur = conn.cursor()
             """ shape for each data entry:
             {

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -558,10 +558,9 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             }
             for metric in result.get("metrics", [])
         ]
-
         aliases_list = PaginatedList(metrics)
         page, nxt = aliases_list.get_page(
-            lambda metric: metric.get("MetricName"),
+            lambda metric: f"{metric.get('Namespace')}-{metric.get('MetricName')}-{metric.get('Dimensions')}",
             next_token=next_token,
             page_size=LIST_METRICS_MAX_RESULTS,
         )

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2283,7 +2283,7 @@ class TestCloudwatch:
         snapshot.match("result", data)
 
     @markers.aws.only_localstack
-    # @pytest.mark.skipif(is_old_provider(), reason="old provider has known concurrency issues")
+    @pytest.mark.skipif(is_old_provider(), reason="old provider has known concurrency issues")
     # test some basic concurrency tasks
     def test_parallel_put_metric_data_list_metrics(self, aws_client):
         num_threads = 20

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1914,5 +1914,54 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_delete_alarm": {
+    "recorded-date": "12-01-2024, 14:06:14",
+    "recorded-content": {
+      "describe-alarm": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "metric1",
+            "Namespace": "<namespace:1>",
+            "OKActions": [],
+            "Period": 60,
+            "StateReason": "Unchecked: Initial alarm creation",
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "INSUFFICIENT_DATA",
+            "Statistic": "Sum",
+            "Threshold": 30.0
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-alarm": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-after-delete": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -17,6 +17,9 @@
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_dashboard_lifecycle": {
     "last_validated_date": "2023-10-25T11:16:20+00:00"
   },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_delete_alarm": {
+    "last_validated_date": "2024-01-12T14:06:42+00:00"
+  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_enable_disable_alarm_actions": {
     "last_validated_date": "2023-09-12T10:00:45+00:00"
   },

--- a/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
@@ -1,7 +1,8 @@
 import logging
 import threading
 
-from localstack.testing import pytest
+import pytest
+
 from localstack.testing.pytest import markers
 
 LOG = logging.getLogger(__name__)

--- a/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
@@ -1,48 +1,67 @@
 import logging
 import threading
+from datetime import datetime
 
 import pytest
+from botocore.config import Config
 
+from localstack.config import is_env_true
 from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+# reusing the same ENV as for test_lambda_performance
+if not is_env_true("TEST_PERFORMANCE"):
+    pytest.skip("Skip slow and resource-intensive tests", allow_module_level=True)
+
 
 LOG = logging.getLogger(__name__)
+
+CUSTOM_CLIENT_CONFIG_RETRY = Config(
+    connect_timeout=60,
+    read_timeout=60,
+    retries={"max_attempts": 3},  # increase retries in case LS cannot accept connections anymore
+    max_pool_connections=3000,
+)
 
 
 class TestCloudWatchPerformance:
     @markers.aws.only_localstack
-    @pytest.mark.skip
-    def test_parallel_write_read_access(self, aws_client):
-        num_threads = 150
+    def test_parallel_put_metric_data_list_metrics(self, aws_client, aws_client_factory):
+        num_threads = 1200
         create_barrier = threading.Barrier(num_threads)
-        errored = False
+        error_counter = Counter()
+        namespace = f"namespace-{short_uid()}"
 
         def _put_metric_list_metrics(runner: int):
-            nonlocal errored
+            nonlocal error_counter
+            nonlocal create_barrier
+            nonlocal namespace
             create_barrier.wait()
             try:
+                cw_client = aws_client_factory(config=CUSTOM_CLIENT_CONFIG_RETRY).cloudwatch
                 if runner % 2:
-                    namespace = f"namespace-{runner}"
-                    aws_client.cloudwatch.put_metric_data(
+                    cw_client.put_metric_data(
                         Namespace=namespace,
                         MetricData=[
                             {
-                                "MetricName": "metric2",
+                                "MetricName": f"metric-{runner}-1",
                                 "Value": 25,
                                 "Unit": "Seconds",
                             },
                             {
-                                "MetricName": "metric1",
+                                "MetricName": f"metric-{runner}-2",
                                 "Value": runner + 1,
                                 "Unit": "Seconds",
                             },
                         ],
                     )
                 else:
-                    aws_client.cloudwatch.list_metrics()
-            except Exception:
-                LOG.exception("failed")
-                errored = True
+                    cw_client.list_metrics()
+            except Exception as e:
+                LOG.exception(f"runner {runner} failed: {e}")
+                error_counter.increment()
 
+        start_time = datetime.utcnow()
         thread_list = []
         for i in range(1, num_threads + 1):
             thread = threading.Thread(target=_put_metric_list_metrics, args=[i])
@@ -52,4 +71,39 @@ class TestCloudWatchPerformance:
         for thread in thread_list:
             thread.join()
 
-        assert not errored
+        end_time = datetime.utcnow()
+        diff = end_time - start_time
+        LOG.info(f"N={num_threads} took {diff.total_seconds()} seconds")
+
+        assert error_counter.get_value() == 0
+        metrics = []
+        result = aws_client.cloudwatch.list_metrics(Namespace=namespace)
+        metrics += result["Metrics"]
+
+        while next_token := result.get("NextToken"):
+            result = aws_client.cloudwatch.list_metrics(NextToken=next_token, Namespace=namespace)
+            metrics += result["Metrics"]
+
+        assert 1200 == len(metrics)  # every second thread inserted two metrics
+
+    @markers.aws.only_localstack
+    def test_run_100_alarms(self, aws_client, aws_client_factory):
+        pass
+
+    @markers.aws.only_localstack
+    def test_sqs_queue_integration(self, aws_client, aws_client_factory):
+        pass
+
+
+class Counter:
+    def __init__(self):
+        self.value = 0
+        self.lock = threading.Lock()
+
+    def increment(self):
+        with self.lock:
+            self.value += 1
+
+    def get_value(self):
+        with self.lock:
+            return self.value

--- a/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
@@ -1,6 +1,7 @@
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import pytest
 from botocore.config import Config
@@ -8,6 +9,10 @@ from botocore.config import Config
 from localstack.config import is_env_true
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+if TYPE_CHECKING:
+    from mypy_boto3_cloudwatch import CloudWatchClient
 
 # reusing the same ENV as for test_lambda_performance
 if not is_env_true("TEST_PERFORMANCE"):
@@ -22,6 +27,23 @@ CUSTOM_CLIENT_CONFIG_RETRY = Config(
     retries={"max_attempts": 3},  # increase retries in case LS cannot accept connections anymore
     max_pool_connections=3000,
 )
+
+ACTION_LAMBDA = """
+def handler(event, context):
+    import json
+    print(json.dumps(event))
+    return {"success": True}
+"""
+
+
+def _delete_alarms(cloudwatch_client: "CloudWatchClient"):
+    response = cloudwatch_client.describe_alarms()
+    metric_alarms = [m["AlarmName"] for m in response["MetricAlarms"]]
+    while next_token := response.get("NextToken"):
+        response = cloudwatch_client.describe_alarms(NextToken=next_token)
+        metric_alarms += [m["AlarmName"] for m in response["MetricAlarms"]]
+
+    cloudwatch_client.delete_alarms(AlarmNames=metric_alarms)
 
 
 class TestCloudWatchPerformance:
@@ -87,8 +109,128 @@ class TestCloudWatchPerformance:
         assert 1200 == len(metrics)  # every second thread inserted two metrics
 
     @markers.aws.only_localstack
-    def test_run_100_alarms(self, aws_client, aws_client_factory):
-        pass
+    def test_run_100_alarms(
+        self, aws_client, aws_client_factory, create_lambda_function, cleanups, account_id
+    ):
+        # create 100 alarms then add metrics
+        # alarms should trigger
+        fn_name = f"fn-cw-{short_uid()}"
+        response = create_lambda_function(
+            func_name=fn_name,
+            handler_file=ACTION_LAMBDA,
+            runtime="python3.11",
+        )
+        function_arn = response["CreateFunctionResponse"]["FunctionArn"]
+        cleanups.append(lambda: _delete_alarms(aws_client.cloudwatch))
+        random_id = short_uid()
+        namespace = f"ns-{random_id}"
+        for i in range(0, 100):
+            # add 100 alarms (we can do this sequentially, they will start checking for matches in the background)
+            alarm_name = f"alarm-{random_id}-{i}"
+            aws_client.cloudwatch.put_metric_alarm(
+                AlarmName=alarm_name,
+                AlarmDescription="testing lambda alarm action",
+                MetricName=f"metric-{i}",
+                Namespace=namespace,
+                Period=10,
+                Threshold=2,
+                Statistic="Average",
+                OKActions=[],
+                AlarmActions=[function_arn],
+                EvaluationPeriods=1,
+                ComparisonOperator="GreaterThanThreshold",
+                TreatMissingData="ignore",
+            )
+            alarm_arn = aws_client.cloudwatch.describe_alarms(AlarmNames=[alarm_name])[
+                "MetricAlarms"
+            ][0]["AlarmArn"]
+
+            # allow cloudwatch to trigger the lambda
+            aws_client.lambda_.add_permission(
+                FunctionName=fn_name,
+                StatementId=f"AlarmAction-{i}",
+                Action="lambda:InvokeFunction",
+                Principal="lambda.alarms.cloudwatch.amazonaws.com",
+                SourceAccount=account_id,
+                SourceArn=alarm_arn,
+            )
+        # add metrics in parallel
+        num_threads = 300
+        create_barrier = threading.Barrier(num_threads)
+        error_counter = Counter()
+
+        def _put_metric_data(runner: int):
+            nonlocal error_counter
+            nonlocal create_barrier
+            nonlocal namespace
+            create_barrier.wait()
+            try:
+                metric_name = f"metric-{runner%100}"
+                cw_client = aws_client_factory(config=CUSTOM_CLIENT_CONFIG_RETRY).cloudwatch
+                cw_client.put_metric_data(
+                    Namespace=namespace,
+                    MetricData=[
+                        {
+                            "MetricName": metric_name,
+                            "Value": 25,
+                        },
+                        {
+                            "MetricName": metric_name,
+                            "Value": 20 + runner,
+                        },
+                    ],
+                )
+            except Exception as e:
+                LOG.exception(f"runner {runner} failed: {e}")
+                error_counter.increment()
+
+        start_time = datetime.utcnow()
+        thread_list = []
+        for i in range(0, num_threads):
+            thread = threading.Thread(target=_put_metric_data, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        end_time = datetime.utcnow()
+        diff = end_time - start_time
+        LOG.info(f"N={num_threads} took {diff.total_seconds()} seconds")
+
+        assert error_counter.get_value() == 0
+        metrics = []
+        result = aws_client.cloudwatch.list_metrics(Namespace=namespace)
+        metrics += result["Metrics"]
+
+        while next_token := result.get("NextToken"):
+            result = aws_client.cloudwatch.list_metrics(NextToken=next_token, Namespace=namespace)
+            metrics += result["Metrics"]
+
+        assert 100 == len(metrics)
+
+        def _assert_lambda_invocation():
+            metric_query_params = {
+                "Namespace": "AWS/Lambda",
+                "MetricName": "Invocations",
+                "Dimensions": [{"Name": "FunctionName", "Value": fn_name}],
+                "StartTime": start_time,
+                "EndTime": end_time + timedelta(minutes=20),
+                "Period": 3600,  # in seconds
+                "Statistics": ["Sum"],
+            }
+            response = aws_client.cloudwatch.get_metric_statistics(**metric_query_params)
+            num_invocations_metric = 0
+            for datapoint in response["Datapoints"]:
+                num_invocations_metric += int(datapoint["Sum"])
+            # assert num_invocations_metric == num_invocations
+            assert num_invocations_metric == 100
+
+        retry(
+            lambda: _assert_lambda_invocation(),
+            retries=200,
+            sleep=5,
+        )
 
     @markers.aws.only_localstack
     def test_sqs_queue_integration(self, aws_client, aws_client_factory):

--- a/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch_performance.py
@@ -1,0 +1,54 @@
+import logging
+import threading
+
+from localstack.testing import pytest
+from localstack.testing.pytest import markers
+
+LOG = logging.getLogger(__name__)
+
+
+class TestCloudWatchPerformance:
+    @markers.aws.only_localstack
+    @pytest.mark.skip
+    def test_parallel_write_read_access(self, aws_client):
+        num_threads = 150
+        create_barrier = threading.Barrier(num_threads)
+        errored = False
+
+        def _put_metric_list_metrics(runner: int):
+            nonlocal errored
+            create_barrier.wait()
+            try:
+                if runner % 2:
+                    namespace = f"namespace-{runner}"
+                    aws_client.cloudwatch.put_metric_data(
+                        Namespace=namespace,
+                        MetricData=[
+                            {
+                                "MetricName": "metric2",
+                                "Value": 25,
+                                "Unit": "Seconds",
+                            },
+                            {
+                                "MetricName": "metric1",
+                                "Value": runner + 1,
+                                "Unit": "Seconds",
+                            },
+                        ],
+                    )
+                else:
+                    aws_client.cloudwatch.list_metrics()
+            except Exception:
+                LOG.exception("failed")
+                errored = True
+
+        thread_list = []
+        for i in range(1, num_threads + 1):
+            thread = threading.Thread(target=_put_metric_list_metrics, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        assert not errored


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Some improvements for thread handling when accessing the sqlite database.

Some observations for sqlite database:
- the sqlite database is compiled once per system, so when you run in host-mode you may have different configuration then when running in docker
- observations on my personal computer: 
  - host mode runs a sqlite with different [threadsafety](https://docs.python.org/3.11/library/sqlite3.html#sqlite3.threadsafety): `THREADSAFE=2`, while in docker runs `THREADSAFE=1` (see also https://sqlite.org/threadsafe.html)
    - 2 means Multithreaded: Threads may share the module, but not connections 
    - 1 means Serialized: Threads may share the module, connections and cursors, should be save to access from multiple threads

General implementation:
* only `put_metric_data` requires write access
* all other operations only require read access, using `sqlite3.connect(file:db_name?mode=ro, uri=True)` 

Given this information my initial assumptions was:
* we only need a Lock for the `add_metrics` (which is called by `put_metric_data`), and when creating the database, or resetting the provider (which clears the table)

However, testing this with a huge amount of threads that run in parallel (see `test_parallel_put_metric_data_list_metrics`), we do need locks for every access (apparently the READ locks may lock the entire database under some circumstances (wasn't able to further pin this down). 

Additionally, when running in host-mode (assuming you only have `THREADSAFE=2`), each operation needs locks as well. 

Some run-time results from the test `test_parallel_put_metric_data_list_metrics` that I run on my computer:

started with `python -m localstack.dev.run` (starting as pro-image)
image-details
```
LocalStack version: 3.0.3.dev
LocalStack Docker container id: 676537bd7304
LocalStack build date: 2024-01-05
LocalStack build git hash: ba992b1
```

**Using v1 or running the tests with no-locks or only locks for `add_metrics` always failed in some iterations.**

I also ran the test `test_lambda_performance#test_lambda_event_invoke` several times successful with that configuration.



<!-- What notable changes does this PR make? -->
## Changes
* fix paging for `get-metrics`
* fix `delete-alarms` + added validated test
* refactor database-helper
  * make sure to create the connection after data has been prepared
  * add Locks for database access
* added `_STORE_LOCK` in the provider, for when we modify the alarm
  * reasoning: the `set-alarm-state` can be triggered any time by the alarm-scheduler, changing the alarm
  * this makes concurrent access way more likely
  * @baermat I saw in SQS a similar approach, maybe you can share some insights + thoughts on this 🙏  
* added a basic concurrency test
* added performance tests (which don't run with the pipeline)

## TODO
- [ ] add performance tests for sqs (will do this is another PR)
- [ ] optional follow-up: do benchmarks for using the `RWLockWrite` that @bentsku [suggested](https://github.com/localstack/localstack/commit/87ceac3595d17916b9edd9a9ae55380a0b3c0e76)
    -  Using the `python -m localstack.dev.run` I tested the approach for `test_parallel_put_metric_data_list_metrics`, and it works for the first run, starting from the second run (not restarting container in between), I get connection errors. 
    - Wild guess: Maybe the write-locks are preferred over reads, and the reads timeout? 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

