### PR TITLE
fix workflow execution for PRs coming from forks

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -85,8 +85,13 @@ env:
 jobs:
   test-pro:
     name: "Community Integration Tests against Pro"
-    # This job needs secrets and cannot be executed on forks, skip it in this case
-    if: github.repository == 'localstack/localstack'
+    # If this is triggered by a pull_request, make sure the PR head repo name is the same as the target repo name
+    # (i.e. do not execute job for workflows coming from forks)
+    if: >-
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -312,7 +317,13 @@ jobs:
       pull-requests: write
       contents: read
       issues: read
-    if: success() || failure()
+    # If this is triggered by a pull_request, make sure the PR head repo name is the same as the target repo name
+    # (i.e. do not execute job for workflows coming from forks)
+    if: >-
+      (success() || failure()) && (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     steps:
       - name: Download Artifacts 1
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -85,6 +85,13 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        # If this is triggered by a pull_request, make sure the PR head repo name is the same as the target repo name
+        # (i.e. do not execute job for workflows coming from forks)
+        if: >-
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -133,7 +140,13 @@ jobs:
       pull-requests: write
       contents: read
       issues: read
-    if: success() || failure()
+    # If this is triggered by a pull_request, make sure the PR head repo name is the same as the target repo name
+    # (i.e. do not execute job for workflows coming from forks)
+    if: >-
+      (success() || failure()) && (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     steps:
       - name: Download AMD64 Results
         uses: actions/download-artifact@v4

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1228,9 +1228,6 @@ class TestDockerClient:
         docker_client.restart_container(name)
         assert docker_client.is_container_running(name)
         docker_client.stop_container(name)
-        import time
-
-        time.sleep(5)
         assert not docker_client.is_container_running(name)
 
     @markers.skip_offline

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1228,6 +1228,9 @@ class TestDockerClient:
         docker_client.restart_container(name)
         assert docker_client.is_container_running(name)
         docker_client.stop_container(name)
+        import time
+
+        time.sleep(5)
         assert not docker_client.is_container_running(name)
 
     @markers.skip_offline


### PR DESCRIPTION
## Motivation
Unfortunately, it turns out that the fix to avoid the execution of test pipelines which rely on secrets implemented in https://github.com/localstack/localstack/pull/9383 is not correctly working, as we saw with the workflows executed on the following PRs:
- https://github.com/localstack/localstack/pull/10363
- https://github.com/localstack/localstack/pull/10365

It turns out that `github.repository` evaluates to the PR target repo (which in this case is `localstack/localstack`.
However, we want to make sure that the source and the target of the PR are not the same repo.
This PR tries to fix this condition by checking the pull request head target as described in https://github.com/orgs/community/discussions/26829.

## Changes
- Prevent the execution of the "Community Tests against Pro" (which inherently rely on the usage of secrets which cannot and shouldn't be provided for runs on untrusted code) by fixing the condition.
- Fixing the S3 image tests by only using the secrets if they are available.

## Testing
Unfortunately, this cannot really be tested properly as long as it's in a PR. Happy for any feedback / tips on how to test this though!