### PR TITLE
Add fallback for deletes in updates and fix update for AWS::Lambda::Permission

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -716,6 +716,19 @@ class ResourceProviderExecutor:
                     return ProgressEvent(
                         status=OperationStatus.SUCCESS, resource_model=request.previous_state
                     )
+                except Exception as e:
+                    # FIXME: this fallback should be removed after fixing updates in general (order/dependenies)
+                    # catch-all for any exception that looks like a not found exception
+                    if check_not_found_exception(e, request.resource_type, request.desired_state):
+                        return ProgressEvent(
+                            status=OperationStatus.SUCCESS, resource_model=request.previous_state
+                        )
+
+                    return ProgressEvent(
+                        status=OperationStatus.FAILED,
+                        resource_model={},
+                        message=f"Failed to delete resource with id {request.logical_resource_id} of type {request.resource_type}",
+                    )
             case "Remove":
                 try:
                     return resource_provider.delete(request)

--- a/localstack/services/lambda_/resource_providers/aws_lambda_permission.py
+++ b/localstack/services/lambda_/resource_providers/aws_lambda_permission.py
@@ -139,9 +139,13 @@ class LambdaPermissionProvider(ResourceProvider[LambdaPermissionProperties]):
             model=model, params=["FunctionName", "Action", "Principal", "SourceArn"]
         )
 
-        lambda_client.remove_permission(
-            FunctionName=model.get("FunctionName"), StatementId=model["Id"]
-        )
+        try:
+            lambda_client.remove_permission(
+                FunctionName=model.get("FunctionName"), StatementId=model["Id"]
+            )
+        except lambda_client.exceptions.ResourceNotFoundException:
+            pass
+
         lambda_client.add_permission(StatementId=model["Id"], **params)
 
         return ProgressEvent(


### PR DESCRIPTION
## Motivation

Addresses a remaining issue from https://github.com/localstack/localstack/pull/10273 that was reported in https://github.com/localstack/localstack/issues/10169

Basically while the removal itself was now fixed, sometimes we perform delete operations in updates that can lead to similar issues because the resource was deleted first.

The proper fix will be in the update rework at some point but for now this should unblock further users that try to redeploy their resources.

## Changes

- Add naive fallback for update operations (similar to delete operations). 
- Fix AWS::Lambda::Permission to just continue when the expected existing policy is missing (This will usually be caused by the uncontrolled delete that occurs before the update)


## Testing

Verified against cdk deployment provided [here](https://github.com/localstack/localstack/issues/10169#issuecomment-1961860354)