### PR TITLE
Enhance parity for DynamoDB to Kinesis stream integration

### DIFF
--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -1,9 +1,8 @@
 import logging
 import re
-from decimal import Decimal
-from typing import Dict, List, Mapping, Optional
+from typing import Dict, List, Optional
 
-from boto3.dynamodb.types import TypeDeserializer
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from cachetools import TTLCache
 from moto.core.exceptions import JsonRESTError
 
@@ -202,94 +201,17 @@ def extract_table_name_from_partiql_update(statement: str) -> Optional[str]:
 
 def dynamize_value(value) -> dict:
     """
-    Taken from boto.dynamodb.types and augmented to support BOOL, M and L types (recursive), as well as fixing binary
-    encoding, already done later by the SDK.
     Take a scalar Python value or dict/list and return a dict consisting of the Amazon DynamoDB type specification and
     the value that needs to be sent to Amazon DynamoDB.  If the type of the value is not supported, raise a TypeError
     """
-    dynamodb_type = _get_dynamodb_type(value)
-    if dynamodb_type == "N":
-        value = {dynamodb_type: _serialize_num(value)}
-    elif dynamodb_type in ("S", "BOOL", "B"):
-        value = {dynamodb_type: value}
-    elif dynamodb_type == "NS":
-        value = {dynamodb_type: list(map(_serialize_num, value))}
-    elif dynamodb_type in ("SS", "BS"):
-        value = {dynamodb_type: [n for n in value]}
-    elif dynamodb_type == "NULL":
-        value = {dynamodb_type: True}
-    elif dynamodb_type == "L":
-        value = {dynamodb_type: [dynamize_value(v) for v in value]}
-    elif dynamodb_type == "M":
-        value = {dynamodb_type: {k: dynamize_value(v) for k, v in value.items()}}
-
-    return value
-
-
-def _get_dynamodb_type(val, use_boolean=True):
-    """
-    Take a scalar Python value and return a string representing the corresponding Amazon DynamoDB type.
-    If the value passed in is not a supported type, raise a TypeError.
-    """
-    dynamodb_type = None
-    if val is None:
-        dynamodb_type = "NULL"
-    elif _is_num(val):
-        if isinstance(val, bool) and use_boolean:
-            dynamodb_type = "BOOL"
-        else:
-            dynamodb_type = "N"
-    elif _is_str(val):
-        dynamodb_type = "S"
-    elif isinstance(val, (set, frozenset)):
-        if False not in map(_is_num, val):
-            dynamodb_type = "NS"
-        elif False not in map(_is_str, val):
-            dynamodb_type = "SS"
-        elif False not in map(_is_binary, val):
-            dynamodb_type = "BS"
-    elif _is_binary(val):
-        dynamodb_type = "B"
-    elif isinstance(val, Mapping):
-        dynamodb_type = "M"
-    elif isinstance(val, list):
-        dynamodb_type = "L"
-    if dynamodb_type is None:
-        msg = 'Unsupported type "%s" for value "%s"' % (type(val), val)
-        raise TypeError(msg)
-    return dynamodb_type
-
-
-def _is_num(n, boolean_as_int=True):
-    if boolean_as_int:
-        types = (int, float, Decimal, bool)
-    else:
-        types = (int, float, Decimal)
-
-    return isinstance(n, types) or n in types
-
-
-def _is_str(n):
-    return isinstance(n, str) or isinstance(n, type) and issubclass(n, str)
-
-
-def _is_binary(n):
-    return isinstance(n, bytes)  # Binary is subclass of bytes.
-
-
-def _serialize_num(val):
-    """Cast a number to a string and perform
-    validation to ensure no loss of precision.
-    """
-    if isinstance(val, bool):
-        return str(int(val))
-    return str(val)
+    return TypeSerializer().serialize(value)
 
 
 def de_dynamize_record(item: dict) -> dict:
     """
     Return the given item in DynamoDB format parsed as regular dict object, i.e., convert
     something like `{'foo': {'S': 'test'}, 'bar': {'N': 123}}` to `{'foo': 'test', 'bar': 123}`.
-    Note: This is the reverse operation of `dynamize_value(..)` above.
+    Note: This is the reverse operation of `dynamize_value(...)` above.
     """
-    return TypeDeserializer().deserialize({"M": item})
+    deserializer = TypeDeserializer()
+    return {k: deserializer.deserialize(v) for k, v in item.items()}

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -618,8 +618,6 @@ def kinesis_create_stream(aws_client):
     def _create_stream(**kwargs):
         if "StreamName" not in kwargs:
             kwargs["StreamName"] = f"test-stream-{short_uid()}"
-        if "ShardCount" not in kwargs:
-            kwargs["ShardCount"] = 1
         aws_client.kinesis.create_stream(**kwargs)
         stream_names.append(kwargs["StreamName"])
         return kwargs["StreamName"]

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -618,6 +618,8 @@ def kinesis_create_stream(aws_client):
     def _create_stream(**kwargs):
         if "StreamName" not in kwargs:
             kwargs["StreamName"] = f"test-stream-{short_uid()}"
