### PR TITLE
update pre-commit hook versions on dep updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.3
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,15 @@ venv: $(VENV_ACTIVATE)    ## Create a new (empty) virtual environment
 freeze:                   ## Run pip freeze -l in the virtual environment
 	@$(VENV_RUN); pip freeze -l
 
-pip-tools: venv
-	$(VENV_RUN); $(PIP_CMD) install --upgrade pip-tools
-
-upgrade-pinned-dependencies: pip-tools
+upgrade-pinned-dependencies: venv
+	$(VENV_RUN); $(PIP_CMD) install --upgrade pip-tools pre-commit
 	$(VENV_RUN); pip-compile --upgrade --strip-extras -o requirements-basic.txt pyproject.toml
 	$(VENV_RUN); pip-compile --upgrade --extra runtime -o requirements-runtime.txt pyproject.toml
 	$(VENV_RUN); pip-compile --upgrade --extra test -o requirements-test.txt pyproject.toml
 	$(VENV_RUN); pip-compile --upgrade --extra dev -o requirements-dev.txt pyproject.toml
 	$(VENV_RUN); pip-compile --upgrade --extra typehint -o requirements-typehint.txt pyproject.toml
 	$(VENV_RUN); pip-compile --upgrade --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
+	$(VENV_RUN); pre-commit autoupdate
 
 install-basic: venv       ## Install basic dependencies for CLI usage into venv
 	$(VENV_RUN); $(PIP_CMD) install -r requirements-basic.txt
@@ -268,4 +267,4 @@ clean-dist:				  ## Clean up python distribution directories
 	rm -rf dist/ build/
 	rm -rf *.egg-info
 
-.PHONY: usage freeze install-basic install-runtime install-test install-dev install entrypoints dist publish coveralls start docker-save-image docker-build docker-build-multiarch docker-push-master docker-create-push-manifests docker-run-tests docker-run docker-mount-run docker-cp-coverage test test-coverage test-docker test-docker-mount test-docker-mount-code lint lint-modified format format-modified init-precommit clean clean-dist pip-tools upgrade-pinned-dependencies
+.PHONY: usage freeze install-basic install-runtime install-test install-dev install entrypoints dist publish coveralls start docker-save-image docker-build docker-build-multiarch docker-push-master docker-create-push-manifests docker-run-tests docker-run docker-mount-run docker-cp-coverage test test-coverage test-docker test-docker-mount test-docker-mount-code lint lint-modified format format-modified init-precommit clean clean-dist upgrade-pinned-dependencies


### PR DESCRIPTION
## Motivation
We now automatically update our pinned dependencies in the `requirements*.txt` files every week using a scheduled GitHub action. However, this currently does not update the - separately managed - `pre-commit` hook versions. This could lead to problems because we enforce the linting rules based on the latest `ruff` version, while the `pre-commit` hook is outdated.
This PR fixes this issue by updating the pre-commit hooks together with the pinned dependencies.

## Changes
- Automatically executes `pre-commit autoupdate` when updating the dependencies such that they are updated together with the dev tools in the venv.

## Testing
- Tested locally, the resulting update of `.pre-commit-config.yaml` is the result of `make upgrade-pinned-dependencies`