### PR TITLE
Fix DynamoDB Table and Global Table Creation with SSESpecification and TTL

### DIFF
--- a/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
+++ b/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
@@ -268,8 +268,7 @@ class DynamoDBGlobalTableProvider(ResourceProvider[DynamoDBGlobalTableProperties
             # add TTL config
             if ttl_config := model.get("TimeToLiveSpecification"):
                 request.aws_client_factory.dynamodb.update_time_to_live(
-                    TableName=model["TableName"],
-                    TimeToLiveSpecification=ttl_config
+                    TableName=model["TableName"], TimeToLiveSpecification=ttl_config
                 )
 
             return ProgressEvent(

--- a/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
+++ b/localstack/services/dynamodb/resource_providers/aws_dynamodb_globaltable.py
@@ -229,12 +229,16 @@ class DynamoDBGlobalTableProvider(ResourceProvider[DynamoDBGlobalTableProperties
                     "SSESpecification",
                     "StreamSpecification",
                     "TableName",
-                    "TimeToLiveSpecification",
                     "WriteProvisionedThroughputSettings",
                 ],
             )
 
             replicas = create_params.pop("Replicas", [])
+
+            if sse_specification := create_params.get("SSESpecification"):
+                # rename bool attribute to fit boto call
+                sse_specification["Enabled"] = sse_specification["SSEEnabled"]
+                del sse_specification["SSEEnabled"]
 
             creation_response = request.aws_client_factory.dynamodb.create_table(**create_params)
             model["Arn"] = creation_response["TableDescription"]["TableArn"]
@@ -259,6 +263,13 @@ class DynamoDBGlobalTableProvider(ResourceProvider[DynamoDBGlobalTableProperties
 
                 request.aws_client_factory.dynamodb.update_table(
                     ReplicaUpdates=replicas_to_create, TableName=model["TableName"]
+                )
+
+            # add TTL config
+            if ttl_config := model.get("TimeToLiveSpecification"):
+                request.aws_client_factory.dynamodb.update_time_to_live(
+                    TableName=model["TableName"],
+                    TimeToLiveSpecification=ttl_config
                 )
 
             return ProgressEvent(


### PR DESCRIPTION
## Motivation
When table is created with following attributes
```
SSESpecification:
    SSEEnabled: True
    SSEType: AES256
TimeToLiveSpecification:
    AttributeName: expire_at
    Enabled: true
```

SSESpecification will cause crash, while TTL is ignored. This PR fixes this

## Changes
 Updated both Table and GlobalTable CFn resource provider to properly pass parameters from CFn Template

## Testing
TODO: Add tests

