### PR TITLE
Add tracking of entire workflow scopes to Tinybird

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,7 @@ commands:
       - run:
           name: Setup Environment Variables
           command: |
-            if [[ $CIRCLE_BRANCH == "master" ]] ; then
-              echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
-            fi
+            echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
             echo "export TINYBIRD_DATASOURCE=localstack-tests-circleci" >> $BASH_ENV
             echo "export TINYBIRD_TOKEN=${TINYBIRD_CI_TOKEN}" >> $BASH_ENV
             echo "export CI_COMMIT_BRANCH=${CIRCLE_BRANCH}" >> $BASH_ENV
@@ -492,13 +490,41 @@ jobs:
             source .venv/bin/activate
             bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
             make publish
+  save-start-time:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    steps:
+      - run:
+          name: Save start time to file
+          command: mkdir -p target/stats && echo $(date +%s) > target/stats/start-time.txt
+      - persist_to_workspace:
+            root: /tmp/workspace
+            paths:
+                - repo/target/stats/
+  send-stats:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load start time from file
+          command: |
+            START_TIME=$(cat target/stats/start-time.txt)
+            END_TIME=$(date +%s)
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > target/stats/stats.json
+            echo 'Sending: '$(cat target/stats/stats.json)
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @target/stats/stats.json
 
 
 
 workflows:
   main:
     jobs:
-      - install
+      - save-start-time
+      - install:
+          requires:
+            - save-start-time
       - preflight:
           requires:
             - install
@@ -564,6 +590,9 @@ workflows:
             - docker-test-arm64
             - collect-not-implemented
             - unit-tests
+      - send-stats:
+          requires:
+            - report
       - push:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ commands:
           name: Setup Environment Variables
           command: |
             echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
-            echo "export TINYBIRD_DATASOURCE=localstack-tests-circleci" >> $BASH_ENV
+            echo "export TINYBIRD_DATASOURCE=community_tests_circleci" >> $BASH_ENV
             echo "export TINYBIRD_TOKEN=${TINYBIRD_CI_TOKEN}" >> $BASH_ENV
             echo "export CI_COMMIT_BRANCH=${CIRCLE_BRANCH}" >> $BASH_ENV
             echo "export CI_COMMIT_SHA=${CIRCLE_SHA1}" >> $BASH_ENV
             echo "export CI_JOB_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
-            echo "export CI_JOB_NAME=${CIRCLE_JOB}" >> $BASH_ENV
+            echo "export CI_JOB_NAME=${CIRCLE_WORKFLOW_ID}" >> $BASH_ENV
             echo "export CI_JOB_ID=${CIRCLE_WORKFLOW_JOB_ID}" >> $BASH_ENV
             source $BASH_ENV
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,15 @@ commands:
       - run:
           name: Setup Environment Variables
           command: |
-            echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
+            if [[ $CIRCLE_BRANCH == "master" ]] ; then
+              echo "export TINYBIRD_PYTEST_ARGS='--report-to-tinybird '" >> $BASH_ENV
+            fi
             echo "export TINYBIRD_DATASOURCE=community_tests_circleci" >> $BASH_ENV
             echo "export TINYBIRD_TOKEN=${TINYBIRD_CI_TOKEN}" >> $BASH_ENV
             echo "export CI_COMMIT_BRANCH=${CIRCLE_BRANCH}" >> $BASH_ENV
             echo "export CI_COMMIT_SHA=${CIRCLE_SHA1}" >> $BASH_ENV
             echo "export CI_JOB_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
+            # workflow ID as the job name to associate the tests with workflows in TB
             echo "export CI_JOB_NAME=${CIRCLE_WORKFLOW_ID}" >> $BASH_ENV
             echo "export CI_JOB_ID=${CIRCLE_WORKFLOW_JOB_ID}" >> $BASH_ENV
             source $BASH_ENV
@@ -602,8 +605,18 @@ workflows:
             - collect-not-implemented
             - unit-tests
       - send-stats:
