### PR TITLE
make SQS dynamic endpoint strategy guess the endpoint strategy used

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -833,7 +833,7 @@ SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 # Used to toggle MessageRetentionPeriod functionality in SQS queues
 SQS_ENABLE_MESSAGE_RETENTION_PERIOD = is_env_true("SQS_ENABLE_MESSAGE_RETENTION_PERIOD")
 
-# Strategy used when creating SQS queue urls. can be "off", "standard" (default), "domain", or "path"
+# Strategy used when creating SQS queue urls. can be "off", "standard" (default), "domain", "path", or "dynamic"
 SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "standard"
 
 # Disable the check for MaxNumberOfMessage in SQS ReceiveMessage

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -337,6 +337,7 @@ class SqsQueue:
 
         if endpoint_strategy == "dynamic":
             scheme = context.request.scheme
+            # determine the endpoint strategy that should be used, and determine the host dynamically
             endpoint_strategy, host_and_port = guess_endpoint_strategy_and_host(
                 context.request.host
             )

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -6,6 +6,7 @@ from localstack.services.sqs import provider
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE
 from localstack.services.sqs.provider import _create_message_attribute_hash
 from localstack.services.sqs.utils import (
+    guess_endpoint_strategy_and_host,
     is_sqs_queue_url,
     parse_queue_url,
 )
@@ -175,3 +176,20 @@ def test_is_sqs_queue_url():
     assert is_sqs_queue_url("http://us-east-1.queue.foo.bar:4566/111111111111/foo") is True
     assert is_sqs_queue_url("http://queue.foo.bar:4566/111111111111/foo") is True
     assert is_sqs_queue_url("http://sqs.us-east-1.foo.bar:4566/111111111111/foo") is True
+
+
+def test_guess_endpoint_strategy_and_host():
+    assert guess_endpoint_strategy_and_host("localhost:4566") == ("path", "localhost:4566")
+    assert guess_endpoint_strategy_and_host("example.com") == ("path", "example.com")
+    assert guess_endpoint_strategy_and_host("sqs.us-east-1.amazonaws.com") == (
+        "standard",
+        "amazonaws.com",
+    )
+    assert guess_endpoint_strategy_and_host("queue.localhost.localstack.cloud") == (
+        "domain",
+        "localhost.localstack.cloud",
+    )
+    assert guess_endpoint_strategy_and_host("us-east-1.queue.localhost.localstack.cloud") == (
+        "domain",
+        "localhost.localstack.cloud",
+    )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

After a lengthy follow-up discussion of #9753, we decided to extend the "dynamic" SQS endpoint strategy to also guess path, standard, or domain strategy of the given host URL.

When starting localstack with `SQS_ENDPOINT_STRATEGY=dynamic`, it will now behave as follows:

* path (fallback)
  ```
   % awslocal sqs list-queues                     
  {
      "QueueUrls": [
          "http://localhost:4566/queue/us-east-1/000000000000/foobar"
      ]
  }
  ```
* standard (when using `sqs.<region>.<host>`)
  ```
   % aws --endpoint-url=https://sqs.us-east-1.localhost.localstack.cloud:4566 sqs list-queues
  {
      "QueueUrls": [
          "https://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/foobar"
      ]
  }
  ```
  :warning: note that, using `--endpoint-url=https://sqs.localhost.localstack.cloud:4566` may not behave as expected, because we cannot for certain say that `localhost` is not a region, we must interpret as such, and therefore the host part will be `localstack.cloud`.
* domain
  ```
   % aws --endpoint-url=https://queue.localhost.localstack.cloud:4566 sqs list-queues
  {
      "QueueUrls": [
          "https://queue.localhost.localstack.cloud:4566/000000000000/foobar"
      ]
  }
  ```
  (note how us-east-1 is the default region, and therefore removed from the URL)
  ```
   % aws --endpoint-url=http://us-east-1.queue.localhost.localstack.cloud:4566 sqs list-queues 
  {
      "QueueUrls": [
          "http://queue.localhost.localstack.cloud:4566/000000000000/foobar"
      ]
  }
  ```

<!-- What notable changes does this PR make? -->
## Changes

* `SQS_ENDPOINT_STRATEGY=dynamic` now dynamically and heuristically determines the endpoint strategy based on the incoming host and renders queue URLs accordingly

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

