### PR TITLE
skip flaky dynamodb streams test

### DIFF
--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams.py
@@ -1,6 +1,8 @@
 import json
 import re
 
+import pytest
+
 from localstack.constants import TEST_AWS_REGION_NAME
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.aws.util import is_aws_cloud
@@ -65,6 +67,7 @@ class TestDynamoDBStreams:
         # assert stream has been deleted
         retry(_assert_stream_deleted, sleep=0.4, retries=5)
 
+    @pytest.mark.skip(reason="Flaky")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..EncryptionType", "$..SizeBytes"])
     def test_enable_kinesis_streaming_destination(


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10143 introduced some new tests for DynamoDB Streams.
Unfortunately, it turned out that the test is pretty flaky, which is why we are skipping it for now.
For example:
- [CircleCI #177869](https://app.circleci.com/pipelines/github/localstack/localstack/22067/workflows/71a4c73b-6383-48eb-9bfb-e88b5476eeee/jobs/177869)
- [CircleCI #177580](https://app.circleci.com/pipelines/github/localstack/localstack/22041/workflows/3c98da8f-d1cc-4730-b0e4-26cbd1b51e1d/jobs/177580)

## Changes
- Skip `TestDynamoDBStreams::test_enable_kinesis_streaming_destination`