### PR TITLE
switch from black to ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,14 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.2
+    rev: v0.3.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      # Run the formatter.
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -12,6 +12,7 @@
   <a href="#sponsors"><img alt="Sponsors on Open Collective" src="https://opencollective.com/localstack/sponsors/badge.svg"></a>
   <a href="https://img.shields.io/pypi/l/localstack.svg"><img alt="PyPI License" src="https://img.shields.io/pypi/l/localstack.svg"></a>
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+  <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://twitter.com/localstack"><img alt="Twitter" src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
 </p>
 
@@ -82,7 +83,7 @@ Create a queue using SQS with LocalStack's [`awslocal`](https://docs.localstack.
 
 ```
 $ awslocal sqs create-queue --queue-name test-queue
-$ awslocal sqs list-queues 
+$ awslocal sqs list-queues
 ```
 
 **Notes**

--- a/Makefile
+++ b/Makefile
@@ -237,22 +237,22 @@ test-docker-mount-code:
 		DOCKER_FLAGS="$(DOCKER_FLAGS) --entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/aws:/opt/code/localstack/localstack/aws -v `pwd`/Makefile:/opt/code/localstack/Makefile -v $$PACKAGES_DIR/moto:/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ -e TEST_PATH=\\'$(TEST_PATH)\\' -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS) $(ENTRYPOINT)" CMD="make test" make docker-run
 
 lint:              		  ## Run code linter to check code style, check if formatter would make changes and check if dependency pins need to be updated
-	($(VENV_RUN); python -m ruff check --output-format=full . && python -m black --check .)
+	($(VENV_RUN); python -m ruff check --output-format=full . && python -m ruff format --check .)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 
 
 lint-modified:     		  ## Run code linter to check code style, check if formatter would make changes on modified files, and check if dependency pins need to be updated because of modified files
