### PR TITLE
Adding missing parameter for authorization scopes

### DIFF
--- a/localstack/services/apigateway/resource_providers/aws_apigateway_method.py
+++ b/localstack/services/apigateway/resource_providers/aws_apigateway_method.py
@@ -111,6 +111,7 @@ class ApiGatewayMethodProvider(ResourceProvider[ApiGatewayMethodProperties]):
             "httpMethod",
             "apiKeyRequired",
             "authorizationType",
+            "authorizationScopes",
             "authorizerId",
             "requestParameters",
             "requestModels",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `AWS::ApiGateway::Method` resource was not using the `authorizedScopes` parameter.
This led to a bug in APIGW Cognito Authorizer as described in the [companion PR](https://github.com/localstack/localstack-ext/pull/2776).
