### PR TITLE
fix disk space issues in GitHub workflow

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -82,6 +82,17 @@ jobs:
       CI_JOB_NAME: ${{ github.job }}
       CI_JOB_ID: ${{ github.job }}
     steps:
+      # TODO try to get rid of this again!
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          # reserve disk space on root for the Docker build
+          root-reserve-mb: 35840
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
       - name: Checkout Community
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -82,17 +82,6 @@ jobs:
       CI_JOB_NAME: ${{ github.job }}
       CI_JOB_ID: ${{ github.job }}
     steps:
-      # TODO try to get rid of this again!
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          # reserve disk space on root for the Docker build
-          root-reserve-mb: 35840
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-
       - name: Checkout Community
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Motivation
Recently, the Community Tests against Pro are failing somewhat regularly.
@maxhoheiser found out that they fail with an error message indicating that they are running out of disk space.
After a bit of analysis, it shows that there's a lot OpenSearch versions downloaded and cached. In order to mitigate these issues, I changed the tests a bit to avoid some OpenSearch versions to be downloaded.
If we hit the limit again, there's lot of potential in maximizing the disk space (f.e. with [easimon/maximize-build-space](https://github.com/easimon/maximize-build-space)).

## Changes
- Reduces the disk space being used by decreasing the number of OpenSearch versions being used in the tests.


## Testing
- The pipeline in question is now running stable again in this PR.
- I analyzed the cache storage logs of the following runs:
  - [Before the OpenSearch optimization: ~5553 MB](https://github.com/localstack/localstack/actions/runs/7802506071/job/21280116439)
  - [Afterwards: ~2401 MB](https://github.com/localstack/localstack/actions/runs/7805006599/job/21288220013)

## TODO
- [x] Optimize the workflow to get a proper run.
- [x] Analyze the run and see if we can optimize the tests instead of the environment.
- [x] Fix it!