### PR TITLE
patch HTTPServer fixture to spawn daemon thread

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,39 @@ pytest_plugins = [
 ]
 
 
+# FIXME: remove this, quick hack to prevent the HTTPServer fixture to spawn non-daemon threads
+def patch_http_server_fixture():
+    import threading
+
+    try:
+        from pytest_httpserver import HTTPServer, HTTPServerError
+        from werkzeug.serving import make_server
+
+        from localstack.utils.patch import patch
+
+        print("is this executed")
+
+        @patch(HTTPServer.start, pass_target=False)
+        def start_non_daemon_thread(self):
+            if self.is_running():
+                raise HTTPServerError("Server is already running")
+
+            self.server = make_server(
+                self.host, self.port, self.application, ssl_context=self.ssl_context
+            )
+            self.port = self.server.port  # Update port (needed if `port` was set to 0)
+            self.server_thread = threading.Thread(target=self.thread_target, daemon=True)
+            self.server_thread.start()
+
+    except ImportError:
+        # this will be executed in the CLI tests as well, where we don't have the pytest_httpserver dependency
+        # skip in that case
+        pass
+
+
+patch_http_server_fixture()
+
+
 @pytest.hookimpl
 def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
     parser.addoption(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've had issue with the pipeline timing out very frequently for the community tests against Pro.
It seems all test runs timing out had a leftover thread in common, spawned by the `httpserver` fixture. 
This thread was not spawned as `daemon`, meaning it would prevent the interpreter from shutting down.

<!-- What notable changes does this PR make? -->
## Changes
Temporary fix: patch the fixture to spawn the thread as daemon, so that even if it's still running, we can force its removal.

## Next up
- Investigate why this thread is still there, prevent it and remove the patch

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

