### PR TITLE
added support for arn based retrivals for secretsmanager

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -10,6 +10,15 @@ from botocore.utils import InvalidArnException
 from moto.iam.policy_validation import IAMPolicyDocumentValidator
 from moto.secretsmanager import secretsmanager_backends
 from moto.secretsmanager import utils as secretsmanager_utils
+from moto.secretsmanager.exceptions import (
+    InvalidRequestException as MotoInvalidRequestException,
+)
+from moto.secretsmanager.exceptions import (
+    OperationNotPermittedOnReplica as MotoOperationNotPermittedOnReplica,
+)
+from moto.secretsmanager.exceptions import (
+    SecretHasNoValueException as MotoSecretHasNoValueException,
+)
 from moto.secretsmanager.exceptions import SecretNotFoundException as MotoSecretNotFoundException
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
 from moto.secretsmanager.responses import SecretsManagerResponse
@@ -118,6 +127,19 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         return backend
 
     @staticmethod
+    def _raise_if_default_kms_key(
+        secret_id: str, request: RequestContext, backend: SecretsManagerBackend
+    ):
+        try:
+            secret = backend.describe_secret(secret_id)
+        except MotoSecretNotFoundException:
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret.")
+        if secret.kms_key_id is None and request.account_id != secret.account_id:
+            raise InvalidRequestException(
+                "You can't access a secret from a different AWS account if you encrypt the secret with the default KMS service key."
+            )
+
+    @staticmethod
     def _validate_secret_id(secret_id: SecretIdType) -> bool:
         # The secret name can contain ASCII letters, numbers, and the following characters: /_+=.@-
         return bool(re.match(r"^[A-Za-z0-9/_+=.@-]+\Z", secret_id))
@@ -209,8 +231,19 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def get_secret_value(
         self, context: RequestContext, request: GetSecretValueRequest
     ) -> GetSecretValueResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request.get("SecretId")
