### PR TITLE
[wip] Add util script for building/pushing Docker images

### DIFF
--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage() {
+    echo "A set of commands that facilitate building and pushing versioned Docker images"
+    echo ""
+    echo "USAGE"
+    echo "  docker-helper <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  build"
+    echo "      Build the Docker image for the project in the working directory"
+    echo ""
+    echo "  push"
+    echo "      Push the Docker image for the project in the working directory"
+    echo ""
+    echo "  help"
+    echo "      Show this message"
+}
+
+function get_current_version() {
+    egrep -h "^__version__ = " ${VERSION_FILE} | sed -r 's/^__version__ = "(.*)"/\1/g'
+}
+
+function set_defaults() {
+    if [ "$DOCKERFILE" = "" ]; then DOCKERFILE=Dockerfile; fi
+    if [ "$SOURCE_IMAGE_NAME" = "" ]; then SOURCE_IMAGE_NAME=$IMAGE_NAME; fi
+    if [ "$TARGET_IMAGE_NAME" = "" ]; then TARGET_IMAGE_NAME=$IMAGE_NAME; fi
+}
+
+function docker_build() {
+    # start build
+    # --add-host: Fix for Centos host OS
+    # --build-arg BUILDKIT_INLINE_CACHE=1: Instruct buildkit to inline the caching information into the image
+    # --cache-from: Use the inlined caching information when building the image
+    DOCKER_BUILDKIT=1 docker buildx build --pull --progress=plain \
+      --cache-from $TAG --build-arg BUILDKIT_INLINE_CACHE=1 \
+      --build-arg LOCALSTACK_PRE_RELEASE=$(cat localstack/__init__.py | grep '^__version__ =' | grep -v '.dev' >> /dev/null && echo "0" || echo "1") \
+      --build-arg LOCALSTACK_BUILD_GIT_HASH=$(git rev-parse --short HEAD) \
+      --build-arg=LOCALSTACK_BUILD_DATE=$(date -u +"%Y-%m-%d") \
+      --build-arg=LOCALSTACK_BUILD_VERSION=$IMAGE_TAG \
+      --add-host="localhost.localdomain:127.0.0.1" \
+      -t $TAG $DOCKER_BUILD_FLAGS . -f $DOCKERFILE
+}
+
+function docker_build_multiarch() {
+    ## Build the Multi-Arch full Docker image
+	  # Make sure to prepare your environment for cross-platform docker builds! (see doc/developer_guides/README.md)
+	  # Multi-Platform builds cannot be loaded to the docker daemon from buildx, so we can't add "--load".
+	  DOCKER_BUILD_FLAGS="--platform linux/amd64,linux/arm64" docker_build
+}
+
+function docker_push_main() {
+    # Push a single platform-specific Docker image to registry IF we are currently on the master branch
+    (CURRENT_BRANCH=`(git rev-parse --abbrev-ref HEAD | grep '^master$$' || ((git branch -a | grep 'HEAD detached at [0-9a-zA-Z]*)') && git branch -a)) | grep '^[* ]*master$$' | sed 's/[* ]//g' || true`; \
+      test "$$CURRENT_BRANCH" != 'master' && echo "Not on master branch.") || \
+    ((test "$$DOCKER_USERNAME" = '' || test "$$DOCKER_PASSWORD" = '' ) && \
+      echo "Skipping docker push as no credentials are provided.") || \
+    (REMOTE_ORIGIN="`git remote -v | grep '/localstack' | grep origin | grep push | awk '{print $$2}'`"; \
+      test "$$REMOTE_ORIGIN" != 'https://github.com/localstack/localstack.git' && \
+      test "$$REMOTE_ORIGIN" != 'git@github.com:localstack/localstack.git' && \
+      echo "This is a fork and not the main repo.") || \
+    ( \
+      docker info | grep Username || docker login -u $$DOCKER_USERNAME -p $$DOCKER_PASSWORD; \
+        docker tag $SOURCE_IMAGE_NAME:latest $TARGET_IMAGE_NAME:latest-$PLATFORM && \
+      ((! (git diff HEAD~1 localstack/__init__.py | grep '^+__version__ =' | grep -v '.dev') && \
+        echo "Only pushing tag 'latest' as version has not changed.") || \
+        (docker tag $TARGET_IMAGE_NAME:latest-$PLATFORM $TARGET_IMAGE_NAME:stable-$PLATFORM && \
+          docker tag $TARGET_IMAGE_NAME:latest-$PLATFORM $TARGET_IMAGE_NAME:$IMAGE_TAG-$PLATFORM && \
+          docker tag $TARGET_IMAGE_NAME:latest-$PLATFORM $TARGET_IMAGE_NAME:$MAJOR_VERSION-$PLATFORM && \
+          docker tag $TARGET_IMAGE_NAME:latest-$PLATFORM $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION-$PLATFORM && \
+          docker tag $TARGET_IMAGE_NAME:latest-$PLATFORM $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION-$PLATFORM && \
+          docker push $TARGET_IMAGE_NAME:stable-$PLATFORM && \
+          docker push $TARGET_IMAGE_NAME:$IMAGE_TAG-$PLATFORM && \
+          docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION-$PLATFORM && \
+          docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION-$PLATFORM && \
+          docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION-$PLATFORM \
+          )) && \
+            docker push $TARGET_IMAGE_NAME:latest-$PLATFORM \
+    )
+}
+
+
+# commands
+
+function cmd-build() {
+    set_defaults
+    docker_build
+}
+
+function cmd-build-multiarch() {
+    set_defaults
+    docker_build_multiarch
+}
+
+function cmd-push() {
+    set_defaults
+    docker_push
+}
+
+function cmd-push-main() {
+    set_defaults
+    docker_push_main
+}
+
+function main() {
+    [[ $# -lt 1 ]] && { usage; exit 1; }
+
+    command_name=$1
+    shift
+
+    # invoke command
+    case $command_name in
+        "build")             cmd-build "$@" ;;
+        "build-multiarch")   cmd-build-multiarch "$@" ;;
+        "push")              cmd-push "$@" ;;
+        "push-main")         cmd-push-main "$@" ;;
+        "help")              usage && exit 0 ;;
+        *)                   usage && exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -45,10 +45,12 @@ function set_defaults() {
     fi
 
     # determine major/minor/patch versions
-    IMAGE_TAG?=$(cat $PYTHON_CODE_DIR/__init__.py | grep '^__version__ =' | sed "s/__version__ = ['\"]\(.*\)['\"].*/\1/")
-    MAJOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f1)
-    MINOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f2)
-    PATCH_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f3)
+    if [ -z "$IMAGE_TAG" ]; then
+      IMAGE_TAG=$(cat $PYTHON_CODE_DIR/__init__.py | grep '^__version__ =' | sed "s/__version__ = ['\"]\(.*\)['\"].*/\1/")
+    fi
+    if [ -z "$MAJOR_VERSION" ]; then MAJOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f1); fi
+    if [ -z "$MINOR_VERSION" ]; then MINOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f2); fi
+    if [ -z "$PATCH_VERSION" ]; then PATCH_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f3); fi
 
     if [ -z "$DOCKERFILE" ]; then DOCKERFILE=Dockerfile; fi
     if [ -z "$SOURCE_IMAGE_NAME" ]; then SOURCE_IMAGE_NAME=$IMAGE_NAME; fi

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -12,8 +12,11 @@ function usage() {
     echo "  build"
     echo "      Build the Docker image for the project in the working directory"
     echo ""
-    echo "  push"
-    echo "      Push the Docker image for the project in the working directory"
+    echo "  push-main"
+    echo "      Push the Docker image for the project if we're on the main branch"
+    echo ""
+    echo "  push-manifests-main"
+    echo "      Push the multi-arch Docker manifests if we're on the main branch"
     echo ""
     echo "  help"
     echo "      Show this message"
@@ -41,6 +44,12 @@ function set_defaults() {
         PYTHON_CODE_DIR=$(dirname $entry)
     fi
 
+    # determine major/minor/patch versions
+    IMAGE_TAG?=$(cat $PYTHON_CODE_DIR/__init__.py | grep '^__version__ =' | sed "s/__version__ = ['\"]\(.*\)['\"].*/\1/")
+    MAJOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f1)
+    MINOR_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f2)
+    PATCH_VERSION=$(echo ${IMAGE_TAG} | cut -d '.' -f3)
+
     if [ -z "$DOCKERFILE" ]; then DOCKERFILE=Dockerfile; fi
     if [ -z "$SOURCE_IMAGE_NAME" ]; then SOURCE_IMAGE_NAME=$IMAGE_NAME; fi
     if [ -z "$TARGET_IMAGE_NAME" ]; then TARGET_IMAGE_NAME=$IMAGE_NAME; fi
