### PR TITLE
Api gateway integration proxy only accepts post method

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -270,7 +270,7 @@ class LambdaProxyIntegration(BackendIntegration):
     @staticmethod
     def validate_integration_method(invocation_context: ApiInvocationContext):
         if invocation_context.integration["httpMethod"] != HTTPMethod.POST:
-            raise ApiGatewayIntegrationError("InternalServerError", status_code=500)
+            raise ApiGatewayIntegrationError("Internal server error", status_code=500)
 
     @classmethod
     def construct_invocation_event(

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -313,6 +313,7 @@ def connect_api_gateway_to_http_with_lambda_proxy(
                 "httpMethod": method,
                 "authorizationType": auth_type,
                 "authorizerId": None,
+                "integrationHttpMethod": "POST",
                 "integrations": [integration],
             }
         )

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -1799,7 +1799,7 @@ def test_rest_api_multi_region(
         resourceId=resource_eu_id,
         httpMethod=method,
         type="AWS_PROXY",
-        integrationHttpMethod=method,
+        integrationHttpMethod="POST",
         uri=uri_eu,
     )
 
@@ -1811,7 +1811,7 @@ def test_rest_api_multi_region(
         resourceId=resource_us_id,
         httpMethod=method,
         type="AWS_PROXY",
-        integrationHttpMethod=method,
+        integrationHttpMethod="POST",
         uri=uri_us,
     )
 

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -66,7 +66,6 @@ from tests.aws.services.apigateway.conftest import (
     STEPFUNCTIONS_ASSUME_ROLE_POLICY,
 )
 from tests.aws.services.lambda_.test_lambda import (
-    TEST_LAMBDA_AWS_PROXY,
     TEST_LAMBDA_HTTP_RUST,
     TEST_LAMBDA_NODEJS,
     TEST_LAMBDA_NODEJS_APIGW_502,
@@ -220,57 +219,6 @@ class TestAPIGateway:
             patchOperations=patch_operations,
         )
         assert deployment["description"] == "new-description"
-
-    @markers.aws.unknown
-    def test_api_gateway_lambda_integration(
-        self,
-        create_rest_apigw,
-        create_lambda_function,
-        aws_client,
-        region_name,
-    ):
-        """
-        API gateway to lambda integration test returns a response with the same body as the lambda
-        function input event.
-        """
-        fn_name = f"test-{short_uid()}"
-        lambda_arn = create_lambda_function(
-            func_name=fn_name,
-            handler_file=TEST_LAMBDA_AWS_PROXY,
-            runtime=Runtime.python3_9,
-        )["CreateFunctionResponse"]["FunctionArn"]
-
-        api_id, _, root = create_rest_apigw(name="aws lambda api")
-        resource_id, _ = create_rest_resource(
-            aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="test"
-        )
-
-        # create method and integration
-        create_rest_resource_method(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            authorizationType="NONE",
-        )
-        create_rest_api_integration(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            integrationHttpMethod="GET",
-            type="AWS_PROXY",
-            uri=f"arn:aws:apigateway:{region_name}:lambda:path//2015-03-31/function"
-            f"s/{lambda_arn}/invocations",
-        )
-
-        url = api_invoke_url(api_id=api_id, stage="local", path="/test")
-        response = requests.get(url)
-        body = response.json()
-        assert response.status_code == 200
-        # authorizer contains an object that does not contain the authorizer type ('lambda', 'sns')
-        # TODO this should not only be empty, but the key should not exist (like in aws)
-        assert not body.get("requestContext").get("authorizer")
 
     @markers.aws.validated
     def test_api_gateway_lambda_integration_aws_type(

--- a/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.snapshot.json
@@ -1084,5 +1084,13 @@
         "statusCode": 400
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
+    "recorded-date": "20-03-2024, 22:16:43",
+    "recorded-content": {
+      "invocation-payload-with-get-proxy-method": {
+        "message": "Internal server error"
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_lambda.validation.json
@@ -11,6 +11,9 @@
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration": {
     "last_validated_date": "2024-03-20T14:44:59+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_integration_non_post_method": {
+    "last_validated_date": "2024-03-20T22:16:43+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_lambda.py::test_lambda_aws_proxy_response_format": {
     "last_validated_date": "2024-02-23T18:39:48+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Apigateway's integration with AWS_PROXY can only use POST as integration method. See [AWS Documentation](api-gateway-integration-proxy-only-accepts-POST-method) and documented on issue #10473 . Currently, we were accepting and forwarding any calls with consideration for this expected error to be returned.

<!-- What notable changes does this PR make? -->
## Changes

Aws does allow for the Proxy Integration to be created even with the wrong method. And returning a Internal Server Error when a call is attempted. This fix will mimic this behavior.

## Testing

One `aws.validated` test was added to confirm the error message. Many other `aws.unknown` tests were failing as they were creating integration with `integrationHttpMethod` not equal to `POST`. One of these test was removed but in view of the upcoming rework of the service, the other tests simply got patched to use the POST method and will be left to properly refactor in `aws.validated` tests.
