### PR TITLE
fix disk space issues in GitHub workflow again

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -117,11 +117,13 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 30720
+          root-reserve-mb: 30000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true
           remove-codeql: true
+          remove-docker-images: true
+        continue-on-error: true
 
       - name: Checkout Community
         uses: actions/checkout@v4

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           path: |
             localstack-ext/.venv
-          # include the matrix group (to re-use the venv used in the specific test group)
+          # include the matrix group (to re-use the venv)
           key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.result}}
           restore-keys: |
             community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-refs/heads/master

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -221,17 +221,16 @@ jobs:
           sudo apt-get update
           # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
           sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.11-0ubuntu0* postgresql-client postgresql-plpython3
-
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true
         uses: actions/cache@v4
         with:
           path: |
             localstack-ext/.venv
-          # include the matrix group (to re-use the var-libs used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt', 'localstack/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.result}}
+          # include the matrix group (to re-use the venv used in the specific test group)
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.ref}}-group-${{ matrix.group }}
           restore-keys: |
-            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt', 'localstack/requirements-test.txt') }}-refs/heads/master
+            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-refs/heads/master-group-${{ matrix.group }}
 
       - name: Cache Ext Dependencies (libs)
         if: inputs.disableCaching != true
@@ -240,10 +239,9 @@ jobs:
           path: |
             localstack/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('localstack-ext/**/packages.py','localstack-ext/packages/*.py', 'localstack/**/packages.py',  'localstack/packages/*.py') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ '**/packages.py', '**/packages/*') }}-${{steps.determine-companion-ref.outputs.ref}}-group-${{ matrix.group }}
           restore-keys: |
-            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('localstack-ext/**/packages.py','localstack-ext/packages/*.py','localstack/**/packages.py',  'localstack/packages/*.py') }}-refs/heads/master-group-${{ matrix.group }}
-
+            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('**/packages.py', '**/packages/*') }}-refs/heads/master-group-${{ matrix.group }}
 
       - name: Restore Lambda common runtime packages
         id: cached-lambda-common-restore

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -228,9 +228,9 @@ jobs:
           path: |
             localstack-ext/.venv
           # include the matrix group (to re-use the venv used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.ref}}-group-${{ matrix.group }}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-${{steps.determine-companion-ref.outputs.result}}
           restore-keys: |
-            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-refs/heads/master-group-${{ matrix.group }}
+            community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('localstack-ext/requirements-test.txt') }}-refs/heads/master
 
       - name: Cache Ext Dependencies (libs)
         if: inputs.disableCaching != true
@@ -239,7 +239,7 @@ jobs:
           path: |
             localstack/.filesystem/var/lib/localstack
           # include the matrix group (to re-use the var-libs used in the specific test group)
-          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ '**/packages.py', '**/packages/*') }}-${{steps.determine-companion-ref.outputs.ref}}-group-${{ matrix.group }}
+          key: community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('**/packages.py', '**/packages/*') }}-${{steps.determine-companion-ref.outputs.result}}-group-${{ matrix.group }}
           restore-keys: |
             community-it-${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-libs-${{ hashFiles('**/packages.py', '**/packages/*') }}-refs/heads/master-group-${{ matrix.group }}
 

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -114,16 +114,12 @@ jobs:
       CI_JOB_NAME: ${{ github.job }}
       CI_JOB_ID: ${{ github.job }}
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          root-reserve-mb: 30000
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-        continue-on-error: true
+          # don't perform all optimizations to decrease action execution time
+          large-packages: false
+          docker-images: false
 
       - name: Checkout Community
         uses: actions/checkout@v4

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -114,6 +114,9 @@ jobs:
       CI_JOB_NAME: ${{ github.job }}
       CI_JOB_ID: ${{ github.job }}
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+
       - name: Checkout Community
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -116,6 +116,12 @@ jobs:
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 30720
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
 
       - name: Checkout Community
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/10186, we tried to optimize the tests a bit in order to mitigate issues where the Community Tests against Pro would run out of disk space on the default GitHub runners.
Unfortunately, we are seeing these issues again, which is why we will (as predicted in the previous PR) use an action to remove some of the (insane amount of) unused toolchains on the runner.

## Changes
- Adds an initial action call for `easimon/maximize-build-space@v10` to remove some unused stuff from the runner.

## Testing
- The action is quite effective in freeing some disk space, but it can cause issues with Docker (since it might reduce the root partition).
- The action's runtime could also be interesting to look at.
- Both things can be analyzed by triggering multiple runs from this PR's branch.

## Test Run Analysis
- [x] https://github.com/localstack/localstack/actions/runs/8268124777/attempts/1
  - Worked well. ~1m15s per parallel job for the cleanup. Caching also worked well.
- [x] https://github.com/localstack/localstack/actions/runs/8268124777/attempts/2
  - Worked well. ~1m30s per parallel job for the cleanup. Caching also worked well.
- [x] https://github.com/localstack/localstack/actions/runs/8268124777/attempts/3
  - This run had some outliers in the time the "free disk space action" took: 2m40s and 5m52s
- [x] https://github.com/localstack/localstack/actions/runs/8268124777/attempts/4
  - In turn, in this run the action was super-fast: 10s on each runner.

## Conclusion
Unfortunately, all ways to free up space on the runner are somewhat hacky or at least an execution-time overhead which should not be necessary. However, the current solution is imho the best short term fix available...