+        version_id = request.get("VersionId")
+        version_stage = request.get("VersionStage")
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        self._raise_if_default_kms_key(secret_id, context, backend)
+        try:
+            response = backend.get_secret_value(secret_id, version_id, version_stage)
+        except MotoSecretHasNoValueException:
+            raise ResourceNotFoundException(
+                f"Secrets Manager can't find the specified secret value for staging label: {version_stage}"
+            )
+        return GetSecretValueResponse(**response)
 
     @handler("ListSecretVersionIds", expand=False)
     def list_secret_version_ids(
@@ -236,9 +269,29 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def put_secret_value(
         self, context: RequestContext, request: PutSecretValueRequest
     ) -> PutSecretValueResponse:
-        self._raise_if_missing_client_req_token(request)
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        client_req_token = request.get("ClientRequestToken")
+        secret_string = request.get("SecretString")
+        secret_binary = request.get("SecretBinary")
+        if not secret_binary and not secret_string:
+            raise InvalidRequestException("You must provide either SecretString or SecretBinary.")
+
+        version_stages = request.get("VersionStages", ["AWSCURRENT"])
+        if not isinstance(version_stages, list):
+            version_stages = [version_stages]
+
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        self._raise_if_default_kms_key(secret_id, context, backend)
+
+        response = backend.put_secret_value(
+            secret_id=secret_id,
+            secret_binary=secret_binary,
+            secret_string=secret_string,
+            version_stages=version_stages,
+            client_request_token=client_req_token,
+        )
+        return PutSecretValueResponse(**json.loads(response))
 
     @handler("RemoveRegionsFromReplication", expand=False)
     def remove_regions_from_replication(
@@ -258,8 +311,14 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def restore_secret(
         self, context: RequestContext, request: RestoreSecretRequest
     ) -> RestoreSecretResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        try:
+            arn, name = backend.restore_secret(secret_id)
+        except MotoSecretNotFoundException:
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret.")
+        return RestoreSecretResponse(ARN=arn, Name=name)
 
     @handler("RotateSecret", expand=False)
     def rotate_secret(
@@ -297,10 +356,36 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         self, context: RequestContext, request: UpdateSecretRequest
     ) -> UpdateSecretResponse:
         # if we're modifying the value of the secret, ClientRequestToken is required
-        if any(key for key in request if key in ("SecretBinary", "SecretString")):
-            self._raise_if_missing_client_req_token(request)
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return call_moto(context, request)
+        secret_id = request["SecretId"]
+        secret_string = request.get("SecretString")
+        secret_binary = request.get("SecretBinary")
+        description = request.get("Description")
+        kms_key_id = request.get("KmsKeyId")
+        client_req_token = request.get("ClientRequestToken")
+        self._raise_if_invalid_secret_id(secret_id)
+
+        backend = SecretsmanagerProvider.get_moto_backend_for_resource(secret_id, context)
+        try:
+            secret = backend.update_secret(
+                secret_id,
+                description=description,
+                secret_string=secret_string,
+                secret_binary=secret_binary,
+                client_request_token=client_req_token,
+                kms_key_id=kms_key_id,
+            )
+        except MotoSecretNotFoundException:
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret.")
+        except MotoOperationNotPermittedOnReplica:
+            raise InvalidRequestException(
+                "Operation not permitted on a replica secret. Call must be made in primary secret's region."
+            )
+        except MotoInvalidRequestException:
+            raise InvalidRequestException(
+                "An error occurred (InvalidRequestException) when calling the UpdateSecret operation: "
+                "You can't perform this operation on the secret because it was marked for deletion."
+            )
+        return UpdateSecretResponse(**json.loads(secret))
 
     @handler("UpdateSecretVersionStage", expand=False)
     def update_secret_version_stage(

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -180,6 +180,28 @@ class TestSecretsManager:
         sm_snapshot.match("delete_secret_res_1", delete_secret_res_1)
 
     @markers.aws.validated
+    def test_secret_restore(self, secret_name: str, sm_snapshot, cleanups, aws_client):
+        cleanups.append(
+            lambda: aws_client.secretsmanager.delete_secret(
+                SecretId=secret_name, ForceDeleteWithoutRecovery=True
+            )
+        )
+        create_secret_rs = aws_client.secretsmanager.create_secret(
+            Name=secret_name,
+            SecretString="my_secret",
+            Description="test description",
+        )
+        sm_snapshot.add_transformers_list(
+            sm_snapshot.transform.secretsmanager_secret_id_arn(create_secret_rs, 0)
+        )
+
+        delete_secret_res = aws_client.secretsmanager.delete_secret(SecretId=secret_name)
+        sm_snapshot.match("delete_secret_res", delete_secret_res)
+
+        restore_secret_res = aws_client.secretsmanager.restore_secret(SecretId=secret_name)
+        sm_snapshot.match("restore_secret_res", restore_secret_res)
+
+    @markers.aws.validated
     def test_secret_not_found(self, sm_snapshot, aws_client):
         with pytest.raises(Exception) as not_found:
             aws_client.secretsmanager.get_secret_value(SecretId=f"s-{short_uid()}")
@@ -2136,6 +2158,164 @@ class TestSecretsManagerMultiAccounts:
         )
         poll_condition(
             lambda: secondary_aws_client.secretsmanager.list_secrets()["SecretList"] == [],
+            timeout=5.0,
+            interval=0.5,
+        )
+
+    @markers.aws.validated
+    def test_cross_account_access_non_default_key(
+        self, aws_client, secondary_aws_client, aws_client_factory, cleanups
+    ):
+        SECONDARY_KMS_KEY_REGION = "us-east-2"
+
+        # GetSecretValue and PutSecretValue can't be used if the default keys are used
+        primary_identity = aws_client.sts.get_caller_identity()
+        primary_principal = primary_identity["Arn"]
+        primary_account_id = primary_identity["Account"]
+        secondary_principal = secondary_aws_client.sts.get_caller_identity()["Arn"]
+        aws_client_us_east_2 = aws_client_factory(region_name=SECONDARY_KMS_KEY_REGION)
+
+        resource_policy_secretsmanager = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": secondary_principal},
+                    "Action": ["secretsmanager:*"],
+                    "Resource": "*",
+                }
+            ],
+        }
+
+        kms_policy_document = """{
+        "Version": "2012-10-17",
+        "Id": "key-default-1",
+        "Statement": [
+            {
+                "Sid": "Enable IAM User Permissions",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::%s:root"
+                },
+                "Action": "kms:*",
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow administration of the key",
+                "Effect": "Allow",
+                "Principal": {"AWS": "%s"},
+                "Action": "kms:*",
+                "Resource": "*"
+            },
+            {
+                "Sid": "Allow use of the key",
+                "Effect": "Allow",
+                "Principal": {"AWS": "%s"},
+                "Action": [
+                    "kms:Encrypt",
+                    "kms:Decrypt",
+                    "kms:ReEncrypt*",
+                    "kms:GenerateDataKey*",
+                    "kms:DescribeKey"
+                ],
+                "Resource": "*"
+            }
+        ]
+        }"""
+        secret_name = f"test-secret-{short_uid()}"
+
+        kms_policy = kms_policy_document % (
+            primary_account_id,
+            primary_principal,
+            secondary_principal,
+        )
+        key_arn = aws_client.kms.create_key(
+            Description="test-key",
+            Policy=kms_policy,
+        )[
+            "KeyMetadata"
+        ]["Arn"]
+
+        cleanups.append(
+            lambda: aws_client.kms.schedule_key_deletion(KeyId=key_arn, PendingWindowInDays=7)
+        )
+
+        secondary_key_arn = aws_client_us_east_2.kms.create_key(
+            Description="test-key",
+            Policy=kms_policy,
+        )["KeyMetadata"]["Arn"]
+
+        cleanups.append(
+            lambda: aws_client_us_east_2.kms.schedule_key_deletion(
+                KeyId=secondary_key_arn, PendingWindowInDays=7
+            )
+        )
+
+        secret_arn = aws_client.secretsmanager.create_secret(
+            Name=secret_name, SecretString="secret", KmsKeyId=key_arn
+        )["ARN"]
+
+        cleanups.append(
+            lambda: aws_client.secretsmanager.delete_secret(
+                SecretId=secret_name, ForceDeleteWithoutRecovery=True
+            )
+        )
+
+        aws_client.secretsmanager.put_resource_policy(
+            SecretId=secret_arn, ResourcePolicy=json.dumps(resource_policy_secretsmanager)
+        )
+
+        response = secondary_aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
+        assert response["SecretString"] == "secret"
+
+        secondary_aws_client.secretsmanager.put_secret_value(
+            SecretId=secret_arn, SecretString="new-secret"
+        )
+
+        response = secondary_aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
+        assert response["SecretString"] == "new-secret"
+
+        secondary_aws_client.secretsmanager.update_secret(
+            SecretId=secret_arn,
+            ClientRequestToken="EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE",
+            Description="updated",
+            SecretString="updated",
+        )
+
+        response = aws_client.secretsmanager.get_secret_value(SecretId=secret_arn)
+        assert response["SecretString"] == "updated"
+
+        aws_client.secretsmanager.delete_secret(
+            SecretId=secret_arn, ForceDeleteWithoutRecovery=False, RecoveryWindowInDays=7
+        )
+
+        # assert that the secret is deleted
+        poll_condition(
+            lambda: aws_client.secretsmanager.describe_secret(SecretId=secret_arn).get(
+                "DeletedDate"
+            )
+            is not None,
+            timeout=5.0,
+            interval=0.5,
+        )
+
+        secondary_aws_client.secretsmanager.restore_secret(SecretId=secret_arn)
+
+        # assert that the secret is deleted
+        poll_condition(
+            lambda: aws_client.secretsmanager.describe_secret(SecretId=secret_arn).get(
+                "DeletedDate"
+            )
+            is None,
+            timeout=5.0,
+            interval=0.5,
+        )
+
+        poll_condition(
+            lambda: aws_client.secretsmanager.describe_secret(SecretId=secret_arn).get(
+                "ReplicationStatus"
+            )
+            == "InSync",
             timeout=5.0,
             interval=0.5,
         )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4014,5 +4014,27 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_restore": {
+    "recorded-date": "20-03-2024, 13:43:42",
+    "recorded-content": {
+      "delete_secret_res": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "restore_secret_res": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -101,6 +101,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_not_found": {
     "last_validated_date": "2024-03-15T08:11:49+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_restore": {
+    "last_validated_date": "2024-03-20T13:43:42+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_description": {
     "last_validated_date": "2024-03-15T08:12:49+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to add support for arn based resource retrivals for the following apis.

- `get_secret_value`
- `put_secret_value`
- `restore_secret`
- `rotate_secret`

<!-- What notable changes does this PR make? -->
## Changes
We now return data for resources that are in other account based on the ARN provided.

NOTE: IAM enforcement is supported in LocalStack PRO - which means we are not testing against unauthorized resource access in Community version.


## Testing
Added aws validated test cases to access secretsmanager from cross-account.

## Related PR
- https://github.com/localstack/localstack/pull/10457