### PR TITLE
fix typo in FAQ link description, closes #10343

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To start using LocalStack, check out our [documentation](https://docs.localstack
 - [LocalStack Integrations](https://docs.localstack.cloud/user-guide/integrations/)
 - [LocalStack Tools](https://docs.localstack.cloud/user-guide/tools/)
 - [Understanding LocalStack](https://docs.localstack.cloud/references/)
-- [Frequency Asked Questions](https://docs.localstack.cloud/getting-started/faq/)
+- [Frequently Asked Questions](https://docs.localstack.cloud/getting-started/faq/)
 
 To use LocalStack with a graphical user interface, you can use the following UI clients:
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is raised to correct a minor typo found in the documentation under the "Getting Started" section. The FAQ link was mistakenly labeled as "Frequency Asked Questions," which could potentially confuse readers or detract from the professional quality of the documentation. Correcting this typo enhances readability and ensures accuracy in the documentation.

Related issue: https://github.com/localstack/localstack/issues/10343

<!-- What notable changes does this PR make? -->
## Changes
Corrected the typo from "Frequency Asked Questions" to "Frequently Asked Questions" in the documentation markdown file responsible for the FAQ link description.

<!-- The following sections are optional, but can be useful! 

## Testing

Testing for this change involves verifying that the updated documentation renders correctly on the website. No code or functional tests are applicable for this documentation typo fix.

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

