### PR TITLE
fix functhread daemon status and tmp_thread cleanup

### DIFF
--- a/localstack/utils/threads.py
+++ b/localstack/utils/threads.py
@@ -135,7 +135,7 @@ def cleanup_threads_and_processes(quiet=True):
             kill_process_tree(proc.pid)
             # proc.terminate()
         except Exception as e:
-            LOG.debug("[shutdown] Error process thread %s: %s", proc, e)
+            LOG.debug("[shutdown] Error cleaning up process tree %s: %s", proc, e)
     # clean up async tasks
     try:
         import asyncio
@@ -144,7 +144,7 @@ def cleanup_threads_and_processes(quiet=True):
             try:
                 task.cancel()
             except Exception as e:
-                LOG.debug("[shutdown] Error cancelling task %s: %s", task, e)
+                LOG.debug("[shutdown] Error cancelling asyncio task %s: %s", task, e)
     except Exception:
         pass
     LOG.debug("[shutdown] Done cleaning up threads / processes / tasks")

--- a/localstack/utils/threads.py
+++ b/localstack/utils/threads.py
@@ -27,6 +27,7 @@ class FuncThread(threading.Thread):
         quiet=False,
         on_stop: Callable[["FuncThread"], None] = None,
         name: Optional[str] = None,
+        daemon=True,
     ):
         global counter
         global counter_lock
@@ -36,11 +37,12 @@ class FuncThread(threading.Thread):
                 counter += 1
                 thread_counter_current = counter
 
-            threading.Thread.__init__(self, name=f"{name}-functhread{thread_counter_current}")
+            threading.Thread.__init__(
+                self, name=f"{name}-functhread{thread_counter_current}", daemon=daemon
+            )
         else:
-            threading.Thread.__init__(self)
+            threading.Thread.__init__(self, daemon=daemon)
 
-        self.daemon = True
         self.params = params
         self.func = func
         self.quiet = quiet
@@ -115,7 +117,6 @@ def cleanup_threads_and_processes(quiet=True):
     for thread in TMP_THREADS:
         if thread:
             try:
-                # LOG.debug('[shutdown] Cleaning up thread: %s', thread)
                 if hasattr(thread, "shutdown"):
                     thread.shutdown()
                     continue
@@ -124,24 +125,26 @@ def cleanup_threads_and_processes(quiet=True):
                     continue
                 thread.stop(quiet=quiet)
             except Exception as e:
-                print(e)
+                LOG.debug("[shutdown] Error stopping thread %s: %s", thread, e)
+                if not thread.daemon:
+                    LOG.warning(
+                        "[shutdown] Non-daemon thread %s may block localstack shutdown", thread
+                    )
     for proc in TMP_PROCESSES:
         try:
-            # LOG.debug('[shutdown] Cleaning up process: %s', proc)
             kill_process_tree(proc.pid)
             # proc.terminate()
         except Exception as e:
-            print(e)
+            LOG.debug("[shutdown] Error process thread %s: %s", proc, e)
     # clean up async tasks
     try:
         import asyncio
 
         for task in asyncio.all_tasks():
             try:
-                # LOG.debug('[shutdown] Canceling asyncio task: %s', task)
                 task.cancel()
             except Exception as e:
-                print(e)
+                LOG.debug("[shutdown] Error cancelling task %s: %s", task, e)
     except Exception:
         pass
     LOG.debug("[shutdown] Done cleaning up threads / processes / tasks")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I noticed log lines in the builds during shutdown
```
'Thread' object has no attribute 'stop'
'Thread' object has no attribute 'stop'
...
```

After some digging, I found that our new stepfunctions provider is putting plain python threads into `TMP_THREADS` that don't have a `stop` attribute. This PR doesn't fix this problem, but it improves error logging during shutdown for these types of issues.
While doing that, I noticed that those stepfunction threads aren't daemon threads, and may potentially be blocking the shutdown, so I added specific logging for that as well.

I also noticed that `FuncThread` sets `self.daemon = True`, but it's never passed to the constructor which does some additional setup to create a daemonic thread.


<!-- What notable changes does this PR make? -->
## Changes

* `FuncThread` instances are now properly instantiated as daemon threads
* the thread cleanup procedure now does better debug logging


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

