### PR TITLE
raise exception if required ENV is missing

### DIFF
--- a/scripts/tinybird/upload_raw_test_metrics_and_coverage.py
+++ b/scripts/tinybird/upload_raw_test_metrics_and_coverage.py
@@ -301,20 +301,16 @@ def main():
     )
     if not metric_report_dir:
         print(missing_info)
-        print("missing METRIC_REPORT_DIR_PATH")
-        return
+        raise Exception("missing METRIC_REPORT_DIR_PATH")
     if not impl_coverage_file:
         print(missing_info)
-        print("missing IMPLEMENTATION_COVERAGE_FILE")
-        return
+        raise Exception("missing IMPLEMENTATION_COVERAGE_FILE")
     if not source_type:
         print(missing_info)
-        print("missing SOURCE_TYPE")
-        return
+        raise Exception("missing SOURCE_TYPE")
     if not token:
         print(missing_info)
-        print("missing TINYBIRD_PARITY_ANALYTICS_TOKEN")
-        return
+        raise Exception("missing TINYBIRD_PARITY_ANALYTICS_TOKEN")
 
     # create one timestamp that will be used for all the data sent
     timestamp: str = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The helper script to upload tinybird coverage metrics was silently failing on ext, as we only had a return statement if any ENV was missing.

<!-- What notable changes does this PR make? -->
## Changes
* raise Exception if required ENV is missing to fail the workflow

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

