### PR TITLE
fix function get azs cloudformation template 

### DIFF
--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from localstack.aws.api.lambda_ import Runtime
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
 from localstack.testing.aws.cloudformation_utils import load_template_file, load_template_raw
 from localstack.testing.pytest import markers
@@ -250,6 +251,7 @@ class TestIntrinsicFunctions:
             template_path=template_path,
         )
 
+        snapshot.add_transformer(snapshot.transform.regex(AWS_REGION_US_EAST_1, "<region>"))
         snapshot.match("azs", deployed.outputs["Zones"].split(";"))
 
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -601,7 +601,7 @@
     }
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
-    "recorded-date": "27-11-2023, 13:14:35",
+    "recorded-date": "03-04-2024, 07:12:29",
     "recorded-content": {
       "azs": [
         "<region>a",

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -1,6 +1,9 @@
 {
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
-    "last_validated_date": "2023-11-27T12:14:35+00:00"
+    "last_validated_date": "2024-04-03T07:12:29+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-1]": {
+    "last_validated_date": "2024-04-03T06:32:28+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -2,9 +2,6 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
     "last_validated_date": "2024-04-03T07:12:29+00:00"
   },
-  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-1]": {
-    "last_validated_date": "2024-04-03T06:32:28+00:00"
-  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"
   },

--- a/tests/aws/templates/functions_get_azs.yml
+++ b/tests/aws/templates/functions_get_azs.yml
@@ -1,12 +1,24 @@
+Parameters:
+  DeployRegion:
+    Type: String
+    Default: us-east-1
+
+Conditions:
+  DeployInUSEast1:
+    Fn::Equals:
+      - !Ref DeployRegion
+      - us-east-1
+
 Resources:
   SsmParameter:
     Type: AWS::SSM::Parameter
+    Condition: DeployInUSEast1
     Properties:
       Type: String
       Value:
         Fn::Join:
           - ";"
-          - Fn::GetAZs: !Ref "AWS::Region"
+          - Fn::GetAZs: !Ref DeployRegion
 Outputs:
   Zones:
     Value:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The cfn test to check the template engine `test_get_azs_function` generates a snapshot against `us-east-1` AWS region. But when it is run against localstack for different AZs of non-default region values it results in error after the merge of #10586 which instead of just expanding values from a to f, now uses `connect_to().ec2.describe_availability_zones(...)` to get AZs of a specified region. 

According to previous commits in this file, we can see that this is a known gap and there is already a TODO added: 

```
TODO parametrize this test.
For that we need to be able to parametrize the client region. The docs show the we should be
able to put any region in the parameters but it doesn't work. It only accepts the same region from the client config
if you put anything else it just returns an empty list.
```

When run against different non default regions in LS, the workflow throws an error [here](https://app.circleci.com/pipelines/github/localstack/localstack/23867/workflows/850aa662-034b-4481-a508-d4569e85e7b1/jobs/196075/tests): 

```
>> match key: azs
	#x1B[31m(-)#x1B[0m /[3] ( '<region>d' )
	#x1B[32m(+)#x1B[0m /[3] ( not present )
	#x1B[31m(-)#x1B[0m /[4] ( '<region>e' )
	#x1B[32m(+)#x1B[0m /[4] ( not present )
	#x1B[31m(-)#x1B[0m /[5] ( '<region>f' )
	#x1B[32m(+)#x1B[0m /[5] ( not present )

	Ignore list (please keep in mind list indices might not work and should be replaced):
	["$"]
```

<!-- What notable changes does this PR make? -->
## Changes
This PR deploys `functions_get_azs.yml` specifically in `us-east-1` and regenerates the snapshots.  


<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

