### PR TITLE
Update runtime init, add dynamic configuration for folders to run chmod on in Lambda

### DIFF
--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -17,6 +17,7 @@ from localstack.services.lambda_.invocation.executor_endpoint import (
 )
 from localstack.services.lambda_.invocation.lambda_models import FunctionVersion
 from localstack.services.lambda_.invocation.runtime_executor import (
+    ChmodPath,
     LambdaPrebuildContext,
     LambdaRuntimeException,
     RuntimeExecutor,
@@ -40,7 +41,7 @@ from localstack.utils.container_utils.container_client import (
     VolumeMappings,
 )
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
-from localstack.utils.files import rm_rf
+from localstack.utils.files import chmod_r, rm_rf
 from localstack.utils.net import get_free_tcp_port
 from localstack.utils.strings import short_uid, truncate
 
@@ -218,11 +219,15 @@ def prepare_image(function_version: FunctionVersion, platform: DockerPlatform) -
     init_destination_path.chmod(0o755)
 
     # copy function code
+    context_code_path = prebuild_context.context_path / "code"
     shutil.copytree(
         f"{str(code_path)}/",
-        str(prebuild_context.context_path / "code"),
+        str(context_code_path),
         dirs_exist_ok=True,
     )
+    # if layers are present, permissions should be 0755
+    if prebuild_context.function_version.config.layers:
+        chmod_r(str(context_code_path), 0o755)
 
     try:
         image_name = get_image_name_for_function(function_version)
@@ -319,6 +324,9 @@ class DockerRuntimeExecutor(RuntimeExecutor):
                     )
                 )
 
+        # always chmod /tmp to 700
+        chmod_paths = [ChmodPath(path="/tmp", mode="0700")]
+
         # set the dns server of the lambda container to the LocalStack container IP
         # the dns server will automatically respond with the right target for transparent endpoint injection
         if config.LAMBDA_DOCKER_DNS:
@@ -348,6 +356,19 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             if not container_config.ports:
                 container_config.ports = PortMappings()
             container_config.ports.add(config.LAMBDA_INIT_DELVE_PORT, config.LAMBDA_INIT_DELVE_PORT)
+
+        if (
+            self.function_version.config.layers
+            and not config.LAMBDA_PREBUILD_IMAGES
+            and self.function_version.config.package_type == PackageType.Zip
+        ):
+            # avoid chmod on mounted code paths
+            hot_reloading_env = container_config.env_vars.get(HOT_RELOADING_ENV_VARIABLE, "")
+            if "/opt" not in hot_reloading_env:
+                chmod_paths.append(ChmodPath(path="/opt", mode="0755"))
+            if "/var/task" not in hot_reloading_env:
+                chmod_paths.append(ChmodPath(path="/var/task", mode="0755"))
+        container_config.env_vars["LOCALSTACK_CHMOD_PATHS"] = json.dumps(chmod_paths)
 
         CONTAINER_CLIENT.create_container_from_config(container_config)
         if (

--- a/localstack/services/lambda_/invocation/runtime_executor.py
+++ b/localstack/services/lambda_/invocation/runtime_executor.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Type
+from typing import Type, TypedDict
 
 from plux import PluginManager
 
@@ -126,6 +126,11 @@ class LambdaPrebuildContext:
     docker_file_content: str
     context_path: Path
     function_version: FunctionVersion
+
+
+class ChmodPath(TypedDict):
+    path: str
+    mode: str
 
 
 EXECUTOR_PLUGIN_MANAGER: PluginManager[Type[RuntimeExecutor]] = PluginManager(

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -10,7 +10,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.27-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.28-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -782,6 +782,7 @@ class TestLambdaBehavior:
             "$..Payload.environment.LOCALSTACK_USER",
             "$..Payload.environment.LOCALSTACK_POST_INVOKE_WAIT_MS",
             "$..Payload.environment.LOCALSTACK_MAX_PAYLOAD_SIZE",
+            "$..Payload.environment.LOCALSTACK_CHMOD_PATHS",
             # internal AWS lambda functionality
             "$..Payload.environment._AWS_XRAY_DAEMON_ADDRESS",
             "$..Payload.environment._LAMBDA_CONSOLE_SOCKET",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently always run a `chmod` operation on certain task related folders when starting up a Lambda environment.
This however can take a lot of time if lambda prebuild mode is on, since it will do a copy on write operation on all changed files (which can be a lot). This introduces unnecessary IO load and can lead to extremely long startup times.

We should avoid running `chmod` on everything but `/tmp` in prebuild mode, and configure which folders to `chmod` on the LocalStack side, to avoid relying on potentially unreliable heuristics.

<!-- What notable changes does this PR make? -->
## Changes
* Update lambda init to include localstack/lambda-runtime-init#34
* Configure lambda init to run chmod operations:
  - On `/tmp`: always
  - On `/var/task` and `/opt` if there are layers configured (no matter if pro or not)
* Configure prebuild mode to run chmod on the code directory before building if layers are present (chmod on layers will be in pro, due to the design of the hook)

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

