### PR TITLE
Handle analytics publishing errors more gracefully

### DIFF
--- a/localstack/utils/analytics/usage.py
+++ b/localstack/utils/analytics/usage.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import math
 from typing import Any
 
@@ -6,6 +7,8 @@ from localstack import config
 from localstack.utils.analytics import get_session_id
 from localstack.utils.analytics.events import Event, EventMetadata
 from localstack.utils.analytics.publisher import AnalyticsClientPublisher
+
+LOG = logging.getLogger(__name__)
 
 # Counters have to register with the registry
 collector_registry: dict[str, Any] = dict()
@@ -116,6 +119,9 @@ def aggregate_and_send():
     aggregated_payload = aggregate()
 
     publisher = AnalyticsClientPublisher()
-    publisher.publish(
-        [Event(name="ls:usage_analytics", metadata=metadata, payload=aggregated_payload)]
-    )
+    try:
+        publisher.publish(
+            [Event(name="ls:usage_analytics", metadata=metadata, payload=aggregated_payload)]
+        )
+    except Exception as e:
+        LOG.info("Unable to report analytics: %s", e)

--- a/localstack/utils/analytics/usage.py
+++ b/localstack/utils/analytics/usage.py
@@ -124,4 +124,5 @@ def aggregate_and_send():
             [Event(name="ls:usage_analytics", metadata=metadata, payload=aggregated_payload)]
         )
     except Exception as e:
-        LOG.info("Unable to report analytics: %s", e)
+        if config.DEBUG_ANALYTICS:
+            LOG.exception("Error while publishing analytics")


### PR DESCRIPTION
## Motivation

In a support channel, we've seen error stack trace related to SSL verification when connecting to the analytics service (can happen if the user is behind a corporate proxy/firewall).

This behavior can be reproduced by setting `analytics.localstack.cloud` to an invalid IP address (where the TLS certificate doesn't match our hostname), then shutting down the container:
```
$ DOCKER_FLAGS='--add-host analytics.localstack.cloud:1.1.1.1' DEBUG=1 localstack start
...
Ready.

[CTRL-C]
...
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/requests/adapters.py", line 517, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: MyHTTPSConnectionPool(host='analytics.localstack.cloud', port=443): Max retries exceeded with url: /v1/events (Caused by SSLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'analytics.localstack.cloud'. (_ssl.c:1006)")))
LocalStack supervisor: localstack process (PID 15) returned with exit code 0
```

These logs should not be presented to the user, and the error also causes the shutdown hooks not to be executed properly on shutdown in `stop_infra()`.

## Changes

Add a try/except block to catch the exception, and log it with an INFO log message.

Let me know if you'd like to see this covered with a test - happy to try and wire something up, if we think it could be useful.