### PR TITLE
fix SQS DLQ message attributes and redrive into multiple source queues

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -16,6 +16,7 @@ from localstack.aws.api.sqs import (
     AttributeNameList,
     InvalidAttributeName,
     Message,
+    MessageSystemAttributeName,
     QueueAttributeMap,
     QueueAttributeName,
     ReceiptHandleIsInvalid,
@@ -97,15 +98,30 @@ class SqsMessage:
 
     @property
     def message_group_id(self) -> Optional[str]:
-        return self.message["Attributes"].get("MessageGroupId")
+        return self.message["Attributes"].get(MessageSystemAttributeName.MessageGroupId)
 
     @property
     def message_deduplication_id(self) -> Optional[str]:
-        return self.message["Attributes"].get("MessageDeduplicationId")
+        return self.message["Attributes"].get(MessageSystemAttributeName.MessageDeduplicationId)
+
+    @property
+    def dead_letter_queue_source_arn(self) -> Optional[str]:
+        return self.message["Attributes"].get(MessageSystemAttributeName.DeadLetterQueueSourceArn)
 
     @property
     def message_id(self):
         return self.message["MessageId"]
+
+    def increment_approximate_receive_count(self):
+        """
+        Increment the message system attribute ``ApproximateReceiveCount``.
+        """
+        # TODO: need better handling of system attributes
+        cnt = int(
+            self.message["Attributes"].get(MessageSystemAttributeName.ApproximateReceiveCount, "0")
+        )
+        cnt += 1
+        self.message["Attributes"][MessageSystemAttributeName.ApproximateReceiveCount] = str(cnt)
 
     def set_last_received(self, timestamp: float):
         """
@@ -702,7 +718,7 @@ class SqsQueue:
 
 
 class StandardQueue(SqsQueue):
-    visible: PriorityQueue
+    visible: PriorityQueue[SqsMessage]
     inflight: Set[SqsMessage]
 
     def __init__(self, name: str, region: str, account_id: str, attributes=None, tags=None) -> None:
@@ -824,6 +840,7 @@ class StandardQueue(SqsQueue):
                 result.dead_letter_messages.append(message)
             else:
                 result.successful.append(message)
+                message.increment_approximate_receive_count()
 
                 # now we can return
                 if len(result.successful) == num_messages:
@@ -1151,6 +1168,7 @@ class FifoQueue(SqsQueue):
                         result.dead_letter_messages.append(message)
                     else:
                         result.successful.append(message)
+                        message.increment_approximate_receive_count()
 
                         # now we can break the inner loop
                         if len(result.successful) == num_messages:

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -96,6 +96,11 @@ class SqsMessage:
         else:
             self.message["Attributes"] = attributes
 
+        # set attribute default values if not set
+        self.message["Attributes"].setdefault(
+            MessageSystemAttributeName.ApproximateReceiveCount, "0"
+        )
+
     @property
     def message_group_id(self) -> Optional[str]:
         return self.message["Attributes"].get(MessageSystemAttributeName.MessageGroupId)

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -2830,8 +2830,21 @@ class TestSqsProvider:
         snapshot.match("dlq-arn", dl_queue_arn)
         snapshot.match("sourcen-arn", sqs_get_queue_arn(queue_url))
 
+        # check that attributes are retained
+        msg_attrs = {"MyAttribute": {"StringValue": "foobar", "DataType": "String"}}
+        msg_system_attrs = {
+            "AWSTraceHeader": {
+                "StringValue": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1",
+                "DataType": "String",
+            }
+        }
         # send a messages
-        sqs.send_message(QueueUrl=queue_url, MessageBody="message-1")
+        sqs.send_message(
+            QueueUrl=queue_url,
+            MessageBody="message-1",
+            MessageSystemAttributes=msg_system_attrs,
+            MessageAttributes=msg_attrs,
+        )
         sqs.send_message(QueueUrl=queue_url, MessageBody="message-2")
 
         # receive each message two times to move them into the dlq
@@ -3378,6 +3391,7 @@ class TestSqsProvider:
         self, sqs_create_queue, create_lambda_function, aws_sqs_client, region_name
     ):
         # TODO: lambda triggered dead letter delivery does not preserve the message id
+        # FIXME: message id is now preserved, but test is broken
         # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
         queue_name = f"queue-{short_uid()}"
         dead_letter_queue_name = "dl-queue-{}".format(short_uid())

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3073,5 +3073,62 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
+    "recorded-date": "08-03-2024, 22:24:07",
+    "recorded-content": {
+      "dlq-arn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+      "sourcen-arn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
+      "rec-pre-dlq": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "3d6b824fd8c1520e9a047d21fee6fb1f",
+          "Body": "message-1",
+          "Attributes": {
+            "ApproximateFirstReceiveTimestamp": "timestamp",
+            "ApproximateReceiveCount": "1",
+            "SentTimestamp": "timestamp"
+          }
+        },
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "95ef155b66299d14edf7ed57c468c13b",
+          "Body": "message-2",
+          "Attributes": {
+            "ApproximateFirstReceiveTimestamp": "timestamp",
+            "ApproximateReceiveCount": "1",
+            "SentTimestamp": "timestamp"
+          }
+        }
+      ],
+      "dlq-messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:3>",
+          "MD5OfBody": "3d6b824fd8c1520e9a047d21fee6fb1f",
+          "Body": "message-1",
+          "Attributes": {
+            "ApproximateFirstReceiveTimestamp": "timestamp",
+            "ApproximateReceiveCount": "2",
+            "SentTimestamp": "timestamp",
+            "DeadLetterQueueSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+          }
+        },
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:4>",
+          "MD5OfBody": "95ef155b66299d14edf7ed57c468c13b",
+          "Body": "message-2",
+          "Attributes": {
+            "ApproximateFirstReceiveTimestamp": "timestamp",
+            "ApproximateReceiveCount": "2",
+            "SentTimestamp": "timestamp",
+            "DeadLetterQueueSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3075,7 +3075,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
-    "recorded-date": "08-03-2024, 22:24:07",
+    "recorded-date": "08-03-2024, 23:14:22",
     "recorded-content": {
       "dlq-arn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
       "sourcen-arn": "arn:aws:sqs:<region>:111111111111:<resource:2>",
@@ -3088,7 +3088,15 @@
           "Attributes": {
             "ApproximateFirstReceiveTimestamp": "timestamp",
             "ApproximateReceiveCount": "1",
-            "SentTimestamp": "timestamp"
+            "SentTimestamp": "timestamp",
+            "AWSTraceHeader": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+          },
+          "MD5OfMessageAttributes": "adb59cd4678ea5a855436b949cd07ab6",
+          "MessageAttributes": {
+            "MyAttribute": {
+              "StringValue": "foobar",
+              "DataType": "String"
+            }
           }
         },
         {
@@ -3113,7 +3121,15 @@
             "ApproximateFirstReceiveTimestamp": "timestamp",
             "ApproximateReceiveCount": "2",
             "SentTimestamp": "timestamp",
+            "AWSTraceHeader": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1",
             "DeadLetterQueueSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:2>"
+          },
+          "MD5OfMessageAttributes": "adb59cd4678ea5a855436b949cd07ab6",
+          "MessageAttributes": {
+            "MyAttribute": {
+              "StringValue": "foobar",
+              "DataType": "String"
+            }
           }
         },
         {

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2023-11-14T10:57:50+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
-    "last_validated_date": "2024-03-08T22:24:07+00:00"
+    "last_validated_date": "2024-03-08T23:14:22+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[]": {
     "last_validated_date": "2023-11-14T10:58:57+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -14,6 +14,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception": {
     "last_validated_date": "2023-11-14T10:57:50+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
+    "last_validated_date": "2024-03-08T22:24:07+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[]": {
     "last_validated_date": "2023-11-14T10:58:57+00:00"
   },

--- a/tests/aws/services/sqs/test_sqs_move_task.py
+++ b/tests/aws/services/sqs/test_sqs_move_task.py
@@ -8,67 +8,11 @@ from botocore.exceptions import ClientError
 from localstack.services.sqs.utils import decode_move_task_handle, encode_move_task_handle
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
-from localstack.utils.sync import poll_condition, retry
+from localstack.utils.sync import retry
+
+from .utils import sqs_collect_messages, sqs_wait_queue_size
 
 QueueUrl = str
-
-
-def sqs_collect_messages(
-    sqs_client, queue_url: str, expected: int, timeout: int, delete: bool = True
-):
-    collected = []
-
-    def _receive():
-        response = sqs_client.receive_message(
-            QueueUrl=queue_url,
-            # try not to wait too long, but also not poll too often
-            WaitTimeSeconds=min(max(1, timeout), 5),
-            MaxNumberOfMessages=1,
-        )
-
-        if messages := response.get("Messages"):
-            collected.extend(messages)
-
-            if delete:
-                for m in messages:
-                    sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"])
-
-        return len(collected) >= expected
-
-    if not poll_condition(_receive, timeout=timeout):
-        raise TimeoutError(
-            f"gave up waiting for messages (expected={expected}, actual={len(collected)}"
-        )
-
-    return collected
-
-
-def get_approx_number_of_messages(
-    sqs_client,
-    queue_url: str,
-) -> int:
-    response = sqs_client.get_queue_attributes(
-        QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
-    )
-    return int(response["Attributes"]["ApproximateNumberOfMessages"])
-
-
-def sqs_wait_queue_size(
-    sqs_client,
-    queue_url: str,
-    expected_num_messages: int,
-    timeout: float = None,
-) -> int:
-    def _check_num_messages():
-        return get_approx_number_of_messages(sqs_client, queue_url) >= expected_num_messages
-
-    if not poll_condition(_check_num_messages, timeout=timeout):
-        raise TimeoutError(
-            f"gave up waiting for messages (expected={expected_num_messages}, "
-            f"actual={get_approx_number_of_messages(sqs_client, queue_url)})"
-        )
-
-    return get_approx_number_of_messages(sqs_client, queue_url)
 
 
 @pytest.fixture(autouse=True)
@@ -300,7 +244,6 @@ def test_move_task_workflow_with_default_destination(
     assert not response.get("Messages")
 
 
-@pytest.mark.skip(reason="Feature not yet implemented")
 @markers.aws.validated
 def test_move_task_workflow_with_multiple_sources_as_default_destination(
     sqs_create_queue,

--- a/tests/aws/services/sqs/utils.py
+++ b/tests/aws/services/sqs/utils.py
@@ -1,0 +1,73 @@
+from typing import TYPE_CHECKING
+
+from localstack.utils.sync import poll_condition
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs import SQSClient
+    from mypy_boto3_sqs.type_defs import MessageTypeDef
+
+
+def sqs_collect_messages(
+    sqs_client: "SQSClient",
+    queue_url: str,
+    expected: int,
+    timeout: int,
+    delete: bool = True,
+    attribute_names: list[str] = None,
+    message_attribute_names: list[str] = None,
+) -> list["MessageTypeDef"]:
+    collected = []
+
+    def _receive():
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            # try not to wait too long, but also not poll too often
+            WaitTimeSeconds=min(max(1, timeout), 5),
+            MaxNumberOfMessages=1,
+            AttributeNames=attribute_names or [],
+            MessageAttributeNames=message_attribute_names or [],
+        )
+
+        if messages := response.get("Messages"):
+            collected.extend(messages)
+
+            if delete:
+                for m in messages:
+                    sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"])
+
+        return len(collected) >= expected
+
+    if not poll_condition(_receive, timeout=timeout):
+        raise TimeoutError(
+            f"gave up waiting for messages (expected={expected}, actual={len(collected)}"
+        )
+
+    return collected
+
+
+def get_approx_number_of_messages(
+    sqs_client: "SQSClient",
+    queue_url: str,
+) -> int:
+    response = sqs_client.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
+    )
+    return int(response["Attributes"]["ApproximateNumberOfMessages"])
+
+
+def sqs_wait_queue_size(
+    sqs_client: "SQSClient",
+    queue_url: str,
+    expected_num_messages: int,
+    timeout: float = None,
+) -> int:
+    def _check_num_messages():
+        return get_approx_number_of_messages(sqs_client, queue_url) >= expected_num_messages
+
+    if not poll_condition(_check_num_messages, timeout=timeout):
+        raise TimeoutError(
+            f"gave up waiting for messages (expected={expected_num_messages}, "
+            f"actual={get_approx_number_of_messages(sqs_client, queue_url)})"
+        )
+
+    return get_approx_number_of_messages(sqs_client, queue_url)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As discussed in #10414, SQS DLQ redrive returns the messages back to their original source when no destination ARN is specified. To implement that, "some sort of tracking" is needed, and it turns out that AWS already has an attribute for that, namely the `DeadLetterQueueSourceArn` (which of course is not really documented anywhere...).

Basically what @baermat suggested here:
>  This is only supported for DLQs, and we know where we move to DLQ -> add an internal field to sqs messages dlq_origin or something similar. Set this when moved to DLQ. Then retrieve the source from the message itself.

which is exactly how it's implemented now.

A necessary fix was to make sure that the `message["Attributes"]` dict is retained correctly when it's being passed around through the queues. I was also reminded of [one of the limitations ](https://docs.localstack.cloud/user-guide/aws/sqs/#limitations), that `ApproximateReceiveCount` will be reset to 0 when a message moves to a DLQ. The problem was very similar so I fixed that along the way.

I briefly tested what happens when you delete one of the original source queues while the move task is running, and it simply moves into a `FAILED` state with a QueueNotFound error. So it's no different from the `test_move_task_delete_destination_queue_while_running` test case we already have.

At some point we should clean up the message system attribute handling, and also re-think whether `SqsQueue.put(Message, ...)` is the correct signature, or whether it should be `SqsQueue.put(SqsMessage)`.

<!-- What notable changes does this PR make? -->
## Changes

* `StartMessageMoveTask` will now correctly route messages back to their original source queues
* `ApproximateReceiveCount` is now correctly counted when the messages moves through DLQs
* Other message attributes are now also retained when messages move through DLQs (including the MessageID)

## Other notes

* The TODO in `test_dead_letter_queue_execution_lambda_mapping_preserves_id` is now obsolete, but something else is wrong with the test. there have been so many refactorings of it but it was never run because it's being skipped.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

