### PR TITLE
fix lambda event source mapping FilterCriteria

### DIFF
--- a/localstack/services/lambda_/event_source_listeners/utils.py
+++ b/localstack/services/lambda_/event_source_listeners/utils.py
@@ -45,28 +45,28 @@ def filter_stream_record(filter_rule: Dict[str, any], record: Dict[str, any]) ->
                 append_record = filter_stream_record(value, record_value)
         else:
             # special case 'exists'
-            def filter_rule_value_list(val):
+            def _filter_rule_value_list(val):
                 if isinstance(val[0], dict):
                     return not val[0].get("exists", True)
                 elif val[0] is None:
                     # support null filter
                     return True
 
-            def filter_rule_value_dict(val):
+            def _filter_rule_value_dict(val):
                 for k, v in val.items():
                     return (
-                        filter_rule_value_list(val[k])
+                        _filter_rule_value_list(val[k])
                         if isinstance(val[k], list)
-                        else filter_rule_value_dict(val[k])
+                        else _filter_rule_value_dict(val[k])
                     )
                 return True
 
             if isinstance(value, list) and len(value) > 0:
-                append_record = filter_rule_value_list(value)
+                append_record = _filter_rule_value_list(value)
             elif isinstance(value, dict):
                 # special case 'exists' for S type, e.g. {"S": [{"exists": false}]}
                 # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial2.html
-                append_record = filter_rule_value_dict(value)
+                append_record = _filter_rule_value_dict(value)
 
         filter_results.append(append_record)
     return all(filter_results)

--- a/localstack/services/lambda_/event_source_listeners/utils.py
+++ b/localstack/services/lambda_/event_source_listeners/utils.py
@@ -51,6 +51,11 @@ def filter_stream_record(filter_rule: Dict[str, any], record: Dict[str, any]) ->
                 elif value[0] is None:
                     # support null filter
                     append_record = True
+            # special case 'exists' for S type, e.g. {"S": [{"exists": false}]}
+            # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial2.html
+            elif isinstance(value, dict) and len(value) > 0:
+                if isinstance(value["S"], list) and isinstance(value["S"][0], dict):
+                    append_record = not value["S"][0].get("exists", True)
 
         filter_results.append(append_record)
     return all(filter_results)

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -525,6 +525,40 @@ class TestCfnLambdaIntegrations:
         with pytest.raises(aws_client.lambda_.exceptions.ResourceNotFoundException):
             aws_client.lambda_.get_event_source_mapping(UUID=esm_id)
 
+    @markers.aws.validated
+    def test_lambda_dynamodb_event_filter(
+        self, dynamodb_wait_for_table_active, deploy_cfn_template, aws_client
+    ):
+        function_name = f"test-fn-{short_uid()}"
+        table_name = f"ddb-tbl-{short_uid()}"
+
+        item_to_put = {
+            "PK": {"S": "person1"},
+            "SK": {"S": "details"},
+            "name": {"S": "John Doe"},
+        }
+
+        deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../../templates/lambda_dynamodb_event_filter.yaml"
+            ),
+            parameters={
+                "FunctionName": function_name,
+                "TableName": table_name,
+                "Filter": '{"dynamodb": {"NewImage": {"homemade": {"S": [{"exists": false}]}}}}',
+            },
+        )
+        aws_client.dynamodb.put_item(TableName=table_name, Item=item_to_put)
+
+        def _send_events():
+            log_events = aws_client.logs.filter_log_events(
+                logGroupName=f"/aws/lambda/{function_name}"
+            )["events"]
+            return any(["Hello world!" in e["message"] for e in log_events])
+
+        sleep = 10 if os.getenv("TEST_TARGET") == "AWS_CLOUD" else 1
+        assert wait_until(_send_events, wait=sleep, max_retries=50)
+
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             # Lambda

--- a/tests/aws/services/cloudformation/resources/test_lambda.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_lambda.validation.json
@@ -11,6 +11,9 @@
   "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_sqs_source": {
     "last_validated_date": "2023-02-27T16:38:51+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_lambda_dynamodb_event_filter": {
+    "last_validated_date": "2024-03-12T18:17:17+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_lambda.py::test_cfn_function_url": {
     "last_validated_date": "2023-02-27T16:27:12+00:00"
   },

--- a/tests/aws/templates/lambda_dynamodb_event_filter.yaml
+++ b/tests/aws/templates/lambda_dynamodb_event_filter.yaml
@@ -1,0 +1,115 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >-
+  Sample SAM Template for Lambda fn Event-filtering with DynamoDB Streams
+
+Parameters:
+  FunctionName:
+    Type: String
+  TableName:
+    Type: String
+  Filter:
+    Type: String
+
+Globals:
+  Function:
+    Timeout: 3
+    MemorySize: 128
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - dynamodb:DescribeStream
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:ListStreams
+                Resource: !GetAtt StreamsSampleDDBTable.StreamArn
+
+  StreamsSampleDDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref TableName
+      AttributeDefinitions:
+        - AttributeName: "PK"
+          AttributeType: "S"
+        - AttributeName: "SK"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "PK"
+          KeyType: "HASH"
+        - AttributeName: "SK"
+          KeyType: "RANGE"
+      StreamSpecification:
+        StreamViewType: "NEW_AND_OLD_IMAGES"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+
+  DBEventStreamProcessor:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Timeout: 300
+      Role: !GetAtt LambdaExecutionRole.Arn
+      InlineCode: exports.handler = async (event, context) =>
+        {
+        console.log('Hello world!');
+        console.log(JSON.stringify(event))
+        }
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Architectures:
+        - x86_64
+      Events:
+        DBProfileEventStream:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt StreamsSampleDDBTable.StreamArn
+            ParallelizationFactor: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+            StartingPosition: TRIM_HORIZON
+            BatchSize: 5
+            FilterCriteria:
+              Filters:
+                - Pattern: |
+                    {
+                      "dynamodb": {
+                        "NewImage": {
+                          "homemade": {
+                            "S": [
+                              {
+                                "exists": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+            Enabled: true

--- a/tests/unit/services/lambda_/test_lambda_utils.py
+++ b/tests/unit/services/lambda_/test_lambda_utils.py
@@ -142,3 +142,9 @@ class TestFilterStreamRecords:
         ]
 
         assert [] == filter_stream_records(self.records, filters)
+
+    def test_no_match_exists_dict(self):
+        filters = [
+            {"Filters": [{"Pattern": json.dumps({"data": {"Foo": {"S": [{"exists": True}]}}})}]}
+        ]
+        assert [] == filter_stream_records(self.records, filters)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While using Lambda event source mappings with Dynamodb Streams there was a bug reported in #10325 surrounding `FilterCriteria`. It appears that the comparison operator `exists` doesn't work as intended when it's false. When `exists` is set to false and the property doesn't exist in the item the lambda doesn't trigger.

For instance in the [AWS tutorial to process events with Lambda and DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial2.html), when we use `[{"homemade": {"S": [{"exists": false}]}}]` the lambda doesn't trigger when the property is missing in dynamodb `PutItem` call. 

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- Adds a condition in while filtering the stream record to handle special case of exists when the value is a `dict`. 
- Adds a test case to validate the fix. 

This closes first part of #10325 bug. 
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

