### PR TITLE
remove the conditional provider in `test_dashboard_lifecycle`

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1393,7 +1393,7 @@ class TestCloudwatch:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider,
         paths=[
-            "$..DashboardArn",
+            "$..DashboardArn",  # ARN has a typo in moto
             "$..DashboardEntries..Size",
         ],
     )

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1391,7 +1391,7 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn", "$..DashboardEntries..Size"], condition=is_old_provider
+        paths=["$..DashboardArn", "$..DashboardEntries..Size"]
     )  # ARN has a typo in moto
     def test_dashboard_lifecycle(self, aws_client, region_name, snapshot):
         dashboard_name = f"test-{short_uid()}"

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1394,7 +1394,6 @@ class TestCloudwatch:
         condition=is_old_provider,
         paths=[
             "$..DashboardArn",  # ARN has a typo in moto
-            "$..DashboardEntries..Size",
         ],
     )
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -1391,8 +1391,17 @@ class TestCloudwatch:
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
-        paths=["$..DashboardArn", "$..DashboardEntries..Size"]
-    )  # ARN has a typo in moto
+        condition=is_old_provider,
+        paths=[
+            "$..DashboardArn",
+            "$..DashboardEntries..Size",
+        ],
+    )
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..DashboardEntries..Size",  # need to be skipped because size changes if the region name length is longer
+        ]
+    )
     def test_dashboard_lifecycle(self, aws_client, region_name, snapshot):
         dashboard_name = f"test-{short_uid()}"
         dashboard_body = {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As per previous discussion in #10550 PR [here](https://github.com/localstack/localstack/pull/10550#pullrequestreview-1963137286), we should remove the conditional provider in `test_dashboard_lifecycle`  to make the test more robust for old and `v2` both cloudwatch providers.  

<!-- What notable changes does this PR make? -->
## Changes
This PR removes the conditional old provider in skip snapshot verifification. 

## Testing
The following test has been verified against new(`PROVIDER_OVERRIDE_CLOUDWATCH=v2`) and old providers. 

<!-- The following sections are optional, but can be useful! 

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

