### PR TITLE
fix and enable several ruff linting rules

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -92,7 +92,7 @@ def _get_allowed_cors_ports() -> Set[int]:
     Construct the list of allowed ports for CORS enforcement purposes
     Defined as function to allow easier testing with monkeypatch of config values
     """
-    return set([host_and_port.port for host_and_port in config.GATEWAY_LISTEN])
+    return {host_and_port.port for host_and_port in config.GATEWAY_LISTEN}
 
 
 _ALLOWED_INTERNAL_PORTS = _get_allowed_cors_ports()

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -238,9 +238,7 @@ class ServiceResponseParser(Handler):
 
         if exception := context.service_exception:
             if isinstance(exception, ServiceException):
-                try:
-                    exception.code
-                except AttributeError:
+                if not hasattr(exception, "code"):
                     # FIXME: we should set the exception attributes in the scaffold when we generate the exceptions.
                     #  this is a workaround for now, since we are not doing that yet, and the attributes may be unset.
                     self._set_exception_attributes(context.operation, exception)

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -846,9 +846,9 @@ class BaseJSONRequestParser(RequestParser, ABC):
         parsed = {}
         key_shape = shape.key
         value_shape = shape.value
-        for key, value in value.items():
+        for key, val in value.items():
             actual_key = self._parse_shape(request, key_shape, key, uri_params)
-            actual_value = self._parse_shape(request, value_shape, value, uri_params)
+            actual_value = self._parse_shape(request, value_shape, val, uri_params)
             parsed[actual_key] = actual_value
         return parsed
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -591,7 +591,7 @@ class UniqueHostAndPortList(List[HostAndPort]):
 
         # if we add 0.0.0.0:<port> and already contain *:<port> then bind on
         # 0.0.0.0
-        contained_ports = set(every.port for every in self)
+        contained_ports = {every.port for every in self}
         if value.host == "0.0.0.0" and value.port in contained_ports:
             for item in self:
                 if item.port == value.port:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1358,6 +1358,7 @@ def service_url(service_key, host=None, port=None):
         """@deprecated: Use `internal_service_url()` instead. We assume that most usages are
         internal but really need to check and update each usage accordingly.""",
         DeprecationWarning,
+        stacklevel=2,
     )
     return internal_service_url(host=host, port=port)
 
@@ -1369,6 +1370,7 @@ def service_port(service_key: str, external: bool = False) -> int:
         "Deprecated: use `localstack_host().port` for external and `GATEWAY_LISTEN[0].port` for "
         "internal use.",
         DeprecationWarning,
+        stacklevel=2,
     )
     if external:
         return LOCALSTACK_HOST.port
@@ -1384,6 +1386,7 @@ def get_edge_port_http():
         for internal use. This function is also not needed anymore because we don't separate
         between HTTP and HTTP ports anymore since LocalStack listens to both.""",
         DeprecationWarning,
+        stacklevel=2,
     )
     return GATEWAY_LISTEN[0].port
 
