### PR TITLE
Reduce the range of dependencies to speed up pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ runtime = [
     "antlr4-python3-runtime==4.13.1",
     "apispec>=5.1.1",
     "aws-sam-translator>=1.15.1",
-    "awscli>=1.22.90",
+    "awscli>=1.32.69",
     "crontab>=0.22.6",
     "cryptography>=41.0.5",
     "json5>=0.9.11",
@@ -127,7 +127,7 @@ dev = [
 typehint = [
     # typehint is an optional extension of the dev dependencies
     "localstack-core[dev]",
-    "boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]",
+    "boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]>=1.34.69",
 ]
 
 [tool.setuptools]

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -114,7 +114,7 @@ packaging==24.0
     #   docker
 pbr==6.0.0
     # via stevedore
-plux==1.8.1
+plux==1.9.0
     # via localstack-core (pyproject.toml)
 priority==1.3.0
     # via

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -34,7 +34,7 @@ packaging==24.0
     # via build
 pbr==6.0.0
     # via stevedore
-plux==1.8.1
+plux==1.9.0
     # via localstack-core (pyproject.toml)
 psutil==5.9.8
     # via localstack-core (pyproject.toml)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -195,7 +195,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.2
+importlib-resources==6.4.0
     # via jsii
 incremental==22.10.0
     # via localstack-twisted
@@ -218,7 +218,7 @@ joserfc==0.9.0
     # via moto-ext
 jschema-to-python==1.2.3
     # via cfn-lint
-jsii==1.95.0
+jsii==1.96.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
@@ -317,7 +317,7 @@ pluggy==1.4.0
     #   pytest
 plumbum==1.8.2
     # via pandoc
-plux==1.8.1
+plux==1.9.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -326,7 +326,7 @@ ply==3.11
     #   jsonpath-ng
     #   jsonpath-rw
     #   pandoc
-pre-commit==3.6.2
+pre-commit==3.7.0
     # via localstack-core (pyproject.toml)
 priority==1.3.0
     # via
@@ -446,7 +446,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core (pyproject.toml)
-ruff==0.3.3
+ruff==0.3.4
     # via localstack-core (pyproject.toml)
 s3transfer==0.10.1
     # via

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -236,7 +236,7 @@ pbr==6.0.0
     #   jschema-to-python
     #   sarif-om
     #   stevedore
-plux==1.8.1
+plux==1.9.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -179,7 +179,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.2
+importlib-resources==6.4.0
     # via jsii
 incremental==22.10.0
     # via localstack-twisted
@@ -202,7 +202,7 @@ joserfc==0.9.0
     # via moto-ext
 jschema-to-python==1.2.3
     # via cfn-lint
-jsii==1.95.0
+jsii==1.96.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
@@ -291,7 +291,7 @@ pluggy==1.4.0
     # via
     #   localstack-core (pyproject.toml)
     #   pytest
-plux==1.8.1
+plux==1.9.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -60,7 +60,7 @@ boto3==1.34.69
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.34.67
+boto3-stubs[acm,acm-pca,amplify,apigateway,apigatewayv2,appconfig,appconfigdata,application-autoscaling,appsync,athena,autoscaling,backup,batch,ce,cloudcontrol,cloudformation,cloudfront,cloudtrail,cloudwatch,codecommit,cognito-identity,cognito-idp,dms,docdb,dynamodb,dynamodbstreams,ec2,ecr,ecs,efs,eks,elasticache,elasticbeanstalk,elbv2,emr,emr-serverless,es,events,firehose,fis,glacier,glue,iam,identitystore,iot,iot-data,iotanalytics,iotwireless,kafka,kinesis,kinesisanalytics,kinesisanalyticsv2,kms,lakeformation,lambda,logs,managedblockchain,mediaconvert,mediastore,mq,mwaa,neptune,opensearch,organizations,pi,pipes,qldb,qldb-session,rds,rds-data,redshift,redshift-data,resource-groups,resourcegroupstaggingapi,route53,route53resolver,s3,s3control,sagemaker,sagemaker-runtime,secretsmanager,serverlessrepo,servicediscovery,ses,sesv2,sns,sqs,ssm,sso-admin,stepfunctions,sts,timestream-query,timestream-write,transcribe,wafv2,xray]==1.34.69
     # via localstack-core (pyproject.toml)
 botocore==1.34.69
     # via
@@ -71,7 +71,7 @@ botocore==1.34.69
     #   localstack-snapshot
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.34.67
+botocore-stubs==1.34.69
     # via boto3-stubs
 build==1.1.1
     # via
@@ -199,7 +199,7 @@ idna==3.6
     #   hyperlink
     #   localstack-twisted
     #   requests
-importlib-resources==6.3.2
+importlib-resources==6.4.0
     # via jsii
 incremental==22.10.0
     # via localstack-twisted
@@ -222,7 +222,7 @@ joserfc==0.9.0
     # via moto-ext
 jschema-to-python==1.2.3
     # via cfn-lint
-jsii==1.95.0
+jsii==1.96.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
@@ -359,7 +359,7 @@ mypy-boto3-es==1.34.36
     # via boto3-stubs
 mypy-boto3-events==1.34.17
     # via boto3-stubs
-mypy-boto3-firehose==1.34.46
+mypy-boto3-firehose==1.34.69
     # via boto3-stubs
 mypy-boto3-fis==1.34.63
     # via boto3-stubs
@@ -513,7 +513,7 @@ pluggy==1.4.0
     #   pytest
 plumbum==1.8.2
     # via pandoc
-plux==1.8.1
+plux==1.9.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -522,7 +522,7 @@ ply==3.11
     #   jsonpath-ng
     #   jsonpath-rw
     #   pandoc
-pre-commit==3.6.2
+pre-commit==3.7.0
     # via localstack-core
 priority==1.3.0
     # via
@@ -642,7 +642,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core
-ruff==0.3.3
+ruff==0.3.4
     # via localstack-core
 s3transfer==0.10.1
     # via


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In `localstack-ext`, the dependency pinning can take a very long time now. This is connected to the switch to `pyproject.toml` as well as to backtracking a lot inside the dependencies of `localstack-core`. 


<!-- What notable changes does this PR make? -->
## Changes

This PR reduces the admissible range for the following packages, so that the backtracking is reduced:
- `awscli>=1.32.69`
- `boto3-stubs>=1.34.69`

## Testing

Locally, this achieves a reduction in the pinning of `localstack-ext` from 45min to 6min30 on my machine. 

To check it locally, you can replace the dependencies to `localstack-core` in `localstack-ext` to reference this instead:

`localstack-core @ file://localhost/{absolute-path-to-package}#egg=localstack_core`

However, effectively checking the performance is not possible this way, as using such a specific version of `localstack-core` here will lead to performance improvements without changes as well.

