### PR TITLE
Fix delete issues in resource providers for "AWS::ApiGateway::UsagePlanKey" and "AWS::Kinesis::StreamConsumer"

### DIFF
--- a/localstack/services/apigateway/resource_providers/aws_apigateway_usageplankey.py
+++ b/localstack/services/apigateway/resource_providers/aws_apigateway_usageplankey.py
@@ -91,7 +91,6 @@ class ApiGatewayUsagePlanKeyProvider(ResourceProvider[ApiGatewayUsagePlanKeyProp
         IAM permissions required:
           - apigateway:DELETE
         """
-        raise NotImplementedError
         model = request.desired_state
         apigw = request.aws_client_factory.apigateway
 

--- a/localstack/services/kinesis/resource_providers/aws_kinesis_streamconsumer.py
+++ b/localstack/services/kinesis/resource_providers/aws_kinesis_streamconsumer.py
@@ -98,15 +98,7 @@ class KinesisStreamConsumerProvider(ResourceProvider[KinesisStreamConsumerProper
 
 
         """
-        model = request.desired_state
-        kinesis = request.aws_client_factory.kinesis
-        kinesis.deregister_stream_consumer(ConsumerARN=model["ConsumerARN"])
-
-        return ProgressEvent(
-            status=OperationStatus.SUCCESS,
-            resource_model=model,
-            custom_context=request.custom_context,
-        )
+        raise NotImplementedError
 
     def delete(
         self,
@@ -117,7 +109,15 @@ class KinesisStreamConsumerProvider(ResourceProvider[KinesisStreamConsumerProper
 
 
         """
-        raise NotImplementedError
+        model = request.desired_state
+        kinesis = request.aws_client_factory.kinesis
+        kinesis.deregister_stream_consumer(ConsumerARN=model["ConsumerARN"])
+
+        return ProgressEvent(
+            status=OperationStatus.SUCCESS,
+            resource_model=model,
+            custom_context=request.custom_context,
+        )
 
     def update(
         self,


### PR DESCRIPTION
## Motivation

When trying to do some analysis over the implemented resources / operations, I found that two resources had some issues in their implementation of deletes.

## Changes
- Fix `AWS::ApiGateway::UsagePlanKey`: removed the exception raising
- Fix `AWS::Kinesis::StreamConsumer`: delete / read operations were exchanged
