### PR TITLE
KMS: Fixup ImportKeyMaterial for non-symmetric keys

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1105,9 +1105,10 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 "A validTo date must be set if the ExpirationModel is KEY_MATERIAL_EXPIRES"
             )
         # TODO actually set validTo and make the key expire
-        key_to_import_material_to.crypto_key.key_material = key_material
         key_to_import_material_to.metadata["Enabled"] = True
         key_to_import_material_to.metadata["KeyState"] = KeyState.Enabled
+        key_to_import_material_to.crypto_key.load_key_material(key_material)
+
         return ImportKeyMaterialResponse()
 
     def delete_imported_key_material(

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1073,7 +1073,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             enabled_key_allowed=True,
             disabled_key_allowed=True,
         )
-        self._validate_key_for_encryption_decryption(context, key_to_import_material_to)
 
         if import_state.wrapping_algo == AlgorithmSpec.RSAES_PKCS1_V1_5:
             decrypt_padding = padding.PKCS1v15()

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -628,6 +628,65 @@ class TestKMS:
         snapshot.match("encrypt-after-delete-error", e.value.response)
 
     @markers.aws.validated
+    def test_import_key_asymmetric(self, kms_create_key, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("Description"))
+        key = kms_create_key(Origin="EXTERNAL", KeySpec="ECC_NIST_P256", KeyUsage="SIGN_VERIFY")
+        snapshot.match("created-key", key)
+        key_id = key["KeyId"]
+
+        crypto_key = ec.generate_private_key(ec.SECP256R1())
+        raw_private_key = crypto_key.private_bytes(
+            serialization.Encoding.DER,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        raw_public_key = crypto_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        plaintext = b"test content 123 !#"
+
+        # get key import params
+        params = aws_client.kms.get_parameters_for_import(
+            KeyId=key_id, WrappingAlgorithm="RSAES_OAEP_SHA_256", WrappingKeySpec="RSA_2048"
+        )
+
+        # import asymmetric key (key material) into KMS
+        public_key = load_der_public_key(params["PublicKey"])
+        encrypted_key = public_key.encrypt(raw_private_key,
+                                           padding.OAEP(
+                                               mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                                               algorithm=hashes.SHA256(),
+                                               label=None
+                                           ))
+        describe_key_before_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-before-import", describe_key_before_import)
+
+        aws_client.kms.import_key_material(
+            KeyId=key_id,
+            ImportToken=params["ImportToken"],
+            EncryptedKeyMaterial=encrypted_key,
+            ExpirationModel="KEY_MATERIAL_DOES_NOT_EXPIRE",
+        )
+        describe_key_after_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-after-import", describe_key_after_import)
+
+        # Check whether public key is derived correctly
+        get_public_key_after_import = aws_client.kms.get_public_key(KeyId=key_id)
+        assert get_public_key_after_import["PublicKey"] == raw_public_key
+
+        # Do a sign/verify cycle
+        signed_data = aws_client.kms.sign(Message=plaintext, MessageType="RAW", SigningAlgorithm="ECDSA_SHA_256",
+                                          KeyId=key_id)
+        verify_data = aws_client.kms.verify(Message=plaintext, Signature=signed_data["Signature"], MessageType="RAW",
+                                            SigningAlgorithm="ECDSA_SHA_256", KeyId=key_id)
+        assert verify_data["SignatureValid"]
+
+        aws_client.kms.delete_imported_key_material(KeyId=key_id)
+        describe_key_after_deleted_import = aws_client.kms.describe_key(KeyId=key_id)
+        snapshot.match("describe-key-after-deleted-import", describe_key_after_deleted_import)
+
+    @markers.aws.validated
     def test_list_aliases_of_key(self, kms_create_key, kms_create_alias, aws_client):
         aliased_key_id = kms_create_key()["KeyId"]
         comparison_key_id = kms_create_key()["KeyId"]

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -1207,8 +1207,8 @@
       }
     }
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key": {
-    "recorded-date": "13-04-2023, 11:30:39",
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_symmetric": {
+    "recorded-date": "24-01-2024, 10:44:12",
     "recorded-content": {
       "created-key": {
         "AWSAccountId": "111111111111",
@@ -1331,6 +1331,102 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_asymmetric": {
+    "recorded-date": "24-01-2024, 10:44:14",
+    "recorded-content": {
+      "created-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+        "CreationDate": "datetime",
+        "CustomerMasterKeySpec": "ECC_NIST_P256",
+        "Description": "<description:1>",
+        "Enabled": false,
+        "KeyId": "<key-id:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "ECC_NIST_P256",
+        "KeyState": "PendingImport",
+        "KeyUsage": "SIGN_VERIFY",
+        "MultiRegion": false,
+        "Origin": "EXTERNAL",
+        "SigningAlgorithms": [
+          "ECDSA_SHA_256"
+        ]
+      },
+      "describe-key-before-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "ECC_NIST_P256",
+          "Description": "<description:1>",
+          "Enabled": false,
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "ECC_NIST_P256",
+          "KeyState": "PendingImport",
+          "KeyUsage": "SIGN_VERIFY",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL",
+          "SigningAlgorithms": [
+            "ECDSA_SHA_256"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-key-after-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "ECC_NIST_P256",
+          "Description": "<description:1>",
+          "Enabled": true,
+          "ExpirationModel": "KEY_MATERIAL_DOES_NOT_EXPIRE",
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "ECC_NIST_P256",
+          "KeyState": "Enabled",
+          "KeyUsage": "SIGN_VERIFY",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL",
+          "SigningAlgorithms": [
+            "ECDSA_SHA_256"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-key-after-deleted-import": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<key-id:1>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "ECC_NIST_P256",
+          "Description": "<description:1>",
+          "Enabled": false,
+          "KeyId": "<key-id:1>",
+          "KeyManager": "CUSTOMER",
+          "KeySpec": "ECC_NIST_P256",
+          "KeyState": "PendingImport",
+          "KeyUsage": "SIGN_VERIFY",
+          "MultiRegion": false,
+          "Origin": "EXTERNAL",
+          "SigningAlgorithms": [
+            "ECDSA_SHA_256"
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -83,8 +83,11 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_hmac_create_key_invalid_operations": {
     "last_validated_date": "2023-04-13T09:31:06+00:00"
   },
-  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key": {
-    "last_validated_date": "2023-04-13T09:30:39+00:00"
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_asymmetric": {
+    "last_validated_date": "2024-01-24T10:44:14+00:00"
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_import_key_symmetric": {
+    "last_validated_date": "2024-01-24T10:44:12+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_invalid_generate_mac[HMAC_224-HMAC_SHA_256]": {
     "last_validated_date": "2023-04-13T09:31:14+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
KMS allows you to import key material, that is, create KMS keys with "private keys" you already have. In the context of Localstack this is fairly important now that the old "local-kms" backend was removed since the new backend cannot be preseeded at the moment and controlling key material can be very important in testing.

<!-- What notable changes does this PR make? -->
## Changes
This PR drops the restriction on encrypt/decrypt for the KeyUsage in ImportKeyMaterial (the restriction for GetParametersForImport was already dropped as part of the fix for #9111) and should therefore fix #10115. It then fixes the issues that crop up when trying to use this with existing code - notably the hardcoded assumption that all imported key material is a symmetric key. Finally, it adds a new test to track this usecase and fixes a few other small issues you bump into when you update the KMS test snapshots.

<!-- The following sections are optional, but can be useful! 

## Testing

A test is included and the test snapshots were updated against an AWS Sandbox account

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

