### PR TITLE
Add support for composite physical resource ID quirks

### DIFF
--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -26,10 +26,10 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::ApiGateway::BasePathMapping": "/properties/RestApiId",
     "AWS::ApiGateway::Model": "/properties/Name",
     "AWS::Cognito::UserPoolClient": "/properties/ClientId",
+    "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",
     "AWS::Logs::LogStream": "/properties/LogStreamName",
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::SSM::Parameter": "/properties/Name",
-    "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",
 }
 
 # You can usually find the available GetAtt targets in the official resource documentation:

--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -29,6 +29,7 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::Logs::LogStream": "/properties/LogStreamName",
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::SSM::Parameter": "/properties/Name",
+    "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",
 }
 
 # You can usually find the available GetAtt targets in the official resource documentation:

--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -11,22 +11,20 @@ Since this is therefore rather part of the cloudformation layer and *not* the re
 
 # note: format here is subject to change (e.g. it might not be a pure str -> str mapping, it could also involve more sophisticated handlers
 PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
-    # Example
-    # "AWS::ApiGateway::Resource": "/properties/ResourceId",
-    "AWS::Events::EventBus": "/properties/Name",
-    "AWS::ApiGateway::RequestValidator": "/properties/RequestValidatorId",
     "AWS::ApiGateway::Authorizer": "/properties/AuthorizerId",
+    "AWS::ApiGateway::RequestValidator": "/properties/RequestValidatorId",
     "AWS::ApiGatewayV2::Authorizer": "/properties/AuthorizerId",
-    "AWS::ApiGatewayV2::IntegrationResponse": "/properties/IntegrationResponseId",
     "AWS::ApiGatewayV2::Deployment": "/properties/DeploymentId",
+    "AWS::ApiGatewayV2::IntegrationResponse": "/properties/IntegrationResponseId",
     "AWS::ApiGatewayV2::Route": "/properties/RouteId",
+    "AWS::ApiGateway::BasePathMapping": "/properties/RestApiId",
     "AWS::ApiGateway::Deployment": "/properties/DeploymentId",
+    "AWS::ApiGateway::Model": "/properties/Name",
     "AWS::ApiGateway::Resource": "/properties/ResourceId",
     "AWS::ApiGateway::Stage": "/properties/StageName",
-    "AWS::ApiGateway::BasePathMapping": "/properties/RestApiId",
-    "AWS::ApiGateway::Model": "/properties/Name",
     "AWS::Cognito::UserPoolClient": "/properties/ClientId",
-    "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",
+    "AWS::EKS::FargateProfile": "</properties/ClusterName>|</properties/FargateProfileName>",  # composite
+    "AWS::Events::EventBus": "/properties/Name",
     "AWS::Logs::LogStream": "/properties/LogStreamName",
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::SSM::Parameter": "/properties/Name",


### PR DESCRIPTION
## Motivation

Ran into this with the `AWS::EKS::FargateProfile` resource in -ext. We currently don't have a way to support the equivalent of this code from the old legacy model:

```python
        def _handle_result(
            account_id: str,
            region_name: str,
            result: dict,
            logical_resource_id: str,
            resource: dict,
        ):
            fargateProfile = result["fargateProfile"]
            resource[
                "PhysicalResourceId"
            ] = f"{fargateProfile['clusterName']}|{fargateProfile['fargateProfileName']}"  # <== this here
            resource["Properties"]["Arn"] = result["fargateProfile"]["fargateProfileArn"]
```

## Changes

- Add a new way to optionally use multiple properties in a physical resource id quirk. Specify the json pointer enclosed in `<>` and those parts will be extracted and replaced to build the final value for the physical resource id
  -  Example from this PR: `"</properties/ClusterName>|</properties/FargateProfileName>"`
