### PR TITLE
Add pipes service principal

### DIFF
--- a/localstack/utils/aws/client_types.py
+++ b/localstack/utils/aws/client_types.py
@@ -252,6 +252,7 @@ class ServicePrincipal(str):
     firehose = "firehose"
     lambda_ = "lambda"
     logs = "logs"
+    pipes = "pipes"
     s3 = "s3"
     sns = "sns"
     sqs = "sqs"


### PR DESCRIPTION
## Motivation

Required change for IAM implementation of EventBridge Pipes:

> To make API calls on the resources that you own, EventBridge Pipes needs appropriate permission. EventBridge Pipes uses the IAM role that you specify on the pipe for enrichment and target calls using the IAM principal `pipes.amazonaws.com`.
Source: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-permissions.html#pipes-perms-enhance-target 

## Changes

* Add pipes service principal