+        if "ShardCount" not in kwargs:
+            kwargs["ShardCount"] = 1
         aws_client.kinesis.create_stream(**kwargs)
         stream_names.append(kwargs["StreamName"])
         return kwargs["StreamName"]

--- a/localstack/utils/aws/queries.py
+++ b/localstack/utils/aws/queries.py
@@ -52,7 +52,9 @@ def get_apigateway_path_for_resource(
     )
 
 
-def kinesis_get_latest_records(stream_name, shard_id, count=10, client=None):
+def kinesis_get_latest_records(
+    stream_name: str, shard_id: str, count: int = 10, client=None
+) -> list[dict]:
     kinesis = client or connect_to().kinesis
     result = []
     response = kinesis.get_shard_iterator(

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
@@ -93,7 +93,7 @@ class TestDynamoDBStreams:
         # create DDB table and Kinesis stream
         table = dynamodb_create_table()
         table_name = table["TableDescription"]["TableName"]
-        stream_name = kinesis_create_stream()
+        stream_name = kinesis_create_stream(ShardCount=1)
         wait_for_stream_ready(stream_name)
         stream_arn = kinesis_stream_arn(
             stream_name, account_id, region_name=kinesis.meta.region_name

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
@@ -1,0 +1,130 @@
+import json
+import re
+
+from localstack.constants import TEST_AWS_REGION_NAME
+from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
+from localstack.testing.aws.util import is_aws_cloud
+from localstack.testing.pytest import markers
+from localstack.utils.aws import resources
+from localstack.utils.aws.arns import kinesis_stream_arn
+from localstack.utils.aws.queries import kinesis_get_latest_records
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+# default partition key used for test tables
+PARTITION_KEY = "id"
+
+
+class TestDynamoDBStreams:
+    @markers.aws.only_localstack
+    def test_stream_spec_and_region_replacement(self, aws_client):
+        ddbstreams = aws_client.dynamodbstreams
+        kinesis = aws_client.kinesis
+        table_name = f"ddb-{short_uid()}"
+        resources.create_dynamodb_table(
+            table_name,
+            partition_key=PARTITION_KEY,
+            stream_view_type="NEW_AND_OLD_IMAGES",
+            client=aws_client.dynamodb,
+        )
+
+        table = aws_client.dynamodb.describe_table(TableName=table_name)["Table"]
+
+        # assert ARN formats
+        expected_arn_prefix = f"arn:aws:dynamodb:{TEST_AWS_REGION_NAME}"
+        assert table["TableArn"].startswith(expected_arn_prefix)
+        assert table["LatestStreamArn"].startswith(expected_arn_prefix)
+
+        # test list_streams filtering
+        stream_tables = ddbstreams.list_streams(TableName="foo")["Streams"]
+        assert len(stream_tables) == 0
+
+        # assert stream has been created
+        stream_tables = [
+            s["TableName"] for s in ddbstreams.list_streams(TableName=table_name)["Streams"]
+        ]
+        assert table_name in stream_tables
+        assert len(stream_tables) == 1
+        stream_name = get_kinesis_stream_name(table_name)
+        assert stream_name in kinesis.list_streams()["StreamNames"]
+
+        # assert shard ID formats
+        result = ddbstreams.describe_stream(StreamArn=table["LatestStreamArn"])["StreamDescription"]
+        assert "Shards" in result
+        for shard in result["Shards"]:
+            assert re.match(r"^shardId-[0-9]{20}-[a-zA-Z0-9]{1,36}$", shard["ShardId"])
+
+        # clean up
+        aws_client.dynamodb.delete_table(TableName=table_name)
+
+        def _assert_stream_deleted():
+            stream_tables = [s["TableName"] for s in ddbstreams.list_streams()["Streams"]]
+            assert table_name not in stream_tables
+            assert stream_name not in kinesis.list_streams()["StreamNames"]
+
+        # assert stream has been deleted
+        retry(_assert_stream_deleted, sleep=0.4, retries=5)
+
+    @markers.aws.validated
+    def test_enable_kinesis_streaming_destination(
+        self,
+        aws_client,
+        dynamodb_create_table,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        account_id,
+        snapshot,
+    ):
+        snapshot.add_transformer(snapshot.transform.key_value("SequenceNumber"))
+        snapshot.add_transformer(snapshot.transform.key_value("PartitionKey"))
+        snapshot.add_transformer(
+            snapshot.transform.key_value("ApproximateArrivalTimestamp", reference_replacement=False)
+        )
+        snapshot.add_transformer(
+            snapshot.transform.key_value("ApproximateCreationDateTime", reference_replacement=False)
+        )
+        snapshot.add_transformer(snapshot.transform.key_value("eventID"))
+        snapshot.add_transformer(snapshot.transform.key_value("tableName"))
+
+        dynamodb = aws_client.dynamodb
+        kinesis = aws_client.kinesis
+
+        # create DDB table and Kinesis stream
+        table = dynamodb_create_table()
+        table_name = table["TableDescription"]["TableName"]
+        stream_name = kinesis_create_stream()
+        wait_for_stream_ready(stream_name)
+        stream_arn = kinesis_stream_arn(
+            stream_name, account_id, region_name=kinesis.meta.region_name
+        )
+        stream_details = kinesis.describe_stream(StreamName=stream_name)["StreamDescription"]
+        shards = stream_details["Shards"]
+        assert len(shards) == 1
+
+        # enable kinesis streaming destination
+        dynamodb.enable_kinesis_streaming_destination(TableName=table_name, StreamArn=stream_arn)
+
+        def _stream_active():
+            details = dynamodb.describe_kinesis_streaming_destination(TableName=table_name)
+            destinations = details["KinesisDataStreamDestinations"]
+            assert len(destinations) == 1
+            assert destinations[0]["DestinationStatus"] == "ACTIVE"
+            return destinations[0]
+
+        # wait until stream is active
+        retry(_stream_active, sleep=10 if is_aws_cloud() else 0.7, retries=10)
+
+        # write item to table
+        updates = [{"Put": {"Item": {PARTITION_KEY: {"S": "test"}}, "TableName": table_name}}]
+        dynamodb.transact_write_items(TransactItems=updates)
+
+        def _receive_records():
+            records = kinesis_get_latest_records(stream_name, shards[0]["ShardId"], client=kinesis)
+            assert records
+            return records
+
+        # assert that record has been received in the stream
+        records = retry(_receive_records, sleep=0.7, retries=15)
+        for record in records:
+            record["Data"] = json.loads(record["Data"])
+        snapshot.match("result-records", records)

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
@@ -1,0 +1,37 @@
+{
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
+    "recorded-date": "30-01-2024, 10:33:36",
+    "recorded-content": {
+      "result-records": [
+        {
+          "SequenceNumber": "<sequence-number:1>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": {
+            "awsRegion": "<region>",
+            "eventID": "<event-i-d:1>",
+            "eventName": "INSERT",
+            "userIdentity": null,
+            "recordFormat": "application/json",
+            "tableName": "<table-name:1>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "approximate-creation-date-time",
+              "Keys": {
+                "id": {
+                  "S": "test"
+                }
+              },
+              "NewImage": {
+                "id": {
+                  "S": "test"
+                }
+              },
+              "SizeBytes": 12
+            },
+            "eventSource": "aws:dynamodb"
+          },
+          "PartitionKey": "<partition-key:1>"
+        }
+      ]
+    }
+  }
+}

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
-    "recorded-date": "30-01-2024, 10:33:36",
+    "recorded-date": "30-01-2024, 20:27:32",
     "recorded-content": {
       "result-records": [
         {

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
+    "last_validated_date": "2024-01-30T10:33:36+00:00"
+  }
+}

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/dynamodbstreams/test_dynamodb_streams.py::TestDynamoDBStreams::test_enable_kinesis_streaming_destination": {
-    "last_validated_date": "2024-01-30T10:33:36+00:00"
+    "last_validated_date": "2024-01-30T20:27:32+00:00"
   }
 }

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -51,18 +51,9 @@ class TestKinesis:
 
     @markers.aws.validated
     def test_create_stream_without_shard_count(
-        self, wait_for_stream_ready, snapshot, aws_client, cleanups
+        self, kinesis_create_stream, wait_for_stream_ready, snapshot, aws_client, cleanups
     ):
