### PR TITLE
Feature: Events: Add input transformers

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -610,6 +610,8 @@ def process_event_with_input_transformer(target: Dict, event: Dict) -> Dict:
         raise e
     for key, path in input_paths.items():
         value = extract_jsonpath(event, path)
+        if not value:
+            value = ""
         input_template = input_template.replace(f"<{key}>", value)
     templated_event = re.sub('"', "", input_template)
     return templated_event

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -602,8 +602,12 @@ def process_event_with_input_transformer(target: Dict, event: Dict) -> Dict:
     input_transformer = target.get("InputTransformer")
     if not input_transformer:
         return event
-    input_paths = input_transformer["InputPathsMap"]
-    input_template = input_transformer["InputTemplate"]
+    try:
+        input_paths = input_transformer["InputPathsMap"]
+        input_template = input_transformer["InputTemplate"]
+    except KeyError as e:
+        LOG.error("%s key does not exist in input_transformer.", e)
+        raise e
     for key, path in input_paths.items():
         value = extract_jsonpath(event, path)
         input_template = input_template.replace(f"<{key}>", value)

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -164,7 +164,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                     if target.get("InputPath"):
                         event = filter_event_with_target_input_path(target, event)
                     if target.get("InputTransformer"):
-                        event = filter_event_with_input_transformer(target, event)
+                        event = process_event_with_input_transformer(target, event)
 
                 attr = pick_attributes(target, ["$.SqsParameters", "$.KinesisParameters"])
 
@@ -593,7 +593,12 @@ def filter_event_with_target_input_path(target: Dict, event: Dict) -> Dict:
     return event
 
 
-def filter_event_with_input_transformer(target: Dict, event: Dict) -> Dict:
+def process_event_with_input_transformer(target: Dict, event: Dict) -> Dict:
+    """
+    Process the event with the input transformer of the target event,
+    by replacing the message with the populated InputTemplate.
+    docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html
+    """
     input_transformer = target.get("InputTransformer")
     if not input_transformer:
         return event
@@ -610,7 +615,7 @@ def process_events(event: Dict, targets: list[Dict]):
     for target in targets:
         arn = target["Arn"]
         changed_event = filter_event_with_target_input_path(target, event)
-        changed_event = filter_event_with_input_transformer(target, changed_event)
+        changed_event = process_event_with_input_transformer(target, changed_event)
         if target.get("Input"):
             changed_event = json.loads(target.get("Input"))
         try:

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -161,14 +161,14 @@ def put_events_with_filter_to_sqs(aws_client, sqs_get_queue_arn, clean_up):
         kwargs = {"InputPath": input_path} if input_path else {}
         if input_transformer:
             kwargs["InputTransformer"] = input_transformer
-        rs = events_client.put_targets(
+        response = events_client.put_targets(
             Rule=rule_name,
             EventBusName=bus_name,
             Targets=[{"Id": target_id, "Arn": queue_arn, **kwargs}],
         )
 
-        assert rs["FailedEntryCount"] == 0
-        assert rs["FailedEntries"] == []
+        assert response["FailedEntryCount"] == 0
+        assert response["FailedEntries"] == []
 
         try:
             messages = []

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -124,6 +124,7 @@ def put_events_with_filter_to_sqs(aws_client, sqs_get_queue_arn, clean_up):
         pattern: dict,
         entries_asserts: list[Tuple[list[dict], bool]],
         input_path: str = None,
+        input_transformer: dict[dict, str] = None,
     ):
         queue_name = f"queue-{short_uid()}"
         rule_name = f"rule-{short_uid()}"
@@ -158,6 +159,8 @@ def put_events_with_filter_to_sqs(aws_client, sqs_get_queue_arn, clean_up):
             EventPattern=json.dumps(pattern),
         )
         kwargs = {"InputPath": input_path} if input_path else {}
