### PR TITLE
added support for resource based policies in secretsmanager

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -232,7 +232,8 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         secret_id = request["SecretId"]
         self._raise_if_invalid_secret_id(secret_id)
         backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
-        backend.put_resource_policy(request["SecretId"], request["ResourcePolicy"])
+        arn, name = backend.put_resource_policy(secret_id, request["ResourcePolicy"])
+        return PutResourcePolicyResponse(ARN=arn, Name=name)
 
     @handler("PutSecretValue", expand=False)
     def put_secret_value(

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -6,13 +6,14 @@ import re
 import time
 from typing import Final, Optional, Union
 
+from botocore.utils import InvalidArnException
 from moto.iam.policy_validation import IAMPolicyDocumentValidator
 from moto.secretsmanager import secretsmanager_backends
 from moto.secretsmanager import utils as secretsmanager_utils
 from moto.secretsmanager.exceptions import SecretNotFoundException as MotoSecretNotFoundException
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
 from moto.secretsmanager.responses import SecretsManagerResponse
-from botocore.utils import InvalidArnException
+
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.secretsmanager import (
     CancelRotateSecretRequest,

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -7,6 +7,7 @@ import time
 from typing import Final, Optional, Union
 
 from moto.iam.policy_validation import IAMPolicyDocumentValidator
+from moto.secretsmanager import secretsmanager_backends
 from moto.secretsmanager import utils as secretsmanager_utils
 from moto.secretsmanager.exceptions import SecretNotFoundException as MotoSecretNotFoundException
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
@@ -105,6 +106,21 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         apply_patches()
 
     @staticmethod
+    def _check_is_arn(name_or_arn: str):
+        return ":" in name_or_arn
+
+    @staticmethod
+    def get_moto_backend_for_resource(
+        name_or_arn: str, context: RequestContext
+    ) -> SecretsManagerBackend:
+        if SecretsmanagerProvider._check_is_arn(name_or_arn):
+            arn_data = arns.parse_arn(name_or_arn)
+            backend = secretsmanager_backends[arn_data["account"]][arn_data["region"]]
+        else:
+            backend = secretsmanager_backends[context.account_id][context.region]
+        return backend
+
+    @staticmethod
     def _validate_secret_id(secret_id: SecretIdType) -> bool:
         # The secret name can contain ASCII letters, numbers, and the following characters: /_+=.@-
         return bool(re.match(r"^[A-Za-z0-9/_+=.@-]+\Z", secret_id))
@@ -173,15 +189,24 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def describe_secret(
         self, context: RequestContext, request: DescribeSecretRequest
     ) -> DescribeSecretResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id: str = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        try:
+            secret = backend.describe_secret(secret_id)
+        except MotoSecretNotFoundException:
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret.")
+        return DescribeSecretResponse(**secret.to_dict() if secret else {})
 
     @handler("GetResourcePolicy", expand=False)
     def get_resource_policy(
         self, context: RequestContext, request: GetResourcePolicyRequest
     ) -> GetResourcePolicyResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        policy = backend.get_resource_policy(secret_id)
+        return GetResourcePolicyResponse(**json.loads(policy))
 
     @handler("GetSecretValue", expand=False)
     def get_secret_value(
@@ -194,15 +219,20 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def list_secret_version_ids(
         self, context: RequestContext, request: ListSecretVersionIdsRequest
     ) -> ListSecretVersionIdsResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        secrets = backend.list_secret_version_ids(secret_id)
+        return ListSecretVersionIdsResponse(**json.loads(secrets))
 
     @handler("PutResourcePolicy", expand=False)
     def put_resource_policy(
         self, context: RequestContext, request: PutResourcePolicyRequest
     ) -> PutResourcePolicyResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        backend.put_resource_policy(request["SecretId"], request["ResourcePolicy"])
 
     @handler("PutSecretValue", expand=False)
     def put_secret_value(
@@ -250,13 +280,19 @@ class SecretsmanagerProvider(SecretsmanagerApi):
 
     @handler("TagResource", expand=False)
     def tag_resource(self, context: RequestContext, request: TagResourceRequest) -> None:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        tags = request["Tags"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        backend.tag_resource(secret_id, tags)
 
     @handler("UntagResource", expand=False)
     def untag_resource(self, context: RequestContext, request: UntagResourceRequest) -> None:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        tag_keys = request.get("TagKeys")
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        backend.untag_resource(secret_id=secret_id, tag_keys=tag_keys)
 
     @handler("UpdateSecret", expand=False)
     def update_secret(

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -193,7 +193,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
             secret = backend.describe_secret(secret_id)
         except MotoSecretNotFoundException:
             raise ResourceNotFoundException("Secrets Manager can't find the specified secret.")
-        return DescribeSecretResponse(**secret.to_dict() if secret else {})
+        return DescribeSecretResponse(**secret.to_dict())
 
     @handler("GetResourcePolicy", expand=False)
     def get_resource_policy(

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2046,3 +2046,91 @@ class TestSecretsManager:
             SecretId=secret_id, SecretString="example-string-to-protect"
         )
         snapshot.match("put-secret-value", response)
+
+
+class TestSecretsManagerMultiAccounts:
+    @markers.aws.validated
+    def test_cross_account_access(self, aws_client, secondary_aws_client, cleanups):
+        # GetSecretValue and PutSecretValue can't be used if the default keys are used
+        principal_arn = secondary_aws_client.sts.get_caller_identity()["Arn"]
+        resource_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": principal_arn},
+                    "Action": ["secretsmanager:*"],
+                    "Resource": "*",
+                }
+            ],
+        }
+
+        secret_name = f"test-secret-{short_uid()}"
+        secret_arn = aws_client.secretsmanager.create_secret(
+            Name=secret_name,
+            SecretString="secret",
+        )["ARN"]
+
+        cleanups.append(
+            lambda: aws_client.secretsmanager.delete_secret(
+                SecretId=secret_name, ForceDeleteWithoutRecovery=True
+            )
+        )
+
+        aws_client.secretsmanager.put_resource_policy(
+            SecretId=secret_arn, ResourcePolicy=json.dumps(resource_policy)
+        )
+
+        # try to access the secret from the secondary account without the resource policy
+        response = secondary_aws_client.secretsmanager.describe_secret(SecretId=secret_arn)
+        assert response["ARN"] == secret_arn
+
+        # try to add resource policy from the secondary account
+        policy = resource_policy
+        policy["Statement"][0]["Sid"] = "AllowCrossAccount"
+        secondary_aws_client.secretsmanager.put_resource_policy(
+            SecretId=secret_arn, ResourcePolicy=json.dumps(policy)
+        )
+
+        # try to get the resource policy from the secondary account
+        response = secondary_aws_client.secretsmanager.get_resource_policy(SecretId=secret_arn)
+        assert json.loads(response["ResourcePolicy"])["Statement"][0]["Sid"] == "AllowCrossAccount"
+
+        # try to access the secret version ids from the secondary account
+        response = secondary_aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_arn)
+        assert len(response["Versions"]) == 1
+
+        # should not list the secret from the primary account
+        response = secondary_aws_client.secretsmanager.list_secrets()
+        assert len(response["SecretList"]) == 0
+
+        # set tags from the secondary account
+        secondary_aws_client.secretsmanager.tag_resource(
+            SecretId=secret_arn, Tags=[{"Key": "tag1", "Value": "value1"}]
+        )
+
+        # get tags from the primary account
+        response = aws_client.secretsmanager.describe_secret(SecretId=secret_arn)
+        assert response["Tags"] == [{"Key": "tag1", "Value": "value1"}]
+
+        # set tags from the secondary account
+        secondary_aws_client.secretsmanager.untag_resource(SecretId=secret_arn, TagKeys=["tag1"])
+
+        # get tags from the primary account
+        # Note: when removing tags, the response will be empty list in case of AWS,
+        # but it will be None in Localstack. To avoid failing the test, we will use the default value as list
+        poll_condition(
+            lambda: aws_client.secretsmanager.describe_secret(SecretId=secret_arn).get("Tags", [])
+            == [],
+            timeout=5.0,
+            interval=0.5,
+        )
+
+        secondary_aws_client.secretsmanager.delete_secret(
+            SecretId=secret_arn, ForceDeleteWithoutRecovery=True
+        )
+        poll_condition(
+            lambda: secondary_aws_client.secretsmanager.list_secrets()["SecretList"] == [],
+            timeout=5.0,
+            interval=0.5,
+        )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -3982,5 +3982,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_resource_policy": {
+    "recorded-date": "19-03-2024, 14:42:34",
+    "recorded-content": {
+      "put_resource_policy": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_resource_policy": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResourcePolicy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "secretsmanager:GetSecretValue",
+              "Resource": "*"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -78,7 +78,7 @@
     "last_validated_date": "2024-03-15T08:12:26+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_resource_policy": {
-    "last_validated_date": "2024-03-15T08:12:02+00:00"
+    "last_validated_date": "2024-03-19T14:42:34+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_invalid_lambda_arn": {
     "last_validated_date": "2024-03-15T10:11:13+00:00"
@@ -86,14 +86,14 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
     "last_validated_date": "2024-03-15T08:12:22+00:00"
   },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
-    "last_validated_date": "2024-03-15T08:14:33+00:00"
-  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
     "last_validated_date": "2024-03-14T21:03:56+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
     "last_validated_date": "2024-03-14T21:03:47+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
+    "last_validated_date": "2024-03-15T08:14:33+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists_snapshots": {
     "last_validated_date": "2024-03-15T08:14:55+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -124,5 +124,8 @@
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_return_type": {
     "last_validated_date": "2024-03-15T08:12:50+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManagerMultiAccounts::test_cross_account_access": {
+    "last_validated_date": "2024-03-18T05:54:28+00:00"
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -1,98 +1,128 @@
 {
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_call_lists_secrets_multiple_times": {
-    "last_validated_date": "2022-08-09T14:47:36+00:00"
+    "last_validated_date": "2024-03-15T08:11:53+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_call_lists_secrets_multiple_times_snapshots": {
     "last_validated_date": "2022-09-28T08:06:28+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_can_recreate_delete_secret": {
-    "last_validated_date": "2022-09-28T08:17:08+00:00"
+    "last_validated_date": "2024-03-15T08:13:48+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name-a1b2]": {
-    "last_validated_date": "2023-04-14T14:43:18+00:00"
+    "last_validated_date": "2024-03-15T08:11:46+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name-a1b2c3-]": {
-    "last_validated_date": "2023-04-14T14:43:20+00:00"
+    "last_validated_date": "2024-03-15T08:11:48+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name]": {
-    "last_validated_date": "2023-04-14T14:43:15+00:00"
+    "last_validated_date": "2024-03-15T08:11:45+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[s-c64bdc03]": {
-    "last_validated_date": "2023-04-14T14:43:13+00:00"
+    "last_validated_date": "2024-03-15T08:11:43+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_multi_secrets": {
-    "last_validated_date": "2022-08-09T14:48:10+00:00"
+    "last_validated_date": "2024-03-15T08:12:00+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_multi_secrets_snapshot": {
     "last_validated_date": "2022-09-28T08:10:00+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_version_from_empty_secret": {
-    "last_validated_date": "2023-09-05T20:19:06+00:00"
+    "last_validated_date": "2024-03-15T08:14:58+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_delete_non_existent_secret_returns_as_if_secret_exists": {
+    "last_validated_date": "2024-03-15T08:13:15+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
-    "last_validated_date": "2022-09-28T08:16:20+00:00"
+    "last_validated_date": "2024-03-15T08:13:16+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
+    "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
-    "last_validated_date": "2022-09-28T08:11:37+00:00"
+    "last_validated_date": "2024-03-15T08:12:44+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv Name]": {
-    "last_validated_date": "2022-09-28T08:11:27+00:00"
+    "last_validated_date": "2024-03-15T08:12:35+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv*Name? ]": {
-    "last_validated_date": "2022-09-28T08:11:32+00:00"
+    "last_validated_date": "2024-03-15T08:12:39+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[Inv Name]": {
-    "last_validated_date": "2022-09-28T08:11:22+00:00"
+    "last_validated_date": "2024-03-15T08:12:30+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_accessed_date": {
+    "last_validated_date": "2024-03-15T08:12:46+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_updated_date": {
+    "last_validated_date": "2024-03-15T08:12:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
-    "last_validated_date": "2023-05-12T10:09:22+00:00"
+    "last_validated_date": "2024-03-15T08:14:56+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[PutSecretValue]": {
-    "last_validated_date": "2023-05-12T10:09:24+00:00"
+    "last_validated_date": "2024-03-15T08:14:58+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[RotateSecret]": {
-    "last_validated_date": "2023-05-12T10:09:23+00:00"
+    "last_validated_date": "2024-03-15T08:14:57+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[UpdateSecret]": {
-    "last_validated_date": "2023-05-12T10:09:23+00:00"
+    "last_validated_date": "2024-03-15T08:14:57+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_non_versioning_version_stages_no_replacement": {
-    "last_validated_date": "2022-09-28T08:15:24+00:00"
+    "last_validated_date": "2024-03-15T08:13:15+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_non_versioning_version_stages_replacement": {
-    "last_validated_date": "2022-09-28T08:14:57+00:00"
+    "last_validated_date": "2024-03-15T08:13:14+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_put_secret_value_with_version_stages": {
-    "last_validated_date": "2022-09-28T08:10:50+00:00"
+    "last_validated_date": "2024-03-15T08:12:26+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_resource_policy": {
+    "last_validated_date": "2024-03-15T08:12:02+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_invalid_lambda_arn": {
+    "last_validated_date": "2024-03-15T10:11:13+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
+    "last_validated_date": "2024-03-15T08:12:22+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
+    "last_validated_date": "2024-03-15T08:14:33+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
+    "last_validated_date": "2024-03-14T21:03:56+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
+    "last_validated_date": "2024-03-14T21:03:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists_snapshots": {
-    "last_validated_date": "2022-10-27T15:29:07+00:00"
+    "last_validated_date": "2024-03-15T08:14:55+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_not_found": {
-    "last_validated_date": "2022-09-28T08:05:07+00:00"
+    "last_validated_date": "2024-03-15T08:11:49+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_description": {
-    "last_validated_date": "2022-09-28T08:12:12+00:00"
+    "last_validated_date": "2024-03-15T08:12:49+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending": {
-    "last_validated_date": "2022-09-28T08:13:21+00:00"
+    "last_validated_date": "2024-03-15T08:13:02+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle": {
-    "last_validated_date": "2022-09-28T08:13:41+00:00"
+    "last_validated_date": "2024-03-15T08:13:05+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_1": {
-    "last_validated_date": "2022-09-28T08:14:08+00:00"
+    "last_validated_date": "2024-03-15T08:13:07+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_2": {
-    "last_validated_date": "2022-09-28T08:14:32+00:00"
+    "last_validated_date": "2024-03-15T08:13:10+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_3": {
+    "last_validated_date": "2024-03-15T08:13:13+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_previous": {
-    "last_validated_date": "2022-09-28T08:13:01+00:00"
+    "last_validated_date": "2024-03-15T08:13:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_return_type": {
-    "last_validated_date": "2022-09-28T08:12:32+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManagerMultiAccounts::test_cross_account_access": {
-    "last_validated_date": "2024-03-13T13:32:57+00:00"
+    "last_validated_date": "2024-03-15T08:12:50+00:00"
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -1,128 +1,98 @@
 {
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_call_lists_secrets_multiple_times": {
-    "last_validated_date": "2024-03-15T08:11:53+00:00"
+    "last_validated_date": "2022-08-09T14:47:36+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_call_lists_secrets_multiple_times_snapshots": {
     "last_validated_date": "2022-09-28T08:06:28+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_can_recreate_delete_secret": {
-    "last_validated_date": "2024-03-15T08:13:48+00:00"
+    "last_validated_date": "2022-09-28T08:17:08+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name-a1b2]": {
-    "last_validated_date": "2024-03-15T08:11:46+00:00"
+    "last_validated_date": "2023-04-14T14:43:18+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name-a1b2c3-]": {
-    "last_validated_date": "2024-03-15T08:11:48+00:00"
+    "last_validated_date": "2023-04-14T14:43:20+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[Valid/_+=.@-Name]": {
-    "last_validated_date": "2024-03-15T08:11:45+00:00"
+    "last_validated_date": "2023-04-14T14:43:15+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_and_update_secret[s-c64bdc03]": {
-    "last_validated_date": "2024-03-15T08:11:43+00:00"
+    "last_validated_date": "2023-04-14T14:43:13+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_multi_secrets": {
-    "last_validated_date": "2024-03-15T08:12:00+00:00"
+    "last_validated_date": "2022-08-09T14:48:10+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_multi_secrets_snapshot": {
     "last_validated_date": "2022-09-28T08:10:00+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_version_from_empty_secret": {
-    "last_validated_date": "2024-03-15T08:14:58+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_delete_non_existent_secret_returns_as_if_secret_exists": {
-    "last_validated_date": "2024-03-15T08:13:15+00:00"
+    "last_validated_date": "2023-09-05T20:19:06+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
-    "last_validated_date": "2024-03-15T08:13:16+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
-    "last_validated_date": "2024-03-15T08:12:01+00:00"
+    "last_validated_date": "2022-09-28T08:16:20+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
-    "last_validated_date": "2024-03-15T08:12:44+00:00"
+    "last_validated_date": "2022-09-28T08:11:37+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv Name]": {
-    "last_validated_date": "2024-03-15T08:12:35+00:00"
+    "last_validated_date": "2022-09-28T08:11:27+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv*Name? ]": {
-    "last_validated_date": "2024-03-15T08:12:39+00:00"
+    "last_validated_date": "2022-09-28T08:11:32+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[Inv Name]": {
-    "last_validated_date": "2024-03-15T08:12:30+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_accessed_date": {
-    "last_validated_date": "2024-03-15T08:12:46+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_updated_date": {
-    "last_validated_date": "2024-03-15T08:12:47+00:00"
+    "last_validated_date": "2022-09-28T08:11:22+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
-    "last_validated_date": "2024-03-15T08:14:56+00:00"
+    "last_validated_date": "2023-05-12T10:09:22+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[PutSecretValue]": {
-    "last_validated_date": "2024-03-15T08:14:58+00:00"
+    "last_validated_date": "2023-05-12T10:09:24+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[RotateSecret]": {
-    "last_validated_date": "2024-03-15T08:14:57+00:00"
+    "last_validated_date": "2023-05-12T10:09:23+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[UpdateSecret]": {
-    "last_validated_date": "2024-03-15T08:14:57+00:00"
+    "last_validated_date": "2023-05-12T10:09:23+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_non_versioning_version_stages_no_replacement": {
-    "last_validated_date": "2024-03-15T08:13:15+00:00"
+    "last_validated_date": "2022-09-28T08:15:24+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_non_versioning_version_stages_replacement": {
-    "last_validated_date": "2024-03-15T08:13:14+00:00"
+    "last_validated_date": "2022-09-28T08:14:57+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_put_secret_value_with_version_stages": {
-    "last_validated_date": "2024-03-15T08:12:26+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_resource_policy": {
-    "last_validated_date": "2024-03-15T08:12:02+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_invalid_lambda_arn": {
-    "last_validated_date": "2024-03-15T10:11:13+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success": {
-    "last_validated_date": "2024-03-15T08:12:22+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists": {
-    "last_validated_date": "2024-03-15T08:14:33+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[None]": {
-    "last_validated_date": "2024-03-14T21:03:56+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_rotate_secret_with_lambda_success[True]": {
-    "last_validated_date": "2024-03-14T21:03:47+00:00"
+    "last_validated_date": "2022-09-28T08:10:50+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_exists_snapshots": {
-    "last_validated_date": "2024-03-15T08:14:55+00:00"
+    "last_validated_date": "2022-10-27T15:29:07+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_not_found": {
-    "last_validated_date": "2024-03-15T08:11:49+00:00"
+    "last_validated_date": "2022-09-28T08:05:07+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_description": {
-    "last_validated_date": "2024-03-15T08:12:49+00:00"
+    "last_validated_date": "2022-09-28T08:12:12+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending": {
-    "last_validated_date": "2024-03-15T08:13:02+00:00"
+    "last_validated_date": "2022-09-28T08:13:21+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle": {
-    "last_validated_date": "2024-03-15T08:13:05+00:00"
+    "last_validated_date": "2022-09-28T08:13:41+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_1": {
-    "last_validated_date": "2024-03-15T08:13:07+00:00"
+    "last_validated_date": "2022-09-28T08:14:08+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_2": {
-    "last_validated_date": "2024-03-15T08:13:10+00:00"
-  },
-  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_pending_cycle_custom_stages_3": {
-    "last_validated_date": "2024-03-15T08:13:13+00:00"
+    "last_validated_date": "2022-09-28T08:14:32+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_current_previous": {
-    "last_validated_date": "2024-03-15T08:13:01+00:00"
+    "last_validated_date": "2022-09-28T08:13:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_version_stages_return_type": {
-    "last_validated_date": "2024-03-15T08:12:50+00:00"
+    "last_validated_date": "2022-09-28T08:12:32+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManagerMultiAccounts::test_cross_account_access": {
+    "last_validated_date": "2024-03-13T13:32:57+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This Pull Request introduces support for resource-based policies in `secretsmanager`.


**Supported APIS**
- `DescribeSecret`
- `GetResourcePolicy`
- `ListSecretVersionIds`
- `PutResourcePolicy`
- `TagResource`
- `UntagResource`


<!-- What notable changes does this PR make? -->
## Changes
We now return data for resources that are in other account based on the `ARN` provided.
- NOTE: IAM enforcement is supported in LocalStack PRO - which means we are not testing against unauthorized resource access in Community version.

## Testing
Added aws validated test cases to access secretsmanager from cross-account.