### PR TITLE
add support for ObjectLock for CFN S3 Bucket

### DIFF
--- a/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -461,6 +461,12 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
                 CORSConfiguration=cors_configuration,
             )
 
+        if object_lock_configuration := model.get("ObjectLockConfiguration"):
+            s3_client.put_object_lock_configuration(
+                Bucket=model["BucketName"],
+                ObjectLockConfiguration=object_lock_configuration,
+            )
+
         if tags := model.get("Tags"):
             s3_client.put_bucket_tagging(Bucket=model["BucketName"], Tagging={"TagSet": tags})
 
@@ -604,6 +610,9 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
                 "Bucket": model["BucketName"],
                 "ACL": self._convert_acl_cf_to_s3(model.get("AccessControl", "PublicRead")),
             }
+
+            if model.get("ObjectLockEnabled"):
+                params["ObjectLockEnabledForBucket"] = True
 
             if region_name != "us-east-1":
                 params["CreateBucketConfiguration"] = {

--- a/tests/aws/services/cloudformation/resources/test_s3.py
+++ b/tests/aws/services/cloudformation/resources/test_s3.py
@@ -100,3 +100,22 @@ def test_cors_configuration(deploy_cfn_template, snapshot, aws_client):
     bucket_name_required = result.outputs["BucketNameOnlyRequired"]
     cors_info = aws_client.s3.get_bucket_cors(Bucket=bucket_name_required)
     snapshot.match("cors-info-only-required", cors_info)
+
+
+@markers.aws.validated
+def test_object_lock_configuration(deploy_cfn_template, snapshot, aws_client):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.s3_api())
+
+    result = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/s3_object_lock_config.yaml"
+        ),
+    )
+    bucket_name_optional = result.outputs["LockConfigAllParameters"]
+    cors_info = aws_client.s3.get_object_lock_configuration(Bucket=bucket_name_optional)
+    snapshot.match("object-lock-info-with-configuration", cors_info)
+
+    bucket_name_required = result.outputs["LockConfigOnlyRequired"]
+    cors_info = aws_client.s3.get_object_lock_configuration(Bucket=bucket_name_required)
+    snapshot.match("object-lock-info-only-enabled", cors_info)

--- a/tests/aws/services/cloudformation/resources/test_s3.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_s3.snapshot.json
@@ -72,5 +72,34 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_s3.py::test_object_lock_configuration": {
+    "recorded-date": "15-01-2024, 02:31:58",
+    "recorded-content": {
+      "object-lock-info-with-configuration": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled",
+          "Rule": {
+            "DefaultRetention": {
+              "Days": 2,
+              "Mode": "GOVERNANCE"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-lock-info-only-enabled": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_s3.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_s3.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/cloudformation/resources/test_s3.py::test_cors_configuration": {
     "last_validated_date": "2023-04-20T18:17:17+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_s3.py::test_object_lock_configuration": {
+    "last_validated_date": "2024-01-15T02:31:58+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_s3.py::test_website_configuration": {
     "last_validated_date": "2023-06-02T16:24:39+00:00"
   }

--- a/tests/aws/templates/s3_object_lock_config.yaml
+++ b/tests/aws/templates/s3_object_lock_config.yaml
@@ -1,0 +1,22 @@
+Resources:
+  LocalBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      ObjectLockEnabled: true
+      ObjectLockConfiguration:
+        ObjectLockEnabled: "Enabled"
+        Rule:
+          DefaultRetention:
+            Mode: "GOVERNANCE"
+            Days: 2
+
+  LocalBucket2:
+    Type: AWS::S3::Bucket
+    Properties:
+      ObjectLockEnabled: true
+
+Outputs:
+  LockConfigAllParameters:
+    Value: !Ref LocalBucket
+  LockConfigOnlyRequired:
+    Value: !Ref LocalBucket2


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #9912, we did not support enabling ObjectLock for S3 Bucket, nor setting the object lock configuration to the bucket.

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-objectlockconfiguration.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html#cfn-s3-bucket-objectlockenabled
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html#cfn-s3-bucket-objectlockconfiguration

<!-- What notable changes does this PR make? -->
## Changes
- update the CloudFormation model to support it
- created a new test checking the functionality and the split between enabling the bucket to be locked and setting up the configuration
- renamed some variables in the regular S3 tests because PyCharm now checks for fixture usage, and the name clashed (it was saying the fixture wasn't imported when we did not need it)

_fixes #9912_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

