### PR TITLE
Make keys_pascalcase_to_lower_camelcase recursive

### DIFF
--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -49,7 +49,13 @@ def convert_pascalcase_to_lower_camelcase(item: str) -> str:
 
 
 def keys_pascalcase_to_lower_camelcase(model: dict) -> dict:
-    return {convert_pascalcase_to_lower_camelcase(k): v for k, v in model.items()}
+    # TODO: might want to support lists here as well in the future
+    return {
+        convert_pascalcase_to_lower_camelcase(k): (
+            keys_pascalcase_to_lower_camelcase(v) if isinstance(v, dict) else v
+        )
+        for k, v in model.items()
+    }
 
 
 def transform_list_to_dict(param, key_attr_name="Key", value_attr_name="Value"):

--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -10,6 +10,7 @@ import re
 import uuid
 from copy import deepcopy
 from pathlib import Path
+from typing import Callable
 
 
 def generate_default_name(stack_name: str, logical_resource_id: str):
@@ -48,14 +49,30 @@ def convert_pascalcase_to_lower_camelcase(item: str) -> str:
         return f"{item[0].lower()}{item[1:]}"
 
 
+def _recurse_properties(obj: dict | list, fn: Callable) -> dict | list:
+    obj = fn(obj)
+    if isinstance(obj, dict):
+        return {k: _recurse_properties(v, fn) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_recurse_properties(v, fn) for v in obj]
+    else:
+        return obj
+
+
+def recurse_properties(properties: dict, fn: Callable) -> dict:
+    return _recurse_properties(deepcopy(properties), fn)
+
+
 def keys_pascalcase_to_lower_camelcase(model: dict) -> dict:
-    # TODO: might want to support lists here as well in the future
-    return {
-        convert_pascalcase_to_lower_camelcase(k): (
-            keys_pascalcase_to_lower_camelcase(v) if isinstance(v, dict) else v
-        )
-        for k, v in model.items()
-    }
+    """Recursively change any dicts keys to lower camelcase"""
+
+    def _keys_pascalcase_to_lower_camelcase(obj):
+        if isinstance(obj, dict):
+            return {convert_pascalcase_to_lower_camelcase(k): v for k, v in obj.items()}
+        else:
+            return obj
+
+    return _recurse_properties(model, _keys_pascalcase_to_lower_camelcase)
 
 
 def transform_list_to_dict(param, key_attr_name="Key", value_attr_name="Value"):


### PR DESCRIPTION
## Motivation
Extended `keys_pascalcase_to_lower_camelcase` cloudformation resource provider util since a few resources need this functionality to be recursive.

## Changes

- make `keys_pascalcase_to_lower_camelcase` recursive