@@ -1397,6 +1400,7 @@ def get_edge_url(localstack_hostname=None, protocol=None):
     We assume that most usages are internal but really need to check and update each usage accordingly.
     """,
         DeprecationWarning,
+        stacklevel=2,
     )
     return internal_service_url(host=localstack_hostname, protocol=protocol)
 

--- a/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack/services/cloudformation/scaffolding/__main__.py
@@ -69,7 +69,7 @@ def resolve_ref(schema: ResourceSchema, target: str) -> dict:
     """
     Given a schema {"a": {"b": "c"}} and the ref "#/a/b" return "c"
     """
-    target_path = filter(None, map(lambda elem: elem.strip(), target.lstrip("#").split("/")))
+    target_path = filter(None, (elem.strip() for elem in target.lstrip("#").split("/")))
 
     T = TypeVar("T")
 

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -657,7 +657,7 @@ def events_handler_put_events(self):
     if config.is_local_test_mode():
         TEST_EVENTS_CACHE.extend(entries)
 
-    events = list(map(lambda event: {"event": event, "uuid": str(long_uid())}, entries))
+    events = [{"event": event, "uuid": str(long_uid())} for event in entries]
 
     _dump_events_to_files(events)
 
@@ -714,7 +714,7 @@ def events_handler_put_events(self):
 
     content = {
         "FailedEntryCount": 0,  # TODO: dynamically set proper value when refactoring
-        "Entries": list(map(lambda event: {"EventId": event["uuid"]}, events)),
+        "Entries": [{"EventId": event["uuid"]} for event in events],
     }
 
     self.response_headers.update(

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -160,7 +160,7 @@ class CloudFormationUi:
             "stackName": "stack1",
             "templateBody": "{}",
             "errorMessage": "''",
-            "regions": json.dumps(sorted(list(get_valid_regions()))),
+            "regions": json.dumps(sorted(get_valid_regions())),
         }
 
         download_url = req_params.get("templateURL")

--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -65,12 +65,10 @@ HOT_RELOADING_ENV_VARIABLE = "LOCALSTACK_HOT_RELOADING_PATHS"
 
 
 """Map AWS Lambda architecture to Docker platform flags. Example: arm64 => linux/arm64"""
-ARCHITECTURE_PLATFORM_MAPPING: dict[Architecture, DockerPlatform] = dict(
-    {
-        Architecture.x86_64: DockerPlatform.linux_amd64,
-        Architecture.arm64: DockerPlatform.linux_arm64,
-    }
-)
+ARCHITECTURE_PLATFORM_MAPPING: dict[Architecture, DockerPlatform] = {
+    Architecture.x86_64: DockerPlatform.linux_amd64,
+    Architecture.arm64: DockerPlatform.linux_arm64,
+}
 
 
 def docker_platform(lambda_architecture: Architecture) -> DockerPlatform | None:

--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -416,7 +416,7 @@ def moto_filter_log_events(
 ):
     # moto currently raises an exception if filter_patterns is None, so we skip it
     events = filter_log_events(
-        self, start_time=start_time, end_time=end_time, filter_pattern=None, *args, **kwargs
+        self, *args, start_time=start_time, end_time=end_time, filter_pattern=None, **kwargs
     )
 
     if not filter_pattern:

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -89,7 +89,7 @@ def init_directories(dirs: Directories):
     chmod_r(dirs.backup, 0o777)
 
     # clear potentially existing lock files (which cause problems since ES 7.10)
-    for d, dirs, files in os.walk(dirs.data, True):
+    for d, _, files in os.walk(dirs.data, True):
         for f in files:
             if f.endswith(".lock"):
                 rm_rf(os.path.join(d, f))

--- a/localstack/services/s3/validation.py
+++ b/localstack/services/s3/validation.py
@@ -276,7 +276,7 @@ def validate_website_configuration(website_config: WebsiteConfiguration) -> None
         if len(routing_rules) == 0:
             raise MalformedXML()
         if len(routing_rules) > 50:
-            raise "Something?"
+            raise ValueError("Too many routing rules")  # TODO: correct exception
         for routing_rule in routing_rules:
             redirect = routing_rule.get("Redirect", {})
             # todo: this does not raise an error? check what GetWebsiteConfig returns? empty field?

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -213,16 +213,13 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     )
 
             if is_fifo := (".fifo" in topic_arn):
-                if not all(["MessageGroupId" in entry for entry in publish_batch_request_entries]):
+                if not all("MessageGroupId" in entry for entry in publish_batch_request_entries):
                     raise InvalidParameterException(
                         "Invalid parameter: The MessageGroupId parameter is required for FIFO topics"
                     )
                 if moto_topic.content_based_deduplication == "false":
                     if not all(
-                        [
-                            "MessageDeduplicationId" in entry
-                            for entry in publish_batch_request_entries
-                        ]
+                        "MessageDeduplicationId" in entry for entry in publish_batch_request_entries
                     ):
                         raise InvalidParameterException(
                             "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",

--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -126,7 +126,7 @@ class SsmProvider(SsmApi, ABC):
         if SsmProvider._has_secrets(names):
             return SsmProvider._get_params_and_secrets(context.account_id, context.region, names)
 
-        norm_names = list([SsmProvider._normalize_name(name, validate=True) for name in names])
+        norm_names = [SsmProvider._normalize_name(name, validate=True) for name in names]
         request = {"Names": norm_names, "WithDecryption": bool(with_decryption)}
         res = call_moto_with_request(context, request)
 

--- a/localstack/testing/pytest/path_filter.py
+++ b/localstack/testing/pytest/path_filter.py
@@ -56,11 +56,11 @@ def pytest_collection_modifyitems(config, items):
             return  # No filtering if the list is empty => full test suite
 
         # this is technically redundant since we can just add "tests/" instead as a line item. still prefer to be explicit here
-        if any([p == SENTINEL_ALL_TESTS for p in pathfilter_substrings]):
+        if any(p == SENTINEL_ALL_TESTS for p in pathfilter_substrings):
             return  # at least one change should lead to a full run
 
         # technically doesn't even need to be checked since the loop below will take care of it
-        if all([p == SENTINEL_NO_TEST for p in pathfilter_substrings]):
+        if all(p == SENTINEL_NO_TEST for p in pathfilter_substrings):
             items[:] = []
             #  we only got sentinal values that signal a change that doesn't need to be tested, so delesect all
             config.hook.pytest_deselected(items=items)

--- a/localstack/testing/scenario/cdk_lambda_helper.py
+++ b/localstack/testing/scenario/cdk_lambda_helper.py
@@ -19,7 +19,7 @@ def load_python_lambda_to_s3(
     bucket_name: str,
     key_name: str,
     code_path: str,
-    additional_python_packages: list[str] = [],
+    additional_python_packages: list[str] = None,
 ):
     """
     Helper function to setup Lambdas that need additional python libs.
@@ -65,8 +65,8 @@ def load_nodejs_lambda_to_s3(
     bucket_name: str,
     key_name: str,
     code_path: str,
-    additional_nodjs_packages: list[str] = [],
-    additional_resources: list[str] = [],
+    additional_nodjs_packages: list[str] = None,
+    additional_resources: list[str] = None,
 ):
     """
     Helper function to setup nodeJS Lambdas that need additional libs.
@@ -81,6 +81,8 @@ def load_nodejs_lambda_to_s3(
     :param additional_resources: list of path-strings to resources or internal libs that should be packaged into the lambda
     :return: None
     """
