### PR TITLE
fix SNS MessageBody filtering when value is a list

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -1179,6 +1179,9 @@ class SubscriptionFilter:
         return False
 
     def _evaluate_condition(self, value, condition, field_exists: bool):
+        if isinstance(value, list):
+            return any(self._evaluate_condition(val, condition, field_exists) for val in value)
+
         if not isinstance(condition, dict):
             return field_exists and value == condition
         elif (must_exist := condition.get("exists")) is not None:

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5023,8 +5023,108 @@
       }
     }
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[True]": {
-    "recorded-date": "02-04-2024, 22:14:08",
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_exists_filter_policy_attributes_array": {
+    "recorded-date": "02-04-2024, 22:27:18",
+    "recorded-content": {
+      "subscription-attributes-policy": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "store": [
+              "value1"
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+          "SubscriptionPrincipal": "arn:aws:iam::111111111111:user/<resource:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-init": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-1",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "store": {
+                  "Type": "String",
+                  "Value": "value1"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-2": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:4>",
+              "Message": "message-2",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:2>",
+              "MessageAttributes": {
+                "store": {
+                  "Type": "String.Array",
+                  "Value": "[\"value1\", \"value2\"]"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-3": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes": {
+    "recorded-date": "02-04-2024, 22:36:25",
     "recorded-content": {
       "recv-init-0": {
         "ResponseMetadata": {
@@ -5116,119 +5216,6 @@
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:4>"
-          }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[False]": {
-    "recorded-date": "02-04-2024, 22:14:15",
-    "recorded-content": {
-      "recv-init-0": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "recv-init-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "messages-queue-0": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:1>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "{\"headers\": {\"route-to\": [\"queue1\"]}}",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "{\"headers\": {\"route-to\": [\"queue1\", \"queue2\"]}}",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:4>",
-            "ReceiptHandle": "<receipt-handle:2>"
-          }
-        ]
-      },
-      "messages-queue-1": {
-        "Messages": [
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:5>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "{\"headers\": {\"route-to\": [\"queue2\"]}}",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:6>",
-            "ReceiptHandle": "<receipt-handle:3>"
-          },
-          {
-            "Attributes": {
-              "ApproximateFirstReceiveTimestamp": "timestamp",
-              "ApproximateReceiveCount": "1",
-              "SenderId": "<sender-id>",
-              "SentTimestamp": "timestamp"
-            },
-            "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:3>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-              "Message": "{\"headers\": {\"route-to\": [\"queue1\", \"queue2\"]}}",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
-            },
-            "MD5OfBody": "<md5-hash>",
-            "MessageId": "<uuid:7>",
             "ReceiptHandle": "<receipt-handle:4>"
           }
         ]

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5022,5 +5022,217 @@
         "UnsubscribeUrl": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[True]": {
+    "recorded-date": "02-04-2024, 22:14:08",
+    "recorded-content": {
+      "recv-init-0": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-init-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-queue-0": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "headers": {
+                "route-to": [
+                  "queue1",
+                  "queue2"
+                ]
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "headers": {
+                "route-to": [
+                  "queue1"
+                ]
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ]
+      },
+      "messages-queue-1": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "headers": {
+                "route-to": [
+                  "queue1",
+                  "queue2"
+                ]
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "headers": {
+                "route-to": [
+                  "queue2"
+                ]
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[False]": {
+    "recorded-date": "02-04-2024, 22:14:15",
+    "recorded-content": {
+      "recv-init-0": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-init-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-queue-0": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"headers\": {\"route-to\": [\"queue1\"]}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"headers\": {\"route-to\": [\"queue1\", \"queue2\"]}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ]
+      },
+      "messages-queue-1": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:5>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"headers\": {\"route-to\": [\"queue2\"]}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          },
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"headers\": {\"route-to\": [\"queue1\", \"queue2\"]}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "<cert-domain>/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:7>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -20,12 +20,6 @@
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes": {
     "last_validated_date": "2024-04-02T22:36:24+00:00"
   },
-  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[False]": {
-    "last_validated_date": "2024-04-02T22:32:31+00:00"
-  },
-  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[True]": {
-    "last_validated_date": "2024-04-02T22:32:24+00:00"
-  },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_dot_attribute": {
     "last_validated_date": "2023-11-09T17:50:59+00:00"
   },

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_exists_filter_policy": {
     "last_validated_date": "2023-11-09T20:04:02+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_exists_filter_policy_attributes_array": {
+    "last_validated_date": "2024-04-02T22:27:17+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy": {
     "last_validated_date": "2024-01-25T18:07:57+00:00"
   },
@@ -14,11 +17,14 @@
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[True]": {
     "last_validated_date": "2023-11-09T19:58:29+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes": {
+    "last_validated_date": "2024-04-02T22:36:24+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[False]": {
-    "last_validated_date": "2024-04-02T22:14:14+00:00"
+    "last_validated_date": "2024-04-02T22:32:31+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[True]": {
-    "last_validated_date": "2024-04-02T22:14:07+00:00"
+    "last_validated_date": "2024-04-02T22:32:24+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_dot_attribute": {
     "last_validated_date": "2023-11-09T17:50:59+00:00"

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -14,6 +14,12 @@
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body[True]": {
     "last_validated_date": "2023-11-09T19:58:29+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[False]": {
+    "last_validated_date": "2024-04-02T22:14:14+00:00"
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_array_attributes[True]": {
+    "last_validated_date": "2024-04-02T22:14:07+00:00"
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSFilter::test_filter_policy_on_message_body_dot_attribute": {
     "last_validated_date": "2023-11-09T17:50:59+00:00"
   },

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -601,6 +601,14 @@ class TestSns:
                     ({"f1": "v3", "f2": "v5"}, False),
                 ),
             ),
+            (
+                {"f1": ["v1", "v2"]},  # f1 must be v1 OR v2 (f1=v1 OR f1=v2)
+                (
+                    ({"f1": ["v1"], "f2": "v4"}, True),
+                    ({"f1": ["v2", "v3"], "f2": "v5"}, True),
+                    ({"f1": ["v3", "v4"], "f2": "v5"}, False),
+                ),
+            ),
         ]
 
         sub_filter = SubscriptionFilter()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #10567, JSON array properties were not handled well when the scope of the filter was `MessageBody`. We would handle it correctly for `MessagesAttributes` but it was only tested in unit tests. 

<!-- What notable changes does this PR make? -->
## Changes
- add 2 AWS validated tests: one for `MessageAttributes` scope with `String.Array` filter and one for array property in a JSON message body
- add the fix to recursively match the values of an array if the value is an array in an `OR` fashion (at least one value must match)

_fixes #10567_

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

