### PR TITLE
Spike: Kinesis client native python implementation

### DIFF
--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -316,11 +316,11 @@ class FirehoseProvider(FirehoseApi):
                     )
                     process = kinesis_connector.listen_to_kinesis(
                         stream_name=kinesis_stream_name,
+                        stream_anr=kinesis_stream_arn,
                         account_id=context.account_id,
                         region_name=context.region,
                         listener_func=listener_function,
-                        wait_until_started=True,
-                        ddb_lease_table_suffix="-firehose",
+                        wait_for_client_ready=True,
                     )
 
                     self.kinesis_listeners[delivery_stream_arn] = process

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -1,369 +1,249 @@
-#!/usr/bin/env python
-import json
+import base64
 import logging
-import os
-import re
-import socket
-import tempfile
 import threading
-from typing import Any, Callable
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
 
-from amazon_kclpy import kcl
-from amazon_kclpy.v2 import processor
+import botocore
 
-from localstack import config
-from localstack.constants import LOCALSTACK_ROOT_FOLDER, LOCALSTACK_VENV_FOLDER
-from localstack.utils.aws import arns
-from localstack.utils.files import TMP_FILES, chmod_r, save_file
-from localstack.utils.kinesis import kclipy_helper
-from localstack.utils.run import ShellCommandThread
-from localstack.utils.strings import short_uid, truncate
-from localstack.utils.sync import retry
+from localstack.aws.api.firehose import Record
+from localstack.aws.connect import connect_to
+from localstack.utils.aws.arns import parse_arn
 from localstack.utils.threads import TMP_THREADS, FuncThread
-from localstack.utils.time import now
-
-DEFAULT_DDB_LEASE_TABLE_SUFFIX = "-kclapp"
-
-# define Java class names
-MULTI_LANG_DAEMON_CLASS = "software.amazon.kinesis.multilang.MultiLangDaemon"
 
 # set up local logger
 LOG = logging.getLogger(__name__)
 
-INITIALIZATION_REGEX = re.compile(r".*Initialization complete.*")
-SUBPROCESS_INITIALIZED_REGEX = re.compile(r".*Received response .* for initialize.*")
-
-# checkpointing settings
-CHECKPOINT_RETRIES = 5
-CHECKPOINT_SLEEP_SECS = 5
-CHECKPOINT_FREQ_SECS = 60
-
 ListenerFunction = Callable[[list], Any]
 
