### PR TITLE
eventbridge: fix handling of list elements

### DIFF
--- a/localstack/services/events/utils.py
+++ b/localstack/services/events/utils.py
@@ -70,13 +70,16 @@ def matches_event(event_pattern: dict[str, any], event: dict[str, Any]) -> bool:
                 ):
                     return False
 
-        # 3. recursively call filter_event(..) for dict types
+        # 3. recursively call matches_event(..) for dict types
         elif isinstance(value, (str, dict)):
             try:
                 # TODO: validate whether inner JSON-encoded strings actually get decoded recursively
                 value = json.loads(value) if isinstance(value, str) else value
-                if isinstance(value, dict) and not matches_event(value, event_value):
-                    return False
+                if isinstance(event_value, list):
+                    return any(matches_event(value, ev) for ev in event_value)
+                else:
+                    if isinstance(value, dict) and not matches_event(value, event_value):
+                        return False
             except json.decoder.JSONDecodeError:
                 return False
 

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -573,10 +573,12 @@ def get_lambda_log_events(
         raw_message = event["message"]
         if (
             not raw_message
-            or "START" in raw_message
-            or "END" in raw_message
-            or "REPORT" in raw_message
-            # necessary until tail is updated in docker images. See this PR:
+            or raw_message.startswith("INIT_START")
+            or raw_message.startswith("START")
+            or raw_message.startswith("END")
+            or raw_message.startswith(
+                "REPORT"
+            )  # necessary until tail is updated in docker images. See this PR:
             # http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commitdiff;h=v8.24-111-g1118f32
             or "tail: unrecognized file system type" in raw_message
             or regex_filter

--- a/tests/aws/services/events/event_pattern_templates/list_within_dict.json5
+++ b/tests/aws/services/events/event_pattern_templates/list_within_dict.json5
@@ -1,0 +1,26 @@
+// Motivated by https://github.com/localstack/localstack/pull/10600
+{
+  "Event": {
+    "id": "1",
+    "source": "test-source",
+    "detail-type": "test-detail-type",
+    "account": "123456789012",
+    "region": "us-east-2",
+    "time": "2022-07-13T13:48:01Z",
+    "detail": {
+      "automations": [
+        {"key1": "value1"},
+        // the "exists" operator matches because at least one element of the list matches
+        {"id": "match-does-exist"},
+        {"key2": "value2"}
+      ]
+    }
+  },
+  "EventPattern": {
+    "detail": {
+      "automations": {
+        "id": [{"exists":  true}]
+      }
+    }
+  }
+}

--- a/tests/aws/services/events/test_event_patterns.snapshot.json
+++ b/tests/aws/services/events/test_event_patterns.snapshot.json
@@ -1,18 +1,18 @@
 {
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_repeating]": {
-    "recorded-date": "04-04-2024, 08:07:53",
+    "recorded-date": "08-04-2024, 19:33:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:54",
+    "recorded-date": "08-04-2024, 19:33:54",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_multi_match]": {
-    "recorded-date": "04-04-2024, 08:07:54",
+    "recorded-date": "08-04-2024, 19:33:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[int_nolist_EXC]": {
-    "recorded-date": "04-04-2024, 08:07:54",
+    "recorded-date": "08-04-2024, 19:33:55",
     "recorded-content": {
       "int_nolist_EXC": {
         "exception_message": {
@@ -30,39 +30,39 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays]": {
-    "recorded-date": "04-04-2024, 08:07:54",
+    "recorded-date": "08-04-2024, 19:33:55",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_repeating_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:54",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_simplified]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-exists]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_nonrepeating]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_multi_match_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "recorded-date": "04-04-2024, 08:07:55",
+    "recorded-date": "08-04-2024, 19:33:56",
     "recorded-content": {
       "content_numeric_operatorcasing_EXC": {
         "exception_message": {
@@ -80,19 +80,19 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_list_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:56",
+    "recorded-date": "08-04-2024, 19:33:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ip_address]": {
-    "recorded-date": "04-04-2024, 08:07:56",
+    "recorded-date": "08-04-2024, 19:33:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_prefix_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:56",
+    "recorded-date": "08-04-2024, 19:33:57",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string_nolist_EXC]": {
-    "recorded-date": "04-04-2024, 08:07:56",
+    "recorded-date": "08-04-2024, 19:33:57",
     "recorded-content": {
       "string_nolist_EXC": {
         "exception_message": {
@@ -110,19 +110,19 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:57",
+    "recorded-date": "08-04-2024, 19:33:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[boolean_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:57",
+    "recorded-date": "08-04-2024, 19:33:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-exists-parent]": {
-    "recorded-date": "04-04-2024, 08:07:57",
+    "recorded-date": "08-04-2024, 19:33:58",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_empty_EXC]": {
-    "recorded-date": "04-04-2024, 08:07:57",
+    "recorded-date": "08-04-2024, 19:33:58",
     "recorded-content": {
       "arrays_empty_EXC": {
         "exception_message": {
@@ -140,55 +140,55 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[nested_json_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_pattern]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[operator_multiple_list]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_list]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dynamodb]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string_empty]": {
-    "recorded-date": "04-04-2024, 08:07:58",
+    "recorded-date": "08-04-2024, 19:33:59",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_many_rules]": {
-    "recorded-date": "04-04-2024, 08:11:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[null_value]": {
-    "recorded-date": "04-04-2024, 08:07:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_list]": {
-    "recorded-date": "04-04-2024, 08:07:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_NEG]": {
-    "recorded-date": "04-04-2024, 08:07:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[operator_case_sensitive_EXC]": {
-    "recorded-date": "04-04-2024, 08:07:59",
+    "recorded-date": "08-04-2024, 19:34:00",
     "recorded-content": {
       "operator_case_sensitive_EXC": {
         "exception_message": {
@@ -206,15 +206,15 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists]": {
-    "recorded-date": "04-04-2024, 08:08:00",
+    "recorded-date": "08-04-2024, 19:34:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ip_address_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:00",
+    "recorded-date": "08-04-2024, 19:34:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_EXC]": {
-    "recorded-date": "04-04-2024, 08:08:00",
+    "recorded-date": "08-04-2024, 19:34:01",
     "recorded-content": {
       "content_numeric_EXC": {
         "exception_message": {
@@ -232,87 +232,87 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_or_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:00",
+    "recorded-date": "08-04-2024, 19:34:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_or]": {
-    "recorded-date": "04-04-2024, 08:08:00",
+    "recorded-date": "08-04-2024, 19:34:01",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_and_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_event]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_suffix_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix_ignorecase]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_ignorecase]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[null_value_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_pattern_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_prefix]": {
-    "recorded-date": "04-04-2024, 08:08:01",
+    "recorded-date": "08-04-2024, 19:34:02",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[sample1]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[key_case_sensitive_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_event_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[prefix]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_suffix]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_list]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string]": {
-    "recorded-date": "04-04-2024, 08:08:02",
+    "recorded-date": "08-04-2024, 19:34:03",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_empty_null_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:03",
+    "recorded-date": "08-04-2024, 19:34:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:03",
+    "recorded-date": "08-04-2024, 19:34:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_complex_EXC]": {
-    "recorded-date": "04-04-2024, 08:08:03",
+    "recorded-date": "08-04-2024, 19:34:04",
     "recorded-content": {
       "content_wildcard_complex_EXC": {
         "exception_message": {
@@ -330,55 +330,55 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_list_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:04",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ignorecase_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[minimal]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_false]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[number_comparison_float]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix]": {
-    "recorded-date": "04-04-2024, 08:08:04",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:05",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ignorecase]": {
-    "recorded-date": "04-04-2024, 08:08:05",
+    "recorded-date": "08-04-2024, 19:34:05",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_false_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:05",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_NEG]": {
-    "recorded-date": "04-04-2024, 08:08:05",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_syntax_EXC]": {
-    "recorded-date": "04-04-2024, 08:08:05",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {
       "content_numeric_syntax_EXC": {
         "exception_message": {
@@ -396,19 +396,23 @@
     }
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_and]": {
-    "recorded-date": "04-04-2024, 08:08:06",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[boolean]": {
-    "recorded-date": "04-04-2024, 08:08:06",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number]": {
-    "recorded-date": "04-04-2024, 08:08:06",
+    "recorded-date": "08-04-2024, 19:34:06",
     "recorded-content": {}
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-anything-but]": {
-    "recorded-date": "04-04-2024, 08:08:06",
+    "recorded-date": "08-04-2024, 19:34:07",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[list_within_dict]": {
+    "recorded-date": "08-04-2024, 19:33:54",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/events/test_event_patterns.validation.json
+++ b/tests/aws/services/events/test_event_patterns.validation.json
@@ -1,228 +1,231 @@
 {
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays]": {
-    "last_validated_date": "2024-04-04T08:07:54+00:00"
+    "last_validated_date": "2024-04-08T19:33:55+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:05+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_empty_EXC]": {
-    "last_validated_date": "2024-04-04T08:07:57+00:00"
+    "last_validated_date": "2024-04-08T19:33:58+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays_empty_null_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:03+00:00"
+    "last_validated_date": "2024-04-08T19:34:04+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[boolean]": {
-    "last_validated_date": "2024-04-04T08:08:06+00:00"
+    "last_validated_date": "2024-04-08T19:34:06+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[boolean_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:57+00:00"
+    "last_validated_date": "2024-04-08T19:33:58+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_many_rules]": {
-    "last_validated_date": "2024-04-04T08:11:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_multi_match]": {
-    "last_validated_date": "2024-04-04T08:07:54+00:00"
+    "last_validated_date": "2024-04-08T19:33:55+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_multi_match_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_or]": {
-    "last_validated_date": "2024-04-04T08:08:00+00:00"
+    "last_validated_date": "2024-04-08T19:34:01+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[complex_or_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:00+00:00"
+    "last_validated_date": "2024-04-08T19:34:01+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_list]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_ignorecase_list_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number]": {
-    "last_validated_date": "2024-04-04T08:08:06+00:00"
+    "last_validated_date": "2024-04-08T19:34:06+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_list]": {
-    "last_validated_date": "2024-04-04T08:07:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_number_list_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:56+00:00"
+    "last_validated_date": "2024-04-08T19:33:57+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:57+00:00"
+    "last_validated_date": "2024-04-08T19:33:58+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_list]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_but_string_list_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:04+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_prefix]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_prefix_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:56+00:00"
+    "last_validated_date": "2024-04-08T19:33:57+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_suffix]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_anything_suffix_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists]": {
-    "last_validated_date": "2024-04-04T08:08:00+00:00"
+    "last_validated_date": "2024-04-08T19:34:01+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:05+00:00"
+    "last_validated_date": "2024-04-08T19:34:06+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_false]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_exists_false_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:05+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ignorecase]": {
-    "last_validated_date": "2024-04-04T08:08:05+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ignorecase_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ip_address]": {
-    "last_validated_date": "2024-04-04T08:07:56+00:00"
+    "last_validated_date": "2024-04-08T19:33:57+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_ip_address_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:00+00:00"
+    "last_validated_date": "2024-04-08T19:34:01+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_EXC]": {
-    "last_validated_date": "2024-04-04T08:08:00+00:00"
+    "last_validated_date": "2024-04-08T19:34:01+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_and]": {
-    "last_validated_date": "2024-04-04T08:08:06+00:00"
+    "last_validated_date": "2024-04-08T19:34:06+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_and_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_operatorcasing_EXC]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_numeric_syntax_EXC]": {
-    "last_validated_date": "2024-04-04T08:08:05+00:00"
+    "last_validated_date": "2024-04-08T19:34:06+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:04+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_prefix_ignorecase]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:54+00:00"
+    "last_validated_date": "2024-04-08T19:33:54+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_ignorecase]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_suffix_ignorecase_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:03+00:00"
+    "last_validated_date": "2024-04-08T19:34:04+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_complex_EXC]": {
-    "last_validated_date": "2024-04-04T08:08:03+00:00"
+    "last_validated_date": "2024-04-08T19:34:04+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_nonrepeating]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_nonrepeating_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_repeating]": {
-    "last_validated_date": "2024-04-04T08:07:53+00:00"
+    "last_validated_date": "2024-04-08T19:33:54+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_repeating_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:54+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[content_wildcard_simplified]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_event]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_event_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_pattern]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dot_joining_pattern_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[dynamodb]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[int_nolist_EXC]": {
-    "last_validated_date": "2024-04-04T08:07:54+00:00"
+    "last_validated_date": "2024-04-08T19:33:55+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[key_case_sensitive_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
+  },
+  "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[list_within_dict]": {
+    "last_validated_date": "2024-04-08T19:33:54+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[minimal]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[nested_json_NEG]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[null_value]": {
-    "last_validated_date": "2024-04-04T08:07:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[null_value_NEG]": {
-    "last_validated_date": "2024-04-04T08:08:01+00:00"
+    "last_validated_date": "2024-04-08T19:34:02+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[number_comparison_float]": {
-    "last_validated_date": "2024-04-04T08:08:04+00:00"
+    "last_validated_date": "2024-04-08T19:34:05+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[operator_case_sensitive_EXC]": {
-    "last_validated_date": "2024-04-04T08:07:59+00:00"
+    "last_validated_date": "2024-04-08T19:34:00+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[operator_multiple_list]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-anything-but]": {
-    "last_validated_date": "2024-04-04T08:08:06+00:00"
+    "last_validated_date": "2024-04-08T19:34:07+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-exists-parent]": {
-    "last_validated_date": "2024-04-04T08:07:57+00:00"
+    "last_validated_date": "2024-04-08T19:33:58+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[or-exists]": {
-    "last_validated_date": "2024-04-04T08:07:55+00:00"
+    "last_validated_date": "2024-04-08T19:33:56+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[prefix]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[sample1]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string]": {
-    "last_validated_date": "2024-04-04T08:08:02+00:00"
+    "last_validated_date": "2024-04-08T19:34:03+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string_empty]": {
-    "last_validated_date": "2024-04-04T08:07:58+00:00"
+    "last_validated_date": "2024-04-08T19:33:59+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[string_nolist_EXC]": {
-    "last_validated_date": "2024-04-04T08:07:56+00:00"
+    "last_validated_date": "2024-04-08T19:33:57+00:00"
   },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern_with_escape_characters": {
     "last_validated_date": "2024-04-04T08:08:06+00:00"

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -239,6 +239,251 @@ def test_put_events_with_target_lambda(create_lambda_function, cleanups, aws_cli
 
 @markers.aws.validated
 @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
+def test_put_events_with_target_lambda_list_entry(
+    create_lambda_function, cleanups, aws_client, clean_up, snapshot
+):
+    rule_name = f"rule-{short_uid()}"
+    function_name = f"lambda-func-{short_uid()}"
+    target_id = f"target-{short_uid()}"
+    bus_name = f"bus-{short_uid()}"
+
+    # clean up
+    cleanups.append(lambda: aws_client.lambda_.delete_function(FunctionName=function_name))
+    cleanups.append(lambda: clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id))
+
+    rs = create_lambda_function(
+        handler_file=TEST_LAMBDA_PYTHON_ECHO,
+        func_name=function_name,
+        runtime=Runtime.python3_9,
+    )
+
+    func_arn = rs["CreateFunctionResponse"]["FunctionArn"]
+
+    event_pattern = {"detail": {"payload": {"automations": {"id": [{"exists": True}]}}}}
+
+    aws_client.events.create_event_bus(Name=bus_name)
+    rs = aws_client.events.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps(event_pattern),
+    )
+    aws_client.lambda_.add_permission(
+        FunctionName=function_name,
+        StatementId=f"{rule_name}-Event",
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rs["RuleArn"],
+    )
+    rs = aws_client.events.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[{"Id": target_id, "Arn": func_arn}],
+    )
+
+    assert "FailedEntryCount" in rs
+    assert "FailedEntries" in rs
+    assert rs["FailedEntryCount"] == 0
+    assert rs["FailedEntries"] == []
+
+    event_detail = {
+        "payload": {
+            "userId": 10,
+            "businessId": 3,
+            "channelId": 6,
+            "card": {
+                "planLimitImposed": False,
+                "createdAt": "2024-02-09T14: 47: 22.694Z",
+                "updatedAt": "2024-02-20T16: 31: 53.468Z",
+                "id": "3f761415-125c-48bf-9c7e-83ab91da9ecb",
+                "channelId": 6,
+                "userId": 10,
+                "sequenceNumber": 1,
+                "threadId": "c8d2c98e-8074-410c-a89a-610fdf8e7696",
+                "cardDefinitionId": None,
+                "workflowTemplateId": "b8214841-e8ce-42ac-929c-d0bd3abc987e",
+                "urgent": False,
+                "timezone": "America/New_York",
+                "name": "test 11143r",
+                "startDate": None,
+                "startDateOffset": 0,
+                "endDateOffset": None,
+                "recurrenceDate": "2024-02-09T14: 47: 22.694Z",
+                "fields": {
+                    "name": "test 11143r",
+                    "userId": [10],
+                    "version": "v1",
+                    "createdAt": "2024-02-09T14: 47: 22.694Z",
+                    "updatedAt": "2024-02-20T16: 31: 53.468Z",
+                    "sequenceNumber": 1,
+                },
+                "deletedAt": None,
+                "kanbanSortKey": "1707490042553",
+                "status": "ACTIVE",
+                "assignees": [],
+                "tags": [],
+                "relatedCards": [],
+                "cardReminders": [],
+                "entityRecurrence": None,
+            },
+            "targetEntity": True,
+            "entityAuditTrailEvent": {
+                "timestamp": "2024-02-20T16: 31: 53.468Z",
+                "workflowTemplateId": "b8214841-e8ce-42ac-929c-d0bd3abc987e",
+                "userId": 10,
+                "cardId": "3f761415-125c-48bf-9c7e-83ab91da9ecb",
+                "entries": [
+                    {
+                        "componentId": "name",
+                        "componentType": "TEXT",
+                        "newData": {"value": "test 11143r"},
+                        "originalData": {"value": "test 11143r43"},
+                    }
+                ],
+            },
+            "automations": [
+                {
+                    "id": "123",
+                    "actions": [
+                        {
+                            "id": "321",
+                            "type": "SEND_NOTIFICATION",
+                            "settings": {
+                                "message": "",
+                                "recipientEmails": [],
+                                "subject": "",
+                                "type": "SEND_NOTIFICATION",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    aws_client.events.put_events(
+        Entries=[
+            {
+                "EventBusName": bus_name,
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(event_detail),
+            }
+        ]
+    )
+
+    # Get lambda's log events
+    events = retry(
+        check_expected_lambda_log_events_length,
+        retries=3,
+        sleep=1,
+        function_name=function_name,
+        expected_length=1,
+        logs_client=aws_client.logs,
+    )
+    snapshot.match("events", events)
+
+
+@markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
+def test_put_events_with_target_lambda_list_entries_partial_match(
+    create_lambda_function, cleanups, aws_client, clean_up, snapshot
+):
+    rule_name = f"rule-{short_uid()}"
+    function_name = f"lambda-func-{short_uid()}"
+    target_id = f"target-{short_uid()}"
+    bus_name = f"bus-{short_uid()}"
+
+    # clean up
+    cleanups.append(lambda: aws_client.lambda_.delete_function(FunctionName=function_name))
+    cleanups.append(lambda: clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id))
+
+    rs = create_lambda_function(
+        handler_file=TEST_LAMBDA_PYTHON_ECHO,
+        func_name=function_name,
+        runtime=Runtime.python3_9,
+    )
+
+    func_arn = rs["CreateFunctionResponse"]["FunctionArn"]
+
+    event_pattern = {"detail": {"payload": {"automations": {"id": [{"exists": True}]}}}}
+
+    aws_client.events.create_event_bus(Name=bus_name)
+    rs = aws_client.events.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps(event_pattern),
+    )
+    aws_client.lambda_.add_permission(
+        FunctionName=function_name,
+        StatementId=f"{rule_name}-Event",
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rs["RuleArn"],
+    )
+    rs = aws_client.events.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[{"Id": target_id, "Arn": func_arn}],
+    )
+
+    assert "FailedEntryCount" in rs
+    assert "FailedEntries" in rs
+    assert rs["FailedEntryCount"] == 0
+    assert rs["FailedEntries"] == []
+
+    event_detail_partial_match = {
+        "payload": {
+            "userId": 10,
+            "businessId": 3,
+            "channelId": 6,
+            "card": {"foo": "bar"},
+            "targetEntity": True,
+            "entityAuditTrailEvent": {"foo": "bar"},
+            "automations": [
+                {"foo": "bar"},
+                {
+                    "id": "123",
+                    "actions": [
+                        {
+                            "id": "321",
+                            "type": "SEND_NOTIFICATION",
+                            "settings": {
+                                "message": "",
+                                "recipientEmails": [],
+                                "subject": "",
+                                "type": "SEND_NOTIFICATION",
+                            },
+                        }
+                    ],
+                },
+                {"bar": "foo"},
+            ],
+        }
+    }
+    aws_client.events.put_events(
+        Entries=[
+            {
+                "EventBusName": bus_name,
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(event_detail_partial_match),
+            },
+        ]
+    )
+
+    # Get lambda's log events
+    events = retry(
+        check_expected_lambda_log_events_length,
+        retries=3,
+        sleep=1,
+        function_name=function_name,
+        expected_length=1,
+        logs_client=aws_client.logs,
+    )
+    snapshot.match("events", events)
+
+
+@markers.aws.validated
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_should_ignore_schedules_for_put_event(create_lambda_function, cleanups, aws_client):
     """Regression test for https://github.com/localstack/localstack/issues/7847"""
     fn_name = f"test-event-fn-{short_uid()}"

--- a/tests/aws/services/events/test_events_integrations.snapshot.json
+++ b/tests/aws/services/events/test_events_integrations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entry": {
-    "recorded-date": "03-04-2024, 19:52:23",
+    "recorded-date": "08-04-2024, 17:32:58",
     "recorded-content": {
       "events": [
         {
@@ -18,60 +18,11 @@
               "businessId": 3,
               "channelId": 6,
               "card": {
-                "planLimitImposed": false,
-                "createdAt": "2024-02-09T14: 47: 22.694Z",
-                "updatedAt": "2024-02-20T16: 31: 53.468Z",
-                "id": "<uuid:2>",
-                "channelId": 6,
-                "userId": 10,
-                "sequenceNumber": 1,
-                "threadId": "<uuid:3>",
-                "cardDefinitionId": null,
-                "workflowTemplateId": "<uuid:4>",
-                "urgent": false,
-                "timezone": "America/New_York",
-                "name": "test 11143r",
-                "startDate": null,
-                "startDateOffset": 0,
-                "endDateOffset": null,
-                "recurrenceDate": "2024-02-09T14: 47: 22.694Z",
-                "fields": {
-                  "name": "test 11143r",
-                  "userId": [
-                    10
-                  ],
-                  "version": "v1",
-                  "createdAt": "2024-02-09T14: 47: 22.694Z",
-                  "updatedAt": "2024-02-20T16: 31: 53.468Z",
-                  "sequenceNumber": 1
-                },
-                "deletedAt": null,
-                "kanbanSortKey": "1707490042553",
-                "status": "ACTIVE",
-                "assignees": [],
-                "tags": [],
-                "relatedCards": [],
-                "cardReminders": [],
-                "entityRecurrence": null
+                "foo": "bar"
               },
               "targetEntity": true,
               "entityAuditTrailEvent": {
-                "timestamp": "timestamp",
-                "workflowTemplateId": "<uuid:4>",
-                "userId": 10,
-                "cardId": "<uuid:2>",
-                "entries": [
-                  {
-                    "componentId": "name",
-                    "componentType": "TEXT",
-                    "newData": {
-                      "value": "test 11143r"
-                    },
-                    "originalData": {
-                      "value": "test 11143r43"
-                    }
-                  }
-                ]
+                "foo": "bar"
               },
               "automations": [
                 {

--- a/tests/aws/services/events/test_events_integrations.snapshot.json
+++ b/tests/aws/services/events/test_events_integrations.snapshot.json
@@ -1,0 +1,153 @@
+{
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entry": {
+    "recorded-date": "03-04-2024, 19:52:23",
+    "recorded-content": {
+      "events": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "core.update-account-command",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "payload": {
+              "userId": 10,
+              "businessId": 3,
+              "channelId": 6,
+              "card": {
+                "planLimitImposed": false,
+                "createdAt": "2024-02-09T14: 47: 22.694Z",
+                "updatedAt": "2024-02-20T16: 31: 53.468Z",
+                "id": "<uuid:2>",
+                "channelId": 6,
+                "userId": 10,
+                "sequenceNumber": 1,
+                "threadId": "<uuid:3>",
+                "cardDefinitionId": null,
+                "workflowTemplateId": "<uuid:4>",
+                "urgent": false,
+                "timezone": "America/New_York",
+                "name": "test 11143r",
+                "startDate": null,
+                "startDateOffset": 0,
+                "endDateOffset": null,
+                "recurrenceDate": "2024-02-09T14: 47: 22.694Z",
+                "fields": {
+                  "name": "test 11143r",
+                  "userId": [
+                    10
+                  ],
+                  "version": "v1",
+                  "createdAt": "2024-02-09T14: 47: 22.694Z",
+                  "updatedAt": "2024-02-20T16: 31: 53.468Z",
+                  "sequenceNumber": 1
+                },
+                "deletedAt": null,
+                "kanbanSortKey": "1707490042553",
+                "status": "ACTIVE",
+                "assignees": [],
+                "tags": [],
+                "relatedCards": [],
+                "cardReminders": [],
+                "entityRecurrence": null
+              },
+              "targetEntity": true,
+              "entityAuditTrailEvent": {
+                "timestamp": "timestamp",
+                "workflowTemplateId": "<uuid:4>",
+                "userId": 10,
+                "cardId": "<uuid:2>",
+                "entries": [
+                  {
+                    "componentId": "name",
+                    "componentType": "TEXT",
+                    "newData": {
+                      "value": "test 11143r"
+                    },
+                    "originalData": {
+                      "value": "test 11143r43"
+                    }
+                  }
+                ]
+              },
+              "automations": [
+                {
+                  "id": "123",
+                  "actions": [
+                    {
+                      "id": "321",
+                      "type": "SEND_NOTIFICATION",
+                      "settings": {
+                        "message": "",
+                        "recipientEmails": [],
+                        "subject": "",
+                        "type": "SEND_NOTIFICATION"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entries_partial_match": {
+    "recorded-date": "03-04-2024, 20:00:13",
+    "recorded-content": {
+      "events": [
+        {
+          "version": "0",
+          "id": "<uuid:1>",
+          "detail-type": "core.update-account-command",
+          "source": "core.update-account-command",
+          "account": "111111111111",
+          "time": "date",
+          "region": "<region>",
+          "resources": [],
+          "detail": {
+            "payload": {
+              "userId": 10,
+              "businessId": 3,
+              "channelId": 6,
+              "card": {
+                "foo": "bar"
+              },
+              "targetEntity": true,
+              "entityAuditTrailEvent": {
+                "foo": "bar"
+              },
+              "automations": [
+                {
+                  "foo": "bar"
+                },
+                {
+                  "id": "123",
+                  "actions": [
+                    {
+                      "id": "321",
+                      "type": "SEND_NOTIFICATION",
+                      "settings": {
+                        "message": "",
+                        "recipientEmails": [],
+                        "subject": "",
+                        "type": "SEND_NOTIFICATION"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "bar": "foo"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/aws/services/events/test_events_integrations.validation.json
+++ b/tests/aws/services/events/test_events_integrations.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entries_partial_match": {
+    "last_validated_date": "2024-04-03T20:00:13+00:00"
+  },
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs": {
     "last_validated_date": "2024-03-26T15:49:59+00:00"
   },

--- a/tests/aws/services/events/test_events_integrations.validation.json
+++ b/tests/aws/services/events/test_events_integrations.validation.json
@@ -1,6 +1,9 @@
 {
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entries_partial_match": {
-    "last_validated_date": "2024-04-03T20:00:13+00:00"
+    "last_validated_date": "2024-04-08T17:36:24+00:00"
+  },
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_lambda_list_entry": {
+    "last_validated_date": "2024-04-08T17:33:44+00:00"
   },
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs": {
     "last_validated_date": "2024-03-26T15:49:59+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A customer reported internal errors when submitting events that contained a list within a dict. This PR adds the presumably correct behavior as AWS does it (checked with 2 validated tests). During the replication, another issue surfaced in our own testing code: The function that collects the event logs will also discard actual messages if the message happens to contain certain key words, while we should only discard messages that *start* with said keywords.
/cc @maxhoheiser 

<!-- What notable changes does this PR make? -->
## Changes
- Fixes handling of list entries in dicts in eventbridge
- Fixes the discarding of status event logs


## TODO

What's left to do:

- [ ] For some reason, no entry is created in validations.json for `test_put_events_with_target_lambda_list_entry`?


