### PR TITLE
correctly execute host and container configuration hooks in dev.run

### DIFF
--- a/localstack/dev/run/__main__.py
+++ b/localstack/dev/run/__main__.py
@@ -268,6 +268,7 @@ def run(
         ConfigEnvironmentConfigurator(pro),
         ContainerConfigurators.mount_localstack_volume(host_paths.volume_dir),
         CoverageRunScriptConfigurator(host_paths=host_paths),
+        ContainerConfigurators.config_env_vars,
     ]
 
     # create stub container with configuration to apply


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In #9339, we added a way to explicitly load the extension dev mode configuration hooks. This was highly specific to this one use case, and a better way would be to run the hooks that are also run during bootstrapping when running `localstack start`.

This PR adds both the `prepare_host` and `configure_container` hooks to the dev script, to more closely match what `localstack start` is doing, which also includes extension dev mode when available.

The PR also passes through the config environment variables to the container as `localstack start` does

<!-- What notable changes does this PR make? -->
## Changes

* `prepare_host` and `configure_container` hooks are now run when running `localstack.dev.run`
* as a consequence, a license check is performed on the host before starting the container (it's in a `prepare_host` hook in ext)
  * this would require us to set `LOCALSTACK_API_KEY=test python -m localstack.dev.run -e LOCALSTACK_API_KEY`, which is a bit annoying as it breaks existing scripts, so i extracted the licensing credentials from the CLI arguments, so you can continue to just use `python -m localstack.dev.run -e LOCALSTACK_API_KEY=test`.
  * at the same time, i added the `config_env_vars` configurator, so you can also just `LOCALSTACK_API_KEY=test python -m localstack.dev.run`

## Testing

* check out the branch and activate the venv in localstack
* navigate to localstack-ext and try out `EXTENSION_DEV_MODE=1 LOCALSTACK_API_KEY=test python -m localstack.dev.run`


<!-- The following sections are optional, but can be useful! 
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

