### PR TITLE
Fix secretsmanager secret rotation failing because RotateImmediately is unset

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -527,7 +527,7 @@ def rotate_secret(self) -> str:
         client_request_token=client_request_token,
         rotation_lambda_arn=rotation_lambda_arn,
         rotation_rules=rotation_rules,
-        rotate_immediately=rotate_immediately,
+        rotate_immediately=True if rotate_immediately is None else rotate_immediately,
     )
 
 

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -337,10 +337,11 @@ class TestSecretsManager:
             SecretId=secret_name, ForceDeleteWithoutRecovery=True
         )
 
+    @pytest.mark.parametrize("rotate_immediately", [True, None])
     @markers.snapshot.skip_snapshot_verify(paths=["$..Versions..KmsKeyIds"])
     @markers.aws.validated
     def test_rotate_secret_with_lambda_success(
-        self, sm_snapshot, secret_name, create_secret, create_lambda_function, aws_client
+        self, sm_snapshot, secret_name, create_secret, create_lambda_function, aws_client, rotate_immediately
     ):
         cre_res = create_secret(
             Name=secret_name,
@@ -373,7 +374,7 @@ class TestSecretsManager:
             RotationRules={
                 "AutomaticallyAfterDays": 1,
             },
-            RotateImmediately=True,
+            RotateImmediately=rotate_immediately,
         )
 
         sm_snapshot.match("rotate_secret_immediately", rot_res)

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -341,7 +341,13 @@ class TestSecretsManager:
     @markers.snapshot.skip_snapshot_verify(paths=["$..Versions..KmsKeyIds"])
     @markers.aws.validated
     def test_rotate_secret_with_lambda_success(
-        self, sm_snapshot, secret_name, create_secret, create_lambda_function, aws_client, rotate_immediately
+        self,
+        sm_snapshot,
+        secret_name,
+        create_secret,
+        create_lambda_function,
+        aws_client,
+        rotate_immediately,
     ):
         cre_res = create_secret(
             Name=secret_name,

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -349,6 +349,10 @@ class TestSecretsManager:
         aws_client,
         rotate_immediately,
     ):
+        """
+        Tests secret rotation via a lambda function.
+        Parametrization ensures we test the default behavior which is an immediate rotation.
+        """
         cre_res = create_secret(
             Name=secret_name,
             SecretString="my_secret",
@@ -374,13 +378,17 @@ class TestSecretsManager:
             Principal="secretsmanager.amazonaws.com",
         )
 
+        rotation_kwargs = {}
+        if rotate_immediately is not None:
+            rotation_kwargs["RotateImmediately"] = rotate_immediately
         rot_res = aws_client.secretsmanager.rotate_secret(
             SecretId=secret_name,
             RotationLambdaARN=function_arn,
             RotationRules={
                 "AutomaticallyAfterDays": 1,
             },
-            RotateImmediately=rotate_immediately,
+            **rotation_kwargs
+            # RotateImmediately=False,
         )
 
         sm_snapshot.match("rotate_secret_immediately", rot_res)

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -387,7 +387,7 @@ class TestSecretsManager:
             RotationRules={
                 "AutomaticallyAfterDays": 1,
             },
-            **rotation_kwargs
+            **rotation_kwargs,
         )
 
         sm_snapshot.match("rotate_secret_immediately", rot_res)

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -388,7 +388,6 @@ class TestSecretsManager:
                 "AutomaticallyAfterDays": 1,
             },
             **rotation_kwargs
-            # RotateImmediately=False,
         )
 
         sm_snapshot.match("rotate_secret_immediately", rot_res)

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3686,8 +3686,54 @@
       }
     }
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
-    "recorded-date": "19-12-2023, 13:20:04",
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
+    "recorded-date": "14-03-2024, 21:02:51",
+    "recorded-content": {
+      "rotate_secret_immediately": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_versions_rotated_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "LastAccessedDate": "datetime",
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSCURRENT",
+              "AWSPENDING"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
+    "recorded-date": "14-03-2024, 21:03:01",
     "recorded-content": {
       "rotate_secret_immediately": {
         "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -65,6 +65,12 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_put_secret_value_with_version_stages": {
     "last_validated_date": "2022-09-28T08:10:50+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
+    "last_validated_date": "2024-03-14T21:03:56+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
+    "last_validated_date": "2024-03-14T21:03:47+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists_snapshots": {
     "last_validated_date": "2022-10-27T15:29:07+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Issue: https://github.com/localstack/localstack/issues/9986

Secret rotation currently doesn't work when the `RotateImmediately` parameter is unset. It looks like this is because `backend_rotate_secret` receives the argument `rotate_immediately` with the value `None` when the parameter `RotateImmediately` is unset (if the argument is unset it defaults to `True`, but in this case it's being explicitly set to `None`), this causes the `new_version_id` to not be set resulting in the error described in the issue `cannot access local variable 'new_version_id' where it is not associated with a value`.


<!-- What notable changes does this PR make? -->
## Changes

Check if rotate_immediately is `None` and set it to `True` in that case

## Testing

I'm unable to run any of the tests locally, so that'll be worth paying extra attention to when reviewing. 
