### PR TITLE
fix query string parser with non encoded http url in parameters

### DIFF
--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -19,6 +19,8 @@ from localstack.utils.strings import short_uid, str_startswith_ignore_case, to_b
 
 REGEX_FLAGS = re.MULTILINE | re.DOTALL
 
+regex_url_start = re.compile("^[a-z]{1,5}://")
+
 
 class ErrorResponse(Exception):
     def __init__(self, response):
@@ -235,7 +237,8 @@ def create_sqs_system_attributes(headers: Dict[str, str]) -> Dict[str, Any]:
 
 def parse_query_string(url_or_qs: str, multi_values=False) -> Dict[str, str]:
     url_or_qs = str(url_or_qs or "").strip()
-    if "://" in url_or_qs and "?" not in url_or_qs:
+    # we match if the `url_or_qs` passed is maybe a URL
+    if regex_url_start.match(url_or_qs) and "?" not in url_or_qs:
         url_or_qs = f"{url_or_qs}?"
     url_or_qs = url_or_qs.split("?", maxsplit=1)[-1]
     result = parse_qs(url_or_qs, keep_blank_values=True)

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -19,7 +19,7 @@ from localstack.utils.strings import short_uid, str_startswith_ignore_case, to_b
 
 REGEX_FLAGS = re.MULTILINE | re.DOTALL
 
-regex_url_start = re.compile("^[a-z]{1,5}://")
+regex_url_start = re.compile("^[a-z]{2,5}://")
 
 
 class ErrorResponse(Exception):

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -53,3 +53,9 @@ def test_parse_query_string():
         "a": ["1", "2", "3"],
         "b": ["0"],
     }
+    assert parse_query_string("ws://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
+    assert parse_query_string("ws://example.com/foo/bar") == {}
+    assert parse_query_string("wss://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
+    assert parse_query_string("wss://example.com/foo/bar") == {}
+    assert parse_query_string("https://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
+    assert parse_query_string("https://example.com/foo/bar") == {}

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -40,6 +40,13 @@ def test_parse_query_string():
     assert parse_query_string("http://example.com/foo/bar#test") == {}
     assert parse_query_string("http://example.com/foo/bar?a=1") == {"a": "1"}
     assert parse_query_string("http://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
+    assert parse_query_string(
+        "http://example.com/foo/bar?foo=1&redirect=http://test.com/redirect"
+    ) == {"foo": "1", "redirect": "http://test.com/redirect"}
+    assert parse_query_string(
+        "http://example.com/foo/bar?foo=1&redirect=http%3A%2F%2Flocalhost%3A3001%2Fredirect"
+    ) == {"foo": "1", "redirect": "http://localhost:3001/redirect"}
+    assert parse_query_string("http://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
 
     assert parse_query_string("?foo=1&foo=2&", multi_values=True) == {"foo": ["1", "2"]}
     assert parse_query_string("?a=1&a=2&b=0&a=3", multi_values=True) == {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10451, we would have an issue when trying to parse query string parameters containing a URL. 
I suspected a split somewhere with `http://`. It seems it was a somewhat related issue.

<!-- What notable changes does this PR make? -->
## Changes
Fix the `parse_query_string` util (actually only used in APIGW, would maybe be good to move it around). 
It was checking for the presence of `http://` in the string (to check if it was a full URL, a path or a query string), but it could be container as a query string parameter also. 
I've replaced it with a regex containing lower case characters between 2 and 5 (for `ws://` to `https://`) now at the beginning of the string. I've added more cases to the test and verified that it fixes the issue. (More tests in the companion PR). 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

