### PR TITLE
fix `test_function_arns` for `eu-central-1`

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -409,7 +409,11 @@ class TestLambdaFunction:
 
     # TODO: fix type of AccessDeniedException yielding null
     @markers.snapshot.skip_snapshot_verify(
-        paths=["function_arn_other_account_exc..Error.Message", "$..CodeSha256"]
+        paths=[
+            "function_arn_other_account_exc..Error.Message",
+            "$..CodeSha256",
+            "$..CreateFunctionResponse.LoggingConfig",
+        ]
     )
     @markers.aws.validated
     def test_function_arns(
@@ -464,7 +468,9 @@ class TestLambdaFunction:
         max_function_arn_length = 140
         function_arn_prefix = f"arn:aws:lambda:{region_name}:{account_id}:function:"
         suffix_length = max_function_arn_length - len(function_arn_prefix) + 1
-        long_function_arn = function_arn_prefix + "a" * suffix_length
+        long_function_name = "a" * suffix_length
+        snapshot.add_transformer(snapshot.transform.regex(long_function_name, "<function-name>"))
+        long_function_arn = function_arn_prefix + long_function_name
         with pytest.raises(ClientError) as e:
             aws_client.lambda_.create_function(
                 FunctionName=long_function_arn,
@@ -474,6 +480,7 @@ class TestLambdaFunction:
                 Role=lambda_su_role,
                 Runtime=Runtime.python3_12,
             )
+
         snapshot.match("long_function_arn_exc", e.value.response)
 
         # test other region in function arn than client

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -480,7 +480,6 @@ class TestLambdaFunction:
                 Role=lambda_su_role,
                 Runtime=Runtime.python3_12,
             )
-
         snapshot.match("long_function_arn_exc", e.value.response)
 
         # test other region in function arn than client

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13374,7 +13374,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "recorded-date": "08-12-2023, 12:27:16",
+    "recorded-date": "27-03-2024, 09:37:39",
     "recorded-content": {
       "create-function-arn-response": {
         "CreateEventSourceMappingResponse": null,
@@ -13395,6 +13395,10 @@
           "FunctionName": "<function-name:1>",
           "Handler": "handler.handler",
           "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
@@ -13440,6 +13444,10 @@
           "FunctionName": "<function-name:2>",
           "Handler": "handler.handler",
           "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:2>"
+          },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:2>",
@@ -13491,7 +13499,7 @@
       "long_function_arn_exc": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:function:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
+          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:function:<function-name>' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -48,7 +48,7 @@
     "last_validated_date": "2023-11-20T15:46:21+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_arns": {
-    "last_validated_date": "2023-12-08T11:27:16+00:00"
+    "last_validated_date": "2024-03-27T09:37:34+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
     "last_validated_date": "2023-11-20T15:46:00+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `lambda` test was failing when the [workflow](https://app.circleci.com/pipelines/github/localstack/localstack/23708/workflows/e17be93c-ffcb-446f-a8f0-2f355da30539/jobs/194487/tests) was run against `eu-central-1` with the following error: 

```
>> match key: long_function_arn_exc
	#x1B[33m(~)#x1B[0m /Error/Message "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:function:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140" → "1 validation error detected: Value 'arn:aws:lambda:<region>:111111111111:function:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140" ... (expected → actual)

	Ignore list (please keep in mind list indices might not work and should be replaced):
	["$..Error.Message"]
```

The issue is caused due to variable lengths of suffix length: 

`suffix_length = max_function_arn_length - len(function_arn_prefix) + 1` can be seen [here](https://github.com/localstack/localstack/blob/18a8863d1ca7c6791dfc43246150d92b3b8bae46/tests/aws/services/lambda_/test_lambda_api.py#L466-L467) in the code. 

<!-- What notable changes does this PR make? -->
## Changes
This PR adds a transformer to the long function name generated through the suffix length from function arn and regenerates the snapshots. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

