### PR TITLE
Change AWS_EXECUTION_ENV set in the lambda init binary

### DIFF
--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -358,10 +358,11 @@ class DockerRuntimeExecutor(RuntimeExecutor):
                 self.container_name, f"{str(get_runtime_client_path())}/.", "/"
             )
             # tiny bit inefficient since we actually overwrite the init, but otherwise the path might not exist
-            if config.LAMBDA_INIT_DEBUG:
+            if config.LAMBDA_INIT_BIN_PATH:
                 CONTAINER_CLIENT.copy_into_container(
                     self.container_name, config.LAMBDA_INIT_BIN_PATH, "/var/rapid/init"
                 )
+            if config.LAMBDA_INIT_DEBUG:
                 CONTAINER_CLIENT.copy_into_container(
                     self.container_name, config.LAMBDA_INIT_DELVE_PATH, "/var/rapid/dlv"
                 )

--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -154,7 +154,7 @@ class ExecutionEnvironment:
         # config.handler is None for image lambdas and will be populated at runtime (e.g., by RIE)
         if self.function_version.config.handler:
             env_vars["_HANDLER"] = self.function_version.config.handler
-        # Not defined for custom runtimes (e.g., provided, provided.al2)
+        # Will be overriden by the runtime itself unless it is a provided runtime
         if self.function_version.config.runtime:
             env_vars["AWS_EXECUTION_ENV"] = "AWS_Lambda_rapid"
         if self.function_version.config.environment:

--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -156,7 +156,7 @@ class ExecutionEnvironment:
             env_vars["_HANDLER"] = self.function_version.config.handler
         # Not defined for custom runtimes (e.g., provided, provided.al2)
         if self.function_version.config.runtime:
-            env_vars["AWS_EXECUTION_ENV"] = f"Aws_Lambda_{self.function_version.config.runtime}"
+            env_vars["AWS_EXECUTION_ENV"] = "AWS_Lambda_rapid"
         if self.function_version.config.environment:
             env_vars.update(self.function_version.config.environment)
         if config.LAMBDA_INIT_DEBUG:

--- a/tests/aws/services/lambda_/functions/lambda_process_inspection.py
+++ b/tests/aws/services/lambda_/functions/lambda_process_inspection.py
@@ -3,6 +3,6 @@ def handler(event, context):
     with open(f"/proc/{pid}/environ", mode="rt") as f:
         environment = f.read()
     environment = environment.split("\x00")
-    environment = [env.partition("=") for env in environment if env]
-    environment = dict((env[0], env[2]) for env in environment)
-    return {"environment": environment}
+    env_partition = [env.partition("=") for env in environment if env]
+    env_dict = dict((env[0], env[2]) for env in env_partition)
+    return {"environment": env_dict}

--- a/tests/aws/services/lambda_/functions/lambda_process_inspection.py
+++ b/tests/aws/services/lambda_/functions/lambda_process_inspection.py
@@ -1,0 +1,8 @@
+def handler(event, context):
+    pid = event.get("pid")
+    with open(f"/proc/{pid}/environ", mode="rt") as f:
+        environment = f.read()
+    environment = environment.split("\x00")
+    environment = [env.partition("=") for env in environment if env]
+    environment = dict((env[0], env[2]) for env in environment)
+    return {"environment": environment}

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -699,21 +699,27 @@ class TestLambdaBehavior:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
+            "$..CreateFunctionResponse.LoggingConfig",
+            # not set directly on init in lambda, but only on runtime processes
             "$..Payload.environment.AWS_ACCESS_KEY_ID",
-            "$..Payload.environment.AWS_ENDPOINT_URL",
-            "$..Payload.environment.AWS_LAMBDA_FUNCTION_TIMEOUT",
             "$..Payload.environment.AWS_SECRET_ACCESS_KEY",
             "$..Payload.environment.AWS_SESSION_TOKEN",
             "$..Payload.environment.AWS_XRAY_DAEMON_ADDRESS",
-            "$..Payload.environment.EDGE_PORT",
+            # variables set by default in the image/docker
             "$..Payload.environment.HOME",
             "$..Payload.environment.HOSTNAME",
