### PR TITLE
add tests for fix to SNS empty filter policy

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -275,7 +275,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
         if attribute_name == "FilterPolicy":
             store = self.get_store(account_id=context.account_id, region_name=context.region)
-            store.subscription_filter_policy[subscription_arn] = json.loads(attribute_value)
+            store.subscription_filter_policy[subscription_arn] = (
+                json.loads(attribute_value) if attribute_value else None
+            )
 
         sub[attribute_name] = attribute_value
 

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -422,8 +422,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if not sub:
             raise NotFoundException("Subscription does not exist")
         removed_attrs = ["sqs_queue_url"]
-        if "FilterPolicyScope" in sub and "FilterPolicy" not in sub:
+        if "FilterPolicyScope" in sub and not sub.get("FilterPolicy"):
             removed_attrs.append("FilterPolicyScope")
+            removed_attrs.append("FilterPolicy")
         elif "FilterPolicy" in sub and "FilterPolicyScope" not in sub:
             sub["FilterPolicyScope"] = "MessageAttributes"
 
@@ -640,8 +641,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if attributes:
             subscription.update(attributes)
             if "FilterPolicy" in attributes:
-                store.subscription_filter_policy[subscription_arn] = json.loads(
-                    attributes["FilterPolicy"]
+                store.subscription_filter_policy[subscription_arn] = (
+                    json.loads(attributes["FilterPolicy"]) if attributes["FilterPolicy"] else None
                 )
 
         store.subscriptions[subscription_arn] = subscription

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -3190,7 +3190,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
-    "recorded-date": "07-12-2023, 10:17:45",
+    "recorded-date": "25-01-2024, 18:07:57",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -3315,6 +3315,30 @@
         }
       },
       "messages-3": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-4": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "This the test message for null",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -3,7 +3,7 @@
     "last_validated_date": "2023-11-09T20:04:02+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
-    "last_validated_date": "2023-11-09T20:05:40+00:00"
+    "last_validated_date": "2024-01-25T18:07:57+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_for_batch": {
     "last_validated_date": "2023-11-09T20:01:32+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #10009, we've had an issue when setting empty filter policy. This fix is based on https://github.com/getmoto/moto/pull/7251, now part of LocalStack with #10112, and has additional logic in place where we manually work with the filter policy.

<!-- What notable changes does this PR make? -->
## Changes
Update existing tests to validate the fix, and update the logic in `Subscribe` too. 

_fixes #10009_

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

