### PR TITLE
Validation lambda function name pattern on invoke

### DIFF
--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     )
     from localstack.services.lambda_.invocation.models import LambdaStore
 
+
 # Pattern for a full (both with and without qualifier) lambda function ARN
 FULL_FN_ARN_PATTERN = re.compile(
     r"^arn:aws:lambda:(?P<region_name>[^:]+):(?P<account_id>\d{12}):function:(?P<function_name>[^:]+)(:(?P<qualifier>.*))?$"
@@ -55,6 +56,10 @@ LAYER_VERSION_ARN_PATTERN = re.compile(
 # Pattern for a valid destination arn
 DESTINATION_ARN_PATTERN = re.compile(
     r"^$|arn:(aws[a-zA-Z0-9-]*):([a-zA-Z0-9\-])+:([a-z]{2}(-gov)?-[a-z]+-\d{1})?:(\d{12})?:(.*)"
+)
+
+AWS_FUNCTION_NAME_REGEX = re.compile(
+    "^(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?$"
 )
 
 # Pattern for extracting various attributes from a full or partial ARN or just a function name.
@@ -618,3 +623,7 @@ def validate_layer_runtimes_and_architectures(
 
 def is_layer_arn(layer_name: str) -> bool:
     return LAYER_VERSION_ARN_PATTERN.match(layer_name) is not None
+
+
+def validate_function_name(function_name):
+    return AWS_FUNCTION_NAME_REGEX.match(function_name)

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1359,6 +1359,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         **kwargs,
     ) -> InvocationResponse:
         account_id, region = api_utils.get_account_and_region(function_name, context)
+        if not api_utils.validate_function_name(function_name):
+            raise ValidationException(
+                f"1 validation error detected: Value '{function_name}' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso(b?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+            )
+
         function_name, qualifier = api_utils.get_name_and_qualifier(
             function_name, qualifier, context
         )

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -808,6 +808,14 @@ class TestLambdaFunction:
             "delete_vpcconfig_get_function_response", delete_vpcconfig_get_function_response
         )
 
+    @markers.aws.validated
+    def test_invalid_invoke(self, aws_client, snapshot):
+        with pytest.raises(aws_client.lambda_.exceptions.ClientError) as e:
+            aws_client.lambda_.invoke(
+                FunctionName="arn:aws:lambda:us-east-1:123400000000@function:myfn", Payload=b"{}"
+            )
+        snapshot.match("invoke_function_name_pattern_exc", e.value.response)
+
 
 class TestLambdaImages:
     @pytest.fixture(scope="class")

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13763,5 +13763,20 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
+    "recorded-date": "26-02-2024, 17:04:08",
+    "recorded-content": {
+      "invoke_function_name_pattern_exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:123400000000@function:myfn' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -77,6 +77,9 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
     "last_validated_date": "2023-11-20T15:46:48+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
+    "last_validated_date": "2024-02-26T17:04:08+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
     "last_validated_date": "2023-11-20T15:46:59+00:00"
   },


### PR DESCRIPTION
## Motivation

This surfaced when debugging a customer issue where a lambda was invoked via stepfunctions but the specified ARN was incorrect. This lead to a misleading error message which should be fixed with this PR

## Changes

- Extract regex from exception message and raise ValidationException when a  non-matching function name is provided on invoke(). 

## Discussion
We might want to add this to other places as well but that will require more extensive test adaptations.