### PR TITLE
Implement dynamodb TimeToLive in cloudformation

### DIFF
--- a/localstack/services/dynamodb/resource_providers/aws_dynamodb_table.py
+++ b/localstack/services/dynamodb/resource_providers/aws_dynamodb_table.py
@@ -231,12 +231,6 @@ class DynamoDBTableProvider(ResourceProvider[DynamoDBTableProperties]):
                     **self.get_ddb_kinesis_stream_specification(model)
                 )
 
-            if model.get("TimeToLiveSpecification"):
-                request.aws_client_factory.dynamodb.update_time_to_live(
-                    TableName=model["TableName"],
-                    TimeToLiveSpecification=model["TimeToLiveSpecification"],
-                )
-
             return ProgressEvent(
                 status=OperationStatus.IN_PROGRESS,
                 resource_model=model,
@@ -252,6 +246,12 @@ class DynamoDBTableProvider(ResourceProvider[DynamoDBTableProperties]):
                 status=OperationStatus.IN_PROGRESS,
                 resource_model=model,
                 custom_context=request.custom_context,
+            )
+
+        if model.get("TimeToLiveSpecification"):
+            request.aws_client_factory.dynamodb.update_time_to_live(
+                TableName=model["TableName"],
+                TimeToLiveSpecification=model["TimeToLiveSpecification"],
             )
 
         if description["Table"].get("LatestStreamArn"):

--- a/localstack/services/dynamodb/resource_providers/aws_dynamodb_table.py
+++ b/localstack/services/dynamodb/resource_providers/aws_dynamodb_table.py
@@ -231,6 +231,12 @@ class DynamoDBTableProvider(ResourceProvider[DynamoDBTableProperties]):
                     **self.get_ddb_kinesis_stream_specification(model)
                 )
 
+            if model.get("TimeToLiveSpecification"):
+                request.aws_client_factory.dynamodb.update_time_to_live(
+                    TableName=model["TableName"],
+                    TimeToLiveSpecification=model["TimeToLiveSpecification"],
+                )
+
             return ProgressEvent(
                 status=OperationStatus.IN_PROGRESS,
                 resource_model=model,

--- a/tests/aws/cdk_templates/DDBTableTTL/DDBStackTTL.json
+++ b/tests/aws/cdk_templates/DDBTableTTL/DDBStackTTL.json
@@ -1,0 +1,35 @@
+{
+  "Resources": {
+    "TableCD117FA1": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "expire_at",
+          "Enabled": true
+        }
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain"
+    }
+  },
+  "Outputs": {
+    "TableName": {
+      "Value": {
+        "Ref": "TableCD117FA1"
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
@@ -188,7 +188,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_ttl_cdk": {
-    "recorded-date": "13-02-2024, 22:58:14",
+    "recorded-date": "14-02-2024, 13:29:07",
     "recorded-content": {
       "table": {
         "TimeToLiveDescription": {

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.snapshot.json
@@ -186,5 +186,20 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_ttl_cdk": {
+    "recorded-date": "13-02-2024, 22:58:14",
+    "recorded-content": {
+      "table": {
+        "TimeToLiveDescription": {
+          "AttributeName": "expire_at",
+          "TimeToLiveStatus": "ENABLED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.validation.json
@@ -10,5 +10,8 @@
   },
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_global_table": {
     "last_validated_date": "2023-12-01T11:54:13+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_ttl_cdk": {
+    "last_validated_date": "2024-02-13T22:58:14+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_dynamodb.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_dynamodb.validation.json
@@ -12,6 +12,6 @@
     "last_validated_date": "2023-12-01T11:54:13+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_dynamodb.py::test_ttl_cdk": {
-    "last_validated_date": "2024-02-13T22:58:14+00:00"
+    "last_validated_date": "2024-02-14T13:29:07+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With https://github.com/localstack/localstack/pull/10041 we recently introduced the TTL in DynamoDB.
While working on a platform test today @lukqw noticed that this feature was not working when deploying a DDB table with cdk. To enable TTL in DDB you would first create the table with the `CreateTable` operation and then call the `UpdateTimeToLive` operation to enable the feature and specify the attribute name.
The `AWS::DynamoDB::Table` template has a `TimeToLiveSpecification` attribute that carries the same payload we would pass to `UpdateTimeToLive`. However, we were not reading this attribute and performing the additional call in our `DynamoDBTableProvider`.

<!-- What notable changes does this PR make? -->
## Changes
- We implemented the missing logic in the `DynamoDBTableProvider` cloudformation provider. We read the eventual `TimeToLiveSpecification` and eventually make a `UpdateTimeToLive` call.
- We added a verified cdk-based test with the same configuration as the platform test that let surface the issue.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

