### PR TITLE
Invalid routes must return HTTP 404 Not Found

### DIFF
--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -38,7 +38,7 @@ def set_close_connection_header(_chain: HandlerChain, context: RequestContext, r
 
 
 class EdgeRouterHandler(RouterHandler):
-    def __init__(self, respond_not_found=False) -> None:
+    def __init__(self, respond_not_found=True) -> None:
         from localstack.services.edge import ROUTER
 
         super().__init__(ROUTER, respond_not_found)


### PR DESCRIPTION
## Summary

LocalStack has the `localstack.services.edge.ROUTER` object where custom endpoint handlers can be registered. This is used to add internal/debug/developer endpoints such as `/_aws/sqs/messages` or `/_aws/dynamodb/expired` which have higher eval precedance in the request handler chain.

The issue is that if an invalid endpoint is queried, LocalStack returns an HTTP 200:

```
$ curl -v localhost:4566/_aws/bad/endpoint
*   Trying 127.0.0.1:4566...
* Connected to localhost (127.0.0.1) port 4566 (#0)
> GET /_aws/bad/endpoint HTTP/1.1
> Host: localhost:4566
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200
< Content-Type: text/plain; charset=utf-8
< Connection: close
< Content-Length: 0
< date: Fri, 02 Feb 2024 12:38:22 GMT
< server: hypercorn-h11
<
* Closing connection 0
```

This makes it difficult to identify certain issues, eg. when a custom route fails to register during provider initialisation and the route still returns an HTTP 200.

## Changes

This PR sets the `respond_not_found` flag for the `EdgeRouterHandler` which wraps `ROUTER`. Now, querying an invalid endpoint will return an HTTP 404 as one would expect.

```
$ curl -v localhost:4566/_aws/bad/endpoint
*   Trying 127.0.0.1:4566...
* Connected to localhost (127.0.0.1) port 4566 (#0)
> GET /_aws/bad/endpoint HTTP/1.1
> Host: localhost:4566
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404
< Content-Type: text/plain; charset=utf-8
< Content-Length: 9
< Connection: close
< date: Fri, 02 Feb 2024 12:42:16 GMT
< server: hypercorn-h11
<
* Closing connection 0
not found
```