### PR TITLE
Pin cryptography package to below 42.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages=find:
 install_requires =
     click>=7.1
     cachetools>=5.0
-    cryptography
+    cryptography<42.0.0
     dill==0.3.6
     dnslib>=0.9.10
     dnspython>=1.16.0
@@ -90,7 +90,7 @@ runtime =
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     crontab>=0.22.6
-    cryptography>=41.0.5
+    cryptography>=41.0.5,<42.0.0
     json5==0.9.11
     jsonpath-ng==1.5.3
     jsonpath-rw>=1.4.0,<2.0.0


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The newest version of the cryptography package ([`42.0.0`](https://pypi.org/project/cryptography/42.0.0/)) seems to cause issues with the pipeline:

```
     from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePrivateKey
E   ModuleNotFoundError: No module named 'cryptography.hazmat.backends.openssl.ec'
```

<!-- What notable changes does this PR make? -->
## Changes

Pin cryptography to below 42.0.0 until the underlying issue is resolved

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

