### PR TITLE
fix cfn templates deployed in invalid AZs

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -610,9 +610,11 @@ def _resolve_refs_recursively(
                 )
                 or region_name
             )
-            azs = []
-            for az in ("a", "b", "c", "d", "e", "f"):
-                azs.append("%s%s" % (region, az))
+
+            get_availability_zones = connect_to(
+                aws_access_key_id=account_id, region_name=region
+            ).ec2.describe_availability_zones()["AvailabilityZones"]
+            azs = [az["ZoneName"] for az in get_availability_zones]
 
             return azs
 

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -9,6 +9,6 @@
     "last_validated_date": "2024-03-28T06:48:11+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
-    "last_validated_date": "2024-03-28T06:26:23+00:00"
+    "last_validated_date": "2024-04-01T11:21:54+00:00"
   }
 }

--- a/tests/aws/templates/ec2_vpc_default_sg.yaml
+++ b/tests/aws/templates/ec2_vpc_default_sg.yaml
@@ -1,18 +1,6 @@
-Parameters:
-  DeployRegion:
-    Type: String
-    Default: us-east-1
-
-Conditions:
-  DeployInUSEast1:
-    Fn::Equals:
-      - !Ref DeployRegion
-      - us-east-1
-
 Resources:
   vpcA2121C38:
     Type: AWS::EC2::VPC
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/16
       EnableDnsHostnames: true
@@ -23,7 +11,6 @@ Resources:
           Value: RdsTestStack/vpc
   vpcPublicSubnet1Subnet2E65531E:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/18
       VpcId:
@@ -31,7 +18,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ""
       MapPublicIpOnLaunch: true
       Tags:
         - Key: aws-cdk:subnet-name
@@ -42,7 +29,6 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet1
   vpcPublicSubnet1RouteTable48A2DF9B:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -51,7 +37,6 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet1
   vpcPublicSubnet1RouteTableAssociation5D3F4579:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet1RouteTable48A2DF9B
@@ -59,7 +44,6 @@ Resources:
         Ref: vpcPublicSubnet1Subnet2E65531E
   vpcPublicSubnet1DefaultRoute10708846:
     Type: AWS::EC2::Route
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet1RouteTable48A2DF9B
@@ -70,7 +54,6 @@ Resources:
       - vpcVPCGW7984C166
   vpcPublicSubnet2Subnet009B674F:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.64.0/18
       VpcId:
@@ -78,7 +61,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ""
       MapPublicIpOnLaunch: true
       Tags:
         - Key: aws-cdk:subnet-name
@@ -89,7 +72,6 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet2
   vpcPublicSubnet2RouteTableEB40D4CB:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -98,7 +80,6 @@ Resources:
           Value: RdsTestStack/vpc/PublicSubnet2
   vpcPublicSubnet2RouteTableAssociation21F81B59:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet2RouteTableEB40D4CB
@@ -106,7 +87,6 @@ Resources:
         Ref: vpcPublicSubnet2Subnet009B674F
   vpcPublicSubnet2DefaultRouteA1EC0F60:
     Type: AWS::EC2::Route
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcPublicSubnet2RouteTableEB40D4CB
@@ -117,7 +97,6 @@ Resources:
       - vpcVPCGW7984C166
   vpcIsolatedSubnet1Subnet8B28CEB3:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.128.0/18
       VpcId:
@@ -125,7 +104,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ""
       MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-cdk:subnet-name
@@ -136,7 +115,6 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet1
   vpcIsolatedSubnet1RouteTable0D6B2D3D:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -145,7 +123,6 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet1
   vpcIsolatedSubnet1RouteTableAssociation172210D4:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcIsolatedSubnet1RouteTable0D6B2D3D
@@ -153,7 +130,6 @@ Resources:
         Ref: vpcIsolatedSubnet1Subnet8B28CEB3
   vpcIsolatedSubnet2Subnet2C6B375C:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.192.0/18
       VpcId:
@@ -161,7 +137,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ""
       MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-cdk:subnet-name
@@ -172,7 +148,6 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet2
   vpcIsolatedSubnet2RouteTable3455CBFC:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38
