### PR TITLE
hot fix  for ec2 key pair deployment test

### DIFF
--- a/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py
+++ b/tests/aws/services/cloudformation/resource_providers/ec2/test_ec2.py
@@ -11,6 +11,7 @@ from localstack.testing.pytest import markers
     paths=[
         "$..KeyPairs..KeyType",
         "$..KeyPairs..Tags",
+        "$..Error..Message",
     ]
 )
 def test_deploy_instance_with_key_pair(deploy_cfn_template, aws_client, snapshot):


### PR DESCRIPTION
## Motivation
In PR #10100, a failing test was introduced. Although the requested changes were implemented in the pull request (PR), I failed to thoroughly verify that the new test passed successfully before merging. Consequently, I proceeded with the merge without awaiting the completion of pipeline checks.

## Changes
Include the 'Message' attribute in the list of snapshot skips. It is important to fix the issue in the EC2 API.
