### PR TITLE
Add support for CFn dot attributes that conflict with schema

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -97,9 +97,16 @@ def get_attr_from_model_instance(
 
     attribute_candidate = properties.get(attribute_name)
     if "." in attribute_name:
+        # in case we explicitly add a property with a dot, e.g. resource["Properties"]["Endpoint.Port"]
+        # this is only really used for legacy cases since this isn't supported in the propertiers part of the schema
         if attribute_candidate:
-            # in case we explicitly add a property with a dot, e.g. resource["Properties"]["Endpoint.Port"]
             return attribute_candidate
+
+        # some resources (e.g. ElastiCache) have their readOnly attributes defined as Aa.Bb but the property is named AaBb
+        if attribute_candidate := properties.get(attribute_name.replace(".", "")):
+            return attribute_candidate
+
+        # accessing nested properties
         parts = attribute_name.split(".")
         attribute = properties
         # TODO: the attribute fetching below is a temporary workaround for the dependency resolution.


### PR DESCRIPTION
## Motivation
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-cachecluster.html#aws-resource-elasticache-cachecluster-return-values

For -ext we need to support a case where the schema has a conflict between the specified readOnlyProperties, i.e. normally the attributes and the actual property spec. 

Example:  a `!GetAtt Cluster.RedisEndpoint.Address` will look up `RedisEndpointAddress` on the resource


## Changes

- Try to access attribute/property by removing `.` from the attribute name