### PR TITLE
Add version.py file to list of added git files in release helper

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -3,7 +3,7 @@
 set -e
 
 VERSION_FILE=${VERSION_FILE-VERSION}
-VERSION_PACKAGE=${VERSION_PACKAGE-*/version.py}
+VERSION_PY=${VERSION_PY-*/version.py}
 DEPENDENCY_FILE=${DEPENDENCY_FILE-pyproject.toml}
 
 function usage() {
@@ -192,13 +192,13 @@ function cmd-git-commit-release() {
 
     echo $1 || verify_valid_version
 
-    git add ${VERSION_FILE} ${VERSION_PACKAGE} ${DEPENDENCY_FILE}
+    git add ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}
     git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"
 }
 
 function cmd-git-commit-increment() {
-    git add ${VERSION_FILE} ${VERSION_PACKAGE} ${DEPENDENCY_FILE}
+    git add ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}
     git commit -m "prepare next development iteration"
 }
 

--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -3,6 +3,7 @@
 set -e
 
 VERSION_FILE=${VERSION_FILE-VERSION}
+VERSION_PACKAGE=${VERSION_PACKAGE-*/version.py}
 DEPENDENCY_FILE=${DEPENDENCY_FILE-pyproject.toml}
 
 function usage() {
@@ -191,13 +192,13 @@ function cmd-git-commit-release() {
 
     echo $1 || verify_valid_version
 
-    git add ${VERSION_FILE} ${DEPENDENCY_FILE}
+    git add ${VERSION_FILE} ${VERSION_PACKAGE} ${DEPENDENCY_FILE}
     git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"
 }
 
 function cmd-git-commit-increment() {
-    git add ${VERSION_FILE} ${DEPENDENCY_FILE}
+    git add ${VERSION_FILE} ${VERSION_PACKAGE} ${DEPENDENCY_FILE}
     git commit -m "prepare next development iteration"
 }
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The release helper currently does not commit the generated `version.py` file. (Which is created everywhere consistently with the change in the release workflow)

<!-- What notable changes does this PR make? -->
## Changes

It adds the `version.py` file to the commits for releasing and incrementing development iteration


## Testing

Check the changes in the release workflow for guides on how to test this