-
-class EventFileReaderThread(FuncThread):
-    def __init__(self, events_file, callback: Callable[[list], Any]):
-        super().__init__(
-            self.retrieve_loop, None, name="kinesis-event-file-reader", on_stop=self._on_stop
-        )
-        self.events_file = events_file
-        self.callback = callback
-        self.is_ready = threading.Event()
-        self.sock = None
-
-    def retrieve_loop(self, params):
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.bind(self.events_file)
-        self.sock.listen(1)
-        self.is_ready.set()
-        with self.sock as sock:
-            while self.running:
-                try:
-                    conn, client_addr = sock.accept()
-                    thread = FuncThread(
-                        self.handle_connection,
-                        conn,
-                        name="kinesis-event-file-reader-connectionhandler",
-                    )
-                    thread.start()
-                except Exception as e:
-                    # ignore any errors happening during shutdown
-                    if self.running:
-                        LOG.error(
-                            "Error dispatching client request: %s",
-                            e,
-                            exc_info=LOG.isEnabledFor(logging.DEBUG),
-                        )
-        LOG.debug("Stopping retrieve loop for event file %s", self.events_file)
-
-    def wait_for_ready(self):
-        self.is_ready.wait()
-
-    def _on_stop(self, *args, **kwargs):
-        if self.sock:
-            LOG.debug("Shutting down event file reader for event file %s", self.events_file)
-            # shutdown is needed to unblock sock.accept. However, it will raise a OSError: [Errno 22] Invalid argument
-            # in the retrieve loop
-            # still, the easiest way to shut down the accept call without setting socket timeout for now
-            self.sock.shutdown(socket.SHUT_RDWR)
-            self.sock.close()
-
-    def handle_connection(self, conn: socket):
-        socket_file = conn.makefile()
-        with socket_file as sock:
-            while self.running:
-                line = ""
-                try:
-                    line = sock.readline()
-                    line = line.strip()
-                    if not line:
-                        # end of socket input stream
-                        break
-                    event = json.loads(line)
-                    records = event["records"]
-                    self.callback(records)
-                except Exception as e:
-                    LOG.warning(
-                        "Unable to process JSON line: '%s': %s. Callback: %s",
-                        truncate(line),
-                        e,
-                        self.callback,
-                        exc_info=LOG.isEnabledFor(logging.DEBUG),
-                    )
-        LOG.debug("Shutting down connection handler for events file %s", self.events_file)
-
-
-# needed by the processor script farther down
-class KinesisProcessor(processor.RecordProcessorBase):
-    def __init__(self, log_file=None, processor_func=None, auto_checkpoint=True):
-        self.log_file = log_file
-        self.processor_func = processor_func
-        self.shard_id = None
-        self.auto_checkpoint = auto_checkpoint
-        self.last_checkpoint_time = 0
-        self._largest_seq = (None, None)
-
-    def initialize(self, initialize_input):
-        self.shard_id = initialize_input.shard_id
-        if self.log_file:
-            self.log(f"initialize '{self.shard_id}'")
-        self.shard_id = initialize_input.shard_id
-
-    def process_records(self, process_records_input):
-        if self.processor_func:
-            records = process_records_input.records
-            checkpointer = process_records_input.checkpointer
-            self.processor_func(records=records, checkpointer=checkpointer, shard_id=self.shard_id)
-            for record in records:
-                seq = int(record.sequence_number)
-                sub_seq = record.sub_sequence_number
-                if self.should_update_sequence(seq, sub_seq):
-                    self._largest_seq = (seq, sub_seq)
-            if self.auto_checkpoint:
-                time_now = now()
-                if (time_now - CHECKPOINT_FREQ_SECS) > self.last_checkpoint_time:
-                    self.checkpoint(checkpointer, str(self._largest_seq[0]), self._largest_seq[1])
-                    self.last_checkpoint_time = time_now
-
-    def shutdown_requested(self, shutdown_requested_input):
-        if self.log_file:
-            self.log(f"Shutdown processor for shard '{self.shard_id}'")
-        if shutdown_requested_input.action == "TERMINATE":
-            self.checkpoint(shutdown_requested_input.checkpointer)
-
-    def checkpoint(self, checkpointer, sequence_number=None, sub_sequence_number=None):
-        def do_checkpoint():
-            checkpointer.checkpoint(sequence_number, sub_sequence_number)
-
-        try:
-            retry(do_checkpoint, retries=CHECKPOINT_RETRIES, sleep=CHECKPOINT_SLEEP_SECS)
-        except Exception as e:
-            LOG.warning("Unable to checkpoint Kinesis after retries: %s", e)
-
-    def should_update_sequence(self, sequence_number, sub_sequence_number):
-        return (
-            self._largest_seq == (None, None)
-            or sequence_number > self._largest_seq[0]
-            or (
-                sequence_number == self._largest_seq[0]
-                and sub_sequence_number > self._largest_seq[1]
-            )
-        )
-
-    def log(self, s):
-        if self.log_file:
-            save_file(self.log_file, f"{s}\n", append=True)
-
-    @staticmethod
-    def run_processor(log_file=None, processor_func=None):
-        proc = kcl.KCLProcess(KinesisProcessor(log_file, processor_func))
-        proc.run()
-
-
-class KinesisProcessorThread(ShellCommandThread):
-    def __init__(
-        self,
-        stream_name: str,
-        properties_file: str,
-        env_vars: dict[str, str],
-        listener_function: ListenerFunction,
-        events_file: str,
-    ):
-        self.initialization_completed = threading.Event()
-        self.subprocesses_initialized = threading.Event()
-        self.event_reader = EventFileReaderThread(events_file, listener_function)
-        self.stream_name = stream_name
-        cmd = kclipy_helper.get_kcl_app_command("java", MULTI_LANG_DAEMON_CLASS, properties_file)
-        super().__init__(
-            cmd,
-            log_listener=self._startup_listener,
-            env_vars=env_vars,
-            quiet=False,
-            name="kinesis-processor",
-        )
-
-    def start(self):
-        self.event_reader.start()
-        # Wait until the event reader thread is ready (to avoid 'Connection refused' error on the UNIX socket)
-        self.event_reader.wait_for_ready()
-        super().start()
-
-    def stop(self, quiet: bool = False):
-        if self.stopped:
-            LOG.debug("Kinesis connector for stream %s already stopped.", self.stream_name)
-        else:
-            LOG.debug("Stopping kinesis connector for stream: %s", self.stream_name)
-            self.event_reader.stop()
-            super().stop(quiet)
-
-    def _startup_listener(self, line: str, **kwargs):
-        line = line.strip()
-        # LOG.debug("KCLPY: %s", line)
-        if not self.initialization_completed.is_set() and INITIALIZATION_REGEX.match(line):
-            self.initialization_completed.set()
-        if not self.subprocesses_initialized.is_set() and SUBPROCESS_INITIALIZED_REGEX.match(line):
-            self.subprocesses_initialized.set()
-
-    def wait_is_up(self, timeout: int | None = None) -> bool:
-        return self.initialization_completed.wait(timeout=timeout)
-
-    def wait_subprocesses_initialized(self, timeout: int | None = None) -> bool:
-        return self.subprocesses_initialized.wait(timeout=timeout)
-
-
-def _start_kcl_client_process(
-    stream_name: str,
-    account_id: str,
-    region_name: str,
-    listener_function: ListenerFunction,
-    ddb_lease_table_suffix=None,
-):
-    # make sure to convert stream ARN to stream name
-    stream_name = arns.kinesis_stream_name(stream_name)
-    # disable CBOR protocol, enforce use of plain JSON
-    # TODO evaluate why?
-    env_vars = {
-        "AWS_CBOR_DISABLE": "true",
-        "AWS_ACCESS_KEY_ID": account_id,
-    }
-
-    events_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.fifo")
-    TMP_FILES.append(events_file)
-    processor_script = _generate_processor_script(events_file)
-
-    properties_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.properties")
-    app_name = f"{stream_name}{ddb_lease_table_suffix}"
-    # create config file
-    kclipy_helper.create_config_file(
-        config_file=properties_file,
-        executableName=processor_script,
-        streamName=stream_name,
-        applicationName=app_name,
-        region_name=region_name,
-        metricsLevel="NONE",
-        initialPositionInStream="LATEST",
-        # set parameters for local connection
-        kinesisEndpoint=config.internal_service_url(protocol="http"),
-        dynamoDBEndpoint=config.internal_service_url(protocol="http"),
-        disableCertChecking="true",
-    )
-    TMP_FILES.append(properties_file)
-    # start stream consumer
-    kinesis_processor = KinesisProcessorThread(
-        stream_name=stream_name,
-        properties_file=properties_file,
-        env_vars=env_vars,
-        listener_function=listener_function,
-        events_file=events_file,
-    )
-    kinesis_processor.start()
-    TMP_THREADS.append(kinesis_processor)
-    return kinesis_processor
-
-
-def _generate_processor_script(events_file: str):
-    script_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.processor.py")
-    content = f"""#!/usr/bin/env python
-import os, sys, glob, json, socket, time, logging, subprocess, tempfile
-logging.basicConfig(level=logging.INFO)
-for path in glob.glob('{LOCALSTACK_VENV_FOLDER}/lib/python*/site-packages'):
-    sys.path.insert(0, path)
-sys.path.insert(0, '{LOCALSTACK_ROOT_FOLDER}')
-from localstack.config import DEFAULT_ENCODING
-from localstack.utils.kinesis import kinesis_connector
-from localstack.utils.time import timestamp
-events_file = '{events_file}'
-log_file = None
-error_log = os.path.join(tempfile.gettempdir(), 'kclipy.error.log')
-if __name__ == '__main__':
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
-    num_tries = 3
-    sleep_time = 2
-    error = None
-    for i in range(0, num_tries):
-        try:
-            sock.connect(events_file)
-            error = None
-            break
-        except Exception as e:
-            error = e
-            if i < num_tries:
-                msg = '%s: Unable to connect to UNIX socket. Retrying.' % timestamp()
-                subprocess.check_output('echo "%s" >> %s' % (msg, error_log), shell=True)
-                time.sleep(sleep_time)
-    if error:
-        print("WARN: Unable to connect to UNIX socket after retrying: %s" % error)
-        raise error
-
-    def receive_msg(records, checkpointer, shard_id):
-        try:
-            # records is a list of amazon_kclpy.messages.Record objects -> convert to JSON
-            records_dicts = [j._json_dict for j in records]
-            message_to_send = {{'shard_id': shard_id, 'records': records_dicts}}
-            string_to_send = '%s\\n' % json.dumps(message_to_send)
-            bytes_to_send = string_to_send.encode(DEFAULT_ENCODING)
-            sock.send(bytes_to_send)
-        except Exception as e:
-            msg = "WARN: Unable to forward event: %s" % e
-            print(msg)
-            subprocess.check_output('echo "%s" >> %s' % (msg, error_log), shell=True)
-    kinesis_connector.KinesisProcessor.run_processor(log_file=log_file, processor_func=receive_msg)
-    """
-    save_file(script_file, content)
-    chmod_r(script_file, 0o755)
-    TMP_FILES.append(script_file)
-    return script_file
+SHARD_SLEEP_TIME = 60
+POLL_STREAM_SLEEP_TIME = 1
+SHARD_LEASE_TIME = 300
 
 
 def listen_to_kinesis(
     stream_name: str,
+    stream_arn: str,
     account_id: str,
     region_name: str,
     listener_func: ListenerFunction,
-    ddb_lease_table_suffix: str | None = None,
-    wait_until_started: bool = False,
+    wait_for_client_ready: bool = True,
 ):
     """
     High-level function that allows to subscribe to a Kinesis stream
-    and receive events in a listener function. A KCL client process is
-    automatically started in the background.
+    and receive events in a listener function.
     """
