### PR TITLE
fix apigw tests for `eu-west-1`

### DIFF
--- a/tests/aws/files/petstore-swagger.json
+++ b/tests/aws/files/petstore-swagger.json
@@ -103,7 +103,7 @@
             "integration.request.querystring.page": "method.request.querystring.page",
             "integration.request.querystring.type": "method.request.querystring.type"
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+          "uri": "${uri}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "GET",
           "type": "http"
@@ -154,7 +154,7 @@
               }
             }
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+          "uri": "${uri}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "POST",
           "type": "http"
@@ -253,7 +253,7 @@
           "requestParameters": {
             "integration.request.path.petId": "method.request.path.petId"
           },
-          "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+          "uri": "${uri}/{petId}",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "GET",
           "type": "http"

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -22,13 +22,18 @@ TEST_IMPORT_PETS = os.path.join(THIS_FOLDER, "../../files/pets.json")
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..body.host",
+        "$..rootResourceId",
     ]
 )
-def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file):
+def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file, region_name):
     snapshot.add_transformer(
         snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
     )
     spec_file = load_file(import_file)
+    spec_file = spec_file.replace(
+        "${uri}", f"http://petstore.execute-api.{region_name}.amazonaws.com/petstore/pets"
+    )
+
     response, _ = import_apigw(body=spec_file, failOnWarnings=True)
     snapshot.match("import-api", response)
     api_id = response["id"]
@@ -58,14 +63,19 @@ def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file)
 @markers.snapshot.skip_snapshot_verify(
     paths=[
         "$..body.servers..url",
+        "$..rootResourceId",
     ]
 )
-def test_export_oas30_openapi(aws_client, snapshot, import_apigw, import_file):
+def test_export_oas30_openapi(aws_client, snapshot, import_apigw, region_name, import_file):
     snapshot.add_transformer(
         snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
     )
 
     spec_file = load_file(import_file)
+    spec_file = spec_file.replace(
+        "${uri}", f"http://petstore.execute-api.{region_name}.amazonaws.com/petstore/pets"
+    )
+
     response, _ = import_apigw(body=spec_file, failOnWarnings=True)
     snapshot.match("import-api", response)
     api_id = response["id"]

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -27,7 +27,10 @@ TEST_IMPORT_PETS = os.path.join(THIS_FOLDER, "../../files/pets.json")
 )
 def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file, region_name):
     snapshot.add_transformer(
-        snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
+        [
+            snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id"),
+            snapshot.transform.key_value("rootResourceId"),
+        ]
     )
     spec_file = load_file(import_file)
     spec_file = spec_file.replace(

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "26-03-2024, 09:53:07",
+    "recorded-date": "26-03-2024, 11:32:19",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -14,7 +14,7 @@
         },
         "id": "<api-id:1>",
         "name": "PetStore",
-        "rootResourceId": "s4lm87o1l0",
+        "rootResourceId": "<root-resource-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -310,6 +310,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -324,8 +325,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -362,6 +362,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -376,8 +377,7 @@
                     "integration.request.querystring.page": "method.request.querystring.page",
                     "integration.request.querystring.type": "method.request.querystring.type"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "post": {
@@ -412,6 +412,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "POST",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -422,8 +423,7 @@
                       }
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -453,6 +453,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -466,8 +467,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -499,6 +499,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
@@ -512,8 +513,7 @@
                   "requestParameters": {
                     "integration.request.path.petId": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -551,6 +551,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -564,8 +565,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "26-03-2024, 09:53:10",
+    "recorded-date": "26-03-2024, 11:32:36",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -651,7 +651,7 @@
         },
         "id": "<api-id:1>",
         "name": "Simple PetStore (Swagger)",
-        "rootResourceId": "m7b1ab5lr9",
+        "rootResourceId": "<root-resource-id:1>",
         "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -727,7 +727,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
                   "responses": {
@@ -735,7 +734,8 @@
                       "statusCode": "200"
                     }
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               }
             },
@@ -755,7 +755,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
                   "responses": {
@@ -766,7 +765,8 @@
                   "requestParameters": {
                     "integration.request.path.id": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               }
             }
@@ -782,7 +782,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "26-03-2024, 10:00:19",
+    "recorded-date": "26-03-2024, 11:32:50",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -796,7 +796,7 @@
         },
         "id": "<api-id:1>",
         "name": "PetStore",
