### PR TITLE
Validate import_certificate test

### DIFF
--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -1,57 +1,114 @@
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+import datetime
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 import pytest
 from moto import settings as moto_settings
-from moto.ec2 import utils as ec2_utils
 
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 
-DIGICERT_ROOT_CERT = """
------BEGIN CERTIFICATE-----
-MIICRjCCAc2gAwIBAgIQC6Fa+h3foLVJRK/NJKBs7DAKBggqhkjOPQQDAzBlMQsw
-CQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cu
-ZGlnaWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJvb3Qg
-RzMwHhcNMTMwODAxMTIwMDAwWhcNMzgwMTE1MTIwMDAwWjBlMQswCQYDVQQGEwJV
-UzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQu
-Y29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJvb3QgRzMwdjAQBgcq
-hkjOPQIBBgUrgQQAIgNiAAQZ57ysRGXtzbg/WPuNsVepRC0FFfLvC/8QdJ+1YlJf
-Zn4f5dwbRXkLzMZTCp2NXQLZqVneAlr2lSoOjThKiknGvMYDOAdfVdp+CW7if17Q
-RSAPWXYQ1qAk8C3eNvJsKTmjQjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/
-BAQDAgGGMB0GA1UdDgQWBBTL0L2p4ZgFUaFNN6KDec6NHSrkhDAKBggqhkjOPQQD
-AwNnADBkAjAlpIFFAmsSS3V0T8gj43DydXLefInwz5FyYZ5eEJJZVrmDxxDnOOlY
-JjZ91eQ0hjkCMHw2U/Aw5WJjOpnitqM7mzT6HtoQknFekROn3aRukswy1vUhZscv
-6pZjamVFkpUBtA==
------END CERTIFICATE-----
-"""
+
+# TODO: functions taken from the cryptography docs, and
+def generate_private_key() -> RSAPrivateKey:
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+def generate_certificate_bytes(key: RSAPrivateKey) -> bytes:
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "mysite.com"),
+        ]
+    )
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            # Our certificate will be valid for 10 days
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=10)
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+            # Sign our certificate with our private key
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    return cert.public_bytes(Encoding.PEM)
 
 
 class TestACM:
-    @markers.aws.unknown
-    def test_import_certificate(self, aws_client, account_id, region_name):
-        certs_before = aws_client.acm.list_certificates().get("CertificateSummaryList", [])
-
-        with pytest.raises(Exception) as exec_info:
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..Certificate.CreatedAt",
+            "$..Certificate.DomainValidationOptions..ResourceRecord",
+            "$..Certificate.DomainValidationOptions..ValidationDomain",
+            "$..Certificate.DomainValidationOptions..ValidationMethod",
+            "$..Certificate.DomainValidationOptions..ValidationStatus",
+            "$..Certificate.ExtendedKeyUsages",
+            "$..Certificate.ExtendedKeyUsages..Name",
+            "$..Certificate.ExtendedKeyUsages..OID",
+            "$..Certificate.Issuer",
+            "$..Certificate.KeyUsages",
+            "$..Certificate.KeyUsages..Name",
+            "$..Certificate.Options.CertificateTransparencyLoggingPreference",
+            "$..Certificate.Serial",
+            "$..Certificate.Subject",
+        ]
+    )
+    def test_import_certificate(self, aws_client, cleanups, snapshot):
+        with pytest.raises(Exception) as exc_info:
             aws_client.acm.import_certificate(Certificate=b"CERT123", PrivateKey=b"KEY123")
-        assert "PEM" in str(exec_info)
+        assert exc_info.value.response["Error"]["Code"] == "ValidationException"
 