@@ -181,7 +156,6 @@ Resources:
           Value: RdsTestStack/vpc/IsolatedSubnet2
   vpcIsolatedSubnet2RouteTableAssociation8A8FAF70:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: vpcIsolatedSubnet2RouteTable3455CBFC
@@ -189,14 +163,12 @@ Resources:
         Ref: vpcIsolatedSubnet2Subnet2C6B375C
   vpcIGWE57CBDCA:
     Type: AWS::EC2::InternetGateway
-    Condition: DeployInUSEast1
     Properties:
       Tags:
         - Key: Name
           Value: RdsTestStack/vpc
   vpcVPCGW7984C166:
     Type: AWS::EC2::VPCGatewayAttachment
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: vpcA2121C38

--- a/tests/aws/templates/transit_gateway_attachment.yml
+++ b/tests/aws/templates/transit_gateway_attachment.yml
@@ -1,18 +1,6 @@
-Parameters:
-  DeployRegion:
-    Type: String
-    Default: us-east-1
-
-Conditions:
-  DeployInUSEast1:
-    Fn::Equals:
-      - !Ref DeployRegion
-      - us-east-1
-
 Resources:
   Vpc8378EB38:
     Type: AWS::EC2::VPC
-    Condition: DeployInUSEast1
     Properties:
       CidrBlock: 10.0.0.0/20
       EnableDnsHostnames: true
@@ -20,7 +8,6 @@ Resources:
       InstanceTenancy: default
   myTransitGateway:
     Type: "AWS::EC2::TransitGateway"
-    Condition: DeployInUSEast1
     Properties:
       AmazonSideAsn: 65000
       Description: "TGW Route Integration Test"
@@ -33,25 +20,22 @@ Resources:
           Value: !Ref 'AWS::StackId'
   VpcIsolatedSubnet1SubnetE48C5737:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ''
       CidrBlock: 10.0.0.0/24
       MapPublicIpOnLaunch: false
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet1RouteTable4771E3E5:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet1RouteTableAssociationD300FCBB:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: VpcIsolatedSubnet1RouteTable4771E3E5
@@ -59,7 +43,6 @@ Resources:
         Ref: VpcIsolatedSubnet1SubnetE48C5737
   VpcIsolatedSubnet1TransitGatewayRouteA907B32D:
     Type: AWS::EC2::Route
-    Condition: DeployInUSEast1
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       RouteTableId:
@@ -69,25 +52,22 @@ Resources:
       - TransitGatewayVpcAttachment
   VpcIsolatedSubnet2Subnet16364B91:
     Type: AWS::EC2::Subnet
-    Condition: DeployInUSEast1
     Properties:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: !Ref DeployRegion
+          - Fn::GetAZs: ''
       CidrBlock: 10.0.1.0/24
       MapPublicIpOnLaunch: false
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet2RouteTable1D30AF7D:
     Type: AWS::EC2::RouteTable
-    Condition: DeployInUSEast1
     Properties:
       VpcId:
         Ref: Vpc8378EB38
   VpcIsolatedSubnet2RouteTableAssociationF7B18CCA:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: DeployInUSEast1
     Properties:
       RouteTableId:
         Ref: VpcIsolatedSubnet2RouteTable1D30AF7D
@@ -95,7 +75,6 @@ Resources:
         Ref: VpcIsolatedSubnet2Subnet16364B91
   VpcIsolatedSubnet2TransitGatewayRoute1E0D0BF2:
     Type: AWS::EC2::Route
-    Condition: DeployInUSEast1
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       RouteTableId:
@@ -105,7 +84,6 @@ Resources:
       - TransitGatewayVpcAttachment
   TransitGatewayVpcAttachment:
     Type: AWS::EC2::TransitGatewayAttachment
-    Condition: DeployInUSEast1
     Properties:
       SubnetIds:
         - Ref: VpcIsolatedSubnet1SubnetE48C5737


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on greenifying cross accounts pipeline #10563, we discovered the issue with creating cfn templates in invalid availability zones.  

<!-- What notable changes does this PR make? -->
## Changes
This PR: 
- updates the way we fetch the AZs: rather than traversing over `"a", "b", "c", "d", "e", "f"`, we call `connect_to().ec2.describe_availability_zones(...)`
- reverts the changes in #10563 for deploying the templates specifically in `us-east-1`. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