+            # LocalStack specific variables
+            "$..Payload.environment.AWS_ENDPOINT_URL",
+            "$..Payload.environment.AWS_LAMBDA_FUNCTION_TIMEOUT",
+            "$..Payload.environment.EDGE_PORT",
             "$..Payload.environment.LOCALSTACK_FUNCTION_ACCOUNT_ID",
             "$..Payload.environment.LOCALSTACK_HOSTNAME",
             "$..Payload.environment.LOCALSTACK_INIT_LOG_LEVEL",
             "$..Payload.environment.LOCALSTACK_RUNTIME_ENDPOINT",
             "$..Payload.environment.LOCALSTACK_RUNTIME_ID",
             "$..Payload.environment.LOCALSTACK_USER",
+            "$..Payload.environment.LOCALSTACK_POST_INVOKE_WAIT_MS",
+            # internal AWS lambda functionality
             "$..Payload.environment._AWS_XRAY_DAEMON_ADDRESS",
             "$..Payload.environment._LAMBDA_CONSOLE_SOCKET",
             "$..Payload.environment._LAMBDA_CONTROL_SOCKET",
@@ -747,9 +753,8 @@ class TestLambdaBehavior:
         create_result = create_lambda_function(
             func_name=func_name,
             handler_file=TEST_LAMBDA_PROCESS_INSPECTION,
-            runtime=Runtime.python3_11,
+            runtime=Runtime.python3_12,
             client=aws_client.lambda_,
-            timeout=1,
         )
         snapshot.match("create-result", create_result)
 

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3492,7 +3492,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
-    "recorded-date": "09-02-2024, 12:22:23",
+    "recorded-date": "13-02-2024, 12:42:59",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -3513,11 +3513,15 @@
           "FunctionName": "<function-name:1>",
           "Handler": "handler.handler",
           "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.11",
+          "Runtime": "python3.12",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
@@ -3528,7 +3532,7 @@
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
-          "Timeout": 1,
+          "Timeout": 30,
           "TracingConfig": {
             "Mode": "PassThrough"
           },

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3490,5 +3490,96 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
+    "recorded-date": "09-02-2024, 12:22:23",
+    "recorded-content": {
+      "create-result": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 1,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "lambda-init-inspection": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "environment": {
+            "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+            "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+            "_LAMBDA_TELEMETRY_API_PASSPHRASE": "<telemetry-passphrase:1>",
+            "LANG": "en_US.UTF-8",
+            "TZ": ":UTC",
+            "_HANDLER": "handler.handler",
+            "_LAMBDA_DIRECT_INVOKE_SOCKET": "9",
+            "_LAMBDA_CONTROL_SOCKET": "11",
+            "_LAMBDA_CONSOLE_SOCKET": "12",
+            "LAMBDA_TASK_ROOT": "/var/task",
+            "LAMBDA_RUNTIME_DIR": "/var/runtime",
+            "_LAMBDA_LOG_FD": "18",
+            "_LAMBDA_SB_ID": "0",
+            "_LAMBDA_SHARED_MEM_FD": "8",
+            "AWS_REGION": "<region>",
+            "AWS_DEFAULT_REGION": "<region>",
+            "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+            "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+            "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "128",
+            "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+            "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+            "_AWS_XRAY_DAEMON_PORT": "2000",
+            "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+            "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+            "_X_AMZN_TRACE_ID": "<xray-trace-id:1>",
+            "AWS_EXECUTION_ENV": "AWS_Lambda_rapid",
+            "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+            "_LAMBDA_RUNTIME_LOAD_TIME": "<runtime-load-time:1>"
+          }
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -27,7 +27,7 @@
     "last_validated_date": "2023-11-20T21:57:14+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
-    "last_validated_date": "2024-02-09T12:23:31+00:00"
+    "last_validated_date": "2024-02-13T12:42:58+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {
     "last_validated_date": "2023-11-20T21:04:53+00:00"

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -26,6 +26,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[python]": {
     "last_validated_date": "2023-11-20T21:57:14+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
+    "last_validated_date": "2024-02-09T12:23:31+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {
     "last_validated_date": "2023-11-20T21:04:53+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The lambda init binary should have the `AWS_EXECUTION_ENV` set to `AWS_Lambda_rapid`. The setting of the concrete value depending on the runtime will be done in `/var/runtime/bootstrap`, and is part of the lambda images.

Some extensions depend on that value being correct for checking what runtime is running (datadog).

Even though this is a parity adjustment, it is a quite significant change, so I labeled it minor for now.

<!-- What notable changes does this PR make? -->
## Changes
* Change execution env variable to `AWS_Lambda_rapid`
* Allow a custom init even if `LAMBDA_INIT_DEBUG` is not set
* Add test for introspection of the init process environment

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

