### PR TITLE
fix ASF update action to fix unused imports

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -45,7 +45,11 @@ jobs:
           python3 -m localstack.aws.scaffold upgrade
 
       - name: Format code
-        run: make format-modified
+        run: |
+          source .venv/bin/activate
+          # explicitly perform an unsafe fix to remove unused imports in the generated ASF APIs
+          ruff check --select F401 --unsafe-fixes --fix . --config "lint.ignore-init-module-imports = false"
+          make format-modified
 
       - name: Check for changes
         id: check-for-changes


### PR DESCRIPTION
## Motivation
The latest `ruff` upgrade switched some defaults avoiding unsafe fixes to remove unused imports in init dunder files (since they would change the API interface of the module): https://github.com/astral-sh/ruff/pull/10365 contained in [0.3.3](https://github.com/astral-sh/ruff/releases/tag/v0.3.3).
This causes our ASF update action to fail because of unfixed linting errors: https://github.com/localstack/localstack/actions/runs/8415318713

The changes in the defaults are safe, but we want to explicitly fix this for the generated APIs (which is all in the init dunder) explicitly directly when generating them.

## Changes
This PR explicitly executes an unsafe lint fix with a changed config on the generated APIs in the ASF update action.

## Testing
Tested locally:
```
source .venv/bin/activate
python3 -m localstack.aws.scaffold generate ec2 --save
ruff check --select F401 --unsafe-fixes --fix . --config "lint.ignore-init-module-imports = false"
make format-modified
```