### PR TITLE
Support XML responses in api gateway templating

### DIFF
--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -371,8 +371,8 @@ class ResponseTemplates(Templates):
     @staticmethod
     def _validate_xml(content: str):
         """
-        Checks that the content received is a valid JSON.
-        :raise JSONDecodeError: if content is not valid JSON
+        Checks that the content received is a valid XML.
+        :raise xml.parsers.expat.ExpatError: if content is not valid XML
         """
         try:
             xmltodict.parse(content)

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -329,10 +329,9 @@ class ResponseTemplates(Templates):
         accept = api_context.headers.get("accept", APPLICATION_JSON)
         supported_types = [APPLICATION_JSON, APPLICATION_XML]
         media_type = accept if accept in supported_types else APPLICATION_JSON
-        if media_type not in response_templates:
+        if not (template := response_templates.get(media_type, {})):
             return response._content
 
-        template = response_templates.get(media_type, {})
         # we render the template with the context data and the response content
         variables = self.build_variables_mapping(api_context)
         # update the response body

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1,15 +1,18 @@
 import json
 import unittest
+import xml
 from json import JSONDecodeError
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock
 
 import boto3
 import pytest
+import xmltodict
 
 from localstack.aws.api.apigateway import Model
 from localstack.constants import (
     APPLICATION_JSON,
+    APPLICATION_XML,
     AWS_REGION_US_EAST_1,
     DEFAULT_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
@@ -528,7 +531,7 @@ class TestApplyTemplate(unittest.TestCase):
         self.assertEqual("[]", rendered_request)
 
 
-RESPONSE_TEMPLATE = """
+RESPONSE_TEMPLATE_JSON = """
 
 #set( $body = $input.json("$") )
 #define( $loop )
@@ -571,6 +574,59 @@ RESPONSE_TEMPLATE = """
 }
 """
 
+RESPONSE_TEMPLATE_WRONG_JSON = """
+#set( $body = $input.json("$") )
+  {
+    "body": $body,
+    "method": $context.httpMethod,
+  }
+"""
+
+RESPONSE_TEMPLATE_XML = """
+
+#set( $body = $input.json("$") )
+#define( $loop )
+    #foreach($e in $map.keySet())
+       #set( $k = $e )
+       #set( $v = $map.get($k))
+       <$k>$v</$k>
+    #end
+#end
+  <root method="$context.httpMethod" principalId="$context.authorizer.principalId" requestPath="$context.resourcePath">
+    <body>$body</body>
+    <stage>$context.stage</stage>
+    <cognitoPoolClaims>
+       <sub>$context.authorizer.claims.sub</sub>
+    </cognitoPoolClaims>
+
+    #set( $map = $context.authorizer )
+    <enhancedAuthContext>$loop</enhancedAuthContext>
+
+    #set( $map = $input.params().header )
+    <headers>$loop</headers>
+
+    #set( $map = $input.params().querystring )
+    <query>$loop</query>
+
+    #set( $map = $input.params().path )
+    <path>$loop</path>
+
+    #set( $map = $context.identity )
+    <identity>$loop</identity>
+
+    #set( $map = $stageVariables )
+    <stageVariables>$loop</stageVariables>
+  </root>
+"""
+
+RESPONSE_TEMPLATE_WRONG_XML = """
+#set( $body = $input.json("$") )
+<root>
+  <body>$body</body>
+  <not-closed>$context.stage
+</root>
+"""
+
 
 class TestTemplates:
     @pytest.mark.parametrize("template", [RequestTemplates(), ResponseTemplates()])
@@ -583,9 +639,9 @@ class TestTemplates:
             stage="local",
         )
         api_context.integration = {
-            "requestTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE},
+            "requestTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE_JSON},
             "integrationResponses": {
-                "200": {"responseTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE}}
+                "200": {"responseTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE_JSON}}
             },
         }
         api_context.resource_path = "/{proxy+}"
@@ -622,15 +678,105 @@ class TestTemplates:
 
         # assert that boolean results of _render_json_result(..) are JSON-parseable
         tstring = '{"mybool": $boolTrue}'
-        result = template._render_as_json(tstring, {"boolTrue": "true"})
+        result = template._render_as_text(tstring, {"boolTrue": "true"})
         assert json.loads(result) == {"mybool": True}
-        result = template._render_as_json(tstring, {"boolTrue": True})
+        result = template._render_as_text(tstring, {"boolTrue": True})
         assert json.loads(result) == {"mybool": True}
 
         # older versions of `airspeed` were rendering booleans as False/True, which is no longer valid now
         tstring = '{"mybool": False}'
         with pytest.raises(JSONDecodeError):
-            template._render_as_json(tstring, {})
+            result = template._render_as_text(tstring, {})
+            template._validate_json(result)
+
+    def test_error_when_render_invalid_json(self):
+        api_context = ApiInvocationContext(
+            method="POST",
+            path="/foo/bar?baz=test",
+            data=b"<root></root>",
+            headers={},
+        )
+        api_context.integration = {
+            "integrationResponses": {
+                "200": {"responseTemplates": {APPLICATION_JSON: RESPONSE_TEMPLATE_WRONG_JSON}}
+            },
+        }
+        api_context.response = requests_response({"spam": "eggs"})
+        api_context.context = {}
+        api_context.stage_variables = {}
+
+        template = ResponseTemplates()
+        with pytest.raises(JSONDecodeError):
+            template.render(api_context=api_context)
+
+    @pytest.mark.parametrize("template", [RequestTemplates(), ResponseTemplates()])
+    def test_render_custom_template_in_xml(self, template):
+        api_context = ApiInvocationContext(
+            method="POST",
+            path="/foo/bar?baz=test",
+            data=b'{"spam": "eggs"}',
+            headers={"content-type": APPLICATION_XML, "accept": APPLICATION_XML},
+            stage="local",
+        )
+        api_context.integration = {
+            "requestTemplates": {APPLICATION_XML: RESPONSE_TEMPLATE_XML},
+            "integrationResponses": {
+                "200": {"responseTemplates": {APPLICATION_XML: RESPONSE_TEMPLATE_XML}}
+            },
+        }
+        api_context.resource_path = "/{proxy+}"
+        api_context.path_params = {"id": "bar"}
+        api_context.response = requests_response({"spam": "eggs"})
+        api_context.context = {
+            "httpMethod": api_context.method,
+            "stage": api_context.stage,
+            "authorizer": {"principalId": "12233"},
+            "identity": {"accountId": "00000", "apiKey": "11111"},
+            "resourcePath": api_context.resource_path,
+        }
+        api_context.stage_variables = {"stageVariable1": "value1", "stageVariable2": "value2"}
+
+        rendered_request = template.render(api_context=api_context, template_key=APPLICATION_XML)
+        result_as_xml = xmltodict.parse(rendered_request).get("root", {})
+
+        assert result_as_xml.get("body") == '{"spam": "eggs"}'
+        assert result_as_xml.get("@method") == "POST"
+        assert result_as_xml.get("@principalId") == "12233"
+        assert result_as_xml.get("stage") == "local"
+        assert result_as_xml.get("enhancedAuthContext") == {"principalId": "12233"}
+        assert result_as_xml.get("identity") == {"accountId": "00000", "apiKey": "11111"}
+        assert result_as_xml.get("headers") == {
+            "content-type": APPLICATION_XML,
+            "accept": APPLICATION_XML,
+        }
+        assert result_as_xml.get("query") == {"baz": "test"}
+        assert result_as_xml.get("path") == {"id": "bar"}
+        assert result_as_xml.get("stageVariables") == {
+            "stageVariable1": "value1",
+            "stageVariable2": "value2",
+        }
+
+    def test_error_when_render_invalid_xml(self):
+        api_context = ApiInvocationContext(
+            method="POST",
+            path="/foo/bar?baz=test",
+            data=b"<root></root>",
+            headers={"content-type": APPLICATION_XML, "accept": APPLICATION_XML},
+            stage="local",
+        )
+        api_context.integration = {
+            "integrationResponses": {
+                "200": {"responseTemplates": {APPLICATION_XML: RESPONSE_TEMPLATE_WRONG_XML}}
+            },
+        }
+        api_context.resource_path = "/{proxy+}"
+        api_context.response = requests_response({"spam": "eggs"})
+        api_context.context = {}
+        api_context.stage_variables = {}
+
+        template = ResponseTemplates()
+        with pytest.raises(xml.parsers.expat.ExpatError):
+            template.render(api_context=api_context, template_key=APPLICATION_XML)
 
 
 def test_openapi_resolver_given_unresolvable_references():


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/issues/10380

## Changes
Read the Accept header of the HTTP request and use the corresponding template and validate the response (only XML support added)

<!-- The following sections are optional, but can be useful! 

## Testing
Define an API gateway with an XML template as response_template, and make an HTTP request with Accept: application/xml header. The response must be formatted as a valid XML instead of JSON.

## TODO

What's left to do:

- Add support to other media types
- **I can't label this PR as semver: patch**