-    process = _start_kcl_client_process(
-        stream_name=stream_name,
-        account_id=account_id,
-        region_name=region_name,
-        listener_function=listener_func,
-        ddb_lease_table_suffix=ddb_lease_table_suffix,
-    )
-
-    if wait_until_started:
-        # Wait at most 90 seconds for initialization. Note that creating the DDB table can take quite a bit
-        success = process.wait_is_up(timeout=90)
-        if not success:
-            raise Exception("Timeout when waiting for KCL initialization.")
-        # ignore success/failure of wait because a timeout merely means that there is no shard available to take
-        # waiting here, since otherwise some messages would be ignored even though the connector reports ready
-        process.wait_subprocesses_initialized(timeout=30)
-
+    process = KinesisClient(stream_name, stream_arn, account_id, region_name, listener_func)
+    process.start()
+    TMP_THREADS.append(process)
+    if wait_for_client_ready:
+        process.initialized(timeout=10)
     return process
+
+
+@dataclass
+class ShardData:
+    # TODO: deal with persisting shard data to not re-read all events on restart if persistence is enabled
+    shard_id: str
+    stream_arn: str
+    shard_iterator: str
+    last_sequence_number: str
+    lock: threading.Lock
+    parent_shard_id: Optional[str] = None
+    worker_thread: Optional[FuncThread] = None
+
+
+class KinesisClient(FuncThread):
+    """
+    Listens to a Kinesis stream, prepares shard iterators and regularly updates
+    adds new shard iterators and spawns a worker thread for each shard.
+    """
+
+    def __init__(
+        self,
+        stream_name: str,
+        stream_arn: str,
+        account_id: str,
+        region_name: str,
+        callback: ListenerFunction,
+    ):
+        self.stream_name = stream_name
+        self.stream_arn = stream_arn
+        self.account_id = account_id
+        self.region_name = region_name
+        self.callback = callback
+        self.kinesis_client = self._get_kinesis_client(stream_arn)
+        self.initialization_completed = threading.Event()
+        self.shards: dict[str, ShardData] = dict()  # key = shard_id
+        self.lease_time = SHARD_LEASE_TIME
+        self.sleep_time = SHARD_SLEEP_TIME
+        super().__init__(self.process_shards_loop, None, name="kinesis-client")
+
+    def process_shards_loop(self, params):
+        while self.running:
+            LOG.debug("run process_shards_loop")
+            self.process_shards()
+            self._stop_event.wait(self.sleep_time)
+
+    def process_shards(self) -> str:
+        stream_info = self.kinesis_client.describe_stream(StreamARN=self.stream_arn)
+
+        for shard_description in stream_info["StreamDescription"]["Shards"]:
+            shard_id = shard_description["ShardId"]
+            self.lock_shard(shard_id)
+
+            kwargs = self._get_iterator_args(shard_id, shard_description)
+            response = self.kinesis_client.get_shard_iterator(
+                StreamARN=self.stream_arn,
+                ShardId=shard_id,
+                **kwargs,
+            )
+            shard_iterator = response["ShardIterator"]
+
+            # TODO add logic to only update if shard iterator changed (parent child, hash key range) or lease run out
+            shard = self.update_shard(
+                shard_id=shard_id,
+                shard_iterator=shard_iterator,
+                shard_description=shard_description,
+            )
+
+            self.unlock_shard(shard_id)
+
+            # start worker thread if not already running
+            if not shard.worker_thread or not shard.worker_thread.is_alive():
+                shard.worker_thread = KinesisWorker(shard, self.callback, self.kinesis_client)
+                shard.worker_thread.start()
+                TMP_THREADS.append(shard.worker_thread)
+
+            self.initialization_completed.set()
+
+    def lock_shard(self, shard_id):
+        try:
+            self.shards[shard_id].lock.acquire()
+        except KeyError:
+            pass
+        except Exception as e:
+            LOG.warning("Unable to lock shard %s: %s", shard_id, e)
+
+    def unlock_shard(self, shard_id):
+        try:
+            self.shards[shard_id].lock.release()
+        except KeyError:
+            pass
+        except Exception as e:
+            LOG.warning("Unable to unlock shard %s: %s", shard_id, e)
+
+    def initialized(self, timeout: int | None = None) -> bool:
+        return self.initialization_completed.wait(timeout=timeout)
+
+    def start(self) -> None:
+        LOG.debug("Starting kinesis client for stream: %s", self.stream_name)
+        self.initialization_completed.clear()
+        super().start()
+
+    def stop(self, quiet: bool = False):
+        LOG.debug("Stopping kinesis client for stream: %s", self.stream_name)
+        super().stop()
+        for shard_id, shard in self.shards.items():
+            try:
+                shard.worker_thread.stop()
+            except Exception as e:
+                LOG.warning("Unable to stop worker thread for shard %s: %s", shard_id, e)
+
+    def update_shard(self, shard_id, shard_iterator, shard_description):
+        if shard_id not in self.shards:
+            lock = threading.Lock()
+            lock.acquire()
+            self.shards[shard_id] = ShardData(
+                shard_id=shard_id,
+                stream_arn=self.stream_arn,
+                shard_iterator=shard_iterator,
+                # TODO: how to deal with worker not read event associated with current sequence number while shard updates before
+                last_sequence_number=shard_description["SequenceNumberRange"][
+                    "StartingSequenceNumber"
+                ],
+                parent_shard_id=shard_description.get("ParentShardId"),
+                lock=lock,
+            )
+        else:
+            self.shards[shard_id].shard_iterator = shard_iterator
+        return self.shards[shard_id]
+
+    def _get_kinesis_client(self, stream_arn: str, client_config: botocore.config.Config = None):
+        parsed_arn = parse_arn(stream_arn)
+        kinesis_client = connect_to(
+            aws_access_key_id=parsed_arn["account"],
+            region_name=parsed_arn["region"],
+            config=client_config,
+        ).kinesis
+        return kinesis_client
+
+    def _get_iterator_args(self, shard_id, shard_description):
+        try:
+            return dict(
+                ShardIteratorType="AFTER_SEQUENCE_NUMBER",
+                StartingSequenceNumber=self.shards[shard_id].last_sequence_number,
+            )
+        except KeyError:
+            return dict(
+                ShardIteratorType="AT_SEQUENCE_NUMBER",
+                StartingSequenceNumber=shard_description["SequenceNumberRange"][
+                    "StartingSequenceNumber"
+                ],
+            )
+
+
+class KinesisWorker(FuncThread):
+    """
+    Listens to a specific shard in a separate thread,
+    applies the callback function to all received events from polled kinesis stream.
+    """
+
+    def __init__(
+        self,
+        shard: ShardData,
+        callback: ListenerFunction,
+        kinesis_client: botocore.client.BaseClient,
+        sleep_time: int = POLL_STREAM_SLEEP_TIME,
+    ):
+        self.shard = shard
+        self.callback = callback
+        self.kinesis_client = kinesis_client
+        self.sleep_time = sleep_time
+        super().__init__(self.poll_stream_loop, None, name="kinesis-worker")
+
+    def poll_stream_loop(self, params):
+        logging.getLogger().setLevel(logging.ERROR)  # supress spamming the logs
+        while self.running:
+            LOG.debug("run poll_stream_loop\n")
+            self.shard.lock.acquire()
+            records = self.poll_events()
+            if records:
+                self.callback(records)
+                # update sequence number
+                self.shard.last_sequence_number = records[-1]["SequenceNumber"]
+            self.shard.lock.release()
+            self._stop_event.wait(self.sleep_time)
+
+    def poll_events(self) -> list[Record]:
+        get_records_response = self.kinesis_client.get_records(
+            StreamARN=self.shard.stream_arn,
+            ShardIterator=self.shard.shard_iterator,
+        )
+        self.shard.shard_iterator = get_records_response["NextShardIterator"]
+        records = get_records_response["Records"]
+        # logic in kinesis consumers expect Base64-encoded string
+        for record in records:
+            record["Data"] = base64.b64encode(record["Data"])
+
+        return records
+
+    def start(self) -> None:
+        LOG.debug("Starting kinesis worker for shard: %s", self.shard.shard_id)
+        return super().start()
+
+    def stop(self, quiet: bool = False):
+        LOG.debug("Stopping kinesis worker for shard: %s", self.shard.shard_id)
+        self.running = False
+        super().stop()
+        self.shard.lock.release()

