### PR TITLE
fix S3 image rate limiting with docker login

### DIFF
--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Build S3 Docker Image
         env:
           PLATFORM: ${{ matrix.arch }}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As encountered here: https://github.com/localstack/localstack/actions/runs/7903228515/job/21570653837
We were getting rate limited by Docker Hub because we would not log in to pull the images.

Thanks to @alexrashed for the pointer!

<!-- What notable changes does this PR make? -->
## Changes
Add a step to login to Docker Hub in order to not be rate limited

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

