### PR TITLE
add support for getAtt string parameter in dependency

### DIFF
--- a/localstack/services/cloudformation/engine/template_utils.py
+++ b/localstack/services/cloudformation/engine/template_utils.py
@@ -37,7 +37,7 @@ def resolve_dependencies(d: dict, evaluated_conditions: dict[str, bool]) -> set[
             elif k == "Ref":
                 items.add(v)
             elif k == "Fn::GetAtt":
-                items.add(v[0])
+                items.add(v[0] if isinstance(v, list) else v.split(".")[0])
             elif k == "Fn::Sub":
                 # we can assume anything in there is a ref
                 if isinstance(v, str):
@@ -74,8 +74,8 @@ def resolve_dependencies(d: dict, evaluated_conditions: dict[str, bool]) -> set[
                     items = items.union(resolve_dependencies(item, evaluated_conditions))
             else:
                 pass
-
-    return {i for i in items if not i.startswith("AWS::")}
+    r = {i for i in items if not i.startswith("AWS::")}
+    return r
 
 
 def resolve_stack_conditions(

--- a/tests/aws/services/cloudformation/engine/test_attributes.py
+++ b/tests/aws/services/cloudformation/engine/test_attributes.py
@@ -25,3 +25,18 @@ class TestResourceAttributes:
             )
         stack_events = exc_info.value.events
         snapshot.match("stack_events", {"events": stack_events})
+
+    @markers.aws.validated
+    def test_dependency_on_attribute_with_dot_notation(
+        self, deploy_cfn_template, aws_client, snapshot
+    ):
+        """
+        Test that a resource can depend on another resource's attribute with dot notation
+        """
+        snapshot.add_transformer(snapshot.transform.cloudformation_api())
+        deployment = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../../templates/engine/cfn_getatt_dot_dependency.yml"
+            )
+        )
+        snapshot.match("outputs", deployment.outputs)

--- a/tests/aws/services/cloudformation/engine/test_attributes.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_attributes.snapshot.json
@@ -50,5 +50,13 @@
         ]
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_attributes.py::TestResourceAttributes::test_dependency_on_attribute_with_dot_notation": {
+    "recorded-date": "21-03-2024, 21:10:29",
+    "recorded-content": {
+      "outputs": {
+        "DeadArn": "arn:aws:sqs:<region>:111111111111:<resource:1>"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_attributes.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_attributes.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/engine/test_attributes.py::TestResourceAttributes::test_dependency_on_attribute_with_dot_notation": {
+    "last_validated_date": "2024-03-21T21:10:29+00:00"
+  },
   "tests/aws/services/cloudformation/engine/test_attributes.py::TestResourceAttributes::test_invalid_getatt_fails": {
     "last_validated_date": "2023-08-01T09:54:31+00:00"
   }

--- a/tests/aws/templates/engine/cfn_getatt_dot_dependency.yml
+++ b/tests/aws/templates/engine/cfn_getatt_dot_dependency.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  SQSDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: test-dead
+
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Value:
+        Fn::GetAtt: SQSDeadLetterQueue.Arn
+      Type: String
+
+Outputs:
+  DeadArn:
+    Value:
+      Fn::GetAtt: SQSDeadLetterQueue.Arn


### PR DESCRIPTION
## Motivation
There is limitation in Localstack's cloudformation implementation (#10481) where it is unable to successfully deploy a resource that utilizes an attribute of another resource when the GetAtt function is used with a string containing a dot instead of an array of parameters.

## Changes
- fix the function that list the dependencies of a resource

## Testing
- snapshoted test to validate the behavior