### PR TITLE
add script for generating Kubernetes dev files

### DIFF
--- a/localstack/dev/kubernetes/__main__.py
+++ b/localstack/dev/kubernetes/__main__.py
@@ -72,14 +72,20 @@ def generate_k8s_cluster_overrides(
     venv_path = os.path.join(target_path, ".venv", "lib", "python3.11", "site-packages")
     for volume in volumes:
         if volume["name"] == "entry-points":
-            project = "localstack_ext-" if pro else "localstack_core-"
-            version = localstack_version.__version__
-            dist_info = f"{project}{version}0.dist-info"
+            entry_points_path = os.path.join(
+                target_path, "localstack_core.egg-info", "entry_points.txt"
+            )
+            if pro:
+                project = "localstack_ext-"
+                version = localstack_version.__version__
+                dist_info = f"{project}{version}0.dist-info"
+                entry_points_path = os.path.join(venv_path, dist_info, "entry_points.txt")
+
             volume_mounts.append(
                 {
                     "name": volume["name"],
                     "readOnly": True,
-                    "mountPath": os.path.join(venv_path, dist_info, "entry_points.txt"),
+                    "mountPath": entry_points_path,
                 }
             )
             continue

--- a/localstack/dev/kubernetes/__main__.py
+++ b/localstack/dev/kubernetes/__main__.py
@@ -145,11 +145,12 @@ def run(pro: bool = None, mount_moto: bool = False, write: bool = False, command
 
     generate_k8s_cluster_overrides(pro, config, write=write)
 
-    print("To create a k3d cluster with the generated configuration, run the following command:")
-    print("k3d cluster create --config cluster-config.yaml")
+    print("\nTo create a k3d cluster with the generated configuration, follow these steps:")
+    print("1. Run the following command to create the cluster:")
+    print("\n    k3d cluster create --config cluster-config.yaml\n")
 
-    print("To start the cluster with the generated overrides, run the following command:")
-    print("helm upgrade --install localstack ./charts/localstack -f cluster-overrides.yaml ")
+    print("2. Once the cluster is created, start LocalStack with the generated overrides:")
+    print("\n   helm upgrade --install localstack ./charts/localstack -f cluster-overrides.yaml\n")
 
 
 def main():

--- a/localstack/dev/kubernetes/__main__.py
+++ b/localstack/dev/kubernetes/__main__.py
@@ -1,0 +1,134 @@
+import os
+
+import click
+import yaml
+
+
+def generate_k8s_cluster_config(
+    pro: bool = False, mount_moto: bool = False, write_files: bool = False
+):
+    volumes = []
+    root_path = os.path.join(os.path.dirname(__file__), "..", "..")
+    volumes.append(
+        {
+            "volume": f"{os.path.normpath(root_path)}:/code/localstack",
+            "nodeFilters": ["server:*", "agent:*"],
+        }
+    )
+
+    if pro:
+        ext_path = os.path.join(root_path, "..", "localstack-ext")
+        egg_path = os.path.join(ext_path, "localstack_ext.egg-info")
+        volumes.append(
+            {
+                "volume": f"{os.path.normpath(ext_path)}:/code/localstack_ext",
+                "nodeFilters": ["server:*", "agent:*"],
+            }
+        )
+    else:
+        egg_path = os.path.join(root_path, "localstack.egg-info")
+
+    volumes.append(
+        {
+            "volume": f"{os.path.normpath(egg_path)}:/code/egg_info",
+            "nodeFilters": ["server:*", "agent:*"],
+        }
+    )
+
+    if mount_moto:
+        moto_path = os.path.join(root_path, "..", "moto")
+        volumes.append(
+            {"volume": f"{moto_path}:/code/moto", "nodeFilters": ["server:*", "agent:*"]}
+        )
+
+    config = {"apiVersion": "k3d.io/v1alpha3", "kind": "Simple", "volumes": volumes}
+
+    if write_files:
+        with open(os.path.join(os.getcwd(), "cluster-config.yaml"), "w") as f:
+            f.write(yaml.dump(config))
+            f.close()
+            print(
+                "Generated kubernetes cluster configuration file at kubernetes/cluster-config.yaml"
+            )
+    else:
+        print("Generated kubernetes cluster configuration:")
+        print("=====================================")
+        print(yaml.dump(config))
+        print("=====================================")
+    return config
+
+
+def convert_snake_to_camel_case(snake_str):
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def generate_k8s_cluster_overrides(
+    pro: bool = False, cluster_config: dict = None, write_files: bool = False
+):
+    volumes = []
+    for volume in cluster_config["volumes"]:
+        volumes.append(
+            {
+                "name": convert_snake_to_camel_case(volume["volume"].split(":")[-1].split("/")[-1]),
+                "hostPath": {"path": volume["volume"].split(":")[-1], "type": "Directory"},
+            }
+        )
+
+    volumen_mounts = []
+    target_path = "/opt/code/localstack/"
+    venv_path = os.path.join(target_path, ".venv", "lib", "python3.11", "site-packages")
+    for volume in volumes:
+        if volume["name"] == "eggInfo":
+            volumen_mounts.append(
+                {
+                    "name": volume["name"],
+                    "mountPath": os.path.join(
+                        target_path, "localstack-ext.egg-info" if pro else "localstack.egg-info"
+                    ),
+                }
+            )
+            continue
+
+        volumen_mounts.append(
+            {
+                "name": volume["name"],
+                "mountPath": os.path.join(venv_path, volume["hostPath"]["path"].split("/")[-1]),
+            }
+        )
+
+    overrides = {
+        "volumes": volumes,
+        "volumeMounts": volumen_mounts,
+    }
+
+    if write_files:
+        with open(os.path.join(os.getcwd(), "cluster-overrides.yaml"), "w") as f:
+            f.write(yaml.dump(overrides))
+            f.close()
+        print("Generated kubernetes cluster overrides file at kubernetes/cluster-overrides.yaml")
+    else:
+        print("Generated kubernetes cluster overrides:")
+        print("=====================================")
+        print(yaml.dump(overrides))
+        print("=====================================")
+
+
+@click.option("--pro", is_flag=True, help="Mount the localstack-ext code into the cluster.")
+@click.option("--mount-moto", is_flag=True, help="Mount the moto code into the cluster.")
+@click.option("--write-files", is_flag=True, help="Write the configuration and overrides to files.")
+@click.argument("command", nargs=-1, required=False)
+def run(pro: bool = None, mount_moto: bool = False, write_files: bool = False):
+    """
+    A tool for localstack developers to generated the kubernetes cluster configuration file and the overrides to mount the localstack code into the cluster.
+    """
+
+    print(pro)
+
+    config = generate_k8s_cluster_config(pro=pro, mount_moto=mount_moto, write_files=write_files)
+
+    generate_k8s_cluster_overrides(pro, config, write_files=write_files)
+
+
+if __name__ == "__main__":
+    run()

--- a/localstack/dev/kubernetes/__main__.py
+++ b/localstack/dev/kubernetes/__main__.py
@@ -6,7 +6,7 @@ import yaml
 from localstack import version as localstack_version
 
 
-def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, write: bool = False):
+def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False):
     volumes = []
     root_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
     localstack_code_path = os.path.join(root_path, "localstack")
