### PR TITLE
fix debug output for tinybird

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ jobs:
 
             # Build the payload
             echo '{"workflow": "'$TINYBIRD_WORKFLOW'", "attempt": 1, "run_id": "'$CIRCLE_WORKFLOW_ID'", "start": '$START_TIME', "end": '$END_TIME', "commit": "'$CIRCLE_SHA1'", "branch": "'$CIRCLE_BRANCH'", "repository": "'$CIRCLE_PROJECT_USERNAME'/'$CIRCLE_PROJECT_REPONAME'", "outcome": "'$OUTCOME'", "workflow_url": "'$CIRCLE_BUILD_URL'"}' > stats.json
-            echo 'Sending: '$(cat stats/stats.json)
+            echo 'Sending: '$(cat stats.json)
 
             # Send the data to Tinybird
             curl -X POST "https://api.tinybird.co/v0/events?name=ci_workflows" -H "Authorization: Bearer $TINYBIRD_CI_TOKEN" -d @stats.json


### PR DESCRIPTION
## Motivation
While working on an issue in our CI dashboard, I stumbled across an error recently introduced with https://github.com/localstack/localstack/pull/10492, which can be seen f.e. [in the output of this run](https://app.circleci.com/pipelines/github/localstack/localstack/23534/workflows/c8171748-3be3-48f8-8309-c1e54a706269/jobs/192545):
```
cat: stats/stats.json: No such file or directory
```

However, this really only impacts the debug info on what data will be sent in the step right below.
Sending the data is not affected at all.

## Changes
- Fix a small reporting issue in the Tinybird CI analytics sending

## Testing
- See in the triggered run that the output of the data to be sent works correctly now.