### PR TITLE
fix kms tests for `ap-southeast-1`

### DIFF
--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.serialization import load_der_public_key
+from localstack_snapshot.snapshots.transformer import RegexTransformer
 
 from localstack.services.kms.models import IV_LEN, Ciphertext, _serialize_ciphertext_blob
 from localstack.services.kms.utils import get_hash_algorithm
@@ -175,7 +176,8 @@ class TestKMS:
         self, kms_client_for_region, kms_create_key, snapshot, region_name, secondary_region_name
     ):
         client_region = region_name
-        key_region = secondary_region_name
+        key_region = secondary_region_name if region_name != "ap-southeast-1" else "us-east-2"
+        snapshot.add_transformer(RegexTransformer(key_region, "<region_2>"))
         us_east_1_kms_client = kms_client_for_region(client_region)
         us_west_2_kms_client = kms_client_for_region(key_region)
 
@@ -821,7 +823,10 @@ class TestKMS:
         secondary_region_name,
     ):
         region_to_replicate_from = region_name
-        region_to_replicate_to = secondary_region_name
+        region_to_replicate_to = (
+            secondary_region_name if region_name != "ap-southeast-1" else "us-east-2"
+        )
+        snapshot.add_transformer(RegexTransformer(region_to_replicate_to, "<region_2>"))
         us_east_1_kms_client = kms_client_for_region(region_to_replicate_from)
         us_west_1_kms_client = kms_client_for_region(region_to_replicate_to)
 

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -188,7 +188,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_in_different_region": {
-    "recorded-date": "13-07-2023, 11:58:37",
+    "recorded-date": "26-03-2024, 08:27:34",
     "recorded-content": {
       "describe-key-diff-region-with-id": {
         "Error": {
@@ -204,9 +204,9 @@
       "describe-key-diff-region-with-arn": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Invalid arn ap-southeast-1"
+          "Message": "Invalid arn <region_2>"
         },
-        "message": "Invalid arn ap-southeast-1",
+        "message": "Invalid arn <region_2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -215,7 +215,7 @@
       "describe-key-same-specific-region-with-id": {
         "KeyMetadata": {
           "AWSAccountId": "111111111111",
-          "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
+          "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
           "CreationDate": "datetime",
           "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
           "Description": "test key 123",
@@ -239,7 +239,7 @@
       "describe-key-same-specific-region-with-arn": {
         "KeyMetadata": {
           "AWSAccountId": "111111111111",
-          "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
+          "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
           "CreationDate": "datetime",
           "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
           "Description": "test key 123",
@@ -339,14 +339,14 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_key": {
-    "recorded-date": "13-07-2023, 11:59:29",
+    "recorded-date": "26-03-2024, 08:47:02",
     "recorded-content": {
       "describe-key-from-different-region": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Key 'arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>' does not exist"
+          "Message": "Key 'arn:aws:kms:<region_2>:111111111111:key/<key-id:1>' does not exist"
         },
-        "message": "Key 'arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>' does not exist",
+        "message": "Key 'arn:aws:kms:<region_2>:111111111111:key/<key-id:1>' does not exist",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -355,7 +355,7 @@
       "replicate-key": {
         "ReplicaKeyMetadata": {
           "AWSAccountId": "111111111111",
-          "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
+          "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
           "CreationDate": "datetime",
           "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
           "Description": "",
@@ -377,8 +377,8 @@
             },
             "ReplicaKeys": [
               {
-                "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
-                "Region": "ap-southeast-1"
+                "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
+                "Region": "<region_2>"
               }
             ]
           },
@@ -429,8 +429,8 @@
             },
             "ReplicaKeys": [
               {
-                "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
-                "Region": "ap-southeast-1"
+                "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
+                "Region": "<region_2>"
               }
             ]
           },
@@ -444,7 +444,7 @@
       "describe-replicated-key": {
         "KeyMetadata": {
           "AWSAccountId": "111111111111",
-          "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
+          "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
           "CreationDate": "datetime",
           "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
           "Description": "",
@@ -466,8 +466,8 @@
             },
             "ReplicaKeys": [
               {
-                "Arn": "arn:aws:kms:ap-southeast-1:111111111111:key/<key-id:1>",
-                "Region": "ap-southeast-1"
+                "Arn": "arn:aws:kms:<region_2>:111111111111:key/<key-id:1>",
+                "Region": "<region_2>"
               }
             ]
           },

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -69,7 +69,7 @@
     "last_validated_date": "2023-04-13T09:29:34+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_in_different_region": {
-    "last_validated_date": "2023-07-13T09:58:37+00:00"
+    "last_validated_date": "2024-03-26T08:27:34+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_invalid_uuid": {
     "last_validated_date": "2023-11-07T13:05:57+00:00"
@@ -108,7 +108,7 @@
     "last_validated_date": "2023-04-13T09:31:24+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_key": {
-    "last_validated_date": "2023-07-13T09:59:29+00:00"
+    "last_validated_date": "2024-03-26T08:47:02+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P256-ECDSA_SHA_256]": {
     "last_validated_date": "2023-04-13T09:30:15+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There were failing kms tests for `ap-southeast-1` in the workflow: https://app.circleci.com/pipelines/github/localstack/localstack/23655/workflows/49291732-7851-49ea-917a-2a293dde3288/jobs/193900/tests

The issue is caused when secondary and primary regions are same. We have set the [TEST_AWS_SECONDARY_REGION_NAME](https://github.com/localstack/localstack/blob/b7f34c67c49c8f8d4aa6e0b08584b248501a64bb/localstack/constants.py#L158) to `ap-southeast-1`.

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- adds fallback if primary and secondary regions are same
- adds regex transformer for to region
- regenerates the snapshots

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

