### PR TITLE
Support custom key material when creating KMS keys

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -103,6 +103,11 @@ RESERVED_ALIASES = [
 # list of key names that should be skipped when serializing the encryption context
 IGNORED_CONTEXT_KEYS = ["aws-crypto-public-key"]
 
+# special tag name to allow specifying a custom ID for created keys
+TAG_KEY_CUSTOM_ID = "_custom_id_"
+# special tag name to allow specifying a custom key material for created keys
+TAG_KEY_CUSTOM_KEY_MATERIAL = "_custom_key_material_"
+
 
 def _serialize_ciphertext_blob(ciphertext: Ciphertext) -> bytes:
     header = struct.pack(
@@ -161,14 +166,14 @@ class KmsCryptoKey:
     key_material: bytes
     key_spec: str
 
-    def __init__(self, key_spec: str):
+    def __init__(self, key_spec: str, key_material: Optional[bytes] = None):
         self.private_key = None
         self.public_key = None
         # Technically, key_material, being a symmetric encryption key, is only relevant for
         #   key_spec == SYMMETRIC_DEFAULT.
         # But LocalStack uses symmetric encryption with this key_material even for other specs. Asymmetric keys are
         # generated, but are not actually used for encryption. Signing is different.
-        self.key_material = os.urandom(SYMMETRIC_DEFAULT_MATERIAL_LENGTH)
+        self.key_material = key_material or os.urandom(SYMMETRIC_DEFAULT_MATERIAL_LENGTH)
         self.key_spec = key_spec
 
         if key_spec == "SYMMETRIC_DEFAULT":
@@ -189,7 +194,9 @@ class KmsCryptoKey:
                     f"ECC_SECG_P256K1, RSA_4096, SYMMETRIC_DEFAULT, HMAC_256, HMAC_224, HMAC_512]"
                 )
             minimum_length, maximum_length = HMAC_RANGE_KEY_LENGTHS.get(key_spec)
-            self.key_material = os.urandom(random.randint(minimum_length, maximum_length))
+            self.key_material = key_material or os.urandom(
+                random.randint(minimum_length, maximum_length)
+            )
             return
         else:
             # We do not support SM2 - asymmetric keys both suitable for ENCRYPT_DECRYPT and SIGN_VERIFY,
@@ -239,8 +246,7 @@ class KmsKey:
         region: str = None,
     ):
         create_key_request = create_key_request or CreateKeyRequest()
-        self._populate_metadata(create_key_request, account_id, region)
-        self.crypto_key = KmsCryptoKey(self.metadata.get("KeySpec"))
+
         # Please keep in mind that tags of a key could be present in the request, they are not a part of metadata. At
         # least in the sense of DescribeKey not returning them with the rest of the metadata. Instead, tags are more
         # like aliases:
@@ -254,6 +260,15 @@ class KmsKey:
         # "Automatic key rotation is disabled by default on customer managed keys but authorized users can enable and
         # disable it."
         self.is_key_rotation_enabled = False
+
+        self._populate_metadata(create_key_request, account_id, region)
+        custom_key_material = None
+        if TAG_KEY_CUSTOM_KEY_MATERIAL in self.tags:
+            # check if the _custom_key_material_ tag is specified, to use a custom key material for this key
+            custom_key_material = base64.b64decode(self.tags[TAG_KEY_CUSTOM_KEY_MATERIAL])
+            # remove the _custom_key_material_ tag from the tags to not readily expose the custom key material
+            del self.tags[TAG_KEY_CUSTOM_KEY_MATERIAL]
+        self.crypto_key = KmsCryptoKey(self.metadata.get("KeySpec"), custom_key_material)
 
     def calculate_and_set_arn(self, account_id, region):
         self.metadata["Arn"] = kms_key_arn(self.metadata.get("KeyId"), account_id, region)
@@ -431,11 +446,15 @@ class KmsKey:
             if create_key_request.get("Origin") != OriginType.EXTERNAL
             else KeyState.PendingImport
         )
-        # https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html
-        # "Notice that multi-Region keys have a distinctive key ID that begins with mrk-. You can use the mrk- prefix to
-        # identify MRKs programmatically."
-        # The ID for MultiRegion keys also do not have dashes.
-        if self.metadata.get("MultiRegion"):
+
+        if TAG_KEY_CUSTOM_ID in self.tags:
+            # check if the _custom_id_ tag is specified, to set a user-defined KeyId for this key
+            self.metadata["KeyId"] = self.tags[TAG_KEY_CUSTOM_ID].strip()
+        elif self.metadata.get("MultiRegion"):
+            # https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html
+            # "Notice that multi-Region keys have a distinctive key ID that begins with mrk-. You can use the mrk- prefix to
+            # identify MRKs programmatically."
+            # The ID for MultiRegion keys also do not have dashes.
             self.metadata["KeyId"] = "mrk-" + str(uuid.uuid4().hex)
         else:
             self.metadata["KeyId"] = str(uuid.uuid4())

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -142,9 +142,6 @@ VALID_OPERATIONS = [
     "GenerateDataKeyPairWithoutPlaintext",
 ]
 
-# special tag name to allow specifying a custom ID for created keys
-TAG_KEY_CUSTOM_ID = "_custom_id_"
-
 
 class ValidationError(CommonServiceException):
     """General validation error type (defined in the AWS docs, but not part of the botocore spec)"""
@@ -202,14 +199,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> KmsKey:
         store = kms_stores[account_id][region_name]
         key = KmsKey(request, account_id, region_name)
-
-        # check if the _custom_id_ tag is specified, to set a user-defined KeyId for this key
-        tags_dict = {tag["TagKey"]: tag["TagValue"] for tag in request.get("Tags", [])}
-        custom_id = tags_dict.get(TAG_KEY_CUSTOM_ID)
-        if custom_id and custom_id.strip():
-            key.metadata["KeyId"] = custom_id.strip()
-            key.calculate_and_set_arn(account_id=account_id, region=region_name)
-
         key_id = key.metadata["KeyId"]
         store.keys[key_id] = key
         return key

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -9,13 +9,11 @@ from random import getrandbits
 import pytest
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding
-from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 
-from localstack.services.kms.models import Ciphertext, _serialize_ciphertext_blob, IV_LEN
+from localstack.services.kms.models import IV_LEN, Ciphertext, _serialize_ciphertext_blob
 from localstack.services.kms.utils import get_hash_algorithm
 from localstack.testing.pytest import markers
 from localstack.utils.crypto import encrypt
@@ -162,9 +160,7 @@ class TestKMS:
         iv = os.urandom(IV_LEN)
         ciphertext, tag = encrypt(custom_key_material, message, iv, b"")
         expected_ciphertext_blob = _serialize_ciphertext_blob(
-            ciphertext=Ciphertext(
-                key_id=key_id, iv=iv, ciphertext=ciphertext, tag=tag
-            )
+            ciphertext=Ciphertext(key_id=key_id, iv=iv, ciphertext=ciphertext, tag=tag)
         )
 
         plaintext = aws_client.kms.decrypt(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Add support for creating KMS keys with custom key material using custom tags. This is similar to an existing feature that allows the KMS Key ID to be set when creating KMS keys. This is necessary when working with external systems and decryption or HMACs must work across localstack reboots.

Fixes #8910

<!-- What notable changes does this PR make? -->
## Changes

* Introduces a new special tag `_custom_key_material_` that can be used when creating a KMS key to set the key material of the key.
* Refactors the existing `_custom_id_` so that it handled in the `KmsKey` model.

## Testing

I've introduced two new unit tests to ensure the custom key material is working for symmetric and HMAC KMS keys.

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