+        if input_transformer:
+            kwargs["InputTransformer"] = input_transformer
         rs = events_client.put_targets(
             Rule=rule_name,
             EventBusName=bus_name,

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -246,7 +246,7 @@ def _put_entries_assert_results_sqs(
 
     if should_match:
         actual_event = json.loads(messages[0]["Body"])
-        if "detail" in actual_event:
+        if isinstance(actual_event, dict) and "detail" in actual_event:
             assert_valid_event(actual_event)
         return messages
     else:

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -222,14 +222,14 @@ def _put_entries_assert_results_sqs(
     if should_match:
         actual_event = json.loads(messages[0]["Body"])
         if "detail" in actual_event:
-            _assert_valid_event(actual_event)
+            assert_valid_event(actual_event)
         return messages
     else:
         assert not messages
         return None
 
 
-def _assert_valid_event(event):
+def assert_valid_event(event):
     expected_fields = (
         "version",
         "id",
@@ -243,8 +243,3 @@ def _assert_valid_event(event):
     )
     for field in expected_fields:
         assert field in event
-
-
-@pytest.fixture
-def assert_valid_event():
-    yield _assert_valid_event

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -201,6 +201,19 @@ def put_events_with_filter_to_sqs(aws_client, sqs_get_queue_arn, clean_up):
 def _put_entries_assert_results_sqs(
     events_client, sqs_client, queue_url: str, entries: list[dict], should_match: bool
 ):
+    """
+    Put events to the event bus, receives the messages resulting from the event in the sqs queue and deletes them out of the queue.
+    If should_match is True, the content of the messages is asserted to be the same as the events put to the event bus.
+
+    :param events_client: boto3.client("events")
+    :param sqs_client: boto3.client("sqs")
+    :param queue_url: URL of the sqs queue
+    :param entries: List of entries to put to the event bus, each entry must
+                    be a dict that contains the keys: "Source", "DetailType", "Detail"
+    :param should_match:
+
+    :return: Messages from the queue if should_match is True, otherwise None
+    """
     response = events_client.put_events(Entries=entries)
     assert not response.get("FailedEntryCount")
 

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -25,6 +25,8 @@ from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
+from .conftest import assert_valid_event
+
 if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSClient
 
@@ -484,7 +486,6 @@ class TestEvents:
         self,
         monkeypatch,
         sns_subscription,
-        assert_valid_event,
         aws_client,
         clean_up,
         strategy,
@@ -546,7 +547,7 @@ class TestEvents:
     @markers.aws.unknown
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
     def test_put_events_into_event_bus(
-        self, monkeypatch, sqs_get_queue_arn, assert_valid_event, aws_client, clean_up, strategy
+        self, monkeypatch, sqs_get_queue_arn, aws_client, clean_up, strategy
     ):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", strategy)
 
@@ -608,7 +609,7 @@ class TestEvents:
 
     @markers.aws.unknown
     def test_put_events_with_target_lambda(
-        self, create_lambda_function, cleanups, assert_valid_event, aws_client, clean_up
+        self, create_lambda_function, cleanups, aws_client, clean_up
     ):
         rule_name = f"rule-{short_uid()}"
         function_name = f"lambda-func-{short_uid()}"
@@ -1001,7 +1002,7 @@ class TestEvents:
         assert "must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]" in message
 
     @markers.aws.unknown
-    def test_put_events_with_target_firehose(self, assert_valid_event, aws_client, clean_up):
+    def test_put_events_with_target_firehose(self, aws_client, clean_up):
         s3_bucket = "s3-{}".format(short_uid())
         s3_prefix = "testeventdata"
         stream_name = "firehose-{}".format(short_uid())
@@ -1108,7 +1109,7 @@ class TestEvents:
         assert "EventId" in response.get("Entries")[0]
 
     @markers.aws.unknown
-    def test_put_events_with_target_kinesis(self, assert_valid_event, aws_client):
+    def test_put_events_with_target_kinesis(self, aws_client):
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
@@ -1502,7 +1503,7 @@ class TestEvents:
 
     @markers.aws.validated
     @pytest.mark.xfail
-    def test_verify_rule_event_content(self, assert_valid_event, aws_client, clean_up):
+    def test_verify_rule_event_content(self, aws_client, clean_up):
         log_group_name = f"/aws/events/testLogGroup-{short_uid()}"
         rule_name = f"rule-{short_uid()}"
         target_id = f"testRuleId-{short_uid()}"
@@ -1553,7 +1554,6 @@ class TestEvents:
         create_policy,
         s3_bucket,
         snapshot,
-        assert_valid_event,
         aws_client,
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1981,8 +1981,12 @@ class TestEventsInputTransformers:
         ]
         entries_asserts = [(entries, True)]
         input_transformer = {
-            "InputPathsMap": {"detail-type": "$.detail-type"},
-            "InputTemplate": '"This event was of <detail-type> type."',
+            "InputPathsMap": {
+                "detail-type": "$.detail-type",
+                "timestamp": "$.time",
+                "command": "$.detail.command",
+            },
+            "InputTemplate": '"This event was of <detail-type> type, at time <timestamp>, with info extracted from detail <command>"',
         }
         messages = put_events_with_filter_to_sqs(
             pattern=pattern,

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -344,5 +344,18 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
+    "recorded-date": "01-02-2024, 19:30:48",
+    "recorded-content": {
+      "custom-variable": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"This event was of customerCreated type.\""
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -346,14 +346,22 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "recorded-date": "08-02-2024, 11:39:04",
+    "recorded-date": "08-02-2024, 12:06:09",
     "recorded-content": {
-      "custom-variable": [
+      "custom-variables-match-all": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"This event was of customerCreated type, at time date, with info extracted from detail display-message\""
+          "Body": "\"Event of customerCreated type, at time date, info extracted from detail display-message\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": "\"Event of customerCreated type, at time date, info extracted from detail \""
         }
       ]
     }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -346,14 +346,14 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "recorded-date": "01-02-2024, 19:30:48",
+    "recorded-date": "08-02-2024, 11:39:04",
     "recorded-content": {
       "custom-variable": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"This event was of customerCreated type.\""
+          "Body": "\"This event was of customerCreated type, at time date, with info extracted from detail display-message\""
         }
       ]
     }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -22,5 +22,8 @@
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_test_event_pattern": {
     "last_validated_date": "2023-07-05T17:41:16+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
+    "last_validated_date": "2024-02-01T19:30:48+00:00"
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -24,6 +24,6 @@
     "last_validated_date": "2023-07-05T17:41:16+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "last_validated_date": "2024-02-08T11:39:04+00:00"
+    "last_validated_date": "2024-02-08T12:06:09+00:00"
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -24,6 +24,6 @@
     "last_validated_date": "2023-07-05T17:41:16+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "last_validated_date": "2024-02-01T19:30:48+00:00"
+    "last_validated_date": "2024-02-08T11:39:04+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, EventBus does not support [Input Transformation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html) as mentioned in this #9918 feature request and requested by another customer. 

Input transformation allows for defining a custom template for the message body, that can be populated with up to 100 key-value pairs using JSON paths to reference values from the original message. This is used to customize the text from an event, before it is passed to the consumer specified by the respective rule. 

Input transformers are defined as InputPaths (JSON paths) and a InputTemplate string
```
{
    "InputPathsMap": {"detail-type": "$.detail-type"},
    "InputTemplate": '"This event was of <detail-type> type."',
}
```

<!-- What notable changes does this PR make? -->
## Changes
This PR adds a validated test for input transformation and the functionality for event bridge to add basic InputTransformers

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes



-->

