### PR TITLE
update README after 3.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-:zap: We are thrilled to announce the release of <a href="https://discuss.localstack.cloud/t/localstack-release-v3-2-0/782">LocalStack 3.2</a> :zap:
+:zap: We are thrilled to announce the release of <a href="https://discuss.localstack.cloud/t/localstack-release-v3-3-0/828">LocalStack 3.3</a> :zap:
 </p>
 
 <p align="center">
@@ -93,7 +93,7 @@ Start LocalStack inside a Docker container by running:
   / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
  /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|
 
- 💻 LocalStack CLI 3.2.0
+ 💻 LocalStack CLI 3.3.0
  👤 Profile: default
 
 [12:47:13] starting LocalStack in Docker mode 🐳                       localstack.py:494


### PR DESCRIPTION
## Motivation
Yesterday, we released [LocalStack 3.3.0](https://github.com/localstack/localstack/releases/tag/v3.3.0)!
This PR really just updates the README accordingly.

## Changes
- Adjusts the release announcement on top of the README to the [latest release 3.3.0](https://github.com/localstack/localstack/releases/tag/v3.3.0). 🥳 