+    additional_resources = additional_resources or []
+
     try:
         temp_dir = tempfile.mkdtemp()
         tmp_zip_path = os.path.join(tempfile.gettempdir(), "helper.zip")

--- a/localstack/testing/scenario/provisioning.py
+++ b/localstack/testing/scenario/provisioning.py
@@ -360,6 +360,7 @@ class InfraProvisioner:
         warnings.warn(
             "`add_custom_setup_provisioning_step` is deprecated. Use `add_custom_setup`",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.add_custom_setup(setup_task)
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -52,7 +52,7 @@ class VtlTemplate:
             return template
 
         # fix "#set" commands
-        template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
+        template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, count=re.MULTILINE)
 
         # enable syntax like "test#${foo.bar}"
         empty_placeholder = " __pLaCe-HoLdEr__ "
@@ -60,7 +60,7 @@ class VtlTemplate:
             r"([^\s]+)#\$({)?(.*)",
             r"\1#%s$\2\3" % empty_placeholder,
             template,
-            re.MULTILINE,
+            count=re.MULTILINE,
         )
 
         # add extensions for common string functions below

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -940,7 +940,7 @@ class RunningContainer:
 
     def exec_in_container(self, *args, **kwargs):
         return self.container_client.exec_in_container(
-            container_name_or_id=self.id, *args, **kwargs
+            *args, container_name_or_id=self.id, **kwargs
         )
 
     def stopped(self) -> Container:

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -356,9 +356,9 @@ def validate_localstack_config(name: str):
     # prepare config options
     container_name = ls_service_details.get("container_name") or ""
     docker_ports = (port.split(":")[-2] for port in ls_service_details.get("ports", []))
-    docker_env = dict(
-        (env.split("=")[0], env.split("=")[1]) for env in ls_service_details.get("environment", {})
-    )
+    docker_env = {
+        env.split("=")[0]: env.split("=")[1] for env in ls_service_details.get("environment", {})
+    }
     edge_port = config.GATEWAY_LISTEN[0].port
     main_container = config.MAIN_CONTAINER_NAME
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -603,7 +603,7 @@ class ContainerClient(metaclass=ABCMeta):
     def get_running_container_names(self) -> List[str]:
         """Returns a list of the names of all running containers"""
         result = self.list_containers(all=False)
-        result = list(map(lambda container: container["name"], result))
+        result = [container["name"] for container in result]
         return result
 
     def is_container_running(self, container_name: str) -> bool:

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -129,8 +129,8 @@ def traverse_file_tree(root: str) -> List[str]:
     try:
         result = []
         if config.in_docker():
-            for root, _, _ in os.walk(root):
-                result.append(root)
+            for dirpath, _, _ in os.walk(root):
+                result.append(dirpath)
         return result
     except Exception as e:
         return ["traversing files failed %s" % e]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "E402", # TODO Module level import not at top of file
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black
     "E721", # TODO Do not compare types, use `isinstance()`
-    "F403", # TODO `from localstack.services.cloudformation.models import *` used; unable to detect undefined names
     "T201", # TODO `print` found
     "T203", # TODO `pprint` found
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ ignore = [
     "B027", # TODO `Server.do_shutdown` is an empty method in an abstract base class, but has no abstract decorator
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)
-    "C414", # TODO Unnecessary `list` call within `sorted()`
     "C416", # TODO Unnecessary `set` comprehension
     "C901", # TODO function is too complex
     "E402", # TODO Module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,6 @@ ignore = [
     "C414", # TODO Unnecessary `list` call within `sorted()`
     "C416", # TODO Unnecessary `set` comprehension
     "C417", # TODO Replace `map` with a generator expression
