### PR TITLE
Support new common string functions in velocity templating

### DIFF
--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -66,6 +66,9 @@ class VtlTemplate:
         # add extensions for common string functions below
 
         class ExtendedString(str):
+            def toString(self, *_, **__):
+                return self
+
             def trim(self, *args, **kwargs):
                 return ExtendedString(self.strip(*args, **kwargs))
 
@@ -74,6 +77,13 @@ class VtlTemplate:
 
             def toUpperCase(self, *_, **__):
                 return ExtendedString(self.upper())
+
+            def contains(self, *args):
+                return self.find(*args) >= 0
+
+            def replaceAll(self, regex, replacement):
+                escaped_replacement = replacement.replace("$", "\\")
+                return ExtendedString(re.sub(regex, escaped_replacement, self))
 
         def apply(obj, **_):
             if isinstance(obj, dict):

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -222,9 +222,17 @@ class TestMessageTransformationApiGateway:
         variables = {"input": {"body": context}}
         template1 = "${foo.bar.strip().lower().replace(' ','-')}"
         template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
-        for template in [template1, template2]:
+        template3 = "${foo.bar.toString().lower().replace(' ','-')}"
+        template4 = '${foo.bar.trim().toLowerCase().replaceAll("^(.*)\\s(.*)$","$1-$2")}'
+        for template in [template1, template2, template3, template4]:
             result = ApiGatewayVtlTemplate().render_vtl(template, variables=variables)
             assert result == "baz-baz"
+
+        contains_template1 = ("${foo.bar.toString().lower().contains('baz')}", "true")
+        contains_template2 = ("${foo.bar.toString().lower().contains('bar')}", "false")
+        for template, expected_result in [contains_template1, contains_template2]:
+            result = ApiGatewayVtlTemplate().render_vtl(template, variables=variables)
+        assert result == expected_result
 
     def test_render_urlencoded_string_data(self):
         template = "MessageBody=$util.base64Encode($input.json('$'))"


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/issues/10369

## Changes
Adds more methods to class ExtendedString

## Testing
Into ApiGateway service, we now can use functions toString(), contains() and replaceAll() in the velocity templates 

## TODO

What's left to do:

- Many others string methods are still missing.
- **This PR should be labeled with semver: patch but I don't have permissions to do it**

