### PR TITLE
Fix Lambda handler update for UpdateFunctionConfiguration

### DIFF
--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -91,7 +91,7 @@ class LambdaService:
         shutdown_futures = []
         for event_manager in self.event_managers.values():
             shutdown_futures.append(self.task_executor.submit(event_manager.stop))
-        # TODO: switch shutdown order?
+        # TODO: switch shutdown order? yes, shutdown starting versions before the running versions would make more sense
         for version_manager in self.lambda_running_versions.values():
             shutdown_futures.append(self.task_executor.submit(version_manager.stop))
         for version_manager in self.lambda_starting_versions.values():

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -30,7 +30,7 @@ from localstack.services.lambda_.invocation.metrics import (
     record_cw_metric_invocation,
 )
 from localstack.services.lambda_.invocation.runtime_executor import get_runtime_executor
-from localstack.utils.strings import truncate
+from localstack.utils.strings import long_uid, truncate
 from localstack.utils.threads import FuncThread, start_thread
 
 if TYPE_CHECKING:
@@ -67,6 +67,7 @@ class LambdaVersionManager:
         counting_service: CountingService,
         assignment_service: AssignmentService,
     ):
+        self.id = long_uid()
         self.function_arn = function_arn
         self.function_version = function_version
         self.function = function
@@ -127,7 +128,7 @@ class LambdaVersionManager:
         )
         self.shutdown_event.set()
         self.log_handler.stop()
-        self.assignment_service.stop_environments_for_version(self.function_version)
+        self.assignment_service.stop_environments_for_version(self.id)
         get_runtime_executor().cleanup_version(self.function_version)  # TODO: make pluggable?
 
     def update_provisioned_concurrency_config(
@@ -157,7 +158,7 @@ class LambdaVersionManager:
 
         def scale_environments(*args, **kwargs) -> None:
             futures = self.assignment_service.scale_provisioned_concurrency(
-                self.function_version, provisioned_concurrent_executions
+                self.id, self.function_version, provisioned_concurrent_executions
             )
 
             concurrent.futures.wait(futures)
@@ -206,7 +207,7 @@ class LambdaVersionManager:
             try:
                 # Blocks and potentially creates a new execution environment for this invocation
                 with self.assignment_service.get_environment(
-                    self.function_version, provisioning_type
+                    self.id, self.function_version, provisioning_type
                 ) as execution_env:
                     invocation_result = execution_env.invoke(invocation)
                     invocation_result.executed_version = self.function_version.id.qualifier

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -619,7 +619,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 f"{runtime} is not supported for SnapStart enabled functions.", Type="User"
             )
 
-    def _validate_layers(self, new_layers: list[str], region: str, account_id: int):
+    def _validate_layers(self, new_layers: list[str], region: str, account_id: str):
         if len(new_layers) > LAMBDA_LAYERS_LIMIT_PER_FUNCTION:
             raise InvalidParameterValueException(
                 "Cannot reference more than 5 layers.", Type="User"
@@ -997,6 +997,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             replace_kwargs["vpc_config"] = self._build_vpc_config(
                 context.account_id, context.region, vpc_config
             )
+
+        if "Handler" in request:
+            replace_kwargs["handler"] = request["Handler"]
 
         if "Runtime" in request:
             runtime = request["Runtime"]

--- a/tests/aws/services/lambda_/functions/lambda_multiple_handlers.py
+++ b/tests/aws/services/lambda_/functions/lambda_multiple_handlers.py
@@ -1,0 +1,14 @@
+def handler(event, context):
+    result = {
+        "handler": "handler",
+    }
+    print(result)
+    return result
+
+
+def handler_two(event, context):
+    result = {
+        "handler": "handler_two",
+    }
+    print(result)
+    return result

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2454,11 +2454,6 @@ class TestLambdaVersions:
         get_function_result = aws_client.lambda_.get_function(FunctionName=func_name)
         snapshot.match("get_function_result", get_function_result)
 
-        # TODO: fix the race condition in lambda_service.update_version_state that causes invokes to be sent
-        #  to an old Lambda version until the old version is stopped **asynchronously** in version_manager.stop via
-        #  assignment_service.stop_environments_for_version
-        time.sleep(1)
-
         invoke_result_handler_two = aws_client.lambda_.invoke(FunctionName=func_name)
         snapshot.match("invoke_result_handler_two", invoke_result_handler_two)
 

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -112,6 +112,9 @@ TEST_LAMBDA_VERSION = os.path.join(THIS_FOLDER, "functions/lambda_version.py")
 TEST_LAMBDA_CONTEXT_REQID = os.path.join(THIS_FOLDER, "functions/lambda_context.py")
 TEST_LAMBDA_PROCESS_INSPECTION = os.path.join(THIS_FOLDER, "functions/lambda_process_inspection.py")
 TEST_LAMBDA_CUSTOM_RESPONSE_SIZE = os.path.join(THIS_FOLDER, "functions/lambda_response_size.py")
+TEST_LAMBDA_PYTHON_MULTIPLE_HANDLERS = os.path.join(
+    THIS_FOLDER, "functions/lambda_multiple_handlers.py"
+)
 
 TEST_EVENTS_SQS_RECEIVE_MESSAGE = os.path.join(THIS_FOLDER, "events/sqs-receive-message.json")
 TEST_EVENTS_APIGATEWAY_AWS_PROXY = os.path.join(THIS_FOLDER, "events/apigateway-aws-proxy.json")
@@ -2425,6 +2428,47 @@ class TestLambdaVersions:
             FunctionName=function_name, Qualifier=first_publish_response["Version"], Payload=b"{}"
         )
         snapshot.match("invocation_result_v1_end", invocation_result_v1)
