### PR TITLE
fix S3 copy-source format validation

### DIFF
--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -116,6 +116,12 @@ def extract_bucket_key_version_id_from_copy_source(
     :param copy_source: the S3 CopySource to parse
     :return: parsed BucketName, ObjectKey and optionally VersionId
     """
+    if "/" not in copy_source:
+        raise InvalidArgument(
+            "Invalid copy source object key",
+            ArgumentName="x-amz-copy-source",
+            ArgumentValue="x-amz-copy-source",
+        )
     copy_source_parsed = urlparser.urlparse(copy_source)
     # we need to manually replace `+` character with a space character before URL decoding, because different languages
     # don't encode their URL the same way (%20 vs +), and Python doesn't unquote + into a space char

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1871,6 +1871,17 @@ class TestS3:
         snapshot.match("copy-success", copy_obj_all_positive)
 
     @markers.aws.validated
+    def test_s3_copy_object_wrong_format(self, s3_bucket, snapshot, aws_client):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket,
+                CopySource="wrongformat",
+                Key="destination-key",
+            )
+        snapshot.match("copy-object-wrong-copy-source", e.value.response)
+
+    @markers.aws.validated
     @pytest.mark.skipif(
         condition=LEGACY_V2_S3_PROVIDER,
         reason="Behaviour is not in line with AWS, does not validate properly",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11210,5 +11210,22 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_wrong_format": {
+    "recorded-date": "27-02-2024, 11:11:22",
+    "recorded-content": {
+      "copy-object-wrong-copy-source": {
+        "Error": {
+          "ArgumentName": "x-amz-copy-source",
+          "ArgumentValue": "x-amz-copy-source",
+          "Code": "InvalidArgument",
+          "Message": "Invalid copy source object key"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -302,6 +302,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_with_checksum[SHA256]": {
     "last_validated_date": "2023-08-03T02:15:56+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_wrong_format": {
+    "last_validated_date": "2024-02-27T11:11:22+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_tagging_directive[COPY]": {
     "last_validated_date": "2023-08-03T02:15:09+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10328, we would not properly validate the `CopySource` parameter before parsing it.

<!-- What notable changes does this PR make? -->
## Changes
Added a check for the presence of `/` before splitting, and a test for the case. 

_fixes #10328_ 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

