### PR TITLE
[SFN] Fix MaxAttempts with Zero Values 

### DIFF
--- a/localstack/services/stepfunctions/asl/component/common/retry/max_attempts_decl.py
+++ b/localstack/services/stepfunctions/asl/component/common/retry/max_attempts_decl.py
@@ -22,10 +22,10 @@ class MaxAttemptsDecl(EvalComponent):
     attempts: Final[int]
 
     def __init__(self, attempts: int = DEFAULT_ATTEMPTS):
-        if not (1 <= attempts <= MaxAttemptsDecl.MAX_VALUE):
+        if not (0 <= attempts <= MaxAttemptsDecl.MAX_VALUE):
             raise ValueError(
                 f"MaxAttempts value MUST be a positive integer between "
-                f"1 and {MaxAttemptsDecl.MAX_VALUE}, got '{attempts}'."
+                f"0 and {MaxAttemptsDecl.MAX_VALUE}, got '{attempts}'."
             )
         self.attempts = attempts
 
@@ -39,10 +39,7 @@ class MaxAttemptsDecl(EvalComponent):
         env.heap[self._attempt_number_key()] = attempt_number
 
     def _eval_body(self, env: Environment) -> None:
-        if self.attempts == 0:
-            env.stack.append(MaxAttemptsOutcome.SUCCESS)
-        else:
-            attempt_number: int = self._access_attempt_number(env=env)
-            attempt_number += 1
-            env.stack.append(MaxAttemptsOutcome(attempt_number < self.attempts))
-            self._store_attempt_number(env=env, attempt_number=attempt_number)
+        attempt_number: int = self._access_attempt_number(env=env)
+        attempt_number += 1
+        env.stack.append(MaxAttemptsOutcome(attempt_number < self.attempts))
+        self._store_attempt_number(env=env, attempt_number=attempt_number)

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -141,6 +141,9 @@ class ScenariosTemplate(TemplateLoader):
     RETRY_INTERVAL_FEATURES_JITTER_NONE: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/retry_interval_features_jitter_none.json5"
     )
+    RETRY_INTERVAL_FEATURES_MAX_ATTEMPTS_ZERO: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/retry_interval_features_max_attempts_zero.json5"
+    )
     WAIT_TIMESTAMP: Final[str] = os.path.join(_THIS_FOLDER, "statemachines/wait_timestamp.json5")
     WAIT_TIMESTAMP_PATH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/wait_timestamp_path.json5"

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/retry_interval_features_max_attempts_zero.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/retry_interval_features_max_attempts_zero.json5
@@ -1,0 +1,30 @@
+{
+  "Comment": "RETRY_INTERVAL_FEATURES_MAX_ATTEMPTS_ZERO",
+  "StartAt": "LambdaTask",
+  "States": {
+    "LambdaTask": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName.$": "$.FunctionName",
+        "Payload": {
+          "RetryAttempt.$": "$$.State.RetryCount"
+        }
+      },
+      "Retry": [
+        {
+          "Comment": "Includes all retry langauge features with zero max attempts.",
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 0,
+          "BackoffRate": 2,
+          "MaxDelaySeconds": 5,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/retry_interval_features_max_attempts_zero.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/retry_interval_features_max_attempts_zero.json5
@@ -13,7 +13,7 @@
       },
       "Retry": [
         {
-          "Comment": "Includes all retry langauge features with zero max attempts.",
+          "Comment": "Includes all retry language features with zero max attempts.",
           "ErrorEquals": [
             "States.ALL"
           ],

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -1547,6 +1547,36 @@ class TestBaseScenarios:
         )
 
     @markers.aws.validated
+    def test_retry_interval_features_max_attempts_zero(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        create_lambda_function,
+        sfn_snapshot,
+    ):
+        function_name = f"lambda_func_{short_uid()}"
+        sfn_snapshot.add_transformer(RegexTransformer(function_name, "lambda_function_name"))
+        create_lambda_function(
+            func_name=function_name,
+            handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
+            runtime="python3.12",
+        )
+
+        template = ST.load_sfn_template(ST.RETRY_INTERVAL_FEATURES_MAX_ATTEMPTS_ZERO)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"FunctionName": function_name})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.aws.validated
     def test_wait_timestamp(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
 
+from localstack.aws.api.lambda_ import Runtime
 from localstack.services.stepfunctions.asl.utils.json_path import JSONPathUtils
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
@@ -1560,7 +1561,7 @@ class TestBaseScenarios:
         create_lambda_function(
             func_name=function_name,
             handler_file=EHT.LAMBDA_FUNC_RAISE_EXCEPTION,
-            runtime="python3.12",
+            runtime=Runtime.python3_12,
         )
 
         template = ST.load_sfn_template(ST.RETRY_INTERVAL_FEATURES_MAX_ATTEMPTS_ZERO)

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -14947,5 +14947,111 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_retry_interval_features_max_attempts_zero": {
+    "recorded-date": "27-03-2024, 09:30:20",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "FunctionName": "lambda_function_name"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "LambdaTask"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Payload": {
+                  "RetryAttempt": 0
+                },
+                "FunctionName": "lambda_function_name"
+              },
+              "region": "<region>",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": {
+                "errorMessage": "Some exception was raised.",
+                "errorType": "Exception",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 2, in handler\n    raise Exception(\"Some exception was raised.\")\n"
+                ]
+              },
+              "error": "Exception",
+              "resource": "invoke",
+              "resourceType": "lambda"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": {
+                "errorMessage": "Some exception was raised.",
+                "errorType": "Exception",
+                "requestId": "<uuid:1>",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 2, in handler\n    raise Exception(\"Some exception was raised.\")\n"
+                ]
+              },
+              "error": "Exception"
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -182,6 +182,9 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_retry_interval_features_jitter_none": {
     "last_validated_date": "2024-02-23T08:37:40+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_retry_interval_features_max_attempts_zero": {
+    "last_validated_date": "2024-03-27T09:30:20+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_wait_timestamp": {
     "last_validated_date": "2023-10-31T18:01:20+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the SFN v2 interpreter incorrectly reports MaxAttempts declarations with non zero positive integers as the only valid range of values. This excluded the [scenario of zero values](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html), which resulting in no attempts. This PR addresses such preprocessing errors and adjusts MaxAttempts logic to support zero values. It also adds snapshot test for this scenario.
Addresses: #10547 

<!-- What notable changes does this PR make? -->
## Changes
- Fix preprocessing errors for zero values to handle the correct range
- Adjust MaxAttempts evaluation logic to handle zero attempts
- Added positive snapshot test for MaxAttempts of zero values

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

