### PR TITLE
fix S3 copy in place in versioned bucket

### DIFF
--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -233,3 +233,31 @@ class S3ObjectStore(abc.ABC):
         Resetting the `S3ObjectStore` will delete all the contained resources.
         """
         pass
+
+
+def should_copy_in_place(
+    src_bucket: BucketName,
+    src_object: S3Object,
+    dest_bucket: BucketName,
+    dest_object: S3Object,
+) -> bool:
+    """
+    Helper method to determine if we should use the same underlying fileobject to avoid copying in place for no gain.
+    :param src_bucket: the source bucket
+    :param src_object: the source S3Object
+    :param dest_bucket: the destination bucket
+    :param dest_object: the destination S3Object
+    :return: if
+    """
+    if src_bucket != dest_bucket:
+        return False
+
+    if src_object.key != dest_object.key:
+        return False
+
+    # if the objects have version id, the bucket is versioned, and we should not copy in place: the new destination
+    # object will be a new version of the source object
+    if src_object.version_id or dest_object.version_id:
+        return False
+
+    return True

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -18,7 +18,13 @@ from localstack.services.s3.utils import ChecksumHash, ObjectRange, get_s3_check
 from localstack.services.s3.v3.models import S3Multipart, S3Object, S3Part
 from localstack.utils.files import mkdir
 
-from .core import LimitedStream, S3ObjectStore, S3StoredMultipart, S3StoredObject
+from .core import (
+    LimitedStream,
+    S3ObjectStore,
+    S3StoredMultipart,
+    S3StoredObject,
+    should_copy_in_place,
+)
 
 # max file size for S3 objects kept in memory (500 KB by default)
 # TODO: make it configurable
@@ -426,12 +432,7 @@ class EphemeralS3ObjectStore(S3ObjectStore):
         """
         # If this is an in-place copy, directly return the EphemeralS3StoredObject of the destination S3Object, no need
         # to copy the underlying data except if we are in a versioned bucket.
-        if (
-            src_bucket == dest_bucket
-            and src_object.key == dest_object.key
-            and not src_object.version_id
-            and not dest_object.version_id
-        ):
+        if should_copy_in_place(src_bucket, src_object, dest_bucket, dest_object):
             return self.open(dest_bucket, dest_object, mode="r")
 
         with self.open(src_bucket, src_object, mode="r") as src_stored_object:

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -425,8 +425,13 @@ class EphemeralS3ObjectStore(S3ObjectStore):
         :return: the destination EphemeralS3StoredObject
         """
         # If this is an in-place copy, directly return the EphemeralS3StoredObject of the destination S3Object, no need
-        # to copy the underlying data.
-        if src_bucket == dest_bucket and src_object.key == dest_object.key:
+        # to copy the underlying data except if we are in a versioned bucket.
+        if (
+            src_bucket == dest_bucket
+            and src_object.key == dest_object.key
+            and not src_object.version_id
+            and not dest_object.version_id
+        ):
             return self.open(dest_bucket, dest_object, mode="r")
 
         with self.open(src_bucket, src_object, mode="r") as src_stored_object:

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1413,9 +1413,9 @@ class TestS3:
         snapshot.match("copy-object-in-place-with-acl", e.value.response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        condition=is_v2_provider,
-        paths=["$..ServerSideEncryption"],
+    @pytest.mark.skipif(
+        condition=LEGACY_V2_S3_PROVIDER,
+        reason="Behaviour is not in line with AWS, does not raise exception",
     )
     def test_s3_copy_object_in_place_versioned(
         self, s3_bucket, allow_bucket_acl, snapshot, aws_client

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -1417,6 +1417,65 @@ class TestS3:
         condition=is_v2_provider,
         paths=["$..ServerSideEncryption"],
     )
+    def test_s3_copy_object_in_place_versioned(
+        self, s3_bucket, allow_bucket_acl, snapshot, aws_client
+    ):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("DisplayName"),
+                snapshot.transform.key_value("ID", value_replacement="owner-id"),
+            ]
+        )
+        aws_client.s3.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        object_key = "source-object"
+
+        resp = aws_client.s3.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body='{"key": "value"}',
+            ContentType="application/json",
+            Metadata={"key": "value"},
+        )
+        snapshot.match("put_object", resp)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head_object", head_object)
+
+        object_attrs = aws_client.s3.get_object_attributes(
+            Bucket=s3_bucket,
+            Key=object_key,
+            ObjectAttributes=["StorageClass"],
+        )
+        snapshot.match("object-attrs", object_attrs)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.s3.copy_object(
+                Bucket=s3_bucket, CopySource=f"{s3_bucket}/{object_key}", Key=object_key
+            )
+        snapshot.match("copy-object-in-place-no-change", e.value.response)
+
+        copy_obj = aws_client.s3.copy_object(
+            Bucket=s3_bucket,
+            CopySource=f"{s3_bucket}/{object_key}",
+            Key=object_key,
+            MetadataDirective="REPLACE",
+        )
+        snapshot.match("copy-in-place-versioned", copy_obj)
+
+        head_object = aws_client.s3.head_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("head-object-copied", head_object)
+
+        get_obj = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key)
+        snapshot.match("get-object-copied", get_obj)
+
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=is_v2_provider,
+        paths=["$..ServerSideEncryption"],
+    )
     def test_s3_copy_object_in_place_storage_class(self, s3_bucket, snapshot, aws_client):
         # this test will validate that setting StorageClass (even the same as source) allows a copy in place
         snapshot.add_transformer(snapshot.transform.s3_api())

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11340,5 +11340,98 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_versioned": {
+    "recorded-date": "19-03-2024, 18:12:57",
+    "recorded-content": {
+      "put_object": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "application/json",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {
+          "key": "value"
+        },
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "LastModified": "datetime",
+        "StorageClass": "STANDARD",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object-in-place-no-change": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-in-place-versioned": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "CopySourceVersionId": "<version-id:1>",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-copied": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-copied": {
+        "AcceptRanges": "bytes",
+        "Body": {
+          "key": "value"
+        },
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -278,6 +278,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_storage_class": {
     "last_validated_date": "2023-08-03T02:15:24+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_versioned": {
+    "last_validated_date": "2024-03-19T18:12:57+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_website_redirect_location": {
     "last_validated_date": "2023-08-03T02:15:36+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in the Community Slack, a user encountered an error after copying in place an object in a versioned bucket. The first reported what about a previously fixed issue, which took a while to understand what was the final bug. 

It turns out that I've had a big gap in the logic of the Storage system of S3 when copying in place. To avoid unnecessary copying of data, if the copy operation was detected as "in place", we would return the same underlying file object. However, for versioned bucket, those are not really "in place", they create a new version. 

<!-- What notable changes does this PR make? -->
## Changes
- fix the logic to not return the same underlying stored object if any of the objects have a version id. Only minor issue is if both objects have their version id set to `null`, which would mean that the bucket has versioning disabled, we could still apply the optimization, but this is fine. Better avoid nasty bugs 😬 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

