### PR TITLE
CFn: improve error reporting

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -217,7 +217,7 @@ class Stack:
 
         self.events.insert(0, event)
 
-    def set_resource_status(self, resource_id: str, status: str):
+    def set_resource_status(self, resource_id: str, status: str, status_reason: str = ""):
         """Update the deployment status of the given resource ID and publish a corresponding stack event."""
         physical_res_id = self.resources.get(resource_id, {}).get("PhysicalResourceId")
         self._set_resource_status_details(resource_id, physical_res_id=physical_res_id)
@@ -225,7 +225,7 @@ class Stack:
         state["PreviousResourceStatus"] = state.get("ResourceStatus")
         state["ResourceStatus"] = status
         state["LastUpdatedTimestamp"] = timestamp_millis()
-        self.add_stack_event(resource_id, physical_res_id, status)
+        self.add_stack_event(resource_id, physical_res_id, status, status_reason=status_reason)
 
     def _set_resource_status_details(self, resource_id: str, physical_res_id: str = None):
         """Helper function to ensure that the status details for the given resource ID are up-to-date."""

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1376,7 +1376,11 @@ class TemplateDeployer:
         stack_action = get_action_name_for_resource_change(action)
         match progress_event.status:
             case OperationStatus.FAILED:
-                stack.set_resource_status(resource_id, f"{stack_action}_FAILED")
+                stack.set_resource_status(
+                    resource_id,
+                    f"{stack_action}_FAILED",
+                    status_reason=progress_event.message or "",
+                )
                 # TODO: remove exception raising here?
                 # TODO: fix request token
                 raise Exception(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -937,10 +937,8 @@ class StackDeployError(Exception):
 
         chronological_events = sorted(events, key=lambda event: event["Timestamp"])
         for event in chronological_events:
-            if not event["ResourceStatus"].endswith("FAILED") and not config.CFN_VERBOSE_ERRORS:
-                continue
-
-            formatted_events.append(self.format_event(event))
+            if event["ResourceStatus"].endswith("FAILED") or config.CFN_VERBOSE_ERRORS:
+                formatted_events.append(self.format_event(event))
 
         return "\n".join(formatted_events)
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -937,7 +937,7 @@ class StackDeployError(Exception):
 
         chronological_events = sorted(events, key=lambda event: event["Timestamp"])
         for event in chronological_events:
-            if event["ResourceStatus"] != "CREATE_FAILED" and not config.CFN_VERBOSE_ERRORS:
+            if not event["ResourceStatus"].endswith("FAILED") and not config.CFN_VERBOSE_ERRORS:
                 continue
 
             formatted_events.append(self.format_event(event))

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -923,27 +923,34 @@ class StackDeployError(Exception):
     def __init__(self, describe_res: dict, events: list[dict]):
         self.describe_result = describe_res
         self.events = events
-        super().__init__(
-            f"Describe output:\n{json.dumps(self.describe_result, cls=CustomEncoder)}\nEvents:\n{self.format_events(events)}"
-        )
+
+        encoded_describe_output = json.dumps(self.describe_result, cls=CustomEncoder)
+        if config.CFN_VERBOSE_ERRORS:
+            msg = f"Describe output:\n{encoded_describe_output}\nEvents:\n{self.format_events(events)}"
+        else:
+            msg = f"Describe output:\n{encoded_describe_output}\nFailing resources:\n{self.format_events(events)}"
+
+        super().__init__(msg)
 
     def format_events(self, events: list[dict]) -> str:
-        event_details = (
-            json.dumps(
-                {
-                    key: event.get(key)
-                    for key in [
-                        "LogicalResourceId",
-                        "ResourceType",
-                        "ResourceStatus",
-                        "ResourceStatusReason",
-                    ]
-                },
-                cls=CustomEncoder,
-            )
-            for event in events
-        )
-        return "\n".join(event_details)
+        formatted_events = []
+
+        chronological_events = sorted(events, key=lambda event: event["Timestamp"])
+        for event in chronological_events:
+            if event["ResourceStatus"] != "CREATE_FAILED" and not config.CFN_VERBOSE_ERRORS:
+                continue
+
+            formatted_events.append(self.format_event(event))
+
+        return "\n".join(formatted_events)
+
+    @staticmethod
+    def format_event(event: dict) -> str:
+        if reason := event.get("ResourceStatusReason"):
+            reason = reason.replace("\n", "; ")
+            return f"- {event['LogicalResourceId']} ({event['ResourceType']}) -> {event['ResourceStatus']} ({reason})"
+        else:
+            return f"- {event['LogicalResourceId']} ({event['ResourceType']}) -> {event['ResourceStatus']}"
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When a stack fails to deploy, the error is not always understandable. Especially in our tests. We should make the output easier to understand, and filter down events to only show the failures.


<!-- What notable changes does this PR make? -->
## Changes

* Only print the resources that failed to create, but allow all events if `CFN_VERBOSE_ERRORS=1`
* Update formatting to be more human readable
* Log (to warning level by default) stack errors if the stack status is set to `*FAILED`



Before:

Log output: n/a

Test exception traceback output:

```
E           localstack.testing.pytest.fixtures.StackDeployError: Describe output:
E           {"StackId": "arn:aws:cloudformation:us-east-1:000000000000:stack/stack-cde16c5d/58ee10c2", "StackName": "stack-cde16c5d", "ChangeSetId": "arn:aws:cloudformation:us-east-1:000000000000:changeSet/change-set-471a5b1a/4cfe257a", "Parameters": [{"ParameterKey": "ApiName", "ParameterValue": "api-68ffffa8"}, {"ParameterKey": "ContainerPort", "ParameterValue": "80"}], "CreationTime": "2024-02-15T17:40:00.025Z", "LastUpdatedTime": "2024-02-15T17:40:00.025Z", "RollbackConfiguration": {}, "StackStatus": "CREATE_FAILED", "StackStatusReason": "Parameter validation failed:\nMissing required parameter in input: \"family\"\nMissing required parameter in input: \"containerDefinitions\"", "DisableRollback": false, "NotificationARNs": [], "Capabilities": ["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"], "Tags": [], "EnableTerminationProtection": false, "DriftInformation": {"StackDriftStatus": "NOT_CHECKED"}}
E           Events:
E           {"LogicalResourceId": "stack-cde16c5d", "ResourceType": "AWS::CloudFormation::Stack", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Parameter validation failed:\nMissing required parameter in input: \"family\"\nMissing required parameter in input: \"containerDefinitions\""}
E           {"LogicalResourceId": "MyFargateServiceTaskDef5DA17B39", "ResourceType": "AWS::ECS::TaskDefinition", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Parameter validation failed:\nMissing required parameter in input: \"family\"\nMissing required parameter in input: \"containerDefinitions\""}
E           {"LogicalResourceId": "MyFargateServiceLBPublicListener61A1042F", "ResourceType": "AWS::ElasticLoadBalancingV2::Listener", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceLBSecurityGrouptoTmpStackMyFargateServiceSecurityGroup3C16E026808915B697", "ResourceType": "AWS::EC2::SecurityGroupEgress", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceLBDE830E97", "ResourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2DefaultRoute97F91067", "ResourceType": "AWS::EC2::Route", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1DefaultRoute3DA9E72A", "ResourceType": "AWS::EC2::Route", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "CDKMetadata", "ResourceType": "AWS::CDK::Metadata", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "HttpApiVpcLink159804837", "ResourceType": "AWS::ApiGatewayV2::VpcLink", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "HttpApiDefaultStage3EEB07D6", "ResourceType": "AWS::ApiGatewayV2::Stage", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "HttpApiF5A9A8A7", "ResourceType": "AWS::ApiGatewayV2::Api", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceSecurityGroupfromTmpStackMyFargateServiceLBSecurityGroupDA064B1380052DE7DE", "ResourceType": "AWS::EC2::SecurityGroupIngress", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceSecurityGroup7016792A", "ResourceType": "AWS::EC2::SecurityGroup", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceTaskDefExecutionRoleDefaultPolicyEC22B20F", "ResourceType": "AWS::IAM::Policy", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceTaskDefExecutionRoleD6305504", "ResourceType": "AWS::IAM::Role", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceTaskDefwebLogGroup4A6C44E8", "ResourceType": "AWS::Logs::LogGroup", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceTaskDefTaskRole62C7D397", "ResourceType": "AWS::IAM::Role", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceLBPublicListenerECSGroup4A3EDF05", "ResourceType": "AWS::ElasticLoadBalancingV2::TargetGroup", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "MyFargateServiceLBSecurityGroup6FBF16F1", "ResourceType": "AWS::EC2::SecurityGroup", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "ClusterEB0386A7", "ResourceType": "AWS::ECS::Cluster", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcVPCGWBF912B6E", "ResourceType": "AWS::EC2::VPCGatewayAttachment", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcIGWD7BA715C", "ResourceType": "AWS::EC2::InternetGateway", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet2DefaultRoute060D2087", "ResourceType": "AWS::EC2::Route", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet2RouteTableAssociationA89CAD56", "ResourceType": "AWS::EC2::SubnetRouteTableAssociation", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet2RouteTableA678073B", "ResourceType": "AWS::EC2::RouteTable", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet2Subnet3788AAA1", "ResourceType": "AWS::EC2::Subnet", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet1DefaultRouteBE02A9ED", "ResourceType": "AWS::EC2::Route", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet1RouteTableAssociation70C59FA6", "ResourceType": "AWS::EC2::SubnetRouteTableAssociation", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet1RouteTableB2C5B500", "ResourceType": "AWS::EC2::RouteTable", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPrivateSubnet1Subnet536B997A", "ResourceType": "AWS::EC2::Subnet", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2NATGateway9182C01D", "ResourceType": "AWS::EC2::NatGateway", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2EIP3C605A87", "ResourceType": "AWS::EC2::EIP", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2RouteTableAssociationDD5762D8", "ResourceType": "AWS::EC2::SubnetRouteTableAssociation", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2RouteTable94F7E489", "ResourceType": "AWS::EC2::RouteTable", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet2Subnet691E08A3", "ResourceType": "AWS::EC2::Subnet", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1NATGateway4D7517AA", "ResourceType": "AWS::EC2::NatGateway", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1EIPD7E02669", "ResourceType": "AWS::EC2::EIP", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1RouteTableAssociation97140677", "ResourceType": "AWS::EC2::SubnetRouteTableAssociation", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1RouteTable6C95E38E", "ResourceType": "AWS::EC2::RouteTable", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "VpcPublicSubnet1Subnet5C2D37C4", "ResourceType": "AWS::EC2::Subnet", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "Vpc8378EB38", "ResourceType": "AWS::EC2::VPC", "ResourceStatus": "CREATE_COMPLETE", "ResourceStatusReason": null}
E           {"LogicalResourceId": "stack-cde16c5d", "ResourceType": "AWS::CloudFormation::Stack", "ResourceStatus": "CREATE_IN_PROGRESS", "ResourceStatusReason": null}
E           {"LogicalResourceId": "stack-cde16c5d", "ResourceType": "AWS::CloudFormation::Stack", "ResourceStatus": "REVIEW_IN_PROGRESS", "ResourceStatusReason": null}
```

After:

Log output:

```
2024-02-15T17:50:09.703 WARNING --- [start_worker_thread-functhread9] localstack.services.cloudformation.engine.entities : CFn resource failed to deploy: stack-2ec176f7 (Parameter validation failed:; Missing required parameter in input: "family"; Missing required parameter in input: "containerDefinitions")
2024-02-15T17:50:09.703 WARNING --- [start_worker_thread-functhread9] localstack.services.cloudformation.engine.entities : CFn resource failed to deploy: MyFargateServiceTaskDef5DA17B39 (Parameter validation failed:; Missing required parameter in input: "family"; Missing required parameter in input: "containerDefinitions")
```

Test exception traceback output:

```
E           localstack.testing.pytest.fixtures.StackDeployError: Describe output:
E           {"StackId": "arn:aws:cloudformation:us-east-1:000000000000:stack/stack-d84ebfe3/f2a8d13a", "StackName": "stack-d84ebfe3", "ChangeSetId": "arn:aws:cloudformation:us-east-1:000000000000:changeSet/change-set-9ef57814/7f1e42d3", "Parameters": [{"ParameterKey": "ApiName", "ParameterValue": "api-3c4bb272"}, {"ParameterKey": "ContainerPort", "ParameterValue": "80"}], "CreationTime": "2024-02-15T17:37:44.915Z", "LastUpdatedTime": "2024-02-15T17:37:44.915Z", "RollbackConfiguration": {}, "StackStatus": "CREATE_FAILED", "StackStatusReason": "Parameter validation failed:\nMissing required parameter in input: \"family\"\nMissing required parameter in input: \"containerDefinitions\"", "DisableRollback": false, "NotificationARNs": [], "Capabilities": ["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"], "Tags": [], "EnableTerminationProtection": false, "DriftInformation": {"StackDriftStatus": "NOT_CHECKED"}}
E           Failing resources:
E           - MyFargateServiceTaskDef5DA17B39 (AWS::ECS::TaskDefinition) -> CREATE_FAILED (Parameter validation failed:; Missing required parameter in input: "family"; Missing required parameter in input: "containerDefinitions")
E           - stack-d84ebfe3 (AWS::CloudFormation::Stack) -> CREATE_FAILED (Parameter validation failed:; Missing required parameter in input: "family"; Missing required parameter in input: "containerDefinitions")
```


## TODO

* Confirm the formatting - sometimes replacing `\n` with `; ` makes for some strange looking sentences, but it's better than nothing!

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

