### PR TITLE
Stop DNS server on shutdown

### DIFF
--- a/localstack/dns/plugins.py
+++ b/localstack/dns/plugins.py
@@ -26,3 +26,13 @@ def setup_dns_configuration_on_host():
             server.setup_network_configuration()
     except Exception as e:
         LOG.warning("error setting up dns server: %s", e)
+
+
+@hooks.on_infra_shutdown()
+def stop_server():
+    try:
+        from localstack.dns import server
+
+        server.stop_servers()
+    except Exception as e:
+        LOG.warning("Unable to stop DNS servers: %s", e)

--- a/localstack/dns/plugins.py
+++ b/localstack/dns/plugins.py
@@ -5,6 +5,12 @@ from localstack.runtime import hooks
 
 LOG = logging.getLogger(__name__)
 
+# Note: Don't want to introduce a possible import order conflict by importing SERVICE_SHUTDOWN_PRIORITY
+# TODO: consider extracting these priorities into some static configuration
+DNS_SHUTDOWN_PRIORITY = -30
+"""Make sure the DNS server is shut down after the ON_AFTER_SERVICE_SHUTDOWN_HANDLERS, which in turn is after
+SERVICE_SHUTDOWN_PRIORITY. Currently this value needs to be less than -20"""
+
 
 @hooks.on_infra_start(priority=10)
 def start_dns_server():
@@ -28,7 +34,7 @@ def setup_dns_configuration_on_host():
         LOG.warning("error setting up dns server: %s", e)
 
 
-@hooks.on_infra_shutdown()
+@hooks.on_infra_shutdown(priority=DNS_SHUTDOWN_PRIORITY)
 def stop_server():
     try:
         from localstack.dns import server


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While looking through a hanging test I saw the DNS server was alive waiting on a `.join` call. This _may_ have contributed to incorrect test shutdown. Regardless, we do not shut the server down properly.


<!-- What notable changes does this PR make? -->
## Changes

Add a shutdown hook for the DNS server for clean termination.

Note: the priority of this hook must come after any hooks that use the gateway, which itself is shutdown with a priority of -20:

https://github.com/localstack/localstack/blob/bda6479827bf3bcf92a54d469588698187af6186/localstack/aws/serving/edge.py#L31-L35

in case DNS resolution is required for any requests using the gateway. The configuration of these priorities is brittle however. To prevent possible import problems I have not made `DNS_SHUTDOWN_PRIORITY` relative to other priorities, which would be more future proof. Instead, I have noted that the priority must be lower than the other priorities, but this may break in the future.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

