### PR TITLE
Fix bin/localstack venv detection

### DIFF
--- a/bin/localstack
+++ b/bin/localstack
@@ -4,8 +4,9 @@ import glob
 import os
 import sys
 
+VIRTUAL_ENV_PATH = os.getenv("VIRTUAL_ENV")
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
-venv_dir = os.path.join(PARENT_FOLDER, ".venv")
+venv_dir = VIRTUAL_ENV_PATH or os.path.join(PARENT_FOLDER, ".venv")
 insert_pos = min(len(sys.path), 2)
 if os.path.isdir(venv_dir):
     for path in glob.glob(os.path.join(venv_dir, "lib/python*/site-packages")):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While using [functiontrace](https://functiontrace.com/) to profile LocalStack performance, I tried to use the `bin/localstack` script to run the code in host mode. `functiontrace` requires a script to run, so this seemed a script to run for profiling. Unfortunately it did not pick up my virtual environment correctly (I do not use `.venv`), so this PR aims to detect the venv path correctly (or at least _better_).



<!-- What notable changes does this PR make? -->
## Changes

Try to read the venv path from the standard `VIRTUAL_ENV` environment variable, and fall back to `.venv` if not present.


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