-    "C418", # TODO Unnecessary `dict` literal passed to `dict()` (remove the outer call to `dict()`)
     "C901", # TODO function is too complex
     "E402", # TODO Module level import not at top of file
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ exclude = [
 [tool.ruff.lint]
 ignore = [
     "B005", # TODO Using `.strip()` with multi-character strings is misleading
-    "B006", # TODO Do not use mutable data structures for argument defaults
     "B007", # TODO Loop control variable x not used within loop body
     "B017", # TODO `pytest.raises(Exception)` should be considered evil
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "B028", # TODO No explicit `stacklevel` keyword argument found
     "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-    "C401", # TODO Unnecessary generator (rewrite as a `set` comprehension)
     "C402", # TODO Unnecessary generator (rewrite as a `dict` comprehension)
     "C403", # TODO Unnecessary `list` comprehension (rewrite as a `set` comprehension)
     "C405", # TODO Unnecessary `list` literal (rewrite as a `set` literal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ exclude = [
 
 [tool.ruff.lint]
 ignore = [
-    "B005", # TODO Using `.strip()` with multi-character strings is misleading
     "B007", # TODO Loop control variable x not used within loop body
     "B017", # TODO `pytest.raises(Exception)` should be considered evil
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "B028", # TODO No explicit `stacklevel` keyword argument found
     "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-    "C402", # TODO Unnecessary generator (rewrite as a `dict` comprehension)
     "C403", # TODO Unnecessary `list` comprehension (rewrite as a `set` comprehension)
     "C405", # TODO Unnecessary `list` literal (rewrite as a `set` literal)
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "B028", # TODO No explicit `stacklevel` keyword argument found
     "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-    "C405", # TODO Unnecessary `list` literal (rewrite as a `set` literal)
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)
     "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)
     "C414", # TODO Unnecessary `list` call within `sorted()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ ignore = [
     "B024", # TODO x is an abstract base class, but it has no abstract methods
     "B026", # TODO Star-arg unpacking after a keyword argument is strongly discouraged
     "B027", # TODO `Server.do_shutdown` is an empty method in an abstract base class, but has no abstract decorator
-    "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)
     "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ ignore = [
     "B005", # TODO Using `.strip()` with multi-character strings is misleading
     "B006", # TODO Do not use mutable data structures for argument defaults
     "B007", # TODO Loop control variable x not used within loop body
-    "B011", # TODO Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "B017", # TODO `pytest.raises(Exception)` should be considered evil
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B020", # TODO Loop control variable `invalid_values` overrides iterable it iterates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,11 +188,8 @@ ignore = [
     "B005", # TODO Using `.strip()` with multi-character strings is misleading
     "B006", # TODO Do not use mutable data structures for argument defaults
     "B007", # TODO Loop control variable x not used within loop body
-    "B008", # TODO Do not perform function call `Queue` in argument defaults
     "B011", # TODO Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
-    "B016", # TODO Cannot raise a literal. Did you intend to return it or raise an Exception?
     "B017", # TODO `pytest.raises(Exception)` should be considered evil
-    "B018", # TODO Found useless expression. Either assign it to a variable or remove it.
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B020", # TODO Loop control variable `invalid_values` overrides iterable it iterates
     "B022", # TODO No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and therefore this context manager is redundant
@@ -213,7 +210,6 @@ ignore = [
     "C416", # TODO Unnecessary `set` comprehension
     "C417", # TODO Replace `map` with a generator expression
     "C418", # TODO Unnecessary `dict` literal passed to `dict()` (remove the outer call to `dict()`)
-    "C419", # TODO Unnecessary list comprehension.
     "C901", # TODO function is too complex
     "E402", # TODO Module level import not at top of file
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ ignore = [
     "B007", # TODO Loop control variable x not used within loop body
     "B017", # TODO `pytest.raises(Exception)` should be considered evil
     "B019", # TODO Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-    "B020", # TODO Loop control variable `invalid_values` overrides iterable it iterates
     "B022", # TODO No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and therefore this context manager is redundant
     "B023", # TODO Function definition does not bind loop variable `server`
     "B024", # TODO x is an abstract base class, but it has no abstract methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ ignore = [
     "B024", # TODO x is an abstract base class, but it has no abstract methods
     "B026", # TODO Star-arg unpacking after a keyword argument is strongly discouraged
     "B027", # TODO `Server.do_shutdown` is an empty method in an abstract base class, but has no abstract decorator
-    "B028", # TODO No explicit `stacklevel` keyword argument found
     "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ ignore = [
     "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)
     "C414", # TODO Unnecessary `list` call within `sorted()`
     "C416", # TODO Unnecessary `set` comprehension
-    "C417", # TODO Replace `map` with a generator expression
     "C901", # TODO function is too complex
     "E402", # TODO Module level import not at top of file
     "E501", # E501 Line too long - handled by black, see https://docs.astral.sh/ruff/faq/#is-ruff-compatible-with-black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ ignore = [
     "B027", # TODO `Server.do_shutdown` is an empty method in an abstract base class, but has no abstract decorator
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)
-    "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)
     "C414", # TODO Unnecessary `list` call within `sorted()`
     "C416", # TODO Unnecessary `set` comprehension
     "C901", # TODO function is too complex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "B028", # TODO No explicit `stacklevel` keyword argument found
     "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-    "C403", # TODO Unnecessary `list` comprehension (rewrite as a `set` comprehension)
     "C405", # TODO Unnecessary `list` literal (rewrite as a `set` literal)
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)
     "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,6 @@ ignore = [
     "B022", # TODO No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and therefore this context manager is redundant
     "B023", # TODO Function definition does not bind loop variable `server`
     "B024", # TODO x is an abstract base class, but it has no abstract methods
-    "B026", # TODO Star-arg unpacking after a keyword argument is strongly discouraged
     "B027", # TODO `Server.do_shutdown` is an empty method in an abstract base class, but has no abstract decorator
     "B904", # TODO Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C408", # TODO Unnecessary `list` call (rewrite as a literal)

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -132,7 +132,7 @@ def snapshot(request, _snapshot_session: SnapshotSession, account_id, region_nam
         "tests/aws/scenario/lambda_destination",
         "tests/aws/scenario/loan_broker",
     ]
-    if any([e in request.fspath.dirname for e in exemptions]):
+    if any(e in request.fspath.dirname for e in exemptions):
         _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER, priority=2)
     else:
         _snapshot_session.add_transformer(SNAPSHOT_BASIC_TRANSFORMER_NEW, priority=2)

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -41,7 +41,7 @@ def test_create_change_set_without_parameters(
     try:
         # make sure the change set wasn't executed (which would create a topic)
         topics = aws_client.sns.list_topics()
-        topic_arns = list(map(lambda x: x["TopicArn"], topics["Topics"]))
+        topic_arns = [x["TopicArn"] for x in topics["Topics"]]
         assert not any("sns-topic-simple" in arn for arn in topic_arns)
         # stack is initially in REVIEW_IN_PROGRESS state. only after executing the change_set will it change its status
         stack_response = aws_client.cloudformation.describe_stacks(StackName=stack_id)
@@ -328,7 +328,7 @@ def test_create_change_set_with_ssm_parameter(
         wait_until(is_stack_created(stack_id))
 
         topics = aws_client.sns.list_topics()
-        topic_arns = list(map(lambda x: x["TopicArn"], topics["Topics"]))
+        topic_arns = [x["TopicArn"] for x in topics["Topics"]]
         assert any((parameter_value in t) for t in topic_arns)
     finally:
         cleanup_changesets([change_set_id])
@@ -383,7 +383,7 @@ def test_execute_change_set(
         assert wait_until(is_change_set_finished(change_set_id))
         # check if stack resource was created
         topics = aws_client.sns.list_topics()
-        topic_arns = list(map(lambda x: x["TopicArn"], topics["Topics"]))
+        topic_arns = [x["TopicArn"] for x in topics["Topics"]]
         assert any(("sns-topic-simple" in t) for t in topic_arns)
 
         # new change set name

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -198,7 +198,7 @@ class TestStacksApi:
         ]
         resources_before = len(resources)
         assert resources_before == 3
-        statuses = set([res["ResourceStatus"] for res in resources])
+        statuses = {res["ResourceStatus"] for res in resources}
         assert statuses == {"CREATE_COMPLETE"}
 
         # remove one resource from the template, then update stack (via change set)
@@ -218,7 +218,7 @@ class TestStacksApi:
             "StackResourceSummaries"
         ]
         assert len(resources) == resources_before - 1
-        statuses = set([res["ResourceStatus"] for res in resources])
+        statuses = {res["ResourceStatus"] for res in resources}
         assert statuses == {"UPDATE_COMPLETE"}
 
     @markers.aws.needs_fixing
@@ -579,7 +579,7 @@ def test_events_resource_types(deploy_cfn_template, snapshot, aws_client):
         "StackEvents"
     ]
 
-    resource_types = list(set([event["ResourceType"] for event in events]))
+    resource_types = list({event["ResourceType"] for event in events})
     resource_types.sort()
     snapshot.match("resource_types", resource_types)
 

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -396,7 +396,7 @@ class TestCfnLambdaIntegrations:
             log_events = aws_client.logs.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")[
                 "events"
             ]
