### PR TITLE
Fix release helper for cli release

### DIFF
--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -159,7 +159,7 @@ function cmd-set-dep-ver() {
     dep=$1
     ver=$2
 
-    grep -Eh "^(\s*\"?)(${dep})(\[[a-zA-Z0-9,]+\])?(>=|==|<=)([^\"]*)(\")?(,)?$" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
+    egrep -h "^(\s*\"?)(${dep})(\[[a-zA-Z0-9,]+\])?(>=|==|<=)([^\"]*)(\")?(,)?$" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
     sed -i -r "s/^(\s*\"?)(${dep})(\[[a-zA-Z0-9,]+\])?(>=|==|<=)([^\"]*)(\")?(,)?$/\1\2\3${ver}\6\7/g" ${DEPENDENCY_FILE}
 }
 

--- a/bin/release-helper.sh
+++ b/bin/release-helper.sh
@@ -159,8 +159,8 @@ function cmd-set-dep-ver() {
     dep=$1
     ver=$2
 
-    grep -Eh "^(\s*\")${dep}(\[[a-zA-Z0-9]+\])?(>|=|<)(.*\",)" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
-    sed -i -r "s/^(\s*\")(${dep})(\[[a-zA-Z0-9,]+\])?(>|=|<)(.*\",)/\1\2\3${ver}\",/g" ${DEPENDENCY_FILE}
+    grep -Eh "^(\s*\"?)(${dep})(\[[a-zA-Z0-9,]+\])?(>=|==|<=)([^\"]*)(\")?(,)?$" ${DEPENDENCY_FILE} || { echo "dependency ${dep} not found in ${DEPENDENCY_FILE}"; return 1; }
+    sed -i -r "s/^(\s*\"?)(${dep})(\[[a-zA-Z0-9,]+\])?(>=|==|<=)([^\"]*)(\")?(,)?$/\1\2\3${ver}\6\7/g" ${DEPENDENCY_FILE}
 }
 
 function cmd-github-outputs() {
@@ -192,13 +192,17 @@ function cmd-git-commit-release() {
 
     echo $1 || verify_valid_version
 
-    git add ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}
+    for file in ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}; do
+            [ -e "$file" ] && git add "$file"
+    done
     git commit -m "release version ${1}"
     git tag -a "v${1}" -m "Release version ${1}"
 }
 
 function cmd-git-commit-increment() {
-    git add ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}
+    for file in ${VERSION_FILE} ${VERSION_PY} ${DEPENDENCY_FILE}; do
+            [ -e "$file" ] && git add "$file"
+    done
     git commit -m "prepare next development iteration"
 }
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Switching the release helper to work with `pyproject.toml` broke the CLI release since it did not work with `requirements.txt` files anymore. Also, changing the version single sourcing broke the release commit function, since it does not have a version.py file.

<!-- What notable changes does this PR make? -->
## Changes

1. The regular expressions in `grep` and `sed` were changed, so that they can capture both `requirements.txt` as well as `pyproject.toml` files.
2. The `git add` for the release and increment commits was changed, so that only files are added that truly exist. 
3. Reintroduce the usage of `egrep` which was previously removed because it is deprecated in modern versions of `grep`. However, on macOS, `egrep` is still the way to go.


## Testing

In `localstack/localstack-cli` you can execute the following:

```
DEPENDENCY_FILE="requirements.txt" ../localstack/bin/release-helper.sh set-dep-ver "localstack" "==3.4.0"
DEPENDENCY_FILE="requirements.txt" VERSION_FILE="" ../localstack/bin/release-helper.sh git-commit-release 3.4.0
```

And check if there is a new commit which changes the version of localstack correctly.

You can also check setting an arbitrary dependency in `localstack/localstack` and see if it still works.

Additionally you can see in this screenshot that all relevant options are matched:

![Screenshot 2024-04-03 at 11 15 15](https://github.com/localstack/localstack/assets/13120099/3d8123ee-13eb-4c38-8b3d-7e568d8b086d)

## TODO

- [x] Check whether we need to make the release script default Mac compatible. I had to install the GNU versions `grep` and `sed` via `brew` and adapt the `$PATH` for it to work. Can we expect LocalStack team members with Macs to do the same?