### PR TITLE
Bump moto-ext to 5.0.4.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.0.3.post1",
+    "moto-ext[all]==5.0.4.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -273,7 +273,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext[all]==5.0.3.post1
+moto-ext[all]==5.0.4.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -344,7 +344,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.1
+py-partiql-parser==0.5.2
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -210,7 +210,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext[all]==5.0.3.post1
+moto-ext[all]==5.0.4.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy
@@ -252,7 +252,7 @@ psutil==5.9.8
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-py-partiql-parser==0.5.1
+py-partiql-parser==0.5.2
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -257,7 +257,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext[all]==5.0.3.post1
+moto-ext[all]==5.0.4.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -315,7 +315,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.1
+py-partiql-parser==0.5.2
     # via moto-ext
 pyasn1==0.6.0
     # via rsa

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -277,7 +277,7 @@ markupsafe==2.1.5
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-moto-ext[all]==5.0.3.post1
+moto-ext[all]==5.0.4.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -540,7 +540,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-py-partiql-parser==0.5.1
+py-partiql-parser==0.5.2
     # via moto-ext
 pyasn1==0.6.0
     # via rsa


### PR DESCRIPTION
Bumps Moto to latest upstream release and brings in:
- https://github.com/getmoto/moto/pull/7496
- https://github.com/getmoto/moto/pull/7511
- https://github.com/getmoto/moto/pull/7547

Ext Integration Tests # 5639 :green_circle: Passing

cc: @macnev2013 