### PR TITLE
fix pro auth token check

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 shopt -s nullglob
 
 # When trying to activate pro features in the community version, raise a warning
-if [[ -n $LOCALSTACK_API_KEY || -n $LOCALSTACK_AUTH_TOKEN ]] && ! compgen -G /usr/lib/localstack/.*pro-version >/dev/null; then
+if [[ -n $LOCALSTACK_API_KEY || -n $LOCALSTACK_AUTH_TOKEN ]]; then
     echo "WARNING"
     echo "============================================================================"
     echo "  It seems you are trying to use the LocalStack Pro version without using "

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -3,9 +3,8 @@
 set -eo pipefail
 shopt -s nullglob
 
-# the Dockerfile creates .pro-version file for the pro image and .bigdata-pro-version for the bigdata image.
-# When trying to activate pro features with any other version, a warning is printed.
-if [[ $LOCALSTACK_API_KEY ]] && ! compgen -G /usr/lib/localstack/.*pro-version >/dev/null; then
+# When trying to activate pro features in the community version, raise a warning
+if [[ -n $LOCALSTACK_API_KEY || -n $LOCALSTACK_AUTH_TOKEN ]] && ! compgen -G /usr/lib/localstack/.*pro-version >/dev/null; then
     echo "WARNING"
     echo "============================================================================"
     echo "  It seems you are trying to use the LocalStack Pro version without using "


### PR DESCRIPTION
## Motivation
With #7197, we added a big warning to warn users when using our community project's Docker image with LocalStack Pro (as a preparation for the split of the images executed with v2 in #7927.
With v3, we deprecated the `LOCALSTACK_API_KEY` in favor of `LOCALSTACK_AUTH_TOKEN` in our pro offerings.
This PR adjusts the warning such that it also warns users when an auth token is used with the Docker image of the community project.

## Changes
- Also check if the auth token is set when trying to warn the users that they might be using the wrong image.

## Testing
- I tested the script locally:
  ```bash
  # The following commands raise the warning:
  LOCALSTACK_API_KEY="1" LOCALSTACK_AUTH_TOKEN="1" ./bin/docker-entrypoint.sh
  LOCALSTACK_API_KEY="1" ./bin/docker-entrypoint.sh
  LOCALSTACK_AUTH_TOKEN="1" ./bin/docker-entrypoint.sh

  # The following commands do _not_ raise the warning:
  LOCALSTACK_API_KEY="" LOCALSTACK_AUTH_TOKEN="" ./bin/docker-entrypoint.sh
  ./bin/docker-entrypoint.sh
  ```
