### PR TITLE
fix S3 v-host unit tests after rolo migration

### DIFF
--- a/tests/unit/services/s3/test_virtual_host.py
+++ b/tests/unit/services/s3/test_virtual_host.py
@@ -30,6 +30,9 @@ class _RequestCollectingClient(HttpClient):
             config.internal_service_url(host="localhost"), preserve_host=False, client=self
         )
 
+    def close(self):
+        pass
+
 
 class TestS3VirtualHostProxyHandler:
     def test_vhost_without_region(self):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We were missing an abstract class method definition following the rolo migration

<!-- What notable changes does this PR make? -->
## Changes
Added the `close` method to the test class for the S3 vhost tests. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

