### PR TITLE
add update operations for AWS::SNS::Subscription and AWS::SQS::QueuePolicy. 

### DIFF
--- a/localstack/services/sns/resource_providers/aws_sns_subscription.py
+++ b/localstack/services/sns/resource_providers/aws_sns_subscription.py
@@ -66,9 +66,6 @@ class SNSSubscriptionProvider(ResourceProvider[SNSSubscriptionProperties]):
 
         params = util.select_attributes(model=model, params=["TopicArn", "Protocol", "Endpoint"])
 
-        def attr_val(val):
-            return json.dumps(val) if isinstance(val, (dict, list)) else str(val)
-
         attrs = [
             "DeliveryPolicy",
             "FilterPolicy",
@@ -76,7 +73,7 @@ class SNSSubscriptionProvider(ResourceProvider[SNSSubscriptionProperties]):
             "RawMessageDelivery",
             "RedrivePolicy",
         ]
-        attributes = {a: attr_val(model[a]) for a in attrs if a in model}
+        attributes = {a: self.attr_val(model[a]) for a in attrs if a in model}
 
         if attributes:
             params["Attributes"] = attributes
@@ -130,6 +127,7 @@ class SNSSubscriptionProvider(ResourceProvider[SNSSubscriptionProperties]):
 
         """
         model = request.desired_state
+        model["Id"] = request.previous_state["Id"]
         sns = request.aws_client_factory.sns
 
         attrs = [
@@ -144,11 +142,14 @@ class SNSSubscriptionProvider(ResourceProvider[SNSSubscriptionProperties]):
                 sns.set_subscription_attributes(
                     SubscriptionArn=model["Id"],
                     AttributeName=a,
-                    AttributeValue=json.dumps(model[a]),
+                    AttributeValue=self.attr_val(model[a]),
                 )
-
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
             resource_model=model,
             custom_context=request.custom_context,
         )
+
+    @staticmethod
+    def attr_val(val):
+        return json.dumps(val) if isinstance(val, dict) else str(val)

--- a/localstack/services/sns/resource_providers/aws_sns_subscription.py
+++ b/localstack/services/sns/resource_providers/aws_sns_subscription.py
@@ -128,6 +128,27 @@ class SNSSubscriptionProvider(ResourceProvider[SNSSubscriptionProperties]):
         """
         Update a resource
 
