### PR TITLE
[SFN] Fix Evaluation of Nested Map States

### DIFF
--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/distributed_iteration_component.py
@@ -38,7 +38,7 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
     IterationWorker,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
-    Job,
+    JobClosed,
     JobPool,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.max_concurrency import (
@@ -133,7 +133,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
         if worker_exception is not None:
             raise worker_exception
 
-        closed_jobs: list[Job] = self._job_pool.get_closed_jobs()
+        closed_jobs: list[JobClosed] = self._job_pool.get_closed_jobs()
         outputs: list[Any] = [closed_job.job_output for closed_job in closed_jobs]
 
         env.stack.append(outputs)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_map/iteration/inline_iteration_component.py
@@ -22,7 +22,7 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
     IterationWorker,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.iteration.job import (
-    Job,
+    JobClosed,
     JobPool,
 )
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_map.max_concurrency import (
@@ -110,7 +110,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
         if worker_exception is not None:
             raise worker_exception
 
-        closed_jobs: list[Job] = self._job_pool.get_closed_jobs()
+        closed_jobs: list[JobClosed] = self._job_pool.get_closed_jobs()
         outputs: list[Any] = [closed_job.job_output for closed_job in closed_jobs]
 
         env.stack.append(outputs)

--- a/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
+++ b/tests/aws/services/stepfunctions/templates/scenarios/scenarios_templates.py
@@ -15,6 +15,9 @@ class ScenariosTemplate(TemplateLoader):
     PARALLEL_STATE_FAIL: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/parallel_state_fail.json5"
     )
+    PARALLEL_NESTED_NESTED: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/parallel_state_nested.json5"
+    )
     PARALLEL_STATE_CATCH: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/parallel_state_catch.json5"
     )
@@ -57,6 +60,9 @@ class ScenariosTemplate(TemplateLoader):
     )
     MAP_STATE_CONFIG_INLINE_ITEM_SELECTOR: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_config_inline_item_selector.json5"
