### PR TITLE
Fix/multi account kinesis

### DIFF
--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -245,6 +245,7 @@ def _start_kcl_client_process(
     env_vars = {
         "AWS_CBOR_DISABLE": "true",
         "AWS_ACCESS_KEY_ID": account_id,
+        "AWS_SECRET_ACCESS_KEY": account_id,
     }
 
     events_file = os.path.join(tempfile.gettempdir(), f"kclipy.{short_uid()}.fifo")

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -8,7 +8,7 @@ from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
 from localstack import config, constants
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME, TEST_AWS_ACCOUNT_ID
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import resources

--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -8,7 +8,7 @@ from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
 from localstack import config, constants
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_REGION_NAME, TEST_AWS_ACCOUNT_ID
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.testing.pytest import markers
 from localstack.utils.aws import resources
@@ -465,7 +465,7 @@ class TestKinesisPythonClient:
         resources.create_kinesis_stream(kinesis, stream_name, delete=True)
         process = kinesis_connector.listen_to_kinesis(
             stream_name=stream_name,
-            account_id=TEST_AWS_ACCESS_KEY_ID,
+            account_id=TEST_AWS_ACCOUNT_ID,
             region_name=TEST_AWS_REGION_NAME,
             listener_func=process_records,
             wait_until_started=True,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes multi-account support for kinesis related tests. This is a follow-up PR for https://github.com/localstack/localstack/pull/9785. We have discovered that some of the changes made in https://github.com/localstack/localstack/pull/8204 were causing failure in test cases when running against [formatted-access-key-id-for-tests](https://github.com/localstack/localstack/tree/formatted-access-key-id-for-tests) branch.

<!-- What notable changes does this PR make? -->
## Changes
We have added `AWS_SECRET_ACCESS_KEY` additionally in the environment variable while running the KCL command. Since in the [original PR ](https://github.com/localstack/localstack/pull/9785) we have removed the function setting up access key and secret key globally.

## Testing
Added non-default account related changes in commit [f6c3fd](https://github.com/localstack/localstack/commit/a67f1f8520b999a0eb438aae73b3cda634809c3b).


## TODO

What's left to do:

- [ ] Let the CI run complete
- [ ] Revert the changes