-        private_key = ec2_utils.random_rsa_key_pair()["material"]
-        result = None
-        try:
-            result = aws_client.acm.import_certificate(
-                Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key
-            )
-            assert "CertificateArn" in result
+        private_key = generate_private_key()
+        private_key_bytes = private_key.private_bytes(
+            Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()
+        )
+        certificate_bytes = generate_certificate_bytes(private_key)
+        result = aws_client.acm.import_certificate(
+            Certificate=certificate_bytes, PrivateKey=private_key_bytes
+        )
+        certificate_arn = result["CertificateArn"]
+        cert_id = certificate_arn.split("certificate/")[-1]
+        snapshot.add_transformer(snapshot.transform.regex(cert_id, "<cert-id>"))
 
-            expected_arn = f"arn:aws:acm:{region_name}:{account_id}:certificate"
-            acm_cert_arn = result["CertificateArn"].split("/")[0]
-            assert expected_arn == acm_cert_arn
+        cleanups.append(lambda: aws_client.acm.delete_certificate(CertificateArn=certificate_arn))
+        snapshot.match("import-certificate-response", result)
 
-            certs_after = aws_client.acm.list_certificates().get("CertificateSummaryList", [])
-            assert len(certs_before) + 1 == len(certs_after)
-        finally:
-            if result is not None:
-                aws_client.acm.delete_certificate(CertificateArn=result["CertificateArn"])
+        def _certificate_present():
+            return aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
+
+        describe_res = retry(_certificate_present)
+
+        snapshot.add_transformer(
+            SortingTransformer("DomainValidationOptions", lambda o: o["DomainName"])
+        )
+        snapshot.add_transformer(SortingTransformer("SubjectAlternativeNames"))
+
+        snapshot.match("describe-certificate-response", describe_res)
 
     @markers.aws.unknown
     def test_domain_validation(self, acm_request_certificate, aws_client):

--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -1,7 +1,7 @@
 import pytest
+from localstack_snapshot.snapshots.transformer import SortingTransformer
 from moto import settings as moto_settings
 
-from localstack_snapshot.snapshots.transformer import SortingTransformer
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.crypto import generate_ssl_cert

--- a/tests/aws/services/acm/test_acm.snapshot.json
+++ b/tests/aws/services/acm/test_acm.snapshot.json
@@ -218,7 +218,7 @@
     }
   },
   "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
-    "recorded-date": "22-02-2024, 17:27:28",
+    "recorded-date": "22-02-2024, 17:41:15",
     "recorded-content": {
       "import-certificate-response": {
         "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
@@ -231,28 +231,40 @@
         "Certificate": {
           "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
           "CreatedAt": "datetime",
-          "DomainName": "mysite.com",
+          "DomainName": "localhost",
           "DomainValidationOptions": [
             {
               "DomainName": "localhost"
             },
             {
-              "DomainName": "mysite.com"
+              "DomainName": "localhost.localstack.cloud"
+            },
+            {
+              "DomainName": "localhost.localstack.cloudIP:127.0.0.1"
+            },
+            {
+              "DomainName": "test.localhost.atlassian.io"
             }
           ],
           "ExtendedKeyUsages": [
             {
-              "Name": "NONE",
-              "OID": ""
+              "Name": "TLS_WEB_SERVER_AUTHENTICATION",
+              "OID": "1.3.6.1.5.5.7.3.1"
             }
           ],
           "ImportedAt": "datetime",
           "InUseBy": [],
-          "Issuer": "My Company",
+          "Issuer": "LocalStack Org",
           "KeyAlgorithm": "RSA-2048",
           "KeyUsages": [
             {
-              "Name": "ANY"
+              "Name": "DIGITAL_SIGNATURE"
+            },
+            {
+              "Name": "NON_REPUDIATION"
+            },
+            {
+              "Name": "KEY_ENCIPHERMENT"
             }
           ],
           "NotAfter": "datetime",
@@ -261,13 +273,15 @@
             "CertificateTransparencyLoggingPreference": "DISABLED"
           },
           "RenewalEligibility": "INELIGIBLE",
-          "Serial": "3e:25:17:25:90:91:c2:2c:05:f6:63:f4:aa:1a:bf:f2:b6:04:88:38",
+          "Serial": "03:e9",
           "SignatureAlgorithm": "SHA256WITHRSA",
           "Status": "ISSUED",
-          "Subject": "C=US,ST=California,L=San Francisco,O=My Company,CN=mysite.com",
+          "Subject": "C=AU,ST=Some-State,L=Some-Locality,O=LocalStack Org,OU=Testing,CN=localhost",
           "SubjectAlternativeNames": [
             "localhost",
-            "mysite.com"
+            "localhost.localstack.cloud",
+            "localhost.localstack.cloudIP:127.0.0.1",
+            "test.localhost.atlassian.io"
           ],
           "Type": "IMPORTED"
         },

--- a/tests/aws/services/acm/test_acm.snapshot.json
+++ b/tests/aws/services/acm/test_acm.snapshot.json
@@ -216,5 +216,66 @@
         "Type": "AMAZON_ISSUED"
       }
     }
