### PR TITLE
Sqs fix message groups visibility

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -1021,7 +1021,7 @@ class FifoQueue(SqsQueue):
             # put the message into the group
             message_group.push(message)
 
-            # if an older message becomes visible again in the queue
+            # if an older message becomes visible again in the queue, that message's group becomes visible also.
             if message.receive_count < 1:
                 return
             if message_group in self.inflight_groups:

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -1086,7 +1086,8 @@ class FifoQueue(SqsQueue):
             self.inflight_groups.add(group)
 
             if group.empty():
-                # this can be the case if all messages of a group have been processed.
+                # this can be the case if all messages in the group are still invisible or
+                # if all messages of a group have been processed.
                 # TODO: it should be blocking until at least one message is in the queue, but we don't
                 #  want to block the group
                 # TODO: check behavior in case it happens if all messages were removed from a group due to message

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1154,7 +1154,7 @@ class TestSqsProvider:
         # try to delete the expired message
         aws_client.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_fifo_empty_message_groups_added_back_to_queue(
         self, sqs_create_queue, aws_sqs_client, snapshot
     ):

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1179,7 +1179,7 @@ class TestSqsProvider:
             QueueUrl=queue_url, ReceiptHandle=resp["Messages"][0]["ReceiptHandle"]
         )
 
-        # call receive on an empty message group, removing it from the message group queue
+        # call receive on the now empty message group
         resp = aws_sqs_client.receive_message(QueueUrl=queue_url)
         snapshot.match("empty-fifo-receive", resp)
 

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -2615,5 +2615,83 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
+    "recorded-date": "12-02-2024, 16:08:11",
+    "recorded-content": {
+      "inital-fifo-receive": {
+        "Messages": [
+          {
+            "Body": "Message 1",
+            "MD5OfBody": "68390233272823b7adf13a1db79b2cd7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty-fifo-receive": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "final-fifo-receive": {
+        "Messages": [
+          {
+            "Body": "Message 2",
+            "MD5OfBody": "88ef8f31ed540f1c4c03d5fdb06a7935",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs_json]": {
+    "recorded-date": "12-02-2024, 16:08:14",
+    "recorded-content": {
+      "inital-fifo-receive": {
+        "Messages": [
+          {
+            "Body": "Message 1",
+            "MD5OfBody": "68390233272823b7adf13a1db79b2cd7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "empty-fifo-receive": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "final-fifo-receive": {
+        "Messages": [
+          {
+            "Body": "Message 2",
+            "MD5OfBody": "88ef8f31ed540f1c4c03d5fdb06a7935",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -41,6 +41,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_message_with_expired_receipt_handle": {
     "last_validated_date": "2023-11-14T10:58:50+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
+    "last_validated_date": "2024-02-12T16:08:11+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs_json]": {
+    "last_validated_date": "2024-02-12T16:08:14+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_message_attributes": {
     "last_validated_date": "2023-11-14T10:58:35+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Users reported an issue with message groups becoming blocked when polling fifo queues. It turned out that a [recent change](https://github.com/localstack/localstack/pull/9975) that was generally correct had a side effect on empty message groups which we didn't consider.
The current implementation relies on removing message groups from the group queue when receiving until the queue is empty. We cannot iterate over the group queue, and it seems to be impractical to add the groups back when new messages arrive (since we then have to distinguish between empty groups due to all messages processed and empty groups due to invisible messages). Therefore this PR collects all empty groups on receive and adds them back to the group queue once the receive call is finished.
<!-- What notable changes does this PR make? -->
## Changes
- add  empty message groups back to the queue on receive.
- fixes #10107

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

