### PR TITLE
Fix: Firehose: Multiple firehose delivery streams not receiving messages from kinesis event stream

### DIFF
--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -320,7 +320,7 @@ class FirehoseProvider(FirehoseApi):
                         region_name=context.region,
                         listener_func=listener_function,
                         wait_until_started=True,
-                        ddb_lease_table_suffix="-firehose",
+                        ddb_lease_table_suffix=f"-firehose-{delivery_stream_name}",
                     )
 
                     self.kinesis_listeners[delivery_stream_arn] = process

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -612,15 +612,17 @@ def transcribe_create_job(s3_bucket, aws_client):
 
 
 @pytest.fixture
-def kinesis_create_stream(aws_client):
+def kinesis_create_stream(aws_client, wait_for_stream_ready):
     stream_names = []
 
     def _create_stream(**kwargs):
         if "StreamName" not in kwargs:
             kwargs["StreamName"] = f"test-stream-{short_uid()}"
+        stream_name = kwargs["StreamName"]
         aws_client.kinesis.create_stream(**kwargs)
-        stream_names.append(kwargs["StreamName"])
-        return kwargs["StreamName"]
+        stream_names.append(stream_name)
+        wait_for_stream_ready(stream_name)
+        return stream_name
 
     yield _create_stream
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1592,13 +1592,18 @@ def lambda_su_role(aws_client):
 def create_iam_role_with_policy(aws_client):
     roles = {}
 
-    def _create_role_and_policy(**kwargs):
+    def _create_role_and_policy(**kwargs: dict[str, any]) -> str:
+        if "RoleName" not in kwargs:
+            kwargs["RoleName"] = f"test-role-{short_uid()}"
         role = kwargs["RoleName"]
+        if "PolicyName" not in kwargs:
+            kwargs["PolicyName"] = f"test-policy-{short_uid()}"
         policy = kwargs["PolicyName"]
         role_policy = json.dumps(kwargs["RoleDefinition"])
 
         result = aws_client.iam.create_role(RoleName=role, AssumeRolePolicyDocument=role_policy)
         role_arn = result["Role"]["Arn"]
+
         policy_document = json.dumps(kwargs["PolicyDefinition"])
         aws_client.iam.put_role_policy(
             RoleName=role, PolicyName=policy, PolicyDocument=policy_document

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1613,21 +1613,24 @@ def create_iam_role_with_policy(aws_client):
 
 @pytest.fixture
 def firehose_create_delivery_stream(wait_for_delivery_stream_ready, aws_client):
-    delivery_streams = {}
+    delivery_stream_names = []
 
     def _create_delivery_stream(**kwargs):
         if "DeliveryStreamName" not in kwargs:
             kwargs["DeliveryStreamName"] = f"test-delivery-stream-{short_uid()}"
-
-        delivery_stream = aws_client.firehose.create_delivery_stream(**kwargs)
-        delivery_streams.update({kwargs["DeliveryStreamName"]: delivery_stream})
-        wait_for_delivery_stream_ready(kwargs["DeliveryStreamName"])
-        return delivery_stream
+        delivery_stream_name = kwargs["DeliveryStreamName"]
+        response = aws_client.firehose.create_delivery_stream(**kwargs)
+        delivery_stream_names.append(delivery_stream_name)
+        wait_for_delivery_stream_ready(delivery_stream_name)
+        return response
 
     yield _create_delivery_stream
 
-    for delivery_stream_name in delivery_streams.keys():
-        aws_client.firehose.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+    for delivery_stream_name in delivery_stream_names:
+        try:
+            aws_client.firehose.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+        except Exception:
+            LOG.info("Failed to delete delivery stream %s", delivery_stream_name)
 
 
 @pytest.fixture

--- a/tests/aws/services/firehose/conftest.py
+++ b/tests/aws/services/firehose/conftest.py
@@ -1,0 +1,96 @@
+import logging
+from typing import List, Literal, Union
+
+import pytest
+
+from localstack.utils.sync import retry
+
+StreamType = Literal["DirectPut", "KinesisStreamAsSource", "MSKAsSource"]
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def get_firehose_iam_documents():
+    def _get_iam_document(
+        bucket_arns: Union[List[str], str], stream_arns: Union[List[str], str]
+    ) -> tuple[dict, dict]:
+        if isinstance(bucket_arns, str):
+            bucket_arns = [bucket_arns]
+        bucket_arns.extend([f"{bucket_arn}/*" for bucket_arn in bucket_arns])
+        if isinstance(stream_arns, str):
+            stream_arns = [stream_arns]
+
+        role_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "FirehoseAssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "firehose.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:AbortMultipartUpload",
+                        "s3:GetBucketLocation",
+                        "s3:GetObject",
+                        "s3:ListBucket",
+                        "s3:ListBucketMultipartUploads",
+                        "s3:PutObject",
+                    ],
+                    "Resource": bucket_arns,
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "kinesis:DescribeStream",
+                        "kinesis:GetShardIterator",
+                        "kinesis:GetRecords",
+                        "kinesis:ListShards",
+                    ],
+                    "Resource": stream_arns,
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["logs:PutLogEvents", "logs:CreateLogStream"],
+                    "Resource": "arn:aws:logs:*:*:*",
+                },
+            ],
+        }
+        return role_document, policy_document
+
+    return _get_iam_document
+
+
+@pytest.fixture
+def read_s3_data(aws_client):
+    s3 = aws_client.s3
+
+    def _read_s3_data(bucket_name: str, timeout: int = 10) -> dict[str, str]:
+        def _get_data():
+            response = s3.list_objects(Bucket=bucket_name)
+            if response.get("Contents") is None:
+                raise Exception("No da in bucket yet")
+
+            keys = [obj.get("Key") for obj in response.get("Contents")]
+
+            bucket_data = dict()
+            for key in keys:
+                response = s3.get_object(Bucket=bucket_name, Key=key)
+                data = response["Body"].read().decode("utf-8")
+                bucket_data[key] = data
+            return bucket_data
+
+        bucket_data = retry(_get_data, sleep=1, retries=timeout)
+
+        return bucket_data
+
+    return _read_s3_data

