### PR TITLE
fix dynamodb router rule removal

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -477,8 +477,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
     def on_before_stop(self):
         self._expired_items_worker.stop()
-        for rule in self._router_rules:
-            ROUTER.remove_rule(rule)
+        ROUTER.remove(self._router_rules)
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(dynamodb_stores)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

shutdown hook of dynamodb was using an old API to remove rules from the router, leading to exceptions:

```
Traceback (most recent call last):
  File "/opt/code/localstack/localstack/utils/functions.py", line 41, in call_safe
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/localstack/services/dynamodb/provider.py", line 481, in on_before_stop
    ROUTER.remove_rule(rule)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'Router' object has no attribute 'remove_rule'
```


<!-- What notable changes does this PR make? -->
## Changes

* dynamodb routes are now removed using `ROUTER.remove`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

