### PR TITLE
Add SQS high-throughput deduplication behaviour

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -663,6 +663,8 @@ class SqsQueue:
                 value = func()
                 if value is not None:
                     result[attr] = value
+            elif value == "False" or value == "True":
+                result[attr] = str(value).lower()
             elif value is not None:
                 result[attr] = value
         return result
@@ -897,6 +899,7 @@ class FifoQueue(SqsQueue):
     message_groups: dict[str, MessageGroup]
     inflight_groups: set[MessageGroup]
     message_group_queue: Queue
+    high_throughput: bool
 
     def __init__(self, name: str, region: str, account_id: str, attributes=None, tags=None) -> None:
         super().__init__(name, region, account_id, attributes, tags)
@@ -905,6 +908,15 @@ class FifoQueue(SqsQueue):
         self.message_groups = {}
         self.inflight_groups = set()
         self.message_group_queue = Queue()
+        self.high_throughput = False
+
+        # SQS does not seem to change the deduplication behaviour of fifo queues if you
+        # change to/from high-throughput mode after creation -> we need to set this on creation
+        if (
+            self.attributes[QueueAttributeName.DeduplicationScope] == "messageGroup"
+            and self.attributes[QueueAttributeName.FifoThroughputLimit] == "perMessageGroupId"
+        ):
+            self.high_throughput = True
 
     @property
     def approx_number_of_messages(self):
@@ -992,11 +1004,15 @@ class FifoQueue(SqsQueue):
             fifo_message.delay_seconds = self.delay_seconds
 
         original_message = self.deduplication.get(dedup_id)
-
         if (
             original_message
             and original_message.priority + sqs_constants.DEDUPLICATION_INTERVAL_IN_SEC
             > fifo_message.priority
+            # account for high-throughput-mode
+            and (
+                not self.high_throughput
+                or fifo_message.message_group_id == original_message.message_group_id
+            )
         ):
             message["MessageId"] = original_message.message["MessageId"]
         else:

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -664,7 +664,7 @@ class SqsQueue:
                 if value is not None:
                     result[attr] = value
             elif value == "False" or value == "True":
-                result[attr] = str(value).lower()
+                result[attr] = value.lower()
             elif value is not None:
                 result[attr] = value
         return result

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -2809,5 +2809,269 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs_json]": {
+    "recorded-date": "26-02-2024, 18:54:41",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test1",
+            "MD5OfBody": "e1b849f9631ffc1829b2e31402373e3c",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-to-high-throughput": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "messageGroup",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perMessageGroupId",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-high-throughput": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-high-throughput-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {
+    "recorded-date": "26-02-2024, 18:54:48",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test1",
+            "MD5OfBody": "e1b849f9631ffc1829b2e31402373e3c",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-to-high-throughput": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "messageGroup",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perMessageGroupId",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-high-throughput": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-high-throughput-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_regular_throughput_after_creation[sqs_json]": {
+    "recorded-date": "26-02-2024, 19:05:27",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test1",
+            "MD5OfBody": "e1b849f9631ffc1829b2e31402373e3c",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "Messages": [
+          {
+            "Body": "Test2",
+            "MD5OfBody": "c454552d52d55d3ef56408742887362b",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-to-regular-throughput": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-regular-throughput": {
+        "Messages": [
+          {
+            "Body": "Test3",
+            "MD5OfBody": "b3f66ec1535de7702c38e94408fa4a17",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_regular_throughput_after_creation[sqs]": {
+    "recorded-date": "26-02-2024, 19:05:32",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test1",
+            "MD5OfBody": "e1b849f9631ffc1829b2e31402373e3c",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "Messages": [
+          {
+            "Body": "Test2",
+            "MD5OfBody": "c454552d52d55d3ef56408742887362b",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-to-regular-throughput": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "0",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "true",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-regular-throughput": {
+        "Messages": [
+          {
+            "Body": "Test3",
+            "MD5OfBody": "b3f66ec1535de7702c38e94408fa4a17",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -26,6 +26,18 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_with_too_large_batch": {
     "last_validated_date": "2023-11-14T10:59:02+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {
+    "last_validated_date": "2024-02-26T18:54:48+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs_json]": {
+    "last_validated_date": "2024-02-26T18:54:41+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_regular_throughput_after_creation[sqs]": {
+    "last_validated_date": "2024-02-26T19:05:32+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_regular_throughput_after_creation[sqs_json]": {
+    "last_validated_date": "2024-02-26T19:05:27+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_deduplication_arrives_once_after_delete[False]": {
     "last_validated_date": "2023-11-14T10:59:33+00:00"
   },


### PR DESCRIPTION

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow-up of #10274 
This PR implements "FIFO high-throughput" mode. More precisely, since we do not enforce any rate limits for SQS, this PR adds the necessary changes in regards to the deduplication behaviour.
Usually, messages in a queue are treated as duplicates simply if they have the same deduplication ID. Message groups are ignored. In HT mode deduplication happens at MessageGroup level.
On a side-note: it seems that you cannot change a "regular" FIFO queue to a HT one after creation. You can change the attributes, but AWS does not seem to change the deduplication behaviour of the queue. This makes it necessary to track HT FIFO queues somehow. For now this is simply a flag because a new queue type seemed like overkill.

<!-- What notable changes does this PR make? -->
## Changes
- adds deduplication behaviour for high-throughput mode FIFO queues
- add flag to mark HT FIFO queues.
- fixes small discrepancy in how we return bool values of queue attributes

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