--- a/tests/aws/services/firehose/conftest.py
+++ b/tests/aws/services/firehose/conftest.py
@@ -78,7 +78,7 @@ def read_s3_data(aws_client):
         def _get_data():
             response = s3.list_objects(Bucket=bucket_name)
             if response.get("Contents") is None:
-                raise Exception("No da in bucket yet")
+                raise Exception("No data in bucket yet")
 
             keys = [obj.get("Key") for obj in response.get("Contents")]
 

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -31,6 +31,8 @@ def handler(event, context):
     return {"records": records}
 """
 
+TEST_MESSAGE = "Test-message-2948294kdlsie"
+
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
 @markers.aws.unknown
@@ -498,7 +500,7 @@ class TestFirehoseIntegration:
             retry(_create_firehose_delivery_stream, sleep=1, retries=10)
 
         # put message to kinesis event stream
-        record_data = "Test-message-2948294kdlsie"
+        record_data = TEST_MESSAGE
         aws_client.kinesis.put_record(
             StreamName=stream_name,
             Data=record_data,

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -480,7 +480,7 @@ class TestFirehoseIntegration:
                 "ErrorOutputPrefix": "firehoseTest-errors/!{firehose:error-output-type}/",
                 "CloudWatchLoggingOptions": {
                     "Enabled": True,
-                    "LogGroupName": f"group-{short_uid()}",
+                    "LogGroupName": log_group_name,
                     "LogStreamName": f"stream-{short_uid()}",
                 },
             }

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -38,7 +38,7 @@ TEST_MESSAGE = "Test-message-2948294kdlsie"
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
 @markers.aws.unknown
-def test_firehose_http(
+def test_kinesis_firehose_http(
     aws_client,
     lambda_processor_enabled: bool,
     create_lambda_function,
@@ -352,7 +352,7 @@ class TestFirehoseIntegration:
             aws_client.opensearch.delete_domain(DomainName=domain_name)
 
     @markers.aws.unknown
-    def test_delivery_stream_with_kinesis_as_source(
+    def test_kinesis_firehose_kinesis_as_source(
         self, s3_bucket, kinesis_create_stream, cleanups, aws_client
     ):
         bucket_arn = arns.s3_bucket_arn(s3_bucket)
@@ -420,7 +420,7 @@ class TestFirehoseIntegration:
         assert poll_condition(check_stream_state, 45, 1)
 
     @markers.aws.validated
-    def test_multiple_delivery_streams_with_kinesis_as_source(
+    def test_kinesis_firehose_kinesis_as_source_multiple_delivery_streams(
         self,
         s3_create_bucket,
         kinesis_create_stream,

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -415,7 +415,7 @@ class TestFirehoseIntegration:
 
         assert poll_condition(check_stream_state, 45, 1)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_multiple_delivery_streams_with_kinesis_as_source(
         self,
         s3_create_bucket,

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -478,11 +478,11 @@ class TestFirehoseIntegration:
             extended_s3_destination_configuration = {
                 "RoleARN": role_arn,
                 "BucketARN": bucket_arn,
-                "Prefix": "test-prefix",
+                "Prefix": "firehoseTest",
+                "ErrorOutputPrefix": "firehoseTest-errors/!{firehose:error-output-type}/",
                 "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 1},
                 "CompressionFormat": "UNCOMPRESSED",
                 "EncryptionConfiguration": {"NoEncryptionConfig": "NoEncryption"},
-                "ErrorOutputPrefix": "firehoseTest-errors/!{firehose:error-output-type}/",
                 "CloudWatchLoggingOptions": {
                     "Enabled": True,
                     "LogGroupName": log_group_name,
@@ -519,8 +519,8 @@ class TestFirehoseIntegration:
 
         snapshot.add_transformer(
             [
-                snapshot.transform.regex(bucket_a_name, "bucket-a"),
-                snapshot.transform.regex(bucket_b_name, "bucket-b"),
+                snapshot.transform.regex(bucket_a_name, "<bucket-a>"),
+                snapshot.transform.regex(bucket_b_name, "<bucket-b>"),
             ]
         )
         snapshot.match("kinesis-event-stream-multiple-delivery-streams", s3_data)

--- a/tests/aws/services/firehose/test_firehose.snapshot.json
+++ b/tests/aws/services/firehose/test_firehose.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_multiple_delivery_streams_with_kinesis_as_source": {
+  "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_kinesis_firehose_kinesis_as_source_multiple_delivery_streams": {
     "recorded-date": "25-01-2024, 10:54:39",
     "recorded-content": {
       "kinesis-event-stream-multiple-delivery-streams": {

--- a/tests/aws/services/firehose/test_firehose.snapshot.json
+++ b/tests/aws/services/firehose/test_firehose.snapshot.json
@@ -1,12 +1,12 @@
 {
   "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_multiple_delivery_streams_with_kinesis_as_source": {
-    "recorded-date": "21-01-2024, 17:23:36",
+    "recorded-date": "25-01-2024, 10:54:39",
     "recorded-content": {
       "kinesis-event-stream-multiple-delivery-streams": {
-        "bucket-a": {
+        "<bucket-a>": {
           "folder-name": "Test-message-2948294kdlsie"
         },
-        "bucket-b": {
+        "<bucket-b>": {
           "folder-name": "Test-message-2948294kdlsie"
         }
       }

--- a/tests/aws/services/firehose/test_firehose.snapshot.json
+++ b/tests/aws/services/firehose/test_firehose.snapshot.json
@@ -1,0 +1,15 @@
+{
+  "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_multiple_delivery_streams_with_kinesis_as_source": {
+    "recorded-date": "21-01-2024, 17:23:36",
+    "recorded-content": {
+      "kinesis-event-stream-multiple-delivery-streams": {
+        "bucket-a": {
+          "folder-name": "Test-message-2948294kdlsie"
+        },
+        "bucket-b": {
+          "folder-name": "Test-message-2948294kdlsie"
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/firehose/test_firehose.validation.json
+++ b/tests/aws/services/firehose/test_firehose.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_multiple_delivery_streams_with_kinesis_as_source": {
-    "last_validated_date": "2024-01-21T17:23:36+00:00"
+    "last_validated_date": "2024-01-25T10:54:39+00:00"
   }
 }

--- a/tests/aws/services/firehose/test_firehose.validation.json
+++ b/tests/aws/services/firehose/test_firehose.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/firehose/test_firehose.py::TestFirehoseIntegration::test_multiple_delivery_streams_with_kinesis_as_source": {
+    "last_validated_date": "2024-01-21T17:23:36+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Multiple instances of kcl listening to the same Kinesis event stream - only the "first" will process events, due to all using the same dynamoDB lease table. This was raised in #9476 

We are spinning up a mock Kinesis server (https://github.com/etspaceman/kinesis-mock) and use the java plication aws kinesis client library to connect to this mock server. For services queriing events from the mock kinesis server, we provide a connector function `listen_to_kinesis` in `kinesis_connector` 

This method starts the kcl for each listener. Kcl starts one or more instances with a worker bound to one or more shards. Each worker processes messages from the shard(s) and sends received messages to a programmatically created Python script that sends the messages to a socket. A listener function running in a separate thread listens to incoming messages on this socket and handles further processing defined by the initiator e.g. Firehose

To track shard lease and assignment shards to worker processes as well as to track checkpoints (latest read message from the shard) kcl uses a dynamoDB “lease table”

<!-- What notable changes does this PR make? -->
## Changes
Adding a unique id to the lease table name for each instance of kcl that is instantiated. 
Adding an AWS validated snapshot test for multiple Firehose delivery streams subscribing to the same Kinesis event stream

This PR fixes #9476

<!--
## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

