### PR TITLE
fix deprecated secret versions preservation in secretsmanager

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -876,9 +876,19 @@ def put_resource_policy_response(self):
     )
 
 
+def _form_version_ids_to_stages_modal(self):
+    version_id_to_stages = {}
+    for key, value in self.versions.items():
+        if len(value["version_stages"]) > 0:
+            version_id_to_stages[key] = value["version_stages"]
+
+    return version_id_to_stages
+
+
 def apply_patches():
     SecretsManagerBackend.get_resource_policy = get_resource_policy_model
     SecretsManagerResponse.get_resource_policy = get_resource_policy_response
+    FakeSecret._form_version_ids_to_stages = _form_version_ids_to_stages_modal
 
     if not hasattr(SecretsManagerBackend, "delete_resource_policy"):
         SecretsManagerBackend.delete_resource_policy = delete_resource_policy_model

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -484,7 +484,9 @@ def moto_smb_create_secret(fn, self, name, *args, **kwargs):
 
 
 @patch(SecretsManagerBackend.list_secret_version_ids)
-def moto_smb_list_secret_version_ids(_, self, secret_id, include_deprecated, *args, **kwargs):
+def moto_smb_list_secret_version_ids(
+    _, self, secret_id: str, include_deprecated: bool, *args, **kwargs
+):
     if secret_id not in self.secrets:
         raise SecretNotFoundException()
 
@@ -645,10 +647,10 @@ def fake_secret_reset_default_version(fn, self, secret_version, version_id):
     fn(self, secret_version, version_id)
 
     # Remove versions with no version stages, if max limit of outdated versions is exceeded.
