### PR TITLE
use request parameter resolvers

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -590,7 +590,7 @@ def get_stage_variables(context: ApiInvocationContext) -> Optional[Dict[str, str
     ).apigateway
     try:
         response = api_gateway_client.get_stage(restApiId=context.api_id, stageName=context.stage)
-        return response.get("variables")
+        return response.get("variables", {})
     except Exception:
         LOG.info("Failed to get stage %s for API id %s", context.stage, context.api_id)
         return {}

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -401,8 +401,7 @@ class RequestParametersResolver:
         # }
         request_params = context.integration.get("requestParameters", {})
 
-        # resolve all integration request parameters with the already resolved method
-        # request parameters
+        # resolve all integration request parameters with the already resolved method request parameters
         integrations_parameters = {}
         for k, v in request_params.items():
             if v.lower() in method_request_params:
@@ -1503,23 +1502,6 @@ def extract_api_id_from_hostname_in_url(hostname: str) -> str:
     """Extract API ID 'id123' from URLs like https://id123.execute-api.localhost.localstack.cloud:4566"""
     match = re.match(HOST_REGEX_EXECUTE_API, hostname)
     return match.group(1)
-
-
-# This need to be extended to handle mappings and not just literal values.
-def create_invocation_headers(invocation_context: ApiInvocationContext) -> Dict[str, Any]:
-    headers = invocation_context.headers
-    integration = invocation_context.integration
-
-    if request_parameters := integration.get("requestParameters"):
-        for req_parameter_key, req_parameter_value in request_parameters.items():
-            if (
-                header_name := req_parameter_key.lstrip("integration.request.header.")
-                if "integration.request.header." in req_parameter_key
-                else None
-            ):
-                headers.update({header_name: req_parameter_value})
-    return headers
-
 
 def is_greedy_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("+}")

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1503,6 +1503,7 @@ def extract_api_id_from_hostname_in_url(hostname: str) -> str:
     match = re.match(HOST_REGEX_EXECUTE_API, hostname)
     return match.group(1)
 
+
 def is_greedy_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("+}")
 


### PR DESCRIPTION

## Motivation

Improves community PR by using the `RequestParametersResolver` that can handle, headers, path and query strings and also static values.

Fixes the previous test - static values are configured using single quotes, "'Fixed-Header-Value'", but transformed into normal header values when passed to the integration.