### PR TITLE
fix 'test_import_swagger_api' for 'eu-west-1'

### DIFF
--- a/tests/aws/files/petstore-authorizer.swagger.json
+++ b/tests/aws/files/petstore-authorizer.swagger.json
@@ -114,7 +114,7 @@
             "integration.request.querystring.page": "method.request.querystring.page",
             "integration.request.querystring.type": "method.request.querystring.type"
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+          "uri": "${uri}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "GET",
           "type": "http"
@@ -165,7 +165,7 @@
               }
             }
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+          "uri": "${uri}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "POST",
           "type": "http"
@@ -264,7 +264,7 @@
           "requestParameters": {
             "integration.request.path.petId": "method.request.path.petId"
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+          "uri": "${uri}/{petId}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "GET",
           "type": "http"

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -272,11 +272,13 @@ class TestApiGatewayImportRestApi:
             "$.resources.items..resourceMethods.GET",  # TODO: this is really weird, after importing, AWS returns them empty?
             "$.resources.items..resourceMethods.OPTIONS",
             "$.resources.items..resourceMethods.POST",
+            "$..rootResourceId",
             "$.get-authorizers.items[1].authorizerResultTtlInSeconds",
         ]
     )
     def test_import_swagger_api(
         self,
+        region_name,
         import_apigw,
         snapshot,
         aws_client,
@@ -300,6 +302,10 @@ class TestApiGatewayImportRestApi:
             ]
         )
         spec_file = load_file(PETSTORE_SWAGGER_JSON)
+        spec_file = spec_file.replace(
+            "${uri}", f"http://petstore.execute-api.{region_name}.amazonaws.com/petstore/pets"
+        )
+
         spec_file = spec_file.replace(
             "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:account-id:function:function-name/invocations",
             apigateway_placeholder_authorizer_lambda_invocation_arn,

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -25,7 +25,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "recorded-date": "06-07-2023, 22:05:59",
+    "recorded-date": "22-03-2024, 07:03:04",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -39,6 +39,7 @@
         },
         "id": "<rest-id:1>",
         "name": "PetStore",
+        "rootResourceId": "<resource-id:1>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -319,7 +320,7 @@
           },
           "timeoutInMillis": 29000,
           "type": "HTTP",
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets"
+          "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets"
         },
         "methodResponses": {
           "200": {
@@ -374,7 +375,7 @@
         },
         "timeoutInMillis": 29000,
         "type": "HTTP",
-        "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+        "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -507,7 +508,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "HTTP",
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets"
+          "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets"
         },
         "methodResponses": {
           "200": {
@@ -558,7 +559,7 @@
         "passthroughBehavior": "WHEN_NO_MATCH",
         "timeoutInMillis": 29000,
         "type": "HTTP",
-        "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+        "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -597,7 +598,7 @@
           },
           "timeoutInMillis": 29000,
           "type": "HTTP",
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}"
+          "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}"
         },
         "methodResponses": {
           "200": {
@@ -651,7 +652,7 @@
         },
         "timeoutInMillis": 29000,
         "type": "HTTP",
-        "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+        "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -27,7 +27,7 @@
     "last_validated_date": "2023-06-03T12:14:07+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "last_validated_date": "2023-07-06T20:05:59+00:00"
+    "last_validated_date": "2024-03-22T07:03:03+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models": {
     "last_validated_date": "2023-06-07T00:26:07+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We ran a pipeline for randomised region and account: [here](https://app.circleci.com/pipelines/github/localstack/localstack/23423/workflows/679f1237-6253-495d-947e-45f19e2fc8e9/jobs/191264/tests) and found that `test_import_swagger_api` fails with the following error: 

> >> match key: method-pets-get
> 	#x1B[33m(~)#x1B[0m /methodIntegration/uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..methodIntegration.uri"]
> >> match key: integration-pets-post
> 	#x1B[33m(~)#x1B[0m /uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..uri"]
> >> match key: method-pets/{petId}-get
> 	#x1B[33m(~)#x1B[0m /methodIntegration/uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets/{petId}' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..methodIntegration.uri"]
> >> match key: integration-pets-get
> 	#x1B[33m(~)#x1B[0m /uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..uri"]
> >> match key: method-pets-post
> 	#x1B[33m(~)#x1B[0m /methodIntegration/uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..methodIntegration.uri"]
> >> match key: integration-pets/{petId}-get
> 	#x1B[33m(~)#x1B[0m /uri 'http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}' → 'http://petstore.execute-api.region.amazonaws.com/petstore/pets/{petId}' ... (expected → actual)
> 
> 	Ignore list (please keep in mind list indices might not work and should be replaced):
> 	["$..uri"]

When we set the `TEST_AWS_REGION_NAME` to `eu-west-1` we get this error. Kindly refer [here](https://app.circleci.com/pipelines/github/localstack/localstack/23423/workflows/679f1237-6253-495d-947e-45f19e2fc8e9/jobs/191264/tests#:~:text=test_import_swagger_api) for detailed error message.  

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- removes the static value for 'eu-west-1' in `petstore-authorizer.swagger.json` and replaces it with the `region_name` (fixture) value. 
- updates the snapshots

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

