### PR TITLE
fix s3 create bucket constraint

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -925,6 +925,13 @@ class KeyTooLongError(ServiceException):
     Size: Optional[KeyLength]
 
 
+class InvalidLocationConstraint(ServiceException):
+    code: str = "InvalidLocationConstraint"
+    sender_fault: bool = False
+    status_code: int = 400
+    LocationConstraint: Optional[BucketRegion]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1176,6 +1176,20 @@
         "documentation": "<p>Your key is too long</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidLocationConstraint",
+      "value": {
+        "type": "structure",
+        "members": {
+          "LocationConstraint": {
+            "shape": "BucketRegion"
+          }
+        },
+        "documentation": "<p>The specified location-constraint is not valid</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/exceptions.py
+++ b/localstack/services/s3/exceptions.py
@@ -1,11 +1,6 @@
 from localstack.aws.api import CommonServiceException
 
 
-class InvalidLocationConstraint(CommonServiceException):
-    def __init__(self, message=None):
-        super().__init__("InvalidLocationConstraint", status_code=400, message=message)
-
-
 class MalformedXML(CommonServiceException):
     def __init__(self, message=None):
         if not message:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -101,6 +101,7 @@ from localstack.aws.api.s3 import (
     InvalidArgument,
     InvalidBucketName,
     InvalidDigest,
+    InvalidLocationConstraint,
     InvalidObjectState,
     InvalidPartNumber,
     InvalidPartOrder,
@@ -211,7 +212,6 @@ from localstack.services.s3.constants import (
 from localstack.services.s3.cors import S3CorsHandler, s3_cors_request_handler
 from localstack.services.s3.exceptions import (
     InvalidBucketState,
-    InvalidLocationConstraint,
     InvalidRequest,
     MalformedPolicy,
     MalformedXML,
@@ -433,7 +433,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 raise MalformedXML()
 
             if bucket_region == "us-east-1":
-                raise InvalidLocationConstraint("The specified location-constraint is not valid")
+                raise InvalidLocationConstraint(
+                    "The specified location-constraint is not valid",
+                    LocationConstraint=bucket_region,
+                )
         else:
             bucket_region = "us-east-1"
             if context.region != bucket_region:

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2581,6 +2581,8 @@ class TestS3:
                 CreateBucketConfiguration={"LocationConstraint": region_us_east_1},
             )
         snapshot.match("create-bucket-constraint-us-east-1", exc.value.response)
+        if is_aws_cloud() or not is_v2_provider():
+            assert exc.value.response["Error"]["LocationConstraint"] == region_us_east_1
 
         # assert creation fails with location constraint with the region unset
         with pytest.raises(Exception) as exc:

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -2540,6 +2540,10 @@ class TestS3:
         snapshot.match("bucket-replication", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=is_v2_provider,
+        paths=["$..Error.LocationConstraint"],  # not returned by Moto
+    )
     def test_different_location_constraint(
         self,
         s3_create_bucket,

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1078,7 +1078,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "25-03-2024, 17:20:27",
+    "recorded-date": "04-04-2024, 14:24:17",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,
@@ -1087,8 +1087,29 @@
           "HTTPStatusCode": 200
         }
       },
+      "create-bucket-constraint-us-east-1": {
+        "Error": {
+          "Code": "InvalidLocationConstraint",
+          "LocationConstraint": "<location-constraint>",
+          "Message": "The specified location-constraint is not valid"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-bucket-constraint-us-east-1-with-None": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "get_bucket_location_bucket_2": {
-        "LocationConstraint": "<region_2>",
+        "LocationConstraint": "<location-constraint>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1112,7 +1133,7 @@
         }
       },
       "get_bucket_location_bucket_3": {
-        "LocationConstraint": "<region_2>",
+        "LocationConstraint": "<location-constraint>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1078,7 +1078,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "04-04-2024, 14:24:17",
+    "recorded-date": "04-04-2024, 17:13:12",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2023-10-22T02:25:14+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "last_validated_date": "2024-03-25T17:20:27+00:00"
+    "last_validated_date": "2024-04-04T14:24:17+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_empty_bucket_fixture": {
     "last_validated_date": "2023-09-08T16:52:15+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2023-10-22T02:25:14+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "last_validated_date": "2024-04-04T14:24:17+00:00"
+    "last_validated_date": "2024-04-04T17:13:12+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_empty_bucket_fixture": {
     "last_validated_date": "2023-09-08T16:52:15+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We had some issues with our WebApp regarding Bucket Location Constraint, and one proposed fixed was to pass a `undefined` location constraint when the bucket region was `us-east-1`. This fix worked with LocalStack, but this was missing parity. AWS will not accepted an empty constraint either for `us-east-1`. 

<!-- What notable changes does this PR make? -->
## Changes
- add a check if the constraint is actually set or not. Some quirks of XML parsing makes it that a full empty body and the location constraint set to `None` will end up as an empty dict for both. We have to check if the body is really empty, in that case no constraint are set. 
- extend the test to validate a constraint for `us-east-1` and validate a `None` constraint


\cc @webdev51 @lukqw 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

