### PR TITLE
DynamoDB: Fix startup in non-default account ID/region

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -151,10 +151,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "LSIAQAAAAAAAQAATEST1"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-2"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -151,10 +151,10 @@ DEFAULT_AWS_ACCOUNT_ID = "000000000000"
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 # If a structured access key ID is used, it must correspond to the account ID
-TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or "000000000001"
-TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "LSIAQAAAAAAAQAATEST1"
-TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test1"
-TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-west-2"
+TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
+TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
+TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
+TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION") or "us-east-1"
 
 # Additional credentials used in the test suite (when running cross-account tests)
 SECONDARY_TEST_AWS_ACCOUNT_ID = os.getenv("SECONDARY_TEST_AWS_ACCOUNT_ID") or "000000000002"

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -6,6 +6,7 @@ from localstack import config
 from localstack.aws.connect import connect_externally_to
 from localstack.aws.forwarder import AwsRequestProxy
 from localstack.config import is_env_true
+from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.dynamodb.packages import dynamodblocal_package
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.functions import run_safe
@@ -165,16 +166,19 @@ class DynamodbServer(Server):
         t.start()
         return t
 
-    def check_dynamodb(self, expect_shutdown: bool = False, print_error: bool = False) -> None:
+    def check_dynamodb(self, expect_shutdown: bool = False) -> None:
         """Checks if DynamoDB server is up"""
         out = None
 
         try:
             self.wait_is_up()
-            out = connect_externally_to(endpoint_url=self.url).dynamodb.list_tables()
+            out = connect_externally_to(
+                endpoint_url=self.url,
+                aws_access_key_id=DEFAULT_AWS_ACCOUNT_ID,
+                aws_secret_access_key=DEFAULT_AWS_ACCOUNT_ID,
+            ).dynamodb.list_tables()
         except Exception:
-            if print_error:
-                LOG.exception("DynamoDB health check failed")
+            LOG.exception("DynamoDB health check failed")
         if expect_shutdown:
             assert out is None
         else:


### PR DESCRIPTION
## Summary

It was observed that `test_time_to_live_deletion` would fail in non-default account/region setting (https://github.com/localstack/localstack/pull/8204), specifically the second of the below two assertions that it performs:

https://github.com/localstack/localstack/blob/75042c5c7feb0a3eafa2beea6cc30471e2b527a0/tests/aws/services/dynamodb/test_dynamodb.py#L127-L128

The first assertion would pass with HTTP 200 but for the second, the response value would be `''` cause JSON deserialisation error.

There were two root problems:

1. How `rolo` works. By default, if an invalid route is queried at the LocalStack endpoint, it returns an HTTP 200 with an empty response by default. See https://github.com/localstack/localstack/pull/10167 for details
2. Lack of credentials passed to `connect_externally_to()`: This is used when DDB Local is started to do a health check. Lack of explicit credentials meant that the factory would fallback to env values, which we are removing in https://github.com/localstack/localstack/pull/8204. Boto client creation would fail, causing the healthcheck to fail, which in turn prevented the custom routes from being registered.

https://github.com/localstack/localstack/blob/75042c5c7feb0a3eafa2beea6cc30471e2b527a0/localstack/services/dynamodb/provider.py#L472-L476

## Changes

- Pass dummy credentials (for now, just `000000000000`) to the `connect_externally_to()` usage. The client is only used to check if DDB returns a valid response, and we don't really care about the actual value.
- Minor refactoring so that DDB startup always prints error messages

## Tests

Changes were tested with non-default credentials, see commit 4da325ecffb7a373430b8de3b42fd75332f47a0f, where the `test_time_to_live_deletion` passes :green_circle: 