### PR TITLE
Feature: Eventbridge v2: Scaffold new provider

### DIFF
--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -1,0 +1,75 @@
+import logging
+
+from localstack.aws.api import RequestContext, handler
+from localstack.aws.api.events import (
+    CreateEventBusResponse,
+    EventBusName,
+    EventBusNameOrArn,
+    EventPattern,
+    EventsApi,
+    EventSourceName,
+    PutRuleResponse,
+    RoleArn,
+    RuleDescription,
+    RuleName,
+    RuleState,
+    ScheduleExpression,
+    TagList,
+)
+from localstack.services.plugins import ServiceLifecycleHook
+
+LOG = logging.getLogger(__name__)
+
+
+class EventsProvider(EventsApi, ServiceLifecycleHook):
+    def __init__(self):
+        self._rules = {}
+        self._event_buses = {}
+
+    @handler("CreateEventBus")
+    def create_event_bus(
+        self,
+        context: RequestContext,
+        name: EventBusName,
+        event_source_name: EventSourceName = None,
+        tags: TagList = None,
+        **kwargs,
+    ) -> CreateEventBusResponse:
+        event_bus_arn = f"arn:aws:events:{context.region}:{context.account_id}:event-bus/{name}"
+        event_bus = {"Name": name, "Arn": event_bus_arn}
+        self._event_buses[name] = event_bus
+
+        response = CreateEventBusResponse(
+            EventBusArn=event_bus_arn,
+        )
+        return response
+
+    @handler("PutRule")
+    def put_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        schedule_expression: ScheduleExpression = None,
+        event_pattern: EventPattern = None,
+        state: RuleState = None,
+        description: RuleDescription = None,
+        role_arn: RoleArn = None,
+        tags: TagList = None,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> PutRuleResponse:
+        rule = {
+            "Name": name,
+            "ScheduleExpression": schedule_expression,
+            "EventPattern": event_pattern,
+            "State": state,
+            "Description": description,
+            "RoleArn": role_arn,
+            "EventBusName": event_bus_name,
+        }
+        self._rules[name] = rule
+
+        response = PutRuleResponse(
+            RuleArn=f"arn:aws:events:{context.region}:{context.account_id}:rule/{name}",
+        )
+        return response

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -336,13 +336,30 @@ def ssm():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-@aws_provider()
+@aws_provider(api="events", name="default")
 def events():
     from localstack.services.events.provider import EventsProvider
     from localstack.services.moto import MotoFallbackDispatcher
 
     provider = EventsProvider()
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
+
+
+@aws_provider(api="events", name="v1")
+def events_v1():
+    from localstack.services.events.provider import EventsProvider
+    from localstack.services.moto import MotoFallbackDispatcher
+
+    provider = EventsProvider()
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
+
+
+@aws_provider(api="events", name="v2")
+def events_v2():
+    from localstack.services.events.provider_v2 import EventsProvider
+
+    provider = EventsProvider()
+    return Service.for_provider(provider)
 
 
 @aws_provider()

--- a/tests/aws/services/events/helper_functions.py
+++ b/tests/aws/services/events/helper_functions.py
@@ -1,0 +1,7 @@
+import os
+
+from localstack.testing.aws.util import is_aws_cloud
+
+
+def is_v2_provider():
+    return os.environ.get("PROVIDER_OVERRIDE_EVENTS") == "v2" and not is_aws_cloud()

--- a/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
+++ b/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_logs.py
@@ -8,6 +8,7 @@ from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
+from tests.aws.services.events.helper_functions import is_v2_provider
 
 LOG = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ def logs_log_group(aws_client):
 
 
 @pytest.fixture
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def add_logs_resource_policy_for_rule(aws_client):
     policies = []
 

