### PR TITLE
fix s3 and sns tests for `ap-southeast-1`

### DIFF
--- a/tests/aws/services/s3/test_s3_notifications_sqs.py
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.py
@@ -462,7 +462,7 @@ class TestS3NotificationsToSQS:
         assert events[0]["s3"]["object"]["key"] == key
 
         # test with the bucket in a different region than the client
-        region_2 = secondary_region_name if region_name != "ap-southeast-1" else "us-east-2"
+        region_2 = secondary_region_name if region_name != secondary_region_name else "us-east-2"
         bucket_name_region_2 = s3_create_bucket(
             CreateBucketConfiguration={"LocationConstraint": region_2},
         )

--- a/tests/aws/services/s3/test_s3_notifications_sqs.py
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.py
@@ -436,6 +436,7 @@ class TestS3NotificationsToSQS:
         snapshot,
         aws_client,
         aws_client_factory,
+        region_name,
         secondary_region_name,
     ):
         """This test validates that pre-signed URL works with notification, and that the awsRegion field is the
@@ -461,11 +462,12 @@ class TestS3NotificationsToSQS:
         assert events[0]["s3"]["object"]["key"] == key
 
         # test with the bucket in a different region than the client
+        region_2 = secondary_region_name if region_name != "ap-southeast-1" else "us-east-2"
         bucket_name_region_2 = s3_create_bucket(
-            CreateBucketConfiguration={"LocationConstraint": secondary_region_name},
+            CreateBucketConfiguration={"LocationConstraint": region_2},
         )
         # the SQS queue needs to be in the same region as the S3 bucket
-        sqs_client_region_2 = aws_client_factory(region_name=secondary_region_name).sqs
+        sqs_client_region_2 = aws_client_factory(region_name=region_2).sqs
         queue_url_region_2 = sqs_create_queue_with_client(sqs_client_region_2)
         s3_create_sqs_bucket_notification(
             bucket_name=bucket_name_region_2,

--- a/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.snapshot.json
@@ -317,7 +317,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
-    "recorded-date": "17-10-2023, 17:13:15",
+    "recorded-date": "26-03-2024, 11:46:54",
     "recorded-content": {
       "receive_messages": {
         "messages": [

--- a/tests/aws/services/s3/test_s3_notifications_sqs.validation.json
+++ b/tests/aws/services/s3/test_s3_notifications_sqs.validation.json
@@ -33,7 +33,7 @@
     "last_validated_date": "2023-08-04T22:55:23+00:00"
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
-    "last_validated_date": "2023-10-17T15:13:15+00:00"
+    "last_validated_date": "2024-03-26T11:46:54+00:00"
   },
   "tests/aws/services/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_put_acl": {
     "last_validated_date": "2023-08-04T22:56:22+00:00"

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -409,7 +409,9 @@ class TestSNSPublishCrud:
         # create a client in another region
         sns_client_region_2 = aws_client_factory.get_client(
             service_name="sns",
-            region_name=secondary_region_name if region_name != "ap-southeast-1" else "us-east-2",
+            region_name=secondary_region_name
+            if region_name != secondary_region_name
+            else "us-east-2",
         )
 
         message = "This is a test message"
@@ -4746,7 +4748,7 @@ class TestSNSRetrospectionEndpoints:
             api_platform_endpoints_msgs[endpoint_arn][0]["MessageAttributes"] == message_attributes
         )
 
-        region_2 = secondary_region_name if region_name != "ap-southeast-1" else "us-east-2"
+        region_2 = secondary_region_name if region_name != secondary_region_name else "us-east-2"
 
         # Ensure you can select the region
         msg_with_region = requests.get(

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -1111,7 +1111,7 @@ class TestSNSSubscriptionLambda:
         snapshot.match("messages", response)
 
     @markers.aws.validated
-    @pytest.mark.parametrize("signature_version", ["2"])
+    @pytest.mark.parametrize("signature_version", ["1", "2"])
     def test_publish_lambda_verify_signature(
         self,
         aws_client,

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4839,7 +4839,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_topic_publish_another_region": {
-    "recorded-date": "17-11-2023, 18:14:28",
+    "recorded-date": "26-03-2024, 11:45:50",
     "recorded-content": {
       "success": {
         "MessageId": "<uuid:1>",
@@ -4955,7 +4955,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_publish_lambda_verify_signature[1]": {
-    "recorded-date": "04-01-2024, 18:31:42",
+    "recorded-date": "26-03-2024, 11:44:06",
     "recorded-content": {
       "notification": {
         "Message": "Hello world.",
@@ -4973,7 +4973,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_publish_lambda_verify_signature[2]": {
-    "recorded-date": "04-01-2024, 18:33:47",
+    "recorded-date": "26-03-2024, 11:44:20",
     "recorded-content": {
       "notification": {
         "Message": "Hello world.",

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2024-03-11T10:36:34+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_topic_publish_another_region": {
-    "last_validated_date": "2023-11-17T17:14:28+00:00"
+    "last_validated_date": "2024-03-26T11:45:50+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSPublishCrud::test_unknown_topic_publish": {
     "last_validated_date": "2023-08-24T20:31:45+00:00"
@@ -114,10 +114,10 @@
     "last_validated_date": "2023-10-11T22:47:24+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_publish_lambda_verify_signature[1]": {
-    "last_validated_date": "2024-01-04T18:31:41+00:00"
+    "last_validated_date": "2024-03-26T11:44:04+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_publish_lambda_verify_signature[2]": {
-    "last_validated_date": "2024-01-04T18:33:46+00:00"
+    "last_validated_date": "2024-03-26T11:44:17+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionLambda::test_python_lambda_subscribe_sns_topic": {
     "last_validated_date": "2023-08-24T21:28:59+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There were failing sns and s3 tests for `ap-southeast-1` in the workflow: https://app.circleci.com/pipelines/github/localstack/localstack/23655/workflows/49291732-7851-49ea-917a-2a293dde3288/jobs/193896/tests 

The issue is caused when secondary and primary regions are same. We have set the [TEST_AWS_SECONDARY_REGION_NAME](https://github.com/localstack/localstack/blob/b7f34c67c49c8f8d4aa6e0b08584b248501a64bb/localstack/constants.py#L158) to `ap-southeast-1`.

<!-- What notable changes does this PR make? -->
## Changes
This PR:
- adds fallback if primary and secondary regions are same

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

