### PR TITLE
refactor s3 storage to use context manager to avoid race condition

### DIFF
--- a/localstack/services/s3/v3/models.py
+++ b/localstack/services/s3/v3/models.py
@@ -268,6 +268,7 @@ class S3Object:
     is_current: bool
     parts: Optional[dict[int, tuple[int, int]]]
     restore: Optional[Restore]
+    internal_last_modified: int
 
     def __init__(
         self,
@@ -318,6 +319,7 @@ class S3Object:
         self.parts = {}
         self.restore = None
         self.owner = owner
+        self.internal_last_modified = 0
 
     def get_system_metadata_fields(self) -> dict:
         headers = {

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -1,6 +1,6 @@
 import abc
 from io import RawIOBase
-from typing import IO, Iterable, Iterator, Optional
+from typing import IO, Iterable, Iterator, Literal, Optional
 
 from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
 from localstack.services.s3.utils import ObjectRange
@@ -30,6 +30,10 @@ class LimitedIterableStream(Iterable[bytes]):
                 break
 
         return
+
+    def close(self):
+        if hasattr(self.iterable, "close"):
+            self.iterable.close()
 
 
 class LimitedStream(RawIOBase):
@@ -69,8 +73,10 @@ class S3StoredObject(abc.ABC, Iterable[bytes]):
 
     s3_object: S3Object
 
-    def __init__(self, s3_object: S3Object | S3Part):
+    def __init__(self, s3_object: S3Object | S3Part, mode: Literal["r", "w"] = "r"):
         self.s3_object = s3_object
+        self._mode = mode
+        self.closed = False
 
     @abc.abstractmethod
     def close(self):
@@ -110,6 +116,16 @@ class S3StoredObject(abc.ABC, Iterable[bytes]):
     def __iter__(self) -> Iterator[bytes]:
         pass
 
+    def __enter__(self):
+        """Context management protocol.  Returns self (an instance of S3StoredObject)."""
+        if self.closed:
+            raise ValueError("I/O operation on closed S3 Object.")
+        return self
+
+    def __exit__(self, *args):
+        """Context management protocol.  Calls close()"""
+        self.close()
+
 
 class S3StoredMultipart(abc.ABC):
     """
@@ -128,7 +144,7 @@ class S3StoredMultipart(abc.ABC):
         self.parts = {}
 
     @abc.abstractmethod
-    def open(self, s3_part: S3Part) -> S3StoredObject:
+    def open(self, s3_part: S3Part, mode: Literal["r", "w"] = "r") -> S3StoredObject:
         pass
 
     @abc.abstractmethod
@@ -136,7 +152,7 @@ class S3StoredMultipart(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def complete_multipart(self, parts: list[PartNumber]) -> S3StoredObject:
+    def complete_multipart(self, parts: list[PartNumber]) -> None:
         pass
 
     @abc.abstractmethod
@@ -161,7 +177,9 @@ class S3ObjectStore(abc.ABC):
     """
 
     @abc.abstractmethod
-    def open(self, bucket: BucketName, s3_object: S3Object) -> S3StoredObject:
+    def open(
+        self, bucket: BucketName, s3_object: S3Object, mode: Literal["r", "w"] = "r"
+    ) -> S3StoredObject:
         pass
 
     @abc.abstractmethod

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -103,6 +103,11 @@ class S3StoredObject(abc.ABC, Iterable[bytes]):
 
     @property
     @abc.abstractmethod
+    def last_modified(self) -> int:
+        pass
+
+    @property
+    @abc.abstractmethod
     def checksum(self) -> Optional[str]:
         if not self.s3_object.checksum_algorithm:
             return None

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -1,5 +1,4 @@
 import base64
-import contextlib
 import hashlib
 import os
 import threading
@@ -8,7 +7,7 @@ from io import BytesIO
 from shutil import rmtree
 from tempfile import SpooledTemporaryFile, mkdtemp
 from threading import RLock
-from typing import IO, Iterator, Optional, TypedDict
+from typing import IO, Iterator, Literal, Optional, TypedDict
 
 from readerwriterlock import rwlock
 
@@ -57,15 +56,27 @@ class EphemeralS3StoredObject(S3StoredObject):
     etag: Optional[str]
     checksum_hash: Optional[ChecksumHash]
     _checksum: Optional[str]
+    _lock: rwlock.Lockable
 
-    def __init__(self, s3_object: S3Object | S3Part, file: LockedSpooledTemporaryFile):
-        super().__init__(s3_object=s3_object)
+    def __init__(
+        self,
+        s3_object: S3Object | S3Part,
+        file: LockedSpooledTemporaryFile,
+        mode: Literal["r", "w"] = "r",
+    ):
+        super().__init__(s3_object=s3_object, mode=mode)
         self.file = file
         self.size = 0
         self._etag = None
         self.checksum_hash = None
         self._checksum = None
         self._pos = 0
+        self._lock = (
+            self.file.readwrite_lock.gen_wlock()
+            if mode == "w"
+            else self.file.readwrite_lock.gen_rlock()
+        )
+        self._lock.acquire()
 
     def read(self, s: int = -1) -> bytes | None:
         """Read at most `s` bytes from the underlying fileobject, and keeps the internal position"""
@@ -120,25 +131,17 @@ class EphemeralS3StoredObject(S3StoredObject):
             self.checksum_hash = get_s3_checksum(self.s3_object.checksum_algorithm)
 
         file = self.file
-        # if the incoming stream has a file containing a readwrite_lock, from a `copy` call, then we need to lock
-        # around the iteration to block any concurrent write of the underlying object
-        if hasattr(stream, "file") and hasattr(stream.file, "readwrite_lock"):
-            read_lock = stream.file.readwrite_lock.gen_rlock()
-        else:
-            read_lock = contextlib.nullcontext()
-
-        with file.readwrite_lock.gen_wlock():
+        with file.position_lock:
             file.seek(0)
             file.truncate()
 
             etag = hashlib.md5(usedforsecurity=False)
 
-            with read_lock:
-                while data := stream.read(S3_CHUNK_SIZE):
-                    file.write(data)
-                    etag.update(data)
-                    if self.checksum_hash:
-                        self.checksum_hash.update(data)
+            while data := stream.read(S3_CHUNK_SIZE):
+                file.write(data)
+                etag.update(data)
+                if self.checksum_hash:
+                    self.checksum_hash.update(data)
 
             etag = etag.hexdigest()
             self.size = self.s3_object.size = file.tell()
@@ -146,7 +149,7 @@ class EphemeralS3StoredObject(S3StoredObject):
 
             self._pos = file.seek(0)
 
-            return self.size
+        return self.size
 
     def append(self, part: "EphemeralS3StoredObject") -> int:
         """
@@ -156,18 +159,18 @@ class EphemeralS3StoredObject(S3StoredObject):
         :return: number of written bytes
         """
         read = 0
-        with part.file.readwrite_lock.gen_rlock():
-            while data := part.read(S3_CHUNK_SIZE):
-                self.file.write(data)
-                read += len(data)
+        while data := part.read(S3_CHUNK_SIZE):
+            self.file.write(data)
+            read += len(data)
 
         self.size += read
         self.s3_object.size = self.size
         return read
 
     def close(self):
-        """This is a noop, because closing the underlying file object will delete it"""
-        pass
+        """We only release the lock, because closing the underlying file object will delete it"""
+        self._lock.release()
+        self.closed = True
 
     @property
     def checksum(self) -> Optional[str]:
@@ -183,12 +186,11 @@ class EphemeralS3StoredObject(S3StoredObject):
             self.checksum_hash = get_s3_checksum(self.s3_object.checksum_algorithm)
             original_pos = self._pos
 
-            with self.file.readwrite_lock.gen_rlock():
-                self._pos = 0
-                while data := self.read(S3_CHUNK_SIZE):
-                    self.checksum_hash.update(data)
+            self._pos = 0
+            while data := self.read(S3_CHUNK_SIZE):
+                self.checksum_hash.update(data)
 
-                self._pos = original_pos
+            self._pos = original_pos
 
         if not self._checksum:
             self._checksum = base64.b64encode(self.checksum_hash.digest()).decode()
@@ -201,11 +203,10 @@ class EphemeralS3StoredObject(S3StoredObject):
             etag = hashlib.md5(usedforsecurity=False)
             original_pos = self._pos
 
-            with self.file.readwrite_lock.gen_rlock():
-                self._pos = 0
-                while data := self.read(S3_CHUNK_SIZE):
-                    etag.update(data)
-                self._pos = original_pos
+            self._pos = 0
+            while data := self.read(S3_CHUNK_SIZE):
+                etag.update(data)
+            self._pos = original_pos
 
             self._etag = etag.hexdigest()
 
@@ -213,22 +214,22 @@ class EphemeralS3StoredObject(S3StoredObject):
 
     def __iter__(self) -> Iterator[bytes]:
         """
-        This is mostly used as convenience to directly passed this object to a Werkzeug response object, hiding the
+        This is mostly used as convenience to directly pass this object to a Werkzeug response object, hiding the
         iteration locking logic.
+        The caller needs to call `close()` once it is done to release the lock.
         :return:
         """
-        with self.file.readwrite_lock.gen_rlock():
-            while data := self.read(S3_CHUNK_SIZE):
-                if not data:
-                    return b""
+        while data := self.read(S3_CHUNK_SIZE):
+            if not data:
+                return b""
 
-                yield data
+            yield data
 
 
 class EphemeralS3StoredMultipart(S3StoredMultipart):
     upload_dir: str
     _s3_store: "EphemeralS3ObjectStore"
-    parts: dict[PartNumber, EphemeralS3StoredObject]
+    parts: dict[PartNumber, LockedSpooledTemporaryFile]
 
     def __init__(
         self,
@@ -240,20 +241,20 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         super().__init__(s3_store=s3_store, bucket=bucket, s3_multipart=s3_multipart)
         self.upload_dir = upload_dir
 
-    def open(self, s3_part: S3Part) -> EphemeralS3StoredObject:
+    def open(self, s3_part: S3Part, mode: Literal["r", "w"] = "r") -> EphemeralS3StoredObject:
         """
         Returns an EphemeralS3StoredObject for an S3Part, allowing direct access to the object. This will add a part
-        into the Multipart collection. We can directly store the EphemeralS3StoredObject in the collection, as S3Part
+        into the Multipart collection. We can directly store the EphemeralS3Stored Object in the collection, as S3Part
         cannot be accessed/read directly from the API.
         :param s3_part: S3Part object
+        :param mode: opening mode, "read" or "write"
         :return: EphemeralS3StoredObject, most often to directly `write` into it.
         """
-        if not (stored_part := self.parts.get(s3_part.part_number)):
+        if not (file := self.parts.get(s3_part.part_number)):
             file = LockedSpooledTemporaryFile(dir=self.upload_dir, max_size=S3_MAX_FILE_SIZE_BYTES)
-            stored_part = EphemeralS3StoredObject(s3_part, file)
-            self.parts[s3_part.part_number] = stored_part
+            self.parts[s3_part.part_number] = file
 
-        return stored_part
+        return EphemeralS3StoredObject(s3_part, file, mode=mode)
 
     def remove_part(self, s3_part: S3Part):
         """
@@ -261,34 +262,34 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :param s3_part: S3Part
         :return:
         """
-        stored_part = self.parts.pop(s3_part.part_number, None)
-        if stored_part:
-            stored_part.file.close()
+        stored_part_file = self.parts.pop(s3_part.part_number, None)
+        if stored_part_file:
+            stored_part_file.close()
 
-    def complete_multipart(self, parts: list[S3Part]) -> EphemeralS3StoredObject:
+    def complete_multipart(self, parts: list[S3Part]) -> None:
         """
         Takes a list of parts numbers, and will iterate over it to assemble all parts together into a single
         EphemeralS3StoredObject containing all those parts.
         :param parts: list of PartNumber
         :return: the resulting EphemeralS3StoredObject
         """
-        s3_stored_object = self._s3_store.open(self.bucket, self.s3_multipart.object)
-        # reset the file to overwrite
-        s3_stored_object.seek(0)
-        s3_stored_object.truncate()
-        for s3_part in parts:
-            stored_part = self.parts.get(s3_part.part_number)
-            s3_stored_object.append(stored_part)
-
-        return s3_stored_object
+        with self._s3_store.open(
+            self.bucket, self.s3_multipart.object, mode="w"
+        ) as s3_stored_object:
+            # reset the file to overwrite
+            s3_stored_object.seek(0)
+            s3_stored_object.truncate()
+            for s3_part in parts:
+                with self.open(s3_part, mode="r") as stored_part:
+                    s3_stored_object.append(stored_part)
 
     def close(self):
         """
         Iterates over all parts of the collection to close them and clean them up. Closing a part will delete it.
         :return:
         """
-        for part in self.parts.values():
-            part.file.close()
+        for stored_part_file in self.parts.values():
+            stored_part_file.close()
         self.parts.clear()
 
     def copy_from_object(
@@ -307,15 +308,15 @@ class EphemeralS3StoredMultipart(S3StoredMultipart):
         :param range_data: the range data from which the S3Part will copy its data.
         :return: the EphemeralS3StoredObject representing the stored part
         """
-        src_stored_object = self._s3_store.open(src_bucket, src_s3_object)
-        stored_part = self.open(s3_part)
+        with self._s3_store.open(
+            src_bucket, src_s3_object, mode="r"
+        ) as src_stored_object, self.open(s3_part, mode="w") as stored_part:
+            if not range_data:
+                stored_part.write(src_stored_object)
+                return
 
-        if not range_data:
-            stored_part.write(src_stored_object)
-            return
-
-        object_slice = LimitedStream(src_stored_object, range_data=range_data)
-        stored_part.write(object_slice)
+            object_slice = LimitedStream(src_stored_object, range_data=range_data)
+            stored_part.write(object_slice)
 
 
 class BucketTemporaryFileSystem(TypedDict):
@@ -351,13 +352,16 @@ class EphemeralS3ObjectStore(S3ObjectStore):
         self.root_directory = root_directory
         self._lock_multipart_create = threading.RLock()
 
-    def open(self, bucket: BucketName, s3_object: S3Object) -> EphemeralS3StoredObject:
+    def open(
+        self, bucket: BucketName, s3_object: S3Object, mode: Literal["r", "w"] = "r"
+    ) -> EphemeralS3StoredObject:
         """
         Returns a EphemeralS3StoredObject from an S3Object, a wrapper around an underlying fileobject underneath,
         exposing higher level actions for the provider to interact with. This allows the provider to store data for an
         S3Object.
         :param bucket: the S3Object bucket
         :param s3_object: an S3Object
+        :param mode: read or write mode for the object to open
         :return: EphemeralS3StoredObject
         """
         key = self._key_from_s3_object(s3_object)
@@ -366,7 +370,7 @@ class EphemeralS3ObjectStore(S3ObjectStore):
             file = LockedSpooledTemporaryFile(dir=bucket_tmp_dir, max_size=S3_MAX_FILE_SIZE_BYTES)
             self._filesystem[bucket]["keys"][key] = file
 
-        return EphemeralS3StoredObject(s3_object=s3_object, file=file)
+        return EphemeralS3StoredObject(s3_object=s3_object, file=file, mode=mode)
 
     def remove(self, bucket: BucketName, s3_object: S3Object | list[S3Object]):
         """
@@ -403,12 +407,11 @@ class EphemeralS3ObjectStore(S3ObjectStore):
         # If this is an in-place copy, directly return the EphemeralS3StoredObject of the destination S3Object, no need
         # to copy the underlying data.
         if src_bucket == dest_bucket and src_object.key == dest_object.key:
-            return self.open(dest_bucket, dest_object)
+            return self.open(dest_bucket, dest_object, mode="r")
 
-        src_stored_object = self.open(src_bucket, src_object)
-        dest_stored_object = self.open(dest_bucket, dest_object)
-
-        dest_stored_object.write(src_stored_object)
+        with self.open(src_bucket, src_object, mode="r") as src_stored_object:
+            dest_stored_object = self.open(dest_bucket, dest_object, mode="w")
+            dest_stored_object.write(src_stored_object)
 
         return dest_stored_object
 

--- a/tests/aws/services/s3/test_s3_concurrency.py
+++ b/tests/aws/services/s3/test_s3_concurrency.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import threading
 
 from localstack.testing.pytest import markers
@@ -63,6 +64,71 @@ class TestParallelBucketCreation:
         thread_list = []
         for i in range(1, num_threads + 1):
             thread = threading.Thread(target=_create_or_list, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        assert not errored
+
+    @markers.aws.only_localstack
+    def test_parallel_object_creation_and_read(self, aws_client, s3_bucket):
+        num_threads = 100
+        create_barrier = threading.Barrier(num_threads)
+        errored = False
+        aws_client.s3.put_object(Bucket=s3_bucket, Key="random-key", Body="random")
+
+        def _create_or_read(runner: int):
+            nonlocal errored
+            create_barrier.wait()
+            try:
+                if random.choice((1, 2)) == 1:
+                    aws_client.s3.get_object(Bucket=s3_bucket, Key="random-key")
+                else:
+                    aws_client.s3.put_object(Bucket=s3_bucket, Key="random-key", Body="random")
+            except Exception:
+                LOG.exception("Put/get objects failed")
+                errored = True
+
+        thread_list = []
+        for i in range(1, num_threads + 1):
+            thread = threading.Thread(target=_create_or_read, args=[i])
+            thread.start()
+            thread_list.append(thread)
+
+        for thread in thread_list:
+            thread.join()
+
+        assert not errored
+
+    @markers.aws.only_localstack
+    def test_parallel_object_read_range(self, aws_client, s3_bucket):
+        num_threads = 100
+        create_barrier = threading.Barrier(num_threads)
+        errored = False
+        body = "random" * 100
+        len_body = len(body)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key="random-key", Body=body)
+
+        def _create_or_read(runner: int):
+            nonlocal errored
+            create_barrier.wait()
+            try:
+                start = random.randrange(0, len_body)
+                end = random.randrange(start, len_body)
+
+                aws_client.s3.get_object(
+                    Bucket=s3_bucket, Key="random-key", Range=f"bytes={start}-{end}"
+                )
+
+            except Exception:
+                LOG.exception("get ranged objects failed")
+                errored = True
+
+        thread_list = []
+        for i in range(1, num_threads + 1):
+            thread = threading.Thread(target=_create_or_read, args=[i])
             thread.start()
             thread_list.append(thread)
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -663,20 +663,19 @@ class TestS3TemporaryStorageBackend:
     def test_get_fileobj_no_bucket(self, tmpdir):
         temp_storage_backend = EphemeralS3ObjectStore(root_directory=tmpdir)
         fake_object = S3Object(key="test-key")
-        s3_stored_object = temp_storage_backend.open("test-bucket", fake_object)
+        with temp_storage_backend.open("test-bucket", fake_object, mode="w") as s3_stored_object:
+            s3_stored_object.write(BytesIO(b"abc"))
 
-        s3_stored_object.write(BytesIO(b"abc"))
+            assert s3_stored_object.read() == b"abc"
 
-        assert s3_stored_object.read() == b"abc"
+            s3_stored_object.seek(1)
+            assert s3_stored_object.read() == b"bc"
 
-        s3_stored_object.seek(1)
-        assert s3_stored_object.read() == b"bc"
+            s3_stored_object.seek(0)
+            assert s3_stored_object.read(1) == b"a"
 
-        s3_stored_object.seek(0)
-        assert s3_stored_object.read(1) == b"a"
-
-        temp_storage_backend.remove("test-bucket", fake_object)
-        assert s3_stored_object.file.closed
+            temp_storage_backend.remove("test-bucket", fake_object)
+            assert s3_stored_object.file.closed
 
         temp_storage_backend.close()
 
@@ -689,10 +688,10 @@ class TestS3TemporaryStorageBackend:
         stored_parts = []
         for i in range(1, 6):
             fake_s3_part = S3Part(part_number=i)
-            stored_part = s3_stored_multipart.open(fake_s3_part)
-            stored_part.write(BytesIO(b"abc"))
-            parts.append(fake_s3_part)
-            stored_parts.append(stored_part)
+            with s3_stored_multipart.open(fake_s3_part, mode="w") as stored_part:
+                stored_part.write(BytesIO(b"abc"))
+                parts.append(fake_s3_part)
+                stored_parts.append(stored_part)
 
         s3_stored_multipart.complete_multipart(parts=parts)
         temp_storage_backend.remove_multipart("test-bucket", fake_multipart)
@@ -711,25 +710,28 @@ class TestS3TemporaryStorageBackend:
     def test_concurrent_file_access(self, tmpdir):
         temp_storage_backend = EphemeralS3ObjectStore(root_directory=tmpdir)
         fake_object = S3Object(key="test-key")
-        s3_stored_object_1 = temp_storage_backend.open("test-bucket", fake_object)
-        s3_stored_object_2 = temp_storage_backend.open("test-bucket", fake_object)
 
-        s3_stored_object_1.write(BytesIO(b"abc"))
+        with temp_storage_backend.open("test-bucket", fake_object, mode="w") as s3_object_writer:
+            s3_object_writer.write(BytesIO(b"abc"))
 
-        assert s3_stored_object_1.read() == b"abc"
+        with (
+            temp_storage_backend.open("test-bucket", fake_object, mode="r") as s3_stored_object_1,
+            temp_storage_backend.open("test-bucket", fake_object, mode="r") as s3_stored_object_2,
+        ):
+            assert s3_stored_object_1.read() == b"abc"
 
-        # assert that another StoredObject moving the position does not influence the other object
-        s3_stored_object_1.seek(1)
-        s3_stored_object_2.seek(2)
-        assert s3_stored_object_1.read() == b"bc"
-        assert s3_stored_object_2.read() == b"c"
+            # assert that another StoredObject moving the position does not influence the other object
+            s3_stored_object_1.seek(1)
+            s3_stored_object_2.seek(2)
+            assert s3_stored_object_1.read() == b"bc"
+            assert s3_stored_object_2.read() == b"c"
 
-        s3_stored_object_1.seek(0)
-        assert s3_stored_object_1.read(1) == b"a"
+            s3_stored_object_1.seek(0)
+            assert s3_stored_object_1.read(1) == b"a"
 
-        temp_storage_backend.remove("test-bucket", fake_object)
-        assert s3_stored_object_1.file.closed
-        assert s3_stored_object_2.file.closed
+            temp_storage_backend.remove("test-bucket", fake_object)
+            assert s3_stored_object_1.file.closed
+            assert s3_stored_object_2.file.closed
 
         temp_storage_backend.close()
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10003 (also in https://github.com/apache/arrow-rs/issues/5283), we would sometimes encounter an error when doing a lot of concurrent access (read and write) to S3 on the same object. 
The bug is extremely hard to reproduce, the only way I could do it was by running the LocalStack image with the docker flag `--cpus=0.5` to simulate a constrained environment, and run the rust test suite of `object_store` (which is really fast) forever until it would break (between 5% and 10% of the time I would say...). 

When it would fail, we would have a cryptic message from the ASGI bridge. After reproducing the issue a few times, I could add a bunch of debug statement in `rolo` and find the culprit:
A GetObject request with Content-Length set to 1, with the key prefix RACE-, followed by a PutObject of length 2.
The first call get the object metadata with a still indicated content-length of 1, but then gets the full new data content `10` so it fails.

Basically a very small race condition between the state of the object and its value. I suspect the issue would most probably happen between the Get and Put call, when returning the `S3EphemeralObject` and pass it to the response handler. However, its iterator and `__iter__` would not be called until the end of the chain, which would only generate the read lock then. In between, a Put call could still snatch the write lock and modify its value.

<!-- What notable changes does this PR make? -->
## Changes
Now, after this small refactor, as soon as we create these `S3StoredObject` subclass, we acquire the lock (in `read` or `write` mode). The lock will stay acquired during the life of the object, which means we can control better when we can group action together (modifying the metadata of the object can now be done inside the `WriteLock`). 

Also, it looks much nicer now: we can use the context manager around the `S3StoredObject`, by using it with the `.open()` call. The caller of `open` is always responsible for closing it, and almost every single usage is now done inside a context manager. 

I've modified the `EphemeralS3StoredMultipart` logic to not store the full `EphemeralS3StoredObject` anymore to release the lock, and now properly create an object when we need a part. This looks cleaner. 

Added some checks in place to not write on a non-writable object, to avoid creating race condition and not acquiring a write lock. 

The only exception is for `GetObject`: in that case, when passing an iterator to the chain, the server is responsible for calling `.close()` on the iterator. (see #8926). This is actually the fix of the issue: we now properly generate the read lock in the provider call, and keep that locked acquired until the response is sent. 

Also, special thanks to @tustvold, which have been very understanding and helpful with the reports and the really nice test suite.


## Testing

I've been running the (sometimes) failing test since 40 minutes now and have encountered only one failure, so it is still not fully fixed, but I believe the window where the race condition can happen have been greatly reduced. I still can pinpoint when it happens, but with the current architecture, we have to get the object metadata before the actual object content, so in between these 2 actions the object can get updated. If anyone has an idea on how to fix this.

edit: [see the comment](https://github.com/localstack/localstack/pull/10387#issuecomment-1977758941) but I got a 3% failure rate on 200 runs, so I've updated it with a workaround using the real object modification time to do a check inside the read lock, where we can fetch a possibly updated object. This seems to have done it, I did 200 runs without failure for now, so this is fixed, combining the new lock system with this little trick.

`for i in {1..200}; do cargo test aws::tests::s3_test --features aws -- --exact; done`