-            return any([msg in e["message"] for e in log_events])
+            return any(msg in e["message"] for e in log_events)
 
         assert wait_until(wait_logs)
 
@@ -517,7 +517,7 @@ class TestCfnLambdaIntegrations:
             log_events = aws_client.logs.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")[
                 "events"
             ]
-            return any([msg in e["message"] for e in log_events])
+            return any(msg in e["message"] for e in log_events)
 
         assert wait_until(wait_logs)
 
@@ -660,7 +660,7 @@ class TestCfnLambdaIntegrations:
             log_events = aws_client.logs.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")[
                 "events"
             ]
-            return any([msg in e["message"] for e in log_events])
+            return any(msg in e["message"] for e in log_events)
 
         assert wait_until(wait_logs)
 
@@ -794,7 +794,7 @@ class TestCfnLambdaIntegrations:
             log_events = aws_client.logs.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")[
                 "events"
             ]
-            return any([data_msg in e["message"] for e in log_events])
+            return any(data_msg in e["message"] for e in log_events)
 
         assert wait_until(wait_logs)
 

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -170,7 +170,7 @@ class TestEvents:
         self, aws_client
     ):
         event_type = str(uuid.uuid4())
-        event_details_to_publish = list(map(lambda n: f"event {n}", range(10)))
+        event_details_to_publish = [f"event {n}" for n in range(10)]
 
         for detail in event_details_to_publish:
             aws_client.events.put_events(
@@ -185,9 +185,9 @@ class TestEvents:
             )
 
         events_tmp_dir = _get_events_tmp_dir()
-        sorted_events_written_to_disk = map(
-            lambda filename: json.loads(str(load_file(os.path.join(events_tmp_dir, filename)))),
-            sorted(os.listdir(events_tmp_dir)),
+        sorted_events_written_to_disk = (
+            json.loads(str(load_file(os.path.join(events_tmp_dir, filename))))
+            for filename in sorted(os.listdir(events_tmp_dir))
         )
         sorted_events = list(
             filter(
@@ -196,10 +196,7 @@ class TestEvents:
             )
         )
 
-        assert (
-            list(map(lambda event: json.loads(event["Detail"]), sorted_events))
-            == event_details_to_publish
-        )
+        assert [json.loads(event["Detail"]) for event in sorted_events] == event_details_to_publish
 
     @markers.aws.validated
     def test_list_tags_for_resource(self, aws_client, clean_up):

--- a/tests/aws/services/lambda_/functions/lambda_process_inspection.py
+++ b/tests/aws/services/lambda_/functions/lambda_process_inspection.py
@@ -4,5 +4,5 @@ def handler(event, context):
         environment = f.read()
     environment = environment.split("\x00")
     env_partition = [env.partition("=") for env in environment if env]
-    env_dict = dict((env[0], env[2]) for env in env_partition)
+    env_dict = {env[0]: env[2] for env in env_partition}
     return {"environment": env_dict}

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -253,7 +253,7 @@ class TestLambdaBaseFeatures:
                 .paginate(logGroupName=f"/aws/lambda/{function_name}")
                 .build_full_result()
             )