+          filters:
+            branches:
+              only: master
           requires:
-            - report
+            - itest-sfn-legacy-provider
+            - itest-s3-v2-legacy-provider
+            - itest-cloudwatch-v2-provider
+            - acceptance-tests
+            - docker-test-amd64
+            - docker-test-arm64
+            - collect-not-implemented
+            - unit-tests
       - push:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,9 +512,9 @@ jobs:
           command: |
             START_TIME=$(cat stats/start-time.txt)
             END_TIME=$(date +%s)
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > /stats/stats.json
-            echo 'Sending: '$(cat /stats/stats.json)
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @/stats/stats.json
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > stats/stats.json
+            echo 'Sending: '$(cat stats/stats.json)
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,11 +496,11 @@ jobs:
     steps:
       - run:
           name: Save start time to file
-          command: mkdir -p target/stats && echo $(date +%s) > target/stats/start-time.txt
+          command: mkdir stats && echo $(date +%s) > stats/start-time.txt
       - persist_to_workspace:
             root: /tmp/workspace
             paths:
-                - repo/target/stats/
+                - repo/stats/
   send-stats:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -510,11 +510,11 @@ jobs:
       - run:
           name: Load start time from file
           command: |
-            START_TIME=$(cat target/stats/start-time.txt)
+            START_TIME=$(cat stats/start-time.txt)
             END_TIME=$(date +%s)
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > target/stats/stats.json
-            echo 'Sending: '$(cat target/stats/stats.json)
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @target/stats/stats.json
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > /stats/stats.json
+            echo 'Sending: '$(cat /stats/stats.json)
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @/stats/stats.json
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,11 +508,22 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+          when: on_fail
+          name: Detecting Job Status (FAIL)
+          command: |
+            echo "export CCI_STATUS='failure'" >> $BASH_ENV
+      - run:
+          when: on_success
+          name: Detecting Job Status (PASS)
+          command: |
+            echo "export CCI_STATUS='success'" >> $BASH_ENV
+      - run:
+          when: always
           name: Load start time from file
           command: |
             START_TIME=$(cat stats/start-time.txt)
             END_TIME=$(date +%s)
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'"}' > stats/stats.json
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$CCI_STATUS'"}' > stats/stats.json
             echo 'Sending: '$(cat stats/stats.json)
             curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
 

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -95,8 +95,9 @@ jobs:
     needs: cli-tests
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v2.0.0
+        uses: localstack/tinybird-workflow-push@v3.0.0
         with:
+          workflow_id: "tests_cli"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -55,8 +55,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  #  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   cli-tests:
@@ -90,7 +89,7 @@ jobs:
           python -m pytest tests/cli/
 
   push-to-tinybird:
-    if: always()
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: cli-tests
     steps:

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -49,13 +49,14 @@ concurrency:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-cli
+  TINYBIRD_DATASOURCE: community_tests_cli
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  #  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
 
 jobs:
   cli-tests:
@@ -87,3 +88,15 @@ jobs:
           PYTEST_ADDOPTS: "${{ env.TINYBIRD_PYTEST_ARGS }}-p no:localstack.testing.pytest.fixtures -p no:localstack_snapshot.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -p no:localstack.testing.pytest.validation_tracking -p no:tests.fixtures -s"
         run: |
           python -m pytest tests/cli/
+
+  push-to-tinybird:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: cli-tests
+    steps:
+      - name: Push to Tinybird
+        uses: localstack/tinybird-workflow-push@v2.0.0
+        with:
+          tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -6,13 +6,14 @@ on:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-podman
+  TINYBIRD_DATASOURCE: community_tests_podman
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  #  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
 
 jobs:
   podman-tests:
@@ -62,3 +63,15 @@ jobs:
           podmanSocket=$(podman system info --format json | jq -r '.host.remoteSocket.path')
           echo "Running tests against local podman socket $podmanSocket"
           DOCKER_HOST=$podmanSocket make test
