### PR TITLE
SFN: Allow ProgramError without details

### DIFF
--- a/localstack/services/stepfunctions/backend/execution.py
+++ b/localstack/services/stepfunctions/backend/execution.py
@@ -67,8 +67,8 @@ class BaseExecutionWorkerComm(ExecutionWorkerComm):
             self.execution.exec_status = ExecutionStatus.ABORTED
         elif isinstance(exit_program_state, ProgramError):
             self.execution.exec_status = ExecutionStatus.FAILED
-            self.execution.error = exit_program_state.error["error"]
-            self.execution.cause = exit_program_state.error["cause"]
+            self.execution.error = exit_program_state.error.get("error")
+            self.execution.cause = exit_program_state.error.get("cause")
         elif isinstance(exit_program_state, ProgramTimedOut):
             self.execution.exec_status = ExecutionStatus.TIMED_OUT
         else:

--- a/tests/aws/services/stepfunctions/utils.py
+++ b/tests/aws/services/stepfunctions/utils.py
@@ -247,6 +247,7 @@ def launch_and_record_execution(
     sfn_snapshot,
     state_machine_arn,
     execution_input,
+    verify_execution_description=False,
 ):
     exec_resp = stepfunctions_client.start_execution(
         stateMachineArn=state_machine_arn, input=execution_input
@@ -257,6 +258,10 @@ def launch_and_record_execution(
     await_execution_terminated(
         stepfunctions_client=stepfunctions_client, execution_arn=execution_arn
     )
+
+    if verify_execution_description:
+        describe_execution = stepfunctions_client.describe_execution(executionArn=execution_arn)
+        sfn_snapshot.match("describe_execution", describe_execution)
 
     get_execution_history = stepfunctions_client.get_execution_history(executionArn=execution_arn)
 
@@ -282,6 +287,7 @@ def create_and_record_execution(
     sfn_snapshot,
     definition,
     execution_input,
+    verify_execution_description=False,
 ):
     state_machine_arn = create(
         create_iam_role_for_sfn, create_state_machine, sfn_snapshot, definition
@@ -291,6 +297,7 @@ def create_and_record_execution(
         sfn_snapshot,
         state_machine_arn,
         execution_input,
+        verify_execution_description,
     )
 
 

--- a/tests/aws/services/stepfunctions/v2/base/test_base.py
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.py
@@ -19,6 +19,7 @@ from tests.aws.services.stepfunctions.utils import (
 @markers.snapshot.skip_snapshot_verify(paths=["$..loggingConfiguration", "$..tracingConfiguration"])
 class TestSnfBase:
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..redriveCount", "$..redriveStatus"])
     def test_state_fail(
         self,
         aws_client,
@@ -37,6 +38,7 @@ class TestSnfBase:
             sfn_snapshot,
             definition,
             exec_input,
+            verify_execution_description=True,
         )
 
     @markers.aws.validated
@@ -82,6 +84,7 @@ class TestSnfBase:
         )
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(paths=["$..redriveCount", "$..redriveStatus"])
     def test_state_fail_empty(
         self,
         aws_client,
@@ -100,6 +103,7 @@ class TestSnfBase:
             sfn_snapshot,
             definition,
             exec_input,
+            verify_execution_description=True,
         )
 
     @markers.aws.validated

--- a/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.snapshot.json
@@ -1,7 +1,27 @@
 {
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail": {
-    "recorded-date": "07-02-2024, 13:49:24",
+    "recorded-date": "06-03-2024, 10:29:14",
     "recorded-content": {
+      "describe_execution": {
+        "cause": "This state machines raises a 'SomeFailure' failure.",
+        "error": "SomeFailure",
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<ExecArnPart_0idx>",
+        "redriveCount": 0,
+        "redriveStatus": "REDRIVABLE",
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "FAILED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get_execution_history": {
         "events": [
           {
@@ -159,8 +179,26 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail_empty": {
-    "recorded-date": "07-02-2024, 13:50:02",
+    "recorded-date": "06-03-2024, 10:24:13",
     "recorded-content": {
+      "describe_execution": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<ExecArnPart_0idx>",
+        "input": {},
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<ExecArnPart_0idx>",
+        "redriveCount": 0,
+        "redriveStatus": "REDRIVABLE",
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
+        "status": "FAILED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get_execution_history": {
         "events": [
           {

--- a/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
+++ b/tests/aws/services/stepfunctions/v2/base/test_base.validation.json
@@ -9,10 +9,10 @@
     "last_validated_date": "2024-02-07T13:52:16+00:00"
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail": {
-    "last_validated_date": "2024-02-07T13:49:24+00:00"
+    "last_validated_date": "2024-03-06T10:29:50+00:00"
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail_empty": {
-    "last_validated_date": "2024-02-07T13:50:02+00:00"
+    "last_validated_date": "2024-03-06T10:24:57+00:00"
   },
   "tests/aws/services/stepfunctions/v2/base/test_base.py::TestSnfBase::test_state_fail_intrinsic": {
     "last_validated_date": "2024-02-07T13:49:50+00:00"


### PR DESCRIPTION
## Motivation
Bugfix in how SFN handles an ErrorState without any details.

## Testing

Example template that I've used to verify this works against AWS:
```
{
  "StartAt": "ChoiceStateX",
  "States": {
    "ChoiceStateX": {
      "Type": "Choice",
      "Choices": [
        {
          "And": [{"Variable": "$.type", "StringEquals": "Public"}],
          "Next": "Public"
        }
      ],
      "Default": "DefaultState"
    },
    "Public": {"Type": "Pass", "End": true},
    "DefaultState": {
      "Type": "Fail"
    }
  }
}
```
Note the `DefaultState` at the end; it does not have an error or cause, and AWS will accept this (and simply return `'cause': None, 'error': None`)

## StackTrace

This is what it looks like without these fixes:
```
Traceback (most recent call last):
    File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
      self.run()
    File "/usr/lib/python3.10/threading.py", line 953, in run
      self._target(*self._args, **self._kwargs)
    File "/.../stepfunctions/backend/execution_worker.py", line 76, in _execution_logic
      self._exec_comm.terminated()
    File "/.../stepfunctions/backend/execution.py", line 68, in terminated
      self.execution.error = exit_program_state.error["error"]
  KeyError: 'error'
  
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```