### PR TITLE
fixed multi account support for logs

### DIFF
--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -263,7 +263,9 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
 
     if role_arn:
         factory = connect_to.with_assumed_role(
-            role_arn=role_arn, service_principal=ServicePrincipal.logs
+            role_arn=role_arn,
+            service_principal=ServicePrincipal.logs,
+            region_name=arn_data["region"],
         )
     else:
         factory = connect_to(aws_access_key_id=arn_data["account"], region_name=arn_data["region"])
@@ -369,7 +371,9 @@ def moto_put_log_events(self: "MotoLogStream", log_events):
 
             if subscription_filter.role_arn:
                 factory = connect_to.with_assumed_role(
-                    role_arn=subscription_filter.role_arn, service_principal=ServicePrincipal.logs
+                    role_arn=subscription_filter.role_arn,
+                    service_principal=ServicePrincipal.logs,
+                    region_name=arn_data["region"],
                 )
             else:
                 factory = connect_to(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR fixes multi account support for logs.

<!-- What notable changes does this PR make? -->
## Changes
The region parameter was omitted when setting up a client with IAM roles. This Pull Request includes the missing region.


## Testing
This PR is tested using [this commit](https://github.com/localstack/localstack/commit/e40421532b141ab2827892ed2ed766e9cadc4d35) on CI


## TODO

What's left to do:

- [x] Community CI run with Non-Default Changes
- [x] Community CI run with Default Changes
- [x] Ext CI run with Default Changes

