### PR TITLE
fix Tinybird workflow datasource for multi-account tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,10 +628,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - push-to-tinybird:
-          filters:
-            branches:
-              only: master
+      - push-to-tinybird
       - install
       - preflight:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,12 +609,18 @@ jobs:
             # Record the time this step is done
             END_TIME=$(date +%s)
 
+            if << pipeline.parameters.randomize-aws-credentials >> ; then
+              echo "export TINYBIRD_WORKFLOW=tests_circleci_ma_mr" >> $BASH_ENV
+            else
+              echo "export TINYBIRD_WORKFLOW=tests_circleci" >> $BASH_ENV
+            fi
+
             # Build the payload
-            echo '{"run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'", "workflow_url": "${CIRCLE_BUILD_URL}"}' > stats.json
+            echo '{"workflow": "'$TINYBIRD_WORKFLOW'", "attempt": 1, "run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'", "workflow_url": "'$CIRCLE_BUILD_URL'"}' > stats.json
             echo 'Sending: '$(cat stats/stats.json)
 
             # Send the data to Tinybird
-            curl -X POST "https://api.tinybird.co/v0/events?name=circle_ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats.json
+            curl -X POST "https://api.tinybird.co/v0/events?name=ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats.json
 
             # Fail this step depending on the success to trigger a rerun of this step together with others in case of a "rerun failed"
             [[ $OUTCOME = "success" ]] && exit 0 || exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,10 @@ jobs:
 workflows:
   main:
     jobs:
-      - push-to-tinybird
+      - push-to-tinybird:
+          filters:
+            branches:
+              only: master
       - install
       - preflight:
           requires:


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10282 added workflow metadata tracking using Tinybird.
https://github.com/localstack/localstack/pull/10367 introduced a new test type to the main CircleCI workflow: Multi-accounts and multi-region testing. /cc @sannya-singal 
Currently, these runs cannot be distinguished in the Tinybird datasource.
This PR fixes that by setting a specific Tinybird target datasource in case the multi-accounts tests are executed.

## Changes
- Use `circle_ci_workflows_ma_mr` as datasource name (instead of `circle_ci_workflows`) in case the `randomize-aws-credentials` parameter is set to `true`.