### PR TITLE
fix Kinesis rejection of log level

### DIFF
--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -147,10 +147,16 @@ class KinesisServerManager:
         if config.KINESIS_MOCK_LOG_LEVEL:
             log_level = config.KINESIS_MOCK_LOG_LEVEL.upper()
         elif config.LS_LOG:
-            if config.LS_LOG == "warning":
+            ls_log_level = config.LS_LOG.upper()
+            if ls_log_level == "WARNING":
                 log_level = "WARN"
+            elif ls_log_level == "TRACE-INTERNAL":
+                log_level = "TRACE"
+            elif ls_log_level not in ("ERROR", "WARN", "INFO", "DEBUG", "TRACE"):
+                # to protect from cases where the log level will be rejected from kinesis-mock
+                log_level = "INFO"
             else:
-                log_level = config.LS_LOG.upper()
+                log_level = ls_log_level
         else:
             log_level = "INFO"
         latency = config.KINESIS_LATENCY + "ms"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I encountered this issue today:
```bash
2024-02-01T16:10:06.933  INFO --- [functhread10] localstack.utils.run       : Restarting process (received exit code 1): ['node', PosixPath('/Users/benjaminsimon/Projects/localstack/localstack/.filesystem/var/lib/localstack/lib/kinesis-local/0.4.5/node_modules/kinesis-local/main.js')]
2024-02-01T16:10:06.933 DEBUG --- [functhread10] localstack.utils.run       : Executing command: ['node', PosixPath('/Users/benjaminsimon/Projects/localstack/localstack/.filesystem/var/lib/localstack/lib/kinesis-local/0.4.5/node_modules/kinesis-local/main.js')]
2024-02-01T16:10:07.026  INFO --- [functhread10] l.s.k.kinesis_mock_server  : ciris.ConfigException: configuration loading failed with the following errors.
2024-02-01T16:10:07.026  INFO --- [functhread10] l.s.k.kinesis_mock_server  : 
2024-02-01T16:10:07.026  INFO --- [functhread10] l.s.k.kinesis_mock_server  : - TRACE-INTERNAL is not a member of Enum (ERROR, WARN, INFO, DEBUG, TRACE).
2024-02-01T16:10:07.026  INFO --- [functhread10] l.s.k.kinesis_mock_server  : 
2024-02-01T16:10:07.026  INFO --- [functhread10] l.s.k.kinesis_mock_server  : <no stack trace available>
```

It seems we already had logic in place for this kind of issue with `warning` level.

<!-- What notable changes does this PR make? -->
## Changes
Added the `trace-internal` case and a fallback to `info` in case our log level is not in line with kinesis-mock ones. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

