### PR TITLE
Fix CircleCI workflow tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,16 +505,31 @@ jobs:
             paths:
                 - repo/stats/
   waiter:
-    docker:
-      - image: circleci/node
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
     steps:
       - run: |
-          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push")|.status' | grep -c "running") -gt 0 ]]
-            do
-              sleep 5
+          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push")|.status' | grep -c "running") -gt 0 ]]; do
+              sleep 10
             done
-          curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_PROJECT_TOKEN"
-      - run: echo "All required jobs have now completed"
+          FAILED_COUNT=$(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" | jq -r '.items[]|.status' | grep -c "failed") || true
+          echo "failed count" $FAILED_COUNT
+          mkdir stats
+          if [[ $FAILED_COUNT -eq 0 ]]; then
+              echo "success" > stats/outcome.txt
+          else
+              echo "failure" > stats/outcome.txt
+          fi
+          cat stats/outcome.txt
+      - persist_to_workspace:
+            root: /tmp/workspace
+            paths:
+                - repo/stats/
+  failer:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    steps:
+      - run: exit 0
   send-stats:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -522,24 +537,15 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          when: on_fail
-          name: Detecting Job Status (FAIL)
-          command: |
-            echo "export CCI_STATUS='failure'" >> $BASH_ENV
-      - run:
-          when: on_success
-          name: Detecting Job Status (PASS)
-          command: |
-            echo "export CCI_STATUS='success'" >> $BASH_ENV
-      - run:
           when: always
           name: Load start time from file
           command: |
             START_TIME=$(cat stats/start-time.txt)
             END_TIME=$(date +%s)
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$CCI_STATUS'"}' > stats/stats.json
+            OUTCOME=$(cat stats/outcome.txt)
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'"}' > stats/stats.json
             echo 'Sending: '$(cat stats/stats.json)
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows_test" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
 
 
 
@@ -550,89 +556,9 @@ workflows:
       - waiter:
           requires:
             - save-start-time
-      - install:
+      - failer:
           requires:
             - save-start-time
-      - preflight:
-          requires:
-            - install
-      - acceptance-tests:
-          requires:
-            - preflight
-      - itest-sfn-legacy-provider:
-          requires:
-            - preflight
-      - itest-s3-v2-legacy-provider:
-          requires:
-            - preflight
-      - itest-cloudwatch-v2-provider:
-          requires:
-            - preflight
-      - unit-tests:
-          requires:
-            - preflight
-      - docker-build:
-          name: docker-build-amd64
-          platform: amd64
-          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
-          resource_class: medium
-          requires:
-            - preflight
-      - docker-build:
-          name: docker-build-arm64
-          platform: arm64
-          # The latest version of ubuntu is not yet supported for ARM:
-          # https://circleci.com/docs/2.0/arm-resources/
-          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
-          resource_class: arm.medium
-          requires:
-            - preflight
-      - docker-test:
-          name: docker-test-arm64
-          platform: arm64
-          resource_class: arm.medium
-          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
-          requires:
-            - docker-build-arm64
-      - docker-test:
-          name: docker-test-amd64
-          platform: amd64
-          resource_class: medium
-          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
-          requires:
-            - docker-build-amd64
-      - bootstrap-tests:
-          requires:
-            - docker-build-amd64
-      - capture-not-implemented:
-          name: collect-not-implemented
-          requires:
-            - docker-build-amd64
-      - report:
-          requires:
-            - itest-sfn-legacy-provider
-            - itest-s3-v2-legacy-provider
-            - itest-cloudwatch-v2-provider
-            - acceptance-tests
-            - docker-test-amd64
-            - docker-test-arm64
-            - collect-not-implemented
-            - unit-tests
       - send-stats:
-          filters:
-            branches:
-              only: master
           requires:
             - waiter
-      - push:
-          filters:
-            branches:
-              only: master
-          requires:
-            - itest-sfn-legacy-provider
-            - itest-s3-v2-legacy-provider
-            - itest-cloudwatch-v2-provider
-            - acceptance-tests
-            - docker-test-amd64
-            - docker-test-arm64
-            - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ jobs:
     working_directory: /tmp/workspace/repo
     steps:
       - run: |
-          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push")|.status' | grep -c "running") -gt 0 ]]; do
+          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
               sleep 10
             done
           FAILED_COUNT=$(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" | jq -r '.items[]|.status' | grep -c "failed") || true
@@ -525,11 +525,6 @@ jobs:
             root: /tmp/workspace
             paths:
                 - repo/stats/
-  failer:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    steps:
-      - run: exit 0
   send-stats:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -545,7 +540,7 @@ jobs:
             OUTCOME=$(cat stats/outcome.txt)
             echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'"}' > stats/stats.json
             echo 'Sending: '$(cat stats/stats.json)
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows_test" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
 
 
 
@@ -556,9 +551,89 @@ workflows:
       - waiter:
           requires:
             - save-start-time
-      - failer:
-          requires:
-            - save-start-time
       - send-stats:
+          filters:
+            branches:
+              only: master
           requires:
             - waiter
+      - install:
+          requires:
+            - save-start-time
+      - preflight:
+          requires:
+            - install
+      - acceptance-tests:
+          requires:
+            - preflight
+      - itest-sfn-legacy-provider:
+          requires:
+            - preflight
+      - itest-s3-v2-legacy-provider:
+          requires:
+            - preflight
+      - itest-cloudwatch-v2-provider:
+          requires:
+            - preflight
+      - unit-tests:
+          requires:
+            - preflight
+      - docker-build:
+          name: docker-build-amd64
+          platform: amd64
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+          resource_class: medium
+          requires:
+            - preflight
+      - docker-build:
+          name: docker-build-arm64
+          platform: arm64
+          # The latest version of ubuntu is not yet supported for ARM:
+          # https://circleci.com/docs/2.0/arm-resources/
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
+          resource_class: arm.medium
+          requires:
+            - preflight
+      - docker-test:
+          name: docker-test-arm64
+          platform: arm64
+          resource_class: arm.medium
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
+          requires:
+            - docker-build-arm64
+      - docker-test:
+          name: docker-test-amd64
+          platform: amd64
+          resource_class: medium
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+          requires:
+            - docker-build-amd64
+      - bootstrap-tests:
+          requires:
+            - docker-build-amd64
+      - capture-not-implemented:
+          name: collect-not-implemented
+          requires:
+            - docker-build-amd64
+      - report:
+          requires:
+            - itest-sfn-legacy-provider
+            - itest-s3-v2-legacy-provider
+            - itest-cloudwatch-v2-provider
+            - acceptance-tests
+            - docker-test-amd64
+            - docker-test-arm64
+            - collect-not-implemented
+            - unit-tests
+      - push:
+          filters:
+            branches:
+              only: master
+          requires:
+            - itest-sfn-legacy-provider
+            - itest-s3-v2-legacy-provider
+            - itest-cloudwatch-v2-provider
+            - acceptance-tests
+            - docker-test-amd64
+            - docker-test-arm64
+            - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
             echo "export CI_JOB_URL=${CIRCLE_BUILD_URL}" >> $BASH_ENV
             # workflow ID as the job name to associate the tests with workflows in TB
             echo "export CI_JOB_NAME=${CIRCLE_WORKFLOW_ID}" >> $BASH_ENV
-            echo "export CI_JOB_ID=${CIRCLE_WORKFLOW_JOB_ID}" >> $BASH_ENV
+            echo "export CI_JOB_ID=${CIRCLE_JOB}" >> $BASH_ENV
             source $BASH_ENV
 
 jobs:
@@ -605,6 +605,7 @@ workflows:
             - collect-not-implemented
             - unit-tests
       - send-stats:
+          when: always
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,19 +547,17 @@ jobs:
 workflows:
   main:
     jobs:
-      - save-start-time
+      - save-start-time:
+          filters:
+            branches:
+              only: master
       - waiter:
           requires:
             - save-start-time
       - send-stats:
-          filters:
-            branches:
-              only: master
           requires:
             - waiter
-      - install:
-          requires:
-            - save-start-time
+      - install
       - preflight:
           requires:
             - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,17 @@ jobs:
             root: /tmp/workspace
             paths:
                 - repo/stats/
+  waiter:
+    docker:
+      - image: circleci/node
+    steps:
+      - run: |
+          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push")|.status' | grep -c "running") -gt 0 ]]
+            do
+              sleep 5
+            done
+          curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_PROJECT_TOKEN"
+      - run: echo "All required jobs have now completed"
   send-stats:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
@@ -536,6 +547,9 @@ workflows:
   main:
     jobs:
       - save-start-time
+      - waiter:
+          requires:
+            - save-start-time
       - install:
           requires:
             - save-start-time
@@ -605,19 +619,11 @@ workflows:
             - collect-not-implemented
             - unit-tests
       - send-stats:
-          when: always
           filters:
             branches:
               only: master
           requires:
-            - itest-sfn-legacy-provider
-            - itest-s3-v2-legacy-provider
-            - itest-cloudwatch-v2-provider
-            - acceptance-tests
-            - docker-test-amd64
-            - docker-test-arm64
-            - collect-not-implemented
-            - unit-tests
+            - waiter
       - push:
           filters:
             branches:

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -89,7 +89,8 @@ jobs:
           python -m pytest tests/cli/
 
   push-to-tinybird:
-    if: always() && github.ref == 'refs/heads/master'
+    # if: always() && github.ref == 'refs/heads/master'
+    if: always()
     runs-on: ubuntu-latest
     needs: cli-tests
     steps:
@@ -99,4 +100,4 @@ jobs:
           workflow_id: "tests_cli"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tinybird_datasource: "ci_workflows"
+          tinybird_datasource: "ci_workflows_test"

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -89,8 +89,7 @@ jobs:
           python -m pytest tests/cli/
 
   push-to-tinybird:
-    # if: always() && github.ref == 'refs/heads/master'
-    if: always()
+    if: always() && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: cli-tests
     steps:
@@ -100,4 +99,4 @@ jobs:
           workflow_id: "tests_cli"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tinybird_datasource: "ci_workflows_test"
+          tinybird_datasource: "ci_workflows"

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -94,7 +94,7 @@ jobs:
     needs: cli-tests
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v3.0.0
+        uses: localstack/tinybird-workflow-push@v3
         with:
           workflow_id: "tests_cli"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}

--- a/.github/workflows/tests-podman.yml
+++ b/.github/workflows/tests-podman.yml
@@ -69,7 +69,7 @@ jobs:
     needs: podman-tests
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v3.0.0
+        uses: localstack/tinybird-workflow-push@v3
         with:
           workflow_id: "tests_podman"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -337,7 +337,7 @@ jobs:
     needs: publish-pro-test-results
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v3.0.0
+        uses: localstack/tinybird-workflow-push@v3
         with:
           workflow_id: "tests_pro_integration"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -218,7 +218,7 @@ jobs:
     needs: push-s3-image
     steps:
       - name: Push to Tinybird
-        uses: localstack/tinybird-workflow-push@v3.0.0
+        uses: localstack/tinybird-workflow-push@v3
         with:
           workflow_id: "tests_s3_image"
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The tracking of workflows does not happen currently when CircleCI tests are failing. Also, the tracked job ID in circle-ci does not match the semantics of the job id in the GitHub actions. In CircleCI it is a specific singular job run in a workflow. In GitHub it means the classifier of a job inside all the workflows.


<!-- What notable changes does this PR make? -->
## Changes

- Use a [workaround](https://discuss.circleci.com/t/workaround-run-jobs-sequentially-regardless-of-the-outcome-of-the-required-jobs/40807) to send circle ci workflow data also on fail (something which CircleCI can't do out of the box)
- Set the job id in the circle-ci job to the classifier of the job.
- Set the GH action version to a major tag so that it does get minor release updates automatically

## Testing

For the CircleCI fix, see these two (simplified) workflow runs:

1. In the [first run](https://app.circleci.com/pipelines/github/localstack/localstack/22737/workflows/1ae80f24-3d73-45a2-b5aa-d17da494a4d5), we have a failing job (`exit 1`), but sending the stats still worked, with the outcome "failure".
2. In the [second run](https://app.circleci.com/pipelines/github/localstack/localstack/22739/workflows/31ee30dc-3519-4ccb-81c8-d8388b550ff6), the failing job was "fixed" (`exit 0`), and the outcome is "success".

For the GitHub Action version fix, see if the push-to-tinybird job works properly with the new version indicator.

## TODO

- [x] Add back the entire CircleCI pipeline, and the guards

