### PR TITLE
Update lambda init binary

### DIFF
--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -141,6 +141,8 @@ class ExecutionEnvironment:
             # 4) Internal LocalStack runtime API
             "LOCALSTACK_RUNTIME_ID": self.id,
             "LOCALSTACK_RUNTIME_ENDPOINT": self.runtime_executor.get_runtime_endpoint(),
+            # 5) Account of the function (necessary for extensions API)
+            "LOCALSTACK_FUNCTION_ACCOUNT_ID": self.function_version.id.account,
             # used by the init to spawn the x-ray daemon
             # LOCALSTACK_USER conditionally added below
         }

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.24-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.25-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.25-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.26-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We pulled upstream changes into our lambda init binary. (see https://github.com/localstack/lambda-runtime-init/pull/30).

We should now update the binary, and set the account id in the environment, so it can properly returned when the `Lambda-Extension-Accept-Feature` header is set to `accountId` during the extension register call (https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html#extensions-registration-api-a)

<!-- What notable changes does this PR make? -->
## Changes
* Update lambda init binary
* Set account id of function into execution environment

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