-            assert any(["generating bytes" in e["message"] for e in log_events["events"]])
+            assert any("generating bytes" in e["message"] for e in log_events["events"])
 
         retry(_check_print_in_logs, retries=10)
 
@@ -636,9 +636,9 @@ class TestLambdaBehavior:
                 logGroupName=log_group_name, logStreamName=log_stream_name
             )["events"]
 
-            assert any(["starting wait" in e["message"] for e in log_events])
+            assert any("starting wait" in e["message"] for e in log_events)
             # TODO: this part is a bit flaky, at least locally with old provider
-            assert not any(["done waiting" in e["message"] for e in log_events])
+            assert not any("done waiting" in e["message"] for e in log_events)
 
         retry(assert_events, retries=15)
 
@@ -671,8 +671,8 @@ class TestLambdaBehavior:
             log_events = aws_client.logs.get_log_events(
                 logGroupName=log_group_name, logStreamName=log_stream_name
             )["events"]
-            return any(["starting wait" in e["message"] for e in log_events]) and any(
-                ["done waiting" in e["message"] for e in log_events]
+            return any("starting wait" in e["message"] for e in log_events) and any(
+                "done waiting" in e["message"] for e in log_events
             )
 
         wait_until(_assert_log_output, strategy="linear")
@@ -740,9 +740,9 @@ class TestLambdaBehavior:
                 logGroupName=log_group_name, logStreamName=log_stream_name
             )["events"]
 
-            assert any(["starting wait" in e["message"] for e in log_events])
+            assert any("starting wait" in e["message"] for e in log_events)
             # TODO: this part is a bit flaky, at least locally with old provider
-            assert not any(["done waiting" in e["message"] for e in log_events])
+            assert not any("done waiting" in e["message"] for e in log_events)
 
         retry(assert_events, retries=15)
 
@@ -2716,7 +2716,7 @@ class TestRequestIdHandling:
 
         def fetch_logs():
             log_events_result = aws_client.logs.filter_log_events(logGroupName=log_group_name)
-            assert any(["REPORT" in e["message"] for e in log_events_result["events"]])
+            assert any("REPORT" in e["message"] for e in log_events_result["events"])
             return log_events_result
 
         log_events = retry(fetch_logs, retries=10, sleep=2)
@@ -2778,7 +2778,7 @@ class TestRequestIdHandling:
 
         def fetch_logs():
             log_events_result = aws_client.logs.filter_log_events(logGroupName=log_group_name)
-            assert any(["REPORT" in e["message"] for e in log_events_result["events"]])
+            assert any("REPORT" in e["message"] for e in log_events_result["events"])
             return log_events_result
 
         log_events = retry(fetch_logs, retries=10, sleep=2)
@@ -2827,7 +2827,7 @@ class TestRequestIdHandling:
         log_events = aws_client.logs.filter_log_events(logGroupName=log_group_name)
         report_messages = [e for e in log_events["events"] if "REPORT" in e["message"]]
         assert len(report_messages) == 2
