### PR TITLE
fix CircleCI Tinybird reporting on reruns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,70 +581,51 @@ jobs:
             source .venv/bin/activate
             bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
             make publish
-  save-start-time:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    steps:
-      - run:
-          name: Save start time to file
-          command: mkdir stats && echo $(date +%s) > stats/start-time.txt
-      - persist_to_workspace:
-            root: /tmp/workspace
-            paths:
-                - repo/stats/
   waiter:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
-      - run: |
-          while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
+      - run:
+          name: Wait for the workflow to complete
+          command: |
+            # Record the time this step started
+            START_TIME=$(date +%s)
+
+            # wait for the workflow to be done
+            while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
               sleep 10
             done
-          FAILED_COUNT=$(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" | jq -r '.items[]|.status' | grep -c "failed") || true
-          echo "failed count" $FAILED_COUNT
-          mkdir stats
-          if [[ $FAILED_COUNT -eq 0 ]]; then
-              echo "success" > stats/outcome.txt
-          else
-              echo "failure" > stats/outcome.txt
-          fi
-          cat stats/outcome.txt
-      - persist_to_workspace:
-            root: /tmp/workspace
-            paths:
-                - repo/stats/
-  send-stats:
-    executor: ubuntu-machine-amd64
-    working_directory: /tmp/workspace/repo
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          when: always
-          name: Load start time from file
-          command: |
-            START_TIME=$(cat stats/start-time.txt)
+
+            # check if a step failed / determine the outcome
+            FAILED_COUNT=$(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" | jq -r '.items[]|.status' | grep -c "failed") || true
+            echo "failed count: $FAILED_COUNT"
+            if [[ $FAILED_COUNT -eq 0 ]]; then
+                OUTCOME="success"
+            else
+                OUTCOME="failure"
+            fi
+            echo "outcome: $OUTCOME"
+
+            # Record the time this step is done
             END_TIME=$(date +%s)
-            OUTCOME=$(cat stats/outcome.txt)
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'"}' > stats/stats.json
+
+            # Build the payload
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'"}' > stats.json
             echo 'Sending: '$(cat stats/stats.json)
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats/stats.json
 
+            # Send the data to Tinybird
+            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats.json
 
+            # Fail this step depending on the success to trigger a rerun of this step together with others in case of a "rerun failed"
+            [[ $OUTCOME = "success" ]] && exit 0 || exit 1
 
 workflows:
   main:
     jobs:
-      - save-start-time:
+      - waiter:
           filters:
             branches:
               only: master
-      - waiter:
-          requires:
-            - save-start-time
-      - send-stats:
-          requires:
-            - waiter
       - install
       - preflight:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,9 +347,6 @@ jobs:
       - prepare-pytest-tinybird
       - prepare-account-region-randomization
       - run:
-          name: Fail for testing
-          command: exit 1
-      - run:
           name: Run integration tests
           # circleci split returns newline separated list, so `tr` is necessary to prevent problems in the Makefile
           # if we're doing performing a test selection, we need to filter the list of files before splitting by timings
@@ -625,7 +622,10 @@ jobs:
 workflows:
   main:
     jobs:
-      - waiter
+      - waiter:
+          filters:
+            branches:
+              only: master
       - install
       - preflight:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,7 +581,7 @@ jobs:
             source .venv/bin/activate
             bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
             make publish
-  waiter:
+  push-to-tinybird:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
@@ -592,7 +592,7 @@ jobs:
             START_TIME=$(date +%s)
 
             # wait for the workflow to be done
-            while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "waiter" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
+            while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job"| jq -r '.items[]|select(.name != "push-to-tinybird" and .name != "push" and .name != "report")|.status' | grep -c "running") -gt 0 ]]; do
               sleep 10
             done
 
@@ -622,7 +622,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - waiter:
+      - push-to-tinybird:
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,9 @@ jobs:
       - prepare-pytest-tinybird
       - prepare-account-region-randomization
       - run:
+          name: Fail for testing
+          command: exit 1
+      - run:
           name: Run integration tests
           # circleci split returns newline separated list, so `tr` is necessary to prevent problems in the Makefile
           # if we're doing performing a test selection, we need to filter the list of files before splitting by timings
@@ -622,10 +625,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - waiter:
-          filters:
-            branches:
-              only: master
+      - waiter
       - install
       - preflight:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,7 +610,7 @@ jobs:
             END_TIME=$(date +%s)
 
             # Build the payload
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'"}' > stats.json
+            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'", "workflow_url": "${CIRCLE_BUILD_URL}"}' > stats.json
             echo 'Sending: '$(cat stats/stats.json)
 
             # Send the data to Tinybird


### PR DESCRIPTION
## Motivation
#10346 introduced reporting of our CircleCI workflow metadata to Tinybird for our internal CI analytics.
Unfortunately, we are seeing that the reporting is not properly updated in case a failed workflow is "rerun workflow from failed":
![image](https://github.com/localstack/localstack/assets/2796604/c9718060-93b4-4b76-b554-7bace47c1674)
This is because this really only executes jobs that failed as well as their dependents.
This PR fixes this by also failing the waiter (running alongside the workflow waiting for the pipeline to finish and to report the result) in case any of the steps failed. This results in the waiter being rerun as well with the "Rerun workflow from failed" feature.

## Changes
- Simplify the waiter jobs to a single job.
- Fail the waiter job in case the outcome of the main workflow is not `success`.

## Testing
- The last commit always fails and removes the filter to only run the waiter on `master`.
- This triggered a run which failed, which I restarted using "rerun workflow from failed": https://app.circleci.com/pipelines/github/localstack/localstack/23482/workflows/26c43878-ad39-4724-9951-8bd9530b1bf0
- This rerun also triggered the waiter to rerun.

## TODO
- [x] Revert the last testing commit.
