### PR TITLE
fix return value for AWS::Cognito::UserPoolClient

### DIFF
--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -25,6 +25,7 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::ApiGateway::Stage": "/properties/StageName",
     "AWS::ApiGateway::BasePathMapping": "/properties/RestApiId",
     "AWS::ApiGateway::Model": "/properties/Name",
+    "AWS::Cognito::UserPoolClient": "/properties/ClientId",
     "AWS::Logs::LogStream": "/properties/LogStreamName",
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::SSM::Parameter": "/properties/Name",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
According to the [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#aws-resource-cognito-userpoolclient-return-values), a `AWS::Cognito::UserPoolClient` resource should return it user pool client id via the `Ref` function.

However, our implementation currently return a combination of the two primary identifier fields, namely the `UserPoolId` and `UserPoolClientId`.

<!-- What notable changes does this PR make? -->
## Changes
- add a special case in `PHYSICAL_RESOURCE_ID_SPECIAL_CASES` for `AWS::Cognito::UserPoolClient`.

## Testing

The fix can be tested verifying the stack output of this simple stack against AWS. 
The companion PR also adds an integration test.

```yaml
Resources:
  MyUserPool:
    Type: AWS::Cognito::UserPool
    Properties:
      UserPoolName: {{ UserPoolName }}
      AdminCreateUserConfig:
        AllowAdminCreateUserOnly: false
      Schema:
        - Name: email
          AttributeDataType: String
          Mutable: true
          Required: true

  MyUserPoolClient:
    Type: AWS::Cognito::UserPoolClient
    Properties:
      ClientName: MyUserPoolClient
      UserPoolId: !Ref MyUserPool
      GenerateSecret: false

Outputs:
  UserPoolId:
    Value: !Ref MyUserPool
  ClientId:
    Value: !Ref MyUserPoolClient
```


