### PR TITLE
fix clouformation ec2 tests for `ap-northeast-1` and validate against AWS

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -45,7 +45,7 @@ def test_simple_route_table_creation(deploy_cfn_template, aws_client):
         ec2.describe_route_tables(RouteTableIds=[route_table_id])
 
 
-@markers.aws.unknown
+@markers.aws.validated
 def test_vpc_creates_default_sg(deploy_cfn_template, aws_client):
     result = deploy_cfn_template(
         template_path=os.path.join(THIS_FOLDER, "../../../templates/ec2_vpc_default_sg.yaml")

--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -91,7 +91,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "recorded-date": "20-10-2023, 08:55:07",
+    "recorded-date": "28-03-2024, 06:48:11",
     "recorded-content": {
       "attachment": {
         "Association": {
@@ -132,7 +132,7 @@
         "Tags": [
           {
             "Key": "Application",
-            "Value": "arn:aws:cloudformation:<region>:111111111111:stack/stack-d2a69315/f9376240-6f4f-11ee-87a2-0a5f03ecaf83"
+            "Value": "arn:aws:cloudformation:<region>:111111111111:stack/stack-31597705/521e4e40-ecce-11ee-806c-0affc1ff51e7"
           }
         ],
         "TransitGatewayArn": "arn:aws:ec2:<region>:111111111111:transit-gateway/<transit-gateway-id:1>",

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2023-02-13T16:13:41+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "last_validated_date": "2023-10-20T06:55:07+00:00"
+    "last_validated_date": "2024-03-28T06:48:11+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
     "last_validated_date": "2024-03-28T06:26:23+00:00"

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -7,5 +7,8 @@
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
     "last_validated_date": "2023-10-20T06:55:07+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
+    "last_validated_date": "2024-03-28T06:26:23+00:00"
   }
 }

--- a/tests/aws/templates/ec2_vpc_default_sg.yaml
+++ b/tests/aws/templates/ec2_vpc_default_sg.yaml
@@ -1,6 +1,18 @@
+Parameters:
+  DeployRegion:
+    Type: String
+    Default: us-east-1
+
+Conditions:
+  DeployInUSEast1:
+    Fn::Equals:
+      - !Ref DeployRegion
+      - us-east-1
+
 Resources:
   vpcA2121C38:
     Type: AWS::EC2::VPC
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/16
       EnableDnsHostnames: true
@@ -11,6 +23,7 @@ Resources:
           Value: RdsTestStack/vpc
   vpcPublicSubnet1Subnet2E65531E:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/18
       VpcId:
@@ -18,7 +31,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: ""
+          - Fn::GetAZs: !Ref DeployRegion
       MapPublicIpOnLaunch: true
       Tags:
         - Key: aws-cdk:subnet-name
@@ -29,6 +42,7 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet1
   vpcPublicSubnet1RouteTable48A2DF9B:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -37,6 +51,7 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet1
   vpcPublicSubnet1RouteTableAssociation5D3F4579:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet1RouteTable48A2DF9B
@@ -44,6 +59,7 @@ Resources:
         Ref: vpcPublicSubnet1Subnet2E65531E
   vpcPublicSubnet1DefaultRoute10708846:
     Type: AWS::EC2::Route
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet1RouteTable48A2DF9B
@@ -54,6 +70,7 @@ Resources:
       - vpcVPCGW7984C166
   vpcPublicSubnet2Subnet009B674F:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.64.0/18
       VpcId:
@@ -61,7 +78,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: ""
+          - Fn::GetAZs: !Ref DeployRegion
       MapPublicIpOnLaunch: true
       Tags:
         - Key: aws-cdk:subnet-name
@@ -72,6 +89,7 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet2
   vpcPublicSubnet2RouteTableEB40D4CB:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -80,6 +98,7 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet2
   vpcPublicSubnet2RouteTableAssociation21F81B59:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet2RouteTableEB40D4CB
@@ -87,6 +106,7 @@ Resources:
         Ref: vpcPublicSubnet2Subnet009B674F
   vpcPublicSubnet2DefaultRouteA1EC0F60:
     Type: AWS::EC2::Route
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet2RouteTableEB40D4CB
@@ -97,6 +117,7 @@ Resources:
       - vpcVPCGW7984C166
   vpcIsolatedSubnet1Subnet8B28CEB3:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.128.0/18
       VpcId:
@@ -104,7 +125,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: ""
+          - Fn::GetAZs: !Ref DeployRegion
       MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-cdk:subnet-name
@@ -115,6 +136,7 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet1
   vpcIsolatedSubnet1RouteTable0D6B2D3D:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -123,6 +145,7 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet1
   vpcIsolatedSubnet1RouteTableAssociation172210D4:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcIsolatedSubnet1RouteTable0D6B2D3D
@@ -130,6 +153,7 @@ Resources:
         Ref: vpcIsolatedSubnet1Subnet8B28CEB3
   vpcIsolatedSubnet2Subnet2C6B375C:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.192.0/18
       VpcId:
@@ -137,7 +161,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: ""
+          - Fn::GetAZs: !Ref DeployRegion
       MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-cdk:subnet-name
@@ -148,6 +172,7 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet2
   vpcIsolatedSubnet2RouteTable3455CBFC:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -156,6 +181,7 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet2
   vpcIsolatedSubnet2RouteTableAssociation8A8FAF70:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcIsolatedSubnet2RouteTable3455CBFC
@@ -163,12 +189,14 @@ Resources:
         Ref: vpcIsolatedSubnet2Subnet2C6B375C
   vpcIGWE57CBDCA:
     Type: AWS::EC2::InternetGateway
+    Condition: DeployInUSEast1
     Properties:
       Tags:
         - Key: Name
           Value: RdsTestStack/vpc
   vpcVPCGW7984C166:
     Type: AWS::EC2::VPCGatewayAttachment
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38

--- a/tests/aws/templates/transit_gateway_attachment.yml
+++ b/tests/aws/templates/transit_gateway_attachment.yml
@@ -1,6 +1,18 @@
+Parameters:
+  DeployRegion:
+    Type: String
+    Default: us-east-1
+
+Conditions:
+  DeployInUSEast1:
+    Fn::Equals:
+      - !Ref DeployRegion
+      - us-east-1
+
 Resources:
   Vpc8378EB38:
     Type: AWS::EC2::VPC
+    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/20
       EnableDnsHostnames: true
@@ -8,6 +20,7 @@ Resources:
       InstanceTenancy: default
   myTransitGateway:
     Type: "AWS::EC2::TransitGateway"
+    Condition: DeployInUSEast1
     Properties:
       AmazonSideAsn: 65000
       Description: "TGW Route Integration Test"
@@ -20,22 +33,25 @@ Resources:
           Value: !Ref 'AWS::StackId'
   VpcIsolatedSubnet1SubnetE48C5737:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: ''
+          - Fn::GetAZs: !Ref DeployRegion
       CidrBlock: 10.0.0.0/24
       MapPublicIpOnLaunch: false
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet1RouteTable4771E3E5:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet1RouteTableAssociationD300FCBB:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: VpcIsolatedSubnet1RouteTable4771E3E5
@@ -43,6 +59,7 @@ Resources:
         Ref: VpcIsolatedSubnet1SubnetE48C5737
   VpcIsolatedSubnet1TransitGatewayRouteA907B32D:
     Type: AWS::EC2::Route
+    Condition: DeployInUSEast1
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       RouteTableId:
@@ -52,22 +69,25 @@ Resources:
       - TransitGatewayVpcAttachment
   VpcIsolatedSubnet2Subnet16364B91:
     Type: AWS::EC2::Subnet
+    Condition: DeployInUSEast1
     Properties:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: ''
+          - Fn::GetAZs: !Ref DeployRegion
       CidrBlock: 10.0.1.0/24
       MapPublicIpOnLaunch: false
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet2RouteTable1D30AF7D:
     Type: AWS::EC2::RouteTable
+    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet2RouteTableAssociationF7B18CCA:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: VpcIsolatedSubnet2RouteTable1D30AF7D
@@ -75,6 +95,7 @@ Resources:
         Ref: VpcIsolatedSubnet2Subnet16364B91
   VpcIsolatedSubnet2TransitGatewayRoute1E0D0BF2:
     Type: AWS::EC2::Route
+    Condition: DeployInUSEast1
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       RouteTableId:
@@ -84,6 +105,7 @@ Resources:
       - TransitGatewayVpcAttachment
   TransitGatewayVpcAttachment:
     Type: AWS::EC2::TransitGatewayAttachment
+    Condition: DeployInUSEast1
     Properties:
       SubnetIds:
         - Ref: VpcIsolatedSubnet1SubnetE48C5737


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Test `test_vpc_creates_default_sg` and `test_transit_gateway_attachment`fail when run in the [workflow](https://app.circleci.com/pipelines/github/localstack/localstack/23755/workflows/5d782a03-6bc1-4bd2-bcad-c6f1170e5381/jobs/194931/tests) for region: `ap-northeast-1` and throws a `StackDeployError`. 

<!-- What notable changes does this PR make? -->
## Changes
This PR validates test: `test_vpc_creates_default_sg` against AWS and deploys both the tests specifically in `us-east-1`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

