### PR TITLE
APIGW: add more debug log when lambda proxy response format is wrong

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -219,7 +219,8 @@ class LambdaProxyIntegration(BackendIntegration):
         keys = parsed_result.keys()
         if "statusCode" not in keys or "body" not in keys:
             LOG.warning(
-                'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'
+                'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}\n Lambda output: %s',
+                parsed_result,
             )
             response.status_code = 502
             response._content = json.dumps({"message": "Internal server error"})
@@ -369,7 +370,8 @@ class LambdaProxyIntegration(BackendIntegration):
 
         if not ("statusCode" in keys and "body" in keys):
             LOG.warning(
-                'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'
+                'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}\n Lambda output: %s',
+                parsed_result,
             )
             response.status_code = 502
             response._content = json.dumps({"message": "Internal server error"})


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When a AWS_PROXY integration type with a lambda is used in API Gateway, the lambda must follow a specific format when responding. It's often a source of confusion when AWS Gateway returns `502` error. 
We would log the following line:
`2024-02-08T07:44:44.336  WARN --- [ asgi_gw_458] l.s.apigateway.integration : Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}`

But in this specific user case, it looked like I could not find a response anywhere in the logs and would like to see what we actually received.

This is the AWS documentation page specifying the format:
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format

<!-- What notable changes does this PR make? -->
## Changes
I would like to add to the logging line the actual payload returned, to understand why exactly the payload did not conform.
The lambda logs did not help a lot, and I'm not sure if in that case the issue is in lambda or APIGW. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

