### PR TITLE
update s3 lambdas to node20

### DIFF
--- a/tests/aws/services/lambda_/functions/lambda_s3_integration.mjs
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration.mjs
@@ -1,12 +1,7 @@
-exports.handler = async (event, context, callback) => {
-    const {
-        S3Client,
-        PutObjectCommand,
-    } = require("@aws-sdk/client-s3");
-    const {
-        getSignedUrl
-    } = require('@aws-sdk/s3-request-presigner');
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
+export const handler = async (event, context) => {
     const BUCKET_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME;
     let s3;
     if (process.env.AWS_ENDPOINT_URL) {

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_presign.mjs
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_presign.mjs
@@ -1,12 +1,7 @@
-exports.handler = async (event, context, callback) => {
-    const {
-        S3Client,
-        PutObjectCommand,
-    } = require("@aws-sdk/client-s3");
-    const {
-        getSignedUrl
-    } = require('@aws-sdk/s3-request-presigner');
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
+export const handler = async (event, context) => {
     const BUCKET_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME;
     const bodyMd5AsBase64 = '4QrcOUm6Wau+VuBX8g+IPg=='; // body should be '123456'
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3612,7 +3612,7 @@ class TestS3:
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint fast-xml-parser",
+            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
         )
 
         function_name = f"func-integration-{short_uid()}"
@@ -6972,7 +6972,7 @@ class TestS3PresignedUrl:
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint fast-xml-parser",
+            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
         )
 
         function_name = f"func-integration-{short_uid()}"

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3608,18 +3608,18 @@ class TestS3:
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())
         handler_file = os.path.join(
-            os.path.dirname(__file__), "../lambda_/functions/lambda_s3_integration.js"
+            os.path.dirname(__file__), "../lambda_/functions/lambda_s3_integration.mjs"
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
+            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint fast-xml-parser",
         )
 
         function_name = f"func-integration-{short_uid()}"
         create_lambda_function(
             func_name=function_name,
             zip_file=testutil.create_zip_file(temp_folder, get_content=True),
-            runtime=Runtime.nodejs14_x,
+            runtime=Runtime.nodejs20_x,
             handler="lambda_s3_integration.handler",
             role=lambda_su_role,
         )
@@ -6968,18 +6968,18 @@ class TestS3PresignedUrl:
         assert "bar-complicated-no-random" not in url
 
         handler_file = os.path.join(
-            os.path.dirname(__file__), "../lambda_/functions/lambda_s3_integration_presign.js"
+            os.path.dirname(__file__), "../lambda_/functions/lambda_s3_integration_presign.mjs"
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
+            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint fast-xml-parser",
         )
 
         function_name = f"func-integration-{short_uid()}"
         create_lambda_function(
             func_name=function_name,
             zip_file=testutil.create_zip_file(temp_folder, get_content=True),
-            runtime=Runtime.nodejs14_x,
+            runtime=Runtime.nodejs20_x,
             handler="lambda_s3_integration_presign.handler",
             role=lambda_su_role,
             envvars={
@@ -7041,16 +7041,14 @@ class TestS3PresignedUrl:
         handler_file = os.path.join(
             os.path.dirname(__file__), "../lambda_/functions/lambda_s3_integration_sdk_v2.js"
         )
-        temp_folder = create_tmp_folder_lambda(
-            handler_file,
-            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
-        )
+        temp_folder = create_tmp_folder_lambda(handler_file)
 
         function_name = f"func-integration-{short_uid()}"
+        # we need the AWS SDK v2, and Node 16 still has it by default
         create_lambda_function(
             func_name=function_name,
             zip_file=testutil.create_zip_file(temp_folder, get_content=True),
-            runtime=Runtime.nodejs14_x,
+            runtime=Runtime.nodejs16_x,
             handler="lambda_s3_integration_sdk_v2.handler",
             role=lambda_su_role,
             envvars={

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -354,7 +354,7 @@
     "last_validated_date": "2023-08-03T02:26:19+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_lambda_integration": {
-    "last_validated_date": "2023-08-03T02:18:58+00:00"
+    "last_validated_date": "2024-03-08T01:15:54+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_multipart_upload_acls": {
     "last_validated_date": "2023-08-03T14:53:20+00:00"
@@ -584,8 +584,11 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3v4-True]": {
     "last_validated_date": "2023-08-04T22:00:20+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_signed_headers_in_qs": {
+    "last_validated_date": "2024-03-08T01:01:09+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_v4_x_amz_in_qs": {
-    "last_validated_date": "2023-11-17T14:56:39+00:00"
+    "last_validated_date": "2024-03-08T01:17:39+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_with_different_user_credentials": {
     "last_validated_date": "2024-02-19T11:00:08+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
~It seems the pipeline just failed with some missing dependency for some lambdas used in S3: `fast-xml-parser`. Not sure what produced this, maybe it's not a default dependency anymore.~

Edit: ah, well, they updated it. https://github.com/aws/aws-sdk-js-v3/pull/5869
It seems they released a version with an issue, so this is not blocking anymore. I'll remove the added dependency but updating the lambda can't be bad. 


<!-- What notable changes does this PR make? -->
## Changes
~Added the dependency to the list of install.~
I've also spotted that Node14 is not supported anymore in lambda, so I've updated the lambda used to Node 20 + to use ES6. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

