### PR TITLE
Add describe_alarms_for_metric and describe_alarm_history

### DIFF
--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -47,7 +47,7 @@ class AlarmScheduler:
         Shutsdown the scheduler, must be called before application stops
         """
         self.scheduler.close()
-        self.thread.join(5)
+        self.thread.join(10)
 
     def schedule_metric_alarm(self, alarm_arn: str) -> None:
         """(Re-)schedules the alarm, if the alarm is re-scheduled, the running alarm scheduler will be cancelled before

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -21,9 +21,12 @@ from localstack.aws.api.cloudwatch import (
     DashboardNames,
     Datapoint,
     DeleteDashboardsOutput,
+    DescribeAlarmHistoryOutput,
+    DescribeAlarmsForMetricOutput,
     DescribeAlarmsOutput,
     DimensionFilters,
     Dimensions,
+    ExtendedStatistic,
     ExtendedStatistics,
     GetDashboardOutput,
     GetMetricDataMaxDatapoints,
@@ -58,6 +61,7 @@ from localstack.aws.api.cloudwatch import (
     StateReason,
     StateReasonData,
     StateValue,
+    Statistic,
     Statistics,
     TagKeyList,
     TagList,
@@ -287,7 +291,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     ) -> None:
         try:
             if state_reason_data:
-                json.loads(state_reason_data)
+                state_reason_data = json.loads(state_reason_data)
         except ValueError:
             raise InvalidParameterValueException(
                 "TODO: check right error message: Json was not correctly formatted"
@@ -311,9 +315,24 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             old_state_reason = alarm.alarm["StateReason"]
             old_state_update_timestamp = alarm.alarm["StateUpdatedTimestamp"]
 
-            self._update_state(context, alarm, state_value, state_reason, state_reason_data)
+            if old_state == state_value:
+                return
 
-            if not alarm.alarm["ActionsEnabled"] or old_state == state_value:
+            alarm.alarm["StateTransitionedTimestamp"] = datetime.datetime.now()
+            # update startDate (=last ALARM date) - should only update when a new alarm is triggered
+            # the date is only updated if we have a reason-data, which is set by an alarm
+            if state_reason_data:
+                state_reason_data["startDate"] = state_reason_data.get("queryDate")
+
+            self._update_state(
+                context,
+                alarm,
+                state_value,
+                state_reason,
+                state_reason_data,
+            )
+
+            if not alarm.alarm["ActionsEnabled"]:
                 return
             if state_value == "OK":
                 actions = alarm.alarm["OKActions"]
@@ -460,6 +479,36 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         metric_alarms = [a for a in alarms if a.get("AlarmRule") is None]
         composite_alarms = [a for a in alarms if a.get("AlarmRule") is not None]
         return DescribeAlarmsOutput(CompositeAlarms=composite_alarms, MetricAlarms=metric_alarms)
+
+    def describe_alarms_for_metric(
+        self,
+        context: RequestContext,
+        metric_name: MetricName,
+        namespace: Namespace,
+        statistic: Statistic = None,
+        extended_statistic: ExtendedStatistic = None,
+        dimensions: Dimensions = None,
+        period: Period = None,
+        unit: StandardUnit = None,
+    ) -> DescribeAlarmsForMetricOutput:
+        store = self.get_store(context.account_id, context.region)
+        alarms = [
+            a.alarm
+            for a in store.Alarms.values()
+            if isinstance(a, LocalStackMetricAlarm)
+            and a.alarm.get("MetricName") == metric_name
+            and a.alarm.get("Namespace") == namespace
+        ]
+
+        if statistic:
+            alarms = [a for a in alarms if a.get("Statistic") == statistic]
+        if dimensions:
+            alarms = [a for a in alarms if a.get("Dimensions") == dimensions]
+        if period:
+            alarms = [a for a in alarms if a.get("Period") == period]
+        if unit:
+            alarms = [a for a in alarms if a.get("Unit") == unit]
+        return DescribeAlarmsForMetricOutput(MetricAlarms=alarms)
 
     def list_tags_for_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName
@@ -651,25 +700,39 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         alarm: LocalStackAlarm,
         state_value: str,
         state_reason: str,
-        state_reason_data: str = None,
+        state_reason_data: dict = None,
     ):
         old_state = alarm.alarm["StateValue"]
+        old_state_reason = alarm.alarm["StateReason"]
         store = self.get_store(context.account_id, context.region)
         current_time = datetime.datetime.now()
+        if state_reason_data:
+            state_reason_data["version"] = "1.0"
+        history_data = {
+            "version": "1.0",
+            "oldState": {"stateValue": old_state, "stateReason": old_state_reason},
+            "newState": {
+                "stateValue": state_value,
+                "stateReason": state_reason,
+                "stateReasonData": state_reason_data,
+            },
+        }
         store.Histories.append(
             {
                 "Timestamp": timestamp_millis(alarm.alarm["StateUpdatedTimestamp"]),
                 "HistoryItemType": HistoryItemType.StateUpdate,
                 "AlarmName": alarm.alarm["AlarmName"],
-                "HistoryData": alarm.alarm.get(
-                    "StateReasonData"
-                ),  # FIXME general formatting and data content not on par with AWS at the moment
+                "HistoryData": json.dumps(history_data),
                 "HistorySummary": f"Alarm updated from {old_state} to {state_value}",
+                "AlarmType": "MetricAlarm"
+                if isinstance(alarm, LocalStackMetricAlarm)
+                else "CompositeAlarm",
             }
         )
         alarm.alarm["StateValue"] = state_value
         alarm.alarm["StateReason"] = state_reason
-        alarm.alarm["StateReasonData"] = state_reason_data
+        if state_reason_data:
+            alarm.alarm["StateReasonData"] = json.dumps(state_reason_data)
         alarm.alarm["StateUpdatedTimestamp"] = current_time
 
     def disable_alarm_actions(self, context: RequestContext, alarm_names: AlarmNames) -> None:
@@ -687,6 +750,34 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             alarm = store.Alarms.get(alarm_arn)
             if alarm:
                 alarm.alarm["ActionsEnabled"] = enabled
+
+    def describe_alarm_history(
+        self,
+        context: RequestContext,
+        alarm_name: AlarmName = None,
+        alarm_types: AlarmTypes = None,
+        history_item_type: HistoryItemType = None,
+        start_date: Timestamp = None,
+        end_date: Timestamp = None,
+        max_records: MaxRecords = None,
+        next_token: NextToken = None,
+        scan_by: ScanBy = None,
+    ) -> DescribeAlarmHistoryOutput:
+        store = self.get_store(context.account_id, context.region)
+        history = store.Histories
+        if alarm_name:
+            history = [h for h in history if h["AlarmName"] == alarm_name]
+
+        def _get_timestamp(input: dict):
+            if timestamp_string := input.get("Timestamp"):
+                return datetime.datetime.fromisoformat(timestamp_string)
+            return None
+
+        if start_date:
+            history = [h for h in history if (date := _get_timestamp(h)) and date >= start_date]
+        if end_date:
+            history = [h for h in history if (date := _get_timestamp(h)) and date <= end_date]
+        return DescribeAlarmHistoryOutput(AlarmHistoryItems=history)
 
 
 def create_metric_data_query_from_alarm(alarm: LocalStackMetricAlarm):

--- a/localstack/services/cloudwatch/provider_v2.py
+++ b/localstack/services/cloudwatch/provider_v2.py
@@ -97,7 +97,7 @@ MOTO_INITIAL_UNCHECKED_REASON = "Unchecked: Initial alarm creation"
 LIST_METRICS_MAX_RESULTS = 500
 # If the values in these fields are not the same, their values are added when generating labels
 LABEL_DIFFERENTIATORS = ["Stat", "Period"]
-
+HISTORY_VERSION = "1.0"
 
 LOG = logging.getLogger(__name__)
 _STORE_LOCK = threading.RLock()
@@ -707,9 +707,9 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         store = self.get_store(context.account_id, context.region)
         current_time = datetime.datetime.now()
         if state_reason_data:
-            state_reason_data["version"] = "1.0"
+            state_reason_data["version"] = HISTORY_VERSION
         history_data = {
-            "version": "1.0",
+            "version": HISTORY_VERSION,
             "oldState": {"stateValue": old_state, "stateReason": old_state_reason},
             "newState": {
                 "stateValue": state_value,

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -369,7 +369,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm": {
-    "recorded-date": "26-10-2023, 11:44:13",
+    "recorded-date": "19-01-2024, 13:46:30",
     "recorded-content": {
       "describe-alarm": {
         "CompositeAlarms": [],
@@ -404,68 +404,7 @@
             "StateValue": "INSUFFICIENT_DATA",
             "Statistic": "Average",
             "Threshold": 2.0,
-            "TreatMissingData": "notBreaching",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "alarm-triggered-describe": {
-        "CompositeAlarms": [],
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:aws:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:aws:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 30,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
-            "StateReasonData": {
-              "version": "1.0",
-              "queryDate": "date",
-              "startDate": "date",
-              "unit": "Seconds",
-              "statistic": "Average",
-              "period": 30,
-              "recentDatapoints": [
-                21.5
-              ],
-              "threshold": 2.0,
-              "evaluatedDatapoints": [
-                {
-                  "timestamp": "date",
-                  "sampleCount": 2.0,
-                  "value": 21.5
-                }
-              ]
-            },
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "ALARM",
-            "Statistic": "Average",
-            "Threshold": 2.0,
-            "TreatMissingData": "notBreaching",
+            "TreatMissingData": "ignore",
             "Unit": "Seconds"
           }
         ],
@@ -484,7 +423,7 @@
         "AlarmDescription": "testing cloudwatch alarms",
         "AlarmName": "<alarm-name:1>",
         "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
+        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (2.0).",
         "NewStateValue": "ALARM",
         "OKActions": [
           "arn:aws:sns:<region>:111111111111:<topic_arn>"
@@ -508,7 +447,7 @@
           "Statistic": "AVERAGE",
           "StatisticType": "Statistic",
           "Threshold": 2.0,
-          "TreatMissingData": "notBreaching",
+          "TreatMissingData": "ignore",
           "Unit": "Seconds"
         }
       },
@@ -525,7 +464,7 @@
               },
               "newState": {
                 "stateValue": "ALARM",
-                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
+                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (2.0).",
                 "stateReasonData": {
                   "version": "1.0",
                   "queryDate": "date",
@@ -583,7 +522,7 @@
               "arn:aws:sns:<region>:111111111111:<topic_arn>"
             ],
             "Period": 30,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (26/10/23 16:42:00)] was greater than the threshold (2.0).",
+            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (2.0).",
             "StateReasonData": {
               "version": "1.0",
               "queryDate": "date",
@@ -608,107 +547,13 @@
             "StateValue": "ALARM",
             "Statistic": "Average",
             "Threshold": 2.0,
-            "TreatMissingData": "notBreaching",
+            "TreatMissingData": "ignore",
             "Unit": "Seconds"
           }
         ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      },
-      "ok-triggered-describe": {
-        "CompositeAlarms": [],
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:aws:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:aws:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 30,
-            "StateReason": "Threshold Crossed: no datapoints were received for 1 period and 1 missing datapoint was treated as [NonBreaching].",
-            "StateReasonData": {
-              "version": "1.0",
-              "queryDate": "date",
-              "unit": "Seconds",
-              "statistic": "Average",
-              "period": 30,
-              "recentDatapoints": [],
-              "threshold": 2.0,
-              "evaluatedDatapoints": [
-                {
-                  "timestamp": "date"
-                }
-              ]
-            },
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "OK",
-            "Statistic": "Average",
-            "Threshold": 2.0,
-            "TreatMissingData": "notBreaching",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "ok-triggered-sqs-msg": {
-        "AWSAccountId": "111111111111",
-        "AlarmActions": [
-          "arn:aws:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-        "AlarmConfigurationUpdatedTimestamp": "date",
-        "AlarmDescription": "testing cloudwatch alarms",
-        "AlarmName": "<alarm-name:1>",
-        "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: no datapoints were received for 1 period and 1 missing datapoint was treated as [NonBreaching].",
-        "NewStateValue": "OK",
-        "OKActions": [
-          "arn:aws:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "OldStateValue": "ALARM",
-        "Region": "<region-name-full:1>",
-        "StateChangeTime": "date",
-        "Trigger": {
-          "ComparisonOperator": "GreaterThanThreshold",
-          "Dimensions": [
-            {
-              "name": "InstanceId",
-              "value": "abc"
-            }
-          ],
-          "EvaluateLowSampleCountPercentile": "",
-          "EvaluationPeriods": 1,
-          "MetricName": "my-metric1",
-          "Namespace": "<namespace:1>",
-          "Period": 30,
-          "Statistic": "AVERAGE",
-          "StatisticType": "Statistic",
-          "Threshold": 2.0,
-          "TreatMissingData": "notBreaching",
-          "Unit": "Seconds"
         }
       }
     }
@@ -1750,7 +1595,6 @@
       }
     }
   },
