### PR TITLE
fix S3 GLACIER_IR not being an archive type

### DIFF
--- a/localstack/services/s3/constants.py
+++ b/localstack/services/s3/constants.py
@@ -49,10 +49,8 @@ VALID_STORAGE_CLASSES = [
     StorageClass.DEEP_ARCHIVE,
 ]
 
-# TODO validate those?
 ARCHIVES_STORAGE_CLASSES = [
     StorageClass.GLACIER,
-    StorageClass.GLACIER_IR,
     StorageClass.DEEP_ARCHIVE,
 ]
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4605,9 +4605,9 @@ class TestS3:
             (StorageClass.DEEP_ARCHIVE, False),
         ],
     )
-    @markers.snapshot.skip_snapshot_verify(
-        condition=is_v2_provider,
-        paths=["$..ServerSideEncryption"],
+    @pytest.mark.skipif(
+        condition=LEGACY_V2_S3_PROVIDER,
+        reason="GLACIER_IR is considered as an archive class in Moto and raises an exception",
     )
     def test_put_object_storage_class(
         self, s3_bucket, snapshot, storage_class, is_retrievable, aws_client

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4593,19 +4593,21 @@ class TestS3:
 
     @markers.aws.validated
     @pytest.mark.parametrize(
-        "storage_class",
+        "storage_class, is_retrievable",
         [
-            StorageClass.STANDARD,
-            StorageClass.STANDARD_IA,
-            StorageClass.GLACIER,
-            StorageClass.GLACIER_IR,
-            StorageClass.REDUCED_REDUNDANCY,
-            StorageClass.ONEZONE_IA,
-            StorageClass.INTELLIGENT_TIERING,
-            StorageClass.DEEP_ARCHIVE,
+            (StorageClass.STANDARD, True),
+            (StorageClass.STANDARD_IA, True),
+            (StorageClass.GLACIER, False),
+            (StorageClass.GLACIER_IR, True),
+            (StorageClass.REDUCED_REDUNDANCY, True),
+            (StorageClass.ONEZONE_IA, True),
+            (StorageClass.INTELLIGENT_TIERING, True),
+            (StorageClass.DEEP_ARCHIVE, False),
         ],
     )
-    def test_put_object_storage_class(self, s3_bucket, snapshot, storage_class, aws_client):
+    def test_put_object_storage_class(
+        self, s3_bucket, snapshot, storage_class, is_retrievable, aws_client
+    ):
         key_name = "test-put-object-storage-class"
         aws_client.s3.put_object(
             Bucket=s3_bucket,
@@ -4620,6 +4622,14 @@ class TestS3:
             ObjectAttributes=["StorageClass"],
         )
         snapshot.match("get-object-storage-class", response)
+
+        if is_retrievable:
+            response = aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+            snapshot.match("get-object", response)
+        else:
+            with pytest.raises(ClientError) as e:
+                aws_client.s3.get_object(Bucket=s3_bucket, Key=key_name)
+            snapshot.match("get-object", e.value.response)
 
     @markers.aws.validated
     def test_put_object_storage_class_outposts(

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4605,6 +4605,10 @@ class TestS3:
             (StorageClass.DEEP_ARCHIVE, False),
         ],
     )
+    @markers.snapshot.skip_snapshot_verify(
+        condition=is_v2_provider,
+        paths=["$..ServerSideEncryption"],
+    )
     def test_put_object_storage_class(
         self, s3_bucket, snapshot, storage_class, is_retrievable, aws_client
     ):

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -4311,8 +4311,8 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD]": {
-    "recorded-date": "03-08-2023, 04:24:40",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD-True]": {
+    "recorded-date": "05-03-2024, 17:17:29",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4321,11 +4321,25 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA]": {
-    "recorded-date": "03-08-2023, 04:24:42",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA-True]": {
+    "recorded-date": "05-03-2024, 17:17:31",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4334,11 +4348,26 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "STANDARD_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER]": {
-    "recorded-date": "03-08-2023, 04:24:44",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER-False]": {
+    "recorded-date": "05-03-2024, 17:17:34",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4347,11 +4376,23 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-object": {
+        "Error": {
+          "Code": "InvalidObjectState",
+          "Message": "The operation is not valid for the object's storage class",
+          "StorageClass": "GLACIER"
+        },
+        "StorageClass": "GLACIER",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR]": {
-    "recorded-date": "03-08-2023, 04:24:46",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR-True]": {
+    "recorded-date": "05-03-2024, 17:17:36",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4360,15 +4401,17 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      }
-    }
-  },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY]": {
-    "recorded-date": "03-08-2023, 04:24:48",
-    "recorded-content": {
-      "get-object-storage-class": {
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
         "LastModified": "datetime",
-        "StorageClass": "REDUCED_REDUNDANCY",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "GLACIER_IR",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4376,8 +4419,8 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA]": {
-    "recorded-date": "03-08-2023, 04:24:50",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA-True]": {
+    "recorded-date": "05-03-2024, 17:17:40",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4386,11 +4429,26 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "ONEZONE_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING]": {
-    "recorded-date": "03-08-2023, 04:24:52",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING-True]": {
+    "recorded-date": "05-03-2024, 17:17:42",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
@@ -4399,15 +4457,70 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "INTELLIGENT_TIERING",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE]": {
-    "recorded-date": "03-08-2023, 04:24:54",
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE-False]": {
+    "recorded-date": "05-03-2024, 17:17:44",
     "recorded-content": {
       "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "DEEP_ARCHIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object": {
+        "Error": {
+          "Code": "InvalidObjectState",
+          "Message": "The operation is not valid for the object's storage class",
+          "StorageClass": "DEEP_ARCHIVE"
+        },
+        "StorageClass": "DEEP_ARCHIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY-True]": {
+    "recorded-date": "05-03-2024, 17:17:38",
+    "recorded-content": {
+      "get-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "REDUCED_REDUNDANCY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "body-test",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"43ad557eaff4fdc42b9886b5a68147ab\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "StorageClass": "REDUCED_REDUNDANCY",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -194,29 +194,29 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
     "last_validated_date": "2023-10-05T18:33:43+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE]": {
-    "last_validated_date": "2023-08-03T02:24:54+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE-False]": {
+    "last_validated_date": "2024-03-05T17:17:44+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER]": {
-    "last_validated_date": "2023-08-03T02:24:44+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER-False]": {
+    "last_validated_date": "2024-03-05T17:17:33+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR]": {
-    "last_validated_date": "2023-08-03T02:24:46+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR-True]": {
+    "last_validated_date": "2024-03-05T17:17:36+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING]": {
-    "last_validated_date": "2023-08-03T02:24:52+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING-True]": {
+    "last_validated_date": "2024-03-05T17:17:42+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA]": {
-    "last_validated_date": "2023-08-03T02:24:50+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA-True]": {
+    "last_validated_date": "2024-03-05T17:17:40+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY]": {
-    "last_validated_date": "2023-08-03T02:24:48+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY-True]": {
+    "last_validated_date": "2024-03-05T17:17:38+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD]": {
-    "last_validated_date": "2023-08-03T02:24:40+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD-True]": {
+    "last_validated_date": "2024-03-05T17:17:29+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA]": {
-    "last_validated_date": "2023-08-03T02:24:42+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA-True]": {
+    "last_validated_date": "2024-03-05T17:17:31+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class_outposts": {
     "last_validated_date": "2023-08-03T02:24:56+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10393, the `GLACIER_IR` is not an archive type and can be retrieved instantly.

<!-- What notable changes does this PR make? -->
## Changes
- update an existing test to validate the instant retrieval of storage classes or not
- remove `GLACIER_IR` from the archive types

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

