### PR TITLE
add docstring for cw test and assertion

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2220,6 +2220,12 @@ class TestCloudwatch:
 
     @markers.aws.validated
     def test_get_metric_with_null_dimensions(self, aws_client, snapshot):
+        """
+        This test validates the behaviour when there is metric data with dimensions and the get_metric_data call
+        has no dimensions specified. The expected behaviour is that the call should return the metric data with
+        no dimensions, which in this test, there is no such data, so the total sum should equal 0. And since the
+        Sum equals 0, the response will have no values.
+        """
         snapshot.add_transformer(snapshot.transform.key_value("Id"))
         snapshot.add_transformer(snapshot.transform.key_value("Label"))
         namespace = f"n-{short_uid()}"
@@ -2260,9 +2266,10 @@ class TestCloudwatch:
                 StartTime=datetime.utcnow() - timedelta(hours=1),
                 EndTime=datetime.utcnow(),
             )
+            assert len(response["MetricDataResults"][0]["Values"]) == 0
             snapshot.match("get_metric_with_null_dimensions", response)
 
-        retry(assert_results, retries=10, sleep=1.0, sleep_before=2.0 if is_aws_cloud() else 0.0)
+        retry(assert_results, retries=10, sleep=1.0, sleep_before=2 if is_aws_cloud() else 0.0)
 
     @markers.aws.validated
     def test_alarm_lambda_target(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -36,7 +36,7 @@
     "last_validated_date": "2024-01-10T15:29:50+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_get_metric_with_null_dimensions": {
-    "last_validated_date": "2024-01-09T20:13:11+00:00"
+    "last_validated_date": "2024-03-05T14:34:47+00:00"
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_handle_different_units": {
     "last_validated_date": "2024-01-05T16:15:39+00:00"


### PR DESCRIPTION
## Motivation
This pull request includes a documentation string for a test that verifies a specific functionality of the CloudWatch service. Additionally, an assertion has been added to ensure that the snapshot accurately reflects the expected values.


## Changes
- Docstring  and validation before snapshot added to test

