### PR TITLE
Fix Lambda function alias name checks

### DIFF
--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -83,7 +83,7 @@ VERSION_REGEX = re.compile(r"^[0-9]+$")
 # Pattern for an alias qualifier
 # Rules: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html#SSS-CreateAlias-request-Name
 # The original regex from AWS misses ^ and $ in the second regex, which allowed for partial substring matches
-ALIAS_REGEX = re.compile(r"(?!^[0-9]+)(^[a-zA-Z0-9-_]+$)")
+ALIAS_REGEX = re.compile(r"(?!^[0-9]+$)(^[a-zA-Z0-9-_]+$)")
 # Permission statement id
 STATEMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9-_]+$")
 

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1513,6 +1513,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         routing_config: AliasRoutingConfiguration = None,
         **kwargs,
     ) -> AliasConfiguration:
+        if not api_utils.qualifier_is_alias(name):
+            raise ValidationException(
+                f"1 validation error detected: Value '{name}' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: (?!^[0-9]+$)([a-zA-Z0-9-_]+)"
+            )
+
         account_id, region = api_utils.get_account_and_region(function_name, context)
         function_name = api_utils.get_function_name(function_name, context)
         target_version = self._get_function_version(

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -1636,6 +1636,54 @@ class TestLambdaAlias:
             )
         snapshot.match("alias_does_not_exist_esc", e.value.response)
 
+    @markers.aws.unknown
+    def test_alias_naming(self, aws_client, snapshot, create_lambda_function_aws, lambda_su_role):
+        """
+        numbers can be included and can even start the alias name, but it can't be purely a number
+        """
+        function_name = f"alias-fn-{short_uid()}"
+        create_response = create_lambda_function_aws(
+            FunctionName=function_name,
+            Handler="index.handler",
+            Code={
+                "ZipFile": create_lambda_archive(
+                    load_file(TEST_LAMBDA_PYTHON_ECHO), get_content=True
+                )
+            },
+            PackageType="Zip",
+            Role=lambda_su_role,
+            Runtime=Runtime.python3_9,
+            Environment={"Variables": {"testenv": "staging"}},
+        )
+        snapshot.match("create_response", create_response)
+
+        publish_v1 = aws_client.lambda_.publish_version(FunctionName=function_name)
+        snapshot.match("publish_v1", publish_v1)
+
+        # alias in date format
+        alias_name = "2024-01-02"
+        create_alias_date = aws_client.lambda_.create_alias(
+            FunctionName=function_name,
+            Name=alias_name,
+            FunctionVersion="1",
+            Description="custom-alias",
+        )
+        snapshot.match("create_alias_date", create_alias_date)
+        get_alias_date = aws_client.lambda_.get_alias(FunctionName=function_name, Name=alias_name)
+        snapshot.match("get_alias_date", get_alias_date)
+        aws_client.lambda_.invoke(FunctionName=f"{function_name}:{alias_name}")
+
+        # alias as a number should fail
+        alias_name_number = "2024"
+        with pytest.raises(aws_client.lambda_.exceptions.ClientError) as e:
+            aws_client.lambda_.create_alias(
+                FunctionName=function_name,
+                Name=alias_name_number,
+                FunctionVersion="1",
+                Description="custom-alias",
+            )
+        snapshot.match("create_alias_number_exception", e.value.response)
+
 
 class TestLambdaRevisions:
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -1636,7 +1636,8 @@ class TestLambdaAlias:
             )
         snapshot.match("alias_does_not_exist_esc", e.value.response)
 
-    @markers.aws.unknown
+    @markers.snapshot.skip_snapshot_verify(paths=["$..LoggingConfig"])
+    @markers.aws.validated
     def test_alias_naming(self, aws_client, snapshot, create_lambda_function_aws, lambda_su_role):
         """
         numbers can be included and can even start the alias name, but it can't be purely a number

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13630,5 +13630,137 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_naming": {
+    "recorded-date": "13-02-2024, 08:44:31",
+    "recorded-content": {
+      "create_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "testenv": "staging"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "publish_v1": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "testenv": "staging"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create_alias_date": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:2024-01-02",
+        "Description": "custom-alias",
+        "FunctionVersion": "1",
+        "Name": "2024-01-02",
+        "RevisionId": "<uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_alias_date": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:2024-01-02",
+        "Description": "custom-alias",
+        "FunctionVersion": "1",
+        "Name": "2024-01-02",
+        "RevisionId": "<uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_alias_number_exception": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '2024' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: (?!^[0-9]+$)([a-zA-Z0-9-_]+)"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -17,6 +17,9 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_lifecycle": {
     "last_validated_date": "2023-11-20T15:57:06+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_alias_naming": {
+    "last_validated_date": "2024-02-13T08:47:11+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
     "last_validated_date": "2023-11-20T15:57:21+00:00"
   },

--- a/tests/unit/services/lambda_/test_api_utils.py
+++ b/tests/unit/services/lambda_/test_api_utils.py
@@ -60,6 +60,8 @@ class TestApiUtils:
     def test_qualifier_is_alias(self):
         assert qualifier_is_alias("abczABCZ")
         assert qualifier_is_alias("a01239")
-        assert not qualifier_is_alias("1numeric")
+        assert qualifier_is_alias("1numeric")
+        assert qualifier_is_alias("2024-01-01")
+        assert not qualifier_is_alias("20240101")
         assert not qualifier_is_alias("invalid-with-$-char")
         assert not qualifier_is_alias("invalid-with-?-char")


### PR DESCRIPTION
## Motivation

A user reported an issue where invoking a lambda with an alias like `2024-01-01` would fail.

## Changes

- Introduce test covering both a valid case like `2024-01-01` and invalid one like `2024`
- Fix the alias regex we're using to check if a qualifier is an alias or not
- Add a check to the `create_alias` method. In the reported case, the alias was created but we only checked the regex on invoke which then failed to resolve the proper alias.