@@ -45,17 +45,6 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, wri
 
     config = {"apiVersion": "k3d.io/v1alpha3", "kind": "Simple", "volumes": volumes}
 
-    if write:
-        path = os.path.join(os.getcwd(), "cluster-config.yaml")
-        with open(path, "w") as f:
-            f.write(yaml.dump(config))
-            f.close()
-            print(f"Generated kubernetes cluster configuration file at {path}")
-    else:
-        print("Generated kubernetes cluster configuration:")
-        print("=====================================")
-        print(yaml.dump(config))
-        print("=====================================")
     return config
 
 

--- a/localstack/dev/kubernetes/__main__.py
+++ b/localstack/dev/kubernetes/__main__.py
@@ -8,25 +8,27 @@ def generate_k8s_cluster_config(
     pro: bool = False, mount_moto: bool = False, write_files: bool = False
 ):
     volumes = []
-    root_path = os.path.join(os.path.dirname(__file__), "..", "..")
+    root_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    localstack_code_path = os.path.join(root_path, "localstack")
     volumes.append(
         {
-            "volume": f"{os.path.normpath(root_path)}:/code/localstack",
+            "volume": f"{os.path.normpath(localstack_code_path)}:/code/localstack",
             "nodeFilters": ["server:*", "agent:*"],
         }
     )
 
+    egg_path = os.path.join(root_path, "localstack_core.egg-info")
     if pro:
         ext_path = os.path.join(root_path, "..", "localstack-ext")
+        ext_code_path = os.path.join(ext_path, "localstack_ext")
         egg_path = os.path.join(ext_path, "localstack_ext.egg-info")
+
         volumes.append(
             {
-                "volume": f"{os.path.normpath(ext_path)}:/code/localstack_ext",
+                "volume": f"{os.path.normpath(ext_code_path)}:/code/localstack_ext",
                 "nodeFilters": ["server:*", "agent:*"],
             }
         )