+
+  push-to-tinybird:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: podman-tests
+    steps:
+      - name: Push to Tinybird
+        uses: localstack/tinybird-workflow-push@v2.0.0
+        with:
+          tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -12,8 +12,7 @@ env:
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  #  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   podman-tests:
@@ -65,7 +64,7 @@ jobs:
           DOCKER_HOST=$podmanSocket make test
 
   push-to-tinybird:
-    if: always()
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: podman-tests
     steps:

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -70,8 +70,9 @@ jobs:
     needs: podman-tests
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v2.0.0
+        uses: localstack/tinybird-workflow-push@v3.0.0
         with:
+          workflow_id: "tests_podman"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -74,13 +74,15 @@ concurrency:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-pro-integration
+#  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-pro-integration
+  TINYBIRD_DATASOURCE: community_tests_pro_integration
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+#  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
 
 jobs:
   test-pro:
@@ -330,3 +332,15 @@ jobs:
           files: "pytest-junit-community-*.xml"
           check_name: "LocalStack Community integration with Pro"
           action_fail_on_inconclusive: true
+
+  push-to-tinybird:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: publish-pro-test-results
+    steps:
+      - name: Push to Tinybird
+        uses: localstack/tinybird-workflow-push@v2.0.0
+        with:
+          tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -74,15 +74,13 @@ concurrency:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-#  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-pro-integration
   TINYBIRD_DATASOURCE: community_tests_pro_integration
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-#  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 jobs:
   test-pro:
@@ -334,7 +332,7 @@ jobs:
           action_fail_on_inconclusive: true
 
   push-to-tinybird:
-    if: always()
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: publish-pro-test-results
     steps:

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -339,8 +339,9 @@ jobs:
     needs: publish-pro-test-results
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v2.0.0
+        uses: localstack/tinybird-workflow-push@v3.0.0
         with:
+          workflow_id: "tests_pro_integration"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -54,13 +54,15 @@ concurrency:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-s3-image
+#  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-s3-image
+  TINYBIRD_DATASOURCE: community_tests_s3_image
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
-  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+#  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
+  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
 
 
 jobs:
@@ -211,3 +213,15 @@ jobs:
         with:
           name: localstack-s3-*
           failOnError: false
+
+  push-to-tinybird:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: push-s3-image
+    steps:
+      - name: Push to Tinybird
+        uses: localstack/tinybird-workflow-push@v2.0.0
+        with:
+          tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -220,8 +220,9 @@ jobs:
     needs: push-s3-image
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v2.0.0
+        uses: localstack/tinybird-workflow-push@v3.0.0
         with:
+          workflow_id: "tests_s3_image"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -54,15 +54,13 @@ concurrency:
 env:
   # Set non-job-specific environment variables for pytest-tinybird
   TINYBIRD_URL: https://api.tinybird.co
-#  TINYBIRD_DATASOURCE: ${{ github.event.repository.name }}-tests-s3-image
   TINYBIRD_DATASOURCE: community_tests_s3_image
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_CI_TOKEN }}
   CI_COMMIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CI_COMMIT_SHA: ${{ github.sha }}
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
-#  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TINYBIRD_PYTEST_ARGS: "--report-to-tinybird "
+  TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
 
 jobs:
@@ -215,7 +213,7 @@ jobs:
           failOnError: false
 
   push-to-tinybird:
-    if: always()
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: push-s3-image
     steps:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Currently, our CI tracking in Tinybird does not take into account the concept of a workflow (and reruns). This makes it difficult to truly understand if a workflow is finished or not.

<!-- What notable changes does this PR make? -->
## Changes

This PR adds a notion of a workflow to tinybird by pushing information about workflows at the end of each run attempt. To this end, a github action, published on the marketplace was added: https://github.com/marketplace/actions/push-workflow-data-to-tinybird


## Testing

Check in Tinybird if the data contains the same information (+ the newly added workflow start+end information) 

## TODO

What's left to do:

- [x] Reintroduce the guardrails to only execute the tracking on the master branch before merge
- [x] Make further considerations about the naming of the produced tinybird datasources


