### PR TITLE
Fix attributes, create and delete for AWS::Redshift::Cluster

### DIFF
--- a/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
+++ b/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
@@ -130,17 +130,46 @@ class RedshiftClusterProvider(ResourceProvider[RedshiftClusterProperties]):
         model = request.desired_state
         redshift = request.aws_client_factory.redshift
 
-        if not model.get("ClusterIdentifier"):
-            model["ClusterIdentifier"] = util.generate_default_name(
-                stack_name=request.stack_name, logical_resource_id=request.logical_resource_id
-            )
+        if not request.custom_context.get(REPEATED_INVOCATION):
+            request.custom_context[REPEATED_INVOCATION] = True
 
-        redshift.create_cluster(**model)
-        return ProgressEvent(
-            status=OperationStatus.SUCCESS,
-            resource_model=model,
-            custom_context=request.custom_context,
-        )
+            if not model.get("ClusterIdentifier"):
+                model["ClusterIdentifier"] = util.generate_default_name(
+                    stack_name=request.stack_name, logical_resource_id=request.logical_resource_id
+                )
+
+            result = redshift.create_cluster(**model)
+            model["Id"] = result["Cluster"]["ClusterIdentifier"]  # TODO: verify
+
+        try:
+            cluster = redshift.describe_clusters(ClusterIdentifier=model["ClusterIdentifier"])[
+                "Clusters"
+            ][0]
+            match cluster["ClusterStatus"]:
+                case "available":
+                    model["Endpoint"]["Port"] = str(cluster["Endpoint"]["Port"])
+                    model["Endpoint"]["Address"] = cluster["Endpoint"]["Address"]
+                    model["DeferMaintenanceIdentifier"] = "?"  # TODO: no idea
+
+                    return ProgressEvent(
+                        status=OperationStatus.SUCCESS,
+                        resource_model=model,
+                        custom_context=request.custom_context,
+                    )
+                case failed_state:
+                    return ProgressEvent(
+                        status=OperationStatus.FAILED,
+                        resource_model=model,
+                        custom_context=request.custom_context,
+                        message=f"Cluster in failed state: {failed_state}",
+                    )
+
+        except redshift.exceptions.ClusterNotFoundFault:
+            return ProgressEvent(
+                status=OperationStatus.IN_PROGRESS,
+                resource_model=model,
+                custom_context=request.custom_context,
+            )
 
     def read(
         self,
@@ -170,6 +199,8 @@ class RedshiftClusterProvider(ResourceProvider[RedshiftClusterProperties]):
         """
         model = request.desired_state
         redshift = request.aws_client_factory.redshift
+
+        # TODO: async delete
 
         redshift.delete_cluster(ClusterIdentifier=model["ClusterIdentifier"])
         return ProgressEvent(

--- a/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
+++ b/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
@@ -150,7 +150,8 @@ class RedshiftClusterProvider(ResourceProvider[RedshiftClusterProperties]):
                     model.setdefault("Endpoint", {})
                     model["Endpoint"]["Address"] = cluster["Endpoint"]["Address"]
                     model["Endpoint"]["Port"] = str(cluster["Endpoint"]["Port"])
-                    model["DeferMaintenanceIdentifier"] = "?"  # TODO: investigate
+                    # getting "Attribute 'DeferMaintenanceIdentifier' does not exist." on AWS
+                    # model["DeferMaintenanceIdentifier"] = "?"
 
                     return ProgressEvent(
                         status=OperationStatus.SUCCESS,

--- a/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
+++ b/localstack/services/redshift/resource_providers/aws_redshift_cluster.py
@@ -147,8 +147,9 @@ class RedshiftClusterProvider(ResourceProvider[RedshiftClusterProperties]):
             ][0]
             match cluster["ClusterStatus"]:
                 case "available":
-                    model["Endpoint"]["Address"] = cluster.get("Endpoint", {}).get("Address", "?")
-                    model["Endpoint"]["Port"] = str(cluster.get("Endpoint", {}).get("Port", 0))
+                    model.setdefault("Endpoint", {})
+                    model["Endpoint"]["Address"] = cluster["Endpoint"]["Address"]
+                    model["Endpoint"]["Port"] = str(cluster["Endpoint"]["Port"])
                     model["DeferMaintenanceIdentifier"] = "?"  # TODO: investigate
 
                     return ProgressEvent(

--- a/tests/aws/services/cloudformation/resources/test_redshift.py
+++ b/tests/aws/services/cloudformation/resources/test_redshift.py
@@ -12,4 +12,7 @@ def test_redshift_cluster(deploy_cfn_template, aws_client):
     )
 
     # very basic test to check the cluster deploys
-    assert stack.outputs["ClusterRef"] is not None
+    assert stack.outputs["ClusterRef"]
+    assert stack.outputs["ClusterAttEndpointPort"]
+    assert stack.outputs["ClusterAttEndpointAddress"]
+    assert stack.outputs["ClusterAttDeferMaintenanceIdentifier"]

--- a/tests/aws/services/cloudformation/resources/test_redshift.py
+++ b/tests/aws/services/cloudformation/resources/test_redshift.py
@@ -3,7 +3,7 @@ import os
 from localstack.testing.pytest import markers
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_redshift_cluster(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(
         template_path=os.path.join(
@@ -15,4 +15,3 @@ def test_redshift_cluster(deploy_cfn_template, aws_client):
     assert stack.outputs["ClusterRef"]
     assert stack.outputs["ClusterAttEndpointPort"]
     assert stack.outputs["ClusterAttEndpointAddress"]
-    assert stack.outputs["ClusterAttDeferMaintenanceIdentifier"]

--- a/tests/aws/services/cloudformation/resources/test_redshift.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_redshift.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/cloudformation/resources/test_redshift.py::test_redshift_cluster": {
+    "last_validated_date": "2024-02-28T12:42:35+00:00"
+  }
+}

--- a/tests/aws/templates/cfn_redshift.yaml
+++ b/tests/aws/templates/cfn_redshift.yaml
@@ -1,9 +1,3 @@
-# awslocal redshift create-cluster
-# --cluster-identifier mysamplecluster
-# --master-username masteruser
-# --master-user-password secret1
-# --node-type ds2.xlarge
-# --cluster-type single-node
 Resources:
   Cluster:
     Type: AWS::Redshift::Cluster
@@ -11,9 +5,9 @@ Resources:
       ClusterIdentifier: mysamplecluster
       ClusterType: single-node
       DBName: db
-      MasterUserPassword: masterpassword
+      MasterUserPassword: MasterPassword123
       MasterUsername: masteruser
-      NodeType: dx2.xlarge
+      NodeType: ra3.xlplus
 
 Outputs:
   ClusterRef:
@@ -22,5 +16,3 @@ Outputs:
     Value: !GetAtt Cluster.Endpoint.Port
   ClusterAttEndpointAddress:
     Value: !GetAtt Cluster.Endpoint.Address
-  ClusterAttDeferMaintenanceIdentifier:
-    Value: !GetAtt Cluster.DeferMaintenanceIdentifier

--- a/tests/aws/templates/cfn_redshift.yaml
+++ b/tests/aws/templates/cfn_redshift.yaml
@@ -18,3 +18,9 @@ Resources:
 Outputs:
   ClusterRef:
     Value: !Ref Cluster
+  ClusterAttEndpointPort:
+    Value: !GetAtt Cluster.Endpoint.Port
+  ClusterAttEndpointAddress:
+    Value: !GetAtt Cluster.Endpoint.Address
+  ClusterAttDeferMaintenanceIdentifier:
+    Value: !GetAtt Cluster.DeferMaintenanceIdentifier


### PR DESCRIPTION
## Motivation

@maxhoheiser found some issues with the current provider which this PR aims to address

## Changes

- Made create wait for the actual cluster state
- Made delete wait for the resource not existing anymore
- Added missing read-only properties (`Endpoint.Address`, `Endpoint.Port`)
- Extended test with GetAtt