### PR TITLE
fix capitalization of Authorization header for AWS_PROXY integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -276,11 +276,20 @@ class LambdaProxyIntegration(BackendIntegration):
         single_value_query_string_params = {
             k: v[-1] if isinstance(v, list) else v for k, v in query_string_params.items()
         }
+        # Some headers get capitalized like in CloudFront, see
+        # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-forward-authorization
+        # It seems AWS_PROXY lambda integrations are behind cloudfront, as seen by the returned headers in AWS
+        to_capitalize: list[str] = ["authorization"]  # some headers get capitalized
+        headers = {
+            k.capitalize() if k.lower() in to_capitalize else k: v for k, v in headers.items()
+        }
+
         # AWS canonical header names, converting them to lower-case
         headers = canonicalize_headers(headers)
+
         return {
             "path": path,
-            "headers": dict(headers),
+            "headers": headers,
             "multiValueHeaders": multi_value_dict_for_list(headers),
             "body": data,
             "isBase64Encoded": is_base64_encoded,

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1,12 +1,13 @@
 {
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "recorded-date": "26-04-2023, 20:03:23",
+    "recorded-date": "20-03-2024, 14:44:59",
     "recorded-content": {
       "invocation-payload-without-trailing-slash": {
         "body": null,
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -32,6 +33,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -91,6 +95,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:1>",
@@ -126,6 +131,7 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -151,6 +157,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -210,6 +219,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:2>",
@@ -245,6 +255,7 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -270,6 +281,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -335,6 +349,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:3>",
@@ -370,6 +385,7 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -395,6 +411,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -460,6 +479,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:4>",
@@ -495,6 +515,7 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -520,6 +541,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -579,6 +603,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:5>",
@@ -614,6 +639,7 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
+          "Authorization": "random-value",
           "CloudFront-Forwarded-Proto": "https",
           "CloudFront-Is-Desktop-Viewer": "true",
           "CloudFront-Is-Mobile-Viewer": "false",
@@ -639,6 +665,9 @@
           ],
           "Accept-Encoding": [
             "gzip, deflate"
+          ],
+          "Authorization": [
+            "random-value"
           ],
           "CloudFront-Forwarded-Proto": [
             "https"
@@ -724,6 +753,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:6>",
@@ -772,7 +802,7 @@
           "Content-Type": "application/json;charset=utf-8",
           "Host": "<api-id>.execute-api.<region>.amazonaws.com",
           "User-Agent": "python-requests/testing",
-          "Via": "<via:6>",
+          "Via": "<via:7>",
           "X-Amz-Cf-Id": "<cf-id:7>",
           "X-Amzn-Trace-Id": "<trace-id:7>",
           "X-Forwarded-For": "<source-ip:1>, <ip>",
@@ -822,7 +852,7 @@
             "python-requests/testing"
           ],
           "Via": [
-            "<via:6>"
+            "<via:7>"
           ],
           "X-Amz-Cf-Id": [
             "<cf-id:7>"
@@ -862,6 +892,7 @@
         "requestContext": {
           "accountId": "111111111111",
           "apiId": "<api-id>",
+          "deploymentId": "<deployment-id:1>",
           "domainName": "<api-id>.execute-api.<region>.amazonaws.com",
           "domainPrefix": "<api-id>",
           "extendedRequestId": "<extended-request-id:7>",

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2023-05-31T21:09:38+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
-    "last_validated_date": "2023-04-26T18:03:23+00:00"
+    "last_validated_date": "2024-03-20T14:44:59+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_response_format": {
     "last_validated_date": "2024-02-23T18:39:48+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10437, we were missing the capitalization of Authorization header in API Gateway AWS_PROXY integration. 
This is a weird fix, because it seems that AWS_PROXY integrations are behind CloudFront in some way, because it returns CloudFront headers even if not configured. The user does not have any say in the configuration of said "default" cloudfront distribution. But it seems to have the same logic around the Authorization header.
See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-forward-authorization

<!-- What notable changes does this PR make? -->
## Changes
- add a fix to capitalize the authorization header if present in any casing
- modify a currently existing test to verify the assumption

\cc @giograno @Morijarti 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