-
         """
-        raise NotImplementedError
+        model = request.desired_state
+        sns = request.aws_client_factory.sns
+
+        attrs = [
+            "DeliveryPolicy",
+            "FilterPolicy",
+            "FilterPolicyScope",
+            "RawMessageDelivery",
+            "RedrivePolicy",
+        ]
+        for a in attrs:
+            if a in model:
+                sns.set_subscription_attributes(
+                    SubscriptionArn=model["Id"],
+                    AttributeName=a,
+                    AttributeValue=json.dumps(model[a]),
+                )
+
+        return ProgressEvent(
+            status=OperationStatus.SUCCESS,
+            resource_model=model,
+            custom_context=request.custom_context,
+        )

--- a/localstack/services/sqs/resource_providers/aws_sqs_queuepolicy.py
+++ b/localstack/services/sqs/resource_providers/aws_sqs_queuepolicy.py
@@ -98,4 +98,13 @@ class SQSQueuePolicyProvider(ResourceProvider[SQSQueuePolicyProperties]):
         """
         Update a resource
         """
-        raise NotImplementedError
+        model = request.desired_state
+        sqs = request.aws_client_factory.sqs
+        for queue in model.get("Queues", []):
+            policy = json.dumps(model["PolicyDocument"])
+            sqs.set_queue_attributes(QueueUrl=queue, Attributes={"Policy": policy})
+
+        return ProgressEvent(
+            status=OperationStatus.SUCCESS,
+            resource_model=request.desired_state,
+        )

--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -103,7 +103,6 @@ def test_deploy_stack_with_sns_topic(deploy_cfn_template, aws_client):
 
 
 @markers.aws.validated
-@markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.RawMessageDelivery"])
 def test_update_subscription(snapshot, deploy_cfn_template, aws_client, sqs_queue, sns_topic):
     topic_arn = sns_topic["Attributes"]["TopicArn"]
     queue_url = sqs_queue
@@ -129,6 +128,9 @@ def test_update_subscription(snapshot, deploy_cfn_template, aws_client, sqs_queu
         stack_name=stack.stack_name,
         is_update=True,
     )
-    subscription = aws_client.sns.get_subscription_attributes(SubscriptionArn=sub_arn)
-    snapshot.match("subscription-2", subscription)
+    subscription_updated = aws_client.sns.get_subscription_attributes(SubscriptionArn=sub_arn)
+    snapshot.match("subscription-2", subscription_updated)
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(
+        snapshot.transform.jsonpath("$..Attributes..RawMessageDelivery", "bool")
+    )

--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -131,6 +131,3 @@ def test_update_subscription(snapshot, deploy_cfn_template, aws_client, sqs_queu
     subscription_updated = aws_client.sns.get_subscription_attributes(SubscriptionArn=sub_arn)
     snapshot.match("subscription-2", subscription_updated)
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
-    snapshot.add_transformer(
-        snapshot.transform.jsonpath("$..Attributes..RawMessageDelivery", "bool")
-    )

--- a/tests/aws/services/cloudformation/resources/test_sns.py
+++ b/tests/aws/services/cloudformation/resources/test_sns.py
@@ -100,3 +100,8 @@ def test_deploy_stack_with_sns_topic(deploy_cfn_template, aws_client):
     rs = aws_client.sns.list_topics()
     topics = [tp for tp in rs["Topics"] if tp["TopicArn"] == topic_arn]
     assert not topics
+
+
+@markers.aws.validated
+def test_update_subscription():
+    pass

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -65,5 +65,44 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
+    "recorded-date": "28-03-2024, 18:29:30",
+    "recorded-content": {
+      "subscription-1": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "true",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscription-2": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -67,7 +67,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
-    "recorded-date": "28-03-2024, 18:29:30",
+    "recorded-date": "29-03-2024, 18:22:29",
     "recorded-content": {
       "subscription-1": {
         "Attributes": {
@@ -76,7 +76,7 @@
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
-          "RawMessageDelivery": "true",
+          "RawMessageDelivery": "<bool:1>",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
           "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
@@ -93,7 +93,7 @@
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
-          "RawMessageDelivery": "false",
+          "RawMessageDelivery": "<bool:2>",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
           "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"

--- a/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.snapshot.json
@@ -67,7 +67,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
-    "recorded-date": "29-03-2024, 18:22:29",
+    "recorded-date": "29-03-2024, 21:16:26",
     "recorded-content": {
       "subscription-1": {
         "Attributes": {
@@ -76,7 +76,7 @@
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
-          "RawMessageDelivery": "<bool:1>",
+          "RawMessageDelivery": "true",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
           "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
@@ -93,7 +93,7 @@
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
-          "RawMessageDelivery": "<bool:2>",
+          "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
           "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"

--- a/tests/aws/services/cloudformation/resources/test_sns.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.validation.json
@@ -3,6 +3,6 @@
     "last_validated_date": "2023-11-27T20:27:29+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
-    "last_validated_date": "2024-03-28T18:29:25+00:00"
+    "last_validated_date": "2024-03-29T21:16:21+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sns.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sns.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/cloudformation/resources/test_sns.py::test_sns_topic_fifo_with_deduplication": {
     "last_validated_date": "2023-11-27T20:27:29+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_sns.py::test_update_subscription": {
+    "last_validated_date": "2024-03-28T18:29:25+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sqs.py
+++ b/tests/aws/services/cloudformation/resources/test_sqs.py
@@ -120,3 +120,32 @@ def test_update_queue_no_change(deploy_cfn_template, aws_client, snapshot):
         },
     )
     snapshot.match("outputs-2", updated_stack.outputs)
+
+
+@markers.aws.validated
+def test_update_sqs_queuepolicy(deploy_cfn_template, aws_client, snapshot):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/sqs_with_queuepolicy.yaml"
+        )
+    )
+
+    policy = aws_client.sqs.get_queue_attributes(
+        QueueUrl=stack.outputs["QueueUrlOutput"], AttributeNames=["Policy"]
+    )
+    snapshot.add_transformer(snapshot.transform.regex(policy["Attributes"]["Policy"], "<policy>"))
+    snapshot.match("policy1", policy["Attributes"]["Policy"])
+
+    # deploy a second time with
+    updated_stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../../templates/sqs_with_queuepolicy_updated.yaml"
+        ),
+        is_update=True,
+        stack_name=stack.stack_name,
+    )
+    policy = aws_client.sqs.get_queue_attributes(
+        QueueUrl=updated_stack.outputs["QueueUrlOutput"], AttributeNames=["Policy"]
+    )
+    snapshot.add_transformer(snapshot.transform.regex(policy["Attributes"]["Policy"], "<policy>"))
+    snapshot.match("policy2", policy["Attributes"]["Policy"])

--- a/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
@@ -13,7 +13,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_update_sqs_queuepolicy": {
-    "recorded-date": "26-03-2024, 21:26:03",
+    "recorded-date": "27-03-2024, 20:30:24",
     "recorded-content": {
       "policy1": {
         "Version": "2012-10-17",
@@ -26,7 +26,7 @@
               "sqs:GetQueueAttributes",
               "sqs:GetQueueUrl"
             ],
-            "Resource": "arn:aws:sqs:<region>:111111111111:stack-55fde856-Queue4A7E3555-WrfiOcX0cO4h"
+            "Resource": "arn:aws:sqs:<region>:111111111111:<resource:1>"
           }
         ]
       },
@@ -34,14 +34,14 @@
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Effect": "Allow",
+            "Effect": "Deny",
             "Principal": "*",
             "Action": [
               "sqs:SendMessage",
               "sqs:GetQueueAttributes",
               "sqs:GetQueueUrl"
             ],
-            "Resource": "arn:aws:sqs:<region>:111111111111:stack-55fde856-Queue4A7E3555-WrfiOcX0cO4h"
+            "Resource": "arn:aws:sqs:<region>:111111111111:<resource:1>"
           }
         ]
       }

--- a/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.snapshot.json
@@ -11,5 +11,40 @@
         "QueueUrl": "<queue-url>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_sqs.py::test_update_sqs_queuepolicy": {
+    "recorded-date": "26-03-2024, 21:26:03",
+    "recorded-content": {
+      "policy1": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+              "sqs:SendMessage",
+              "sqs:GetQueueAttributes",
+              "sqs:GetQueueUrl"
+            ],
+            "Resource": "arn:aws:sqs:<region>:111111111111:stack-55fde856-Queue4A7E3555-WrfiOcX0cO4h"
+          }
+        ]
+      },
+      "policy2": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+              "sqs:SendMessage",
+              "sqs:GetQueueAttributes",
+              "sqs:GetQueueUrl"
+            ],
+            "Resource": "arn:aws:sqs:<region>:111111111111:stack-55fde856-Queue4A7E3555-WrfiOcX0cO4h"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sqs.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_update_queue_no_change": {
     "last_validated_date": "2023-12-08T20:11:26+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_sqs.py::test_update_sqs_queuepolicy": {
+    "last_validated_date": "2024-03-26T21:26:03+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_sqs.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_sqs.validation.json
@@ -3,6 +3,6 @@
     "last_validated_date": "2023-12-08T20:11:26+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_sqs.py::test_update_sqs_queuepolicy": {
-    "last_validated_date": "2024-03-26T21:26:03+00:00"
+    "last_validated_date": "2024-03-27T20:30:23+00:00"
   }
 }

--- a/tests/aws/templates/sns_subscription.yml
+++ b/tests/aws/templates/sns_subscription.yml
@@ -1,0 +1,20 @@
+Parameters:
+  TopicArn:
+    Type: String
+    Description: The ARN of the SNS topic to subscribe to
+  QueueArn:
+    Type: String
+    Description: The URL of the SQS queue to send messages to
+Resources:
+    SnsSubscription:
+        Type: AWS::SNS::Subscription
+        Properties:
+          Protocol: sqs
+          TopicArn: !Ref TopicArn
+          Endpoint: !Ref QueueArn
+          RawMessageDelivery: true
+
+Outputs:
+  SubscriptionArn:
+    Value: !Ref SnsSubscription
+    Description: The ARN of the SNS subscription

--- a/tests/aws/templates/sns_subscription_update.yml
+++ b/tests/aws/templates/sns_subscription_update.yml
@@ -1,0 +1,20 @@
+Parameters:
+  TopicArn:
+    Type: String
+    Description: The ARN of the SNS topic to subscribe to
+  QueueArn:
+    Type: String
+    Description: The URL of the SQS queue to send messages to
+Resources:
+    SnsSubscription:
+        Type: AWS::SNS::Subscription
+        Properties:
+          Protocol: sqs
+          TopicArn: !Ref TopicArn
+          Endpoint: !Ref QueueArn
+          RawMessageDelivery: false
+
+Outputs:
+  SubscriptionArn:
+    Value: !Ref SnsSubscription
+    Description: The ARN of the SNS subscription

--- a/tests/aws/templates/sqs_with_queuepolicy_updated.yaml
+++ b/tests/aws/templates/sqs_with_queuepolicy_updated.yaml
@@ -7,10 +7,8 @@ Resources:
       PolicyDocument:
         Statement:
           - Action:
-              - sqs:SendMessage
-              - sqs:GetQueueAttributes
               - sqs:GetQueueUrl
-            Effect: Allow
+            Effect: Deny
             Principal: "*"
             Resource:
               Fn::GetAtt:

--- a/tests/aws/templates/sqs_with_queuepolicy_updated.yaml
+++ b/tests/aws/templates/sqs_with_queuepolicy_updated.yaml
@@ -7,6 +7,8 @@ Resources:
       PolicyDocument:
         Statement:
           - Action:
+              - sqs:SendMessage
+              - sqs:GetQueueAttributes
               - sqs:GetQueueUrl
             Effect: Deny
             Principal: "*"


### PR DESCRIPTION
## Motivation
This pull request (PR) addresses a feature request from a customer. It introduces the update operation functionality for two AWS resource types: AWS::SNS::Subscription and AWS::SQS::QueuePolicy. 

## Changes
- update operation for AWS::SNS::Subscription
- update operation for AWS::SQS::QueuePolicy

## Testing
- tests that create the resource in a CFn stack and update them.
