### PR TITLE
add option to serve gateway through werkzeug

### DIFF
--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -39,8 +39,11 @@ def _serve_werkzeug(
 ):
     from werkzeug.serving import ThreadedWSGIServer
 
+    from .werkzeug import CustomWSGIRequestHandler
+
     params = {
         "app": WsgiGateway(gateway),
+        "handler": CustomWSGIRequestHandler,
     }
 
     if use_ssl:

--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -1,11 +1,15 @@
 import logging
+import threading
 from typing import List
 
+from rolo.gateway.wsgi import WsgiGateway
+
 from localstack import config
+from localstack.aws.app import LocalstackAwsGateway
 from localstack.config import HostAndPort
-from localstack.http.hypercorn import GatewayServer
 from localstack.runtime.shutdown import ON_AFTER_SERVICE_SHUTDOWN_HANDLERS
 from localstack.services.plugins import SERVICE_PLUGINS
+from localstack.utils.collections import ensure_list
 
 LOG = logging.getLogger(__name__)
 
@@ -17,9 +21,73 @@ def serve_gateway(
     Implementation of the edge.do_start_edge_proxy interface to start a Hypercorn server instance serving the
     LocalstackAwsGateway.
     """
-    from localstack.aws.app import LocalstackAwsGateway
 
     gateway = LocalstackAwsGateway(SERVICE_PLUGINS)
+
+    listens = ensure_list(listen)
+
+    if config.GATEWAY_SERVER == "hypercorn":
+        return _serve_hypercorn(gateway, listens, use_ssl, asynchronous)
+    elif config.GATEWAY_SERVER == "werkzeug":
+        return _serve_werkzeug(gateway, listens, use_ssl, asynchronous)
+    else:
+        raise ValueError(f"Unknown gateway server type {config.GATEWAY_SERVER}")
+
+
+def _serve_werkzeug(
+    gateway: LocalstackAwsGateway, listen: List[HostAndPort], use_ssl: bool, asynchronous: bool
+):
+    from werkzeug.serving import ThreadedWSGIServer
+
+    params = {
+        "app": WsgiGateway(gateway),
+    }
+
+    if use_ssl:
+        from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
+
+        install_predefined_cert_if_available()
+        serial_number = listen[0].port
+        _, cert_file_name, key_file_name = create_ssl_cert(serial_number=serial_number)
+        params["ssl_context"] = (cert_file_name, key_file_name)
+
+    threads = []
+    servers: List[ThreadedWSGIServer] = []
+
+    for host_port in listen:
+        kwargs = dict(params)
+        kwargs["host"] = host_port.host
+        kwargs["port"] = host_port.port
+        server = ThreadedWSGIServer(**kwargs)
+        servers.append(server)
+        threads.append(
+            threading.Thread(
+                target=server.serve_forever, name=f"werkzeug-server-{host_port.port}", daemon=True
+            )
+        )
+
+    def _shutdown_servers():
+        LOG.debug("[shutdown] Shutting down gateway servers")
+        for _srv in servers:
+            _srv.shutdown()
+
+    ON_AFTER_SERVICE_SHUTDOWN_HANDLERS.register(_shutdown_servers)
+
+    for thread in threads:
+        thread.start()
+
+    if not asynchronous:
+        for thread in threads:
+            return thread.join()
+
+    # FIXME: thread handling is a bit wonky
+    return threads[0]
+
+
+def _serve_hypercorn(
+    gateway: LocalstackAwsGateway, listen: List[HostAndPort], use_ssl: bool, asynchronous: bool
+):
+    from localstack.http.hypercorn import GatewayServer
 
     # start serving gateway
     server = GatewayServer(gateway, listen, use_ssl, config.GATEWAY_WORKER_COUNT)
@@ -33,8 +101,6 @@ def serve_gateway(
         server.shutdown()
 
     ON_AFTER_SERVICE_SHUTDOWN_HANDLERS.register(_shutdown_gateway)
-
     if not asynchronous:
         server.join()
-
     return server._thread

--- a/localstack/aws/serving/werkzeug.py
+++ b/localstack/aws/serving/werkzeug.py
@@ -1,10 +1,20 @@
+from typing import Any, Optional, Tuple
+
+from rolo.gateway import Gateway
+from rolo.gateway.wsgi import WsgiGateway
 from werkzeug import run_simple
 
-from ..gateway import Gateway
-from .wsgi import WsgiGateway
+from localstack import constants
 
 
-def serve(gateway: Gateway, host="localhost", port=4566, use_reloader=True, **kwargs) -> None:
+def serve(
+    gateway: Gateway,
+    host: str = "localhost",
+    port: int = constants.DEFAULT_PORT_EDGE,
+    use_reloader: bool = True,
+    ssl_creds: Optional[Tuple[Any, Any]] = None,
+    **kwargs,
+) -> None:
     """
     Serve a Gateway as a WSGI application through werkzeug. This is mostly for development purposes.
 
@@ -15,4 +25,5 @@ def serve(gateway: Gateway, host="localhost", port=4566, use_reloader=True, **kw
     :param kwargs: any other arguments that can be passed to `werkzeug.run_simple`
     """
     kwargs["threaded"] = kwargs.get("threaded", True)  # make sure requests don't block
+    kwargs["ssl_context"] = ssl_creds
     run_simple(host, port, WsgiGateway(gateway), use_reloader=use_reloader, **kwargs)

--- a/localstack/aws/serving/werkzeug.py
+++ b/localstack/aws/serving/werkzeug.py
@@ -31,6 +31,7 @@ def serve(
     """
     kwargs["threaded"] = kwargs.get("threaded", True)  # make sure requests don't block
     kwargs["ssl_context"] = ssl_creds
+    kwargs.setdefault("request_handler", CustomWSGIRequestHandler)
     run_simple(host, port, WsgiGateway(gateway), use_reloader=use_reloader, **kwargs)
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -657,8 +657,8 @@ def populate_edge_configuration(
 
 GATEWAY_WORKER_COUNT = int(os.environ.get("GATEWAY_WORKER_COUNT") or 1000)
 
-# the gateway server that should be used (supported: hypercorn, werkzeug)
-GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "werkzeug"
+# the gateway server that should be used (supported: hypercorn, dev: werkzeug)
+GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "hypercorn"
 
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -657,6 +657,9 @@ def populate_edge_configuration(
 
 GATEWAY_WORKER_COUNT = int(os.environ.get("GATEWAY_WORKER_COUNT") or 1000)
 
+# the gateway server that should be used (supported: hypercorn, werkzeug)
+GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "werkzeug"
+
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
 
@@ -1132,6 +1135,7 @@ CONFIG_ENV_VARS = [
     "EXTRA_CORS_ALLOWED_ORIGINS",
     "EXTRA_CORS_EXPOSE_HEADERS",
     "GATEWAY_LISTEN",
+    "GATEWAY_SERVER",
     "GATEWAY_WORKER_THREAD_COUNT",
     "HOSTNAME",
     "HOSTNAME_FROM_LAMBDA",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

There have been several situations in the recent past where we needed to figure out whether certain issues come from our Gateway or Hypercorn. Because we have no alternative way of serving the gateway other than hypercorn, this is very difficult. This PR does some refactoring and provides a first alternative: a werkzeug dev server, that can be activated by setting `GATEWAY_SERVER=werkzeug`.

The werkzeug dev server integration for now is mostly for testing/development purposes. With werkzeug there are also some expected test failures (websockets, anything streaming or HTTP2 related). So I wouldn't run a test suite on this regularly. Here's [a test run](https://app.circleci.com/pipelines/github/localstack/localstack/22651/workflows/3ab377f0-36b7-4bdd-a049-3491fe7716a5) showing the remaining failing tests. AFAICT all those are expected since they involve streaming or websockets, or they are making unnecessarily strict assumptions on headers. The `test_s3_get_response_case_sensitive_headers` should probably be removed since it uses and old variable from the `http2_server`.

It can be used to test whether some issues are related to hypercorn or not.

This is not something I would document right now or give to users, but can be useful for us internally for troubleshooting. The underlying refactoring also gives way to serious alternatives like twisted #9834.

<!-- What notable changes does this PR make? -->
## Changes

* The config now has a `GATEWAY_SERVER` variable that can be set to either `hypercorn` (default) or `werkzeug`.
* LocalStack can now be served through a werkzeug dev server


## Testing

start localstack with `GATEWAY_SERVER=werkzeug`

<!-- The following sections are optional, but can be useful! 
## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

