### PR TITLE
fix entrypoint discovery for Pro tests

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -267,6 +267,9 @@ jobs:
         # Entrypoints need to be generated _after_ the community edition has been linked into the venv
         run: |
           make entrypoints
+          make dist
+          ls -la dist/
+          ls -la localstack_ext.egg-info
           cat localstack_ext.egg-info/entry_points.txt
 
       - name: Test Pro Startup


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The current Pro workflow actually runs with Pro not activated, as the entrypoints were not discovered (so just running twice our community tests)

<!-- What notable changes does this PR make? -->
## Changes
TBD

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

