### PR TITLE
Load new resource providers by default if available and fall back to legacy models 

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -50,146 +50,6 @@ Properties = TypeVar("Properties")
 
 PUBLIC_REGISTRY: dict[str, Type[ResourceProvider]] = {}
 
-# by default we use the GenericBaseModel (the legacy model), unless the resource is listed below
-# add your new provider here when you want it to be the default
-PROVIDER_DEFAULTS = {
-    "AWS::ApiGateway::Account": "ResourceProvider",
-    "AWS::ApiGateway::ApiKey": "ResourceProvider",
-    "AWS::ApiGateway::Authorizer": "ResourceProvider",
-    "AWS::ApiGateway::BasePathMapping": "ResourceProvider",
-    "AWS::ApiGateway::Deployment": "ResourceProvider",
-    "AWS::ApiGateway::DomainName": "ResourceProvider",
-    "AWS::ApiGateway::GatewayResponse": "ResourceProvider",
-    "AWS::ApiGateway::Method": "ResourceProvider",
-    "AWS::ApiGateway::Model": "ResourceProvider",
-    "AWS::ApiGateway::RequestValidator": "ResourceProvider",
-    "AWS::ApiGateway::Resource": "ResourceProvider",
-    "AWS::ApiGateway::RestApi": "ResourceProvider",
-    "AWS::ApiGateway::Stage": "ResourceProvider",
-    "AWS::ApiGateway::UsagePlan": "ResourceProvider",
-    "AWS::ApiGateway::UsagePlanKey": "ResourceProvider",
-    "AWS::ApiGateway::VpcLink": "ResourceProvider",
-    "AWS::ApiGatewayV2::Api": "ResourceProvider",
-    "AWS::ApiGatewayV2::ApiMapping": "ResourceProvider",
-    "AWS::ApiGatewayV2::Authorizer": "ResourceProvider",
-    "AWS::ApiGatewayV2::Deployment": "ResourceProvider",
-    "AWS::ApiGatewayV2::DomainName": "ResourceProvider",
-    "AWS::ApiGatewayV2::Integration": "ResourceProvider",
-    "AWS::ApiGatewayV2::IntegrationResponse": "ResourceProvider",
-    "AWS::ApiGatewayV2::Route": "ResourceProvider",
-    "AWS::ApiGatewayV2::RouteResponse": "ResourceProvider",
-    "AWS::ApiGatewayV2::Stage": "ResourceProvider",
-    "AWS::ApiGatewayV2::VpcLink": "ResourceProvider",
-    "AWS::AppConfig::Application": "ResourceProvider",
-    "AWS::AppConfig::ConfigurationProfile": "ResourceProvider",
-    "AWS::AppConfig::Deployment": "ResourceProvider",
-    "AWS::AppConfig::DeploymentStrategy": "ResourceProvider",
-    "AWS::AppConfig::Environment": "ResourceProvider",
-    "AWS::AppConfig::HostedConfigurationVersion": "ResourceProvider",
-    "AWS::AppSync::ApiKey": "ResourceProvider",
-    "AWS::AppSync::DataSource": "ResourceProvider",
-    "AWS::AppSync::FunctionConfiguration": "ResourceProvider",
-    "AWS::AppSync::GraphQLApi": "ResourceProvider",
-    "AWS::AppSync::GraphQLSchema": "ResourceProvider",
-    "AWS::AppSync::Resolver": "ResourceProvider",
-    "AWS::Athena::DataCatalog": "ResourceProvider",
-    "AWS::Athena::NamedQuery": "ResourceProvider",
-    "AWS::Athena::WorkGroup": "ResourceProvider",
-    "AWS::CDK::Metadata": "ResourceProviders",
-    "AWS::CertificateManager::Certificate": "ResourceProvider",
-    "AWS::CloudFormation::Stack": "ResourceProvider",
-    "AWS::CloudWatch::Alarm": "ResourceProvider",
-    "AWS::CloudWatch::CompositeAlarm": "ResourceProvider",
-    "AWS::Cognito::UserPool": "ResourceProvider",
-    "AWS::Cognito::UserPoolGroup": "ResourceProvider",
-    "AWS::Cognito::IdentityPool": "ResourceProvider",
-    "AWS::Cognito::UserPoolClient": "ResourceProvider",
-    "AWS::Cognito::UserPoolDomain": "ResourceProvider",
-    "AWS::Cognito::IdentityPoolRoleAttachment": "ResourceProvider",
-    "AWS::Cognito::UserPoolIdentityProvider": "ResourceProvider",
-    "AWS::Cognito::UserPoolResourceServer": "ResourceProvider",
-    "AWS::DynamoDB::GlobalTable": "ResourceProvider",
-    "AWS::DynamoDB::Table": "ResourceProvider",
-    "AWS::EC2::DHCPOptions": "ResourceProvider",
-    "AWS::EC2::Instance": "ResourceProvider",
-    "AWS::EC2::InternetGateway": "ResourceProvider",
-    "AWS::EC2::KeyPair": "ResourceProvider",
-    "AWS::EC2::NatGateway": "ResourceProvider",
-    "AWS::EC2::NetworkAcl": "ResourceProvider",
-    "AWS::EC2::Route": "ResourceProvider",
-    "AWS::EC2::RouteTable": "ResourceProvider",
-    "AWS::EC2::SecurityGroup": "ResourceProvider",
-    "AWS::EC2::Subnet": "ResourceProvider",
-    "AWS::EC2::SubnetRouteTableAssociation": "ResourceProvider",
-    "AWS::EC2::TransitGateway": "ResourceProvider",
-    "AWS::EC2::TransitGatewayAttachment": "ResourceProvider",
-    "AWS::EC2::VPC": "ResourceProvider",
-    "AWS::EC2::VPCGatewayAttachment": "ResourceProvider",
-    "AWS::ECR::Repository": "ResourceProvider",
-    "AWS::EKS::Nodegroup": "ResourceProvider",
-    "AWS::ElasticBeanstalk::Application": "ResourceProvider",
-    "AWS::ElasticBeanstalk::ApplicationVersion": "ResourceProvider",
-    "AWS::ElasticBeanstalk::ConfigurationTemplate": "ResourceProvider",
-    "AWS::ElasticBeanstalk::Environment": "ResourceProvider",
-    "AWS::Events::Connection": "ResourceProvider",
-    "AWS::Events::EventBus": "ResourceProvider",
-    "AWS::Events::EventBusPolicy": "ResourceProvider",
-    "AWS::Events::Rule": "ResourceProvider",
-    "AWS::IAM::AccessKey": "ResourceProvider",
-    "AWS::IAM::Group": "ResourceProvider",
-    "AWS::IAM::InstanceProfile": "ResourceProvider",
-    "AWS::IAM::ManagedPolicy": "ResourceProvider",
-    "AWS::IAM::Policy": "ResourceProvider",
-    "AWS::IAM::Role": "ResourceProvider",
-    "AWS::IAM::ServiceLinkedRole": "ResourceProvider",
-    "AWS::IAM::User": "ResourceProvider",
-    "AWS::KMS::Alias": "ResourceProvider",
-    "AWS::KMS::Key": "ResourceProvider",
-    "AWS::Kinesis::Stream": "ResourceProvider",
-    "AWS::Kinesis::StreamConsumer": "ResourceProvider",
-    "AWS::KinesisAnalytics::Application": "ResourceProvider",
-    "AWS::KinesisFirehose::DeliveryStream": "ResourceProvider",
-    "AWS::Lambda::Alias": "ResourceProvider",
-    "AWS::Lambda::CodeSigningConfig": "ResourceProvider",
-    "AWS::Lambda::EventInvokeConfig": "ResourceProvider",
-    "AWS::Lambda::EventSourceMapping": "ResourceProvider",
-    "AWS::Lambda::Function": "ResourceProvider",
-    "AWS::Lambda::LayerVersion": "ResourceProvider",
-    "AWS::Lambda::LayerVersionPermission": "ResourceProvider",
-    "AWS::Lambda::Permission": "ResourceProvider",
-    "AWS::Lambda::Version": "ResourceProvider",
-    "AWS::Logs::LogGroup": "ResourceProvider",
-    "AWS::Logs::LogStream": "ResourceProvider",
-    "AWS::Logs::SubscriptionFilter": "ResourceProvider",
-    "AWS::OpenSearchService::Domain": "ResourceProvider",
-    "AWS::Pipes::Pipe": "ResourceProvider",
-    "AWS::RDS::DBCluster": "ResourceProvider",
-    "AWS::Redshift::Cluster": "ResourceProvider",
-    "AWS::Route53::HealthCheck": "ResourceProvider",
-    "AWS::Route53::RecordSet": "ResourceProvider",
-    "AWS::S3::Bucket": "ResourceProvider",
-    "AWS::S3::BucketPolicy": "ResourceProvider",
-    "AWS::SNS::Topic": "ResourceProvider",
-    "AWS::SQS::Queue": "ResourceProvider",
-    "AWS::SQS::QueuePolicy": "ResourceProvider",
-    "AWS::Scheduler::Schedule": "ResourceProvider",
-    "AWS::Scheduler::ScheduleGroup": "ResourceProvider",
-    "AWS::SecretsManager::ResourcePolicy": "ResourceProvider",
-    "AWS::SecretsManager::RotationSchedule": "ResourceProvider",
-    "AWS::SecretsManager::Secret": "ResourceProvider",
-    "AWS::SecretsManager::SecretTargetAttachment": "ResourceProvider",
-    "AWS::SES::ReceiptRule": "ResourceProvider",
-    "AWS::SES::ReceiptRuleSet": "ResourceProvider",
-    "AWS::SES::Template": "ResourceProvider",
-    "AWS::SSM::Parameter": "ResourceProvider",
-    "AWS::SSM::MaintenanceWindow": "ResourceProvider",
-    "AWS::SSM::MaintenanceWindowTarget": "ResourceProvider",
-    "AWS::SSM::MaintenanceWindowTask": "ResourceProvider",
-    "AWS::SSM::PatchBaseline": "ResourceProvider",
-    "AWS::StepFunctions::Activity": "ResourceProvider",
-    "AWS::StepFunctions::StateMachine": "ResourceProvider",
-}
-
 
 class OperationStatus(Enum):
     PENDING = auto()
