### PR TITLE
added aws validate test case for ListSecrets filtering

### DIFF
--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -283,7 +283,6 @@ class TestSecretsManager:
                 assert secret["Name"] in include_secrets
                 assert secret["Name"] not in exclude_secrets
 
-        # name based filtering
         response = aws_client.secretsmanager.list_secrets(
             Filters=[{"Key": "name", "Values": ["/"]}]
         )
@@ -305,7 +304,6 @@ class TestSecretsManager:
             response, [], [secret_name_1, secret_name_2, secret_name_3, secret_name_4]
         )
 
-        # description based filtering
         response = aws_client.secretsmanager.list_secrets(
             Filters=[{"Key": "description", "Values": ["a"]}]
         )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -262,6 +262,125 @@ class TestSecretsManager:
         sm_snapshot.match("delete_secret_res_1", delete_secret_res_1)
 
     @markers.aws.validated
+    def test_list_secrets_filtering(self, aws_client, create_secret):
+        secret_name_1 = "testing1/one"
+        secret_name_2 = "/testing2/two"
+        secret_name_3 = "testing3/three"
+        secret_name_4 = "/testing4/four"
+
+        create_secret(Name=secret_name_1, SecretString="secret", Description="a secret")
+        create_secret(Name=secret_name_2, SecretString="secret", Description="an secret")
+        create_secret(Name=secret_name_3, SecretString="secret", Description="asecret")
+        create_secret(Name=secret_name_4, SecretString="secret", Description="thesecret")
+
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_id=secret_name_1)
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_id=secret_name_2)
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_id=secret_name_3)
+        self._wait_created_is_listed(aws_client.secretsmanager, secret_id=secret_name_4)
+
+        def assert_secret_names(res, include_secrets, exclude_secrets):
+            for secret in res["SecretList"]:
+                assert secret["Name"] in include_secrets
+                assert secret["Name"] not in exclude_secrets
+
+        # name based filtering
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "name", "Values": ["/"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_2, secret_name_4], [secret_name_1, secret_name_3]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "name", "Values": ["!/"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_3], [secret_name_2, secret_name_4]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "name", "Values": ["testing1 one"]}]
+        )
+        assert_secret_names(
+            response, [], [secret_name_1, secret_name_2, secret_name_3, secret_name_4]
+        )
+
+        # description based filtering
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "description", "Values": ["a"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2, secret_name_3], [secret_name_4]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "description", "Values": ["!a"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_4], [secret_name_1, secret_name_2, secret_name_3]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "description", "Values": ["a secret"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2], [secret_name_3, secret_name_4]
+        )
+
+        # name and description based filtering
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[
+                {"Key": "description", "Values": ["a"]},
+                {"Key": "name", "Values": ["secret"]},
+            ]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2, secret_name_3, secret_name_4], []
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[
+                {"Key": "description", "Values": ["a"]},
+                {"Key": "name", "Values": ["an"]},
+            ]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2, secret_name_3, secret_name_4], []
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[
+                {"Key": "description", "Values": ["a secret"]},
+            ]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2], [secret_name_3, secret_name_4]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[
+                {"Key": "description", "Values": ["!a"]},
+            ]
+        )
+        assert_secret_names(
+            response, [secret_name_4], [secret_name_1, secret_name_2, secret_name_3]
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "description", "Values": ["!c"]}]
+        )
+        assert_secret_names(
+            response, [secret_name_1, secret_name_2, secret_name_3, secret_name_4], []
+        )
+
+        response = aws_client.secretsmanager.list_secrets(
+            Filters=[{"Key": "name", "Values": ["testing1 one"]}]
+        )
+        assert_secret_names(
+            response, [], [secret_name_1, secret_name_2, secret_name_3, secret_name_4]
+        )
+
+    @markers.aws.validated
     def test_create_multi_secrets(self, cleanups, aws_client):
         secret_names = [short_uid(), short_uid(), short_uid()]
         arns = []

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -263,10 +263,11 @@ class TestSecretsManager:
 
     @markers.aws.validated
     def test_list_secrets_filtering(self, aws_client, create_secret):
-        secret_name_1 = "testing1/one"
-        secret_name_2 = "/testing2/two"
-        secret_name_3 = "testing3/three"
-        secret_name_4 = "/testing4/four"
+        unique_id = short_uid()
+        secret_name_1 = f"testing1/one-{unique_id}"
+        secret_name_2 = f"/testing2/two-{unique_id}"
+        secret_name_3 = f"testing3/three-{unique_id}"
+        secret_name_4 = f"/testing4/four-{unique_id}"
 
         create_secret(Name=secret_name_1, SecretString="secret", Description="a secret")
         create_secret(Name=secret_name_2, SecretString="secret", Description="an secret")

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -327,7 +327,6 @@ class TestSecretsManager:
             response, [secret_name_1, secret_name_2], [secret_name_3, secret_name_4]
         )
 
-        # name and description based filtering
         response = aws_client.secretsmanager.list_secrets(
             Filters=[
                 {"Key": "description", "Values": ["a"]},

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -57,7 +57,7 @@
     "last_validated_date": "2024-03-15T08:12:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_list_secrets_filtering": {
-    "last_validated_date": "2024-04-05T17:30:18+00:00"
+    "last_validated_date": "2024-04-09T12:45:26+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
     "last_validated_date": "2024-03-15T08:14:56+00:00"

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -56,6 +56,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_last_updated_date": {
     "last_validated_date": "2024-03-15T08:12:47+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_list_secrets_filtering": {
+    "last_validated_date": "2024-04-05T17:30:18+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_no_client_request_token[CreateSecret]": {
     "last_validated_date": "2024-03-15T08:14:56+00:00"
   },


### PR DESCRIPTION
## Motivation
This PR addresses issues introduced by a recent addition to the test (PR https://github.com/localstack/localstack/pull/10520) (which was reverted  in PR https://github.com/localstack/localstack/pull/10607), that resulted in a failing test case due to leftover resources from other tests.

This PR builds upon the changes proposed in https://github.com/localstack/localstack/pull/10520 by refining the affected test case to ensure it operates independently from the outcomes of other tests.

## Changes
- Implemented an AWS-validated test case to enhance test's reliability.