+    )
+    MAP_STATE_NESTED: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/map_state_nested.json5"
     )
     MAP_STATE_NO_PROCESSOR_CONFIG: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/map_state_no_processor_config.json5"

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/map_state_nested.json5
@@ -1,0 +1,31 @@
+{
+  "StartAt": "MapL1",
+  "States": {
+    "MapL1": {
+      "Type": "Map",
+      "MaxConcurrency": 1,
+      "ItemProcessor": {
+        "ProcessorConfig": { "Mode": "INLINE" },
+        "StartAt": "MapL2",
+        "States": {
+          "MapL2": {
+            "Type": "Map",
+            "MaxConcurrency": 1,
+            "ItemProcessor": {
+              "ProcessorConfig": { "Mode": "INLINE" },
+              "StartAt": "MapL2Pass",
+              "States": {
+                "MapL2Pass": {
+                  "Type": "Pass",
+                  "End": true
+                }
+              }
+            },
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/scenarios/statemachines/parallel_state_nested.json5
+++ b/tests/aws/services/stepfunctions/templates/scenarios/statemachines/parallel_state_nested.json5
@@ -1,0 +1,31 @@
+{
+  "StartAt": "ParallelStateL1",
+  "States": {
+    "ParallelStateL1": {
+      "Type": "Parallel",
+      "End": true,
+      "Branches": [
+        {
+          "StartAt": "ParallelStateL2",
+          "States": {
+            "ParallelStateL2": {
+              "Type": "Parallel",
+              "End": true,
+              "Branches": [
+                {
+                  "StartAt": "BranchL2",
+                  "States": {
+                    "BranchL2": {
+                      "Type": "Pass",
+                      "End": true
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.snapshot.json
@@ -15053,5 +15053,603 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested": {
+    "recorded-date": "29-03-2024, 16:26:02",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL1"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 3,
+            "mapStateStartedEventDetails": {
+              "length": 2
+            },
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 4,
+            "mapIterationStartedEventDetails": {
+              "index": 0,
+              "name": "MapL1"
+            },
+            "previousEventId": 3,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateEnteredEventDetails": {
+              "input": "[1,2,3]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 6,
+            "mapStateStartedEventDetails": {
+              "length": 3
+            },
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 7,
+            "mapIterationStartedEventDetails": {
+              "index": 0,
+              "name": "MapL2"
+            },
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": "1",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "1",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 10,
+            "mapIterationSucceededEventDetails": {
+              "index": 0,
+              "name": "MapL2"
+            },
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 11,
+            "mapIterationStartedEventDetails": {
+              "index": 1,
+              "name": "MapL2"
+            },
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 12,
+            "previousEventId": 11,
+            "stateEnteredEventDetails": {
+              "input": "2",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 13,
+            "previousEventId": 12,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "2",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 14,
+            "mapIterationSucceededEventDetails": {
+              "index": 1,
+              "name": "MapL2"
+            },
+            "previousEventId": 13,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 15,
+            "mapIterationStartedEventDetails": {
+              "index": 2,
+              "name": "MapL2"
+            },
+            "previousEventId": 13,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 16,
+            "previousEventId": 15,
+            "stateEnteredEventDetails": {
+              "input": "3",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 17,
+            "previousEventId": 16,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "3",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 18,
+            "mapIterationSucceededEventDetails": {
+              "index": 2,
+              "name": "MapL2"
+            },
+            "previousEventId": 17,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 19,
+            "previousEventId": 18,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 20,
+            "previousEventId": 18,
+            "stateExitedEventDetails": {
+              "name": "MapL2",
+              "output": "[1,2,3]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "id": 21,
+            "mapIterationSucceededEventDetails": {
+              "index": 0,
+              "name": "MapL1"
+            },
+            "previousEventId": 20,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 22,
+            "mapIterationStartedEventDetails": {
+              "index": 1,
+              "name": "MapL1"
+            },
+            "previousEventId": 20,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 23,
+            "previousEventId": 22,
+            "stateEnteredEventDetails": {
+              "input": "[4,5,6]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2"
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateEntered"
+          },
+          {
+            "id": 24,
+            "mapStateStartedEventDetails": {
+              "length": 3
+            },
+            "previousEventId": 23,
+            "timestamp": "timestamp",
+            "type": "MapStateStarted"
+          },
+          {
+            "id": 25,
+            "mapIterationStartedEventDetails": {
+              "index": 0,
+              "name": "MapL2"
+            },
+            "previousEventId": 24,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 26,
+            "previousEventId": 25,
+            "stateEnteredEventDetails": {
+              "input": "4",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 27,
+            "previousEventId": 26,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "4",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 28,
+            "mapIterationSucceededEventDetails": {
+              "index": 0,
+              "name": "MapL2"
+            },
+            "previousEventId": 27,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 29,
+            "mapIterationStartedEventDetails": {
+              "index": 1,
+              "name": "MapL2"
+            },
+            "previousEventId": 27,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 30,
+            "previousEventId": 29,
+            "stateEnteredEventDetails": {
+              "input": "5",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 31,
+            "previousEventId": 30,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "5",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 32,
+            "mapIterationSucceededEventDetails": {
+              "index": 1,
+              "name": "MapL2"
+            },
+            "previousEventId": 31,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 33,
+            "mapIterationStartedEventDetails": {
+              "index": 2,
+              "name": "MapL2"
+            },
+            "previousEventId": 31,
+            "timestamp": "timestamp",
+            "type": "MapIterationStarted"
+          },
+          {
+            "id": 34,
+            "previousEventId": 33,
+            "stateEnteredEventDetails": {
+              "input": "6",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "MapL2Pass"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 35,
+            "previousEventId": 34,
+            "stateExitedEventDetails": {
+              "name": "MapL2Pass",
+              "output": "6",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 36,
+            "mapIterationSucceededEventDetails": {
+              "index": 2,
+              "name": "MapL2"
+            },
+            "previousEventId": 35,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 37,
+            "previousEventId": 36,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 38,
+            "previousEventId": 36,
+            "stateExitedEventDetails": {
+              "name": "MapL2",
+              "output": "[4,5,6]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "id": 39,
+            "mapIterationSucceededEventDetails": {
+              "index": 1,
+              "name": "MapL1"
+            },
+            "previousEventId": 38,
+            "timestamp": "timestamp",
+            "type": "MapIterationSucceeded"
+          },
+          {
+            "id": 40,
+            "previousEventId": 39,
+            "timestamp": "timestamp",
+            "type": "MapStateSucceeded"
+          },
+          {
+            "id": 41,
+            "previousEventId": 39,
+            "stateExitedEventDetails": {
+              "name": "MapL1",
+              "output": "[[1,2,3],[4,5,6]]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "MapStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[[1,2,3],[4,5,6]]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 42,
+            "previousEventId": 41,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_parallel_state_nested": {
+    "recorded-date": "29-03-2024, 17:05:02",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ParallelStateL1"
+            },
+            "timestamp": "timestamp",
+            "type": "ParallelStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ParallelStateStarted"
+          },
+          {
+            "id": [
+              0
+            ],
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ParallelStateL2"
+            },
+            "timestamp": "timestamp",
+            "type": "ParallelStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "timestamp": "timestamp",
+            "type": "ParallelStateStarted"
+          },
+          {
+            "id": [
+              0
+            ],
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": "[[1, 2, 3], [4, 5, 6]]",
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "BranchL2"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": [
+              0
+            ],
+            "previousEventId": 0,
+            "stateExitedEventDetails": {
+              "name": "BranchL2",
+              "output": "[[1, 2, 3], [4, 5, 6]]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "id": 11,
+            "previousEventId": 9,
+            "stateExitedEventDetails": {
+              "name": "ParallelStateL1",
+              "output": "[[[[1, 2, 3], [4, 5, 6]]]]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ParallelStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": "[[[[1, 2, 3], [4, 5, 6]]]]",
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 12,
+            "previousEventId": 11,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.validation.json
@@ -152,6 +152,9 @@
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_legacy_config_inline_parameters": {
     "last_validated_date": "2024-02-08T21:07:39+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_nested": {
+    "last_validated_date": "2024-03-29T16:26:02+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_map_state_no_processor_config": {
     "last_validated_date": "2023-12-15T21:25:27+00:00"
   },
@@ -172,6 +175,9 @@
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_parallel_state": {
     "last_validated_date": "2023-07-17T10:41:25+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_parallel_state_nested": {
+    "last_validated_date": "2024-03-29T17:05:02+00:00"
   },
   "tests/aws/services/stepfunctions/v2/scenarios/test_base_scenarios.py::TestBaseScenarios::test_parallel_state_order": {
     "last_validated_date": "2023-12-15T22:15:11+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the SFN interpreter is unable to evaluate nested Map states as the deep copying of executed programs during the closing of Map jobs fails to serialise lock objects within the program. As the evaluated program is not useful when propagated after job closure, this PR resolved this issue by propagate JobClosed objects past closure which only consist of the index (useful for output ordering) and output value.
Addresses #10467

<!-- What notable changes does this PR make? -->
## Changes
- Adds JobClosed objects as output of closed objects in Job Pools
- nested Map and Parallel state

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

