### PR TITLE
add dynamic SQS endpoint strategy to build SQS queues from called host

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -346,6 +346,12 @@ class SqsQueue:
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
             host_url = f"{scheme}://{host_definition.host_and_port()}/queue/{self.region}"
+        elif config.SQS_ENDPOINT_STRATEGY == "dynamic":
+            # undocumented strategy to help unblock folks who depended on the feature previously,
+            # especially when running localstack in the container on a different port than the one exposed
+            # by docker (let's say :<random-port>->:4566/tcp.). however, this should be handled in a more
+            # fundamental way in localstack.
+            host_url = f"{context.request.host_url.rstrip('/')}/queue/{self.region}"
         else:
             host_url = f"{scheme}://{host_definition.host_and_port()}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When there is no way to control the port creation of the localstack gateway port (say you're get a random port mapping `:34567->:4566/tcp` from docker), there's currently no good way of configuring localstack s.t. endpoints are accessible from both the host and inside the container network. The ideal solution would be to gain control of the port creation, and if you need random ports, make sure the gateway is bound to the same port by setting `GATEWAY_LISTEN=:<random-port>`.

In #9753, users mentioned that they work in an environment where this is not possible, and they rely on random ports. In this scenario, SQS queue URLs won't work either from the host or from within the container network. Users have asked us to put in place the old "dynamic" endpoint strategy which allowed queue URL generation based on the incoming host header. This way you can run `ListQueues` or `GetQueueUrl` from both the host or the container, and will receive URLs that you can always call from where you resolved them. This PR adds it back to unblock the users, albeit as an undocumented flag.

This is not a problem unique to SQS, which is why we've been reluctant to add this back. Services like API Gateway, AppSync, ELB, or any other service that generates routes/endpoints exposed through the gateway, would have to have the same functionality, which is significant effort. Moving forward, instead we should address the issue of diverging gateway ports (different port on the host than inside the container) in some generalized way.



<!-- What notable changes does this PR make? -->
## Changes

* add `SQS_ENDPOINT_STRATEGY=dynamic` which generates queue URLs dynamically based on the host. the pattern follows the `path` strategy, but where the host url part is populated dynamically from the incoming request. e.g., `http://localhost:9999/queue/us-east-1/000000000000/foobar` 
* fixes #9753

## Testing

tested this manually using
* `python -m localstack.dev.run -p 9999:4566 -e SQS_ENDPOINT_STRATEGY=dynamic` and then things like
* `aws --endpoint-url=http://localhost:9999 sqs create-queue --queue-name foobar`, ...
* `curl "http://localhost:9999/queue/us-east-1/000000000000/foobar?Action=ReceiveMessage"`
* but also `curl "http://localhost:4566/queue/us-east-1/000000000000/foobar?Action=ReceiveMessage"`

<!-- The following sections are optional, but can be useful! 
Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

