### PR TITLE
Change schedule for dependency pin upgrade

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -2,7 +2,7 @@ name: Upgrade Pinned Python Dependencies
 
 on:
   schedule:
-    - cron: 0 5 * * MON
+    - cron: 0 5 * * TUE
   workflow_dispatch:
 
 


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Upgrading the botocore dependencies and the regular dependencies might run into conflicts at some point. Therefore we should only upgrade the other dependencies after the botocore dependency upgrades are already merged.

<!-- What notable changes does this PR make? -->
## Changes

This PR changes the schedule so that the upgrade of the pinned dependencies happens on Tuesday morning instead of Monday morning, so that we have time to merge the botocore upgrades before the PR for the other dependencies is created.