### PR TITLE
fix `test_dashboard_lifecycle` for `eu-central-1`

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1391,7 +1391,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn"], condition=is_old_provider
+        paths=["$..DashboardArn", "$..DashboardEntries..Size"], condition=is_old_provider
     )  # ARN has a typo in moto
     def test_dashboard_lifecycle(self, aws_client, region_name, snapshot):
         dashboard_name = f"test-{short_uid()}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `cloudwatch` test was failing when the [workflow](https://app.circleci.com/pipelines/github/localstack/localstack/23708/workflows/e17be93c-ffcb-446f-a8f0-2f355da30539/jobs/194487/tests) was run against `eu-central-1` with the following error: 

```
>> match key: list_dashboards_prefix
	#x1B[33m(~)#x1B[0m /DashboardEntries/[0]/Size 225 → 228 ... (expected → actual)

	Ignore list (please keep in mind list indices might not work and should be replaced):
	["$..DashboardEntries..Size"]
>> match key: list_dashboards
	#x1B[33m(~)#x1B[0m /DashboardEntries/[0]/Size 225 → 228 ... (expected → actual)

	Ignore list (please keep in mind list indices might not work and should be replaced):
	["$..DashboardEntries..Size"]
```

The issue is caused due to variable lengths regions causing difference in `size` parameter of list dashboard entries. 

<!-- What notable changes does this PR make? -->
## Changes
This PR skips verifying the `Size` of `DashboardEntries`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