-        stream_name = f"test-stream-{short_uid()}"
-        # we need to manually create a stream and its cleanup, because the `kinesis_create_stream` fixture will
-        # automatically set a shard count for better resource usage (only in AWS)
-
-        cleanups.append(
-            lambda: aws_client.kinesis.delete_stream(
-                StreamName=stream_name, EnforceConsumerDeletion=True
-            )
-        )
-        aws_client.kinesis.create_stream(StreamName=stream_name)
+        stream_name = kinesis_create_stream()
         wait_for_stream_ready(stream_name)
         describe_stream = aws_client.kinesis.describe_stream(StreamName=stream_name)
 


### PR DESCRIPTION
## Motivation

Following a customer request, it seems that our integration between DynamoDB tables and Kinesis streams is not fully working for certain DDB operations, in particular when using the `transact_write_items` operation. (Apparently it worked for older versions prior to 3.0, but I haven't confirmed).

🚧  At this point, the PR only adds a snapshot test to illustrate the behavior - proper logic still needs to be implemented. (may need some help from service owners here, if possible 🙌 ) 

Wondering if this TODO comment could be related (as I know @bentsku has been working on some pretty significant performance enhancements recently 🚀 ): https://github.com/localstack/localstack/blob/45d39edbdc27c00d1f762c40e3c050d5b1b36e39/localstack/services/dynamodb/provider.py#L1112

**Update**: After discussing with @bentsku , the TODO above is not related - the fix was essentially related to converting a table ARN to the table name.

## Changes

* enhance logic in `has_streams_enabled(..)` to extract the table name from incoming table ARN
* fix attributes in forwarded `record`s, for better parity
* add a `de_dynamize_record` util function and refactor `dynamize_value` to use boto `TypeSerializer` utils
* add a `test_enable_kinesis_streaming_destination` snapshot test to cover the functionality