### PR TITLE
CFn: improve error message for invalid ref

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -40,7 +40,7 @@ from localstack.utils.objects import get_all_subclasses
 from localstack.utils.strings import to_bytes, to_str
 from localstack.utils.threads import start_worker_thread
 
-from localstack.services.cloudformation.models import *  # noqa: F401, isort:skip
+from localstack.services.cloudformation.models import *  # noqa: F401, F403, isort:skip
 from localstack.utils.urls import localstack_host
 
 ACTION_CREATE = "create"
@@ -169,7 +169,9 @@ def resolve_ref(
     # resource
     resource = resources.get(ref)
     if not resource:
-        raise Exception("Should be detected earlier.")
+        raise Exception(
+            f"Resource target for `!Ref {ref}` could not be found. Is there a resource with name {ref} in your stack?"
+        )
 
     return resources[ref].get("PhysicalResourceId")
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -170,7 +170,7 @@ def resolve_ref(
     resource = resources.get(ref)
     if not resource:
         raise Exception(
-            f"Resource target for `!Ref {ref}` could not be found. Is there a resource with name {ref} in your stack?"
+            f"Resource target for `Ref {ref}` could not be found. Is there a resource with name {ref} in your stack?"
         )
 
     return resources[ref].get("PhysicalResourceId")
@@ -329,7 +329,7 @@ def _resolve_refs_recursively(
             if resolved_getatt is None:
                 raise DependencyNotYetSatisfied(
                     resource_ids=resource_logical_id,
-                    message=f"Could not resolve attribute {attribute_name} on resource {resource_logical_id}",
+                    message=f"Could not resolve attribute '{attribute_name}' on resource '{resource_logical_id}'",
                 )
             return resolved_getatt
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When we cannot resolve a `Ref` - specifically if it is targeting a non-existent resource or parameter, we currently print "Should be detected earlier." which is not very useful. Instead, since this is a programming error from the creator of the template, we should be more helpful and print out the ref that cannot be resolved.

<!-- What notable changes does this PR make? -->
## Changes

- Increase clarity of error message when not finding a ref
- Add test to ensure the ref target is in the error message
- Add more clarity to additional error messages


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