-
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_data_different_units_no_unit_in_query[metric_data1]": {
     "recorded-date": "15-12-2023, 08:58:42",
     "recorded-content": {
@@ -1994,6 +1838,95 @@
             "StatusCode": "Complete",
             "Timestamps": "timestamp",
             "Values": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_set_alarm": {
+    "recorded-date": "19-01-2024, 15:29:42",
+    "recorded-content": {
+      "triggered-alarm": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:aws:sns:<region>:111111111111:<topic_alarm>"
+            ],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "Test Alarm when CPU exceeds 50 percent",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "InstanceId",
+                "Value": "i-0317828c84edbe100"
+              }
+            ],
+            "EvaluationPeriods": 2,
+            "InsufficientDataActions": [],
+            "MetricName": "CPUUtilization-3",
+            "Namespace": "<namespace:1>",
+            "OKActions": [
+              "<topic_ok>"
+            ],
+            "Period": 300,
+            "StateReason": "testing alarm",
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "ALARM",
+            "Statistic": "Average",
+            "Threshold": 50.0,
+            "TreatMissingData": "ignore",
+            "Unit": "Percent"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "reset-alarm": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:aws:sns:<region>:111111111111:<topic_alarm>"
+            ],
+            "AlarmArn": "arn:aws:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "Test Alarm when CPU exceeds 50 percent",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "InstanceId",
+                "Value": "i-0317828c84edbe100"
+              }
+            ],
+            "EvaluationPeriods": 2,
+            "InsufficientDataActions": [],
+            "MetricName": "CPUUtilization-3",
+            "Namespace": "<namespace:1>",
+            "OKActions": [
+              "<topic_ok>"
+            ],
+            "Period": 300,
+            "StateReason": "resetting alarm",
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "OK",
+            "Statistic": "Average",
+            "Threshold": 50.0,
+            "TreatMissingData": "ignore",
+            "Unit": "Percent"
           }
         ],
         "ResponseMetadata": {

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-09-25T08:25:29+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_breaching_alarm_actions": {
-    "last_validated_date": "2023-09-12T09:56:52+00:00"
+    "last_validated_date": "2024-01-19T15:05:50+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_create_metric_stream": {
     "last_validated_date": "2023-10-26T07:12:10+00:00"
@@ -45,10 +45,13 @@
     "last_validated_date": "2023-10-26T08:07:59+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm": {
-    "last_validated_date": "2023-10-26T09:44:13+00:00"
+    "last_validated_date": "2024-01-19T14:26:26+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_data_values_list": {
     "last_validated_date": "2023-09-25T08:26:17+00:00"
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_set_alarm": {
+    "last_validated_date": "2024-01-19T15:30:05+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_store_tags": {
     "last_validated_date": "2023-09-12T09:54:46+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When checking the tests, I realized there is still a flaky, and currently skipped test `test_put_metric_alarm`. 
It turns out that the current test setup was the reason for the flakiness, so I refactored it.
Also two operations where still missing from the provider v2 that are used in this test.


<!-- What notable changes does this PR make? -->
## Changes
- added missing implementation for `describe_alarms_for_metric` and `describe_alarm_history`
- parity fixes, test refactoring

For the test `test_put_metric_alarm`:
- initially, it would treat missing data as not breaching. depending on when the alarm is evaluated the first state would either change to OK or to ALARM (because the metrics we insert after breaches the condition)
- changed the alarm evaluation to "ignore", and removed the second part, where we expected the alarm to go back to state OK



<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

