### PR TITLE
Add trailing newline for linter compliance

### DIFF
--- a/localstack/testing/pytest/validation_tracking.py
+++ b/localstack/testing/pytest/validation_tracking.py
@@ -60,6 +60,7 @@ def record_passed_validation(item: pytest.Item, timestamp: Optional[datetime.dat
         # save updates
         fd.seek(0)
         json.dump(content, fd, indent=2, sort_keys=True)
+        fd.write("\n")  # add trailing newline for linter and Git compliance
 
 
 # TODO: we should skip if we're updating snapshots

--- a/localstack/testing/scenario/provisioning.py
+++ b/localstack/testing/scenario/provisioning.py
@@ -319,6 +319,7 @@ class InfraProvisioner:
                 with open(template_path, "wt") as fd:
                     template_json = cdk.assertions.Template.from_stack(cdk_stack).to_json()
                     json.dump(template_json, fd, indent=2)
+                    fd.write("\n")  # add trailing newline for linter and Git compliance
 
             self.cloudformation_stacks[cdk_stack.stack_name] = {
                 "StackName": cdk_stack.stack_name,


### PR DESCRIPTION
## Motivation

Synthesized CloudFormation stacks (from CDK) and recorded validation files (i.e., `.validation.json`) are not compliant with our linter rules requiring a trailing newline. Example:

```diff
diff --git a/tests/aws/cdk_templates/HelloWorld/HelloWorldStack.json b/tests/aws/cdk_templates/HelloWorld/HelloWorldStack.json
index 19b415de9..f2a4165e2 100644
--- a/tests/aws/cdk_templates/HelloWorld/HelloWorldStack.json
+++ b/tests/aws/cdk_templates/HelloWorld/HelloWorldStack.json
@@ -3,7 +3,7 @@
     "MyBucketF68F3FF0": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
        "BucketName": "my-unique-bucket-name-2942856d"
       },
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
@@ -16,4 +16,4 @@
       }
     }
   }
-}
\ No newline at end of file
+}
diff --git a/tests/aws/scenario/hello_world/test_hello_world.validation.json b/tests/aws/scenario/hello_world/test_hello_world.validation.json
index 1d582f613..b945ab537 100644
--- a/tests/aws/scenario/hello_world/test_hello_world.validation.json
+++ b/tests/aws/scenario/hello_world/test_hello_world.validation.json
@@ -2,4 +2,4 @@
   "tests/aws/scenario/hello_world/test_hello_world.py::TestNoteTakingScenario::test_validate_infra_setup": {
     "last_validated_date": "2024-02-19T18:10:31+00:00"
   }
-}
\ No newline at end of file
+}

```

## Changes

* Add a trailing newline for synthesized CF templates and validation jsons