-        "rootResourceId": "002ygmlo8b",
+        "rootResourceId": "kb57q8ij35",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -1140,6 +1140,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1154,8 +1155,7 @@
                     "integration.request.querystring.page": "method.request.querystring.page",
                     "integration.request.querystring.type": "method.request.querystring.type"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "post": {
@@ -1190,6 +1190,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "POST",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1200,8 +1201,7 @@
                       }
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -1235,6 +1235,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1248,8 +1249,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -1286,6 +1286,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
@@ -1299,8 +1300,7 @@
                   "requestParameters": {
                     "integration.request.path.petId": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               },
               "options": {
@@ -1344,6 +1344,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1357,8 +1358,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -1378,6 +1378,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1392,8 +1393,7 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "mock"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }
@@ -1468,7 +1468,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "26-03-2024, 10:00:25",
+    "recorded-date": "26-03-2024, 11:32:58",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -1481,7 +1481,7 @@
         },
         "id": "<api-id:1>",
         "name": "Simple PetStore (Swagger)",
-        "rootResourceId": "pv78n23kw0",
+        "rootResourceId": "vp8w0yxukk",
         "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1573,7 +1573,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
                   "responses": {
@@ -1581,7 +1580,8 @@
                       "statusCode": "200"
                     }
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               }
             },
@@ -1604,7 +1604,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
                   "responses": {
@@ -1615,7 +1614,8 @@
                   "requestParameters": {
                     "integration.request.path.id": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               }
             }

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-09-2023, 04:27:47",
+    "recorded-date": "26-03-2024, 09:53:07",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -14,6 +14,7 @@
         },
         "id": "<api-id:1>",
         "name": "PetStore",
+        "rootResourceId": "s4lm87o1l0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -362,7 +363,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "GET",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -412,7 +413,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -499,7 +500,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "GET",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -637,7 +638,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-09-2023, 04:27:55",
+    "recorded-date": "26-03-2024, 09:53:10",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -650,6 +651,7 @@
         },
         "id": "<api-id:1>",
         "name": "Simple PetStore (Swagger)",
+        "rootResourceId": "m7b1ab5lr9",
         "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -725,6 +727,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
                   "responses": {
@@ -732,8 +735,7 @@
                       "statusCode": "200"
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -753,6 +755,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
                   "responses": {
@@ -763,8 +766,7 @@
                   "requestParameters": {
                     "integration.request.path.id": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }
@@ -780,7 +782,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "15-09-2023, 04:55:14",
+    "recorded-date": "26-03-2024, 10:00:19",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -794,6 +796,7 @@
         },
         "id": "<api-id:1>",
         "name": "PetStore",
+        "rootResourceId": "002ygmlo8b",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -1138,7 +1141,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "GET",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1188,7 +1191,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1284,7 +1287,7 @@
                 },
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "GET",
-                  "uri": "http://petstore.execute-api.eu-west-1.amazonaws.com/petstore/pets/{petId}",
+                  "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1465,7 +1468,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "15-09-2023, 04:55:22",
+    "recorded-date": "26-03-2024, 10:00:25",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -1478,6 +1481,7 @@
         },
         "id": "<api-id:1>",
         "name": "Simple PetStore (Swagger)",
+        "rootResourceId": "pv78n23kw0",
         "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1569,6 +1573,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets",
                   "responses": {
@@ -1576,8 +1581,7 @@
                       "statusCode": "200"
                     }
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             },
@@ -1600,6 +1604,7 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
+                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
                   "responses": {
@@ -1610,8 +1615,7 @@
                   "requestParameters": {
                     "integration.request.path.id": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match",
-                  "type": "http"
+                  "passthroughBehavior": "when_no_match"
                 }
               }
             }

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -1,14 +1,14 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-03-26T10:00:18+00:00"
+    "last_validated_date": "2024-03-26T11:32:49+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-03-26T10:00:24+00:00"
+    "last_validated_date": "2024-03-26T11:32:53+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-03-26T09:53:06+00:00"
+    "last_validated_date": "2024-03-26T11:32:19+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-03-26T09:53:09+00:00"
+    "last_validated_date": "2024-03-26T11:32:24+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -1,14 +1,14 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2023-09-15T02:55:14+00:00"
+    "last_validated_date": "2024-03-26T10:00:18+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2023-09-15T02:55:22+00:00"
+    "last_validated_date": "2024-03-26T10:00:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2023-09-15T02:27:47+00:00"
+    "last_validated_date": "2024-03-26T09:53:06+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2023-09-15T02:27:55+00:00"
+    "last_validated_date": "2024-03-26T09:53:09+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There were failing api gateway tests for `eu-west-1` in the workflow: https://app.circleci.com/pipelines/github/localstack/localstack/23655/workflows/49291732-7851-49ea-917a-2a293dde3288/jobs/193896/tests

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- removes the static `uri` value hardcoded for `eu-west-1`
- regenerates the snapshots

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

