### PR TITLE
[SFN] Reduce Flakiness of Timeout and Heartbeat Tests

### DIFF
--- a/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_wait_for_task_token_with_timeout.json5
+++ b/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_wait_for_task_token_with_timeout.json5
@@ -4,7 +4,7 @@
     "SendMessageWithWaitAndTimeout": {
       "Type": "Task",
       "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
-      "TimeoutSeconds": 1,
+      "TimeoutSeconds": 5,
       "Parameters": {
         "QueueUrl.$": "$.QueueUrl",
         "MessageBody": {

--- a/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_timeout.json5
+++ b/tests/aws/services/stepfunctions/templates/errorhandling/statemachines/task_service_lambda_invoke_catch_timeout.json5
@@ -5,7 +5,7 @@
     "Start": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "TimeoutSeconds": 1,
+      "TimeoutSeconds": 5,
       "Parameters": {
         "FunctionName.$": "$.FunctionName",
         "Payload.$": "$.Payload",

--- a/tests/aws/services/stepfunctions/templates/timeouts/statemachines/lambda_wait_with_timeout_seconds.json5
+++ b/tests/aws/services/stepfunctions/templates/timeouts/statemachines/lambda_wait_with_timeout_seconds.json5
@@ -4,7 +4,7 @@
   "States": {
     "Start": {
       "Type": "Task",
-      "TimeoutSeconds": 1,
+      "TimeoutSeconds": 5,
       "Resource": "__tbc__",
       "Parameters": {
         "Payload.$": "$.Payload",

--- a/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_lambda_map_function_invoke_with_timeout_seconds.json5
+++ b/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_lambda_map_function_invoke_with_timeout_seconds.json5
@@ -14,7 +14,7 @@
           "LambdaInvoke": {
             "Type": "Task",
             "Resource": "arn:aws:states:::lambda:invoke",
-            "TimeoutSeconds": 1,
+            "TimeoutSeconds": 5,
             "Parameters": {
               "FunctionName.$": "$.FunctionName",
               "Payload.$": "$.Payload",

--- a/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_lambda_wait_with_timeout_seconds.json5
+++ b/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_lambda_wait_with_timeout_seconds.json5
@@ -4,7 +4,7 @@
   "States": {
     "Start": {
       "Type": "Task",
-      "TimeoutSeconds": 1,
+      "TimeoutSeconds": 5,
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName.$": "$.FunctionName",

--- a/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_sqs_send_and_wait_for_task_token_with_heartbeat.json5
+++ b/tests/aws/services/stepfunctions/templates/timeouts/statemachines/service_sqs_send_and_wait_for_task_token_with_heartbeat.json5
@@ -6,7 +6,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
       "TimeoutSeconds": 600,
-      "HeartbeatSeconds": 1,
+      "HeartbeatSeconds": 5,
       "Parameters": {
         "QueueUrl.$": "$.QueueUrl",
         "MessageBody": {

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.snapshot.json
@@ -153,7 +153,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_wait_for_task_token_timeout": {
-    "recorded-date": "25-06-2023, 14:30:43",
+    "recorded-date": "10-03-2024, 16:42:16",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -203,7 +203,7 @@
               "region": "<region>",
               "resource": "sendMessage.waitForTaskToken",
               "resourceType": "sqs",
-              "timeoutInSeconds": 1
+              "timeoutInSeconds": 5
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"
@@ -223,24 +223,28 @@
             "previousEventId": 4,
             "taskSubmittedEventDetails": {
               "output": {
-                "MD5OfMessageBody": "d15eb9a6d32a6653495e8b8765fd56fe",
+                "MD5OfMessageBody": "1761bdfa678f40d2d350e7bdf487f6f6",
                 "MessageId": "<uuid:1>",
                 "SdkHttpMetadata": {
                   "AllHttpHeaders": {
                     "x-amzn-RequestId": [
                       "<uuid:2>"
                     ],
+                    "connection": [
+                      "keep-alive"
+                    ],
                     "Content-Length": [
-                      "378"
+                      "106"
                     ],
                     "Date": "date",
                     "Content-Type": [
-                      "text/xml"
+                      "application/x-amz-json-1.0"
                     ]
                   },
                   "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
                     "Date": "date",
                     "x-amzn-RequestId": "<uuid:2>"
                   },

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.validation.json
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.validation.json
@@ -12,7 +12,7 @@
     "last_validated_date": "2023-06-25T12:30:26+00:00"
   },
   "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_wait_for_task_token_timeout": {
-    "last_validated_date": "2023-06-25T12:30:43+00:00"
+    "last_validated_date": "2024-03-10T16:42:16+00:00"
   },
   "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_start_execution_sync": {
     "last_validated_date": "2023-06-30T12:42:19+00:00"

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.snapshot.json
@@ -511,7 +511,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_invoke_timeout": {
-    "recorded-date": "22-06-2023, 13:30:31",
+    "recorded-date": "10-03-2024, 16:41:35",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -558,7 +558,7 @@
               "region": "<region>",
               "resource": "invoke",
               "resourceType": "lambda",
-              "timeoutInSeconds": 1
+              "timeoutInSeconds": 5
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"

--- a/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
+++ b/tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_invoke_timeout": {
-    "last_validated_date": "2023-06-22T11:30:31+00:00"
+    "last_validated_date": "2024-03-10T16:41:35+00:00"
   },
   "tests/aws/services/stepfunctions/v2/error_handling/test_task_service_lambda.py::TestTaskServiceLambda::test_no_such_function": {
     "last_validated_date": "2023-06-22T11:29:54+00:00"

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py
@@ -20,7 +20,7 @@ from tests.aws.services.stepfunctions.utils import create_and_record_execution
 )
 class TestHeartbeats:
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.needs_fixing
+    @markers.aws.validated
     def test_heartbeat_timeout(
         self,
         aws_client,
@@ -59,7 +59,7 @@ class TestHeartbeats:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.needs_fixing
+    @markers.aws.validated
     def test_heartbeat_path_timeout(
         self,
         aws_client,
@@ -90,7 +90,7 @@ class TestHeartbeats:
 
         message_txt = "test_message_txt"
         exec_input = json.dumps(
-            {"QueueUrl": queue_url, "Message": message_txt, "HeartbeatSecondsPath": 1}
+            {"QueueUrl": queue_url, "Message": message_txt, "HeartbeatSecondsPath": 5}
         )
         create_and_record_execution(
             aws_client.stepfunctions,
@@ -102,7 +102,7 @@ class TestHeartbeats:
         )
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..MD5OfMessageBody"])
-    @markers.aws.needs_fixing
+    @markers.aws.validated
     def test_heartbeat_no_timeout(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_timeout": {
-    "recorded-date": "26-06-2023, 09:12:29",
+    "recorded-date": "10-03-2024, 16:39:54",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -40,7 +40,7 @@
             "id": 3,
             "previousEventId": 2,
             "taskScheduledEventDetails": {
-              "heartbeatInSeconds": 1,
+              "heartbeatInSeconds": 5,
               "parameters": {
                 "MessageBody": {
                   "Message": "test_message_txt",
@@ -71,24 +71,28 @@
             "previousEventId": 4,
             "taskSubmittedEventDetails": {
               "output": {
-                "MD5OfMessageBody": "fb73571f092a3f4109111810ab3831d8",
+                "MD5OfMessageBody": "2e28057614d59d8f7dfcdb8c9ac712f0",
                 "MessageId": "<uuid:1>",
                 "SdkHttpMetadata": {
                   "AllHttpHeaders": {
                     "x-amzn-RequestId": [
                       "<uuid:2>"
                     ],
+                    "connection": [
+                      "keep-alive"
+                    ],
                     "Content-Length": [
-                      "378"
+                      "106"
                     ],
                     "Date": "date",
                     "Content-Type": [
-                      "text/xml"
+                      "application/x-amz-json-1.0"
                     ]
                   },
                   "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
                     "Date": "date",
                     "x-amzn-RequestId": "<uuid:2>"
                   },
@@ -136,7 +140,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_path_timeout": {
-    "recorded-date": "26-06-2023, 09:12:45",
+    "recorded-date": "10-03-2024, 16:40:13",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -145,7 +149,7 @@
               "input": {
                 "QueueUrl": "<sqs_queue_url>",
                 "Message": "test_message_txt",
-                "HeartbeatSecondsPath": 1
+                "HeartbeatSecondsPath": 5
               },
               "inputDetails": {
                 "truncated": false
@@ -164,7 +168,7 @@
               "input": {
                 "QueueUrl": "<sqs_queue_url>",
                 "Message": "test_message_txt",
-                "HeartbeatSecondsPath": 1
+                "HeartbeatSecondsPath": 5
               },
               "inputDetails": {
                 "truncated": false
@@ -178,7 +182,7 @@
             "id": 3,
             "previousEventId": 2,
             "taskScheduledEventDetails": {
-              "heartbeatInSeconds": 1,
+              "heartbeatInSeconds": 5,
               "parameters": {
                 "MessageBody": {
                   "Message": "test_message_txt",
@@ -209,24 +213,28 @@
             "previousEventId": 4,
             "taskSubmittedEventDetails": {
               "output": {
-                "MD5OfMessageBody": "25de2160ee3d3f24143ab58c6d94d338",
+                "MD5OfMessageBody": "e23368b7448139be32aa2f1fbd962673",
                 "MessageId": "<uuid:1>",
                 "SdkHttpMetadata": {
                   "AllHttpHeaders": {
                     "x-amzn-RequestId": [
                       "<uuid:2>"
                     ],
+                    "connection": [
+                      "keep-alive"
+                    ],
                     "Content-Length": [
-                      "378"
+                      "106"
                     ],
                     "Date": "date",
                     "Content-Type": [
-                      "text/xml"
+                      "application/x-amz-json-1.0"
                     ]
                   },
                   "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
                     "Date": "date",
                     "x-amzn-RequestId": "<uuid:2>"
                   },
@@ -274,7 +282,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_no_timeout": {
-    "recorded-date": "26-06-2023, 09:13:01",
+    "recorded-date": "10-03-2024, 16:40:31",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -314,7 +322,7 @@
             "id": 3,
             "previousEventId": 2,
             "taskScheduledEventDetails": {
-              "heartbeatInSeconds": 1,
+              "heartbeatInSeconds": 5,
               "parameters": {
                 "MessageBody": {
                   "Message": "test_message_txt",
@@ -344,24 +352,28 @@
             "previousEventId": 4,
             "taskSubmittedEventDetails": {
               "output": {
-                "MD5OfMessageBody": "50275e94a825e3cea0c549f06c752088",
+                "MD5OfMessageBody": "54d831cd55f1c29412fd982a3f7cb682",
                 "MessageId": "<uuid:1>",
                 "SdkHttpMetadata": {
                   "AllHttpHeaders": {
                     "x-amzn-RequestId": [
                       "<uuid:2>"
                     ],
+                    "connection": [
+                      "keep-alive"
+                    ],
                     "Content-Length": [
-                      "378"
+                      "106"
                     ],
                     "Date": "date",
                     "Content-Type": [
-                      "text/xml"
+                      "application/x-amz-json-1.0"
                     ]
                   },
                   "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
                     "Date": "date",
                     "x-amzn-RequestId": "<uuid:2>"
                   },

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.validation.json
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.validation.json
@@ -1,11 +1,11 @@
 {
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_no_timeout": {
-    "last_validated_date": "2023-06-26T07:13:01+00:00"
+    "last_validated_date": "2024-03-10T16:40:31+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_path_timeout": {
-    "last_validated_date": "2023-06-26T07:12:45+00:00"
+    "last_validated_date": "2024-03-10T16:40:13+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_heartbeats.py::TestHeartbeats::test_heartbeat_timeout": {
-    "last_validated_date": "2023-06-26T07:12:29+00:00"
+    "last_validated_date": "2024-03-10T16:39:54+00:00"
   }
 }

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_lambda": {
-    "recorded-date": "22-06-2023, 13:42:57",
+    "recorded-date": "10-03-2024, 16:23:26",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -44,7 +44,7 @@
                 "truncated": false
               },
               "resource": "arn:aws:lambda:<region>:111111111111:function:<lambda_function_1_name>",
-              "timeoutInSeconds": 1
+              "timeoutInSeconds": 5
             },
             "previousEventId": 2,
             "timestamp": "timestamp",
@@ -83,7 +83,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_service_lambda": {
-    "recorded-date": "22-06-2023, 13:42:21",
+    "recorded-date": "10-03-2024, 16:47:40",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -91,7 +91,8 @@
             "executionStartedEventDetails": {
               "input": {
                 "FunctionName": "<lambda_function_1_name>",
-                "Payload": null
+                "Payload": null,
+                "TimeoutSecondsValue": 5
               },
               "inputDetails": {
                 "truncated": false
@@ -109,7 +110,8 @@
             "stateEnteredEventDetails": {
               "input": {
                 "FunctionName": "<lambda_function_1_name>",
-                "Payload": null
+                "Payload": null,
+                "TimeoutSecondsValue": 5
               },
               "inputDetails": {
                 "truncated": false
@@ -130,7 +132,7 @@
               "region": "<region>",
               "resource": "invoke",
               "resourceType": "lambda",
-              "timeoutInSeconds": 1
+              "timeoutInSeconds": 5
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"
@@ -174,7 +176,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_service_lambda_map_timeout": {
-    "recorded-date": "26-05-2023, 12:48:33",
+    "recorded-date": "10-03-2024, 16:23:46",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -421,7 +423,7 @@
           },
           {
             "id": 16,
-            "previousEventId": 13,
+            "previousEventId": 9,
             "taskStartedEventDetails": {
               "resource": "invoke",
               "resourceType": "lambda"
@@ -441,7 +443,7 @@
           },
           {
             "id": 18,
-            "previousEventId": 15,
+            "previousEventId": 13,
             "taskStartedEventDetails": {
               "resource": "invoke",
               "resourceType": "lambda"
@@ -451,7 +453,7 @@
           },
           {
             "id": 19,
-            "previousEventId": 9,
+            "previousEventId": 15,
             "taskStartedEventDetails": {
               "resource": "invoke",
               "resourceType": "lambda"
@@ -483,17 +485,6 @@
           },
           {
             "id": 22,
-            "previousEventId": 19,
-            "taskTimedOutEventDetails": {
-              "error": "States.Timeout",
-              "resource": "invoke",
-              "resourceType": "lambda"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskTimedOut"
-          },
-          {
-            "id": 23,
             "previousEventId": 17,
             "taskTimedOutEventDetails": {
               "error": "States.Timeout",
@@ -504,14 +495,25 @@
             "type": "TaskTimedOut"
           },
           {
+            "id": 23,
+            "previousEventId": 19,
+            "taskTimedOutEventDetails": {
+              "error": "States.Timeout",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskTimedOut"
+          },
+          {
             "id": 24,
-            "mapIterationAbortedEventDetails": {
+            "mapIterationFailedEventDetails": {
               "index": 0,
               "name": "MapWait"
             },
             "previousEventId": 20,
             "timestamp": "timestamp",
-            "type": "MapIterationAborted"
+            "type": "MapIterationFailed"
           },
           {
             "id": 25,
@@ -537,13 +539,13 @@
           },
           {
             "id": 28,
-            "mapIterationFailedEventDetails": {
+            "mapIterationAbortedEventDetails": {
               "index": 2,
               "name": "MapWait"
             },
             "previousEventId": 20,
             "timestamp": "timestamp",
-            "type": "MapIterationFailed"
+            "type": "MapIterationAborted"
           },
           {
             "id": 29,
@@ -591,14 +593,14 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_service_lambda_with_path": {
-    "recorded-date": "22-06-2023, 13:42:39",
+    "recorded-date": "10-03-2024, 16:23:06",
     "recorded-content": {
       "get_execution_history": {
         "events": [
           {
             "executionStartedEventDetails": {
               "input": {
-                "TimeoutSecondsValue": 1,
+                "TimeoutSecondsValue": 5,
                 "FunctionName": "<lambda_function_1_name>",
                 "Payload": null
               },
@@ -617,7 +619,7 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "TimeoutSecondsValue": 1,
+                "TimeoutSecondsValue": 5,
                 "FunctionName": "<lambda_function_1_name>",
                 "Payload": null
               },
@@ -640,7 +642,7 @@
               "region": "<region>",
               "resource": "invoke",
               "resourceType": "lambda",
-              "timeoutInSeconds": 1
+              "timeoutInSeconds": 5
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"
@@ -684,7 +686,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_global_timeout": {
-    "recorded-date": "29-08-2023, 13:08:44",
+    "recorded-date": "10-03-2024, 16:22:15",
     "recorded-content": {
       "describe_execution": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<ArnPart_0idx>:<execution-name>",
@@ -693,6 +695,8 @@
           "included": true
         },
         "name": "<execution-name>",
+        "redriveCount": 0,
+        "redriveStatus": "REDRIVABLE",
         "startDate": "datetime",
         "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>",
         "status": "TIMED_OUT",

--- a/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.validation.json
+++ b/tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.validation.json
@@ -1,17 +1,17 @@
 {
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_lambda": {
-    "last_validated_date": "2023-06-22T11:42:57+00:00"
+    "last_validated_date": "2024-03-10T16:23:26+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_service_lambda": {
-    "last_validated_date": "2023-06-22T11:42:21+00:00"
+    "last_validated_date": "2024-03-10T16:47:40+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_fixed_timeout_service_lambda_with_path": {
-    "last_validated_date": "2023-06-22T11:42:39+00:00"
+    "last_validated_date": "2024-03-10T16:23:06+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_global_timeout": {
-    "last_validated_date": "2023-08-29T11:08:44+00:00"
+    "last_validated_date": "2024-03-10T16:22:15+00:00"
   },
   "tests/aws/services/stepfunctions/v2/timeouts/test_timeouts.py::TestTimeouts::test_service_lambda_map_timeout": {
-    "last_validated_date": "2023-05-26T10:48:33+00:00"
+    "last_validated_date": "2024-03-10T16:23:46+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've noticed some inconsistency in the StepFunctions tests, particularly related to timeout exceptions. These issues arise due to the strict 1-second timeout value. Consequently, there are instances where the interpreter doesn't have sufficient time to log the events for execution start and scheduling. While this behavior aligns with expectations, our focus lies in validating the state machine's sequence of events. We're particularly interested in testing the scenario where the state returns early.

This pull request aims to address these inconsistencies by mitigating the flakiness of these tests. The proposed solution, for now, involves increasing the timeout or heartbeat time allocated to the states.

<!-- What notable changes does this PR make? -->
## Changes
- Increased Timeout/Heartbeat value
- Recomputed relevant snapshots

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

