### PR TITLE
fix DDB performance when Streams are enabled

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -946,7 +946,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # if the request doesn't ask for ReturnValues and we have stream enabled, we need to modify the request to
         # force DDBLocal to return those values
         if not has_return_values and streams_enabled:
-            # TODO: we could manually override ReturnValues to return the old value?
             service_req = copy.copy(context.service_request)
             service_req["ReturnValues"] = "ALL_OLD"
             result = self._forward_request(
@@ -994,7 +993,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         update_item_input: UpdateItemInput,
     ) -> UpdateItemOutput:
         # TODO: UpdateItem is harder to use ReturnValues for Streams, because it needs the Before and After images.
-        #  optimize ItemFinder to directly access ddblocal
         table_name = update_item_input["TableName"]
         global_table_region = self.get_global_table_region(context, table_name)
 
@@ -1861,7 +1859,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             for write_request in request_items[table_name]:
                 for key, request in write_request.items():
                     if key == "PutRequest":
-                        # TODO: find existing item if possible by extracting the key
                         keys = SchemaExtractor.extract_keys(
                             item=request["Item"],
                             table_name=table_name,
@@ -1886,7 +1883,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         records.append(new_record)
 
                     elif key == "DeleteRequest":
-                        # TODO: find existing item if from the "Key"
                         keys = request["Key"]
                         if not (existing_item := find_existing_item_for_keys_values(keys)):
                             continue

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -39,6 +39,7 @@ from localstack.aws.api.dynamodb import (
     CreateGlobalTableOutput,
     CreateTableInput,
     CreateTableOutput,
+    Delete,
     DeleteItemInput,
     DeleteItemOutput,
     DeleteRequest,
@@ -71,6 +72,7 @@ from localstack.aws.api.dynamodb import (
     PointInTimeRecoveryStatus,
     PositiveIntegerObject,
     ProvisionedThroughputExceededException,
+    Put,
     PutItemInput,
     PutItemOutput,
     PutRequest,
@@ -95,8 +97,10 @@ from localstack.aws.api.dynamodb import (
     TimeToLiveSpecification,
     TransactGetItemList,
     TransactGetItemsOutput,
+    TransactWriteItem,
     TransactWriteItemsInput,
     TransactWriteItemsOutput,
+    Update,
     UpdateContinuousBackupsOutput,
     UpdateGlobalTableOutput,
     UpdateItemInput,
@@ -1181,17 +1185,18 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # TODO: refactor to apply the same logic as in `BatchWriteItem`: don't prep records if not stream enabled
         existing_items = []
         for item in transact_write_items_input["TransactItems"]:
+            item: TransactWriteItem
             for key in ["Put", "Update", "Delete"]:
-                inner_item = item.get(key)
+                inner_item: Put | Delete | Update = item.get(key)
                 if inner_item:
-                    item = ItemFinder.find_existing_item(
+                    existing_item = ItemFinder.find_existing_item(
                         put_item=inner_item,
                         table_name=inner_item["TableName"],
                         account_id=context.account_id,
                         region_name=context.region,
                         endpoint_url=self.server.url,
                     )
-                    existing_items.append(item)
+                    existing_items.append(existing_item)
 
         client_token: str | None = transact_write_items_input.get("ClientRequestToken")
 

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -127,6 +127,7 @@ from localstack.services.dynamodb.utils import (
     SchemaExtractor,
     de_dynamize_record,
     extract_table_name_from_partiql_update,
+    get_ddb_access_key,
 )
 from localstack.services.dynamodbstreams import dynamodbstreams_api
 from localstack.services.dynamodbstreams.dynamodbstreams_api import (
@@ -367,7 +368,7 @@ def modify_context_region(context: RequestContext, region: str):
     original_region = context.region
     original_authorization = context.request.headers.get("Authorization")
 
-    key = DynamoDBProvider.ddb_access_key(context.account_id, region)
+    key = get_ddb_access_key(context.account_id, region)
 
     context.region = region
     context.request.headers["Authorization"] = re.sub(
@@ -1604,18 +1605,18 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     # Helpers
     #
 
-    @staticmethod
-    def ddb_access_key(account_id: str, region_name: str) -> str:
-        """
-        Get the access key to be used while communicating with DynamoDB Local.
-
-        DDBLocal supports namespacing as an undocumented feature. It works based on the value of the `Credentials`
-        field of the `Authorization` header. We use a concatenated value of account ID and region to achieve
-        namespacing.
-        """
-        return "{account_id}{region_name}".format(
-            account_id=account_id, region_name=region_name
-        ).replace("-", "")
+    # @staticmethod
+    # def ddb_access_key(account_id: str, region_name: str) -> str:
+    #     """
+    #     Get the access key to be used while communicating with DynamoDB Local.
+    #
+    #     DDBLocal supports namespacing as an undocumented feature. It works based on the value of the `Credentials`
+    #     field of the `Authorization` header. We use a concatenated value of account ID and region to achieve
+    #     namespacing.
+    #     """
+    #     return "{account_id}{region_name}".format(
+    #         account_id=account_id, region_name=region_name
+    #     ).replace("-", "")
 
     @staticmethod
     def ddb_region_name(region_name: str) -> str:
@@ -1680,7 +1681,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         Modify the Credentials field of Authorization header to achieve namespacing in DynamoDBLocal.
         """
         region_name = DynamoDBProvider.ddb_region_name(region_name)
-        key = DynamoDBProvider.ddb_access_key(account_id, region_name)
+        key = get_ddb_access_key(account_id, region_name)
 
         # DynamoDBLocal namespaces based on the value of Credentials
         # Since we want to namespace by both account ID and region, use an aggregate key

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1849,8 +1849,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
             def find_existing_item_for_keys_values(item_keys: dict) -> AttributeMap | None:
                 """
-                This looks up
-                :param item_keys:
+                This function looks up in the existing items for the provided item keys subset. If present, returns the
+                full item.
+                :param item_keys: the request item keys
                 :return:
                 """
                 for item in existing_items_for_table_unordered:

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -27,6 +27,17 @@ LOG = logging.getLogger(__name__)
 SCHEMA_CACHE = TTLCache(maxsize=50, ttl=20)
 
 
+def get_ddb_access_key(account_id: str, region_name: str) -> str:
+    """
+    Get the access key to be used while communicating with DynamoDB Local.
+
+    DDBLocal supports namespacing as an undocumented feature. It works based on the value of the `Credentials`
+    field of the `Authorization` header. We use a concatenated value of account ID and region to achieve
+    namespacing.
+    """
+    return f"{account_id}{region_name}".replace("-", "")
+
+
 class ItemSet:
     """Represents a set of items and provides utils to find individual items in the set"""
 
@@ -129,9 +140,8 @@ class SchemaExtractor:
 class ItemFinder:
     @staticmethod
     def get_ddb_local_client(account_id: str, region_name: str, endpoint_url: str):
-        ddb_local_access_key = f"{account_id}{region_name}".replace("-", "")
         ddb_client = connect_to(
-            aws_access_key_id=ddb_local_access_key,
+            aws_access_key_id=get_ddb_access_key(account_id, region_name),
             region_name=region_name,
             endpoint_url=endpoint_url,
         ).dynamodb

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -6,7 +6,15 @@ from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from cachetools import TTLCache
 from moto.core.exceptions import JsonRESTError
 
-from localstack.aws.api.dynamodb import ResourceNotFoundException
+from localstack.aws.api.dynamodb import (
+    AttributeMap,
+    BatchGetRequestMap,
+    BatchGetResponseMap,
+    DeleteRequest,
+    PutRequest,
+    ResourceNotFoundException,
+    TableName,
+)
 from localstack.aws.connect import connect_to
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.utils.aws.arns import dynamodb_table_arn
@@ -120,15 +128,26 @@ class SchemaExtractor:
 
 class ItemFinder:
     @staticmethod
+    def get_ddb_local_client(account_id: str, region_name: str, endpoint_url: str):
+        ddb_local_access_key = f"{account_id}{region_name}".replace("-", "")
+        ddb_client = connect_to(
+            aws_access_key_id=ddb_local_access_key,
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+        ).dynamodb
+        return ddb_client
+
+    @staticmethod
     def find_existing_item(
-        put_item: Dict, table_name: str, account_id: str, region_name: str
-    ) -> Optional[Dict]:
+        put_item: Dict,
+        table_name: str,
+        account_id: str,
+        region_name: str,
+        endpoint_url: str,
+    ) -> Optional[AttributeMap]:
         from localstack.services.dynamodb.provider import ValidationException
 
-        ddb_client = connect_to(
-            aws_access_key_id=account_id,
-            region_name=region_name,
-        ).dynamodb
+        ddb_client = ItemFinder.get_ddb_local_client(account_id, region_name, endpoint_url)
 
         search_key = {}
         if "Key" in put_item:
@@ -167,22 +186,73 @@ class ItemFinder:
             return
         return existing_item.get("Item")
 
+    @staticmethod
+    def find_existing_items(
+        put_items_per_table: dict[TableName, list[PutRequest | DeleteRequest]],
+        account_id: str,
+        region_name: str,
+        endpoint_url: str,
+    ) -> BatchGetResponseMap:
+        from localstack.services.dynamodb.provider import ValidationException
+
+        ddb_client = ItemFinder.get_ddb_local_client(account_id, region_name, endpoint_url)
+
+        get_items_request: BatchGetRequestMap = {}
+        for table_name, put_item_reqs in put_items_per_table.items():
+            table_schema = None
+            for put_item in put_item_reqs:
+                search_key = {}
+                if "Key" in put_item:
+                    search_key = put_item["Key"]
+                else:
+                    if not table_schema:
+                        table_schema = SchemaExtractor.get_table_schema(
+                            table_name, account_id, region_name
+                        )
+
+                    schemas = [table_schema["Table"]["KeySchema"]]
+                    for index in table_schema["Table"].get("GlobalSecondaryIndexes", []):
+                        # TODO
+                        # schemas.append(index['KeySchema'])
+                        pass
+                    for schema in schemas:
+                        for key in schema:
+                            key_name = key["AttributeName"]
+                            key_value = put_item["Item"].get(key_name)
+                            if not key_value:
+                                raise ValidationException(
+                                    "The provided key element does not match the schema"
+                                )
+                            search_key[key_name] = key_value
+                    if not search_key:
+                        continue
+                table_keys = get_items_request.setdefault(table_name, {"Keys": []})
+                table_keys["Keys"].append(search_key)
+
+        existing_items = ddb_client.batch_get_item(RequestItems=get_items_request)
+
+        return existing_items.get("Responses", {})
+
     @classmethod
     def list_existing_items_for_statement(
-        cls, account_id: str, region_name: str, partiql_statement: str
+        cls, partiql_statement: str, account_id: str, region_name: str, endpoint_url: str
     ) -> List:
         table_name = extract_table_name_from_partiql_update(partiql_statement)
         if not table_name:
             return []
-        all_items = cls.get_all_table_items(account_id, region_name, table_name)
+        all_items = cls.get_all_table_items(
+            account_id=account_id,
+            region_name=region_name,
+            table_name=table_name,
+            endpoint_url=endpoint_url,
+        )
         return all_items
 
     @staticmethod
-    def get_all_table_items(account_id: str, region_name: str, table_name: str) -> List:
-        ddb_client = connect_to(
-            aws_access_key_id=account_id,
-            region_name=region_name,
-        ).dynamodb
+    def get_all_table_items(
+        account_id: str, region_name: str, table_name: str, endpoint_url: str
+    ) -> List:
+        ddb_client = ItemFinder.get_ddb_local_client(account_id, region_name, endpoint_url)
         dynamodb_kwargs = {"TableName": table_name}
         all_items = list_all_resources(
             lambda kwargs: ddb_client.scan(**{**kwargs, **dynamodb_kwargs}),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #10411 and other reports from users, we need to investigate the performance issues of DynamoDB when streams are configured for the table (DynamoDB Streams or Kinesis).

This PR will try to explain the different changes done to get better results. After the changes, benchmarks will be provided to show the progress.

Maybe a bit of explanation on how we handle streams right now:

If the table has a stream configured, we will try to fetch the item to be inserted with a `connect_to` call directly to LocalStack (there can also be additional calls for the schema of the table), to check if the item already existed and if it will be updated.
We prepare the record to be sent to DynamoDB streams and/or Kinesis, if they're configured. 
Then, we forward the event to be sent (always via Kinesis under the hood) via a spawn thread for each call to forward, which calls `PutRecord` for each update.
For `PutItem`, this isn't so bad, as we can only modify one item each time.
But for `BatchWriteItem`, there is a lot of issues: we fetch each individual objects one by one (each time going through the LocalStack Gateway, having the request parsed and going through the full chain), and we then forward each update with a singular call to `PutRecord`. 

<!-- What notable changes does this PR make? -->
## Changes
 - refactor the `ItemFinder` utility class to directly send a call to the underlying DynamoDB-local server, as we don't need to go through the full gateway
 - add a method to the `ItemFinder` to be able to fetch multiple items with a singular call to `BatchGetItem`, making it more efficient. This call also bypass the LocalStack gateway
 - refactor `PutItem` and `DeleteItem` logic to modify the incoming request to add `ReturnValues` if it's not set in the request. This way, we don't have the fetch the previous item: DynamoDB will return it to us almost for free. If the client didn't ask for it, we remove it from the request. We only do this if streams are enabled on the table. This is not done for `UpdateItem`, as the logic is more complicated and you need both the old value and new value, and `ReturnValues` accept different values. Not worth it for now.
 - refactor `BatchWriteItem` to use the new `ItemFinder.find_existing_items` allowing to fetch all modified objects in one call, plus additional logic to map the written items to the retrieved ones (before it was easy as we fetched them individually), but `BatchGetItem` could return less items if they don't exist, and the order is not guaranteed. 
 - refactor the forwarders to DynamoDB streams and Kinesis (both Kinesis under the hood) to use `PutRecords` instead of `PutRecord`, that way, we can batch records that share the same table and stream, lowering the load on the gateway. 


## Testing and benchmarks

### Scenario 1

This is the scenario provided in the linked GitHub issue (just added a small check if the streams were ready). 
We're testing against 3 setups:
- No stream configured: our baseline
- DDB stream configured
- Kinesis stream configured

We can test with 3 variables:
- `latest` image with no fix
- this PR with the hypercorn server (default)
- this PR with the Twisted server (to verify the speed boost)

What the test looks like: we are starting up 300 threads, waiting on them and concurrently launching 300 `BatchWriteItem` request with 10 items in them. This does an "onslaught" on request. This will not test throughput in itself, but how quick LocalStack can go through those 300 requests. 

**Results**

TLDR; *6x* speed and throughput improvement for `BatchWriteItem` when doing 300 concurrent requests inserting 10 items each.

| / | `latest` | Fix & Hypercorn | Fix & Twisted |
|--------|--------|--------|--------|
| **NoStream** | 0.816 | 0.796 | 0.704 |
| **DDB Stream** | 11.54 | 1.948 | 1.725 |
| **Kinesis** | 11.18 | 2.154 | 2.29 |

As we can see, the baselines are all pretty close, which shows the benchmark is kinda stable.
We can notice around a *6x decrease* in time for the benchmark with the fix. Twisted is not giving much more here, I think because of the shape of the benchmark: just go through all the concurrent requests, only 300, which is not so many, and the pressure must be also on the logic behind. 
We're still around 2x to 3x slower than with no streams at all. I don't think we can go much lower easily with all the additional logic and pressure that happens: we are fetching old items, doing a lot of dict manipulation to format the records, and forwarding them over. We will need to refactor it to streamline it and maybe reduce dict manipulation and such, and simplify the forwarding with some thread workers, or find a way to hook into some kind of transaction log.

I wanted to go further in the testing, to test continuous throughput. 

### Scenario 2

This scenario is the same as the previous DynamoDB performance rework, see the following comment: https://github.com/localstack/localstack/issues/1205#issuecomment-1776138503

We are testing against the same 3 setups, with the same 3 variables. We will just add a check for `PutItem` as well, to see the upgrade.

**Results**
TLDR; *15x* speed and throughput improvement for `BatchWriteItem` when doing 500 requests inserting 25 items each. Now only 2x slower than baseline (but doing a lot more) instead of 30x.

No Stream | `latest` | Fix & Hypercorn | Fix & Twisted
-- | -- | -- | --
**Throughput** (higher is better) |   |   |  
`PutItem` throughput item/s | 333.01 | 313.88 | 473.38
`BatchWriteItem (25)` throughput item/s | 4985.24 | 4943.65 | 6209.03
**Total time** (lower is better) |   |   |  
`PutItem` total seconds (500 items) | 1.5015 | 1.5930 | 1.0562
`BatchWriteItem (25)` total seconds (12k5 items) | 2.5074 | 2.5285 | 2.0132

| DDB Streams | `latest` | Fix & Hypercorn | Fix & Twisted
| --- | --- | --- | --- |
| **Throughput** (higher is better) |  |  |  |
| `PutItem` throughput item/s | 123.14 | 166.73 | 204.27 |
| `BatchWriteItem (25)` throughput item/s | 171.77 | 2161.57 | 2466.23 |
| **Total time** (lower is better) |  |  |  |
| `PutItem` total seconds (500 items) | 4.0604 | 2.9988 | 2.4478 |
| `BatchWriteItem (25)` total seconds (12k5 items) | 72.7713 | 5.7828 | 5.0685 |

| Kinesis | `latest` | Fix & Hypercorn | Fix & Twisted
| --- | --- | --- | --- |
| **Throughput** (higher is better) |  |  |  |
| `PutItem` throughput item/s | 122.19 | 169.20 | 205.97 |
| `BatchWriteItem (25)` throughput item/s | 171.51 | 2534.15 | 2920.69 |
| **Total time** (lower is better) |  |  |  |
| `PutItem` total seconds (500 items) | 4.0920 | 2.9551 |  2.4275 |
| `BatchWriteItem (25)` total seconds (12k5 items) | 72.8815 | 4.9326 | 4.2798 |

Here, we can see that Twisted does make a difference, already in the baseline: **+50%** for `PutItem` and `+20%` for `BatchWriteItem`. It's not going to be as much for the stream ones, same as before, because so much more is happening.

Analyzing the fix, we can now see the fix improved `PutItem` throughput by around **30%**, and Twisted gives it almost an additional **20%** from that. But we're still 3x times slower than without streams.

For `BatchWriteItem`, which was the main concern, we went from a total of 72 seconds to ~5s on average, so almost a **15x** speed and throughput improvement. This is easily explainable from the fetch and batch. Still 2x slower than the baseline, but acceptable. As a funny note, if doing only of those and not the other, we would go from 72 to around 40 only. Only both together allow to relieve the pressure on the Gateway and improve it as much as it does. 