+  },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
+    "recorded-date": "22-02-2024, 17:27:28",
+    "recorded-content": {
+      "import-certificate-response": {
+        "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-certificate-response": {
+        "Certificate": {
+          "CertificateArn": "arn:aws:acm:<region>:111111111111:certificate/<cert-id>",
+          "CreatedAt": "datetime",
+          "DomainName": "mysite.com",
+          "DomainValidationOptions": [
+            {
+              "DomainName": "localhost"
+            },
+            {
+              "DomainName": "mysite.com"
+            }
+          ],
+          "ExtendedKeyUsages": [
+            {
+              "Name": "NONE",
+              "OID": ""
+            }
+          ],
+          "ImportedAt": "datetime",
+          "InUseBy": [],
+          "Issuer": "My Company",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [
+            {
+              "Name": "ANY"
+            }
+          ],
+          "NotAfter": "datetime",
+          "NotBefore": "datetime",
+          "Options": {
+            "CertificateTransparencyLoggingPreference": "DISABLED"
+          },
+          "RenewalEligibility": "INELIGIBLE",
+          "Serial": "3e:25:17:25:90:91:c2:2c:05:f6:63:f4:aa:1a:bf:f2:b6:04:88:38",
+          "SignatureAlgorithm": "SHA256WITHRSA",
+          "Status": "ISSUED",
+          "Subject": "C=US,ST=California,L=San Francisco,O=My Company,CN=mysite.com",
+          "SubjectAlternativeNames": [
+            "localhost",
+            "mysite.com"
+          ],
+          "Type": "IMPORTED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/acm/test_acm.validation.json
+++ b/tests/aws/services/acm/test_acm.validation.json
@@ -4,5 +4,8 @@
   },
   "tests/aws/services/acm/test_acm.py::TestACM::test_create_certificate_for_multiple_alternative_domains": {
     "last_validated_date": "2024-01-09T14:58:14+00:00"
+  },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
+    "last_validated_date": "2024-02-22T17:27:28+00:00"
   }
 }

--- a/tests/aws/services/acm/test_acm.validation.json
+++ b/tests/aws/services/acm/test_acm.validation.json
@@ -6,6 +6,6 @@
     "last_validated_date": "2024-01-09T14:58:14+00:00"
   },
   "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
-    "last_validated_date": "2024-02-22T17:27:28+00:00"
+    "last_validated_date": "2024-02-22T17:41:15+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I wish to use ACM's `import_certificate` in a test, and want to ensure that it's behaviour is validated against AWS.


<!-- What notable changes does this PR make? -->
## Changes

- Validate import_certificate test

A lot of fields in the `describe_certificate` response are skipped, due to mismatches between how `moto` and AWS represent the certificates, however some important fields _are_ validated:

* `CertificateArn`
* `DomainName`
* `KeyAlgorithm`
* `NotAfter`
* `NotBefore`
* `Status`
* `Type`

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

