### PR TITLE
fix test selection for community contributions

### DIFF
--- a/localstack/testing/testselection/github.py
+++ b/localstack/testing/testselection/github.py
@@ -6,7 +6,9 @@ def get_pr_details(repo_name: str, pr_number: str, token: str) -> (str, str):
     Fetch the base commit SHA, and the head commit SHA of a given pull request number from a GitHub repository.
     """
     url = f"https://api.github.com/repos/{repo_name}/pulls/{pr_number}"
-    headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json"}
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
     pr_data = requests.get(url, headers=headers).json()
     return pr_data["base"]["sha"], pr_data["head"]["sha"]
 

--- a/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
+++ b/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
@@ -2,6 +2,7 @@
 USAGE: $ GITHUB_API_TOKEN=<your-token> python -m localstack.testing.testselection.scripts.generate_test_selection_from_pr <git-root-dir> <pull-request-url> <output-file-path>
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -23,9 +24,7 @@ def main():
     pull_request_url = sys.argv[-2]
     repo_root_path = sys.argv[-3]
 
-    # TODO change to the right env var again
-    # github_token = os.environ.get("GITHUB_API_TOKEN")
-    github_token = None
+    github_token = os.environ.get("GITHUB_API_TOKEN")
 
     base_commit_sha, head_commit_sha = get_pr_details_from_url(pull_request_url, github_token)
     print(f"Pull request: {pull_request_url}")

--- a/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
+++ b/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
@@ -24,7 +24,7 @@ def main():
     pull_request_url = sys.argv[-2]
     repo_root_path = sys.argv[-3]
 
-    github_token = os.environ["GITHUB_API_TOKEN"]
+    github_token = os.environ.get("GITHUB_API_TOKEN")
 
     base_commit_sha, head_commit_sha = get_pr_details_from_url(pull_request_url, github_token)
     print(f"Pull request: {pull_request_url}")

--- a/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
+++ b/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
@@ -2,7 +2,6 @@
 USAGE: $ GITHUB_API_TOKEN=<your-token> python -m localstack.testing.testselection.scripts.generate_test_selection_from_pr <git-root-dir> <pull-request-url> <output-file-path>
 """
 
-import os
 import sys
 from pathlib import Path
 
@@ -24,7 +23,9 @@ def main():
     pull_request_url = sys.argv[-2]
     repo_root_path = sys.argv[-3]
 
-    github_token = os.environ.get("GITHUB_API_TOKEN")
+    # TODO change to the right env var again
+    # github_token = os.environ.get("GITHUB_API_TOKEN")
+    github_token = None
 
     base_commit_sha, head_commit_sha = get_pr_details_from_url(pull_request_url, github_token)
     print(f"Pull request: {pull_request_url}")


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10301 introduced a dynamic test selection based on the touched service code.
Unfortunately, this just broke the pipeline of https://github.com/localstack/localstack/pull/10116 (a community contribution) because it expects a `GITHUB_API_TOKEN` which is a secret not being set for PRs coming from forks.

I tested the call to retrieve the PR data locally:
```
curl -v https://api.github.com/repos/localstack/localstack/pulls/10116
```
This call is successful without an auth token.
However, this could be flaky if these runners and their IP are used for a lot of unauthenticated GitHub API calls.

## Changes
- Make it optional to use the auth token, just send an unauthenticated request in case the token is not available.

## Testing
- Test if the execution works without the GitHub token with the last commit: 1a5a10394eb8ca0e04e9296b3927ac3f1d21a1eb

## TODO
- [x] Revert the last commit used for testing.

