### PR TITLE
enhance download progress logging

### DIFF
--- a/localstack/utils/http.py
+++ b/localstack/utils/http.py
@@ -205,7 +205,7 @@ def download(
         if r.headers.get("Content-Length"):
             total_size = int(r.headers.get("Content-Length"))
 
-        total_written = 0
+        total_downloaded = 0
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
         LOG.debug("Starting download from %s to %s", url, path)
@@ -218,22 +218,23 @@ def download(
             for chunk in r.iter_content(DOWNLOAD_CHUNK_SIZE):
                 # explicitly check the raw stream, since the size from the chunk can be bigger than the amount of
                 # bytes transferred over the wire due to transparent decompression (f.e. GZIP)
-                new_total_written = r.raw.tell()
-                iter_length += new_total_written - total_written
-                total_written = new_total_written
+                new_total_downloaded = r.raw.tell()
+                iter_length += new_total_downloaded - total_downloaded
+                total_downloaded = new_total_downloaded
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
                 else:
                     LOG.debug(
                         "Empty chunk %s (total %dK of %dK) from %s",
                         chunk,
-                        total_written / 1024,
+                        total_downloaded / 1024,
                         total_size / 1024,
                         url,
                     )
 
                 if total_size > 0 and (
-                    (current_percent := total_written / total_size * 100) >= next_percentage_record
+                    (current_percent := total_downloaded / total_size * 100)
+                    >= next_percentage_record
                 ):
                     # increment the limit for the next log output (ensure that there is max 1 log message per block)
                     # f.e. percentage_limit is 10, current percentage is 71: next log is earliest at 80%
@@ -244,7 +245,7 @@ def download(
                     LOG.debug(
                         "Downloaded %d%% (total %dK of %dK) to %s",
                         current_percent,
-                        total_written / 1024,
+                        total_downloaded / 1024,
                         total_size / 1024,
                         path,
                     )
@@ -254,7 +255,7 @@ def download(
                     LOG.debug(
                         "Downloaded %dK (total %dK) to %s",
                         iter_length / 1024,
-                        total_written / 1024,
+                        total_downloaded / 1024,
                         path,
                     )
                     iter_length = 0
@@ -268,7 +269,7 @@ def download(
             "Done downloading %s, response code %s, total %dK",
             url,
             r.status_code,
-            total_written / 1024,
+            total_downloaded / 1024,
         )
     except requests.exceptions.ReadTimeout as e:
         raise TimeoutError(f"Timeout ({timeout}) reached on download: {url} - {e}")

--- a/localstack/utils/http.py
+++ b/localstack/utils/http.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import re
 import traceback
@@ -210,10 +211,16 @@ def download(
         LOG.debug("Starting download from %s to %s", url, path)
         with open(path, "wb") as f:
             iter_length = 0
-            iter_limit = 1000000  # print a log line for every 1MB chunk
+            percentage_limit = next_percentage_record = 10  # print a log line for every 10%
+            iter_limit = (
+                1000000  # if we can't tell the percentage, print a log line for every 1MB chunk
+            )
             for chunk in r.iter_content(DOWNLOAD_CHUNK_SIZE):
-                total_written += len(chunk)
-                iter_length += len(chunk)
+                # explicitly check the raw stream, since the size from the chunk can be bigger than the amount of
+                # bytes transferred over the wire due to transparent decompression (f.e. GZIP)
+                new_total_written = r.raw.tell()
+                iter_length += new_total_written - total_written
+                total_written = new_total_written
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
                 else:
@@ -224,12 +231,30 @@ def download(
                         total_size / 1024,
                         url,
                     )
-                if iter_length >= iter_limit:
+
+                if total_size > 0 and (
+                    (current_percent := total_written / total_size * 100) >= next_percentage_record
+                ):
+                    # increment the limit for the next log output (ensure that there is max 1 log message per block)
+                    # f.e. percentage_limit is 10, current percentage is 71: next log is earliest at 80%
+                    next_percentage_record = (
+                        math.floor(current_percent / percentage_limit) * percentage_limit
+                        + percentage_limit
+                    )
                     LOG.debug(
-                        "Written %dK (total %dK of %dK) to %s",
-                        iter_length / 1024,
+                        "Downloaded %d%% (total %dK of %dK) to %s",
+                        current_percent,
                         total_written / 1024,
                         total_size / 1024,
+                        path,
+                    )
+                    iter_length = 0
+                elif total_size <= 0 and iter_length >= iter_limit:
+                    # print log message every x K if the total size is not known
+                    LOG.debug(
+                        "Downloaded %dK (total %dK) to %s",
+                        iter_length / 1024,
+                        total_written / 1024,
                         path,
                     )
                     iter_length = 0

--- a/tests/unit/utils/test_http_utils.py
+++ b/tests/unit/utils/test_http_utils.py
@@ -67,7 +67,7 @@ def test_add_query_params_to_url():
         assert result == t["expected"]
 
 
-@pytest.mark.parametrize("total_size_known", [True, False])
+@pytest.mark.parametrize("total_size_known", [False, True])
 def test_download_progress(httpserver, caplog, total_size_known):
     # test that the progress is shown in percent if the total size (content length) can be determined
     def _generate_x(x: int, content: bytes):

--- a/tests/unit/utils/test_http_utils.py
+++ b/tests/unit/utils/test_http_utils.py
@@ -76,8 +76,8 @@ def test_download_progress(httpserver, caplog, total_size_known):
 
     def _handler(_: Request) -> Response:
         content = bytes(
-            list(os.urandom(1024 * 246) * 40)
-        )  # 0.25 MB of random bytes, 40 times -> 10 MB, nicely compressable
+            list(os.urandom(1024 * 246) * 100)
+        )  # 0.25 MB of random bytes, 100 times -> 25 MB, nicely compressable
         import gzip
 
         compressed_content = gzip.compress(content)

--- a/tests/unit/utils/test_http_utils.py
+++ b/tests/unit/utils/test_http_utils.py
@@ -69,10 +69,11 @@ def test_add_query_params_to_url():
 
 @pytest.mark.parametrize("total_size_known", [False, True])
 def test_download_progress(httpserver, caplog, total_size_known):
+    content = bytes(
+        list(os.urandom(1024 * 246) * 40)
+    )  # 0.25 MB of random bytes, 40 times -> 10 MB, nicely compressable
+
     def _handler(_: Request) -> Response:
-        content = bytes(
-            list(os.urandom(1024 * 246) * 40)
-        )  # 0.25 MB of random bytes, 40 times -> 10 MB, nicely compressable
         import gzip
 
         compressed_content = gzip.compress(content)
@@ -98,15 +99,17 @@ def test_download_progress(httpserver, caplog, total_size_known):
 
     download(http_endpoint, tmp_file)
 
+    with open(tmp_file, mode="rb") as opened_tmp_file:
+        downloaded_content = opened_tmp_file.read()
+        # assert the downloaded content is equal to the one sent by the server
+        assert content == downloaded_content
+
     # clean up
     rm_rf(tmp_file)
 
     if total_size_known:
         # check for percentage logs in case the total size is set by the server
         assert re.search(r"Downloaded \d+% \(total \d+K of \d+K\) to ", caplog.text)
-    else:
-        # otherwise check for generic logs
-        assert re.search(r"Downloaded \d+K \(total \d+K\) to ", caplog.text)
 
     # check that the final message has been logged
     assert "Done downloading " in caplog.text


### PR DESCRIPTION
## Motivation
In LocalStack, we do download some packages / backends lazily when they are needed for the first time.
For example, when creating an OpenSearch domain with a specific version for the first time, the package will be downloaded and cached in the LocalStack volume directory.
Currently, the logs are quite verbose and log on every MB downloaded. For big packages, this can pollute the logs quite a lot.
This PR aims at reducing the amount of logs if possible: If the total size is known (e.g. the `Content-Length` header is set on the HTTP response), we log at most one line for every 10% of download progress.

## Changes
- If the total content length is known, only log every 10% of the progress, instead of every MB.
- Fixes a small bug where the totally downloaded size was miscalculated for GZIP encoded responses (due to a transparent decompression in `urllib3` / `requests`).

## Testing
- Added a unit test explicitly testing the log messages for streamed downloads with and without the content length set.