### PR TITLE
fix API Gateway route matching order

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -738,45 +738,50 @@ def get_resource_for_path(
 
     # if there are no matches, it's not worth to proceed, bail here!
     if not matches:
+        LOG.debug(f"No match found for path: '{path}' and method: '{method}'")
         return None, None
 
-    # so we have matches and perhaps more than one, e.g
+    if len(matches) == 1:
+        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        return matches[0]
+
+    # so we have more than one match
     # /{proxy+} and /api/{proxy+} for inputs like /api/foo/bar
     # /foo/{param1}/baz and /foo/{param1}/{param2} for inputs like /for/bar/baz
-    if len(matches) > 1:
-        proxy_matches = []
-        param_matches = []
-        for match in matches:
-            match_methods = list(match[1].get("resourceMethods", {}).keys())
-            # only look for path matches if the request method is in the resource
-            if method.upper() in match_methods or "ANY" in match_methods:
-                # check if we have an exact match (exact matches take precedence) if the method is the same
-                if match[0] == path:
-                    return match
+    proxy_matches = []
+    param_matches = []
+    for match in matches:
+        match_methods = list(match[1].get("resourceMethods", {}).keys())
+        # only look for path matches if the request method is in the resource
+        if method.upper() in match_methods or "ANY" in match_methods:
+            # check if we have an exact match (exact matches take precedence) if the method is the same
+            if match[0] == path:
+                return match
 
-                elif path_matches_pattern(path, match[0]):
-                    # parameters can fit in
-                    param_matches.append(match)
-                    continue
+            elif path_matches_pattern(path, match[0]):
+                # parameters can fit in
+                param_matches.append(match)
+                continue
 
-                proxy_matches.append(match)
+            proxy_matches.append(match)
 
-        if param_matches:
-            # count the amount of parameters, return the one with the least which is the most precise
-            sorted_matches = sorted(param_matches, key=lambda x: x[0].count("{"))
-            return sorted_matches[0]
+    if param_matches:
+        # count the amount of parameters, return the one with the least which is the most precise
+        sorted_matches = sorted(param_matches, key=lambda x: x[0].count("{"))
+        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        return sorted_matches[0]
 
-        if proxy_matches:
-            # at this stage, we still have more than one match, but we have an eager example like
-            # /{proxy+} or /api/{proxy+}, so we pick the best match by sorting by length, only if they have a method
-            # that could match
-            sorted_matches = sorted(proxy_matches, key=lambda x: len(x[0]), reverse=True)
-            return sorted_matches[0]
+    if proxy_matches:
+        # at this stage, we still have more than one match, but we have an eager example like
+        # /{proxy+} or /api/{proxy+}, so we pick the best match by sorting by length, only if they have a method
+        # that could match
+        sorted_matches = sorted(proxy_matches, key=lambda x: len(x[0]), reverse=True)
+        LOG.debug(f"Match found for path: '{path}' and method: '{method}'")
+        return sorted_matches[0]
 
-        # if there are no matches with a method that would match, return
-        return None, None
-
-    return matches[0]
+    # if there are no matches with a method that would match, return
+    LOG.debug(f"No match found for method: '{method}' for matched path: {path}")
+    return None, None
 
 
 def path_matches_pattern(path, api_path):

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_integration_request_parameters_mapping": {
     "last_validated_date": "2024-02-05T19:37:03+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestApigatewayRouting::test_routing_with_hardcoded_resource_sibling_order": {
+    "last_validated_date": "2024-02-24T23:51:00+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestDeployments::test_create_delete_deployments[False]": {
     "last_validated_date": "2023-09-07T17:20:47+00:00"
   },

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -65,12 +65,14 @@ class TestApiGatewayPaths:
         [
             ("/foo/bar", ["/foo/{param1}"], "/foo/{param1}"),
             ("/foo/bar", ["/foo/bar", "/foo/{param1}"], "/foo/bar"),
+            ("/foo/bar", ["/foo/{param1}", "/foo/bar"], "/foo/bar"),
             ("/foo/bar/baz", ["/foo/bar", "/foo/{proxy+}"], "/foo/{proxy+}"),
             ("/foo/bar/baz", ["/{proxy+}", "/foo/{proxy+}"], "/foo/{proxy+}"),
             ("/foo/bar", ["/foo/bar1", "/foo/bar2"], None),
             ("/foo/bar", ["/{param1}/bar1", "/foo/bar2"], None),
             ("/foo/bar", ["/{param1}/{param2}/foo/{param3}", "/{param}/bar"], "/{param}/bar"),
             ("/foo/bar", ["/{param1}/{param2}", "/{param}/bar"], "/{param}/bar"),
+            ("/foo/bar", ["/{param}/bar", "/{param1}/{param2}"], "/{param}/bar"),
             (
                 "/foo/bar/baz",
                 ["/{param1}/{param2}/baz", "/{param1}/bar/{param2}"],
@@ -78,6 +80,7 @@ class TestApiGatewayPaths:
             ),
             ("/foo/bar/baz", ["/foo123/{param1}/baz"], None),
             ("/foo/bar/baz", ["/foo/{param1}/baz", "/foo/{param1}/{param2}"], "/foo/{param1}/baz"),
+            ("/foo/bar/baz", ["/foo/{param1}/{param2}", "/foo/{param1}/baz"], "/foo/{param1}/baz"),
         ],
     )
     def test_path_matches(self, path, path_parts, expected):

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -73,6 +73,8 @@ class TestApiGatewayPaths:
             ("/foo/bar", ["/{param1}/{param2}/foo/{param3}", "/{param}/bar"], "/{param}/bar"),
             ("/foo/bar", ["/{param1}/{param2}", "/{param}/bar"], "/{param}/bar"),
             ("/foo/bar", ["/{param}/bar", "/{param1}/{param2}"], "/{param}/bar"),
+            ("/foo/bar", ["/foo/bar", "/foo/{param+}"], "/foo/bar"),
+            ("/foo/bar", ["/foo/{param+}", "/foo/bar"], "/foo/bar"),
             (
                 "/foo/bar/baz",
                 ["/{param1}/{param2}/baz", "/{param1}/bar/{param2}"],


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10311, the order of resource creation mattered in our route matching logic, because we put at the same level "exact" matching and "parameter" matching. 
This is a follow up from #9208 in a way, which fixed the logic around method matching, but kept a flaw in the logic. 

<!-- What notable changes does this PR make? -->
## Changes
- only do an early return if we have an exact match. If we have regular parameter matching, return the resource with the least parameters in the path, which means it has more "hardcoded" values. Keep the proxy logic the same
- add cases in the unit tests, which validate the order of the resources
- also add a validated integration test with the user use-case

I've also tested the use reproducer given here: https://github.com/Garethp/localstack-bugs/tree/order-dependant-path-parts, with instructions on how to reproduce, and I've confirmed it fixed the issue (https://github.com/localstack/localstack/issues/10311#issuecomment-1962763343).

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

