### PR TITLE
fix release helper

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -149,7 +149,7 @@ function cmd-next-dev-ver() {
 function cmd-set-ver() {
     [[ $# -eq 1 ]] || { usage; exit 1; }
 
-    cat $1 > ${VERSION_FILE}
+    echo $1 > ${VERSION_FILE}
 }
 
 function cmd-set-dep-ver() {


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10497 broke the `set-ver` command of the release-helper script, which in turn prevents us from pushing dev releases in the CircleCI pipeline on `master` runs:
- Workflow run: https://app.circleci.com/pipelines/github/localstack/localstack/23599/workflows/84eb52c3-af01-4bf4-b4f3-a620bb083c1e/jobs/193324
- Executed commands:
  ```
  #!/bin/bash -eo pipefail
  source .venv/bin/activate
  bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
  make publish
  ```
- Output:
  ```
  cat: 3.2.1.dev20240322105931: No such file or directory
  
  Exited with code exit status 1
  ```

This PR addresses this small issue in the script.

## Changes
- Fix the `set-ver` command of the release-helper script.

## Testing
- Tested locally:
  ```
  # starting on master
  source .venv/bin/activate
  bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
  # Output: cat: 3.2.1.dev20240322113129: No such file or directory
  git switch fix-release-helper
  bin/release-helper.sh set-ver $(bin/release-helper.sh next-dev-ver)
  # Output: Proper diff setting the version in VERSION file
  ```