-        assert all([request_id in rm["message"] for rm in report_messages])
+        assert all(request_id in rm["message"] for rm in report_messages)
         end_messages = [
             e["message"].rstrip() for e in log_events["events"] if "END" in e["message"]
         ]

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4097,8 +4097,8 @@ class TestLambdaAccountSettings:
         }"""
         acc_settings = aws_client.lambda_.get_account_settings()
         acc_settings_modded = acc_settings
-        acc_settings_modded["AccountLimit"] = sorted(list(acc_settings["AccountLimit"].keys()))
-        acc_settings_modded["AccountUsage"] = sorted(list(acc_settings["AccountUsage"].keys()))
+        acc_settings_modded["AccountLimit"] = sorted(acc_settings["AccountLimit"].keys())
+        acc_settings_modded["AccountUsage"] = sorted(acc_settings["AccountUsage"].keys())
         snapshot.match("acc_settings_modded", acc_settings_modded)
 
     @markers.aws.validated

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -364,7 +364,7 @@ class TestOpensearchProvider:
                 f"https://{domain_status['Endpoint']}/_cat/plugins?s=component&h=component"
             )
             plugins_response = requests.get(plugins_url, headers={"Accept": "application/json"})
-            installed_plugins = set(plugin["component"] for plugin in plugins_response.json())
+            installed_plugins = {plugin["component"] for plugin in plugins_response.json()}
             requested_plugins = set(OPENSEARCH_PLUGIN_LIST)
             assert requested_plugins.issubset(installed_plugins)
         finally:
@@ -400,7 +400,7 @@ class TestOpensearchProvider:
             plugins_url, headers={"Accept": "application/json"}, auth=master_user_auth
         )
         assert plugins_response.status_code == 200
-        installed_plugins = set(plugin["component"] for plugin in plugins_response.json())
+        installed_plugins = {plugin["component"] for plugin in plugins_response.json()}
         assert "opensearch-security" in installed_plugins
 
         # create a new index with the admin user

--- a/tests/aws/services/resource_groups/test_resource_groups.py
+++ b/tests/aws/services/resource_groups/test_resource_groups.py
@@ -31,21 +31,21 @@ def resourcegroups_create_group(aws_client):
 
 @pytest.fixture
 def sqs_create_queue_in_region(aws_client_factory):
-    queue_urls = {}
+    region_queue_urls = {}
 
     def factory(region, **kwargs):
         if "QueueName" not in kwargs:
             kwargs["QueueName"] = "test-queue-%s" % short_uid()
         response = aws_client_factory(region_name=region).sqs.create_queue(**kwargs)
         url = response["QueueUrl"]
-        queue_urls.setdefault(region, []).append(url)
+        region_queue_urls.setdefault(region, []).append(url)
 
         return url
 
     yield factory
 
     # cleanup
-    for queues_region, queue_urls in queue_urls.items():
+    for queues_region, queue_urls in region_queue_urls.items():
         sqs_client = aws_client_factory(region_name=queues_region).sqs
         for queue_url in queue_urls:
             with contextlib.suppress(ClientError):

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -7994,7 +7994,7 @@ class TestS3StaticWebsiteHosting:
                     Bucket=s3_bucket,
                     WebsiteConfiguration=invalid_configuration,
                 )
-                assert False, f"{invalid_configuration} should have raised an exception"
+                raise AssertionError(f"{invalid_configuration} should have raised an exception")
             except ClientError as e:
                 snapshot.match(f"invalid-website-conf-{index}", e.response)
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3312,13 +3312,11 @@ class TestS3:
             func_name=function_name,
             role=lambda_su_role,
             runtime=Runtime.python3_9,
-            envvars=dict(
-                {
-                    "BUCKET_NAME": bucket_name,
-                    "OBJECT_NAME": key,
-                    "LOCAL_FILE_NAME": "/tmp/" + key,
-                }
-            ),
+            envvars={
+                "BUCKET_NAME": bucket_name,
+                "OBJECT_NAME": key,
+                "LOCAL_FILE_NAME": "/tmp/" + key,
+            },
         )
         aws_client.lambda_.invoke(FunctionName=function_name, InvocationType="Event")
 

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -1354,8 +1354,8 @@ class TestSecretsManager:
         assert res_json["Name"] == secret_name
         res_versions: [json] = res_json["Versions"]
         assert len(res_versions) == len(versions)
-        assert len(set([rv["VersionId"] for rv in res_versions])) == len(res_versions)
-        assert len(set([v["VersionId"] for v in versions])) == len(versions)
+        assert len({rv["VersionId"] for rv in res_versions}) == len(res_versions)
+        assert len({v["VersionId"] for v in versions}) == len(versions)
         for version in versions:
             vs_in_res: [json] = list(
                 filter(lambda rv: rv["VersionId"] == version["VersionId"], res_versions)

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -334,9 +334,9 @@ class TestSqsProvider:
             )
             i += 1
         assert len(result_recv["Messages"]) == message_count
-        assert set(result_recv["Messages"][b]["Body"] for b in range(message_count)) == set(
+        assert {result_recv["Messages"][b]["Body"] for b in range(message_count)} == {
             f"message-{b}" for b in range(message_count)
-        )
+        }
 
     @markers.aws.validated
     def test_send_message_batch_with_empty_list(self, sqs_create_queue, aws_sqs_client):

--- a/tests/aws/services/swf/test_swf.py
+++ b/tests/aws/services/swf/test_swf.py
@@ -34,9 +34,8 @@ class TestSwf:
             domain=workflow_domain_name, registrationStatus="REGISTERED"
         )
 
-        assert workflow_type_name in map(
-            lambda workflow_type: workflow_type["workflowType"]["name"],
-            workflow_types["typeInfos"],
+        assert workflow_type_name in (
+            workflow_type["workflowType"]["name"] for workflow_type in workflow_types["typeInfos"]
         )
 
         swf_client.register_activity_type(
@@ -103,7 +102,7 @@ class TestSwf:
                 "runId": workflow_execution["runId"],
             },
         )
-        events = map(lambda event: event["eventType"], history["events"])
+        events = (event["eventType"] for event in history["events"])
         for event_type in [
             "WorkflowExecutionStarted",
             "DecisionTaskCompleted",

--- a/tests/aws/test_multi_accounts.py
+++ b/tests/aws/test_multi_accounts.py
@@ -68,7 +68,7 @@ class TestMultiAccounts:
         # Calls originating in Moto must make use of client provided account ID
         ec2_client1.create_vpc(CidrBlock="10.1.0.0/16")
         vpcs = ec2_client1.describe_vpcs()["Vpcs"]
-        assert all([vpc["OwnerId"] == account_id1 for vpc in vpcs])
+        assert all(vpc["OwnerId"] == account_id1 for vpc in vpcs)
 
     @markers.aws.only_localstack
     def test_account_id_namespacing_for_localstack_backends(self, client_factory):

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -827,7 +827,7 @@ class TestDockerClient:
             # Simulate podman API response, Docker returns "sha:..." for Image, podman returns "<image-name>:<tag>".
             #  See https://github.com/containers/podman/issues/8329
             attrs["Image"] = image_name
-            container_init_orig(self, attrs=attrs, *args, **kwargs)
+            container_init_orig(self, *args, attrs=attrs, **kwargs)
 
         monkeypatch.setattr(Container, "__init__", container_init)
 

--- a/tests/unit/packages/test_api.py
+++ b/tests/unit/packages/test_api.py
@@ -65,9 +65,9 @@ class LockingTestPackageInstaller(PackageInstaller):
     Package installer class used for testing the locking behavior.
     """
 
