### PR TITLE
Enhance implementation of is_comma_delimited_list to fix --services in pods CLI

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -29,6 +29,9 @@ import cachetools
 
 LOG = logging.getLogger(__name__)
 
+# default regex to match an item in a comma-separated list string
+DEFAULT_REGEX_LIST_ITEM = r"[\w-]+"
+
 
 class AccessTrackingDict(dict):
     """
@@ -519,9 +522,14 @@ def split_list_by(
     return truthy, falsy
 
 
-def is_comma_delimited_list(string: str) -> bool:
-    """Checks is a string is comma-delimited"""
-    pattern = re.compile(r"^(\w+)(,\s*\w+)*$")
+def is_comma_delimited_list(string: str, item_regex: str | None = None) -> bool:
+    """
+    Checks if the given string is a comma-delimited list of items.
+    The optional `item_regex` parameter specifies the regex pattern for each item in the list.
+    """
+    item_regex = item_regex or DEFAULT_REGEX_LIST_ITEM
+
+    pattern = re.compile(rf"^\s*({item_regex})(\s*,\s*{item_regex})*\s*$")
     if pattern.match(string) is None:
         return False
     return True

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -522,7 +522,7 @@ def split_list_by(
     return truthy, falsy
 
 
-def is_comma_delimited_list(string: str, item_regex: str | None = None) -> bool:
+def is_comma_delimited_list(string: str, item_regex: Optional[str] = None) -> bool:
     """
     Checks if the given string is a comma-delimited list of items.
     The optional `item_regex` parameter specifies the regex pattern for each item in the list.

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -185,6 +185,10 @@ def test_is_comma_limited_list():
     assert is_comma_delimited_list("foo")
     assert is_comma_delimited_list("foo,bar")
     assert is_comma_delimited_list("foo, bar")
+    assert is_comma_delimited_list("foo , bar")
+    assert is_comma_delimited_list(" foo,bar ")
+
+    assert is_comma_delimited_list("s3,cognito-idp")
 
     assert not is_comma_delimited_list("foo, bar baz")
     assert not is_comma_delimited_list("foo,")


### PR DESCRIPTION
## Motivation

Enhance implementation of `is_comma_delimited_list(..)` to fix --services in pods CLI.

We are currently not accepting dashes in items of comma-separated lists, which is required, e.g., for `cognito-idp` in the following command:
```
$ localstack -d pod save --services s3,cognito-idp test-123
...
❌ Error: Input the services as a comma-delimited list
```

## Changes

* adjust the logic in `is_comma_delimited_list(..)` to allow passing an `item_regex`
* define a default `DEFAULT_REGEX_LIST_ITEM` regex that allows alphanumeric characters as well as dashes
* addjust and extend the unit tests

As far as I can see, the util function is currently only used for the pods client logic, so it should not break existing logic in other places.