### PR TITLE
fix custom status code for lambda URLs

### DIFF
--- a/localstack/services/lambda_/urlrouter.py
+++ b/localstack/services/lambda_/urlrouter.py
@@ -192,6 +192,8 @@ def lambda_result_to_response(result: InvocationResult):
         # if it's a dict it might be a proper response
         if isinstance(parsed_result.get("headers"), dict):
             response.headers.update(parsed_result.get("headers"))
+        if "statusCode" in parsed_result:
+            response.status_code = int(parsed_result["statusCode"])
         if "body" not in parsed_result:
             # TODO: test if providing a status code but no body actually works
             response.data = original_payload

--- a/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
@@ -1,0 +1,24 @@
+"""
+Interprets the body of the lambda event as a JSON document and returns it. This allows you to
+dynamically simulate functions that look like::
+
+    def handler(event, context):
+        return {
+           "statusCode": 201,
+            "headers": {
+                "Content-Type": "application/json",
+                "My-Custom-Header": "Custom Value"
+            },
+            "body": json.dumps({
+                "message": "Hello, world!"
+            }),
+            "isBase64Encoded": False,
+        }
+"""
+import json
+
+
+def handler(event, context):
+    # Just print the event that was passed to the Lambda
+    print(json.dumps(event))
+    return json.loads(event["body"])

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -140,6 +140,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_echo_invoke": {
     "last_validated_date": "2023-11-20T21:05:40+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_headers_and_status": {
+    "last_validated_date": "2024-02-04T16:00:29+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[boolean]": {
     "last_validated_date": "2023-11-20T21:05:35+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes #8213. To easily test it, I also created a new test function that makes it easier to return custom bodies. Different lambda URL body interpretations can be found [here](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html).


<!-- What notable changes does this PR make? -->
## Changes

* LocalStack now correctly parses the `statusCode` attribute field when translating lambda responses

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

