### PR TITLE
Bump moto-ext to 5.0.0.post1

### DIFF
--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -505,6 +505,7 @@ class AvailabilityZoneState(str):
     information = "information"
     impaired = "impaired"
     unavailable = "unavailable"
+    constrained = "constrained"
 
 
 class BareMetal(str):
@@ -2891,6 +2892,7 @@ class SubnetCidrReservationType(str):
 class SubnetState(str):
     pending = "pending"
     available = "available"
+    unavailable = "unavailable"
 
 
 class SummaryStatus(str):
@@ -7354,6 +7356,7 @@ class CreateNetworkAclRequest(ServiceRequest):
     DryRun: Optional[Boolean]
     VpcId: VpcId
     TagSpecifications: Optional[TagSpecificationList]
+    ClientToken: Optional[String]
 
 
 class NetworkAclEntry(TypedDict, total=False):
@@ -7391,6 +7394,7 @@ class NetworkAcl(TypedDict, total=False):
 
 class CreateNetworkAclResult(TypedDict, total=False):
     NetworkAcl: Optional[NetworkAcl]
+    ClientToken: Optional[String]
 
 
 class CreateNetworkInsightsAccessScopeRequest(ServiceRequest):
@@ -7726,6 +7730,7 @@ class CreateRouteTableRequest(ServiceRequest):
     DryRun: Optional[Boolean]
     VpcId: VpcId
     TagSpecifications: Optional[TagSpecificationList]
+    ClientToken: Optional[String]
 
 
 class Route(TypedDict, total=False):
@@ -7781,6 +7786,7 @@ class RouteTable(TypedDict, total=False):
 
 class CreateRouteTableResult(TypedDict, total=False):
     RouteTable: Optional[RouteTable]
+    ClientToken: Optional[String]
 
 
 class CreateSecurityGroupRequest(ServiceRequest):
@@ -19171,6 +19177,7 @@ class Ec2Api:
         vpc_id: VpcId,
         dry_run: Boolean = None,
         tag_specifications: TagSpecificationList = None,
+        client_token: String = None,
     ) -> CreateNetworkAclResult:
         raise NotImplementedError
 
@@ -19347,6 +19354,7 @@ class Ec2Api:
         vpc_id: VpcId,
         dry_run: Boolean = None,
         tag_specifications: TagSpecificationList = None,
+        client_token: String = None,
     ) -> CreateRouteTableResult:
         raise NotImplementedError
 

--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -487,15 +487,17 @@ def apply_patches():
     MotoRole.arn = moto_role_arn
 
     # Add missing managed polices
-    @patch(IAMBackend.__init__)
-    def add_attributes(__init__, self, region_name, account_id, aws_policies=None):
-        __init__(self, region_name, account_id, aws_policies=aws_policies)
-        self.aws_managed_policies.extend(
+    # TODO this might not be necessary
+    @patch(IAMBackend._init_aws_policies)
+    def _init_aws_policies_extended(_init_aws_policies, self):
+        loaded_policies = _init_aws_policies(self)
+        loaded_policies.extend(
             [
                 AWSManagedPolicy.from_data(name, self.account_id, d)
                 for name, d in ADDITIONAL_MANAGED_POLICIES.items()
             ]
         )
+        return loaded_policies
 
     if "Principal" not in VALID_STATEMENT_ELEMENTS:
         VALID_STATEMENT_ELEMENTS.append("Principal")

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -93,8 +93,8 @@ def patch_instance_tracker_meta():
     if not find_spec("moto"):
         return
 
-    from moto.core import BaseModel
     from moto.core.base_backend import InstanceTrackerMeta
+    from moto.core.common_models import BaseModel
 
     if hasattr(InstanceTrackerMeta, "_ls_patch_applied"):
         return  # ensure we're not applying the patch multiple times

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import Callable, Optional, Union
 
 import moto.backends as moto_backends
-from moto.core import BackendDict
+from moto.core.base_backend import BackendDict
 from moto.core.exceptions import RESTError
 from moto.moto_server.utilities import RegexConverter
 from werkzeug.exceptions import NotFound

--- a/localstack/state/inspect.py
+++ b/localstack/state/inspect.py
@@ -4,7 +4,7 @@ import logging
 from functools import singledispatchmethod
 from typing import Any, Dict, Optional, TypedDict
 
-from moto.core import BackendDict
+from moto.core.base_backend import BackendDict
 
 from localstack.services.stores import AccountRegionBundle
 from localstack.state.core import StateVisitor

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -137,9 +137,15 @@ def patch_moto_request_handling():
     from importlib.util import find_spec
 
     if not find_spec("moto"):
+        # leave here to avoid import issues
         return
-    # leave here to avoid import issues
+
     from moto.core import utils as moto_utils
+
+    # enable loading AWS IAM managed policies
+    from moto.core.config import default_user_config
+
+    default_user_config["iam"]["load_aws_managed_policies"] = True
 
     # make sure we properly handle/propagate "not implemented" errors
     @patch(moto_utils.convert_to_flask_response.__call__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ runtime =
     jsonpath-rw>=1.4.0,<2.0.0
     # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
-    moto-ext[all]==5.0.0a3.post2
+    moto-ext[all]==5.0.0.post1
     opensearch-py>=2.4.1
     pymongo>=4.2.0
     pyopenssl>=23.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ runtime =
     jsonpath-rw>=1.4.0,<2.0.0
     # to be removed when https://github.com/python-openapi/openapi-schema-validator/issues/131 is resolved
     jsonschema<=4.19.0
-    moto-ext[all]==5.0.0a1.post1
+    moto-ext[all]==5.0.0a3.post2
     opensearch-py>=2.4.1
     pymongo>=4.2.0
     pyopenssl>=23.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ localstack =
 base-runtime =
     awscrt>=0.13.14
     boto3>=1.26.121
-    botocore>=1.34.12,<1.34.24
+    botocore>=1.34.27
     cbor2>=5.2.0
     dnspython>=1.16.0
     # TODO tag incompatibility introduced in 7.0.0 with https://github.com/docker/docker-py/pull/3191

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3825,7 +3825,13 @@ class TestS3:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        condition=is_v2_provider, paths=["$..ServerSideEncryption", "$..Prefix"]
+        condition=is_v2_provider,
+        paths=[
+            "$..ServerSideEncryption",
+            "$..Prefix",
+            "$..Marker",
+            "$..NextMarker",
+        ],
     )
     def test_s3_put_more_than_1000_items(self, s3_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -84,6 +84,7 @@ class TestS3ListObjects:
         condition=is_v2_provider,
         paths=[
             "$..Prefix",
+            "$..Marker",
             "$..NextMarker",
         ],
     )

--- a/tests/unit/state/test_inspect.py
+++ b/tests/unit/state/test_inspect.py
@@ -1,5 +1,5 @@
 import pytest
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.sns import models as sns_models
 
 from localstack.services.sqs import models as sqs_models


### PR DESCRIPTION
## Motivation

[getmoto/moto](https://github.com/getmoto/moto) just had a new major release.

All changes are released with [moto-ext 5.0.0.post1](https://pypi.org/project/moto-ext/5.0.0.post1/)

This bump brings in the following fixes to LocalStack:
- https://github.com/getmoto/moto/pull/7204
- https://github.com/getmoto/moto/pull/7240 by @bentsku 
- https://github.com/getmoto/moto/pull/7251 by @bentsku 

## Changes

- Upgrades moto-ext to v5

## Related

Closes https://github.com/localstack/localstack/issues/8642
