### PR TITLE
supports enabling S3 Object Lock on existing buckets

### DIFF
--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -540,7 +540,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_bucket_versioning_crud": {
-    "recorded-date": "01-08-2023, 16:50:36",
+    "recorded-date": "15-01-2024, 03:12:30",
     "recorded-content": {
       "get-versioning-before": {
         "ResponseMetadata": {
@@ -588,6 +588,16 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "put-versioning-disabled": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       },
       "put-versioning-empty": {
@@ -2140,26 +2150,64 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_on_existing_bucket": {
-    "recorded-date": "09-08-2023, 01:27:32",
+    "recorded-date": "15-01-2024, 03:13:25",
     "recorded-content": {
-      "put-object-lock-existing-bucket-enabled": {
+      "get-object-lock-existing-bucket-no-config": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "ObjectLockConfigurationNotFoundError",
+          "Message": "Object Lock configuration does not exist for this bucket"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-object-lock-existing-bucket-no-versioning": {
         "Error": {
           "Code": "InvalidBucketState",
-          "Message": "Object Lock configuration cannot be enabled on existing buckets"
+          "Message": "Versioning must be 'Enabled' on the bucket to apply a Object Lock configuration"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
         }
       },
-      "put-object-lock-existing-bucket-rule": {
+      "suspended-versioning": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-lock-existing-bucket-versioning-disabled": {
         "Error": {
           "Code": "InvalidBucketState",
-          "Message": "Object Lock configuration cannot be enabled on existing buckets"
+          "Message": "Versioning must be 'Enabled' on the bucket to apply a Object Lock configuration"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
+        }
+      },
+      "enabled-versioning": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-lock-existing-bucket-enabled": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-lock-existing-bucket-enabled": {
+        "ObjectLockConfiguration": {
+          "ObjectLockEnabled": "Enabled"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
@@ -2215,7 +2263,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_exc": {
-    "recorded-date": "10-08-2023, 14:13:45",
+    "recorded-date": "15-01-2024, 03:08:09",
     "recorded-content": {
       "put-lock-config-no-enabled": {
         "Error": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2023-08-10T15:35:26+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketVersioning::test_bucket_versioning_crud": {
-    "last_validated_date": "2023-08-01T14:50:36+00:00"
+    "last_validated_date": "2024-01-15T03:12:29+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_no_copy_source_range": {
     "last_validated_date": "2023-11-14T19:50:28+00:00"
@@ -111,10 +111,10 @@
     "last_validated_date": "2023-08-08T23:40:49+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_exc": {
-    "last_validated_date": "2023-08-10T12:13:45+00:00"
+    "last_validated_date": "2024-01-15T03:08:09+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectLock::test_put_object_lock_configuration_on_existing_bucket": {
-    "last_validated_date": "2023-08-08T23:27:32+00:00"
+    "last_validated_date": "2024-01-15T03:13:25+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3PublicAccessBlock::test_crud_public_access_block": {
     "last_validated_date": "2023-08-10T01:29:18+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS released this statement regarding enabling S3 Object Lock on existing buckets. It wasn't possible before, and the bucket needed to be created with a specific configuration flag. 

See https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-s3-enabling-object-lock-buckets/

<!-- What notable changes does this PR make? -->
## Changes
Update the test and the logic to now allow enabling S3 object lock on existing buckets, if they are versioned. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