@@ -859,42 +719,53 @@ class ResourceProviderExecutor:
                 raise NotImplementedError(change_type)  # TODO: change error type
 
     def should_use_legacy_provider(self, resource_type: str) -> bool:
-        # any config overwrites take precedence over the default list
-        PROVIDER_CONFIG = {**PROVIDER_DEFAULTS, **self.provider_config}
-        if resource_type in PROVIDER_CONFIG:
-            return PROVIDER_CONFIG[resource_type] == "GenericBaseModel"
-
-        return True
+        # any config overwrites take precedence over the default order
+        return self.provider_config.get(resource_type) == "GenericBaseModel"
 
     def load_resource_provider(self, resource_type: str) -> ResourceProvider:
-        # by default look up GenericBaseModel
+        # TODO: unify namespace of plugins
+
+        # opt-in to switch to older resource provider
         if self.should_use_legacy_provider(resource_type):
             return self._load_legacy_resource_provider(resource_type)
 
+        # 1. try to load pro resource provider
         # prioritise pro resource providers
         if PRO_RESOURCE_PROVIDERS:
             try:
                 plugin = pro_plugin_manager.load(resource_type)
                 return plugin.factory()
             except ValueError:
-                # could not load the plugin
+                # could not find a plugin for that name
                 pass
             except Exception:
                 LOG.warning(
-                    "error loading plugin from plugin manager",
+                    "Failed to load PRO resource type %s as a ResourceProvider.",
+                    resource_type,
+                    exc_info=LOG.isEnabledFor(logging.DEBUG),
+                )
+
+        # 2. try to load community resource provider
+        try:
+            plugin = plugin_manager.load(resource_type)
+            return plugin.factory()
+        except ValueError:
+            # could not find a plugin for that name
+            pass
+        except Exception:
+            if config.CFN_VERBOSE_ERRORS:
+                LOG.warning(
+                    "Failed to load community resource type %s as a ResourceProvider.",
+                    resource_type,
                     exc_info=LOG.isEnabledFor(logging.DEBUG),
                 )
 
         try:
