### PR TITLE
S3: Remove use of test credentials in provider

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1447,7 +1447,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
         # TODO: signature validation is not implemented for pre-signed POST
         # policy validation is not implemented either, except expiration and mandatory fields
-        validate_post_policy(context.request.form)
+        validate_post_policy(context)
 
         # Botocore has trouble parsing responses with status code in the 3XX range, it interprets them as exception
         # it then raises a nonsense one with a wrong code

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3621,8 +3621,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # parsing here, as no specs are present for this, as no client directly implements this operation.
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
+        validate_post_policy(context)
         form = context.request.form
-        validate_post_policy(form)
 
         fileobj = context.request.files["file"]
         object_key = context.request.form.get("key")


### PR DESCRIPTION
## Background

Certain functionality in S3 use the test variables.

Test variables (`localstack.constants.TEST_*`) must not be used outside of tests.

## Changes

- Replace use of `TEST_AWS_ACCESS_KEY_ID` and `TEST_AWS_SECRET_ACCESS_KEY` with request account ID