### PR TITLE
Refactor: Kinesis: Clean-up test fixtures

### DIFF
--- a/tests/aws/services/kinesis/conftest.py
+++ b/tests/aws/services/kinesis/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+from localstack.utils.common import poll_condition
+
+
+@pytest.fixture(autouse=True)
+def kinesis_snapshot_transformer(snapshot):
+    snapshot.add_transformer(snapshot.transform.kinesis_api())
+
+
+@pytest.fixture
+def wait_for_consumer_ready(aws_client):
+    def _wait_for_consumer_ready(consumer_arn: str):
+        def is_consumer_ready():
+            describe_response = aws_client.kinesis.describe_stream_consumer(
+                ConsumerARN=consumer_arn
+            )
+            return describe_response["ConsumerDescription"]["ConsumerStatus"] == "ACTIVE"
+
+        poll_condition(is_consumer_ready)
+
+    return _wait_for_consumer_ready

--- a/tests/aws/services/kinesis/conftest.py
+++ b/tests/aws/services/kinesis/conftest.py
@@ -19,7 +19,7 @@ def register_kinesis_consumer(aws_client):
         consumer_arn = response["Consumer"]["ConsumerARN"]
         consumer_arns.append(consumer_arn)
 
-        return consumer_arn
+        return response
 
     yield _register_kinesis_consumer
 

--- a/tests/aws/services/kinesis/conftest.py
+++ b/tests/aws/services/kinesis/conftest.py
@@ -8,11 +8,11 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def register_kinesis_consumer(aws_client):
+def kinesis_register_consumer(aws_client):
     kinesis = aws_client.kinesis
     consumer_arns = []
 
-    def _register_kinesis_consumer(stream_arn: str, consumer_name: str):
+    def _kinesis_register_consumer(stream_arn: str, consumer_name: str):
         response = kinesis.register_stream_consumer(
             StreamARN=stream_arn, ConsumerName=consumer_name
         )
@@ -21,7 +21,7 @@ def register_kinesis_consumer(aws_client):
 
         return response
 
-    yield _register_kinesis_consumer
+    yield _kinesis_register_consumer
 
     for consumer_arn in consumer_arns:
         try:
@@ -36,8 +36,8 @@ def kinesis_snapshot_transformer(snapshot):
 
 
 @pytest.fixture
-def wait_for_consumer_ready(aws_client):
-    def _wait_for_consumer_ready(consumer_arn: str):
+def wait_for_kinesis_consumer_ready(aws_client):
+    def _wait_for_kinesis_consumer_ready(consumer_arn: str):
         def is_consumer_ready():
             describe_response = aws_client.kinesis.describe_stream_consumer(
                 ConsumerARN=consumer_arn
@@ -46,4 +46,4 @@ def wait_for_consumer_ready(aws_client):
 
         poll_condition(is_consumer_ready)
 
-    return _wait_for_consumer_ready
+    return _wait_for_kinesis_consumer_ready

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -13,7 +13,7 @@ from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import resources
 from localstack.utils.aws.request_context import mock_aws_request_headers
-from localstack.utils.common import poll_condition, retry, select_attributes, short_uid
+from localstack.utils.common import retry, select_attributes, short_uid
 from localstack.utils.kinesis import kinesis_connector
 
 
@@ -33,11 +33,6 @@ def get_shard_iterator(stream_name, kinesis_client):
         StartingSequenceNumber=sequence_number,
     )
     return response.get("ShardIterator")
-
-
-@pytest.fixture(autouse=True)
-def kinesis_snapshot_transformer(snapshot):
-    snapshot.add_transformer(snapshot.transform.kinesis_api())
 
 
 class TestKinesis:
@@ -434,20 +429,6 @@ class TestKinesis:
         )["ShardIterator"]
 
         assert aws_client.kinesis.get_records(ShardIterator=f'"{shard_iterator}"')["Records"]
-
-
-@pytest.fixture
-def wait_for_consumer_ready(aws_client):
-    def _wait_for_consumer_ready(consumer_arn: str):
-        def is_consumer_ready():
-            describe_response = aws_client.kinesis.describe_stream_consumer(
-                ConsumerARN=consumer_arn
-            )
-            return describe_response["ConsumerDescription"]["ConsumerStatus"] == "ACTIVE"
-
-        poll_condition(is_consumer_ready)
-
-    return _wait_for_consumer_ready
 
 
 class TestKinesisPythonClient:

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -82,7 +82,8 @@ class TestKinesis:
 
         # create consumer and snapshot 1 consumer by list_stream_consumers
         consumer_name = "consumer"
-        consumer_arn = register_kinesis_consumer(stream_arn, consumer_name)
+        response = register_kinesis_consumer(stream_arn, consumer_name)
+        consumer_arn = response["Consumer"]["ConsumerARN"]
         wait_for_consumer_ready(consumer_arn=consumer_arn)
 
         consumer_list = aws_client.kinesis.list_stream_consumers(StreamARN=stream_arn).get(
@@ -115,7 +116,8 @@ class TestKinesis:
         ]["StreamARN"]
         wait_for_stream_ready(stream_name)
         consumer_name = "c1"
-        consumer_arn = register_kinesis_consumer(stream_arn, consumer_name)
+        response = register_kinesis_consumer(stream_arn, consumer_name)
+        consumer_arn = response["Consumer"]["ConsumerARN"]
         wait_for_consumer_ready(consumer_arn=consumer_arn)
 
         # subscribe to shard
