### PR TITLE
Set package data key to `localstack`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ exclude = ["tests*"]
     "*.md",
     "Makefile"
 ]
-"localstack_ext" = [
+"localstack" = [
     "aws/**/*.json",
     "services/**/*.html",
     "services/**/resource_providers/*.schema.json",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The key for the non-python package data is set to `localstack_ext` which is wrong and leaves out those files in the distribution.

<!-- What notable changes does this PR make? -->
## Changes

Change the key to the correct `localstack` so that those files are included

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

