### PR TITLE
Feat: Events v2: add ci step for eventbridge v2 provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -730,6 +730,7 @@ workflows:
             - itest-sfn-legacy-provider
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
+            - itest-events-v2-provider
             - acceptance-tests
             - docker-test-amd64
             - docker-test-arm64
@@ -743,6 +744,7 @@ workflows:
             - itest-sfn-legacy-provider
             - itest-s3-v2-legacy-provider
             - itest-cloudwatch-v2-provider
+            - itest-events-v2-provider
             - acceptance-tests
             - docker-test-amd64
             - docker-test-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,32 @@ jobs:
       - store_test_results:
           path: target/reports/
 
+  itest-events-v2-provider:
+    executor: ubuntu-machine-amd64
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - prepare-pytest-tinybird
+      - prepare-account-region-randomization
+      - run:
+          name: Test EventBridge v2 provider
+          environment:
+            PROVIDER_OVERRIDE_EVENTS: "v2"
+            TEST_PATH: "tests/aws/services/events/"
+            COVERAGE_ARGS: "-p"
+          command: |
+            COVERAGE_FILE="target/coverage/.coverage.eventsV2.${CIRCLE_NODE_INDEX}" \
+            PYTEST_ARGS="${TINYBIRD_PYTEST_ARGS}${TESTSELECTION_PYTEST_ARGS}--reruns 3 --junitxml=target/reports/events_v2.xml -o junit_suite_name='events_v2'" \
+            make test-coverage
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
   docker-build:
     parameters:
       platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,6 +679,10 @@ workflows:
           requires:
             - preflight
             - test-selection
+      - itest-events-v2-provider:
+          requires:
+            - preflight
+            - test-selection
       - unit-tests:
           requires:
             - preflight


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
https://github.com/localstack/localstack/pull/10552 introduces a new v2 provider for EventBridge, that can be selected via the env variable `PROVIDER_OVERRIDE_EVENTS=v2`. We need a new step in the CI run, that sets this env variable and runs tests against the new provider.

<!-- What notable changes does this PR make? -->
## Changes
Adds new step for CircleCi to test new EventBridge provider

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