@@ -167,7 +169,8 @@ class TestKinesis:
         wait_for_stream_ready(stream_name)
 
         consumer_name = "c1"
-        consumer_arn = register_kinesis_consumer(stream_arn, consumer_name)
+        response = register_kinesis_consumer(stream_arn, consumer_name)
+        consumer_arn = response["Consumer"]["ConsumerARN"]
         wait_for_consumer_ready(consumer_arn=consumer_arn)
 
         # get starting sequence number
@@ -323,7 +326,8 @@ class TestKinesis:
 
         # create consumer
         consumer_name = "c1"
-        consumer_arn = register_kinesis_consumer(stream_arn, consumer_name)
+        response = register_kinesis_consumer(stream_arn, consumer_name)
+        consumer_arn = response["Consumer"]["ConsumerARN"]
         wait_for_consumer_ready(consumer_arn=consumer_arn)
 
         # subscribe to shard

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -62,8 +62,8 @@ class TestKinesis:
         self,
         kinesis_create_stream,
         wait_for_stream_ready,
-        register_kinesis_consumer,
-        wait_for_consumer_ready,
+        kinesis_register_consumer,
+        wait_for_kinesis_consumer_ready,
         snapshot,
         aws_client,
     ):
@@ -82,9 +82,9 @@ class TestKinesis:
 
         # create consumer and snapshot 1 consumer by list_stream_consumers
         consumer_name = "consumer"
-        response = register_kinesis_consumer(stream_arn, consumer_name)
+        response = kinesis_register_consumer(stream_arn, consumer_name)
         consumer_arn = response["Consumer"]["ConsumerARN"]
-        wait_for_consumer_ready(consumer_arn=consumer_arn)
+        wait_for_kinesis_consumer_ready(consumer_arn=consumer_arn)
 
         consumer_list = aws_client.kinesis.list_stream_consumers(StreamARN=stream_arn).get(
             "Consumers"
@@ -104,8 +104,8 @@ class TestKinesis:
         self,
         kinesis_create_stream,
         wait_for_stream_ready,
-        register_kinesis_consumer,
-        wait_for_consumer_ready,
+        kinesis_register_consumer,
+        wait_for_kinesis_consumer_ready,
         snapshot,
         aws_client,
     ):
@@ -116,9 +116,9 @@ class TestKinesis:
         ]["StreamARN"]
         wait_for_stream_ready(stream_name)
         consumer_name = "c1"
-        response = register_kinesis_consumer(stream_arn, consumer_name)
+        response = kinesis_register_consumer(stream_arn, consumer_name)
         consumer_arn = response["Consumer"]["ConsumerARN"]
-        wait_for_consumer_ready(consumer_arn=consumer_arn)
+        wait_for_kinesis_consumer_ready(consumer_arn=consumer_arn)
 
         # subscribe to shard
         response = aws_client.kinesis.describe_stream(StreamName=stream_name)
@@ -156,8 +156,8 @@ class TestKinesis:
         self,
         kinesis_create_stream,
         wait_for_stream_ready,
-        register_kinesis_consumer,
-        wait_for_consumer_ready,
+        kinesis_register_consumer,
+        wait_for_kinesis_consumer_ready,
         snapshot,
         aws_client,
     ):
@@ -169,9 +169,9 @@ class TestKinesis:
         wait_for_stream_ready(stream_name)
 
         consumer_name = "c1"
-        response = register_kinesis_consumer(stream_arn, consumer_name)
+        response = kinesis_register_consumer(stream_arn, consumer_name)
         consumer_arn = response["Consumer"]["ConsumerARN"]
-        wait_for_consumer_ready(consumer_arn=consumer_arn)
+        wait_for_kinesis_consumer_ready(consumer_arn=consumer_arn)
 
         # get starting sequence number
         response = aws_client.kinesis.describe_stream(StreamName=stream_name)
@@ -313,8 +313,8 @@ class TestKinesis:
         self,
         kinesis_create_stream,
         wait_for_stream_ready,
-        register_kinesis_consumer,
-        wait_for_consumer_ready,
+        kinesis_register_consumer,
+        wait_for_kinesis_consumer_ready,
         aws_client,
     ):
         # create stream and consumer
@@ -326,9 +326,9 @@ class TestKinesis:
 
         # create consumer
         consumer_name = "c1"
-        response = register_kinesis_consumer(stream_arn, consumer_name)
+        response = kinesis_register_consumer(stream_arn, consumer_name)
         consumer_arn = response["Consumer"]["ConsumerARN"]
-        wait_for_consumer_ready(consumer_arn=consumer_arn)
+        wait_for_kinesis_consumer_ready(consumer_arn=consumer_arn)
 
         # subscribe to shard
         response = aws_client.kinesis.describe_stream(StreamName=stream_name)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I was working on implementing new tests for kinesis and kinesis firehose and wanted to use the opportunity to clean up the existing tests. I believe it is much cleaner to separate test fixtures and actual tests since this generally keeps test files shorter and easier to read.

<!-- What notable changes does this PR make? -->
## Changes
Moved existing fixtures to `conftest.py` and added a new fixture for creating a kinesis stream consumer that handles cleanup after the fact. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