@@ -50,7 +59,7 @@ function set_defaults() {
 }
 
 function docker_build() {
-    # start build
+    # start build of a platform-specific image (this target will get called for multiple archs like AMD64/ARM64)
 
     # by default we load the result to the docker daemon
     if [ "$DOCKER_BUILD_FLAGS" = "" ]; then DOCKER_BUILD_FLAGS="--load"; fi


### PR DESCRIPTION
## Motivation

A common use case we're seeing is to build multi-arch Docker images with semantic versioning (build tags like `:3`, `3.1`, `latest`, etc), for which we currently have targets in the Makefile (`docker-build`, `docker-push-master`, `docker-create-push-manifests`, etc). Maintaining this non-trivial logic in the Makefile is cumbersome, and we could also benefit from making it reusable across different repos. This PR is a first step towards making these targets reusable across different repos, including -ext, the upcoming Snowflake image, etc.

## Changes

Add util script for building/pushing Docker images. The script follows a similar structure as the existing `bin/release-helper.sh` script we already have in place.

🚧 more details following soon.. /cc @alexrashed 

TODOs:
- [x] add logic to extract correct major/minor/patch version numbers from `__version__` in `__init__.py` files

## Testing

The script has been tested in an upstream pipeline (snowflake repo). Still need to coordinate whether and how to integrate the script into the build process of this repo.

