### PR TITLE
Fix Lambda common build caching

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -248,7 +248,7 @@ jobs:
         with:
           path: |
             localstack/tests/aws/services/lambda_/functions/common
-          key: community-it-${{ runner.os }}-${{ runner.arch }}-lambda-common-${{ hashFiles('tests/aws/services/lambda_/functions/common/**/src/*', 'tests/aws/services/lambda_/functions/common/**/Makefile') }}
+          key: community-it-${{ runner.os }}-${{ runner.arch }}-lambda-common-${{ hashFiles('localstack/tests/aws/services/lambda_/functions/common/**/src/*', 'localstack/tests/aws/services/lambda_/functions/common/**/Makefile') }}
 
       - name: Prebuild lambda common packages
         working-directory: localstack


### PR DESCRIPTION
## Motivation

The adjustments for the Lambda common ARM build introduced a path error here: 
https://github.com/localstack/localstack/pull/10441/files#diff-2c0422c107fb6b5e37ccf7ed62bba7d66f32a1c7f49f627f9e444f064db255a5L251
This resulted in cache keys like `community-it-Linux-X64-lambda-common- ` because not matching any files results in an empty string, according to the GH Actions Docs https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles.

It originated from copy/pasting the hash key from localstack-ext appearing in multiple places.

## Testing

The cache key should contain a hash suffix: https://github.com/localstack/localstack/actions/caches

## Changes

* Fix path issue of missing `localstack` directory