### PR TITLE
CFn: enable AWS::ECS::Service PhysicalResourceId quirk

### DIFF
--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -23,6 +23,7 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::ApiGateway::Resource": "/properties/ResourceId",
     "AWS::ApiGateway::Stage": "/properties/StageName",
     "AWS::Cognito::UserPoolClient": "/properties/ClientId",
+    "AWS::ECS::Service": "/properties/ServiceArn",
     "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",  # composite
     "AWS::Events::EventBus": "/properties/Name",
     "AWS::Logs::LogStream": "/properties/LogStreamName",


### PR DESCRIPTION
Update the CFn quirks file to correctly fetch the physical resource id from an `AWS::ECS::Service`

