### PR TITLE
add fix for cfn-response code for nodejs custome resource

### DIFF
--- a/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -161,7 +161,7 @@ def send(event, context, responseStatus, responseData, physicalResourceId=None, 
 """
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html
-NODEJS_CFN_RESPONSE_CONTENT = """
+NODEJS_CFN_RESPONSE_CONTENT = r"""
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -189,7 +189,7 @@ exports.send = function(event, context, responseStatus, responseData, physicalRe
     var parsedUrl = url.parse(event.ResponseURL);
     var options = {
         hostname: parsedUrl.hostname,
-        port: 443,
+        port: parsedUrl.port,
         path: parsedUrl.path,
         method: "PUT",
         headers: {

--- a/localstack/services/lambda_/resource_providers/aws_lambda_function.py
+++ b/localstack/services/lambda_/resource_providers/aws_lambda_function.py
@@ -189,7 +189,7 @@ exports.send = function(event, context, responseStatus, responseData, physicalRe
     var parsedUrl = url.parse(event.ResponseURL);
     var options = {
         hostname: parsedUrl.hostname,
-        port: parsedUrl.port,
+        port: parsedUrl.port, // Modified line: LS uses port 4566 for https; hard coded 443 causes error
         path: parsedUrl.path,
         method: "PUT",
         headers: {


### PR DESCRIPTION
## Motivation
Custom resource models backed by nodejs lambda are experiencing deployment issues as a result of the nodejs cfn-response file containing an additional line ending character within the container, and the request is directing traffic to port 443.

## Changes
- convert standard string to raw string to avoid extra \n character in the container code
- the request for the insertion of the resource deployment into the bucket uses url port not directly 443

## Testing
The custom resource are not able to be deployed on this project so there is no need for a test

