### PR TITLE
fix SNS Publish exception when using empty topic

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -911,7 +911,8 @@ def extract_tags(
     return True
 
 
-def parse_and_validate_topic_arn(topic_arn: str) -> ArnData:
+def parse_and_validate_topic_arn(topic_arn: str | None) -> ArnData:
+    topic_arn = topic_arn or ""
     try:
         return parse_arn(topic_arn)
     except InvalidArnException:

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -307,6 +307,11 @@ class TestSNSPublishCrud:
 
         snapshot.match("invalid-topic-arn-1", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            aws_client.sns.publish(Message=message, TopicArn="")
+
+        snapshot.match("empty-topic", e.value.response)
+
     @markers.aws.validated
     def test_publish_message_by_target_arn(
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -343,7 +343,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_wrong_arn_format": {
-    "recorded-date": "24-08-2023, 22:31:40",
+    "recorded-date": "11-03-2024, 10:36:34",
     "recorded-content": {
       "invalid-topic-arn": {
         "Error": {
@@ -360,6 +360,17 @@
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 2",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "empty-topic": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not 1",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -60,7 +60,7 @@
     "last_validated_date": "2023-08-24T20:31:46+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_publish_wrong_arn_format": {
-    "last_validated_date": "2023-08-24T20:31:40+00:00"
+    "last_validated_date": "2024-03-11T10:36:34+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_topic_publish_another_region": {
     "last_validated_date": "2023-11-17T17:14:28+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Found out this small issue when launching a benchmark without the initial setup. When calling `SNS.Publish(Message="test", TopicArn="")`, boto accepts it but it fails on LocalStack side. 

<!-- What notable changes does this PR make? -->
## Changes
- add a test for the issue
- add a small check to use an empty string if the value is falsy

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

