### PR TITLE
Fix apigw http proxy response passthrough

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -802,9 +802,10 @@ class HTTPIntegration(BackendIntegration):
                 uri,
                 result.status_code,
             )
-        # apply custom response template
+        # apply custom response template for non-proxy integration
         invocation_context.response = result
-        self.response_templates.render(invocation_context)
+        if integration["type"] != "HTTP_PROXY":
+            self.response_templates.render(invocation_context)
         return invocation_context.response
 
 

--- a/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
@@ -115,14 +115,14 @@
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP_PROXY]": {
     "recorded-date": "01-04-2024, 20:44:46",
     "recorded-content": {
-      "matching-integration": {
+      "matching-response": {
         "body": {
           "message": "",
           "status_code": 200
         },
         "status_code": 200
       },
-      "non-matching-integration": {
+      "non-matching-response": {
         "body": {
           "message": "",
           "status_code": 400

--- a/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.snapshot.json
@@ -92,5 +92,43 @@
         "status_code": 200
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP]": {
+    "recorded-date": "01-04-2024, 21:02:52",
+    "recorded-content": {
+      "matching-response": {
+        "body": {
+          "message": "",
+          "status_code": 200
+        },
+        "status_code": 200
+      },
+      "non-matching-response": {
+        "body": {
+          "message": "",
+          "status_code": 400
+        },
+        "status_code": 200
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP_PROXY]": {
+    "recorded-date": "01-04-2024, 20:44:46",
+    "recorded-content": {
+      "matching-integration": {
+        "body": {
+          "message": "",
+          "status_code": 200
+        },
+        "status_code": 200
+      },
+      "non-matching-integration": {
+        "body": {
+          "message": "",
+          "status_code": 400
+        },
+        "status_code": 400
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_http.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.validation.json
@@ -1,15 +1,12 @@
 {
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP]": {
-    "last_validated_date": "2024-04-01T20:43:41+00:00"
+    "last_validated_date": "2024-04-01T21:45:48+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP_PROXY]": {
-    "last_validated_date": "2024-04-01T20:44:46+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda": {
-    "last_validated_date": "2024-03-28T19:24:09+00:00"
+    "last_validated_date": "2024-04-01T21:46:23+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP]": {
-    "last_validated_date": "2024-03-29T15:12:45+00:00"
+    "last_validated_date": "2024-04-01T21:51:36+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda[HTTP_PROXY]": {
     "last_validated_date": "2024-03-29T15:13:24+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_http.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_http.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP]": {
+    "last_validated_date": "2024-04-01T20:43:41+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_invoke_status_code_passthrough[HTTP_PROXY]": {
+    "last_validated_date": "2024-04-01T20:44:46+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_http.py::test_http_integration_with_lambda": {
     "last_validated_date": "2024-03-28T19:24:09+00:00"
   },

--- a/tests/aws/services/lambda_/functions/lambda_echo_status_code.py
+++ b/tests/aws/services/lambda_/functions/lambda_echo_status_code.py
@@ -1,0 +1,19 @@
+import json
+from http import HTTPStatus
+
+
+def make_response(status_code: int, message: str):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": {"status_code": status_code, "message": message},
+    }
+
+
+def handler(event, context):
+    print(json.dumps(event))
+    path: str = event["requestContext"]["http"].get("path", "")
+    status_code = path.split("/")[-1]
+    if not status_code.isdigit() or int(status_code) not in list(HTTPStatus):
+        return make_response(HTTPStatus.BAD_REQUEST, f"No valid status found at end of path {path}")
+    return make_response(int(status_code), "")

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -49,6 +49,9 @@ THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_LAMBDA_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_integration.py")
 TEST_LAMBDA_PYTHON_ECHO = os.path.join(THIS_FOLDER, "functions/lambda_echo.py")
 TEST_LAMBDA_PYTHON_ECHO_JSON_BODY = os.path.join(THIS_FOLDER, "functions/lambda_echo_json_body.py")
+TEST_LAMBDA_PYTHON_ECHO_STATUS_CODE = os.path.join(
+    THIS_FOLDER, "functions/lambda_echo_status_code.py"
+)
 TEST_LAMBDA_PYTHON_REQUEST_ID = os.path.join(THIS_FOLDER, "functions/lambda_request_id.py")
 TEST_LAMBDA_PYTHON_ECHO_VERSION_ENV = os.path.join(
     THIS_FOLDER, "functions/lambda_echo_version_env.py"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As mentioned in issue #10461, we were matching the response status code to the integration method for `HTTP_PROXY` integrations. As documented [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-response.html), `With a proxy integration, API Gateway passes the backend response through to the method response automatically.`

<!-- What notable changes does this PR make? -->
## Changes

Skipping entirely the response response template rendering for `HTTP_PROXY` integrations. As neither status code nor body transformation should be processed for this type of integration.
