### PR TITLE
FIx: Referencing AWS::StackID is not consistent between AWS and Localstack

### DIFF
--- a/tests/aws/services/cloudformation/engine/test_select_split.py
+++ b/tests/aws/services/cloudformation/engine/test_select_split.py
@@ -1,0 +1,13 @@
+import os
+
+from localstack.testing.pytest import markers
+
+
+@markers.aws.validated
+def test_select_split_stack_id(aws_client, deploy_cfn_template, snapshot):
+    stack = deploy_cfn_template(
+                template_path=os.path.join(
+                    os.path.dirname(__file__), "../../../templates/engine/cfn_select_split.yml"
+                )
+            )
+    snapshot.match("outputs", stack.outputs)

--- a/tests/aws/services/cloudformation/engine/test_select_split.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_select_split.snapshot.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/services/cloudformation/engine/test_select_split.py::test_select_split_stack_id": {
+    "recorded-date": "13-03-2024, 14:53:20",
+    "recorded-content": {
+      "outputs": {
+        "SelectedOutput": "68494ac0-e149-11ee-80ab-0a41b9c91b2d",
+        "StackID": "arn:aws:cloudformation:<region>:111111111111:stack/stack-004e00f4/68494ac0-e149-11ee-80ab-0a41b9c91b2d"
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/engine/test_select_split.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_select_split.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/cloudformation/engine/test_select_split.py::test_select_split_stack_id": {
+    "last_validated_date": "2024-03-13T14:53:20+00:00"
+  }
+}

--- a/tests/aws/templates/engine/cfn_select_split.yml
+++ b/tests/aws/templates/engine/cfn_select_split.yml
@@ -1,0 +1,12 @@
+# we need to have at least resource for the stack to deploy
+Resources:
+  MyResource:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: unimportant
+Outputs:
+  SelectedOutput:
+    Value: !Select [2, !Split ["/", !Ref "AWS::StackId"]]
+  StackID:
+    Value: !Ref "AWS::StackId"


### PR DESCRIPTION
## Motivation
Following template won't work on LS, but will pass on AWS
```
Resources:
  MyResource:
    Type: AWS::SSM::Parameter
    Properties:
      Type: String
      Value: unimportant
Outputs:
  SelectedOutput:
    Value: !Select [2, !Split ["/", !Ref "AWS::StackId"]]
  StackID:
    Value: !Ref "AWS::StackId"
```

This because on AWS `AWS::StackId` is ARN and in Localstack it is something like `stack-619106c6`

## Changes
- Still in exploration phase

## Testing

[test_select_split_stack_id](https://github.com/localstack/localstack/blob/b858e72bf0252e09a041dd009633680f509aa55b/tests/aws/services/cloudformation/engine/test_select_split.py#L7)