### PR TITLE
Fix handling reuse of stack names for describe stack events / delete stack operations

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -95,8 +95,10 @@ from localstack.services.cloudformation.engine.transformers import (
 )
 from localstack.services.cloudformation.stores import (
     cloudformation_stores,
+    find_active_stack_by_name_or_id,
     find_change_set,
     find_stack,
+    find_stack_by_id,
     get_cloudformation_store,
 )
 from localstack.state import StateVisitor
@@ -298,7 +300,10 @@ class CloudformationProvider(CloudformationApi):
         client_request_token: ClientRequestToken = None,
         **kwargs,
     ) -> None:
-        stack = find_stack(context.account_id, context.region, stack_name)
+        stack = find_active_stack_by_name_or_id(context.account_id, context.region, stack_name)
+        if not stack:
+            # aws will silently ignore invalid stack names - we should do the same
+            return
         deployer = template_deployer.TemplateDeployer(context.account_id, context.region, stack)
         deployer.delete_stack()
 
@@ -874,14 +879,19 @@ class CloudformationProvider(CloudformationApi):
         next_token: NextToken = None,
         **kwargs,
     ) -> DescribeStackEventsOutput:
-        state = get_cloudformation_store(context.account_id, context.region)
+        if stack_name is None:
+            raise ValidationError(
+                "1 validation error detected: Value null at 'stackName' failed to satisfy constraint: Member must not be null"
+            )
 
-        events = []
-        for stack_id, stack in state.stacks.items():
-            if stack_name in [None, stack.stack_name, stack.stack_id]:
-                events.extend(stack.events)
-
-        return DescribeStackEventsOutput(StackEvents=events)
+        stack = find_active_stack_by_name_or_id(context.account_id, context.region, stack_name)
+        if not stack:
+            stack = find_stack_by_id(
+                account_id=context.account_id, region_name=context.region, stack_id=stack_name
+            )
+        if not stack:
+            raise ValidationError(f"Stack [{stack_name}] does not exist")
+        return DescribeStackEventsOutput(StackEvents=stack.events)
 
     @handler("DescribeStackResource")
     def describe_stack_resource(

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -709,6 +709,11 @@ def test_name_conflicts(aws_client, snapshot, cleanups):
         aws_client.cloudformation.describe_stacks(StackName=stack_name)
     snapshot.match("deleted_stack_not_found_exc", e.value.response)
 
+    # describe events with name fails
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        aws_client.cloudformation.describe_stack_events(StackName=stack_name)
+    snapshot.match("deleted_stack_events_not_found_by_name", e.value.response)
+
     # describe with stack id (ARN) succeeds
     deleted_stack_desc = aws_client.cloudformation.describe_stacks(StackName=stack_id)
     snapshot.match("deleted_stack_desc", deleted_stack_desc)
@@ -733,3 +738,31 @@ def test_name_conflicts(aws_client, snapshot, cleanups):
     new_stack_id_desc = aws_client.cloudformation.describe_stacks(StackName=new_stack_id)
     snapshot.match("stack_id_desc", stack_id_desc)
     snapshot.match("new_stack_id_desc", new_stack_id_desc)
+
+    # check if the describing the stack events return the right stack
+    stack_events = aws_client.cloudformation.describe_stack_events(StackName=stack_name)[
+        "StackEvents"
+    ]
+    assert all(stack_event["StackId"] == new_stack_id for stack_event in stack_events)
+    # describing events by the old stack id should still yield the old events
+    stack_events = aws_client.cloudformation.describe_stack_events(StackName=stack_id)[
+        "StackEvents"
+    ]
+    assert all(stack_event["StackId"] == stack_id for stack_event in stack_events)
+
+    # deleting the stack by name should delete the new, not already deleted stack
+    aws_client.cloudformation.delete_stack(StackName=stack_name)
+    aws_client.cloudformation.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+    # describe with stack id returns stack deleted
+    deleted_stack_desc = aws_client.cloudformation.describe_stacks(StackName=new_stack_id)
+    snapshot.match("deleted_second_stack_desc", deleted_stack_desc)
+
+
+@markers.aws.validated
+def test_describe_stack_events_errors(aws_client, snapshot):
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        aws_client.cloudformation.describe_stack_events()
+    snapshot.match("describe_stack_events_no_stack_name", e.value.response)
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        aws_client.cloudformation.describe_stack_events(StackName="does-not-exist")
+    snapshot.match("describe_stack_events_stack_not_found", e.value.response)

--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -991,7 +991,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_name_conflicts": {
-    "recorded-date": "16-11-2023, 17:07:37",
+    "recorded-date": "26-03-2024, 17:59:43",
     "recorded-content": {
       "create_stack_already_exists_exc": {
         "Error": {
@@ -1009,6 +1009,17 @@
         "Error": {
           "Code": "ValidationError",
           "Message": "Stack with id <stack-name:1> does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "deleted_stack_events_not_found_by_name": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack [<stack-name:1>] does not exist",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -1102,6 +1113,55 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "deleted_second_stack_desc": {
+        "Stacks": [
+          {
+            "CreationTime": "datetime",
+            "DeletionTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "NotificationARNs": [],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "DELETE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_describe_stack_events_errors": {
+    "recorded-date": "26-03-2024, 17:54:41",
+    "recorded-content": {
+      "describe_stack_events_no_stack_name": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "1 validation error detected: Value null at 'stackName' failed to satisfy constraint: Member must not be null",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "describe_stack_events_stack_not_found": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack [does-not-exist] does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -23,6 +23,9 @@
   "tests/aws/services/cloudformation/api/test_stacks.py::test_blocked_stack_deletion": {
     "last_validated_date": "2023-09-06T09:01:18+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_stacks.py::test_describe_stack_events_errors": {
+    "last_validated_date": "2024-03-26T17:54:41+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_events_resource_types": {
     "last_validated_date": "2023-02-15T09:46:53+00:00"
   },
@@ -30,7 +33,7 @@
     "last_validated_date": "2022-11-11T07:10:14+00:00"
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_name_conflicts": {
-    "last_validated_date": "2023-11-16T16:07:37+00:00"
+    "last_validated_date": "2024-03-26T17:59:43+00:00"
   },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_update_termination_protection": {
     "last_validated_date": "2023-01-04T15:23:22+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10327 , we still have problems while redeploying AWS SAM stacks with the same stack name against LocalStack.
The root cause of this issue is `describe_stack_events` not only returning the events for a single stack, but for all stacks with that name. The expected behavior is for that operation to only work by name if the stack is active (i.e. not deleted), and by id for every stack, but only return the events for one in any case (since there can only be one active with a name, and stack ids are unique anyway).
Also, the `delete_stack` operation by name did not affect the active stack with the name, but the first stack with it (which might already be deleted), leading to deletes not working.

<!-- What notable changes does this PR make? -->
## Changes
* Add new `find_active_stack_by_name_or_id` function, for operations which work on active stacks primarily
* Add new `find_stack_by_id` function, to find any stack, by its id only
* Add test for "not found" or "null" errors for `describe_stack_events`
* Fix behavior for `describe_stack_events` and `delete_stack` when multiple stacks with the same name exist
* Extend `test_name_conflicts` test to test the new behavior

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

