### PR TITLE
fix invalidating S3 CORS cache after resetting state or loading

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -315,6 +315,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def on_before_state_save(self):
         self._storage_backend.flush()
 
+    def on_after_state_reset(self):
+        self._cors_handler.invalidate_cache()
+
+    def on_after_state_load(self):
+        self._cors_handler.invalidate_cache()
+
     def on_before_stop(self):
         self._notification_dispatcher.shutdown()
         self._storage_backend.close()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by @cabeaulac and @webdev51, we had an issue with CORS when restoring S3 state which would go away if you would create a new bucket. This is because we did not invalidate the S3 CORS cache after loading the state, so it would not be aware of any bucket loaded with the state. 

<!-- What notable changes does this PR make? -->
## Changes
- add a call to invalidate the CORS cache in the `on_after_state_reset` and `on_after_state_load` hooks. 

## Testing
The provided steps to replicate the issues:

- first state LocalStack with Pro
```bash
$ awslocal s3 mb s3://test
$ curl -I -H "Origin: https://app.localstack.cloud" https://localhost.localstack.cloud:4566/test
HTTP/2 200 
content-type: application/xml
access-control-allow-origin: https://app.localstack.cloud
access-control-allow-credentials: true
access-control-allow-methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH
access-control-allow-headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request
access-control-expose-headers: etag,x-amz-version-id
vary: Origin
x-amz-bucket-region: us-east-1
x-amz-request-id: cb96a4fe-cad2-4f8e-82ca-a535a235f158
x-amz-id-2: s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=
content-length: 0
date: Sat, 16 Mar 2024 22:34:23 GMT
server: hypercorn-h2
# we can see CORS headers are present
$ localstack state export test-s3-cors.zip
# now restart LocalStack
# this is needed to load the S3 service before importing the state, which will initialize the CORS cache
$ awslocal s3 list-buckets
$ localstack state import test-s3-cors.zip
$ curl -I -H "Origin: https://app.localstack.cloud" https://localhost.localstack.cloud:4566/test
HTTP/2 200 
content-type: application/xml
x-amz-bucket-region: us-east-1
x-amz-request-id: b7aa96d2-9354-4f13-b0ee-14f411e24143
x-amz-id-2: s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=
content-length: 0
date: Sat, 16 Mar 2024 22:29:04 GMT
server: hypercorn-h2
# now the CORS headers are gone, because the request was not properly detected as an S3 request by the special S3 CORS handler, as the bucket would not exist in its cache
```

With the fix, reusing the same created state:
```bash
# start LocalStack
$ awslocal s3 list-buckets
$ localstack state import test-s3-cors.zip
$ curl -I -H "Origin: https://app.localstack.cloud" https://localhost.localstack.cloud:4566/test
HTTP/2 200 
content-type: application/xml
access-control-allow-origin: https://app.localstack.cloud
access-control-allow-credentials: true
access-control-allow-methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH
access-control-allow-headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request
access-control-expose-headers: etag,x-amz-version-id
vary: Origin
x-amz-bucket-region: us-east-1
x-amz-request-id: 0ddc35b7-372c-4aff-b491-84e97e505b68
x-amz-id-2: s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=
content-length: 0
date: Sat, 16 Mar 2024 22:34:23 GMT
server: hypercorn-h2
```




<!-- The following sections are optional, but can be useful! 
Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

