### PR TITLE
Fix UserData regression from provider migration in AWS::EC2::Instance

### DIFF
--- a/localstack/services/ec2/resource_providers/aws_ec2_instance.py
+++ b/localstack/services/ec2/resource_providers/aws_ec2_instance.py
@@ -233,7 +233,7 @@ class EC2InstanceProvider(ResourceProvider[EC2InstanceProperties]):
             params["MinCount"] = 1
 
             if model.get("UserData"):
-                model["UserData"] = to_str(base64.b64decode(model["UserData"]))
+                params["UserData"] = to_str(base64.b64decode(model["UserData"]))
 
             response = ec2.run_instances(**params)
             model["Id"] = response["Instances"][0]["InstanceId"]


### PR DESCRIPTION
## Motivation

Initially introduced into the legacy model with https://github.com/localstack/localstack/pull/8957

Users reported this was broken again, so I investigated and found that there was a small bug in the provider migration that caused this setting to never be passed to the API call.

## Changes

- Fix param selection for API call