### PR TITLE
Restore DNS settings in container after dns server shuts down

### DIFF
--- a/localstack/dns/plugins.py
+++ b/localstack/dns/plugins.py
@@ -39,6 +39,7 @@ def stop_server():
     try:
         from localstack.dns import server
 
+        server.revert_network_configuration()
         server.stop_servers()
     except Exception as e:
         LOG.warning("Unable to stop DNS servers: %s", e)

--- a/localstack/dns/server.py
+++ b/localstack/dns/server.py
@@ -69,6 +69,7 @@ VERIFICATION_DOMAIN = config.DNS_VERIFICATION_DOMAIN
 RCODE_REFUSED = 5
 
 DNS_SERVER: "DnsServerProtocol" = None
+PREVIOUS_RESOLV_CONF_FILE: str | None = None
 
 REQUEST_TIMEOUT_SECS = 7
 
@@ -791,6 +792,7 @@ def get_available_dns_server():
 
 # ###### LEGACY METHODS ######
 def add_resolv_entry(file_path: Path | str = Path("/etc/resolv.conf")):
+    global PREVIOUS_RESOLV_CONF_FILE
     # never overwrite the host configuration without the user's permission
     if not in_docker():
         LOG.warning("Incorrectly attempted to alter host networking config")
@@ -805,11 +807,35 @@ def add_resolv_entry(file_path: Path | str = Path("/etc/resolv.conf")):
     )
     file_path = Path(file_path)
     try:
-        with file_path.open("w") as outfile:
-            print(content, file=outfile)
+        with file_path.open("r+") as outfile:
+            PREVIOUS_RESOLV_CONF_FILE = outfile.read()
+            outfile.seek(0)
+            outfile.write(content)
+            outfile.truncate()
     except Exception:
         LOG.warning(
             "Could not update container DNS settings", exc_info=LOG.isEnabledFor(logging.DEBUG)
+        )
+
+
+def revert_resolv_entry(file_path: Path | str = Path("/etc/resolv.conf")):
+    # never overwrite the host configuration without the user's permission
+    if not in_docker():
+        LOG.warning("Incorrectly attempted to alter host networking config")
+        return
+
+    if not PREVIOUS_RESOLV_CONF_FILE:
+        LOG.warning("resolv.conf file to restore not found.")
+        return
+
+    LOG.debug("Reverting container DNS config")
+    file_path = Path(file_path)
+    try:
+        with file_path.open("w") as outfile:
+            outfile.write(PREVIOUS_RESOLV_CONF_FILE)
+    except Exception:
+        LOG.warning(
+            "Could not revert container DNS settings", exc_info=LOG.isEnabledFor(logging.DEBUG)
         )
 
 
@@ -821,6 +847,16 @@ def setup_network_configuration():
     # add entry to /etc/resolv.conf
     if in_docker():
         add_resolv_entry()
+
+
+def revert_network_configuration():
+    # check if DNS is disabled
+    if not config.use_custom_dns():
+        return
+
+    # add entry to /etc/resolv.conf
+    if in_docker():
+        revert_resolv_entry()
 
 
 def start_server(upstream_dns: str, host: str, port: int = config.DNS_PORT):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently seeing failures due to DNS resolution issues on pytest session finish hooks in LS.
This is likely due to the shutdown of the DNS server after LS shuts down (which can happen before the last session finish hooks are executed).

After we stop the DNS server, we should restore the `resolv.conf` config to avoid all subsequent requests failing.

<!-- What notable changes does this PR make? -->
## Changes
* Cache and restore `resolv.conf` on DNS server start/stop.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

