### PR TITLE
Enhance parity for API Gateway deletion of wildcard method settings

### DIFF
--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -146,6 +146,7 @@ def apply_patches():
         default_settings = self.method_settings.get("*/*", {})
         result["cacheDataEncrypted"] = default_settings.get("cacheDataEncrypted", False)
         result["throttlingRateLimit"] = default_settings.get("throttlingRateLimit", 10000.0)
+        result["throttlingBurstLimit"] = default_settings.get("throttlingBurstLimit", 5000)
         result["metricsEnabled"] = default_settings.get("metricsEnabled", False)
         result["dataTraceEnabled"] = default_settings.get("dataTraceEnabled", False)
         result["unauthorizedCacheControlHeaderStrategy"] = default_settings.get(

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -583,39 +583,53 @@ class TestDocumentations:
 
 
 class TestStages:
-    @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
-    def test_create_update_stages(
+    @pytest.fixture
+    def _create_api_with_stage(
         self, aws_client, create_rest_apigw, apigw_add_transformers, snapshot
     ):
         client = aws_client.apigateway
 
-        # create API, method, integration, deployment
-        api_id, api_name, root_id = create_rest_apigw()
-        client.put_method(
-            restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
-        )
-        client.put_integration(restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK")
-        response = client.create_deployment(restApiId=api_id)
-        deployment_id = response["id"]
+        def _create():
+            # create API, method, integration, deployment
+            api_id, api_name, root_id = create_rest_apigw()
+            client.put_method(
+                restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+            )
+            client.put_integration(
+                restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK"
+            )
+            response = client.create_deployment(restApiId=api_id)
+            deployment_id = response["id"]
 
-        # create documentation
-        client.create_documentation_part(
-            restApiId=api_id,
-            location={"type": "API"},
-            properties=json.dumps({"foo": "bar"}),
-        )
-        client.create_documentation_version(restApiId=api_id, documentationVersion="v123")
+            # create documentation
+            client.create_documentation_part(
+                restApiId=api_id,
+                location={"type": "API"},
+                properties=json.dumps({"foo": "bar"}),
+            )
+            client.create_documentation_version(restApiId=api_id, documentationVersion="v123")
 
-        # create stage
-        response = client.create_stage(
-            restApiId=api_id,
-            stageName="s1",
-            deploymentId=deployment_id,
-            description="my stage",
-            documentationVersion="v123",
-        )
-        snapshot.match("create-stage", response)
+            # create stage
+            response = client.create_stage(
+                restApiId=api_id,
+                stageName="s1",
+                deploymentId=deployment_id,
+                description="my stage",
+                documentationVersion="v123",
+            )
+            snapshot.match("create-stage", response)
+
+            return api_id
+
+        return _create
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
+    def test_create_update_stages(
+        self, _create_api_with_stage, aws_client, create_rest_apigw, snapshot
+    ):
+        client = aws_client.apigateway
+        api_id = _create_api_with_stage()
 
         # negative tests for immutable/non-updateable attributes
 
@@ -658,8 +672,8 @@ class TestStages:
         response = client.get_stage(restApiId=api_id, stageName="s1")
         snapshot.match("get-stage", response)
 
-        # show that updating */* does not override previously set values, only provides default values then like shown
-        # above
+        # show that updating */* does not override previously set values, only
+        # provides default values then like shown above
         response = client.update_stage(
             restApiId=api_id,
             stageName="s1",
@@ -668,6 +682,48 @@ class TestStages:
             ],
         )
         snapshot.match("update-stage-override", response)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..createdDate", "$..lastUpdatedDate"])
+    def test_update_stage_remove_wildcard(self, aws_client, _create_api_with_stage, snapshot):
+        client = aws_client.apigateway
+        api_id = _create_api_with_stage()
+
+        response = client.get_stage(restApiId=api_id, stageName="s1")
+        snapshot.match("get-stage", response)
+
+        def _delete_wildcard():
+            # remove all attributes at path */* (this is an operation Terraform executes when deleting APIs)
+            response = client.update_stage(
+                restApiId=api_id,
+                stageName="s1",
+                patchOperations=[
+                    {"op": "remove", "path": "/*/*"},
+                ],
+            )
+            snapshot.match("update-stage-reset", response)
+
+        # attempt to delete wildcard method settings (should initially fail)
+        with pytest.raises(ClientError) as exc:
+            _delete_wildcard()
+        snapshot.match("delete-error", exc.value)
+
+        # run a patch operation that creates a method mapping for */*
+        response = client.update_stage(
+            restApiId=api_id,
+            stageName="s1",
+            patchOperations=[
+                {"op": "replace", "path": "/*/*/caching/enabled", "value": "true"},
+            ],
+        )
+        snapshot.match("update-stage", response)
+
+        # delete wildcard method settings (should now succeed)
+        _delete_wildcard()
+
+        # assert the content of the stage after the update
+        response = client.get_stage(restApiId=api_id, stageName="s1")
+        snapshot.match("get-stage-after-reset", response)
 
 
 class TestDeployments:

--- a/tests/aws/services/apigateway/test_apigateway_common.py
+++ b/tests/aws/services/apigateway/test_apigateway_common.py
@@ -706,7 +706,7 @@ class TestStages:
         # attempt to delete wildcard method settings (should initially fail)
         with pytest.raises(ClientError) as exc:
             _delete_wildcard()
-        snapshot.match("delete-error", exc.value)
+        snapshot.match("delete-error", exc.value.response)
 
         # run a patch operation that creates a method mapping for */*
         response = client.update_stage(

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -256,7 +256,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
-    "recorded-date": "11-10-2023, 17:39:23",
+    "recorded-date": "05-03-2024, 18:54:23",
     "recorded-content": {
       "create-stage": {
         "cacheClusterEnabled": false,
@@ -383,49 +383,6 @@
         }
       },
       "update-stage-override": {
-        "cacheClusterEnabled": false,
-        "cacheClusterStatus": "NOT_AVAILABLE",
-        "createdDate": "datetime",
-        "deploymentId": "<deployment-id:1>",
-        "description": "stage new",
-        "documentationVersion": "v123",
-        "lastUpdatedDate": "datetime",
-        "methodSettings": {
-          "*/*": {
-            "cacheDataEncrypted": false,
-            "cacheTtlInSeconds": 300,
-            "cachingEnabled": true,
-            "dataTraceEnabled": false,
-            "metricsEnabled": false,
-            "requireAuthorizationForCacheControl": true,
-            "throttlingBurstLimit": 100,
-            "throttlingRateLimit": 10000.0,
-            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
-          },
-          "test/GET": {
-            "cacheDataEncrypted": false,
-            "cacheTtlInSeconds": 300,
-            "cachingEnabled": true,
-            "dataTraceEnabled": false,
-            "metricsEnabled": false,
-            "requireAuthorizationForCacheControl": true,
-            "throttlingBurstLimit": 124,
-            "throttlingRateLimit": 10000.0,
-            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
-          }
-        },
-        "stageName": "s1",
-        "tracingEnabled": true,
-        "variables": {
-          "var1": "test",
-          "var2": "test2"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-stage-override": {
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",
         "createdDate": "datetime",
@@ -928,6 +885,104 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_update_stage_remove_wildcard": {
+    "recorded-date": "05-03-2024, 18:58:45",
+    "recorded-content": {
+      "create-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-error": "An error occurred (BadRequestException) when calling the UpdateStage operation: Cannot remove method setting */* because there is no method setting for this method ",
+      "update-stage": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {
+          "*/*": {
+            "cacheDataEncrypted": false,
+            "cacheTtlInSeconds": 300,
+            "cachingEnabled": true,
+            "dataTraceEnabled": false,
+            "metricsEnabled": false,
+            "requireAuthorizationForCacheControl": true,
+            "throttlingBurstLimit": 5000,
+            "throttlingRateLimit": 10000.0,
+            "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"
+          }
+        },
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-stage-reset": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-stage-after-reset": {
+        "cacheClusterEnabled": false,
+        "cacheClusterStatus": "NOT_AVAILABLE",
+        "createdDate": "datetime",
+        "deploymentId": "<deployment-id:1>",
+        "description": "my stage",
+        "documentationVersion": "v123",
+        "lastUpdatedDate": "datetime",
+        "methodSettings": {},
+        "stageName": "s1",
+        "tracingEnabled": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.snapshot.json
@@ -890,7 +890,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_update_stage_remove_wildcard": {
-    "recorded-date": "05-03-2024, 18:58:45",
+    "recorded-date": "05-03-2024, 21:10:56",
     "recorded-content": {
       "create-stage": {
         "cacheClusterEnabled": false,
@@ -924,7 +924,17 @@
           "HTTPStatusCode": 200
         }
       },
-      "delete-error": "An error occurred (BadRequestException) when calling the UpdateStage operation: Cannot remove method setting */* because there is no method setting for this method ",
+      "delete-error": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Cannot remove method setting */* because there is no method setting for this method "
+        },
+        "message": "Cannot remove method setting */* because there is no method setting for this method ",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "update-stage": {
         "cacheClusterEnabled": false,
         "cacheClusterStatus": "NOT_AVAILABLE",

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -21,7 +21,10 @@
     "last_validated_date": "2023-08-07T20:02:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_create_update_stages": {
-    "last_validated_date": "2023-10-11T15:39:23+00:00"
+    "last_validated_date": "2024-03-05T18:54:23+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_update_stage_remove_wildcard": {
+    "last_validated_date": "2024-03-05T18:58:45+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestUsagePlans::test_api_key_required_for_methods": {
     "last_validated_date": "2023-07-27T15:57:20+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_common.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_common.validation.json
@@ -24,7 +24,7 @@
     "last_validated_date": "2024-03-05T18:54:23+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestStages::test_update_stage_remove_wildcard": {
-    "last_validated_date": "2024-03-05T18:58:45+00:00"
+    "last_validated_date": "2024-03-05T21:10:56+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_common.py::TestUsagePlans::test_api_key_required_for_methods": {
     "last_validated_date": "2023-07-27T15:57:20+00:00"


### PR DESCRIPTION
## Motivation

Enhance parity for API Gateway deletion of wildcard method settings. This issue was recently reported by a customer - Terraform is running this particular type of API requests when deleting API GW resources and stages, which is currently leading to errors (see screenshot below):

![image](https://github.com/localstack/localstack/assets/2807888/3c4ff01d-7f33-41aa-8640-0a9c9ac72900)


## Changes

* handle special logic to the provider to handle updates (for `op=remove`) for wildcard method settings (`*/*`)
* fix the default value for `throttlingBurstLimit`, which moto currently returns as `2000`, but AWS returns `5000`
* add a new snapshot test to cover the functionality
* refactor existing test and pull the creation of API/stage out into a `_create_api_with_stage` fixture, for better re-usability
