### PR TITLE
Lambda: Fix test_cross_account_access flakes

### DIFF
--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1510,6 +1510,14 @@ class TestLambdaMultiAccounts:
     def test_cross_account_access(
         self, primary_client, secondary_client, create_lambda_function, dummylayer
     ):
+        # TODO: AWS validate this test
+        # As of 2024-02, AWS restricts the input for adding resource-based policy to layer versions via AddLayerVersionPermission.
+        # Only 'lambda:GetLayerVersion' is accepted for Action.
+        # https://github.com/boto/botocore/blob/cf7b8449643187670620ab699596ca785e3ec889/botocore/data/lambda/2015-03-31/service-2.json#L3906-L3909
+        # This appears to have been the case atleast since 2021-06.
+        # Furthermore this contradicts with what its docs on valid IAM actions for layer versions:
+        # https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html#permissions-resources-layers
+
         # Create resources using primary test credentials
         func_name = f"func-{short_uid()}"
         func_arn = create_lambda_function(

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1596,14 +1596,14 @@ class TestLambdaMultiAccounts:
 
         assert secondary_client.delete_function_concurrency(FunctionName=func_arn)
 
-        alias_name = short_uid()
+        alias_name = f"alias-{short_uid()}"
         assert secondary_client.create_alias(
             FunctionName=func_arn, FunctionVersion="$LATEST", Name=alias_name
         )
 
         assert secondary_client.get_alias(FunctionName=func_arn, Name=alias_name)
 
-        alias_description = "blyat"
+        alias_description = f"alias-description-{short_uid()}"
         assert secondary_client.update_alias(
             FunctionName=func_arn, Name=alias_name, Description=alias_description
         )


### PR DESCRIPTION
## Background

The test `TestLambdaMultiAccounts:test_cross_account_access` would fail if `short_uid()` returned a value consisting entirely of digits. This failed Boto input validation for `AliasName`

## Changes

- Make sure `AliasName` contains alphabets
- Adds a note that prevented me from AWS validating the test. Is this a bug in AWS? Did this go unnoticed for three years? Not sure