### PR TITLE
use ThreadPoolExecutor to forward DDB Streams events

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -190,7 +190,7 @@ def dynamodb_table_exists(table_name: str, client=None):
 
 
 class EventForwarder:
-    def __init__(self, num_thread: int = 20):
+    def __init__(self, num_thread: int = 10):
         self.executor = ThreadPoolExecutor(num_thread, thread_name_prefix="ddb_stream_fwd")
 
     def shutdown(self):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #10415

We previously spawned a thread for each incoming request, which resulted in a somewhat unbounded amount of threads being spawn when running benchmarks.

We could see this kind of error in logs:
```python
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
    [...]
    raise ConnectionClosedError(
botocore.exceptions.ConnectionClosedError: Connection was closed before we received a valid response from endpoint URL: "http://localhost:4566/".

2024-03-15T01:11:04.444  INFO --- [.reactor-120] localstack.request.aws     : AWS dynamodb.BatchWriteItem => 200
2024-03-15T01:11:16.509  WARN --- [uncthread379] urllib3.connectionpool     : Connection pool is full, discarding connection: localhost. Connection pool size: 150
2024-03-15T01:11:16.610  WARN --- [uncthread380] urllib3.connectionpool     : Connection pool is full, discarding connection: localhost. Connection pool size: 150
2024-03-15T01:11:16.710  WARN --- [uncthread381] urllib3.connectionpool     : Connection pool is full, discarding connection: localhost. Connection pool size: 150
2024-03-15T01:11:16.809  WARN --- [uncthread382] urllib3.connectionpool     : Connection pool is full, discarding connection: localhost. Connection pool size: 150
2024-03-15T01:11:16.916  WARN --- [uncthread383] urllib3.connectionpool     : Connection pool is full, discarding connection: localhost. Connection pool size: 150
```

<!-- What notable changes does this PR make? -->
## Changes
Make use of a `ThreadPoolExecutor`, with a small number of thread, regulating the amount of outbound requests to Kinesis. The "cold start" of a thread in the executor is rather slow, around 0.5ms for me. Once all threads have been spawned, it takes less than 0.03ms, improving the overall performance (only slightly for small amount of items, but by a good amount of big amount of items, due to the onslaught of concurrent requests with the threads).
This might actually slow down the delivery of Kinesis records, but as of now, those records wouldn't even be delivered. 

## Benchmarks

It is the same as Scenario 2 from #10415, but with 1000 requests each. 

| DDB Streams | `latest` with Twisted | Fix & Twisted
| --- | --- | --- |
| **Throughput** (higher is better) |  |  | 
| `PutItem` throughput item/s | 224.66 | 231.41
| `BatchWriteItem (25)` throughput item/s | 2589.46 | 3701.11
| **Total time** (lower is better) |  |  | 
| `PutItem` total seconds (1000 items) | 4.4511 | 4.3214
| `BatchWriteItem (25)` total seconds (25k items) | 9.6545 | 6.7547

| Kinesis | `latest` with Twisted | Fix & Twisted
| --- | --- | --- |
| **Throughput** (higher is better) |  |  | 
| `PutItem` throughput item/s | 227.77 | 232.61
| `BatchWriteItem (25)` throughput item/s | 3102.02 | 4238.63
| **Total time** (lower is better) |  |  | 
| `PutItem` total seconds (1000 items) | 4.3904 | 4.2990
| `BatchWriteItem (25)` total seconds (25k items) | 8.0593 | 5.8981

We can see an improvement of around 30 to 50% for `BatchWriteItem`, and very minimal for `PutItem`, around 5%. 