### PR TITLE
Fix architecture update for Lambda function

### DIFF
--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -728,8 +728,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 f"Request must be smaller than {config.LAMBDA_LIMITS_CREATE_FUNCTION_REQUEST_SIZE} bytes for the CreateFunction operation"
             )
 
-        architectures = request.get("Architectures")
-        if architectures:
+        if architectures := request.get("Architectures"):
             if len(architectures) != 1:
                 raise ValidationException(
                     f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
@@ -1136,6 +1135,21 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         old_function_version = function.versions.get("$LATEST")
         replace_kwargs = {"code": code} if code else {"image": image}
+
+        if architectures := request.get("Architectures"):
+            if len(architectures) != 1:
+                raise ValidationException(
+                    f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
+                    f"satisfy constraint: Member must have length less than or equal to 1",
+                )
+            if architectures[0] not in ARCHITECTURES:
+                raise ValidationException(
+                    f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
+                    f"satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: "
+                    f"[x86_64, arm64], Member must not be null]",
+                )
+            replace_kwargs["architectures"] = architectures
+
         config = dataclasses.replace(
             old_function_version.config,
             internal_revision=short_uid(),

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1142,6 +1142,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "
                     f"satisfy constraint: Member must have length less than or equal to 1",
                 )
+            # An empty list of architectures is also forbidden. Further exceptions are tested here for create_function:
+            # tests.aws.services.lambda_.test_lambda_api.TestLambdaFunction.test_create_lambda_exceptions
             if architectures[0] not in ARCHITECTURES:
                 raise ValidationException(
                     f"1 validation error detected: Value '[{', '.join(architectures)}]' at 'architectures' failed to "

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -523,64 +523,47 @@ class TestLambdaBehavior:
         assert lambda_arch == native_arch
 
     @pytest.mark.skip  # TODO remove once is_arch_compatible checks work properly
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..LoggingConfig",
+            "$..CreateFunctionResponse.LoggingConfig",
+            "$..RuntimeVersionConfig.RuntimeVersionArn",
+        ]
+    )
     @markers.aws.validated
-    def test_mixed_architecture(self, create_lambda_function, aws_client):
-        """Test emulation and interaction of lambda functions with different architectures.
-        Limitation: only works on ARM hosts that support x86 emulation.
+    def test_mixed_architecture(self, create_lambda_function, aws_client, snapshot):
+        """Test emulation of a lambda function changing architectures.
+        Limitation: only works on hosts that support both ARM and AMD64 architectures.
         """
-        func_name = f"test_lambda_x86_{short_uid()}"
-        create_lambda_function(
+        func_name = f"test_lambda_mixed_arch_{short_uid()}"
+        zip_file = create_lambda_archive(load_file(TEST_LAMBDA_INTROSPECT_PYTHON), get_content=True)
+        create_function_response = create_lambda_function(
             func_name=func_name,
-            handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_10,
+            zip_file=zip_file,
+            runtime=Runtime.python3_12,
             Architectures=[Architecture.x86_64],
         )
+        snapshot.match("create_function_response", create_function_response)
 
-        invoke_result = aws_client.lambda_.invoke(FunctionName=func_name)
-        assert "FunctionError" not in invoke_result
-        payload = json.load(invoke_result["Payload"])
+        invoke_result_x86 = aws_client.lambda_.invoke(FunctionName=func_name)
+        assert "FunctionError" not in invoke_result_x86
+        payload = json.load(invoke_result_x86["Payload"])
         assert payload.get("platform_machine") == "x86_64"
 
-        func_name_arm = f"test_lambda_arm_{short_uid()}"
-        create_lambda_function(
-            func_name=func_name_arm,
-            handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
-            runtime=Runtime.python3_10,
-            Architectures=[Architecture.arm64],
+        update_function_configuration_response = aws_client.lambda_.update_function_code(
+            FunctionName=func_name, ZipFile=zip_file, Architectures=[Architecture.arm64]
+        )
+        snapshot.match(
+            "update_function_configuration_response", update_function_configuration_response
+        )
+        aws_client.lambda_.get_waiter(waiter_name="function_updated_v2").wait(
+            FunctionName=func_name
         )
 
-        invoke_result_arm = aws_client.lambda_.invoke(FunctionName=func_name_arm)
+        invoke_result_arm = aws_client.lambda_.invoke(FunctionName=func_name)
         assert "FunctionError" not in invoke_result_arm
         payload_arm = json.load(invoke_result_arm["Payload"])
         assert payload_arm.get("platform_machine") == "aarch64"
-
-        v1_result = aws_client.lambda_.publish_version(FunctionName=func_name)
-        v1 = v1_result["Version"]
-
-        # assert version is available(!)
-        aws_client.lambda_.get_waiter(waiter_name="function_active_v2").wait(
-            FunctionName=func_name, Qualifier=v1
-        )
-
-        arm_v1_result = aws_client.lambda_.publish_version(FunctionName=func_name_arm)
-        arm_v1 = arm_v1_result["Version"]
-
-        # assert version is available(!)
-        aws_client.lambda_.get_waiter(waiter_name="function_active_v2").wait(
-            FunctionName=func_name_arm, Qualifier=arm_v1
-        )
-
-        invoke_result_2 = aws_client.lambda_.invoke(FunctionName=func_name, Qualifier=v1)
-        assert "FunctionError" not in invoke_result_2
-        payload_2 = json.load(invoke_result_2["Payload"])
-        assert payload_2.get("platform_machine") == "x86_64"
-
-        invoke_result_arm_2 = aws_client.lambda_.invoke(
-            FunctionName=func_name_arm, Qualifier=arm_v1
-        )
-        assert "FunctionError" not in invoke_result_arm_2
-        payload_arm_2 = json.load(invoke_result_arm_2["Payload"])
-        assert payload_arm_2.get("platform_machine") == "aarch64"
 
     @pytest.mark.parametrize(
         ["lambda_fn", "lambda_runtime"],

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3472,8 +3472,105 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_mixed_architecture": {
-    "recorded-date": "20-11-2023, 23:14:17",
-    "recorded-content": {}
+    "recorded-date": "16-02-2024, 11:16:11",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "update_function_configuration_response": {
+        "Architectures": [
+          "arm64"
+        ],
+        "CodeSha256": "code-sha256",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.12",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_provisioned_concurrency_scheduling": {
     "recorded-date": "28-11-2023, 16:48:42",

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2023-11-20T21:04:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_mixed_architecture": {
-    "last_validated_date": "2023-11-20T22:14:17+00:00"
+    "last_validated_date": "2024-02-16T11:16:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
     "last_validated_date": "2023-11-20T21:04:08+00:00"


### PR DESCRIPTION
## Motivation

[UpdateFunctionCode](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html) does not support updating the [Architectures](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html#lambda-UpdateFunctionCode-request-Architectures) (e.g., x64 => ARM).
This issue has been reported and reproduced by @cabeaulac based on customer input.

## Changes

* Adjust the mixed architecture test `test_mixed_architecture` to use `UpdateFunctionCode`
* Implement Architecture update in `UpdateFunctionCode`

## Testing

Our CI pipeline currently does not support cross-architecture emulation. Therefore, this change can only be tested locally on a machine with cross-architecture support (e.g., ARM MacBook):

1. Unskip `tests.aws.services.lambda_.test_lambda.TestLambdaBehavior.test_mixed_architecture`
2. Run `tests.aws.services.lambda_.test_lambda.TestLambdaBehavior.test_mixed_architecture`

