### PR TITLE
make twisted default HTTP server in S3 image

### DIFF
--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -93,7 +93,7 @@ RUN echo /var/lib/localstack/lib/python-packages/lib/python3.11/site-packages > 
 RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > localstack-static-python-packages-venv.pth && \
     mv localstack-static-python-packages-venv.pth .venv/lib/python*/site-packages/
 
-# expose edge service, external service ports, and debugpy
+# expose edge service and debugpy
 EXPOSE 4566 5678
 
 HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD ./bin/localstack status services --format=json
@@ -117,6 +117,7 @@ ENV LOCALSTACK_BUILD_GIT_HASH=${LOCALSTACK_BUILD_GIT_HASH}
 ENV LOCALSTACK_BUILD_VERSION=${LOCALSTACK_BUILD_VERSION}
 ENV EAGER_SERVICE_LOADING=1
 ENV SERVICES=s3
+ENV GATEWAY_SERVER=twisted
 # TODO: do we need DNS for the S3 image?
 ENV DNS_ADDRESS=false
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following the introduction of Twisted as the HTTP server of LocalStack in an opt-in manner with #9834, we could make it default in the S3 only image, as we know it is way more performant. 

<!-- What notable changes does this PR make? -->
## Changes
- set `GATEWAY_SERVER=twisted` in the S3-only Docker image to make it default


## Benchmarks

Concurrency of 1, small object size of 1000. 
```
Twisted:      Average: 1.54 MiB/s, 1620.03 obj/s
Hypercorn: Average: 0.21 MiB/s, 219.67 obj/s
```
-> Around 8x performance

Concurrency of 25, small object size of 1000
```
Twisted:      Average: 1.78 MiB/s, 1864.04 obj/s
Hypercorn: Average: 0.55 MiB/s, 572.70 obj/s (encountered 9 time out)

Twisted:      Slowest: 1624.7KiB/s, 1663.71 obj/s
Hypercorn: Slowest: 2.7KiB/s, 2.83 obj/s
```
-> Around 3x performance, but with no massive variations and no errors or blocking operations

Concurrency of 25, medium object size of 100000
```
Twisted:      Average: 160.13 MiB/s, 1679.13 obj/s
Hypercorn: Average: 52.99 MiB/s, 555.62 obj/s (encountered 8 time out)

Twisted:      Slowest: 153.2MiB/s, 1606.23 obj/s
Hypercorn: Slowest: 301.7KiB/s, 3.09 obj/s
```
-> Around 3x performance too, but with no massive variations or blocking operations
