### PR TITLE
upgrade plux to 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ install-s3: venv     ## Install dependencies for the localstack runtime for s3-o
 
 install: install-dev entrypoints  ## Install full dependencies into venv
 
-entrypoints:              ## Run setup.py develop to build entry points
-	$(VENV_RUN); python setup.py plugins egg_info
+entrypoints:              ## Run plux to build entry points
+	$(VENV_RUN); python -m plux entrypoints
 	@# make sure that the entrypoints were correctly created and are non-empty
 	@test -s localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 

--- a/localstack/cli/plugin.py
+++ b/localstack/cli/plugin.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 import click
-from plugin import Plugin, PluginManager
+from plux import Plugin, PluginManager
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/cli/plugins.py
+++ b/localstack/cli/plugins.py
@@ -2,8 +2,9 @@ import os
 import time
 
 import click
-from plugin import PluginManager
-from plugin.entrypoint import find_plugins, spec_to_entry_point
+from plux import PluginManager
+from plux.build.setuptools import find_plugins
+from plux.core.entrypoint import spec_to_entry_point
 from rich import print as rprint
 from rich.console import Console
 from rich.table import Table

--- a/localstack/extensions/api/extension.py
+++ b/localstack/extensions/api/extension.py
@@ -1,4 +1,4 @@
-from plugin import Plugin
+from plux import Plugin
 
 from .aws import CompositeExceptionHandler, CompositeHandler, CompositeResponseHandler
 from .http import RouteHandler, Router

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -8,7 +8,7 @@ from inspect import getmodule
 from threading import RLock
 from typing import Callable, List, Optional, Tuple
 
-from plugin import Plugin, PluginManager, PluginSpec
+from plux import Plugin, PluginManager, PluginSpec
 
 from localstack import config
 

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -1,6 +1,6 @@
 import functools
 
-from plugin import PluginManager, plugin
+from plux import PluginManager, plugin
 
 # plugin namespace constants
 HOOKS_CONFIGURE_LOCALSTACK_CONTAINER = "localstack.hooks.configure_localstack_container"

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypedD
 
 import botocore
 from botocore.exceptions import UnknownServiceError
-from plugin import Plugin, PluginManager
+from plux import Plugin, PluginManager
 
 from localstack import config
 from localstack.aws.connect import ServiceLevelClientFactory, connect_to

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -219,7 +219,7 @@ class PluginsResource:
     """
 
     def on_get(self, request):
-        from plugin import PluginManager
+        from plux import PluginManager
 
         from localstack.runtime import hooks
         from localstack.services.plugins import SERVICE_PLUGINS

--- a/localstack/services/lambda_/invocation/plugins.py
+++ b/localstack/services/lambda_/invocation/plugins.py
@@ -1,4 +1,4 @@
-from plugin import Plugin
+from plux import Plugin
 
 
 class RuntimeExecutorPlugin(Plugin):

--- a/localstack/services/lambda_/invocation/runtime_executor.py
+++ b/localstack/services/lambda_/invocation/runtime_executor.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Type
 
-from plugin import PluginManager
+from plux import PluginManager
 
 from localstack import config
 from localstack.services.lambda_.invocation.lambda_models import FunctionVersion, InvocationResult

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Protocol, Tuple
 
-from plugin import Plugin, PluginLifecycleListener, PluginManager, PluginSpec
+from plux import Plugin, PluginLifecycleListener, PluginManager, PluginSpec
 
 from localstack import config
 from localstack.aws.skeleton import DispatchTable, Skeleton

--- a/localstack/state/snapshot.py
+++ b/localstack/state/snapshot.py
@@ -1,4 +1,4 @@
-from plugin import Plugin
+from plux import Plugin
 
 from .core import StateVisitor
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -1116,7 +1116,7 @@ def configure_container(container: Container):
     else:
         container.config.additional_flags = f"{container.config.additional_flags} {user_flags}"
 
-    # get additional parameters from plugins
+    # get additional parameters from pluxs
     hooks.configure_localstack_container.run(container)
 
     if config.DEVELOP:

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -1116,7 +1116,7 @@ def configure_container(container: Container):
     else:
         container.config.additional_flags = f"{container.config.additional_flags} {user_flags}"
 
-    # get additional parameters from pluxs
+    # get additional parameters from plux
     hooks.configure_localstack_container.run(container)
 
     if config.DEVELOP:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools', 'wheel', 'plux>=1.3.1']
+requires = ['setuptools', 'wheel', 'plux>=1.7']
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -95,7 +95,7 @@ packaging==23.2
     # via docker
 pbr==6.0.0
     # via stevedore
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 priority==2.0.0
     # via hypercorn

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -30,7 +30,7 @@ mdurl==0.1.2
     # via markdown-it-py
 pbr==6.0.0
     # via stevedore
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 psutil==5.9.8
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -292,7 +292,7 @@ pluggy==1.4.0
     #   pytest
 plumbum==1.8.2
     # via pandoc
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 ply==3.11
     # via

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -211,7 +211,7 @@ pbr==6.0.0
     #   jschema-to-python
     #   sarif-om
     #   stevedore
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 ply==3.11
     # via

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -257,7 +257,7 @@ pluggy==1.4.0
     # via
     #   localstack-core (pyproject.toml)
     #   pytest
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 ply==3.11
     # via

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -488,7 +488,7 @@ pluggy==1.4.0
     #   pytest
 plumbum==1.8.2
     # via pandoc
-plux==1.5.0
+plux==1.7.0
     # via localstack-core (pyproject.toml)
 ply==3.11
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     dill==0.3.6
     dnslib>=0.9.10
     dnspython>=1.16.0
-    plux>=1.7,<2.0
+    plux>=1.7
     psutil>=5.4.8
     python-dotenv>=0.19.1
     pyyaml>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     dill==0.3.6
     dnslib>=0.9.10
     dnspython>=1.16.0
-    plux>=1.3.1
+    plux>=1.7,<2.0
     psutil>=5.4.8
     python-dotenv>=0.19.1
     pyyaml>=5.1


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR upgrade plux to 1.7 which provides python 3.12 support (see #10235). The PR also migrates `plugin` imports to the new way to do things (`from plux import ...`). Since 1.7 is backwards compatible, we can make these changes for ext separately.
Moreover, plux now has a way of regenerating entrypoints without invoking setup.py (which is deprecated), therefore unblocking us from moving away from a `setup.py` to `python -m build`.

We could also look into removing `localstack.cli.plugins`, and move some of the functionality to plux (if needed).

<!-- What notable changes does this PR make? -->
## Changes

* localstack now uses plux>=1.7 (also adds a constraint for <2 where restructuring is expected)
* `make entrypoints` now uses the plux frontend `python -m plux entrypoints` instead of `setup.py plugins egg_info`
* localstack now favors `from plux` for imports instead of `from plugin`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

