### PR TITLE
Bump pinned postgres version in CI to 14.11

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -194,7 +194,7 @@ jobs:
         run: |
           sudo apt-get update
           # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.10-0ubuntu0* postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.11-0ubuntu0* postgresql-client postgresql-plpython3
 
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true


### PR DESCRIPTION

## Motivation

Last bump to 14.10 was here: https://github.com/localstack/localstack/pull/9818

[Yesterday another bump to 14.11 was released](https://launchpad.net/ubuntu/+source/postgresql-14) breaking the pro integration pipeline.



## Changes

- Update pinned postgres dependency to 14.11