### PR TITLE
fix `test_different_location_constraint` for `us-east-2`

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2545,6 +2545,7 @@ class TestS3:
         s3_create_bucket,
         aws_client_factory,
         s3_create_bucket_with_client,
+        region_name,
         snapshot,
         aws_client,
     ):
@@ -2563,6 +2564,7 @@ class TestS3:
         snapshot.match("get_bucket_location_bucket_1", response)
 
         region_2 = "us-east-2"
+        snapshot.add_transformer(RegexTransformer(region_2, "<region_2>"))
         client_2 = aws_client_factory(region_name=region_2).s3
         bucket_2_name = f"bucket-{short_uid()}"
         s3_create_bucket_with_client(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1078,7 +1078,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "03-08-2023, 04:16:27",
+    "recorded-date": "25-03-2024, 17:20:27",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,
@@ -1088,7 +1088,7 @@
         }
       },
       "get_bucket_location_bucket_2": {
-        "LocationConstraint": "us-east-2",
+        "LocationConstraint": "<region_2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1112,7 +1112,7 @@
         }
       },
       "get_bucket_location_bucket_3": {
-        "LocationConstraint": "us-east-2",
+        "LocationConstraint": "<region_2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2023-10-22T02:25:14+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "last_validated_date": "2023-08-03T02:16:27+00:00"
+    "last_validated_date": "2024-03-25T17:20:27+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_empty_bucket_fixture": {
     "last_validated_date": "2023-09-08T16:52:15+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Test `test_different_location_constraint` fails for `us-east-2` and throws the following error: 


```
=================================== FAILURES ===================================
__________________ TestS3.test_different_location_constraint ___________________
>> match key: get_bucket_location_bucket_3
        (~) /LocationConstraint 'us-east-2' → '<region>' ... (expected → actual)

        Ignore list (please keep in mind list indices might not work and should be replaced):
        ["$..LocationConstraint"]
>> match key: get_bucket_location_bucket_2
        (~) /LocationConstraint 'us-east-2' → '<region>' ... (expected → actual)

        Ignore list (please keep in mind list indices might not work and should be replaced):
        ["$..LocationConstraint"]
```
when the scheduled flow was triggered: https://app.circleci.com/pipelines/github/localstack/localstack/23638/workflows/ee54cc00-9770-42db-af01-6fed44c5085f/jobs/193748 for `TEST_AWS_REGION_NAME=us-east-2`

<!-- What notable changes does this PR make? -->
## Changes
This PR adds regex transformer for to region and regenerates the snapshots. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

