### PR TITLE
remove `ap-southeast-1` from random regions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
                   export TEST_AWS_ACCOUNT_ID=$(LC_ALL=C tr -dc '0-9' < /dev/urandom | fold -w 12 | head -n 1)
                   export TEST_AWS_ACCESS_KEY_ID=$TEST_AWS_ACCOUNT_ID
                   # Set TEST_AWS_REGION_NAME to a random AWS region other than us-east-1
-                  export AWS_REGIONS=("us-east-2" "us-west-1" "us-west-2" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "eu-central-1" "eu-west-1")
+                  export AWS_REGIONS=("us-east-2" "us-west-1" "us-west-2" "ap-southeast-2" "ap-northeast-1" "eu-central-1" "eu-west-1")
                   export TEST_AWS_REGION_NAME=${AWS_REGIONS[$RANDOM % ${#AWS_REGIONS[@]}]}
                   echo "export TEST_AWS_REGION_NAME=${TEST_AWS_REGION_NAME}" >> $BASH_ENV
                   echo "export TEST_AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID}" >> $BASH_ENV


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
There are failing tests when primary and secondary regions are same. We have set the [TEST_AWS_SECONDARY_REGION_NAME](https://github.com/localstack/localstack/blob/b7f34c67c49c8f8d4aa6e0b08584b248501a64bb/localstack/constants.py#L158) to `ap-southeast-1`.

Example workflow: https://app.circleci.com/pipelines/github/localstack/localstack/23655/workflows/49291732-7851-49ea-917a-2a293dde3288/jobs/193896/tests

<!-- What notable changes does this PR make? -->
## Changes
This PR removes `ap-southeast-1` from the list of random regions. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

