### PR TITLE
Feature: Lambda: Add aws validated test for two lambdas subscribing to same kinensis event stream

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
@@ -124,6 +124,71 @@ class TestKinesisSource:
         assert int(math.log10(timestamp)) == 9
 
     @markers.aws.validated
+    def test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream(
+        self,
+        create_lambda_function,
+        kinesis_create_stream,
+        lambda_su_role,
+        wait_for_stream_ready,
+        cleanups,
+        snapshot,
+        aws_client,
+    ):
+        # create kinesis event stream
+        stream_name = f"test-stream-{short_uid()}"
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
+        wait_for_stream_ready(stream_name=stream_name)
+        stream_summary = aws_client.kinesis.describe_stream_summary(StreamName=stream_name)
+        assert stream_summary["StreamDescriptionSummary"]["OpenShardCount"] == 1
+        stream_arn = aws_client.kinesis.describe_stream(StreamName=stream_name)[
+            "StreamDescription"
+        ]["StreamARN"]
+
+        # create event source mapping for two lambda functions
+        function_a_name = f"lambda_func-{short_uid()}"
+        function_b_name = f"lambda_func-{short_uid()}"
+        functions = [(function_a_name, "a"), (function_b_name, "b")]
+        for function_name, function_id in functions:
+            create_lambda_function(
+                func_name=function_name,
+                handler_file=TEST_LAMBDA_PYTHON_ECHO,
+                runtime=Runtime.python3_9,
+                role=lambda_su_role,
+            )
+            create_event_source_mapping_response = aws_client.lambda_.create_event_source_mapping(
+                EventSourceArn=stream_arn,
+                FunctionName=function_name,
+                StartingPosition="TRIM_HORIZON",  # TODO: test with different starting positions
+            )
+            snapshot.match(
+                f"create_event_source_mapping_response-{function_id}",
+                create_event_source_mapping_response,
+            )
+            uuid = create_event_source_mapping_response["UUID"]
+            cleanups.append(lambda: aws_client.lambda_.delete_event_source_mapping(UUID=uuid))
+            _await_event_source_mapping_enabled(aws_client.lambda_, uuid)
+
+        # send messages to kinesis
+        record_data = "hello"
+        aws_client.kinesis.put_records(
+            Records=[{"Data": record_data, "PartitionKey": "test_1"}],
+            StreamName=stream_name,
+        )
+
+        # verify that both lambdas are invoked
+        for function_name, function_id in functions:
+            events = _get_lambda_invocation_events(
+                aws_client.logs, function_name, expected_num_events=1, retries=5
+            )
+            records = events[0]
+            snapshot.match(f"kinesis_records-{function_id}", records)
+            # check if the timestamp has the correct format
+            timestamp = events[0]["Records"][0]["kinesis"]["approximateArrivalTimestamp"]
+            # check if the timestamp has same amount of numbers before the comma as the current timestamp
+            # this will fail in november 2286, if this code is still around by then, read this comment and update to 10
+            assert int(math.log10(timestamp)) == 9
+
+    @markers.aws.validated
     def test_duplicate_event_source_mappings(
         self,
         create_lambda_function,
@@ -133,7 +198,6 @@ class TestKinesisSource:
         wait_for_stream_ready,
         snapshot,
         aws_client,
-        cleanups,
     ):
         function_name_1 = f"lambda_func-{short_uid()}"
         function_name_2 = f"lambda_func-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.py
@@ -130,7 +130,7 @@ class TestKinesisSource:
         kinesis_create_stream,
         lambda_su_role,
         wait_for_stream_ready,
-        cleanups,
+        create_event_source_mapping,
         snapshot,
         aws_client,
     ):
@@ -155,7 +155,7 @@ class TestKinesisSource:
                 runtime=Runtime.python3_9,
                 role=lambda_su_role,
             )
-            create_event_source_mapping_response = aws_client.lambda_.create_event_source_mapping(
+            create_event_source_mapping_response = create_event_source_mapping(
                 EventSourceArn=stream_arn,
                 FunctionName=function_name,
                 StartingPosition="TRIM_HORIZON",  # TODO: test with different starting positions
@@ -164,9 +164,6 @@ class TestKinesisSource:
                 f"create_event_source_mapping_response-{function_id}",
                 create_event_source_mapping_response,
             )
-            uuid = create_event_source_mapping_response["UUID"]
-            cleanups.append(lambda: aws_client.lambda_.delete_event_source_mapping(UUID=uuid))
-            _await_event_source_mapping_enabled(aws_client.lambda_, uuid)
 
         # send messages to kinesis
         record_data = "hello"

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.snapshot.json
@@ -1479,5 +1479,100 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
+    "recorded-date": "02-02-2024, 10:58:38",
+    "recorded-content": {
+      "create_event_source_mapping_response-a": {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:aws:kinesis:<region>:111111111111:stream/<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 0,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": -1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "create_event_source_mapping_response-b": {
+        "BatchSize": 100,
+        "BisectBatchOnFunctionError": false,
+        "DestinationConfig": {
+          "OnFailure": {}
+        },
+        "EventSourceArn": "arn:aws:kinesis:<region>:111111111111:stream/<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
+        "FunctionResponseTypes": [],
+        "LastModified": "datetime",
+        "LastProcessingResult": "No records processed",
+        "MaximumBatchingWindowInSeconds": 0,
+        "MaximumRecordAgeInSeconds": -1,
+        "MaximumRetryAttempts": -1,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "TRIM_HORIZON",
+        "State": "Creating",
+        "StateTransitionReason": "User action",
+        "TumblingWindowInSeconds": 0,
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "kinesis_records-a": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:<region>:111111111111:stream/<resource:1>",
+            "eventVersion": "1.0",
+            "invokeIdentityArn": "arn:aws:iam::111111111111:role/<resource:4>",
+            "kinesis": {
+              "approximateArrivalTimestamp": "timestamp",
+              "data": "aGVsbG8=",
+              "kinesisSchemaVersion": "1.0",
+              "partitionKey": "test_1",
+              "sequenceNumber": "<sequence-number:1>"
+            }
+          }
+        ]
+      },
+      "kinesis_records-b": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "eventID": "shardId-000000000000:<sequence-number:1>",
+            "eventName": "aws:kinesis:record",
+            "eventSource": "aws:kinesis",
+            "eventSourceARN": "arn:aws:kinesis:<region>:111111111111:stream/<resource:1>",
+            "eventVersion": "1.0",
+            "invokeIdentityArn": "arn:aws:iam::111111111111:role/<resource:4>",
+            "kinesis": {
+              "approximateArrivalTimestamp": "timestamp",
+              "data": "aGVsbG8=",
+              "kinesisSchemaVersion": "1.0",
+              "partitionKey": "test_1",
+              "sequenceNumber": "<sequence-number:1>"
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_integration_kinesis.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
     "last_validated_date": "2023-02-27T15:54:02+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping_multiple_lambdas_single_kinesis_event_stream": {
+    "last_validated_date": "2024-02-02T10:58:36+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
     "last_validated_date": "2023-02-27T15:59:49+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This snapshot test is added to remove questions about supported behavior differences between AWS and LocalStack, as requested by a user. Two lambda functions can be triggered by the same kinesis event stream, if the `StartingPosition="TRIM_HORIZON"` is correctly configured. 
`StartingPosition="LATEST"` does not reliably pick up every event from the subscribed stream. 
If a new subscribed lambda should not be triggered backward for all still existing events in the stream, `StartingPosition="AT_TIMESTAMP"` in combination with a valid timestamp is recommended. 


<!-- What notable changes does this PR make? -->
## Changes


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