--- a/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_sqs.py
+++ b/tests/aws/services/events/scheduled_rules/test_events_scheduled_rules_sqs.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+import pytest
+
 from localstack.testing.aws.eventbus_utils import (
     allow_event_rule_to_sqs_queue,
     trigger_scheduled_rule,
@@ -9,11 +11,13 @@ from localstack.testing.pytest import markers
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
+from tests.aws.services.events.helper_functions import is_v2_provider
 
 LOG = logging.getLogger(__name__)
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_scheduled_rule_sqs(
     sqs_create_queue,
     events_put_rule,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -31,6 +31,7 @@ THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_EVENT_BUS_NAME = "command-bus-dev"
 
 EVENT_DETAIL = {"command": "update-account", "payload": {"acc_id": "0a787ecb-4015", "sf_id": "baz"}}
+
 TEST_EVENT_PATTERN = {
     "source": ["core.update-account-command"],
     "detail-type": ["core.update-account-command"],
@@ -336,6 +337,7 @@ class TestEvents:
 
         # clean up
         target_ids = [topic_target_id, sm_target_id, queue_target_id, fifo_queue_target_id]
+
         clean_up(rule_name=rule_name, target_ids=target_ids, queue_url=queue_url)
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
 
@@ -705,6 +707,16 @@ class TestEvents:
 
 
 class TestEventsEventBus:
+    @markers.aws.validated
+    def test_create_custom_event_bus(self, aws_client, cleanups, snapshot):
+        events = aws_client.events
+        bus_name = "test-bus"
+
+        response = events.create_event_bus(Name=bus_name)
+        cleanups.append(lambda: events.delete_event_bus(Name=bus_name))
+
+        snapshot.match("create-custom-event-bus", response)
+
     @markers.aws.unknown
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -24,6 +24,7 @@ from localstack.utils.files import load_file
 from localstack.utils.strings import long_uid, short_uid, to_str
 from localstack.utils.sync import poll_condition, retry
 from tests.aws.services.events.conftest import assert_valid_event, sqs_collect_messages
+from tests.aws.services.events.helper_functions import is_v2_provider
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 
@@ -75,6 +76,7 @@ EVENT_BUS_ROLE = {
 
 class TestEvents:
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_events_written_to_disk_are_timestamp_prefixed_for_chronological_ordering(
         self, aws_client
     ):
@@ -108,6 +110,7 @@ class TestEvents:
         assert [json.loads(event["Detail"]) for event in sorted_events] == event_details_to_publish
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_list_tags_for_resource(self, aws_client, clean_up):
         rule_name = "rule-{}".format(short_uid())
 
@@ -135,6 +138,7 @@ class TestEvents:
         clean_up(rule_name=rule_name)
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_values_in_array(self, put_events_with_filter_to_sqs):
         pattern = {"detail": {"event": {"data": {"type": ["1", "2"]}}}}
         entries1 = [
@@ -166,6 +170,7 @@ class TestEvents:
         )
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_nested_event_pattern(self, put_events_with_filter_to_sqs):
         pattern = {"detail": {"event": {"data": {"type": ["1"]}}}}
         entries1 = [
@@ -197,6 +202,7 @@ class TestEvents:
         )
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_scheduled_expression_events(
         self,
         sns_create_topic,
@@ -333,8 +339,9 @@ class TestEvents:
         clean_up(rule_name=rule_name, target_ids=target_ids, queue_url=queue_url)
         aws_client.stepfunctions.delete_state_machine(stateMachineArn=state_machine_arn)
 
-    @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
     @markers.aws.unknown
+    @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_api_destinations(self, httpserver: HTTPServer, auth, aws_client, clean_up):
         token = short_uid()
         bearer = f"Bearer {token}"
@@ -493,6 +500,7 @@ class TestEvents:
                 assert oauth_request.args["oauthquery"] == "value3"
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_create_connection_validations(self, aws_client):
         connection_name = "This should fail with two errors 123467890123412341234123412341234"
 
@@ -517,6 +525,7 @@ class TestEvents:
         assert "must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]" in message
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_event_without_source(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
@@ -524,6 +533,7 @@ class TestEvents:
         assert response.get("Entries")
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_event_without_detail(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
@@ -537,6 +547,7 @@ class TestEvents:
         assert response.get("Entries")
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_target_id_validation(
         self, sqs_create_queue, sqs_get_queue_arn, events_put_rule, snapshot, aws_client
     ):
@@ -579,6 +590,7 @@ class TestEvents:
         )
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_event_pattern(self, aws_client, snapshot, account_id, region_name):
         response = aws_client.events.test_event_pattern(
             Event=json.dumps(
@@ -622,6 +634,7 @@ class TestEvents:
         snapshot.match("eventbridge-test-event-pattern-response-no-match", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_time(
         self,
         aws_client,
@@ -694,6 +707,7 @@ class TestEvents:
 class TestEventsEventBus:
     @markers.aws.unknown
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_into_event_bus(
         self,
         monkeypatch,
@@ -761,6 +775,7 @@ class TestEventsEventBus:
         aws_client.sqs.delete_queue(QueueUrl=queue_url)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_to_default_eventbus_for_custom_eventbus(
         self,
         events_create_event_bus,
@@ -893,6 +908,7 @@ class TestEventsEventBus:
         assert_valid_event(received_event)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_nonexistent_event_bus(
         self,
         aws_client,

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -208,5 +208,17 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
+    "recorded-date": "27-03-2024, 09:15:34",
+    "recorded-content": {
+      "create-custom-event-bus": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -26,6 +26,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
     "last_validated_date": "2024-03-26T14:07:18+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
+    "last_validated_date": "2024-03-27T09:15:34+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_nonexistent_event_bus": {
     "last_validated_date": "2024-03-26T14:11:46+00:00"
   },

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -2,16 +2,20 @@
 
 import json
 
+import pytest
+
 from localstack.constants import TEST_AWS_ACCOUNT_ID, TEST_AWS_REGION_NAME
 from localstack.testing.pytest import markers
 from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from tests.aws.services.events.conftest import sqs_collect_messages
+from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
 
 
 class TestEventsInputPath:
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_path(self, aws_client, clean_up):
         queue_name = f"queue-{short_uid()}"
         rule_name = f"rule-{short_uid()}"
@@ -65,6 +69,7 @@ class TestEventsInputPath:
         clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id, queue_url=queue_url)
 
     @markers.aws.unknown
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_path_multiple(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())
         queue_name_1 = "queue-{}".format(short_uid())
@@ -143,6 +148,7 @@ class TestEventsInputPath:
 
 class TestEventsInputTransformers:
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_transformation_to_sqs(
         self, put_events_with_filter_to_sqs, snapshot
     ):

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -14,11 +14,13 @@ from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 from tests.aws.services.events.conftest import assert_valid_event, sqs_collect_messages
+from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
     entries = [
         {
@@ -34,6 +36,7 @@ def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs_new_region(aws_client_factory):
     events_client = aws_client_factory(region_name="eu-west-1").events
     queue_name = "queue-{}".format(short_uid())
@@ -75,6 +78,7 @@ def test_put_events_with_target_sqs_new_region(aws_client_factory):
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs_event_detail_match(put_events_with_filter_to_sqs):
     entries1 = [
         {
@@ -103,6 +107,7 @@ def test_put_events_with_target_sqs_event_detail_match(put_events_with_filter_to
 
 @markers.aws.unknown
 @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sns(
     monkeypatch,
     sns_subscription,
@@ -171,6 +176,7 @@ def test_put_events_with_target_sns(
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_lambda(create_lambda_function, cleanups, aws_client, clean_up):
     rule_name = f"rule-{short_uid()}"
     function_name = f"lambda-func-{short_uid()}"
@@ -232,6 +238,7 @@ def test_put_events_with_target_lambda(create_lambda_function, cleanups, aws_cli
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_should_ignore_schedules_for_put_event(create_lambda_function, cleanups, aws_client):
     """Regression test for https://github.com/localstack/localstack/issues/7847"""
     fn_name = f"test-event-fn-{short_uid()}"
@@ -281,6 +288,7 @@ def test_should_ignore_schedules_for_put_event(create_lambda_function, cleanups,
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_firehose(aws_client, clean_up):
     s3_bucket = "s3-{}".format(short_uid())
     s3_prefix = "testeventdata"
@@ -349,6 +357,7 @@ def test_put_events_with_target_firehose(aws_client, clean_up):
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_kinesis(aws_client):
     rule_name = "rule-{}".format(short_uid())
     target_id = "target-{}".format(short_uid())
@@ -422,6 +431,7 @@ def test_put_events_with_target_kinesis(aws_client):
 
 @markers.aws.unknown
 @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_trigger_event_on_ssm_change(monkeypatch, aws_client, clean_up, strategy):
     monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", strategy)
 

--- a/tests/aws/services/events/test_events_rules.py
+++ b/tests/aws/services/events/test_events_rules.py
@@ -13,10 +13,12 @@ from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 from tests.aws.services.events.conftest import assert_valid_event, sqs_collect_messages
+from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import TEST_EVENT_BUS_NAME, TEST_EVENT_PATTERN
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_rule(aws_client, snapshot, clean_up):
     rule_name = f"rule-{short_uid()}"
     snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule-name>"))
@@ -36,6 +38,7 @@ def test_put_rule(aws_client, snapshot, clean_up):
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_rule_disable(aws_client, clean_up):
     rule_name = f"rule-{short_uid()}"
     aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)")
@@ -73,6 +76,7 @@ def test_rule_disable(aws_client, clean_up):
         " rate(10 minutes)",
     ],
 )
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_rule_invalid_rate_schedule_expression(expression, aws_client):
     with pytest.raises(ClientError) as e:
         aws_client.events.put_rule(Name=f"rule-{short_uid()}", ScheduleExpression=expression)
@@ -84,6 +88,7 @@ def test_put_rule_invalid_rate_schedule_expression(expression, aws_client):
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_anything_but_to_sqs(put_events_with_filter_to_sqs, snapshot):
     snapshot.add_transformer(
         [
@@ -137,6 +142,7 @@ def test_put_events_with_rule_anything_but_to_sqs(put_events_with_filter_to_sqs,
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_exists_true_to_sqs(put_events_with_filter_to_sqs, snapshot):
     """
     Exists matching True condition: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-exists-matching
@@ -184,6 +190,7 @@ def test_put_events_with_rule_exists_true_to_sqs(put_events_with_filter_to_sqs, 
 
 
 @markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_exists_false_to_sqs(put_events_with_filter_to_sqs, snapshot):
     """
     Exists matching False condition: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-exists-matching
@@ -231,6 +238,7 @@ def test_put_events_with_rule_exists_false_to_sqs(put_events_with_filter_to_sqs,
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_event_with_content_base_rule_in_pattern(aws_client, clean_up):
     queue_name = f"queue-{short_uid()}"
     rule_name = f"rule-{short_uid()}"
@@ -327,8 +335,9 @@ def test_put_event_with_content_base_rule_in_pattern(aws_client, clean_up):
     )
 
 
-@pytest.mark.parametrize("schedule_expression", ["rate(1 minute)", "rate(1 day)", "rate(1 hour)"])
 @markers.aws.validated
+@pytest.mark.parametrize("schedule_expression", ["rate(1 minute)", "rate(1 day)", "rate(1 hour)"])
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_create_rule_with_one_unit_in_singular_should_succeed(
     schedule_expression, aws_client, clean_up
 ):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR layers the groundwork for the implementation of the new EventBridge native provider. 

<!-- What notable changes does this PR make? -->
## Changes
This PR implements the basic scaffold of the new native EventBridge provider. 
It also updates the API stubs to add missing docstrings.
Furthermore, a flag to select the new provider is introduced, with `PROVIDER_OVERRIDE_EVENTS=v2`.
Test selection is introduced for all eventbridge tests that are not yet supported by the new provider, as the implementation improves these skips tests will be continuously removed, to gain full test coverage also for the new provider.



## Testing

To test the new provider manually, the env variable `PROVIDER_OVERRIDE_EVENTS=v2` needs to be set. 
All except the test `test_events.TestEventsEventBus.test_create_custom_event_bus` are marked as skipped, since the mocked new provider does not support them yet. 

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

