### PR TITLE
implement SQS DLQ redrive to original source queue

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -205,7 +205,9 @@ class MessageMoveTask:
 
     # configurable fields
     source_arn: str
-    destination_arn: str
+    """The arn of the DLQ the messages are currently in."""
+    destination_arn: str | None = None
+    """If the DestinationArn is not specified, the original source arn will be used as target."""
     max_number_of_messages_per_second: int | None = None
 
     # dynamic fields

--- a/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.snapshot.json
@@ -210,5 +210,64 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_workflow_with_default_destination": {
+    "recorded-date": "07-03-2024, 19:07:58",
+    "recorded-content": {
+      "source-arn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+      "original-source": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+      "start-message-move-task-response": {
+        "TaskHandle": "<task-handle:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-message-move-task-response": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 2,
+            "ApproximateNumberOfMessagesToMove": 2,
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "StartedTimestamp": "timestamp",
+            "Status": "COMPLETED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_workflow_with_multiple_sources_as_default_destination": {
+    "recorded-date": "07-03-2024, 18:42:16",
+    "recorded-content": {
+      "source-arn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+      "original-source-1": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+      "original-source-2": "arn:aws:sqs:<region>:111111111111:<resource:3>",
+      "start-message-move-task-response": {
+        "TaskHandle": "<task-handle:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-message-move-task-response": {
+        "Results": [
+          {
+            "ApproximateNumberOfMessagesMoved": 4,
+            "ApproximateNumberOfMessagesToMove": 4,
+            "SourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "StartedTimestamp": "timestamp",
+            "Status": "COMPLETED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs_move_task.validation.json
+++ b/tests/aws/services/sqs/test_sqs_move_task.validation.json
@@ -23,6 +23,12 @@
   "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_with_throughput_limit": {
     "last_validated_date": "2024-01-03T20:25:11+00:00"
   },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_workflow_with_default_destination": {
+    "last_validated_date": "2024-03-07T19:07:57+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs_move_task.py::test_move_task_workflow_with_multiple_sources_as_default_destination": {
+    "last_validated_date": "2024-03-07T18:42:16+00:00"
+  },
   "tests/aws/services/sqs/test_sqs_move_task.py::test_source_needs_redrive_policy": {
     "last_validated_date": "2024-01-05T12:48:02+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A user correctly noted in #10392 that the `StartMessageMoveTask` doesn't need a destination arn. [The doc says](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_StartMessageMoveTask.html):

> If this field is left blank, the messages will be redriven back to their respective original source queues.

This PR adds this behavior.

The basic case was easy enough, but the plural in that sentence ("source **queues**") turns out to be a bit harder to implement. Messages are split up and returned to their original source queues, which means there is some sort of tracking where the messages originate from. We have no such tracking, and I didn't have enough time to implement this in this iteration. Left a TODO and a test case.

<!-- What notable changes does this PR make? -->
## Changes

* `DestinationArn` in SQS `StartMessageMoveTask` operation is now optional
* There is a skipped test case for the multi source queue case which will be a bit trickier to implement

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

