### PR TITLE
Remove the upper bound on the botocore pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ localstack =
 base-runtime =
     awscrt>=0.13.14
     boto3>=1.26.121
-    botocore>=1.34.12,<1.34.24
+    botocore>=1.34.12
     cbor2>=5.2.0
     dnspython>=1.16.0
     # TODO tag incompatibility introduced in 7.0.0 with https://github.com/docker/docker-py/pull/3191


### PR DESCRIPTION

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

During the release of v3.1.0, AWS released an incompatible update of `botocore`. This disrupted our release process, so we put an upper limit to a known supported version. We no longer need the upper limit.

<!-- What notable changes does this PR make? -->
## Changes

Reverts a4645ad6cfec

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