-    def __init__(self, queue: Queue = Queue(), install_lock: Optional[RLock] = None):
+    def __init__(self, queue: Queue = None, install_lock: Optional[RLock] = None):
         super().__init__("lock-test-installer", "test", install_lock)
-        self.queue = queue
+        self.queue = queue or Queue()
         self.about_to_wait = Event()
 
     def _get_install_marker_path(self, target: InstallTarget) -> str:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -239,9 +239,7 @@ class TestArgumentParsing:
 
 
 def list_in(a, b):
-    return len(a) <= len(b) and any(
-        map(lambda x: b[x : x + len(a)] == a, range(len(b) - len(a) + 1))
-    )
+    return len(a) <= len(b) and any((b[x : x + len(a)] == a for x in range(len(b) - len(a) + 1)))
 
 
 class TestPortMappings:

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -53,23 +53,23 @@ class TestSns:
         try:
             uuid.UUID(result.pop("MessageId"))
         except KeyError:
-            assert False, "MessageId missing in SNS response message body"
+            raise AssertionError("MessageId missing in SNS response message body")
         except ValueError:
-            assert False, "SNS response MessageId not a valid UUID"
+            raise AssertionError("SNS response MessageId not a valid UUID")
 
         try:
             dateutil.parser.parse(result.pop("Timestamp"))
         except KeyError:
-            assert False, "Timestamp missing in SNS response message body"
+            raise AssertionError("Timestamp missing in SNS response message body")
         except ValueError:
-            assert False, "SNS response Timestamp not a valid ISO 8601 date"
+            raise AssertionError("SNS response Timestamp not a valid ISO 8601 date")
 
         try:
             base64.b64decode(result.pop("Signature"))
         except KeyError:
-            assert False, "Signature missing in SNS response message body"
+            raise AssertionError("Signature missing in SNS response message body")
         except ValueError:
-            assert False, "SNS response Signature is not a valid base64 encoded value"
+            raise AssertionError("SNS response Signature is not a valid base64 encoded value")
 
         expected_sns_body = {
             "Message": "msg",

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -549,8 +549,8 @@ class TestSns:
     def test_is_not_raw_message_delivery(self, subscriber):
         invalid_values = ["false", "False", False, "somevalue", ""]
 
-        for invalid_values in invalid_values:
-            subscriber["RawMessageDelivery"] = invalid_values
+        for value in invalid_values:
+            subscriber["RawMessageDelivery"] = value
             assert not is_raw_message_delivery(subscriber)
 
         del subscriber["RawMessageDelivery"]


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I had an hour of time on my hand to do a bit of mindless work, so I spent it to fix several TODOs in the ignored ruff rules. Back to real work on Monday ;-)

I focused on the ones where both the reasoning was obvious to me and that were easy to fix (mostly just applying `ruff check --fix`)

<!-- What notable changes does this PR make? -->
## Changes

Disabled and fixed the following ruff rules:
- "B005", # TODO Using `.strip()` with multi-character strings is misleading
- "B006", # TODO Do not use mutable data structures for argument defaults
- "B008", # TODO Do not perform function call `Queue` in argument defaults
- "B011", # TODO Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
- "B016", # TODO Cannot raise a literal. Did you intend to return it or raise an Exception?
- "B018", # TODO Found useless expression. Either assign it to a variable or remove it.
- "B020", # TODO Loop control variable `invalid_values` overrides iterable it iterates
- "B026", # TODO Star-arg unpacking after a keyword argument is strongly discouraged
- "B028", # TODO No explicit `stacklevel` keyword argument found
- "B034", # TODO `re.sub` should pass `count` and `flags` as keyword arguments to avoid confusion due to unintuitive argument positions
- "C401", # TODO Unnecessary generator (rewrite as a `set` comprehension)
- "C402", # TODO Unnecessary generator (rewrite as a `dict` comprehension)
- "C403", # TODO Unnecessary `list` comprehension (rewrite as a `set` comprehension)
- "C405", # TODO Unnecessary `list` literal (rewrite as a `set` literal)
- "C411", # TODO Unnecessary `list` call (remove the outer call to `list()`)
- "C414", # TODO Unnecessary `list` call within `sorted()`
- "C417", # TODO Replace `map` with a generator expression
- "C418", # TODO Unnecessary `dict` literal passed to `dict()` (remove the outer call to `dict()`)
- "C419", # TODO Unnecessary list comprehension.
- "F403", # TODO `from localstack.services.cloudformation.models import *` used; unable to detect undefined names

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

