### PR TITLE
added aws validate test case for ListSecrets filtering

### DIFF
--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -57,7 +57,7 @@
     "last_validated_date": "2024-03-15T08:12:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_list_secrets_filtering": {
-    "last_validated_date": "2024-03-22T13:30:00+00:00"
+    "last_validated_date": "2024-03-26T09:40:54+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
     "last_validated_date": "2024-03-15T08:14:56+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -56,6 +56,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_updated_date": {
     "last_validated_date": "2024-03-15T08:12:47+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_list_secrets_filtering": {
+    "last_validated_date": "2024-03-22T13:30:00+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
     "last_validated_date": "2024-03-15T08:14:56+00:00"
   },


### PR DESCRIPTION
## Motivation
This PR introduces AWS-validated test cases to verify the filtering functionality of the `secretsmanager` list API.

The issue was originally reported [here](https://github.com/localstack/localstack/issues/4820). The fix has been implemented in [Moto](https://github.com/getmoto/moto/pull/7511).

⚠️ NOTE: This PR should only be merged after the dependent PR in [Moto](https://github.com/getmoto/moto/pull/7511) has been merged and moto version in LocalStack is bumped to support this fix.

## Changes
- Implemented an AWS-validated test case.


cc. @viren-nadkarni 