### PR TITLE
Save session tags when assuming a role

### DIFF
--- a/localstack/services/sts/models.py
+++ b/localstack/services/sts/models.py
@@ -1,0 +1,9 @@
+from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
+
+
+class STSStore(BaseStore):
+    # maps access key ids to tags for the session they belong to
+    session_tags: dict[str, dict[str, str]] = CrossRegionAttribute(default=dict)
+
+
+sts_stores = AccountRegionBundle("sts", STSStore)

--- a/localstack/services/sts/provider.py
+++ b/localstack/services/sts/provider.py
@@ -21,6 +21,7 @@ from localstack.aws.api.sts import (
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sts.models import sts_stores
+from localstack.utils.aws.arns import extract_account_id_from_arn
 
 LOG = logging.getLogger(__name__)
 
@@ -53,7 +54,9 @@ class StsProvider(StsApi, ServiceLifecycleHook):
 
         if tags:
             transformed_tags = {tag["Key"]: tag["Value"] for tag in tags}
-            store = sts_stores[context.account_id][context.region]
+            # we should save it in the store of the role account, not the requester
+            account_id = extract_account_id_from_arn(role_arn)
+            store = sts_stores[account_id]["us-east-1"]
             access_key_id = response["Credentials"]["AccessKeyId"]
             store.session_tags[access_key_id] = transformed_tags
         return response

--- a/localstack/services/sts/provider.py
+++ b/localstack/services/sts/provider.py
@@ -1,9 +1,26 @@
 import logging
 
 from localstack.aws.api import RequestContext
-from localstack.aws.api.sts import GetCallerIdentityResponse, StsApi
+from localstack.aws.api.sts import (
+    AssumeRoleResponse,
+    GetCallerIdentityResponse,
+    ProvidedContextsListType,
+    StsApi,
+    arnType,
+    externalIdType,
+    policyDescriptorListType,
+    roleDurationSecondsType,
+    roleSessionNameType,
+    serialNumberType,
+    sourceIdentityType,
+    tagKeyListType,
+    tagListType,
+    tokenCodeType,
+    unrestrictedSessionPolicyDocumentType,
+)
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
+from localstack.services.sts.models import sts_stores
 
 LOG = logging.getLogger(__name__)
 
@@ -13,4 +30,30 @@ class StsProvider(StsApi, ServiceLifecycleHook):
         response = call_moto(context)
         if "user/moto" in response["Arn"] and "sts" in response["Arn"]:
             response["Arn"] = f"arn:aws:iam::{response['Account']}:root"
+        return response
+
+    def assume_role(
+        self,
+        context: RequestContext,
+        role_arn: arnType,
+        role_session_name: roleSessionNameType,
+        policy_arns: policyDescriptorListType = None,
+        policy: unrestrictedSessionPolicyDocumentType = None,
+        duration_seconds: roleDurationSecondsType = None,
+        tags: tagListType = None,
+        transitive_tag_keys: tagKeyListType = None,
+        external_id: externalIdType = None,
+        serial_number: serialNumberType = None,
+        token_code: tokenCodeType = None,
+        source_identity: sourceIdentityType = None,
+        provided_contexts: ProvidedContextsListType = None,
+        **kwargs,
+    ) -> AssumeRoleResponse:
+        response: AssumeRoleResponse = call_moto(context)
+
+        if tags:
+            transformed_tags = {tag["Key"]: tag["Value"] for tag in tags}
+            store = sts_stores[context.account_id][context.region]
+            access_key_id = response["Credentials"]["AccessKeyId"]
+            store.session_tags[access_key_id] = transformed_tags
         return response

--- a/localstack/services/sts/provider.py
+++ b/localstack/services/sts/provider.py
@@ -56,6 +56,8 @@ class StsProvider(StsApi, ServiceLifecycleHook):
             transformed_tags = {tag["Key"]: tag["Value"] for tag in tags}
             # we should save it in the store of the role account, not the requester
             account_id = extract_account_id_from_arn(role_arn)
+            # the region is hardcoded to "us-east-1" as IAM/STS are global services
+            # this will only differ for other partitions, which are not yet supported
             store = sts_stores[account_id]["us-east-1"]
             access_key_id = response["Credentials"]["AccessKeyId"]
             store.session_tags[access_key_id] = transformed_tags

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1422,14 +1422,14 @@ def create_user(aws_client):
 
 @pytest.fixture
 def wait_and_assume_role(aws_client):
-    def _wait_and_assume_role(role_arn: str, session_name: str = None):
+    def _wait_and_assume_role(role_arn: str, session_name: str = None, **kwargs):
         if not session_name:
             session_name = f"session-{short_uid()}"
 
         def assume_role():
-            return aws_client.sts.assume_role(RoleArn=role_arn, RoleSessionName=session_name)[
-                "Credentials"
-            ]
+            return aws_client.sts.assume_role(
+                RoleArn=role_arn, RoleSessionName=session_name, **kwargs
+            )["Credentials"]
 
         # need to retry a couple of times before we are allowed to assume this role in AWS
         keys = retry(assume_role, sleep=5, retries=4)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There is no API for retrieving session attributes once the session is created. Since we need the session tags for IAM evaluation, we need to store them.

We store them by access key id instead of session ARN, to avoid collisions with identical SessionNames (those sessions still preserve the right session tags).

<!-- What notable changes does this PR make? -->
## Changes
* Allow `create_role` fixture users to pass additional variables
* Save session tags based on access key id.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

