### PR TITLE
Fix override of legacy resource providers over new community ones for certain resources

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -734,6 +734,13 @@ class ResourceProviderExecutor:
         # 1. try to load pro resource provider
         # prioritise pro resource providers
         if PRO_RESOURCE_PROVIDERS:
+            # temporary patch until this has equivalent resource providers in -ext
+            if resource_type in {
+                "AWS::ECR::Repository",
+                "AWS::SecretsManager::SecretTargetAttachment",
+                "AWS::EC2::SubnetRouteTableAssociation",
+            }:
+                return self._load_legacy_resource_provider(resource_type)
             try:
                 plugin = pro_plugin_manager.load(resource_type)
                 return plugin.factory()


### PR DESCRIPTION
## Motivation

After https://github.com/localstack/localstack/pull/10242 the -ext pipeline started failing.

I unfortunately missed an edge case where we previously had legacy providers in both community and -ext (-ext providers with additional features) but now only have a new provider in community and no new one in -ext yet.

What needs to happen is that for those 3 resource types, if PRO is enabled, the **legacy** model from -ext is used. With the recently introduced logic it was falling back to the community provider before considering the legacy models though.


## Changes

- Until we have corresponding resource providers for these 3 resource types in -ext, I've added a manual exemption list in community. Will refactor this soon though, so this is just a temporary inconvenience.
