### PR TITLE
fix pre-signed POST when file is passed as regular form field

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10402,20 +10402,16 @@ class TestS3PresignedPost:
             ],
         )
 
-        # this is a hack needed for requests to properly send the request as multipart/form-data with no files
+        # we need to define a proper format for `files` so that we don't add the filename= field to the form
         # see https://github.com/psf/requests/issues/1081
-
-        class ForceMultipartDict(dict):
-            def __bool__(self):
-                return True
-
-        force_multipart = ForceMultipartDict()  # An empty dict that boolean-evaluates as `True`.
 
         # PostObject
         response = requests.post(
             presigned_request["url"],
-            data={**presigned_request["fields"], "file": "test-body-file-as-field"},
-            files=force_multipart,
+            data=presigned_request["fields"],
+            files={
+                "file": (None, "test-body-file-as-field"),
+            },
             verify=False,
         )
         assert response.status_code == 204
@@ -10434,11 +10430,10 @@ class TestS3PresignedPost:
         )
         response = requests.post(
             presigned_request["url"],
-            data={
-                **presigned_request["fields"],
-                "file": "test-body-file-as-field-filename-replacement",
+            data=presigned_request["fields"],
+            files={
+                "file": (None, "test-body-file-as-field-filename-replacement"),
             },
-            files=force_multipart,
             verify=False,
         )
         assert response.status_code == 204

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10333,6 +10333,119 @@ class TestS3PresignedPost:
         assert response.status_code == 400
         snapshot.match("invalid-storage-error", xmltodict.parse(response.content))
 
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=LEGACY_V2_S3_PROVIDER,
+        reason="not implemented in moto",
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..HostId"],  # FIXME: in CI, it fails sporadically and the form is empty
+    )
+    def test_post_object_with_wrong_content_type(self, s3_bucket, aws_client, snapshot):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("HostId"),
+                snapshot.transform.key_value("RequestId"),
+            ]
+        )
+        object_key = "test-presigned-post-key-wrong-content-type"
+        presigned_request = aws_client.s3.generate_presigned_post(
+            Bucket=s3_bucket,
+            Key=object_key,
+            ExpiresIn=60,
+            Conditions=[
+                {"bucket": s3_bucket},
+            ],
+        )
+        # PostObject
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": "test-body-wrong-content-type"},
+            headers={"Content-Type": "text/html"},
+            verify=False,
+        )
+
+        assert response.status_code == 412
+        snapshot.match("invalid-content-type-error", xmltodict.parse(response.content))
+
+    @markers.aws.validated
+    @pytest.mark.skipif(
+        condition=LEGACY_V2_S3_PROVIDER,
+        reason="not implemented in moto",
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..ContentLength",
+            "$..ETag",
+            "$..HostId",
+        ],  # FIXME: in CI, it fails sporadically and the form is empty
+    )
+    def test_post_object_with_file_as_string(self, s3_bucket, aws_client, snapshot):
+        # this is a test for https://github.com/localstack/localstack/issues/10309
+        # You can send requests with node.js with a different format than what we can with Python
+        # (the actual file would just be a regular `file` key of the form with content)
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("HostId"),
+                snapshot.transform.key_value("RequestId"),
+                snapshot.transform.key_value("Name"),
+            ]
+        )
+        object_key = "test-presigned-post-file-as-field"
+        presigned_request = aws_client.s3.generate_presigned_post(
+            Bucket=s3_bucket,
+            Key=object_key,
+            ExpiresIn=60,
+            Conditions=[
+                {"bucket": s3_bucket},
+            ],
+        )
+
+        # this is a hack needed for requests to properly send the request as multipart/form-data with no files
+        # see https://github.com/psf/requests/issues/1081
+
+        class ForceMultipartDict(dict):
+            def __bool__(self):
+                return True
+
+        force_multipart = ForceMultipartDict()  # An empty dict that boolean-evaluates as `True`.
+
+        # PostObject
+        response = requests.post(
+            presigned_request["url"],
+            data={**presigned_request["fields"], "file": "test-body-file-as-field"},
+            files=force_multipart,
+            verify=False,
+        )
+        assert response.status_code == 204
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object", head_object)
+
+        object_key = "file-as-field-${filename}"
+        presigned_request = aws_client.s3.generate_presigned_post(
+            Bucket=s3_bucket,
+            Key=object_key,
+            ExpiresIn=60,
+            Conditions=[
+                {"bucket": s3_bucket},
+            ],
+        )
+        response = requests.post(
+            presigned_request["url"],
+            data={
+                **presigned_request["fields"],
+                "file": "test-body-file-as-field-filename-replacement",
+            },
+            files=force_multipart,
+            verify=False,
+        )
+        assert response.status_code == 204
+
+        response = aws_client.s3.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects", response)
+
 
 def _s3_client_pre_signed_client(conf: Config, endpoint_url: str = None):
     if is_aws_cloud():

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11166,7 +11166,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
-    "recorded-date": "24-02-2024, 00:37:26",
+    "recorded-date": "24-02-2024, 01:01:59",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11150,5 +11150,65 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_wrong_content_type": {
+    "recorded-date": "23-02-2024, 23:47:44",
+    "recorded-content": {
+      "invalid-content-type-error": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "Bucket POST must be of the enclosure-type multipart/form-data",
+          "HostId": "<host-id:1>",
+          "Message": "At least one of the pre-conditions you specified did not hold",
+          "RequestId": "<request-id:1>"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
+    "recorded-date": "24-02-2024, 00:37:26",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 23,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"518feee9a33977e5047cda470999729a\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects": {
+        "Contents": [
+          {
+            "ETag": "\"31ac3a102af06a3d79f0172d01158b49\"",
+            "Key": "file-as-field-${filename}",
+            "LastModified": "datetime",
+            "Size": 44,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"518feee9a33977e5047cda470999729a\"",
+            "Key": "test-presigned-post-file-as-field",
+            "LastModified": "datetime",
+            "Size": 23,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 2,
+        "MaxKeys": 1000,
+        "Name": "<name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -513,7 +513,7 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
-    "last_validated_date": "2024-02-24T00:37:26+00:00"
+    "last_validated_date": "2024-02-24T01:01:59+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
     "last_validated_date": "2023-08-14T17:54:15+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -512,6 +512,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
+    "last_validated_date": "2024-02-24T00:37:26+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_metadata": {
     "last_validated_date": "2023-08-14T17:54:15+00:00"
   },
@@ -529,6 +532,9 @@
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_tags[single]": {
     "last_validated_date": "2023-08-14T17:32:11+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_wrong_content_type": {
+    "last_validated_date": "2024-02-23T23:47:44+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_expires": {
     "last_validated_date": "2023-08-04T21:58:47+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10309, we were supporting a multipart form that AWS supported. Thanks to the user's reproducer, I could inspect the request we received and see the differences:

This were the two different lines:
```
# from node
Content-Disposition: form-data; name="file"
# from python
Content-Disposition: form-data; name="file" filename="file"
```

Which made the access to `context.request.files["file"]` fail because it could not really parse `file` as a file because it had no filename. 

<!-- What notable changes does this PR make? -->
## Changes
- added a case to directly fetch the file from the form is it is present there (if it is not, it is in the form) and updated the logic around that
- added a test reproducing this exact case
- also added a test case for when we don't set the multipart/form header, to prevent future issues

Also found something around the `${filename}` variable that can actually be used in all form fields, this will be tackled in a follow up PR. 