+
+    @markers.snapshot.skip_snapshot_verify(paths=["$..LoggingConfig"])
+    @markers.aws.validated
+    def test_lambda_handler_update(self, aws_client, create_lambda_function, snapshot):
+        func_name = f"test_lambda_{short_uid()}"
+        create_lambda_function(
+            func_name=func_name,
+            # handler.handler by convention
+            handler_file=TEST_LAMBDA_PYTHON_MULTIPLE_HANDLERS,
+            runtime=Runtime.python3_12,
+            client=aws_client.lambda_,
+        )
+
+        invoke_result_handler_one = aws_client.lambda_.invoke(FunctionName=func_name)
+        snapshot.match("invoke_result_handler_one", invoke_result_handler_one)
+
+        update_function_configuration_result = aws_client.lambda_.update_function_configuration(
+            FunctionName=func_name, Handler="handler.handler_two"
+        )
+        snapshot.match("update_function_configuration_result", update_function_configuration_result)
+        waiter = aws_client.lambda_.get_waiter("function_updated_v2")
+        waiter.wait(FunctionName=func_name)
+
+        get_function_result = aws_client.lambda_.get_function(FunctionName=func_name)
+        snapshot.match("get_function_result", get_function_result)
+
+        # TODO: fix the race condition in lambda_service.update_version_state that causes invokes to be sent
+        #  to an old Lambda version until the old version is stopped **asynchronously** in version_manager.stop via
+        #  assignment_service.stop_environments_for_version
+        time.sleep(1)
+
+        invoke_result_handler_two = aws_client.lambda_.invoke(FunctionName=func_name)
+        snapshot.match("invoke_result_handler_two", invoke_result_handler_two)
+
+        publish_version_result = aws_client.lambda_.publish_version(FunctionName=func_name)
+        waiter.wait(FunctionName=func_name, Qualifier=publish_version_result["Version"])
+
+        invoke_result_handler_two_postpublish = aws_client.lambda_.invoke(FunctionName=func_name)
+        snapshot.match(
+            "invoke_result_handler_two_postpublish", invoke_result_handler_two_postpublish
+        )
 
 
 # TODO: test if routing is static for a single invocation:

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3616,5 +3616,141 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
+    "recorded-date": "14-02-2024, 14:32:32",
+    "recorded-content": {
+      "invoke_result_handler_one": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "handler": "handler"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_function_configuration_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "code-sha256",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler_two",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.12",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_result": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler_two",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke_result_handler_two": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "handler": "handler_two"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke_result_handler_two_postpublish": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "handler": "handler_two"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -179,6 +179,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
     "last_validated_date": "2023-11-20T21:05:44+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
+    "last_validated_date": "2024-02-14T14:32:31+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_versions_with_code_changes": {
     "last_validated_date": "2023-11-20T21:08:09+00:00"
   },


### PR DESCRIPTION
## Motivation

The operation [UpdateFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html) does not support updating the function [Handler](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html#lambda-UpdateFunctionConfiguration-request-Handler) in LocalStack. This issue was reported in a support case.

## Changes

* Add a test `test_lambda_handler_update` to test updating a Lambda function handler
* Add API support for updating the function handler in the Lambda provider
* Introduce a new `id` in the version manager that can be used as a globally unique key within the assignment service to avoid key clashes for updating `$LATEST`

## Notes

In addition to the missing API operation (easy fix), I discovered a race condition in our version manager we should fix. 
Updating the function `handler` of `$LATEST` does not work properly. Invokes somehow use the old version.
The test passes when using `LAMBDA_KEEPALIVE_MS=0`, publishing a new version explicitly, or adding a sleep before the invoke (current test workaround).

The race condition also causes invalid status exceptions such as:

> localstack.services.lambda_.invocation.assignment : InvalidStatusException: Execution environment 99823878c6fbe0dbed4451c5d175b349 can only be set to status ready while running. Current status: RuntimeStatus.STOPPED

👉 The root cause is in the assignment service. It uses the `function_version.qualified_arn` as a key for managing global function versions but this ARN remains the same for updates of `$LATEST`. Therefore, new published versions work but updates for `$LATEST` don't.


## TODO

What's left to do:

- [x] Fix the race condition in `lambda_service.update_version_state` that causes invokes to be sent to an old Lambda version until the old version is stopped **asynchronously** in version_manager.stop via assignment_service.stop_environments_for_version
- [x] Remove the `time.sleep(1)` that make the test pass

