### PR TITLE
Fix non-default-region compatibility for recent lambda invalid invoke test

### DIFF
--- a/localstack/services/lambda_/api_utils.py
+++ b/localstack/services/lambda_/api_utils.py
@@ -59,7 +59,7 @@ DESTINATION_ARN_PATTERN = re.compile(
 )
 
 AWS_FUNCTION_NAME_REGEX = re.compile(
-    "^(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?$"
+    "^(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?$"
 )
 
 # Pattern for extracting various attributes from a full or partial ARN or just a function name.

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1361,7 +1361,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         account_id, region = api_utils.get_account_and_region(function_name, context)
         if not api_utils.validate_function_name(function_name):
             raise ValidationException(
-                f"1 validation error detected: Value '{function_name}' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso(b?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+                f"1 validation error detected: Value '{function_name}' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{{2}}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{{1}}:)?(\\d{{12}}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
             )
 
         function_name, qualifier = api_utils.get_name_and_qualifier(

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -818,7 +818,8 @@ class TestLambdaFunction:
     def test_invalid_invoke(self, aws_client, snapshot):
         with pytest.raises(aws_client.lambda_.exceptions.ClientError) as e:
             aws_client.lambda_.invoke(
-                FunctionName="arn:aws:lambda:us-east-1:123400000000@function:myfn", Payload=b"{}"
+                FunctionName=f"arn:aws:lambda:{aws_client.lambda_.meta.region_name}:123400000000@function:myfn",
+                Payload=b"{}",
             )
         snapshot.match("invoke_function_name_pattern_exc", e.value.response)
 

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13773,12 +13773,12 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
-    "recorded-date": "26-02-2024, 17:04:08",
+    "recorded-date": "28-03-2024, 08:44:26",
     "recorded-content": {
       "invoke_function_name_pattern_exc": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:123400000000@function:myfn' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+          "Message": "1 validation error detected: Value 'arn:aws:lambda:<region>:123400000000@function:myfn' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -78,7 +78,7 @@
     "last_validated_date": "2023-11-20T15:46:48+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_invalid_invoke": {
-    "last_validated_date": "2024-02-26T17:04:08+00:00"
+    "last_validated_date": "2024-03-28T08:45:03+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
     "last_validated_date": "2023-11-20T15:46:59+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10323 we introduced a validation of lambda arns when invoking. However, the test hardcoded us-east-1 in the arn, which was by default replaced by the region snapshot transformer.
However, with different regions, it does not get replaced, making the test incompatible with multiple regions (the functionality itself was correct, though).

Also, there seems to have been a recent update to the error message and validation regex for iso regions, which I adapted in LocalStack as well.

<!-- What notable changes does this PR make? -->
## Changes
* Use current region for invalid arn to allow region snapshot transformer to work properly @sannya-singal 
* Adjust regex and error message to recent AWS changes

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

