### PR TITLE
Add CFn provider util to convert into lower camel case

### DIFF
--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -41,6 +41,17 @@ def keys_lower(model: dict) -> dict:
     return {k.lower(): v for k, v in model.items()}
 
 
+def convert_pascalcase_to_lower_camelcase(item: str) -> str:
+    if len(item) <= 1:
+        return item.lower()
+    else:
+        return f"{item[0].lower()}{item[1:]}"
+
+
+def keys_pascalcase_to_lower_camelcase(model: dict) -> dict:
+    return {convert_pascalcase_to_lower_camelcase(k): v for k, v in model.items()}
+
+
 def transform_list_to_dict(param, key_attr_name="Key", value_attr_name="Value"):
     result = {}
     for entry in param:


### PR DESCRIPTION
## Motivation

Adds a provider util which I needed for converting into lower camel case, e.g. from `ThisWord` into `thisWord` in the Amplify resource provider

## Changes

It'll probably be common enough to add this to the util suite which we'll ultimately move into the externalized repo. 