### PR TITLE
Fix filter for provider detection in legacy StepFunctions tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,6 @@ jobs:
           at: /tmp/workspace
       - prepare-testselection
       - prepare-pytest-tinybird
-      - prepare-account-region-randomization
       - run:
           name: Test SFN Legacy provider
           environment:

--- a/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -289,7 +289,7 @@ def get_machine_arn(sm_name, sfn_client):
 
 
 pytestmark = pytest.mark.skipif(
-    condition=is_not_legacy_provider, reason="Test suite only for legacy provider."
+    condition=is_not_legacy_provider(), reason="Test suite only for legacy provider."
 )
 
 


### PR DESCRIPTION
## Motivation

Noticed during my work on test selection, that the stepfunctions tests are executed particularly quickly. Looking at it in more detail I noticed that all tests are being skipped due to an issue in the conditional for the `skipif` marker.

```
======================= 14 skipped, 1 warning in 11.10s ========================
```

## Changes

- Fixes the skipif condition to actually evaluate instead of using the function itself as a truthy value... Python...