--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -218,6 +218,9 @@ class TestIntegration:
         table_name = short_uid() + "lsbat" + ddb_lease_table_suffix
         lambda_ddb_name = f"lambda-ddb-{short_uid()}"
         stream_name = kinesis_create_stream()
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
 
         events = []
 
@@ -227,12 +230,12 @@ class TestIntegration:
 
         # start the KCL client process in the background
         process = kinesis_connector.listen_to_kinesis(
-            stream_name,
+            stream_name=stream_name,
+            stream_arn=stream_arn,
             account_id=TEST_AWS_ACCOUNT_ID,
             region_name=TEST_AWS_REGION_NAME,
             listener_func=process_records,
-            wait_until_started=True,
-            ddb_lease_table_suffix=ddb_lease_table_suffix,
+            wait_for_client_ready=True,
         )
         cleanups.append(lambda: process.stop())
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
**What**: 
- replace java kcl used to listen to kinesis stream in ) kinesis_connector with native python implementation 

**Why**: 
- depending on jvm bloats the container
- using kcl relies on external dependencies for core functionality

We are spinning up a mock Kinesis server (https://github.com/etspaceman/kinesis-mock) and use the java plication aws kinesis client library to connect to this mock server. For services queriing events from the mock kinesis server, we provide a connector function `listen_to_kinesis` in `kinesis_connector` 

This method starts the kcl for each listener. Kcl starts one or more instances with a worker bound to one or more shards. Each worker processes messages from the shard(s) and sends received messages to a programmatically created Python script that sends the messages to a socket. A listener function running in a separate thread listens to incoming messages on this socket and handles further processing defined by the initiator e.g. Firehose

To track shard lease and assignment shards to worker processes as well as to track checkpoints (latest read message from the shard) kcl uses a dynamoDB “lease table”

used by:
- community: Firehose
- ext: Kinesisanalytics, Kinesisanalytics-v2, Quantum Ledger Database 

**Issues:**

Currently, the system does not handle multiple instantiations of the `listen_to_kinesis` and its child threads subscribing to the same Kinesis event stream. Also, event pipes require more control over

<!-- What notable changes does this PR make? -->
## Changes

KinesisConnector class that starts a thread that monitors existing shards and creates shard iterators (recreates after lease time ran out 5min), as well as creates new shard iterators on resharding.

KinesisWorker class, for each shard a separate worker is instantiated in a separate thread that uses the native boto method kinesis_client.get_records to receive events from the specific shard it listens to, it further processes these events by calling the specified callback function.

Data for synchronization between KinesisConnector and each worker is for now only kept in memory (this might need to change for dealing with restoring states if persistence in localstack is enabled. For each shard, a ShardData object is created, and all shards are kept in a dictionary.


## Testing

Adds test to kinesis_test for recharging. 
Testing for shard timeout and persistence testing is still required

## TODO

What's left to do:

- [ ] further abstract KinesisClient to be usable by all services e.g. event pipes
- [ ] deal with data persistence and not re-reading already processed events by callback function