-	($(VENV_RUN); python -m ruff check --output-format=full `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs` && python -m black --check `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
+	($(VENV_RUN); python -m ruff check --output-format=full `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs` && python -m ruff format --check `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files $(git diff master --name-only) # run pre-commit hook manually here to ensure that this check runs in CI as well
 
 check-aws-markers:     		  ## Lightweight check to ensure all AWS tests have proper compatibilty markers set
 	($(VENV_RUN); python -m pytest --co tests/aws/)
 
-format:            		  ## Run ruff and black to format the whole codebase
-	($(VENV_RUN); python -m ruff check --output-format=full --fix .; python -m black .)
+format:            		  ## Run ruff to format the whole codebase
+	($(VENV_RUN); python -m ruff format .; python -m ruff check --output-format=full --fix .)
 
-format-modified:          ## Run ruff and black to format only modified code
-	($(VENV_RUN); python -m ruff check --output-format=full --fix `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`; python -m black `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs` )
+format-modified:          ## Run ruff to format only modified code
+	($(VENV_RUN); python -m ruff format `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`; python -m ruff check --output-format=full --fix `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
 
 init-precommit:    		  ## install te pre-commit hook into your local git repository
 	($(VENV_RUN); pre-commit install)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="#sponsors"><img alt="Sponsors on Open Collective" src="https://opencollective.com/localstack/sponsors/badge.svg"></a>
   <a href="https://img.shields.io/pypi/l/localstack.svg"><img alt="PyPI License" src="https://img.shields.io/pypi/l/localstack.svg"></a>
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+  <a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
   <a href="https://twitter.com/localstack"><img alt="Twitter" src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
 </p>
 

--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -1,4 +1,5 @@
 """Functionality related to AWS Accounts"""
+
 import base64
 import binascii
 import logging

--- a/localstack/aws/api/dynamodb/__init__.py
+++ b/localstack/aws/api/dynamodb/__init__.py
@@ -618,7 +618,9 @@ class AutoScalingTargetTrackingScalingPolicyConfigurationUpdate(TypedDict, total
 
 class AutoScalingPolicyUpdate(TypedDict, total=False):
     PolicyName: Optional[AutoScalingPolicyName]
-    TargetTrackingScalingPolicyConfiguration: AutoScalingTargetTrackingScalingPolicyConfigurationUpdate
+    TargetTrackingScalingPolicyConfiguration: (
+        AutoScalingTargetTrackingScalingPolicyConfigurationUpdate
+    )
 
 
 PositiveLongObject = int

--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -9367,7 +9367,9 @@ class DeleteLocalGatewayRouteTableResult(TypedDict, total=False):
 
 
 class DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest(ServiceRequest):
-    LocalGatewayRouteTableVirtualInterfaceGroupAssociationId: LocalGatewayRouteTableVirtualInterfaceGroupAssociationId
+    LocalGatewayRouteTableVirtualInterfaceGroupAssociationId: (
+        LocalGatewayRouteTableVirtualInterfaceGroupAssociationId
+    )
     DryRun: Optional[Boolean]
 
 

--- a/localstack/aws/chain.py
+++ b/localstack/aws/chain.py
@@ -1,6 +1,7 @@
 """
 The core concepts of the HandlerChain.
 """
+
 from __future__ import annotations
 
 import logging

--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -1,4 +1,5 @@
 """Utils to process AWS requests as a client."""
+
 import io
 import logging
 from datetime import datetime

--- a/localstack/aws/connect.py
+++ b/localstack/aws/connect.py
@@ -4,6 +4,7 @@ LocalStack client stack.
 This module provides the interface to perform cross-service communication between
 LocalStack providers.
 """
+
 import json
 import logging
 import re

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -2,6 +2,7 @@
 This module contains utilities to call a backend (e.g., an external service process like
 DynamoDBLocal) from a service provider.
 """
+
 from typing import Any, Callable, Mapping, Optional, Union
 from urllib.parse import urlsplit
 
@@ -149,7 +150,7 @@ def HttpFallbackDispatcher(provider: object, forward_url_getter: Callable[[str, 
 
 
 def get_request_forwarder_http(
-    forward_url_getter: Callable[[str, str], str]
+    forward_url_getter: Callable[[str, str], str],
 ) -> ServiceRequestHandler:
     """
     Returns a ServiceRequestHandler that creates for each invocation a new AwsRequestProxy with the result of

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -1,4 +1,4 @@
-""" A set of common handlers to build an AWS server application."""
+"""A set of common handlers to build an AWS server application."""
 
 from .. import chain
 from . import (

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -1,6 +1,7 @@
 """
 A set of handlers which handle Cross Origin Resource Sharing (CORS).
 """
+
 import logging
 import re
 from typing import List, Set

--- a/localstack/aws/handlers/fallback.py
+++ b/localstack/aws/handlers/fallback.py
@@ -1,4 +1,5 @@
 """Handlers for fallback logic, e.g., populating empty requests or defauling with default exceptions."""
+
 import logging
 
 from rolo.gateway.handlers import EmptyResponseHandler

--- a/localstack/aws/handlers/internal.py
+++ b/localstack/aws/handlers/internal.py
@@ -1,4 +1,5 @@
 """Handler for routing internal localstack resources under /_localstack."""
+
 import logging
 
 from werkzeug.exceptions import NotFound

--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -1,4 +1,4 @@
-""" Handlers for compatibility with legacy edge proxy and the quart http framework."""
+"""Handlers for compatibility with legacy edge proxy and the quart http framework."""
 
 import logging
 

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -1,4 +1,5 @@
 """Handlers for logging."""
+
 import logging
 from functools import cached_property
 from typing import Type

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -1,4 +1,5 @@
 """A set of common handlers to parse and route AWS service requests."""
+
 import logging
 import traceback
 from collections import defaultdict

--- a/localstack/aws/handlers/service_plugin.py
+++ b/localstack/aws/handlers/service_plugin.py
@@ -1,4 +1,5 @@
 """Handlers extending the base logic of service handlers with lazy-loading and plugin mechanisms."""
+
 import logging
 import threading
 from typing import Optional

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -61,6 +61,7 @@ The result of the parser methods are the operation model of the
 service's action which the request was aiming for, as well as the
 parsed parameters for the service's function invocation.
 """
+
 import abc
 import base64
 import datetime

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -70,6 +70,7 @@ to certain so-called "traits" in Smithy.
 The result of the serialization methods is the HTTP response which can
 be sent back to the calling client.
 """
+
 import abc
 import base64
 import functools
@@ -1550,9 +1551,9 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         )
         # s3 extended Request ID
         # mostly used internally on AWS and corresponds to a HostId
-        response.headers[
-            "x-amz-id-2"
-        ] = "s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234="
+        response.headers["x-amz-id-2"] = (
+            "s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234="
+        )
         return response
 
     def _add_error_tags(

--- a/localstack/aws/protocol/validate.py
+++ b/localstack/aws/protocol/validate.py
@@ -1,4 +1,5 @@
 """Slightly extends the ``botocore.validate`` package to provide better integration with our parser/serializer."""
+
 from typing import Any, Dict, List, NamedTuple
 
 from botocore.model import OperationModel, Shape

--- a/localstack/aws/serving/twisted.py
+++ b/localstack/aws/serving/twisted.py
@@ -1,6 +1,7 @@
 """
 Bindings to serve LocalStack using twisted.
 """
+
 import logging
 import time
 from typing import List

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -603,7 +603,7 @@ class UniqueHostAndPortList(List[HostAndPort]):
 
 
 def populate_edge_configuration(
-    environment: Mapping[str, str]
+    environment: Mapping[str, str],
 ) -> Tuple[HostAndPort, UniqueHostAndPortList]:
     """Populate the LocalStack edge configuration from environment variables."""
     localstack_host_raw = environment.get("LOCALSTACK_HOST")

--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -1,6 +1,7 @@
 """
 Several ContainerConfigurator implementations to set up a development version of a localstack container.
 """
+
 import gzip
 import os
 from pathlib import Path, PurePosixPath

--- a/localstack/dev/run/paths.py
+++ b/localstack/dev/run/paths.py
@@ -1,4 +1,5 @@
 """Utilities to resolve important paths on the host and in the container."""
+
 import os
 from pathlib import Path
 from typing import Optional, Union

--- a/localstack/extensions/__init__.py
+++ b/localstack/extensions/__init__.py
@@ -1,2 +1,3 @@
 """Extensions are third-party software modules to customize localstack."""
+
 name = "extensions"

--- a/localstack/extensions/api/__init__.py
+++ b/localstack/extensions/api/__init__.py
@@ -1,4 +1,5 @@
 """Public facing API for users to build LocalStack extensions."""
+
 from .extension import Extension
 
 name = "api"

--- a/localstack/logging/format.py
+++ b/localstack/logging/format.py
@@ -1,4 +1,5 @@
 """Tools for formatting localstack logs."""
+
 import logging
 from functools import lru_cache
 from typing import Dict

--- a/localstack/runtime/main.py
+++ b/localstack/runtime/main.py
@@ -1,5 +1,6 @@
 """This is the entrypoint used to start the localstack runtime. It starts the infrastructure and also
 manages the interaction with the operating system - mostly signal handlers for now."""
+
 import signal
 import sys
 

--- a/localstack/services/apigateway/exporter.py
+++ b/localstack/services/apigateway/exporter.py
@@ -66,8 +66,7 @@ class _BaseOpenApiExporter(abc.ABC):
         with_extension: bool,
         account_id: str,
         region_name: str,
-    ) -> str | dict:
-        ...
+    ) -> str | dict: ...
 
     @abc.abstractmethod
     def _add_paths(self, spec: APISpec, resources: dict, with_extension: bool):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1093,9 +1093,9 @@ def import_api_from_openapi_spec(
                         if param_location == "query":
                             param_location = "querystring"
 
-                        request_parameters[
-                            f"method.request.{param_location}.{param_name}"
-                        ] = param_required
+                        request_parameters[f"method.request.{param_location}.{param_name}"] = (
+                            param_required
+                        )
 
                     elif param_location == "body":
                         request_models = {APPLICATION_JSON: param_name}

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -134,9 +134,9 @@ def apply_patches():
         apigateway_models.MethodResponse,
     ]
     for model_class in model_classes:
-        model_class.apply_operations = (
-            model_class.apply_patch_operations
-        ) = backend_model_apply_operations
+        model_class.apply_operations = model_class.apply_patch_operations = (
+            backend_model_apply_operations
+        )
 
     # fix data types for some json-patch operation values
 

--- a/localstack/services/cloudformation/cfn_utils.py
+++ b/localstack/services/cloudformation/cfn_utils.py
@@ -42,8 +42,15 @@ def lambda_rename_attributes(attrs, func=None):
         return o
 
     func = func or (lambda account_id, region_name, x, logical_resource_id, *args, **kwargs: x)
-    return lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: recurse_object(
-        func(account_id, region_name, params, logical_resource_id, *args, **kwargs), recurse
+    return (
+        lambda account_id,
+        region_name,
+        params,
+        logical_resource_id,
+        *args,
+        **kwargs: recurse_object(
+            func(account_id, region_name, params, logical_resource_id, *args, **kwargs), recurse
+        )
     )
 
 

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -89,15 +89,29 @@ def params_list_to_dict(param_name, key_attr_name="Key", value_attr_name="Value"
 
 
 def lambda_keys_to_lower(key=None, skip_children_of: List[str] = None):
-    return lambda account_id, region_name, params, logical_resource_id, *args, **kwargs: common.keys_to_lower(
-        obj=(params.get(key) if key else params), skip_children_of=skip_children_of
+    return (
+        lambda account_id,
+        region_name,
+        params,
+        logical_resource_id,
+        *args,
+        **kwargs: common.keys_to_lower(
+            obj=(params.get(key) if key else params), skip_children_of=skip_children_of
+        )
     )
 
 
 def merge_parameters(func1, func2):
-    return lambda account_id, region_name, properties, logical_resource_id, *args, **kwargs: common.merge_dicts(
-        func1(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
-        func2(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
+    return (
+        lambda account_id,
+        region_name,
+        properties,
+        logical_resource_id,
+        *args,
+        **kwargs: common.merge_dicts(
+            func1(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
+            func2(account_id, region_name, properties, logical_resource_id, *args, **kwargs),
+        )
     )
 
 
@@ -145,8 +159,13 @@ def lambda_select_params(*selected):
 
 
 def select_parameters(*param_names):
-    return lambda account_id, region_name, properties, logical_resource_id, *args, **kwargs: select_attributes(
-        properties, param_names
+    return (
+        lambda account_id,
+        region_name,
+        properties,
+        logical_resource_id,
+        *args,
+        **kwargs: select_attributes(properties, param_names)
     )
 
 

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -89,7 +89,7 @@ class Stack:
         for resource_id, resource in self.template_resources.items():
             resource["LogicalResourceId"] = self.template_original["Resources"][resource_id][
                 "LogicalResourceId"
-            ] = (resource.get("LogicalResourceId") or resource_id)
+            ] = resource.get("LogicalResourceId") or resource_id
         # initialize stack template attributes
         stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
             self.stack_name,

--- a/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack/services/cloudformation/engine/parameters.py
@@ -17,6 +17,7 @@ Documentation extracted from AWS docs (https://docs.aws.amazon.com/AWSCloudForma
         For stack updates, the Use existing value option in the console and the UsePreviousValue attribute for update-stack tell AWS CloudFormation to use the existing Systems Manager parameter key—not its value. AWS CloudFormation always fetches the latest values from Parameter Store when it updates stacks.
 
 """
+
 from typing import Literal, Optional, TypedDict
 
 from localstack.aws.api.cloudformation import Parameter, ParameterDeclaration
@@ -143,7 +144,7 @@ def strip_parameter_type(in_param: StackParameter) -> Parameter:
 
 
 def convert_stack_parameters_to_list(
-    in_params: dict[str, StackParameter] | None
+    in_params: dict[str, StackParameter] | None,
 ) -> list[StackParameter]:
     if not in_params:
         return []

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -935,7 +935,10 @@ class TemplateDeployer:
     def is_deployed(self, resource):
         return self.stack.resource_states.get(resource["LogicalResourceId"], {}).get(
             "ResourceStatus"
-        ) in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]
+        ) in [
+            "CREATE_COMPLETE",
+            "UPDATE_COMPLETE",
+        ]
 
     def all_resource_dependencies_satisfied(self, resource) -> bool:
         unsatisfied = self.get_unsatisfied_dependencies(resource)

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -705,16 +705,16 @@ class CloudformationProvider(CloudformationApi):
         if not changes:
             change_set.metadata["Status"] = "FAILED"
             change_set.metadata["ExecutionStatus"] = "UNAVAILABLE"
-            change_set.metadata[
-                "StatusReason"
-            ] = "The submitted information didn't contain changes. Submit different information to create a change set."
+            change_set.metadata["StatusReason"] = (
+                "The submitted information didn't contain changes. Submit different information to create a change set."
+            )
         else:
-            change_set.metadata[
-                "Status"
-            ] = "CREATE_COMPLETE"  # technically for some time this should first be CREATE_PENDING
-            change_set.metadata[
-                "ExecutionStatus"
-            ] = "AVAILABLE"  # technically for some time this should first be UNAVAILABLE
+            change_set.metadata["Status"] = (
+                "CREATE_COMPLETE"  # technically for some time this should first be CREATE_PENDING
+            )
+            change_set.metadata["ExecutionStatus"] = (
+                "AVAILABLE"  # technically for some time this should first be UNAVAILABLE
+            )
 
         return CreateChangeSetOutput(StackId=change_set.stack_id, Id=change_set.change_set_id)
 

--- a/localstack/services/cloudformation/provider_utils.py
+++ b/localstack/services/cloudformation/provider_utils.py
@@ -4,6 +4,7 @@ A set of utils for use in resource providers.
 Avoid any imports to localstack here and keep external imports to a minimum!
 This is because we want to be able to package a resource provider without including localstack code.
 """
+
 import builtins
 import json
 import re

--- a/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack/services/cloudformation/scaffolding/__main__.py
@@ -114,6 +114,7 @@ class ResourceName:
         )
 
 
+# TODO this needs to switch to ruff
 def run_black(text: str) -> str:
     """Black does not have an API, so spawn a subprocess"""
     try:

--- a/localstack/services/cloudformation/scaffolding/__main__.py
+++ b/localstack/services/cloudformation/scaffolding/__main__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess as sp
 import zipfile
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -114,27 +113,11 @@ class ResourceName:
         )
 
 
-# TODO this needs to switch to ruff
-def run_black(text: str) -> str:
-    """Black does not have an API, so spawn a subprocess"""
-    try:
-        proc = sp.run(["black", "--code", text], capture_output=True, check=True)
-    except FileNotFoundError:
-        # The user does not have black installed
-        return text
-    output = proc.stdout.decode("utf8")
-    return output
-
-
 def get_formatted_template_output(
-    env: Environment, template_name: str, do_run_black: bool, *render_args, **render_kwargs
+    env: Environment, template_name: str, *render_args, **render_kwargs
 ) -> str:
     template = env.get_template(template_name)
-    raw_text = template.render(*render_args, **render_kwargs)
-    if do_run_black:
-        return run_black(raw_text)
-    else:
-        return raw_text
+    return template.render(*render_args, **render_kwargs)
 
 
 class SchemaProvider:
@@ -260,7 +243,6 @@ class TemplateRenderer:
         self,
         file_type: FileType,
         resource_name: ResourceName,
-        do_run_black: bool,
     ) -> str:
         # Generated outputs (template, schema)
         # templates
@@ -354,7 +336,7 @@ class TemplateRenderer:
                 raise NotImplementedError(f"Rendering template of type {file_type}")
 
         return get_formatted_template_output(
-            self.environment, template_mapping[file_type], do_run_black, **kwargs
+            self.environment, template_mapping[file_type], **kwargs
         )
 
     def get_getatt_targets(self) -> Generator[str, None, None]:
@@ -669,15 +651,13 @@ class OutputFactory:
         template_renderer: TemplateRenderer,
         printer: Console,
         writer: FileWriter,
-        do_run_black: bool,
     ):
         self.template_renderer = template_renderer
         self.printer = printer
         self.writer = writer
-        self.do_run_black = do_run_black
 
     def get(self, file_type: FileType, resource_name: ResourceName) -> Output:
-        contents = self.template_renderer.render(file_type, resource_name, self.do_run_black)
+        contents = self.template_renderer.render(file_type, resource_name)
         return Output(contents, file_type, self.printer, self.writer, resource_name)
 
 
@@ -765,14 +745,12 @@ def cli():
 @click.option("-w", "--write/--no-write", default=False)
 @click.option("--overwrite", is_flag=True, default=False)
 @click.option("-t", "--write-tests/--no-write-tests", default=False)
-@click.option("--run-black/--no-run-black", "do_run_black", default=True)
 @click.option("--pro", is_flag=True, default=False)
 def generate(
     resource_type: str,
     write: bool,
     write_tests: bool,
     overwrite: bool,
-    do_run_black: bool,
     pro: bool,
 ):
     console = Console()
@@ -801,7 +779,7 @@ def generate(
 
         template_renderer = TemplateRenderer(schema, env, pro)
         writer = FileWriter(resource_name, console, overwrite, pro)
-        output_factory = OutputFactory(template_renderer, console, writer, do_run_black)  # noqa
+        output_factory = OutputFactory(template_renderer, console, writer)  # noqa
         for file_type in FileType:
             if not write_tests and file_type in {
                 FileType.integration_test,

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -148,7 +148,7 @@ def generate_metric_query(alarm_details: MetricAlarm) -> MetricDataQuery:
             Metric=metric,
             Period=alarm_details["Period"],
             Stat=alarm_details["Statistic"],
-        )
+        ),
         # TODO other fields might be required in the future
     )
 

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -505,9 +505,9 @@ class FirehoseProvider(FirehoseApi):
             )
 
         if amazonopensearchservice_destination_update:
-            destination[
-                "AmazonopensearchserviceDestinationDescription"
-            ] = convert_opensearch_update_to_desc(amazonopensearchservice_destination_update)
+            destination["AmazonopensearchserviceDestinationDescription"] = (
+                convert_opensearch_update_to_desc(amazonopensearchservice_destination_update)
+            )
 
         if s3_destination_update:
             destination["S3DestinationDescription"] = convert_s3_update_to_desc(

--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -243,9 +243,7 @@ class IamProvider(IamApi):
             # Permission boundary should not be a part of the response
             response_role.pop("PermissionsBoundary", None)
             response_roles.append(response_role)
-            if (
-                path_prefix
-            ):  # TODO: this is consistent with the patch it migrates, but should add tests for this.
+            if path_prefix:  # TODO: this is consistent with the patch it migrates, but should add tests for this.
                 response_role["AssumeRolePolicyDocument"] = quote(
                     json.dumps(moto_role.assume_role_policy_document or {})
                 )

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -1,4 +1,5 @@
-"""Module for localstack internal resources, such as health, graph, or _localstack/cloudformation/deploy. """
+"""Module for localstack internal resources, such as health, graph, or _localstack/cloudformation/deploy."""
+
 import json
 import logging
 import os

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1082,9 +1082,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         if expiration_model:
             key_to_import_material_to.metadata["ExpirationModel"] = expiration_model
         else:
-            key_to_import_material_to.metadata[
-                "ExpirationModel"
-            ] = ExpirationModelType.KEY_MATERIAL_EXPIRES
+            key_to_import_material_to.metadata["ExpirationModel"] = (
+                ExpirationModelType.KEY_MATERIAL_EXPIRES
+            )
         if (
             key_to_import_material_to.metadata["ExpirationModel"]
             == ExpirationModelType.KEY_MATERIAL_EXPIRES

--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -1,6 +1,7 @@
-""" Utilities related to Lambda API operations such as ARN handling, validations, and output formatting.
+"""Utilities related to Lambda API operations such as ARN handling, validations, and output formatting.
 Everything related to behavior or implicit functionality goes into `lambda_utils.py`.
 """
+
 import datetime
 import random
 import re

--- a/localstack/services/lambda_/event_source_listeners/dynamodb_event_source_listener.py
+++ b/localstack/services/lambda_/event_source_listeners/dynamodb_event_source_listener.py
@@ -11,9 +11,9 @@ from localstack.utils.threads import FuncThread
 
 class DynamoDBEventSourceListener(StreamEventSourceListener):
     _FAILURE_PAYLOAD_DETAILS_FIELD_NAME = "DDBStreamBatchInfo"
-    _COORDINATOR_THREAD: Optional[
-        FuncThread
-    ] = None  # Thread for monitoring state of event source mappings
+    _COORDINATOR_THREAD: Optional[FuncThread] = (
+        None  # Thread for monitoring state of event source mappings
+    )
     _STREAM_LISTENER_THREADS: Dict[
         str, FuncThread
     ] = {}  # Threads for listening to stream shards and forwarding data to mapped Lambdas

--- a/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
+++ b/localstack/services/lambda_/event_source_listeners/kinesis_event_source_listener.py
@@ -21,9 +21,9 @@ LOG = logging.getLogger(__name__)
 
 class KinesisEventSourceListener(StreamEventSourceListener):
     _FAILURE_PAYLOAD_DETAILS_FIELD_NAME = "KinesisBatchInfo"
-    _COORDINATOR_THREAD: Optional[
-        FuncThread
-    ] = None  # Thread for monitoring state of event source mappings
+    _COORDINATOR_THREAD: Optional[FuncThread] = (
+        None  # Thread for monitoring state of event source mappings
+    )
     _STREAM_LISTENER_THREADS: Dict[
         str, FuncThread
     ] = {}  # Threads for listening to stream shards and forwarding data to mapped Lambdas

--- a/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/lambda_/event_source_listeners/stream_event_source_listener.py
@@ -33,9 +33,9 @@ class StreamEventSourceListener(EventSourceListener):
     these two services.
     """
 
-    _COORDINATOR_THREAD: Optional[
-        FuncThread
-    ] = None  # Thread for monitoring state of event source mappings
+    _COORDINATOR_THREAD: Optional[FuncThread] = (
+        None  # Thread for monitoring state of event source mappings
+    )
     _STREAM_LISTENER_THREADS: Dict[
         str, FuncThread
     ] = {}  # Threads for listening to stream shards and forwarding data to mapped Lambdas

--- a/localstack/services/lambda_/hooks.py
+++ b/localstack/services/lambda_/hooks.py
@@ -1,4 +1,5 @@
 """Definition of Plux extension points (i.e., hooks) for Lambda."""
+
 from localstack.runtime.hooks import hook_spec
 
 HOOKS_LAMBDA_START_DOCKER_EXECUTOR = "localstack.hooks.lambda_start_docker_executor"

--- a/localstack/services/lambda_/invocation/assignment.py
+++ b/localstack/services/lambda_/invocation/assignment.py
@@ -66,9 +66,9 @@ class AssignmentService(OtherServiceEndpoint):
                 )
             elif provisioning_type == "on-demand":
                 execution_environment = self.start_environment(version_manager_id, function_version)
-                self.environments[version_manager_id][
-                    execution_environment.id
-                ] = execution_environment
+                self.environments[version_manager_id][execution_environment.id] = (
+                    execution_environment
+                )
                 execution_environment.reserve()
             else:
                 raise ValueError(f"Invalid provisioning type {provisioning_type}")

--- a/localstack/services/lambda_/invocation/counting_service.py
+++ b/localstack/services/lambda_/invocation/counting_service.py
@@ -101,9 +101,9 @@ class CountingService:
             with self.on_demand_init_lock:
                 on_demand_tracker = self.on_demand_concurrency_trackers.get(scope_tuple)
                 if not on_demand_tracker:
-                    on_demand_tracker = self.on_demand_concurrency_trackers[
-                        scope_tuple
-                    ] = ConcurrencyTracker()
+                    on_demand_tracker = self.on_demand_concurrency_trackers[scope_tuple] = (
+                        ConcurrencyTracker()
+                    )
 
         provisioned_tracker = self.provisioned_concurrency_trackers.get(scope_tuple)
         # Double-checked locking pattern to initialize a provisioned concurrency tracker if it does not exist
@@ -111,9 +111,9 @@ class CountingService:
             with self.provisioned_concurrency_init_lock:
                 provisioned_tracker = self.provisioned_concurrency_trackers.get(scope_tuple)
                 if not provisioned_tracker:
-                    provisioned_tracker = self.provisioned_concurrency_trackers[
-                        scope_tuple
-                    ] = ConcurrencyTracker()
+                    provisioned_tracker = self.provisioned_concurrency_trackers[scope_tuple] = (
+                        ConcurrencyTracker()
+                    )
 
         # TODO: check that we don't give a lease while updating provisioned concurrency
         # Potential challenge if an update happens in between reserving the lease here and actually assigning

--- a/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack/services/lambda_/invocation/execution_environment.py
@@ -151,9 +151,9 @@ class ExecutionEnvironment:
         }
         # Conditionally added environment variables
         if not config.LAMBDA_DISABLE_AWS_ENDPOINT_URL:
-            env_vars[
-                "AWS_ENDPOINT_URL"
-            ] = f"http://{self.runtime_executor.get_endpoint_from_executor()}:{config.GATEWAY_LISTEN[0].port}"
+            env_vars["AWS_ENDPOINT_URL"] = (
+                f"http://{self.runtime_executor.get_endpoint_from_executor()}:{config.GATEWAY_LISTEN[0].port}"
+            )
         # config.handler is None for image lambdas and will be populated at runtime (e.g., by RIE)
         if self.function_version.config.handler:
             env_vars["_HANDLER"] = self.function_version.config.handler

--- a/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack/services/lambda_/invocation/lambda_models.py
@@ -2,6 +2,7 @@
 The LambdaProviderPro in localstack-ext imports this model and configures persistence.
 The actual function code is stored in S3 (see S3Code).
 """
+
 import dataclasses
 import logging
 import shutil
@@ -345,9 +346,9 @@ class FunctionUrlConfig:
     url: str  # full URL (e.g. "https://pfn5bdb2dl5mzkbn6eb2oi3xfe0nthdn.lambda-url.eu-west-3.on.aws/")
     auth_type: FunctionUrlAuthType
     creation_time: str  # time
-    last_modified_time: Optional[
-        str
-    ] = None  # TODO: check if this is the creation time when initially creating
+    last_modified_time: Optional[str] = (
+        None  # TODO: check if this is the creation time when initially creating
+    )
     function_qualifier: Optional[str] = "$LATEST"  # only $LATEST or alias name
     invoke_mode: Optional[InvokeMode] = None
 
@@ -584,9 +585,9 @@ class Function:
         default_factory=dict
     )  # key is $LATEST(?), version or alias
     reserved_concurrent_executions: Optional[int] = None
-    provisioned_concurrency_configs: dict[
-        str, ProvisionedConcurrencyConfiguration
-    ] = dataclasses.field(default_factory=dict)
+    provisioned_concurrency_configs: dict[str, ProvisionedConcurrencyConfiguration] = (
+        dataclasses.field(default_factory=dict)
+    )
     tags: dict[str, str] | None = None
 
     lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)

--- a/localstack/services/lambda_/lambda_utils.py
+++ b/localstack/services/lambda_/lambda_utils.py
@@ -1,6 +1,7 @@
 """Lambda utilities for behavior and implicit functionality.
 Everything related to API operations goes into `api_utils.py`.
 """
+
 import logging
 import os
 

--- a/localstack/services/lambda_/packages.py
+++ b/localstack/services/lambda_/packages.py
@@ -1,4 +1,5 @@
 """Package installers for external Lambda dependencies."""
+
 import os
 import stat
 from typing import List

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -685,9 +685,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                         state.layers[layer_name] = layer
                     else:
                         # Create layer version if another version of the same layer already exists
-                        state.layers[layer_name].layer_versions[
-                            layer_version_str
-                        ] = layer.layer_versions.get(layer_version_str)
+                        state.layers[layer_name].layer_versions[layer_version_str] = (
+                            layer.layer_versions.get(layer_version_str)
+                        )
 
             # only the first two matches in the array are considered for the error message
             layer_arn = ":".join(layer_version_arn.split(":")[:-1])
@@ -1323,7 +1323,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 version, return_qualified_arn=bool(qualifier), alias_name=alias_name
             ),
             Code=code_location,  # TODO
-            **additional_fields
+            **additional_fields,
             # Concurrency={},  # TODO
         )
 
@@ -1849,9 +1849,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 function_name, qualifier, account_id, region
             )
 
-        temp_params = (
-            {}
-        )  # values only set for the returned response, not saved internally (e.g. transient state)
+        temp_params = {}  # values only set for the returned response, not saved internally (e.g. transient state)
 
         if request.get("Enabled") is not None:
             if request["Enabled"]:

--- a/localstack/services/lambda_/runtimes.py
+++ b/localstack/services/lambda_/runtimes.py
@@ -1,4 +1,5 @@
 """This Lambda Runtimes reference defines everything around Lambda runtimes to facilitate adding new runtimes."""
+
 from localstack.aws.api.lambda_ import Runtime
 
 # LocalStack Lambda runtimes support policy

--- a/localstack/services/lambda_/urlrouter.py
+++ b/localstack/services/lambda_/urlrouter.py
@@ -1,4 +1,5 @@
 """Routing for Lambda function URLs: https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html"""
+
 import base64
 import json
 import logging

--- a/localstack/services/lambda_/usage.py
+++ b/localstack/services/lambda_/usage.py
@@ -1,6 +1,7 @@
 """
 Usage reporting for Lambda service
 """
+
 from localstack.utils.analytics.usage import UsageCounter, UsageSetCounter
 
 # usage of lambda hot-reload feature

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -1,6 +1,7 @@
 """
 This module provides tools to call moto using moto and botocore internals without going through the moto HTTP server.
 """
+
 import copy
 import sys
 from functools import lru_cache

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -133,7 +133,7 @@ def build_cluster_run_command(cluster_bin: str, settings: CommandSettings) -> Li
     :param settings: dictionary where each item will be set as a command arguments
     :return: list of strings for the command with the settings to be executed as a shell command
     """
-    cmd_settings = [f"-E {k}={v}" for k, v, in settings.items()]
+    cmd_settings = [f"-E {k}={v}" for k, v in settings.items()]
     return [cluster_bin] + cmd_settings
 
 
@@ -444,9 +444,9 @@ class OpensearchCluster(Server):
             settings["plugins.security.ssl.http.pemcert_filepath"] = "cert.crt"
             settings["plugins.security.ssl.http.pemtrustedcas_filepath"] = "cert.crt"
             settings["plugins.security.allow_default_init_securityindex"] = "true"
-            settings[
-                "plugins.security.restapi.roles_enabled"
-            ] = "all_access,security_rest_api_access"
+            settings["plugins.security.restapi.roles_enabled"] = (
+                "all_access,security_rest_api_access"
+            )
 
         return settings
 

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -27,9 +27,9 @@ class Route53ResolverStore(BaseStore):
         default=dict
     )
     resolver_query_log_configs: Dict[str, ResolverQueryLogConfig] = LocalAttribute(default=dict)
-    resolver_query_log_config_associations: Dict[
-        str, ResolverQueryLogConfigAssociation
-    ] = LocalAttribute(default=dict)
+    resolver_query_log_config_associations: Dict[str, ResolverQueryLogConfigAssociation] = (
+        LocalAttribute(default=dict)
+    )
 
     def get_firewall_rule_group(self, id):
         """returns firewall rule group with the given id if it exists"""

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -576,9 +576,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         **kwargs,
     ) -> CreateResolverEndpointResponse:
         create_resolver_endpoint_resp = call_moto(context)
-        create_resolver_endpoint_resp["ResolverEndpoint"][
-            "Status"
-        ] = ResolverQueryLogConfigStatus.CREATING
+        create_resolver_endpoint_resp["ResolverEndpoint"]["Status"] = (
+            ResolverQueryLogConfigStatus.CREATING
+        )
         return create_resolver_endpoint_resp
 
     def get_resolver_query_log_config(

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -122,9 +122,9 @@ class S3CorsHandler(Handler):
             """
             request_id = context.request_id
             response.headers["x-amz-request-id"] = request_id
-            response.headers[
-                "x-amz-id-2"
-            ] = f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
+            response.headers["x-amz-id-2"] = (
+                f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
+            )
 
             response.set_response(b"")
             response.headers.pop("Content-Type", None)
@@ -197,9 +197,9 @@ class S3CorsHandler(Handler):
         if not is_wildcard:
             response.headers["Access-Control-Allow-Credentials"] = "true"
 
-        response.headers[
-            "Vary"
-        ] = "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
+        response.headers["Vary"] = (
+            "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
+        )
 
         response.headers["Access-Control-Allow-Methods"] = ", ".join(rule["AllowedMethods"])
 

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -40,9 +40,9 @@ class S3Store(BaseStore):
     )
 
     # maps bucket name to bucket's lifecycle configuration
-    bucket_lifecycle_configuration: dict[
-        BucketName, BucketLifecycleConfiguration
-    ] = CrossRegionAttribute(default=dict)
+    bucket_lifecycle_configuration: dict[BucketName, BucketLifecycleConfiguration] = (
+        CrossRegionAttribute(default=dict)
+    )
 
     bucket_versioning_status: dict[BucketName, bool] = CrossRegionAttribute(default=dict)
 
@@ -50,17 +50,17 @@ class S3Store(BaseStore):
         default=dict
     )
 
-    bucket_analytics_configuration: dict[
-        BucketName, dict[AnalyticsId, AnalyticsConfiguration]
-    ] = CrossRegionAttribute(default=dict)
+    bucket_analytics_configuration: dict[BucketName, dict[AnalyticsId, AnalyticsConfiguration]] = (
+        CrossRegionAttribute(default=dict)
+    )
 
     bucket_intelligent_tiering_configuration: dict[
         BucketName, dict[IntelligentTieringId, IntelligentTieringConfiguration]
     ] = CrossRegionAttribute(default=dict)
 
-    bucket_inventory_configurations: dict[
-        BucketName, dict[InventoryId, InventoryConfiguration]
-    ] = CrossRegionAttribute(default=dict)
+    bucket_inventory_configurations: dict[BucketName, dict[InventoryId, InventoryConfiguration]] = (
+        CrossRegionAttribute(default=dict)
+    )
 
 
 class BucketCorsIndex:

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -435,9 +435,9 @@ class BaseNotifier:
                     "lifecycleRestoreStorageClass": ctx.key_storage_class,
                 }
             }
-            record["userIdentity"][
-                "principalId"
-            ] = "AmazonCustomer:A3NL1KOZZKExample"  # TODO: use proper principal?
+            record["userIdentity"]["principalId"] = (
+                "AmazonCustomer:A3NL1KOZZKExample"  # TODO: use proper principal?
+            )
             # a bit hacky, it is to ensure the eventTime is a bit after the `Post` event, as its instant in LS
             # the best would be to delay the publishing of the event
             event_time = parse_timestamp(record["eventTime"]) + datetime.timedelta(milliseconds=500)
@@ -722,9 +722,9 @@ class EventBridgeNotifier(BaseNotifier):
         elif "ObjectRemoved" in ctx.event_type:
             entry["DetailType"] = "Object Deleted"
             event_details["reason"] = "DeleteObject"
-            event_details[
-                "deletion-type"
-            ] = "Permanently Deleted"  # TODO: check with versioned bucket?
+            event_details["deletion-type"] = (
+                "Permanently Deleted"  # TODO: check with versioned bucket?
+            )
             event_details["object"].pop("etag")
             event_details["object"].pop("size")
 

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -192,9 +192,9 @@ from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
 
-os.environ[
-    "MOTO_S3_CUSTOM_ENDPOINTS"
-] = f"s3.{localstack_host().host_and_port()},s3.{localstack_host().host}"
+os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = (
+    f"s3.{localstack_host().host_and_port()},s3.{localstack_host().host}"
+)
 
 MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
 # max file size for S3 objects kept in memory (500 KB by default)
@@ -669,9 +669,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
             dest_key_object.checksum_algorithm = checksum_algorithm
 
-            response["CopyObjectResult"][
-                f"Checksum{checksum_algorithm.upper()}"
-            ] = dest_key_object.checksum_value  # noqa
+            response["CopyObjectResult"][f"Checksum{checksum_algorithm.upper()}"] = (
+                dest_key_object.checksum_value
+            )  # noqa
 
         self._notify(context)
         return response
@@ -1530,9 +1530,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "ObjectSize" in object_attrs:
             response["ObjectSize"] = key.size
         if "Checksum" in object_attrs and (checksum_algorithm := key.checksum_algorithm):
-            response["Checksum"] = {
-                f"Checksum{checksum_algorithm.upper()}": key.checksum_value
-            }  # noqa
+            response["Checksum"] = {f"Checksum{checksum_algorithm.upper()}": key.checksum_value}  # noqa
 
         response["LastModified"] = key.last_modified
 
@@ -1597,9 +1595,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         moto_bucket = get_bucket_from_moto(get_moto_s3_backend(context), bucket)
         store = self.get_store(moto_bucket.account_id, moto_bucket.region_name)
 
-        analytics_configurations: Dict[
-            AnalyticsId, AnalyticsConfiguration
-        ] = store.bucket_analytics_configuration.get(bucket, {})
+        analytics_configurations: Dict[AnalyticsId, AnalyticsConfiguration] = (
+            store.bucket_analytics_configuration.get(bucket, {})
+        )
         analytics_configurations: AnalyticsConfigurationList = sorted(
             analytics_configurations.values(), key=lambda x: x["Id"]
         )
@@ -1722,13 +1720,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         source_bucket_region = moto_bucket.region_name
         if target_bucket.region_name != source_bucket_region:
-            raise CrossLocationLoggingProhibitted(
-                "Cross S3 location logging not allowed. ",
-                TargetBucketLocation=target_bucket.region_name,
-            ) if source_bucket_region == AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
-                "Cross S3 location logging not allowed. ",
-                SourceBucketLocation=source_bucket_region,
-                TargetBucketLocation=target_bucket.region_name,
+            raise (
+                CrossLocationLoggingProhibitted(
+                    "Cross S3 location logging not allowed. ",
+                    TargetBucketLocation=target_bucket.region_name,
+                )
+                if source_bucket_region == AWS_REGION_US_EAST_1
+                else CrossLocationLoggingProhibitted(
+                    "Cross S3 location logging not allowed. ",
+                    SourceBucketLocation=source_bucket_region,
+                    TargetBucketLocation=target_bucket.region_name,
+                )
             )
 
         moto_bucket.logging = logging_config

--- a/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -594,9 +594,9 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
         #   https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html
         #   "Amazon S3 website endpoints do not support HTTPS. If you want to use HTTPS,
         #   you can use Amazon CloudFront [...]"
-        model[
-            "WebsiteURL"
-        ] = f"http://{model['BucketName']}.{S3_STATIC_WEBSITE_HOSTNAME}:{localstack_host().port}"
+        model["WebsiteURL"] = (
+            f"http://{model['BucketName']}.{S3_STATIC_WEBSITE_HOSTNAME}:{localstack_host().port}"
+        )
         # resource["Properties"]["DualStackDomainName"] = ?
 
     def _create_bucket_if_does_not_exist(self, model, region_name, s3_client):

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -139,11 +139,9 @@ class ChecksumHash(Protocol):
     S3CRC32Checksum, and botocore CrtCrc32cChecksum).
     """
 
-    def digest(self) -> bytes:
-        ...
+    def digest(self) -> bytes: ...
 
-    def update(self, value: bytes):
-        ...
+    def update(self, value: bytes): ...
 
 
 def get_s3_checksum(algorithm) -> ChecksumHash:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1281,9 +1281,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             LastModified=s3_object.last_modified,
         )
         if s3_object.checksum_algorithm:
-            copy_object_result[
-                f"Checksum{s3_object.checksum_algorithm.upper()}"
-            ] = s3_object.checksum_value
+            copy_object_result[f"Checksum{s3_object.checksum_algorithm.upper()}"] = (
+                s3_object.checksum_value
+            )
 
         response = CopyObjectOutput(
             CopyObjectResult=copy_object_result,
@@ -3452,13 +3452,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         source_bucket_region = s3_bucket.bucket_region
         if target_s3_bucket.bucket_region != source_bucket_region:
-            raise CrossLocationLoggingProhibitted(
-                "Cross S3 location logging not allowed. ",
-                TargetBucketLocation=target_s3_bucket.bucket_region,
-            ) if source_bucket_region == AWS_REGION_US_EAST_1 else CrossLocationLoggingProhibitted(
-                "Cross S3 location logging not allowed. ",
-                SourceBucketLocation=source_bucket_region,
-                TargetBucketLocation=target_s3_bucket.bucket_region,
+            raise (
+                CrossLocationLoggingProhibitted(
+                    "Cross S3 location logging not allowed. ",
+                    TargetBucketLocation=target_s3_bucket.bucket_region,
+                )
+                if source_bucket_region == AWS_REGION_US_EAST_1
+                else CrossLocationLoggingProhibitted(
+                    "Cross S3 location logging not allowed. ",
+                    SourceBucketLocation=source_bucket_region,
+                    TargetBucketLocation=target_s3_bucket.bucket_region,
+                )
             )
 
         s3_bucket.logging = logging_config
@@ -3932,7 +3936,7 @@ def get_acl_headers_from_request(
         CreateBucketRequest,
         PutBucketAclRequest,
         PutObjectAclRequest,
-    ]
+    ],
 ) -> list[tuple[str, str]]:
     permission_keys = [
         "GrantFullControl",

--- a/localstack/services/s3/v3/storage/ephemeral.py
+++ b/localstack/services/s3/v3/storage/ephemeral.py
@@ -124,9 +124,9 @@ class EphemeralS3StoredObject(S3StoredObject):
 
         with self.file.position_lock:
             truncate = self.file.truncate(size)
-            self.s3_object.internal_last_modified = (
-                self.file.internal_last_modified
-            ) = time.time_ns()
+            self.s3_object.internal_last_modified = self.file.internal_last_modified = (
+                time.time_ns()
+            )
             return truncate
 
     def write(self, stream: IO[bytes] | "EphemeralS3StoredObject" | LimitedStream) -> int:
@@ -164,9 +164,9 @@ class EphemeralS3StoredObject(S3StoredObject):
             etag = etag.hexdigest()
             self.size = self.s3_object.size = file.tell()
             self._etag = self.s3_object.etag = etag
-            self.s3_object.internal_last_modified = (
-                self.file.internal_last_modified
-            ) = time.time_ns()
+            self.s3_object.internal_last_modified = self.file.internal_last_modified = (
+                time.time_ns()
+            )
 
             self._pos = file.seek(0)
 

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -76,9 +76,9 @@ AWSPENDING: Final[str] = "AWSPENDING"
 AWSCURRENT: Final[str] = "AWSCURRENT"
 #
 # Error Messages.
-AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION: Final[
-    str
-] = "You can't create this secret because a secret with this name is already scheduled for deletion."
+AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION: Final[str] = (
+    "You can't create this secret because a secret with this name is already scheduled for deletion."
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
             PutSecretValueRequest,
             RotateSecretRequest,
             UpdateSecretRequest,
-        ]
+        ],
     ):
         if "ClientRequestToken" not in request:
             raise InvalidRequestException(

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -577,9 +577,9 @@ class SNSEmitter:
         }
 
         if emit_source_arn:
-            event_payload["mail"][
-                "sourceArn"
-            ] = f"arn:aws:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}"
+            event_payload["mail"]["sourceArn"] = (
+                f"arn:aws:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}"
+            )
 
         client = self._client_for_topic(sns_topic_arn)
         try:

--- a/localstack/services/sqs/constants.py
+++ b/localstack/services/sqs/constants.py
@@ -2,11 +2,11 @@
 # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
 from localstack.aws.api.sqs import QueueAttributeName
 
-MSG_CONTENT_REGEX = "^[\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$"
+MSG_CONTENT_REGEX = "^[\u0009\u000a\u000d\u0020-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]*$"
 
 # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html
 # While not documented, umlauts seem to be allowed
-ATTR_NAME_CHAR_REGEX = "^[\u00C0-\u017Fa-zA-Z0-9_.-]*$"
+ATTR_NAME_CHAR_REGEX = "^[\u00c0-\u017fa-zA-Z0-9_.-]*$"
 ATTR_NAME_PREFIX_SUFFIX_REGEX = r"^(?!(aws\.|amazon\.|\.)).*(?<!\.)$"
 ATTR_TYPE_REGEX = "^(String|Number|Binary).*$"
 FIFO_MSG_REGEX = "^[0-9a-zA-z!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~-]*$"

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1221,9 +1221,9 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             # TODO: does this need to be atomic?
             for standard_message in result.dead_letter_messages:
                 message = standard_message.message
-                message["Attributes"][
-                    MessageSystemAttributeName.DeadLetterQueueSourceArn
-                ] = queue.arn
+                message["Attributes"][MessageSystemAttributeName.DeadLetterQueueSourceArn] = (
+                    queue.arn
+                )
                 dl_queue.put(
                     message=message,
                     message_deduplication_id=standard_message.message_deduplication_id,
@@ -1415,9 +1415,9 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         if entity.max_number_of_messages_per_second is not None:
             entry["MaxNumberOfMessagesPerSecond"] = entity.max_number_of_messages_per_second
         if entity.approximate_number_of_messages_to_move is not None:
-            entry[
-                "ApproximateNumberOfMessagesToMove"
-            ] = entity.approximate_number_of_messages_to_move
+            entry["ApproximateNumberOfMessagesToMove"] = (
+                entity.approximate_number_of_messages_to_move
+            )
         if entity.approximate_number_of_messages_moved is not None:
             entry["ApproximateNumberOfMessagesMoved"] = entity.approximate_number_of_messages_moved
         if entity.failure_reason is not None:

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -1,7 +1,8 @@
 """The SQS Query API allows using Queue URLs as endpoints for operations on that queue. See:
 https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-making-api-requests.html. This is a
 generic implementation that creates from Query API requests the respective AWS requests, and uses an aws_stack client
-to make the request. """
+to make the request."""
+
 import logging
 from typing import Dict, Optional, Tuple
 from urllib.parse import urlencode

--- a/localstack/services/stepfunctions/asl/component/common/catch/catcher_outcome.py
+++ b/localstack/services/stepfunctions/asl/component/common/catch/catcher_outcome.py
@@ -1,8 +1,7 @@
 import abc
 
 
-class CatcherOutcome(abc.ABC):
-    ...
+class CatcherOutcome(abc.ABC): ...
 
 
 class CatcherOutcomeCaught(CatcherOutcome):

--- a/localstack/services/stepfunctions/asl/component/common/error_name/error_equals_decl.py
+++ b/localstack/services/stepfunctions/asl/component/common/error_name/error_equals_decl.py
@@ -48,8 +48,9 @@ class ErrorEqualsDecl(EvalComponent):
 
         if ErrorEqualsDecl._STATE_ALL_ERROR in self.error_names:
             res = True
-        elif ErrorEqualsDecl._STATE_TASK_ERROR in self.error_names and not isinstance(
-            error_name, StatesErrorName
+        elif (
+            ErrorEqualsDecl._STATE_TASK_ERROR in self.error_names
+            and not isinstance(error_name, StatesErrorName)
         ):  # TODO: consider binding a 'context' variable to error_names to more formally detect their evaluation type.
             res = True
         else:

--- a/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payload_value.py
+++ b/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payload_value.py
@@ -3,5 +3,4 @@ import abc
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 
 
-class PayloadValue(EvalComponent, abc.ABC):
-    ...
+class PayloadValue(EvalComponent, abc.ABC): ...

--- a/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding.py
+++ b/localstack/services/stepfunctions/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding.py
@@ -12,8 +12,7 @@ class PayloadBinding(PayloadValue, abc.ABC):
         self.field: Final[str] = field
 
     @abc.abstractmethod
-    def _eval_val(self, env: Environment) -> Any:
-        ...
+    def _eval_val(self, env: Environment) -> Any: ...
 
     def _eval_body(self, env: Environment) -> None:
         cnt: dict = env.stack.pop()

--- a/localstack/services/stepfunctions/asl/component/common/timeouts/heartbeat.py
+++ b/localstack/services/stepfunctions/asl/component/common/timeouts/heartbeat.py
@@ -8,8 +8,7 @@ from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 
 class Heartbeat(EvalComponent, abc.ABC):
     @abc.abstractmethod
-    def _eval_seconds(self, env: Environment) -> int:
-        ...
+    def _eval_seconds(self, env: Environment) -> int: ...
 
     def _eval_body(self, env: Environment) -> None:
         seconds = self._eval_seconds(env=env)

--- a/localstack/services/stepfunctions/asl/component/common/timeouts/timeout.py
+++ b/localstack/services/stepfunctions/asl/component/common/timeouts/timeout.py
@@ -8,12 +8,10 @@ from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 
 class Timeout(EvalComponent, abc.ABC):
     @abc.abstractmethod
-    def is_default_value(self) -> bool:
-        ...
+    def is_default_value(self) -> bool: ...
 
     @abc.abstractmethod
-    def _eval_seconds(self, env: Environment) -> int:
-        ...
+    def _eval_seconds(self, env: Environment) -> int: ...
 
     def _eval_body(self, env: Environment) -> None:
         seconds = self._eval_seconds(env=env)

--- a/localstack/services/stepfunctions/asl/component/intrinsic/member.py
+++ b/localstack/services/stepfunctions/asl/component/intrinsic/member.py
@@ -3,8 +3,7 @@ from typing import Final
 from localstack.services.stepfunctions.asl.component.intrinsic.component import Component
 
 
-class Member(Component):
-    ...
+class Member(Component): ...
 
 
 class IdentifiedMember(Member):

--- a/localstack/services/stepfunctions/asl/component/state/state.py
+++ b/localstack/services/stepfunctions/asl/component/state/state.py
@@ -104,8 +104,7 @@ class CommonStateField(EvalComponent, ABC):
         )
 
     @abc.abstractmethod
-    def _eval_state(self, env: Environment) -> None:
-        ...
+    def _eval_state(self, env: Environment) -> None: ...
 
     def _eval_body(self, env: Environment) -> None:
         env.event_history.add_event(

--- a/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/comparison.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_choice/comparison/comparison.py
@@ -3,5 +3,4 @@ from abc import ABC
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 
 
-class Comparison(EvalComponent, ABC):
-    ...
+class Comparison(EvalComponent, ABC): ...

--- a/localstack/services/stepfunctions/asl/component/state/state_continue_with.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_continue_with.py
@@ -3,8 +3,7 @@ import abc
 from localstack.services.stepfunctions.asl.component.common.flow.next import Next
 
 
-class ContinueWith(abc.ABC):
-    ...
+class ContinueWith(abc.ABC): ...
 
 
 class ContinueWithEnd(ContinueWith):

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/execute_state.py
@@ -140,8 +140,7 @@ class ExecutionState(CommonStateField, abc.ABC):
         )
 
     @abc.abstractmethod
-    def _eval_execution(self, env: Environment) -> None:
-        ...
+    def _eval_execution(self, env: Environment) -> None: ...
 
     def _handle_retry(self, env: Environment, failure_event: FailureEvent) -> RetryOutcome:
         env.stack.append(failure_event.error_name)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/max_items_decl.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/max_items_decl.py
@@ -9,8 +9,7 @@ from localstack.services.stepfunctions.asl.eval.environment import Environment
 
 class MaxItemsDecl(EvalComponent, abc.ABC):
     @abc.abstractmethod
-    def _get_value(self, env: Environment) -> int:
-        ...
+    def _get_value(self, env: Environment) -> int: ...
 
     def _eval_body(self, env: Environment) -> None:
         max_items: int = self._get_value(env=env)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/reader_config_decl.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/reader_config/reader_config_decl.py
@@ -68,9 +68,9 @@ class ReaderConfig(EvalComponent):
             MaxItemsValue=max_items_value,
         )
         if self.csv_header_location:
-            reader_config_output[
-                "CSVHeaderLocation"
-            ] = self.csv_header_location.csv_header_location_value.value
+            reader_config_output["CSVHeaderLocation"] = (
+                self.csv_header_location.csv_header_location_value.value
+            )
         if self.csv_headers:
             reader_config_output["CSVHeaders"] = self.csv_headers.header_names
         env.stack.append(reader_config_output)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_eval.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_eval.py
@@ -13,5 +13,4 @@ class ResourceEval(abc.ABC):
     def __init__(self, resource: ServiceResource):
         self.resource = resource
 
-    def eval_resource(self, env: Environment) -> None:
-        ...
+    def eval_resource(self, env: Environment) -> None: ...

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/item_reader/resource_eval/resource_output_transformer/resource_output_transformer.py
@@ -3,5 +3,4 @@ import abc
 from localstack.services.stepfunctions.asl.component.eval_component import EvalComponent
 
 
-class ResourceOutputTransformer(EvalComponent, abc.ABC):
-    ...
+class ResourceOutputTransformer(EvalComponent, abc.ABC): ...

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
@@ -89,8 +89,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
         self._workers = list()
 
     @abc.abstractmethod
-    def _create_worker(self, env: Environment) -> IterationWorker:
-        ...
+    def _create_worker(self, env: Environment) -> IterationWorker: ...
 
     def _launch_worker(self, env: Environment) -> IterationWorker:
         worker = super()._launch_worker(env=env)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
@@ -73,8 +73,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
         self._job_pool = None
 
     @abc.abstractmethod
-    def _create_worker(self, env: Environment) -> IterationWorker:
-        ...
+    def _create_worker(self, env: Environment) -> IterationWorker: ...
 
     def _launch_worker(self, env: Environment) -> IterationWorker:
         worker = self._create_worker(env=env)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/iteration_worker.py
@@ -50,8 +50,7 @@ class IterationWorker(abc.ABC):
         return self._stop_signal_received
 
     @abc.abstractmethod
-    def _eval_input(self, env_frame: Environment) -> None:
-        ...
+    def _eval_input(self, env_frame: Environment) -> None: ...
 
     def _eval_job(self, env: Environment, job: Job) -> None:
         map_iteration_event_details = MapIterationEventDetails(

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branch_worker.py
@@ -14,8 +14,7 @@ LOG = logging.getLogger(__name__)
 class BranchWorker:
     class BranchWorkerComm(abc.ABC):
         @abc.abstractmethod
-        def on_terminated(self, env: Environment):
-            ...
+        def on_terminated(self, env: Environment): ...
 
     _branch_worker_comm: Final[BranchWorkerComm]
     _program: Final[Program]

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branches_decl.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_parallel/branches_decl.py
@@ -85,9 +85,9 @@ class BranchesDecl(EvalComponent):
         branch_worker_pool.wait()
 
         # Propagate exception if parallel task failed.
-        exit_event_details: Optional[
-            ExecutionFailedEventDetails
-        ] = branch_worker_pool.get_exit_event_details()
+        exit_event_details: Optional[ExecutionFailedEventDetails] = (
+            branch_worker_pool.get_exit_event_details()
+        )
         if exit_event_details is not None:
             for branch_worker in branch_workers:
                 branch_worker.stop(stop_date=datetime.datetime.now(), cause=None, error=None)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service.py
@@ -95,9 +95,9 @@ class StateTaskService(StateTask, abc.ABC):
         parameters_bind_keys: list[str] = list(parameters.keys())
         for parameter_key in parameters_bind_keys:
             norm_parameter_key = camel_to_snake_case(parameter_key)
-            norm_member_bind: Optional[
-                tuple[str, Optional[StructureShape]]
-            ] = norm_member_binds.get(norm_parameter_key)
+            norm_member_bind: Optional[tuple[str, Optional[StructureShape]]] = (
+                norm_member_binds.get(norm_parameter_key)
+            )
             if norm_member_bind is not None:
                 norm_member_bind_key, norm_member_bind_shape = norm_member_bind
                 parameter_value = parameters.pop(parameter_key)
@@ -178,8 +178,7 @@ class StateTaskService(StateTask, abc.ABC):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-    ):
-        ...
+    ): ...
 
     def _before_eval_execution(
         self, env: Environment, resource_runtime_part: ResourceRuntimePart, raw_parameters: dict

--- a/localstack/services/stepfunctions/asl/component/state/state_fail/cause_path.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_fail/cause_path.py
@@ -23,8 +23,7 @@ _STRING_RETURN_FUNCTIONS: Final[set[str]] = {
 }
 
 
-class CausePath(CauseDecl):
-    ...
+class CausePath(CauseDecl): ...
 
 
 class CausePathJsonPath(CausePath):

--- a/localstack/services/stepfunctions/asl/component/state/state_fail/error_path.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_fail/error_path.py
@@ -23,8 +23,7 @@ _STRING_RETURN_FUNCTIONS: Final[set[str]] = {
 }
 
 
-class ErrorPath(ErrorDecl):
-    ...
+class ErrorPath(ErrorDecl): ...
 
 
 class ErrorPathJsonPath(ErrorPath):

--- a/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/wait_function.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_wait/wait_function/wait_function.py
@@ -10,8 +10,7 @@ LOG = logging.getLogger(__name__)
 
 class WaitFunction(EvalComponent, abc.ABC):
     @abc.abstractmethod
-    def _get_wait_seconds(self, env: Environment) -> int:
-        ...
+    def _get_wait_seconds(self, env: Environment) -> int: ...
 
     def _wait_interval(self, env: Environment, wait_seconds: int) -> None:
         t0 = time.time()

--- a/localstack/services/stepfunctions/asl/eval/callback/callback.py
+++ b/localstack/services/stepfunctions/asl/eval/callback/callback.py
@@ -39,8 +39,7 @@ class CallbackTimeoutError(TimeoutError):
     pass
 
 
-class CallbackConsumerError(abc.ABC):
-    ...
+class CallbackConsumerError(abc.ABC): ...
 
 
 class CallbackConsumerTimeout(CallbackConsumerError):

--- a/localstack/services/stepfunctions/asl/eval/program_state.py
+++ b/localstack/services/stepfunctions/asl/eval/program_state.py
@@ -4,8 +4,7 @@ from typing import Final, Optional
 from localstack.aws.api.stepfunctions import ExecutionFailedEventDetails, Timestamp
 
 
-class ProgramState(abc.ABC):
-    ...
+class ProgramState(abc.ABC): ...
 
 
 class ProgramEnded(ProgramState):

--- a/localstack/services/stepfunctions/backend/execution_worker_comm.py
+++ b/localstack/services/stepfunctions/backend/execution_worker_comm.py
@@ -9,5 +9,4 @@ class ExecutionWorkerComm(abc.ABC):
     """
 
     @abc.abstractmethod
-    def terminated(self) -> None:
-        ...
+    def terminated(self) -> None: ...

--- a/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack/services/stepfunctions/backend/state_machine.py
@@ -77,8 +77,7 @@ class StateMachineInstance:
         return describe_output
 
     @abc.abstractmethod
-    def itemise(self):
-        ...
+    def itemise(self): ...
 
 
 class TagManager:

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -761,9 +761,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     ) -> DescribeMapRunOutput:
         store = self.get_store(context)
         for execution in store.executions.values():
-            map_run_record: Optional[
-                MapRunRecord
-            ] = execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
+            map_run_record: Optional[MapRunRecord] = (
+                execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
+            )
             if map_run_record is not None:
                 return map_run_record.describe()
         raise ResourceNotFound()
@@ -778,9 +778,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     ) -> ListMapRunsOutput:
         # TODO: add support for paging.
         execution = self._get_execution(context=context, execution_arn=execution_arn)
-        map_run_records: list[
-            MapRunRecord
-        ] = execution.exec_worker.env.map_run_record_pool_manager.get_all()
+        map_run_records: list[MapRunRecord] = (
+            execution.exec_worker.env.map_run_record_pool_manager.get_all()
+        )
         return ListMapRunsOutput(
             mapRuns=[map_run_record.list_item() for map_run_record in map_run_records]
         )
@@ -801,9 +801,9 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         # TODO: investigate behaviour of empty requests.
         store = self.get_store(context)
         for execution in store.executions.values():
-            map_run_record: Optional[
-                MapRunRecord
-            ] = execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
+            map_run_record: Optional[MapRunRecord] = (
+                execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
+            )
             if map_run_record is not None:
                 map_run_record.update(
                     max_concurrency=max_concurrency,

--- a/localstack/state/core.py
+++ b/localstack/state/core.py
@@ -1,4 +1,5 @@
 """Core concepts of the persistence API."""
+
 import io
 from typing import IO, Any, Protocol, runtime_checkable
 

--- a/localstack/state/inspect.py
+++ b/localstack/state/inspect.py
@@ -1,4 +1,5 @@
 """Utilities to inspect services and their state containers."""
+
 import importlib
 import logging
 from functools import singledispatchmethod

--- a/localstack/state/pickle.py
+++ b/localstack/state/pickle.py
@@ -27,6 +27,7 @@ entire subclass hierarchy::
 To learn more about this mechanism, read https://docs.python.org/3/library/copyreg.html and
 https://dill.readthedocs.io/en/latest/index.html?highlight=register#dill.Pickler.dispatch.
 """
+
 import inspect
 from typing import Any, BinaryIO, Callable, Generic, Type, TypeVar
 

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -198,8 +198,7 @@ class ParametrizedLambda:
         CodeSigningConfigArn: Optional[str] = None,
         Architectures: Optional[Sequence["ArchitectureType"]] = None,
         EphemeralStorage: Optional["EphemeralStorageTypeDef"] = None,
-    ) -> "FunctionConfigurationResponseMetadataTypeDef":
-        ...
+    ) -> "FunctionConfigurationResponseMetadataTypeDef": ...
 
     def create_function(self, **kwargs):
         kwargs.setdefault("FunctionName", f"{self.scenario}-{short_uid()}")

--- a/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack/testing/pytest/in_memory_localstack.py
@@ -11,6 +11,7 @@ Use in your module as follows::
 
 You can explicitly disable starting localstack by setting ``TEST_SKIP_LOCALSTACK_START=1`` or
 ``TEST_TARGET=AWS_CLOUD``."""
+
 import logging
 import os
 import threading

--- a/localstack/testing/pytest/marking.py
+++ b/localstack/testing/pytest/marking.py
@@ -1,6 +1,7 @@
 """
 Custom pytest mark typings
 """
+
 import os
 from typing import TYPE_CHECKING, Callable, List, Optional
 
@@ -37,13 +38,11 @@ class SkipSnapshotVerifyMarker:
         *,
         paths: "Optional[List[str]]" = None,
         condition: "Optional[Callable[[...], bool]]" = None,
-    ):
-        ...
+    ): ...
 
 
 class MultiRuntimeMarker:
-    def __call__(self, *, scenario: str, runtimes: Optional[List[str]] = None):
-        ...
+    def __call__(self, *, scenario: str, runtimes: Optional[List[str]] = None): ...
 
 
 class SnapshotMarkers:

--- a/localstack/testing/testselection/opt_in.py
+++ b/localstack/testing/testselection/opt_in.py
@@ -3,6 +3,7 @@ During initial rollout of the test selection in PRs this is additionally limited
 
 A test selection will only be effective if all files that would be selected under the testselection also have at least one match in the list below.
 """
+
 import fnmatch
 from typing import Iterable, Optional
 

--- a/localstack/utils/analytics/client.py
+++ b/localstack/utils/analytics/client.py
@@ -1,6 +1,7 @@
 """
 Client for the analytics backend.
 """
+
 import logging
 from typing import Any, Dict, List
 

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -1,4 +1,5 @@
 """Diagnostic tool for a localstack instance running in a container."""
+
 import inspect
 import os
 import socket

--- a/localstack/utils/functions.py
+++ b/localstack/utils/functions.py
@@ -1,4 +1,5 @@
 """Higher-order functional tools."""
+
 import functools
 import inspect
 import logging

--- a/localstack/utils/sync.py
+++ b/localstack/utils/sync.py
@@ -1,4 +1,5 @@
 """Concurrency synchronization utilities"""
+
 import functools
 import threading
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,15 +113,13 @@ test = [
 dev = [
     # test dependencies are required for developing localstack
     "localstack-core[test]",
-    # TODO upgrade black to v24 or replace with ruff format
-    "black>=23.12.0,<24",
     "coveralls>=3.3.1",
     "Cython",
     "networkx>=2.8.4",
     "pandoc",
     "pre-commit>=3.5.0",
     "pypandoc",
-    "ruff>=0.1.0",
+    "ruff>=0.3.3",
     "rstr>=3.2.0",
 ]
 
@@ -162,15 +160,10 @@ exclude = ["tests*"]
     "utils/kinesis/java/cloud/localstack/*.*",
 ]
 
-[tool.black]
-line_length = 100
-include = '(localstack/.*\.py$|tests/.*\.py$)'
-extend_exclude = '(localstack/infra|localstack/node_modules|.filesystem|localstack/services/stepfunctions/asl/antlr/runtime)'
-
 [tool.ruff]
 # Always generate Python 3.8-compatible code.
 target-version = "py38"
-line-length = 110
+line-length = 100
 exclude = [
     ".venv*",
     "venv*",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,8 +47,6 @@ awscli==1.32.64
     # via localstack-core
 awscrt==0.20.5
     # via localstack-core
-black==23.12.1
-    # via localstack-core (pyproject.toml)
 blinker==1.7.0
     # via
     #   flask
@@ -92,13 +90,12 @@ cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==0.86.0
+cfn-lint==0.86.1
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   black
     #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -196,7 +193,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.1
+importlib-resources==6.3.2
     # via jsii
 incremental==22.10.0
     # via localstack-twisted
@@ -279,8 +276,6 @@ mpmath==1.3.0
     # via sympy
 multipart==0.2.4
     # via moto-ext
-mypy-extensions==1.0.0
-    # via black
 networkx==3.2.1
     # via
     #   cfn-lint
@@ -298,7 +293,6 @@ ordered-set==4.1.0
 packaging==24.0
     # via
     #   apispec
-    #   black
     #   build
     #   docker
     #   pytest
@@ -307,17 +301,13 @@ pandoc==2.3
     # via localstack-core (pyproject.toml)
 pathable==0.4.3
     # via jsonschema-path
-pathspec==0.12.1
-    # via black
 pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
     #   stevedore
 platformdirs==4.2.0
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.4.0
     # via
     #   localstack-core

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -71,7 +71,7 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.0
+cfn-lint==0.86.1
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -88,7 +88,7 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.0
+cfn-lint==0.86.1
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
@@ -177,7 +177,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.1
+importlib-resources==6.3.2
     # via jsii
 incremental==22.10.0
     # via localstack-twisted

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -47,8 +47,6 @@ awscli==1.32.64
     # via localstack-core
 awscrt==0.20.5
     # via localstack-core
-black==23.12.1
-    # via localstack-core
 blinker==1.7.0
     # via
     #   flask
@@ -60,7 +58,7 @@ boto3==1.34.64
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.34.65
+boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.34.67
     # via localstack-core (pyproject.toml)
 botocore==1.34.64
     # via
@@ -71,7 +69,7 @@ botocore==1.34.64
     #   localstack-snapshot
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.34.65
+botocore-stubs==1.34.67
     # via boto3-stubs
 build==1.1.1
     # via
@@ -96,13 +94,12 @@ cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==0.86.0
+cfn-lint==0.86.1
     # via moto-ext
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
-    #   black
     #   flask
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -200,7 +197,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.1
+importlib-resources==6.3.2
     # via jsii
 incremental==22.10.0
     # via localstack-twisted
@@ -313,7 +310,7 @@ mypy-boto3-ce==1.34.52
     # via boto3-stubs
 mypy-boto3-cloudcontrol==1.34.0
     # via boto3-stubs
-mypy-boto3-cloudformation==1.34.65
+mypy-boto3-cloudformation==1.34.66
     # via boto3-stubs
 mypy-boto3-cloudfront==1.34.0
     # via boto3-stubs
@@ -331,11 +328,11 @@ mypy-boto3-dms==1.34.0
     # via boto3-stubs
 mypy-boto3-docdb==1.34.13
     # via boto3-stubs
-mypy-boto3-dynamodb==1.34.57
+mypy-boto3-dynamodb==1.34.67
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.34.0
     # via boto3-stubs
-mypy-boto3-ec2==1.34.64
+mypy-boto3-ec2==1.34.66
     # via boto3-stubs
 mypy-boto3-ecr==1.34.0
     # via boto3-stubs
@@ -393,7 +390,7 @@ mypy-boto3-lakeformation==1.34.7
     # via boto3-stubs
 mypy-boto3-lambda==1.34.58
     # via boto3-stubs
-mypy-boto3-logs==1.34.36
+mypy-boto3-logs==1.34.66
     # via boto3-stubs
 mypy-boto3-managedblockchain==1.34.0
     # via boto3-stubs
@@ -475,8 +472,6 @@ mypy-boto3-wafv2==1.34.58
     # via boto3-stubs
 mypy-boto3-xray==1.34.0
     # via boto3-stubs
-mypy-extensions==1.0.0
-    # via black
 networkx==3.2.1
     # via
     #   cfn-lint
@@ -494,7 +489,6 @@ ordered-set==4.1.0
 packaging==24.0
     # via
     #   apispec
-    #   black
     #   build
     #   docker
     #   pytest
@@ -503,17 +497,13 @@ pandoc==2.3
     # via localstack-core
 pathable==0.4.3
     # via jsonschema-path
-pathspec==0.12.1
-    # via black
 pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
     #   stevedore
 platformdirs==4.2.0
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.4.0
     # via
     #   localstack-core

--- a/scripts/render_marker_report.py
+++ b/scripts/render_marker_report.py
@@ -17,6 +17,7 @@ $ MARKER_REPORT_PATH='./target/marker-report.json' \
     COMMIT_SHA=e62e04509d0f950af3027c0f6df4e18c7385c630 \
     python scripts/render_marker_report.py
 """
+
 import dataclasses
 import datetime
 import json

--- a/scripts/tinybird/upload_raw_test_metrics_and_coverage.py
+++ b/scripts/tinybird/upload_raw_test_metrics_and_coverage.py
@@ -1,4 +1,4 @@
-""" Uploading to Tinybird of the metrics collected for a CircleCI run
+"""Uploading to Tinybird of the metrics collected for a CircleCI run
 
 The upload includes:
  * Test Data Raw

--- a/tests/aws/scenario/loan_broker/test_loan_broker.py
+++ b/tests/aws/scenario/loan_broker/test_loan_broker.py
@@ -2,6 +2,7 @@
 This scenario test is taken from https://github.com/localstack-samples/sample-loan-broker-stepfunctions-lambda
 which in turn is based on https://www.enterpriseintegrationpatterns.com/ramblings/loanbroker_stepfunctions.html
 """
+
 import json
 import os
 from dataclasses import dataclass

--- a/tests/aws/scenario/note_taking/test_note_taking.py
+++ b/tests/aws/scenario/note_taking/test_note_taking.py
@@ -2,6 +2,7 @@
 This scenario tests is based on the aws-sample aws-sdk-js-notes app (https://github.com/aws-samples/aws-sdk-js-notes-app),
 which was adapted to work with LocalStack https://github.com/localstack-samples/sample-notes-app-dynamodb-lambda-apigateway.
 """
+
 import copy
 import json
 import logging
@@ -202,10 +203,10 @@ class TestNoteTakingScenario:
         for stack_resource in describe_stack_resources["StackResources"]:
             match stack_resource["ResourceType"]:
                 case "AWS::Lambda::Function":
-                    service_resources_fn[
-                        stack_resource["LogicalResourceId"]
-                    ] = aws_client.lambda_.get_function(
-                        FunctionName=stack_resource["PhysicalResourceId"]
+                    service_resources_fn[stack_resource["LogicalResourceId"]] = (
+                        aws_client.lambda_.get_function(
+                            FunctionName=stack_resource["PhysicalResourceId"]
+                        )
                     )
                 case "AWS::DynamoDB::Table":
                     # we only have one table

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -768,9 +768,7 @@ class TestAPIGateway:
             name="lambda_authorizer",
             type="TOKEN",
             authorizerUri="arn:aws:apigateway:us-east-1:lambda:path/ \
-                2015-03-31/functions/{}/invocations".format(
-                lambda_uri
-            ),
+                2015-03-31/functions/{}/invocations".format(lambda_uri),
             identitySource="method.request.header.Auth",
         )
 
@@ -1653,9 +1651,9 @@ class TestAPIGateway:
             resource_util.create_dynamodb_table(
                 "MusicCollection", partition_key="id", client=dynamodb_client
             )
-            kwargs[
-                "uri"
-            ] = f"arn:aws:apigateway:{apigw_client.meta.region_name}:dynamodb:action/PutItem&Table=MusicCollection"
+            kwargs["uri"] = (
+                f"arn:aws:apigateway:{apigw_client.meta.region_name}:dynamodb:action/PutItem&Table=MusicCollection"
+            )
 
         if role_arn:
             kwargs["credentials"] = role_arn

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -303,9 +303,7 @@ class TestApiGatewayImportRestApi:
         spec_file = spec_file.replace(
             "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:account-id:function:function-name/invocations",
             apigateway_placeholder_authorizer_lambda_invocation_arn,
-        ).replace(
-            "arn:aws:iam::account-id:role", lambda_su_role
-        )  # we just need a placeholder role
+        ).replace("arn:aws:iam::account-id:role", lambda_su_role)  # we just need a placeholder role
 
         response, root_id = import_apigw(body=spec_file, failOnWarnings=True)
 

--- a/tests/aws/services/cloudformation/resources/test_legacy.py
+++ b/tests/aws/services/cloudformation/resources/test_legacy.py
@@ -14,17 +14,14 @@ from localstack.utils.aws import arns
 from localstack.utils.common import load_file, short_uid
 from localstack.utils.testutil import create_zip_file, list_all_resources
 
-TEST_TEMPLATE_3 = (
-    """
+TEST_TEMPLATE_3 = """
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
   S3Setup:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: test-%s
-"""
-    % short_uid()
-)
+""" % short_uid()
 
 TEST_TEMPLATE_8 = {
     "AWSTemplateFormatVersion": "2010-09-09",

--- a/tests/aws/services/cloudformation/resources/test_stepfunctions.py
+++ b/tests/aws/services/cloudformation/resources/test_stepfunctions.py
@@ -147,9 +147,9 @@ def test_apigateway_invoke_localhost(deploy_cfn_template, aws_client):
     api_id = parsed.hostname.split(".")[0]
     state = json.loads(state_def)
     stage = state["States"]["LsCallApi"]["Parameters"]["Stage"]
-    state["States"]["LsCallApi"]["Parameters"][
-        "ApiEndpoint"
-    ] = f"{config.internal_service_url()}/restapis/{api_id}"
+    state["States"]["LsCallApi"]["Parameters"]["ApiEndpoint"] = (
+        f"{config.internal_service_url()}/restapis/{api_id}"
+    )
     state["States"]["LsCallApi"]["Parameters"]["Stage"] = stage
 
     aws_client.stepfunctions.update_state_machine(
@@ -192,9 +192,9 @@ def test_apigateway_invoke_localhost_with_path(deploy_cfn_template, aws_client):
     api_id = parsed.hostname.split(".")[0]
     state = json.loads(state_def)
     stage = state["States"]["LsCallApi"]["Parameters"]["Stage"]
-    state["States"]["LsCallApi"]["Parameters"][
-        "ApiEndpoint"
-    ] = f"{config.internal_service_url()}/restapis/{api_id}"
+    state["States"]["LsCallApi"]["Parameters"]["ApiEndpoint"] = (
+        f"{config.internal_service_url()}/restapis/{api_id}"
+    )
     state["States"]["LsCallApi"]["Parameters"]["Stage"] = stage
 
     aws_client.stepfunctions.update_state_machine(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2532,9 +2532,7 @@ def _sqs_messages_snapshot(expected_state, sqs_client, sqs_queue, snapshot, iden
             found_msg = message
             receipt_handle = msg["ReceiptHandle"]
             break
-    assert (
-        found_msg
-    ), f"no message found for {expected_state}. Got {len(result['Messages'])} messages.\n{json.dumps(result)}"
+    assert found_msg, f"no message found for {expected_state}. Got {len(result['Messages'])} messages.\n{json.dumps(result)}"
     sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=receipt_handle)
     snapshot.match(f"{identifier}-sqs-msg", found_msg)
 

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -984,11 +984,15 @@ class TestEvents:
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 
         with pytest.raises(ClientError) as ctx:
-            aws_client.events.create_connection(
-                Name=connection_name,
-                AuthorizationType="INVALID",
-                AuthParameters={"BasicAuthParameters": {"Username": "user", "Password": "pass"}},
-            ),
+            (
+                aws_client.events.create_connection(
+                    Name=connection_name,
+                    AuthorizationType="INVALID",
+                    AuthParameters={
+                        "BasicAuthParameters": {"Username": "user", "Password": "pass"}
+                    },
+                ),
+            )
 
         assert ctx.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
         assert ctx.value.response["Error"]["Code"] == "ValidationException"

--- a/tests/aws/services/lambda_/functions/common/uncaughtexception/python/src/handler.py
+++ b/tests/aws/services/lambda_/functions/common/uncaughtexception/python/src/handler.py
@@ -7,6 +7,7 @@ Example invoke payload:
     "error_msg": "test123"
 }
 """
+
 import json
 
 

--- a/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_json_body.py
@@ -15,6 +15,7 @@ dynamically simulate functions that look like::
             "isBase64Encoded": False,
         }
 """
+
 import json
 
 

--- a/tests/aws/services/lambda_/functions/lambda_integration.py
+++ b/tests/aws/services/lambda_/functions/lambda_integration.py
@@ -1,6 +1,7 @@
 """
 TODO: replace this file with smaller scoped lambda handlers
 """
+
 import base64
 import json
 import logging

--- a/tests/aws/services/lambda_/functions/lambda_sqs_batch_item_failure.py
+++ b/tests/aws/services/lambda_/functions/lambda_sqs_batch_item_failure.py
@@ -14,6 +14,7 @@ The lambda understands two env variables:
 * OVERWRITE_RESULT: a string (potentially a json document) that can be used to return custom responses to provoke errors
 * DESTINATION_QUEUE_URL: the queue url to send the event and result to
 """
+
 import json
 import os
 

--- a/tests/aws/services/lambda_/functions/lambda_sqs_integration.py
+++ b/tests/aws/services/lambda_/functions/lambda_sqs_integration.py
@@ -10,6 +10,7 @@ invocations, this lambda does this manually. You can pass in an event that looks
 Which will cause the lambda to fail twice (comparing the "ApproximateReceiveCount" of the SQS event triggering
 the lambda), and send either an error or success result to the SQS queue passed in the destination key.
 """
+
 import json
 import os
 

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1,5 +1,6 @@
 """Tests for Lambda behavior and implicit functionality.
 Everything related to API operations goes into test_lambda_api.py instead."""
+
 import base64
 import json
 import logging

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -8,6 +8,7 @@ Don't add tests for asynchronous, blocking or implicit behavior here.
 # TODO: VPC config https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
 
 """
+
 import base64
 import io
 import json

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -7,6 +7,7 @@ Runtime can either be directly one of the supported runtimes (e.g. in case of ve
 or one of the keys in RUNTIMES_AGGREGATED. To selectively execute runtimes, use the runtimes parameter of multiruntime.
 Example: runtimes=[Runtime.go1_x]
 """
+
 import json
 import logging
 import time

--- a/tests/aws/services/lambda_/test_lambda_destinations.py
+++ b/tests/aws/services/lambda_/test_lambda_destinations.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 
 
 class TestLambdaDLQ:
-    @markers.snapshot.skip_snapshot_verify(paths=["$..DeadLetterConfig", "$..result"])
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..DeadLetterConfig", "$..result", "$..LoggingConfig"]
+    )
     @markers.aws.validated
     def test_dead_letter_queue(
         self,

--- a/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.snapshot.json
@@ -61,67 +61,8 @@
       }
     }
   },
-  "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[RetriesExhausted-payload1]": {
-    "recorded-date": "01-09-2022, 09:03:35",
-    "recorded-content": {
-      "put_function_event_invoke_config": {
-        "DestinationConfig": {
-          "OnFailure": {
-            "Destination": "arn:aws:sqs:<region>:111111111111:<resource:1>"
-          },
-          "OnSuccess": {
-            "Destination": "arn:aws:sqs:<region>:111111111111:<resource:1>"
-          }
-        },
-        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
-        "LastModified": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "receive_message_result": {
-        "Messages": [
-          {
-            "Body": {
-              "version": "1.0",
-              "timestamp": "date",
-              "requestContext": {
-                "requestId": "<uuid:1>",
-                "functionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
-                "condition": "RetriesExhausted",
-                "approximateInvokeCount": 3
-              },
-              "requestPayload": {
-                "raise_error": 1
-              },
-              "responseContext": {
-                "statusCode": 200,
-                "executedVersion": "$LATEST",
-                "functionError": "Unhandled"
-              },
-              "responsePayload": {
-                "errorMessage": "Test exception (this is intentional)",
-                "errorType": "Exception",
-                "stackTrace": [
-                  "  File \"/var/task/handler.py\", line 54, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
-                ]
-              }
-            },
-            "MD5OfBody": "<m-d5-of-body:1>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
-    "recorded-date": "23-03-2023, 00:15:17",
+    "recorded-date": "21-03-2024, 12:26:43",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -184,7 +125,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload1]": {
-    "recorded-date": "23-03-2023, 00:15:20",
+    "recorded-date": "21-03-2024, 12:26:48",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -228,7 +169,7 @@
                 "errorType": "Exception",
                 "requestId": "<uuid:1>",
                 "stackTrace": [
-                  "  File \"/var/task/handler.py\", line 54, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
+                  "  File \"/var/task/handler.py\", line 55, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
                 ]
               }
             },
@@ -245,7 +186,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDLQ::test_dead_letter_queue": {
-    "recorded-date": "27-02-2023, 16:00:54",
+    "recorded-date": "21-03-2024, 12:20:31",
     "recorded-content": {
       "create_lambda_with_dlq": {
         "CreateEventSourceMappingResponse": null,
@@ -269,6 +210,10 @@
           "FunctionName": "<function-name:1>",
           "Handler": "handler.handler",
           "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
@@ -349,6 +294,10 @@
         "LastUpdateStatus": "InProgress",
         "LastUpdateStatusReason": "The function is being created.",
         "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
         "MemorySize": 128,
         "PackageType": "Zip",
         "RevisionId": "<uuid:3>",
@@ -381,7 +330,7 @@
           "errorType": "Exception",
           "requestId": "<uuid:4>",
           "stackTrace": [
-            "  File \"/var/task/handler.py\", line 54, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
+            "  File \"/var/task/handler.py\", line 55, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
           ]
         },
         "StatusCode": 200,
@@ -395,9 +344,10 @@
           "START RequestId: <uuid:4> Version: $LATEST",
           "Lambda log message - print function",
           "[INFO]\tdate\t<uuid:4>\tLambda log message - logging module",
+          "LAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html",
           "[ERROR] Exception: Test exception (this is intentional)",
           "Traceback (most recent call last):",
-          "\u00a0\u00a0File \"/var/task/handler.py\", line 54, in handler",
+          "\u00a0\u00a0File \"/var/task/handler.py\", line 55, in handler",
           "\u00a0\u00a0\u00a0\u00a0raise Exception(\"Test exception (this is intentional)\")END RequestId: <uuid:4>"
         ]
       }
@@ -533,7 +483,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_lambda_destination_default_retries": {
-    "recorded-date": "23-03-2023, 00:18:52",
+    "recorded-date": "21-03-2024, 12:24:09",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -576,7 +526,7 @@
                 "errorType": "Exception",
                 "requestId": "<uuid:1>",
                 "stackTrace": [
-                  "  File \"/var/task/handler.py\", line 54, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
+                  "  File \"/var/task/handler.py\", line 55, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
                 ]
               }
             },

--- a/tests/aws/services/lambda_/test_lambda_destinations.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_destinations.validation.json
@@ -1,18 +1,18 @@
 {
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDLQ::test_dead_letter_queue": {
-    "last_validated_date": "2023-02-27T15:00:54+00:00"
+    "last_validated_date": "2024-03-21T12:20:31+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationEventbridge::test_invoke_lambda_eventbridge": {
     "last_validated_date": "2023-08-07T15:39:40+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
-    "last_validated_date": "2023-03-22T23:15:17+00:00"
+    "last_validated_date": "2024-03-21T12:26:43+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload1]": {
-    "last_validated_date": "2023-03-22T23:15:20+00:00"
+    "last_validated_date": "2024-03-21T12:26:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_lambda_destination_default_retries": {
-    "last_validated_date": "2023-03-22T23:18:52+00:00"
+    "last_validated_date": "2024-03-21T12:24:09+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_destinations.py::TestLambdaDestinationSqs::test_maxeventage": {
     "last_validated_date": "2023-03-22T17:52:05+00:00"

--- a/tests/aws/services/lambda_/test_lambda_performance.py
+++ b/tests/aws/services/lambda_/test_lambda_performance.py
@@ -4,6 +4,7 @@ Basic opt-in performance tests for Lambda. Usage:
 2) Set TEST_PERFORMANCE_RESULTS_DIR=$HOME/Downloads if you want to export performance results as CSV
 3) Adjust repeat=100 to configure the number of repetitions
 """
+
 import csv
 import json
 import logging

--- a/tests/aws/services/lambda_/test_lambda_runtimes.py
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.py
@@ -2,6 +2,7 @@
 
 See `test_lambda_common.py` for tests focusing on common functionality across all runtimes.
 """
+
 import json
 import os
 import shutil

--- a/tests/aws/services/route53resolver/test_route53resolver.py
+++ b/tests/aws/services/route53resolver/test_route53resolver.py
@@ -146,9 +146,9 @@ class TestRoute53Resolver:
             resolver_endpoint_request_ids_status = {}
 
             for resolver_endpoint in lst.get("ResolverEndpoints", []):
-                resolver_endpoint_request_ids_status[
-                    resolver_endpoint["CreatorRequestId"]
-                ] = resolver_endpoint["Status"]
+                resolver_endpoint_request_ids_status[resolver_endpoint["CreatorRequestId"]] = (
+                    resolver_endpoint["Status"]
+                )
             for key, value in resolver_endpoint_request_ids_status.items():
                 if key == req_id:
                     return value == status

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -6600,9 +6600,9 @@ class TestS3PresignedUrl:
             # Moto does not register the default returned value from STS as a valid IAM user, which is way we can't
             # retrieve the secret access key
             # we need to hardcode the secret access key to the default one
-            response["Credentials"][
-                "SecretAccessKey"
-            ] = s3_constants.DEFAULT_PRE_SIGNED_SECRET_ACCESS_KEY
+            response["Credentials"]["SecretAccessKey"] = (
+                s3_constants.DEFAULT_PRE_SIGNED_SECRET_ACCESS_KEY
+            )
 
         client = boto3.client(
             "s3",

--- a/tests/aws/services/s3/test_s3_list_operations.py
+++ b/tests/aws/services/s3/test_s3_list_operations.py
@@ -2,6 +2,7 @@
 This file is to test specific behaviour of List* operations of S3, especially pagination, which is pretty specific to
 each implementation. They all have subtle differences which make it difficult to test.
 """
+
 import datetime
 from io import BytesIO
 

--- a/tests/aws/services/s3/test_s3_notifications_lambda.py
+++ b/tests/aws/services/s3/test_s3_notifications_lambda.py
@@ -223,9 +223,9 @@ class TestS3NotificationsToLambda:
         snapshot.match("invalid_skip", e.value.response)
 
         # set valid but not-existing lambda
-        config["LambdaFunctionConfigurations"][0][
-            "LambdaFunctionArn"
-        ] = f"{arns.lambda_function_arn('my-lambda', account_id=account_id, region_name=aws_client.s3.meta.region_name)}"
+        config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"] = (
+            f"{arns.lambda_function_arn('my-lambda', account_id=account_id, region_name=aws_client.s3.meta.region_name)}"
+        )
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/aws/services/s3/test_s3_notifications_sns.py
+++ b/tests/aws/services/s3/test_s3_notifications_sns.py
@@ -282,9 +282,9 @@ class TestS3NotificationsToSns:
         snapshot.match("invalid_skip", e.value.response)
 
         # set valid but not-existing topic
-        config["TopicConfigurations"][0][
-            "TopicArn"
-        ] = f"{arns.sns_topic_arn('my-topic', account_id=account_id, region_name=region_name)}"
+        config["TopicConfigurations"][0]["TopicArn"] = (
+            f"{arns.sns_topic_arn('my-topic', account_id=account_id, region_name=region_name)}"
+        )
         with pytest.raises(ClientError) as e:
             aws_client.s3.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/aws/services/s3/test_s3_notifications_sqs.py
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.py
@@ -597,9 +597,9 @@ class TestS3NotificationsToSQS:
 
         # add boto hook
         def add_xray_header(request, **kwargs):
-            request.headers[
-                "X-Amzn-Trace-Id"
-            ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            request.headers["X-Amzn-Trace-Id"] = (
+                "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            )
 
         aws_client.s3.meta.events.register("before-send.s3.*", add_xray_header)
         # make sure the hook gets cleaned up after the test

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -277,9 +277,9 @@ class TestSNSPublishCrud:
 
         json_response = xmltodict.parse(response.content)
         json_response["PublishResponse"].pop("@xmlns")
-        json_response["PublishResponse"]["ResponseMetadata"][
-            "HTTPStatusCode"
-        ] = response.status_code
+        json_response["PublishResponse"]["ResponseMetadata"]["HTTPStatusCode"] = (
+            response.status_code
+        )
         json_response["PublishResponse"]["ResponseMetadata"]["HTTPHeaders"] = dict(response.headers)
         snapshot.match("post-request", json_response)
 
@@ -1576,9 +1576,9 @@ class TestSNSSubscriptionSQS:
         self, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot, aws_client
     ):
         def add_xray_header(request, **_kwargs):
-            request.headers[
-                "X-Amzn-Trace-Id"
-            ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            request.headers["X-Amzn-Trace-Id"] = (
+                "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            )
 
         try:
             aws_client.sns.meta.events.register("before-send.sns.Publish", add_xray_header)

--- a/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/aws/services/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -347,9 +347,9 @@ class TestStateMachine:
         lambda_arn_3 = arns.lambda_function_arn(
             TEST_LAMBDA_NAME_3, SF_TEST_AWS_ACCOUNT_ID, region_name
         )
-        definition["States"]["ExampleMapState"]["Iterator"]["States"]["CallLambda"][
-            "Resource"
-        ] = lambda_arn_3
+        definition["States"]["ExampleMapState"]["Iterator"]["States"]["CallLambda"]["Resource"] = (
+            lambda_arn_3
+        )
         definition = json.dumps(definition)
         sm_name = f"map-{short_uid()}"
         custom_client.stepfunctions.create_state_machine(
@@ -480,9 +480,9 @@ class TestStateMachine:
             TEST_LAMBDA_NAME_5, SF_TEST_AWS_ACCOUNT_ID, region_name
         )
         if isinstance(definition["States"]["state1"].get("Parameters"), dict):
-            definition["States"]["state1"]["Parameters"]["lambda_params"][
-                "FunctionName"
-            ] = lambda_arn_1
+            definition["States"]["state1"]["Parameters"]["lambda_params"]["FunctionName"] = (
+                lambda_arn_1
+            )
             definition["States"]["state3"]["Resource"] = lambda_arn_2
         definition = json.dumps(definition)
         sm_name = f"intrinsic-{short_uid()}"

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -918,9 +918,9 @@ class TestBaseScenarios:
         output_norm.sort(key=lambda value: value["Key"])
         output_norm_str = json.dumps(output_norm)
         execution_history["events"][-2]["stateExitedEventDetails"]["output"] = output_norm_str
-        execution_history["events"][-1]["executionSucceededEventDetails"][
-            "output"
-        ] = output_norm_str
+        execution_history["events"][-1]["executionSucceededEventDetails"]["output"] = (
+            output_norm_str
+        )
 
         sfn_snapshot.match("get_execution_history", execution_history)
 

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -197,9 +197,9 @@ class TestTaskServiceAwsSdk:
         )
 
         template = ST.load_sfn_template(ST.AWS_SDK_SFN_START_EXECUTION_IMPLICIT_JSON_SERIALISATION)
-        template["States"]["StartTarget"]["Parameters"][
-            "StateMachineArn"
-        ] = state_machine_arn_target
+        template["States"]["StartTarget"]["Parameters"]["StateMachineArn"] = (
+            state_machine_arn_target
+        )
         definition = json.dumps(template)
 
         exec_input = json.dumps({})

--- a/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
+++ b/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
@@ -436,9 +436,9 @@ class TestStateMachine:
         lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5, account_id, region_name)
         lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5, account_id, region_name)
         if isinstance(definition["States"]["state1"].get("Parameters"), dict):
-            definition["States"]["state1"]["Parameters"]["lambda_params"][
-                "FunctionName"
-            ] = lambda_arn_1
+            definition["States"]["state1"]["Parameters"]["lambda_params"]["FunctionName"] = (
+                lambda_arn_1
+            )
             definition["States"]["state3"]["Resource"] = lambda_arn_2
         definition = json.dumps(definition)
         sm_name = f"intrinsic-{short_uid()}"

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,2 +1,2 @@
 """Bootstrapping is the process of starting localstack. This is not always testable in the regular integration test
-environment. This is what this module is for. """
+environment. This is what this module is for."""

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -66,9 +66,9 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
     else:
         headers = {}
 
-    headers[
-        "some-header-with-arn"
-    ] = f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    headers["some-header-with-arn"] = (
+        f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    )
 
     request = Request(
         method="POST",
@@ -362,9 +362,9 @@ def test_arn_partition_rewriting_in_request_and_response(
     else:
         headers = {"Host": f"{httpserver.host}:{httpserver.port}"}
 
-    headers[
-        "Arn-Header"
-    ] = f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    headers["Arn-Header"] = (
+        f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    )
 
     request = Request(
         method="POST",

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -42,7 +42,10 @@ def test_parse_query_string():
     assert parse_query_string("http://example.com/foo/bar?foo=1&1=2") == {"foo": "1", "1": "2"}
     assert parse_query_string(
         "http://example.com/foo/bar?foo=1&redirect=http://test.com/redirect"
-    ) == {"foo": "1", "redirect": "http://test.com/redirect"}
+    ) == {
+        "foo": "1",
+        "redirect": "http://test.com/redirect",
+    }
     assert parse_query_string(
         "http://example.com/foo/bar?foo=1&redirect=http%3A%2F%2Flocalhost%3A3001%2Fredirect"
     ) == {"foo": "1", "redirect": "http://localhost:3001/redirect"}


### PR DESCRIPTION
## Motivation
After https://github.com/localstack/localstack/pull/10502 was filed by Dependabot due to a security vulnerability in `black`, I thought it might be time to also switch to `ruff` for our code formatting (after switching the import sorting and linting with #9399).

This PR removes `black` as a dependency and uses `ruff format` instead.

## Changes
- Remove `black` from the dev dependencies.
- Use `ruff format` everywhere where `black` was used.
- Remove the black execution from cloudformation scaffolding.
  - This is a similar issue we had with the ASF scaffolding (see changes to the ASF update action in #9399).
  - I think formatting can easily be handled outside of the code generation, but I am happy for any suggestions! /cc @simonrw 
- Runs the formatting once, there are slight changes in the formatting.


## TODO
- [x] Update the pinned dependencies.