### PR TITLE
Improve delete reliability for kinesis streams

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -97,7 +97,6 @@ def delete_streams(account_id: str, region_name: str, table_arn: str) -> None:
         # we're basically asynchronously trying to delete the stream, or should we do this "synchronous" with the table deletion?
         def _delete_stream():
             try:
-                # TODO: this might fail when not in ACTIVE state yet, so we'd need to wait for it to be in active state before deleting..
                 kinesis_client = connect_to(
                     aws_access_key_id=account_id, region_name=region_name
                 ).kinesis

--- a/localstack/services/kinesis/resource_providers/aws_kinesis_stream.py
+++ b/localstack/services/kinesis/resource_providers/aws_kinesis_stream.py
@@ -139,7 +139,9 @@ class KinesisStreamProvider(ResourceProvider[KinesisStreamProperties]):
           - kinesis:RemoveTagsFromStream
         """
         model = request.desired_state
-        request.aws_client_factory.kinesis.delete_stream(StreamARN=model["Arn"])
+        request.aws_client_factory.kinesis.delete_stream(
+            StreamARN=model["Arn"], EnforceConsumerDeletion=True
+        )
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
             resource_model={},


### PR DESCRIPTION
## Motivation

Deleting kinesis streams sometimes fails due to still existing consumers and/or because it is trying to be deleted while not in `ACTIVE` state yet.

## Changes

- Add flag to delete so that we can delete even though consumers are still present
- Add flag also to the deletion of streams for dynamodb streams and remove exception suppression
