### PR TITLE
fix SNS RawMessageDelivery casing

### DIFF
--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -59,7 +59,6 @@ def call_moto_with_request(
 
     :param context: the original request context
     :param service_request: the dictionary containing the service request parameters
-    :param override_headers: whether to override headers that are also request parameters
     :return: an ASF ServiceResponse (same as a service provider would return)
     """
     local_context = create_aws_request_context(

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -29,8 +29,10 @@ from localstack.aws.api.sns import (
     PublishBatchResponse,
     PublishBatchResultEntry,
     PublishResponse,
+    SetSubscriptionAttributesInput,
     SnsApi,
     String,
+    SubscribeInput,
     SubscribeResponse,
     SubscriptionAttributesMap,
     TagKeyList,
@@ -51,7 +53,7 @@ from localstack.aws.api.sns import (
 from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.http import Request, Response, Router, route
 from localstack.services.edge import ROUTER
-from localstack.services.moto import call_moto
+from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sns import constants as sns_constants
 from localstack.services.sns.certificate import SNS_SERVER_CERT
@@ -264,8 +266,15 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             topic_arn=sub["TopicArn"],
             endpoint=sub["Endpoint"],
         )
+        if attribute_name == "RawMessageDelivery":
+            attribute_value = attribute_value.lower()
         try:
-            call_moto(context)
+            request = SetSubscriptionAttributesInput(
+                SubscriptionArn=subscription_arn,
+                AttributeName=attribute_name,
+                AttributeValue=attribute_value,
+            )
+            call_moto_with_request(context, service_request=request)
         except CommonServiceException as e:
             # Moto errors don't send the "Type": "Sender" field in their SNS exception
             if e.code == "InvalidParameter":
@@ -613,9 +622,25 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     attribute_value=attr_value,
                     topic_arn=topic_arn,
                     endpoint=endpoint,
+                    is_subscribe_call=True,
                 )
+        if attributes and "RawMessageDelivery" in attributes:
+            # Moto does not lower case the value, so we need to override the request
+            attrs_copy = {
+                **attributes,
+                "RawMessageDelivery": attributes["RawMessageDelivery"].lower(),
+            }
+            request = SubscribeInput(
+                TopicArn=topic_arn,
+                Protocol=protocol,
+                Endpoint=endpoint,
+                Attributes=attrs_copy,
+                ReturnSubscriptionArn=return_subscription_arn,
+            )
+            moto_response = call_moto_with_request(context, service_request=request)
+        else:
+            moto_response = call_moto(context)
 
-        moto_response = call_moto(context)
         subscription_arn = moto_response.get("SubscriptionArn")
         parsed_topic_arn = parse_and_validate_topic_arn(topic_arn)
 
@@ -658,6 +683,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 store.subscription_filter_policy[subscription_arn] = (
                     json.loads(attributes["FilterPolicy"]) if attributes["FilterPolicy"] else None
                 )
+            if raw_msg_delivery := attributes.get("RawMessageDelivery"):
+                subscription["RawMessageDelivery"] = raw_msg_delivery.lower()
 
         store.subscriptions[subscription_arn] = subscription
 
@@ -770,6 +797,7 @@ def validate_subscription_attribute(
     attribute_value: str,
     topic_arn: str,
     endpoint: str,
+    is_subscribe_call: bool = False,
 ) -> None:
     """
     Validate the subscription attribute to be set. See:
@@ -778,40 +806,45 @@ def validate_subscription_attribute(
     :param attribute_value: the subscription attribute value
     :param topic_arn: the topic_arn of the subscription, needed to know if it is FIFO
     :param endpoint: the subscription endpoint (like an SQS queue ARN)
+    :param is_subscribe_call: the error message is different if called from Subscribe or SetSubscriptionAttributes
     :raises InvalidParameterException
     :return:
     """
+    error_prefix = (
+        "Invalid parameter: Attributes Reason: " if is_subscribe_call else "Invalid parameter: "
+    )
     if attribute_name not in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
-        raise InvalidParameterException("Invalid parameter: AttributeName")
+        raise InvalidParameterException(f"{error_prefix}AttributeName")
 
     if attribute_name == "FilterPolicy":
         try:
             json.loads(attribute_value or "{}")
         except json.JSONDecodeError:
-            raise InvalidParameterException(
-                "Invalid parameter: FilterPolicy: failed to parse JSON."
-            )
+            raise InvalidParameterException(f"{error_prefix}FilterPolicy: failed to parse JSON.")
     elif attribute_name == "FilterPolicyScope":
         if attribute_value not in ("MessageAttributes", "MessageBody"):
             raise InvalidParameterException(
-                f"Invalid parameter: FilterPolicyScope: Invalid value [{attribute_value}]. Please use either MessageBody or MessageAttributes"
+                f"{error_prefix}FilterPolicyScope: Invalid value [{attribute_value}]. "
+                f"Please use either MessageBody or MessageAttributes"
             )
     elif attribute_name == "RawMessageDelivery":
         # TODO: only for SQS and https(s) subs, + firehose
-        return
+        if attribute_value.lower() not in ("true", "false"):
+            raise InvalidParameterException(
+                f"{error_prefix}RawMessageDelivery: Invalid value [{attribute_value}]. "
+                f"Must be true or false."
+            )
 
     elif attribute_name == "RedrivePolicy":
         try:
             dlq_target_arn = json.loads(attribute_value).get("deadLetterTargetArn", "")
         except json.JSONDecodeError:
-            raise InvalidParameterException(
-                "Invalid parameter: RedrivePolicy: failed to parse JSON."
-            )
+            raise InvalidParameterException(f"{error_prefix}RedrivePolicy: failed to parse JSON.")
         try:
             parsed_arn = parse_arn(dlq_target_arn)
         except InvalidArnException:
             raise InvalidParameterException(
-                "Invalid parameter: RedrivePolicy: deadLetterTargetArn is an invalid arn"
+                f"{error_prefix}RedrivePolicy: deadLetterTargetArn is an invalid arn"
             )
 
         if topic_arn.endswith(".fifo"):
@@ -819,7 +852,7 @@ def validate_subscription_attribute(
                 not parsed_arn["resource"].endswith(".fifo") or "sqs" not in parsed_arn["service"]
             ):
                 raise InvalidParameterException(
-                    "Invalid parameter: RedrivePolicy: must use a FIFO queue as DLQ for a FIFO Subscription to a FIFO Topic."
+                    f"{error_prefix}RedrivePolicy: must use a FIFO queue as DLQ for a FIFO Subscription to a FIFO Topic."
                 )
 
 

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -653,8 +653,19 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_create_subscriptions_with_attributes": {
-    "recorded-date": "24-08-2023, 23:27:53",
+    "recorded-date": "29-03-2024, 19:44:43",
     "recorded-content": {
+      "subscribe-wrong-attr": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: RawMessageDelivery: Invalid value [wrongvalue]. Must be true or false.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "subscribe": {
         "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:1>",
         "ResponseMetadata": {
@@ -755,12 +766,34 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_validate_set_sub_attributes": {
-    "recorded-date": "24-08-2023, 23:27:58",
+    "recorded-date": "29-03-2024, 19:30:24",
     "recorded-content": {
       "fake-attribute": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: AttributeName",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "raw-message-wrong-value": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: RawMessageDelivery: Invalid value [test-ValUe]. Must be true or false.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "raw-message-empty-value": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: RawMessageDelivery: Invalid value []. Must be true or false.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -782,7 +815,7 @@
       "invalid-json-redrive-policy": {
         "Error": {
           "Code": "InvalidParameter",
-          "Message": "Invalid parameter: RedrivePolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: java.io.StringReader@5498a819; line: 1, column: 3]",
+          "Message": "Invalid parameter: RedrivePolicy: failed to parse JSON. Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: java.io.StringReader@469cc9aa; line: 1, column: 3]",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -78,7 +78,7 @@
     "last_validated_date": "2023-08-24T22:20:07+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_create_subscriptions_with_attributes": {
-    "last_validated_date": "2023-08-24T21:27:53+00:00"
+    "last_validated_date": "2024-03-29T19:44:42+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_list_subscriptions": {
     "last_validated_date": "2023-08-25T14:23:53+00:00"
@@ -105,7 +105,7 @@
     "last_validated_date": "2023-10-20T10:52:36+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_validate_set_sub_attributes": {
-    "last_validated_date": "2023-08-24T21:27:58+00:00"
+    "last_validated_date": "2024-03-29T19:30:23+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionHttp::test_subscribe_external_http_endpoint[False]": {
     "last_validated_date": "2023-10-11T22:47:29+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As shown in #10545, we had an issue with the SNS provider not lower casing incoming value, even though it works with AWS.

<!-- What notable changes does this PR make? -->
## Changes
- fix the casing of `RawMessageDelivery` for `SetSubscriptionAttributes` and `Subscribe`
- add positive and negative tests for both `SetSubscriptionAttributes` and `Subscribe`
- remove a doc string for `call_moto_with_request` that I had added a while back and forgot to remove when the PR was updated

\cc @pinzon 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