-    versions_no_stages = [
+    versions_no_stages: list[str] = [
         version_id for version_id, version in self.versions.items() if not version["version_stages"]
     ]
-    versions_to_delete = []
+    versions_to_delete: list[str] = []
 
     # Patch: remove outdated versions if the max deprecated versions limit is exceeded.
     if len(versions_no_stages) >= MAX_OUTDATED_SECRET_VERSIONS:
@@ -822,7 +824,7 @@ def moto_secret_not_found_exception_init(fn, self):
 
 @patch(FakeSecret._form_version_ids_to_stages, pass_target=False)
 def _form_version_ids_to_stages_modal(self):
-    version_id_to_stages = {}
+    version_id_to_stages: dict[str, list] = {}
     for key, value in self.versions.items():
         # Patch: include version_stages in the response only if it is not empty.
         if len(value["version_stages"]) > 0:

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -502,6 +502,7 @@ def moto_smb_list_secret_version_ids(_, self, secret_id, include_deprecated, *ar
         version_stages = version["version_stages"]
         # Patch: include deprecated versions if include_deprecated is True.
         # version_stages is empty if the version is deprecated.
+        # see: https://docs.aws.amazon.com/secretsmanager/latest/userguide/getting-started.html#term_version
         if len(version_stages) > 0 or include_deprecated:
             entry = SecretVersionsListEntry(
                 CreatedDate=version["createdate"],

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -500,7 +500,8 @@ def moto_smb_list_secret_version_ids(_, self, secret_id, include_deprecated, *ar
     versions: list[SecretVersionsListEntry] = list()
     for version_id, version in secret.versions.items():
         version_stages = version["version_stages"]
-        # Patch: include version_stages in the response only if it is not empty.
+        # Patch: include deprecated versions if include_deprecated is True.
+        # version_stages is empty if the version is deprecated.
         if len(version_stages) > 0 or include_deprecated:
             entry = SecretVersionsListEntry(
                 CreatedDate=version["createdate"],

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -1108,6 +1108,11 @@ class TestSecretsManager:
         response = aws_client.secretsmanager.list_secret_version_ids(
             SecretId=secret_name, IncludeDeprecated=True
         )
+        # In Secrets Manager, versions of secrets without labels are considered deprecated.
+        # There will be two labeled versions:
+        # - The current version, labeled AWSCURRENT
+        # - The previous version, labeled AWSPREVIOUS
+        # see: https://docs.aws.amazon.com/secretsmanager/latest/userguide/getting-started.html#term_version
         assert len(response["Versions"]) == 102
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..KmsKeyId", "$..KmsKeyIds"])

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -709,7 +709,6 @@ class TestSecretsManager:
         sm_snapshot.match("describe_secret_res_0", describe_secret_res_0)
 
         description_v1 = "MyDescription"
-        #
         update_secret_res_0 = aws_client.secretsmanager.update_secret(
             SecretId=secret_name, Description=description_v1
         )
@@ -1036,6 +1035,80 @@ class TestSecretsManager:
             SecretId=secret_name, ForceDeleteWithoutRecovery=True
         )
         sm_snapshot.match("delete_secret_res_0", delete_secret_res_0)
+
+    @markers.snapshot.skip_snapshot_verify(paths=["$..Versions..KmsKeyIds"])
+    @markers.aws.validated
+    def test_deprecated_secret_version_stage(
+        self, secret_name, create_secret, aws_client, sm_snapshot
+    ):
+        response = create_secret(
+            Name=secret_name,
+            SecretString="original",
+            Description="My secret",
+        )
+        sm_snapshot.add_transformers_list(
+            sm_snapshot.transform.secretsmanager_secret_id_arn(response, 0)
+        )
+        sm_snapshot.match("create_secret", response)
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_name)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_name)
+        sm_snapshot.match("list_secret_version_ids", response)
+
+        response = aws_client.secretsmanager.put_secret_value(
+            SecretId=secret_name, SecretString="update1"
+        )
+        sm_snapshot.match("put_secret_value_1", response)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_name)
+        sm_snapshot.match("list_secret_version_ids_1", response)
+
+        response = aws_client.secretsmanager.put_secret_value(
+            SecretId=secret_name, SecretString="update2"
+        )
+        sm_snapshot.match("put_secret_value_2", response)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_name)
+        sm_snapshot.match("list_secret_version_ids_2", response)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(
+            SecretId=secret_name, IncludeDeprecated=True
+        )
+        sm_snapshot.match("list_secret_version_ids_3", response)
+
+        response = aws_client.secretsmanager.put_secret_value(
+            SecretId=secret_name, SecretString="update3"
+        )
+        sm_snapshot.match("put_secret_value_3", response)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(SecretId=secret_name)
+        sm_snapshot.match("list_secret_version_ids_4", response)
+
+        response = aws_client.secretsmanager.list_secret_version_ids(
+            SecretId=secret_name, IncludeDeprecated=True
+        )
+        sm_snapshot.match("list_secret_version_ids_5", response)
+
+    @markers.aws.only_localstack
+    def test_deprecated_secret_version(self, secret_name, create_secret, aws_client):
+        """
+        This test ensures the version cleanup behavior in a simulated AWS environment.
+        Secrets Manager typically retains a maximum of 100 versions and does not
+        immediately delete versions created within the last 24 hours.
+        However, this test operates under the assumption that version timestamps are not evaluated,
+        and the cleanup process solely depends on reaching a version count threshold.
+        """
+        create_secret(Name=secret_name, SecretString="original", Description="My secret")
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_name)
+
+        for i in range(130):
+            aws_client.secretsmanager.put_secret_value(
+                SecretId=secret_name, SecretString=f"update{i}"
+            )
+        response = aws_client.secretsmanager.list_secret_version_ids(
+            SecretId=secret_name, IncludeDeprecated=True
+        )
+        assert len(response["Versions"]) == 102
 
     @markers.snapshot.skip_snapshot_verify(paths=["$..KmsKeyId", "$..KmsKeyIds"])
     @markers.aws.validated

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4233,5 +4233,246 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_deprecated_secret_version_stage": {
+    "recorded-date": "29-03-2024, 11:26:17",
+    "recorded-content": {
+      "create_secret": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_secret_value_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:2>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_secret_value_2": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:3>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids_2": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids_3": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>"
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:2>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_secret_value_3": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:4>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids_4": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:4>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_secret_version_ids_5": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "Versions": [
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:1>"
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:2>"
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:3>",
+            "VersionStages": [
+              "AWSPREVIOUS"
+            ]
+          },
+          {
+            "CreatedDate": "datetime",
+            "KmsKeyIds": [
+              "DefaultEncryptionKey"
+            ],
+            "VersionId": "<version_uuid:4>",
+            "VersionStages": [
+              "AWSCURRENT"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -32,6 +32,12 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_delete_non_existent_secret_returns_as_if_secret_exists": {
     "last_validated_date": "2024-03-15T08:13:15+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_deprecated_secret_version": {
+    "last_validated_date": "2024-03-29T09:36:11+00:00"
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_deprecated_secret_version_stage": {
+    "last_validated_date": "2024-03-29T11:26:17+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
     "last_validated_date": "2024-03-15T08:13:16+00:00"
   },


### PR DESCRIPTION
## Motivation
This PR is raised to address the issue highlighted in [Issue #10086](https://github.com/localstack/localstack/issues/10086). The issue concerns the handling of deprecated secrets within LocalStack. 

Previously, LocalStack removed deprecated secrets, deviating from AWS of retaining up to 100 deprecated secrets. This set of changes aligns LocalStack with AWS by implementing a limit on the number of stored deprecated secrets.

Note: AWS does not remove versions created less than 24 hours ago. Whereas we do not check time difference before deleting the secret as of now.

## Changes
- **`ListSecretVersionIds`:** Enhanced the `ListSecretVersionIds` API to support the `IncludeDeprecated` argument, allowing for the inclusion of deprecated secrets in the response.
- **Deprecated Secrets Management:** Introduced logic to retain up to 100 deprecated secrets. When the count exceeds 100, the oldest secret is deleted.

## Testing
- The changes were tested against AWS using aws-validated and snapshot test cases.
- **Limitations:** Testing of the secret removal functionality is not feasible for validated test case.

## Reference
-  [AWS Secrets Manager API Reference](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_PutSecretValue.html).
- [Versioning and Deprecation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/getting-started.html#term_version)
