### PR TITLE
add automated Python requirements update

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -1,0 +1,13 @@
+name: Upgrade Pinned Python Dependencies
+
+on:
+  schedule:
+    - cron: 0 5 * * MON
+  workflow_dispatch:
+
+
+jobs:
+  upgrade-dependencies:
+    uses: localstack/meta/.github/workflows/upgrade-python-dependencies.yml@main
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation
#10127 introduced dependency pinning, and with #10195 we removed as many pins as possible.
Now we can use a shareable workflow by @silv-io in [localstack/meta](https://github.com/localstack/meta/blob/main/.github/workflows/upgrade-python-dependencies.yml) to automatically update the dependencies once a week using a scheduled GitHub workflow.

## Changes
- Adds a GitHub workflow to update the requirements files once a week.

## Testing
- This workflow has been tested in other repositories already, and it will be triggered manually once it has been merged to `master` (the workflow call trigger cannot be used as long as the workflow is not in `master`).