-    else:
-        egg_path = os.path.join(root_path, "localstack.egg-info")
 
     volumes.append(
         {
@@ -36,7 +38,7 @@ def generate_k8s_cluster_config(
     )
 
     if mount_moto:
-        moto_path = os.path.join(root_path, "..", "moto")
+        moto_path = os.path.join(root_path, "..", "moto", "moto")
         volumes.append(
             {"volume": f"{moto_path}:/code/moto", "nodeFilters": ["server:*", "agent:*"]}
         )
@@ -58,9 +60,8 @@ def generate_k8s_cluster_config(
     return config
 
 
-def convert_snake_to_camel_case(snake_str):
-    components = snake_str.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])
+def snake_to_kebab_case(string: str):
+    return string.lower().replace("_", "-")
 
 
 def generate_k8s_cluster_overrides(
@@ -70,7 +71,7 @@ def generate_k8s_cluster_overrides(
     for volume in cluster_config["volumes"]:
         volumes.append(
             {
-                "name": convert_snake_to_camel_case(volume["volume"].split(":")[-1].split("/")[-1]),
+                "name": snake_to_kebab_case(volume["volume"].split(":")[-1].split("/")[-1]),
                 "hostPath": {"path": volume["volume"].split(":")[-1], "type": "Directory"},
             }
         )
@@ -79,12 +80,14 @@ def generate_k8s_cluster_overrides(
     target_path = "/opt/code/localstack/"
     venv_path = os.path.join(target_path, ".venv", "lib", "python3.11", "site-packages")
     for volume in volumes:
-        if volume["name"] == "eggInfo":
+        if volume["name"] == "egg-info":
             volumen_mounts.append(
                 {
                     "name": volume["name"],
+                    "readOnly": True,
                     "mountPath": os.path.join(
-                        target_path, "localstack-ext.egg-info" if pro else "localstack.egg-info"
+                        target_path,
+                        "localstack-ext.egg-info" if pro else "localstack_core.egg-info",
                     ),
                 }
             )
@@ -93,6 +96,7 @@ def generate_k8s_cluster_overrides(
         volumen_mounts.append(
             {
                 "name": volume["name"],
+                "readOnly": True,
                 "mountPath": os.path.join(venv_path, volume["hostPath"]["path"].split("/")[-1]),
             }
         )
@@ -114,11 +118,21 @@ def generate_k8s_cluster_overrides(
         print("=====================================")
 
 
-@click.option("--pro", is_flag=True, help="Mount the localstack-ext code into the cluster.")
-@click.option("--mount-moto", is_flag=True, help="Mount the moto code into the cluster.")
-@click.option("--write-files", is_flag=True, help="Write the configuration and overrides to files.")
+@click.command("run")
+@click.option(
+    "--pro", is_flag=True, default=None, help="Mount the localstack-ext code into the cluster."
+)
+@click.option(
+    "--mount-moto", is_flag=True, default=None, help="Mount the moto code into the cluster."
+)
+@click.option(
+    "--write-files",
+    is_flag=True,
+    default=None,
+    help="Write the configuration and overrides to files.",
+)
 @click.argument("command", nargs=-1, required=False)
-def run(pro: bool = None, mount_moto: bool = False, write_files: bool = False):
+def run(pro: bool = None, mount_moto: bool = False, write_files: bool = False, command: str = None):
     """
     A tool for localstack developers to generated the kubernetes cluster configuration file and the overrides to mount the localstack code into the cluster.
     """
@@ -130,5 +144,9 @@ def run(pro: bool = None, mount_moto: bool = False, write_files: bool = False):
     generate_k8s_cluster_overrides(pro, config, write_files=write_files)
 
 
-if __name__ == "__main__":
+def main():
     run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new script that simplifies the development workflow for LocalStack contributors and developers working with Kubernetes.

The script generates two essential files:

1. **Configuration File**: This file contains the necessary configurations to mount the LocalStack code into the k3d container when creating a Kubernetes cluster. This allows developers to make changes to the LocalStack codebase and have them immediately reflected in the running cluster, facilitating a streamlined development and testing experience.

2. **Overrides File**: This file provides overrides for the LocalStack Helm charts, enabling the mounting of the LocalStack code into the LocalStack container itself. By mounting the code directly into the container, developers can seamlessly debug and test their changes within the LocalStack environment.

To get started and learn more about the available options and usage, run:

```bash
python -m localstack.dev.kubernetes --help
```