### PR TITLE
add APIGW RequestParametersResolver support for context var

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -453,7 +453,7 @@ class RequestParametersResolver:
         for k, v in context.stage_variables.items():
             params[f"stagevariables.{k}"] = v
 
-        # TODO: add support for missing context variables
+        # TODO: add support for missing context variables, use `context.context` which contains most of the variables
         #  see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference
         #  - all `context.identity` fields
         #  - protocol
@@ -473,9 +473,11 @@ class RequestParametersResolver:
         auth_context_authorizer = context.auth_context.get("authorizer") or {}
         for k, v in auth_context_authorizer.items():
             if isinstance(v, bool):
-                params[f"context.authorizer.{k}"] = canonicalize_bool_to_str(v)
+                v = canonicalize_bool_to_str(v)
             elif is_number(v):
-                params[f"context.authorizer.{k}"] = str(v)
+                v = str(v)
+
+            params[f"context.authorizer.{k.lower()}"] = v
 
         if context.data:
             params["method.request.body"] = context.data

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
     "last_validated_date": "2024-01-10T00:06:10+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
+    "last_validated_date": "2024-02-05T19:37:03+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_delete_deployments[False]": {
     "last_validated_date": "2023-09-07T17:20:47+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1044,7 +1044,7 @@
           "statusCode": 200
         },
         "statusCode": 202
-      },
+      },x
       "response-template-400": {
         "body": {
           "body": "customerror",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1044,7 +1044,7 @@
           "statusCode": 200
         },
         "statusCode": 202
-      },x
+      },
       "response-template-400": {
         "body": {
           "body": "customerror",

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -795,6 +795,7 @@ class TestRequestParameterResolver:
                 "integration.request.querystring.env": "stageVariables.enviroment",
                 "integration.request.header.Content-Type": "'application/json'",
                 "integration.request.header.body-header": "method.request.body",
+                "integration.request.header.testContext": "context.authorizer.myvalue",
             }
         }
 
@@ -808,13 +809,18 @@ class TestRequestParameterResolver:
         context.path_params = {"id": "bar"}
         context.integration = integration
         context.stage_variables = {"enviroment": "dev"}
+        context.auth_context["authorizer"] = {"MyValue": 1}
         resolver = RequestParametersResolver()
         result = resolver.resolve(context)
 
         assert result == {
             "path": {"pathParam": "bar"},
             "querystring": {"baz": "test", "token": "Bearer 1234", "env": "dev"},
-            "headers": {"Content-Type": "application/json", "body-header": "spam_eggs"},
+            "headers": {
+                "Content-Type": "application/json",
+                "body-header": "spam_eggs",
+                "testContext": "1",
+            },
         }
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There was a #TODO for the RequestParametersResolver to properly resolve `context` variables to integration request parameters. 
This was also lacking for a customer use case with AppSync. 

https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-request-parameters

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference

<!-- What notable changes does this PR make? -->
## Changes
- added the context variable manually into the dict used for resolving integration request parameters (this can be revisited  later with the `context.context` variable and more logic into it)
- added an AWS validated test to check we're properly passing integration request parameters and resolving them

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

