### PR TITLE
fix: add transformer to region attribute in failing s3 for 'eu-west-1'

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -340,14 +340,16 @@ class TestS3:
     @markers.snapshot.skip_snapshot_verify(paths=["$..AccessPointAlias"])
     def test_region_header_exists(self, s3_create_bucket, snapshot, aws_client):
         snapshot.add_transformer(snapshot.transform.s3_api())
+        region = "eu-west-1"
+        snapshot.add_transformer(RegexTransformer(region, "<region>"))
         bucket_name = s3_create_bucket(
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": region},
         )
         response = aws_client.s3.head_bucket(Bucket=bucket_name)
-        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == "eu-west-1"
+        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == region
         snapshot.match("head_bucket", response)
         response = aws_client.s3.list_objects_v2(Bucket=bucket_name)
-        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == "eu-west-1"
+        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == region
         snapshot.match("list_objects_v2", response)
 
     @markers.aws.validated

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1,10 +1,10 @@
 {
   "tests/aws/services/s3/test_s3.py::TestS3::test_region_header_exists": {
-    "recorded-date": "06-12-2023, 16:47:40",
+    "recorded-date": "21-03-2024, 08:05:13",
     "recorded-content": {
       "head_bucket": {
         "AccessPointAlias": false,
-        "BucketRegion": "eu-west-1",
+        "BucketRegion": "<region>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -234,7 +234,7 @@
     "last_validated_date": "2023-08-03T02:14:18+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_region_header_exists": {
-    "last_validated_date": "2023-08-03T02:13:15+00:00"
+    "last_validated_date": "2024-03-21T08:05:13+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure": {
     "last_validated_date": "2024-01-03T16:46:18+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We ran a pipeline for randomised region and account: [here](https://app.circleci.com/pipelines/github/localstack/localstack/23423/workflows/679f1237-6253-495d-947e-45f19e2fc8e9/jobs/191264/tests) and found that `test_region_header_exists` fails with the following error: 

> >> match key: head_bucket
> 	#x1B[33m(~)#x1B[0m /BucketRegion 'eu-west-1' → region... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..BucketRegion"]

So, basically when we set the `TEST_AWS_REGION_NAME` to `eu-west-1` we get this error. 

<!-- What notable changes does this PR make? -->
## Changes
This PR adds a transformer for region and re-generates the snapshot for `tests.aws.services.s3.test_s3.TestS3.test_region_header_exists`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