-            plugin = plugin_manager.load(resource_type)
-            return plugin.factory()
-        except Exception:
-            LOG.warning(
-                "Failed to load resource type %s as a ResourceProvider.",
-                resource_type,
-                exc_info=LOG.isEnabledFor(logging.DEBUG),
-            )
-            raise NoResourceProvider
+            # 3. try to load legacy resource provider (and raise if nothing found)
+            return self._load_legacy_resource_provider(resource_type)
+        except NoResourceProvider:
+            LOG.warning("Failed to load resource provider for resource type %s", resource_type)
+            raise
 
     def _load_legacy_resource_provider(self, resource_type: str) -> LegacyResourceProvider:
         if resource_type in self.legacy_base_models:


### PR DESCRIPTION
## Motivation

Adding new resource types is quite annoying right now, especially in our -ext repo, since every new provider needs to be accompanied by a companion PR in community to actually enable that provider.

We never really switched back to a legacy provider and I also don't really see us doing that in the near future. We're also nearly done with the provider migration and if there are any issues coming up will prioritze fixing them in the resource providers over the legacy models.

## Changes

- New resource lookup order: 1. PRO provider (if PRO enabled), 2. Community provider, 3. legacy model
  - This means as long as the entrypoints are generated, any scaffolded provider in -ext will be picked up immediately without adding anything in `resource_provider.py` anymore.
- Remove our manual default override list with all new resource providers, since they are now prioritized over legacy models anyway. 