### PR TITLE
Allow extension hooks to modify non-Boto env vars

### DIFF
--- a/localstack/runtime/init.py
+++ b/localstack/runtime/init.py
@@ -152,8 +152,12 @@ class InitScriptManager:
                 else:
                     script.state = State.SUCCESSFUL
                 finally:
-                    os.environ.clear()
-                    os.environ.update(env_original)
+                    # Restore original state of Boto credentials.
+                    for env_var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"):
+                        if env_var in env_original:
+                            os.environ[env_var] = env_original[env_var]
+                        else:
+                            os.environ.pop(env_var, None)
 
         finally:
             self.stage_completed[stage] = True


### PR DESCRIPTION
## Background

Follow up to https://github.com/localstack/localstack/pull/10272#discussion_r1500576710

## Changes

After an init hook has run, refrain from clearing the environment and doing a full restore. Instead only restore the Boto credentials and region if it has been overridden.