### PR TITLE
Feature: Eventbridge v2: CRUD

### DIFF
--- a/localstack/services/events/event_bus.py
+++ b/localstack/services/events/event_bus.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from localstack.aws.api.events import Arn, EventBusName, TagList
+from localstack.services.events.models_v2 import EventBus, RuleDict
+
+
+class EventBusWorker:
+    def __init__(
+        self,
+        name: EventBusName,
+        region: str,
+        account_id: str,
+        event_source_name: Optional[str] = None,
+        tags: Optional[TagList] = None,
+        policy: Optional[str] = None,
+        rules: Optional[RuleDict] = None,
+    ):
+        self.event_bus = EventBus(
+            name,
+            region,
+            account_id,
+            event_source_name,
+            tags,
+            policy,
+            rules,
+        )
+
+    @property
+    def arn(self):
+        return self.event_bus.arn
+
+
+EventBusWorkerDict = dict[Arn, EventBusWorker]

--- a/localstack/services/events/event_bus.py
+++ b/localstack/services/events/event_bus.py
@@ -4,7 +4,7 @@ from localstack.aws.api.events import Arn, EventBusName, TagList
 from localstack.services.events.models_v2 import EventBus, RuleDict
 
 
-class EventBusWorker:
+class EventBusService:
     def __init__(
         self,
         name: EventBusName,
@@ -30,4 +30,4 @@ class EventBusWorker:
         return self.event_bus.arn
 
 
-EventBusWorkerDict = dict[Arn, EventBusWorker]
+EventBusServiceDict = dict[Arn, EventBusService]

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -1,9 +1,18 @@
+from dataclasses import dataclass, field
 from typing import Optional, TypedDict
 
-from attr import dataclass
-
 from localstack.aws.api.core import ServiceException
-from localstack.aws.api.events import Arn, EventBusName, TagList
+from localstack.aws.api.events import (
+    Arn,
+    EventBusName,
+    EventPattern,
+    RoleArn,
+    RuleDescription,
+    RuleName,
+    RuleState,
+    ScheduleExpression,
+    TagList,
+)
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -12,12 +21,43 @@ from localstack.services.stores import (
 
 
 @dataclass
+class Rule:
+    name: RuleName
+    region: str
+    account_id: str
+    schedule_expression: Optional[ScheduleExpression] = None
+    event_pattern: Optional[EventPattern] = None
+    state: RuleState = RuleState.ENABLED
+    description: Optional[RuleDescription] = None
+    role_arn: Optional[RoleArn] = None
+    tags: TagList = field(default_factory=list)
+    event_bus_name: EventBusName = "default"
+    targets: TagList = field(default_factory=list)
+    arn: Arn = field(init=False)
+
+    def __post_init__(self):
+        if self.event_bus_name != "default":
+            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.event_bus_name}/{self.name}"
+        else:
+            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.name}"
+
+
+RuleDict = dict[RuleName, Rule]
+
+
+@dataclass
 class EventBus:
-    name: str
-    arn: Arn
-    policy: Optional[str]
-    event_source_name: Optional[str]
-    tags: Optional[TagList]
+    name: EventBusName
+    region: str
+    account_id: str
+    event_source_name: Optional[str] = None
+    tags: TagList = field(default_factory=list)
+    policy: Optional[str] = None
+    rules: RuleDict = field(default_factory=dict)
+    arn: Arn = field(init=False)
+
+    def __post_init__(self):
+        self.arn = f"arn:aws:events:{self.region}:{self.account_id}:event-bus/{self.name}"
 
 
 EventBusDict = dict[EventBusName, EventBus]
@@ -39,15 +79,20 @@ class Event(TypedDict, total=False):
 EventList = list[Event]
 
 
-class ValidationException(ServiceException):
-    code: str = "ValidationException"
-    sender_fault: bool = True
-    status_code: int = 400
-
-
 class EventsStore(BaseStore):
     # Map of eventbus names to eventbus objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     event_buses: EventBusDict = LocalAttribute(default=dict)
 
 
 events_store = AccountRegionBundle("events", EventsStore)
+
+
+#######
+# Types
+#######
+
+
+class ValidationException(ServiceException):
+    code: str = "ValidationException"
+    sender_fault: bool = True
+    status_code: int = 400

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -44,10 +44,10 @@ class Rule:
     arn: Arn = field(init=False)
 
     def __post_init__(self):
-        if self.event_bus_name != "default":
-            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.event_bus_name}/{self.name}"
-        else:
+        if self.event_bus_name == "default":
             self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.name}"
+        else:
+            self.arn = f"arn:aws:events:{self.region}:{self.account_id}:rule/{self.event_bus_name}/{self.name}"
         self.created_by = self.account_id
         if self.tags is None:
             self.tags = []

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -14,12 +14,16 @@ from localstack.aws.api.events import (
     RuleState,
     ScheduleExpression,
     TagList,
+    Target,
+    TargetId,
 )
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
     LocalAttribute,
 )
+
+TargetDict = dict[TargetId, Target]
 
 
 @dataclass
@@ -34,7 +38,7 @@ class Rule:
     role_arn: Optional[RoleArn] = None
     tags: TagList = field(default_factory=list)
     event_bus_name: EventBusName = "default"
-    targets: TagList = field(default_factory=list)
+    targets: TargetDict = field(default_factory=dict)
     managed_by: Optional[ManagedBy] = None  # can only be set by AWS services
     created_by: CreatedBy = field(init=False)
     arn: Arn = field(init=False)
@@ -48,7 +52,7 @@ class Rule:
         if self.tags is None:
             self.tags = []
         if self.targets is None:
-            self.targets = []
+            self.targets = {}
         if self.state is None:
             self.state = RuleState.ENABLED
 

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, TypedDict
+from typing import Optional
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
@@ -82,33 +82,12 @@ class EventBus:
 EventBusDict = dict[EventBusName, EventBus]
 
 
-class Event(TypedDict, total=False):
-    version: str
-    id: str
-    source: str
-    account: str
-    time: str
-    region: str
-    resources: list[str]
-    detail_type: str
-    detail: dict
-    additional_attributes: dict
-
-
-EventList = list[Event]
-
-
 class EventsStore(BaseStore):
     # Map of eventbus names to eventbus objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     event_buses: EventBusDict = LocalAttribute(default=dict)
 
 
 events_store = AccountRegionBundle("events", EventsStore)
-
-
-#######
-# Types
-#######
 
 
 class ValidationException(ServiceException):

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -573,9 +573,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         }
         return {key: value for key, value in rule.items() if value is not None}
 
-    def _delete_target_services(self, ids: TargetIdList | TargetId, rule) -> None:
-        if isinstance(ids, TargetId):
-            ids = [ids]
+    def _delete_target_services(self, ids: TargetIdList, rule) -> None:
         for target_id in ids:
             if target := rule.targets.get(target_id):
                 target_arn = target["Arn"]

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -122,10 +122,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         store = self.get_store(context)
         try:
             if event_bus := self.get_event_bus(name, store):
-                if event_bus_service := self._event_bus_services_store.pop(event_bus.arn):
-                    if rules := getattr(event_bus_service, "rules", None):
-                        self._delete_rule_services(rules)
-                store.event_buses.pop(name)
+                del self._event_bus_services_store[event_bus.arn]
+                if rules := event_bus.rules:
+                    self._delete_rule_services(rules)
+                del store.event_buses[name]
         except ResourceNotFoundException as error:
             return error
 
@@ -551,7 +551,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         if isinstance(rules, Rule):
             rules = {rules.name: rules}
         for rule in rules.values():
-            self._rule_services_store.pop(rule.arn)
+            del self._rule_services_store[rule.arn]
 
     def _rule_dict_to_api_type_list(self, rules: RuleDict) -> RuleResponseList:
         """Return a converted dict of Rule model objects as a list of rules in API type Rule format."""

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -411,8 +411,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         # create default event bus for account region on first call
         default_event_bus_name = "default"
         if default_event_bus_name not in store.event_buses.keys():
-            event_bus_service = EventBusService(default_event_bus_name, region, account_id)
-            self._event_bus_services_store[event_bus_service.arn] = event_bus_service
+            event_bus_service = self.create_event_bus_service(
+                default_event_bus_name, region, account_id, None, None
+            )
             store.event_buses[event_bus_service.event_bus.name] = event_bus_service.event_bus
         return store
 

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -2,58 +2,50 @@ from __future__ import annotations
 
 import base64
 import logging
+from typing import Optional
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.events import (
+    Boolean,
     CreateEventBusResponse,
     DescribeEventBusResponse,
+    DescribeRuleResponse,
     EventBusList,
     EventBusName,
     EventBusNameOrArn,
+    EventPattern,
     EventsApi,
     EventSourceName,
     InternalException,
     LimitMax100,
     ListEventBusesResponse,
+    ListRuleNamesByTargetResponse,
     ListRulesResponse,
     NextToken,
+    PutRuleResponse,
     ResourceAlreadyExistsException,
     ResourceNotFoundException,
+    RoleArn,
+    RuleDescription,
     RuleName,
+    RuleState,
+    ScheduleExpression,
     TagList,
+    TargetArn,
 )
 from localstack.aws.api.events import EventBus as ApiTypeEventBus
+from localstack.services.events.event_bus import EventBusWorker, EventBusWorkerDict
 from localstack.services.events.models_v2 import EventBus, EventBusDict, EventsStore, events_store
+from localstack.services.events.rule import RuleWorker, RuleWorkerDict
 from localstack.services.plugins import ServiceLifecycleHook
 
 LOG = logging.getLogger(__name__)
 
 
-def event_bus_dict_to_api_type_event_bus(event_bus: EventBus) -> ApiTypeEventBus:
-    if event_bus.policy:
-        event_bus = {
-            "Name": event_bus.name,
-            "Arn": event_bus.arn,
-            "Policy": event_bus.policy,
-        }
-    else:
-        event_bus = {
-            "Name": event_bus.name,
-            "Arn": event_bus.arn,
-        }
-    return event_bus
-
-
-def event_bust_dict_to_list(event_buses: EventBusDict) -> EventBusList:
-    event_bus_list = [
-        event_bus_dict_to_api_type_event_bus(event_bus) for event_bus in event_buses.values()
-    ]
-    return event_bus_list
-
-
 class EventsProvider(EventsApi, ServiceLifecycleHook):
     def __init__(self):
-        self._events_workers = {}
+        self._event_bus_workers: EventBusWorkerDict = {}
+        self._rule_workers: RuleWorkerDict = {}
 
     ##########
     # EventBus
@@ -68,16 +60,17 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         tags: TagList = None,
         **kwargs,
     ) -> CreateEventBusResponse:
-        account_id = context.account_id
         region = context.region
-        store = self._get_store(account_id, region)
+        account_id = context.account_id
+        store = self.get_store(context)
         if name in store.event_buses.keys():
             raise ResourceAlreadyExistsException(f"Event bus {name} already exists.")
-        event_bus = self._create_event_bus(name, account_id, region, event_source_name, tags)
-        store.event_buses[event_bus.name] = event_bus
-
+        event_bus_worker = self.create_event_bus_worker(
+            name, region, account_id, event_source_name, tags
+        )
+        store.event_buses[event_bus_worker.event_bus.name] = event_bus_worker.event_bus
         response = CreateEventBusResponse(
-            EventBusArn=event_bus.arn,
+            EventBusArn=event_bus_worker.arn,
         )
         return response
 
@@ -85,9 +78,12 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     def delete_event_bus(self, context: RequestContext, name: EventBusName, **kwargs) -> None:
         if name == "default":
             raise InternalException("ValidationException", "Cannot delete event bus default.")
-        store = self._get_store(context.account_id, context.region)
+        store = self.get_store(context)
         try:
-            if self._get_event_bus(name, store):
+            if event_bus := self.get_event_bus(name, store):
+                if event_bus_worker := self._event_bus_workers.pop(event_bus.arn):
+                    if rules := getattr(event_bus_worker, "rules", None):
+                        self._delete_rule_workers(rules)
                 del store.event_buses[name]
         except ResourceNotFoundException as e:
             return e
@@ -101,7 +97,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         limit: LimitMax100 = None,
         **kwargs,
     ) -> ListEventBusesResponse:
-        store = self._get_store(context.account_id, context.region)
+        store = self.get_store(context)
         event_buses = (
             self._get_filtered_event_buses(name_prefix, store.event_buses)
             if name_prefix
@@ -119,7 +115,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             else None
         )
 
-        response = {"EventBuses": event_bust_dict_to_list(limited_event_buses)}
+        response = {"EventBuses": self._event_bust_dict_to_list(limited_event_buses)}
         if next_token is not None:
             response["NextToken"] = next_token
         return response
@@ -129,13 +125,75 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self, context: RequestContext, name: EventBusNameOrArn = None, **kwargs
     ) -> DescribeEventBusResponse:
         name = self._extract_event_bus_name(name)
-        store = self._get_store(context.account_id, context.region)
-        event_bus = self._get_event_bus(name, store)
-        return event_bus_dict_to_api_type_event_bus(event_bus)
+        store = self.get_store(context)
+        event_bus = self.get_event_bus(name, store)
+        response = self._event_bus_dict_to_api_type_event_bus(event_bus)
+        return response
 
     #######
     # Rules
     #######
+
+    @handler("PutRule")
+    def put_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        schedule_expression: ScheduleExpression = None,
+        event_pattern: EventPattern = None,
+        state: RuleState = None,
+        description: RuleDescription = None,
+        role_arn: RoleArn = None,
+        tags: TagList = None,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> PutRuleResponse:
+        region = context.region
+        account_id = context.account_id
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        store = self.get_store(context)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        existing_rule = event_bus.rules.get(name)
+        targets = existing_rule.targets if existing_rule else None
+        # TODO use _get_rule_worker and add logic to auto create rule worker if not exist
+        rule_worker = RuleWorker(
+            name,
+            region,
+            account_id,
+            schedule_expression,
+            event_pattern,
+            state,
+            description,
+            role_arn,
+            tags,
+            event_bus_name,
+            targets,
+        )
+        self._rule_workers[rule_worker.arn] = rule_worker
+        event_bus.rules[name] = rule_worker.rule
+        response = PutRuleResponse(RuleArn=rule_worker.arn)
+        return response
+
+    @handler("DeleteRule")
+    def delete_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        force: Boolean = None,
+        **kwargs,
+    ) -> None:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        if rule := event_bus.rules.get(name):
+            rule_worker = self._rule_workers[rule.arn]
+            rule_worker.delete()
+            self._rule_workers.pop(name)
+            # self._event_bus_workers[event_bus_name].rules.pop(name)
+            del event_bus.rules[name]
+        else:
+            return
 
     @handler("ListRules")
     def list_rules(
@@ -149,36 +207,82 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> ListRulesResponse:
         return {"Rules": []}  # TODO implement
 
-    def _get_store(self, account_id: str, region: str) -> EventsStore:
+    @handler("ListRuleNamesByTarget")
+    def list_rule_names_by_target(
+        self,
+        context: RequestContext,
+        target_arn: TargetArn,
+        event_bus_name: EventBusNameOrArn = None,
+        next_token: NextToken = None,
+        limit: LimitMax100 = None,
+        **kwargs,
+    ) -> ListRuleNamesByTargetResponse:
+        raise NotImplementedError  # TODO implement
+
+    @handler("DescribeRule")
+    def describe_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> DescribeRuleResponse:
+        raise NotImplementedError  # TODO implement
+
+    @handler("DisableRule")
+    def disable_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> None:
+        raise NotImplementedError  # TODO implement
+
+    @handler("EnableRule")
+    def enable_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> None:
+        raise NotImplementedError  # TODO implement
+
+    def get_store(self, context: RequestContext) -> EventsStore:
+        region = context.region
+        account_id = context.account_id
         store = events_store[account_id][region]
         # create default event bus on first call
         name = "default"
         if name not in store.event_buses.keys():
-            event_bus = self._create_event_bus(name, account_id, region)
-            store.event_buses[event_bus.name] = event_bus
-
+            event_bus_worker = EventBusWorker(name, region, account_id)
+            self._event_bus_workers[event_bus_worker.arn] = event_bus_worker
+            store.event_buses[event_bus_worker.event_bus.name] = event_bus_worker.event_bus
         return store
 
-    def _create_event_bus(
-        self,
-        name: EventBusName,
-        account_id: str,
-        region: str,
-        policy: str | None = None,
-        event_source_name: EventSourceName | None = None,
-        tags: TagList = None,
-    ) -> EventBus:
-        arn = self._get_event_bus_arn(name, region, account_id)
-        event_bus = EventBus(name, arn, policy, event_source_name, tags)
-        return event_bus
-
-    def _get_event_bus_arn(self, name: EventBusName, region: str, account_id: str) -> str:
-        return f"arn:aws:events:{region}:{account_id}:event-bus/{name}"
-
-    def _get_event_bus(self, name: EventBusName, store: EventsStore) -> EventBus:
+    def get_event_bus(self, name: EventBusName, store: EventsStore) -> EventBus:
         if name not in store.event_buses.keys():
             raise ResourceNotFoundException(f"Event bus {name} does not exist.")
         return store.event_buses[name]
+
+    def create_event_bus_worker(
+        self,
+        name: EventBusName,
+        region: str,
+        account_id: str,
+        event_source_name: Optional[EventSourceName],
+        tags: Optional[TagList],
+    ) -> EventBusWorker:
+        event_bus_worker = EventBusWorker(
+            name,
+            region,
+            account_id,
+            event_source_name,
+            tags,
+        )
+        self._event_bus_workers[event_bus_worker.arn] = event_bus_worker
+        return event_bus_worker
 
     def _get_filtered_event_buses(
         self, name_prefix: EventBusName, event_buses: EventBusDict
@@ -201,3 +305,28 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         if not event_bus_name_or_arn:
             return "default"
         return event_bus_name_or_arn.split("/")[-1]
+
+    def _event_bus_dict_to_api_type_event_bus(self, event_bus: EventBus) -> ApiTypeEventBus:
+        if event_bus.policy:
+            event_bus = {
+                "Name": event_bus.name,
+                "Arn": event_bus.arn,
+                "Policy": event_bus.policy,
+            }
+        else:
+            event_bus = {
+                "Name": event_bus.name,
+                "Arn": event_bus.arn,
+            }
+        return event_bus
+
+    def _event_bust_dict_to_list(self, event_buses: EventBusDict) -> EventBusList:
+        event_bus_list = [
+            self._event_bus_dict_to_api_type_event_bus(event_bus)
+            for event_bus in event_buses.values()
+        ]
+        return event_bus_list
+
+    def _delete_rule_workers(self, rules: RuleWorkerDict) -> None:
+        for rule in rules.values():
+            self._rule_workers.pop(rule.arn)

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import logging
 from typing import Optional

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -552,6 +552,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         return event_bus
 
     def _delete_rule_services(self, rules: RuleDict | Rule) -> None:
+        """
+        Delete all rule services associated to the input from the store.
+        Accepts a single Rule object or a dict of Rule objects as input.
+        """
         if isinstance(rules, Rule):
             rules = {rules.name: rules}
         for rule in rules.values():

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -571,7 +571,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             "EventBusName": rule.event_bus_name,
             "CreatedBy": rule.created_by,
         }
-        return {k: v for k, v in rule.items() if v is not None and v != {} and v != []}
+        return {key: value for key, value in rule.items() if value is not None}
 
     def _delete_target_services(self, ids: TargetIdList | TargetId, rule) -> None:
         if isinstance(ids, TargetId):

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -530,18 +530,14 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         return event_bus_list
 
     def _event_bus_dict_to_api_type_event_bus(self, event_bus: EventBus) -> ApiTypeEventBus:
+        event_bus_api_type = {
+            "Name": event_bus.name,
+            "Arn": event_bus.arn,
+        }
         if event_bus.policy:
-            event_bus = {
-                "Name": event_bus.name,
-                "Arn": event_bus.arn,
-                "Policy": event_bus.policy,
-            }
-        else:
-            event_bus = {
-                "Name": event_bus.name,
-                "Arn": event_bus.arn,
-            }
-        return event_bus
+            event_bus_api_type["Policy"] = event_bus.policy
+
+        return event_bus_api_type
 
     def _delete_rule_services(self, rules: RuleDict | Rule) -> None:
         """

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -321,7 +321,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus_name = self._extract_event_bus_name(event_bus_name)
         event_bus = self.get_event_bus(event_bus_name, store)
         rule = self.get_rule(rule, event_bus)
-        targets = getattr(rule, "targets", {})
+        targets = rule.targets
         limited_targets, next_token = self._get_limited_dict_and_next_token(
             targets, next_token, limit
         )

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -55,6 +55,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     def __init__(self):
         self._events_workers = {}
 
+    ##########
+    # EventBus
+    ##########
+
     @handler("CreateEventBus")
     def create_event_bus(
         self,
@@ -128,6 +132,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         store = self._get_store(context.account_id, context.region)
         event_bus = self._get_event_bus(name, store)
         return event_bus_dict_to_api_type_event_bus(event_bus)
+
+    #######
+    # Rules
+    #######
 
     @handler("ListRules")
     def list_rules(

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -285,8 +285,8 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus_name = self._extract_event_bus_name(event_bus_name)
         store = self.get_store(context)
         event_bus = self.get_event_bus(event_bus_name, store)
-        existing_rule = getattr(event_bus, "rules", {}).get(name, None)
-        targets = getattr(existing_rule, "targets", None) if existing_rule else None
+        existing_rule = event_bus.rules.get(name)
+        targets = existing_rule.targets if existing_rule else None
         rule_service = self.create_rule_service(
             name,
             region,

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.events import (
+    Arn,
     Boolean,
     CreateEventBusResponse,
     DescribeEventBusResponse,
@@ -17,7 +18,6 @@ from localstack.aws.api.events import (
     EventPattern,
     EventsApi,
     EventSourceName,
-    InternalException,
     LimitMax100,
     ListEventBusesResponse,
     ListRuleNamesByTargetResponse,
@@ -55,20 +55,34 @@ from localstack.services.events.models_v2 import (
     EventsStore,
     Rule,
     RuleDict,
+    TargetDict,
+    ValidationException,
     events_store,
 )
 from localstack.services.events.rule import RuleWorker, RuleWorkerDict
-from localstack.services.events.target import TargetWorker, TargetWorkerFactory
+from localstack.services.events.target import TargetWorker, TargetWorkerDict, TargetWorkerFactory
 from localstack.services.plugins import ServiceLifecycleHook
 
 LOG = logging.getLogger(__name__)
 
 
+def decode_next_token(token: NextToken) -> int:
+    """Decode a pagination token from base64 to integer."""
+    return int.from_bytes(base64.b64decode(token), "big")
+
+
+def encode_next_token(token: int) -> NextToken:
+    """Encode a pagination token to base64 from integer."""
+    return base64.b64encode(token.to_bytes(128, "big")).decode("utf-8")
+
+
 class EventsProvider(EventsApi, ServiceLifecycleHook):
+    # api methods are grouped by resource type and sorted in hierarchical order
+    # each group is sorted alphabetically
     def __init__(self):
         self._event_bus_workers: EventBusWorkerDict = {}
         self._rule_workers: RuleWorkerDict = {}
-        self._target_workers: TargetWorker = {}
+        self._target_workers: TargetWorkerDict = {}
 
     ##########
     # EventBus
@@ -92,6 +106,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             name, region, account_id, event_source_name, tags
         )
         store.event_buses[event_bus_worker.event_bus.name] = event_bus_worker.event_bus
+
         response = CreateEventBusResponse(
             EventBusArn=event_bus_worker.arn,
         )
@@ -100,7 +115,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     @handler("DeleteEventBus")
     def delete_event_bus(self, context: RequestContext, name: EventBusName, **kwargs) -> None:
         if name == "default":
-            raise InternalException("ValidationException", "Cannot delete event bus default.")
+            raise ValidationException("Cannot delete event bus default.")
         store = self.get_store(context)
         try:
             if event_bus := self.get_event_bus(name, store):
@@ -110,6 +125,17 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 store.event_buses.pop(name)
         except ResourceNotFoundException as error:
             return error
+
+    @handler("DescribeEventBus")
+    def describe_event_bus(
+        self, context: RequestContext, name: EventBusNameOrArn = None, **kwargs
+    ) -> DescribeEventBusResponse:
+        name = self._extract_event_bus_name(name)
+        store = self.get_store(context)
+        event_bus = self.get_event_bus(name, store)
+
+        response = self._event_bus_dict_to_api_type_event_bus(event_bus)
+        return response
 
     @handler("ListEventBuses")
     def list_event_buses(
@@ -122,40 +148,127 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> ListEventBusesResponse:
         store = self.get_store(context)
         event_buses = (
-            self._get_filtered_dict(name_prefix, store.event_buses)
+            EventsProvider.get_filtered_dict(name_prefix, store.event_buses)
             if name_prefix
             else store.event_buses
         )
-        event_buses_len = len(event_buses)
-        start_index = self._decode_next_token(next_token) if next_token is not None else 0
-        end_index = start_index + limit if limit is not None else event_buses_len
-        limited_event_buses = dict(list(event_buses.items())[start_index:end_index])
-
-        next_token = (
-            self._encode_next_token(end_index)
-            # return a next_token (encoded integer of next starting index) if not all event buses are returned
-            if end_index < event_buses_len
-            else None
+        limited_event_buses, next_token = self._get_limited_dict_and_next_token(
+            event_buses, next_token, limit
         )
 
-        response = {"EventBuses": self._event_bust_dict_to_list(limited_event_buses)}
+        response = ListEventBusesResponse(
+            EventBuses=self._event_bust_dict_to_api_type_list(limited_event_buses)
+        )
         if next_token is not None:
             response["NextToken"] = next_token
-        return response
-
-    @handler("DescribeEventBus")
-    def describe_event_bus(
-        self, context: RequestContext, name: EventBusNameOrArn = None, **kwargs
-    ) -> DescribeEventBusResponse:
-        name = self._extract_event_bus_name(name)
-        store = self.get_store(context)
-        event_bus = self.get_event_bus(name, store)
-        response = self._event_bus_dict_to_api_type_event_bus(event_bus)
         return response
 
     #######
     # Rules
     #######
+    @handler("EnableRule")
+    def enable_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> None:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        rule = self.get_rule(name, event_bus)
+        rule.state = RuleState.ENABLED
+
+    @handler("DeleteRule")
+    def delete_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        force: Boolean = None,
+        **kwargs,
+    ) -> None:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        try:
+            rule = self.get_rule(name, event_bus)
+            if rule.targets and not force:
+                raise ValidationException("Rule can't be deleted since it has targets.")
+            self._delete_rule_workers(rule)
+            del event_bus.rules[name]
+        except ResourceNotFoundException as error:
+            return error
+
+    @handler("DescribeRule")
+    def describe_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> DescribeRuleResponse:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        rule = self.get_rule(name, event_bus)
+
+        response = self._rule_dict_to_api_type_rule(rule)
+        if created_by := getattr(rule, "created_by", None):
+            response["CreatedBy"] = created_by
+        return response
+
+    @handler("DisableRule")
+    def disable_rule(
+        self,
+        context: RequestContext,
+        name: RuleName,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> None:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        rule = self.get_rule(name, event_bus)
+        rule.state = RuleState.DISABLED
+
+    @handler("ListRules")
+    def list_rules(
+        self,
+        context: RequestContext,
+        name_prefix: RuleName = None,
+        event_bus_name: EventBusNameOrArn = None,
+        next_token: NextToken = None,
+        limit: LimitMax100 = None,
+        **kwargs,
+    ) -> ListRulesResponse:
+        store = self.get_store(context)
+        event_bus_name = self._extract_event_bus_name(event_bus_name)
+        event_bus = self.get_event_bus(event_bus_name, store)
+        rules = (
+            EventsProvider.get_filtered_dict(name_prefix, event_bus.rules)
+            if name_prefix
+            else event_bus.rules
+        )
+        limited_rules, next_token = self._get_limited_dict_and_next_token(rules, next_token, limit)
+
+        response = ListRulesResponse(Rules=list(self._rule_dict_to_api_type_list(limited_rules)))
+        if next_token is not None:
+            response["NextToken"] = next_token
+        return response
+
+    @handler("ListRuleNamesByTarget")
+    def list_rule_names_by_target(
+        self,
+        context: RequestContext,
+        target_arn: TargetArn,
+        event_bus_name: EventBusNameOrArn = None,
+        next_token: NextToken = None,
+        limit: LimitMax100 = None,
+        **kwargs,
+    ) -> ListRuleNamesByTargetResponse:
+        raise NotImplementedError
 
     @handler("PutRule")
     def put_rule(
@@ -178,8 +291,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus = self.get_event_bus(event_bus_name, store)
         existing_rule = getattr(event_bus, "rules", {}).get(name, None)
         targets = getattr(existing_rule, "targets", None) if existing_rule else None
-        # TODO use _get_rule_worker and add logic to auto create rule worker if not exist
-        rule_worker = RuleWorker(
+        rule_worker = self.create_rule_worker(
             name,
             region,
             account_id,
@@ -192,162 +304,13 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             event_bus_name,
             targets,
         )
-        self._rule_workers[rule_worker.arn] = rule_worker
         event_bus.rules[name] = rule_worker.rule
         response = PutRuleResponse(RuleArn=rule_worker.arn)
         return response
 
-    @handler("DeleteRule")
-    def delete_rule(
-        self,
-        context: RequestContext,
-        name: RuleName,
-        event_bus_name: EventBusNameOrArn = None,
-        force: Boolean = None,
-        **kwargs,
-    ) -> None:
-        store = self.get_store(context)
-        event_bus_name = self._extract_event_bus_name(event_bus_name)
-        event_bus = self.get_event_bus(event_bus_name, store)
-        try:
-            rule = self.get_rule(name, event_bus)
-            self._delete_rule_workers(rule)
-            del event_bus.rules[name]
-        except ResourceNotFoundException as error:
-            return error
-
-    @handler("ListRules")
-    def list_rules(
-        self,
-        context: RequestContext,
-        name_prefix: RuleName = None,
-        event_bus_name: EventBusNameOrArn = None,
-        next_token: NextToken = None,
-        limit: LimitMax100 = None,
-        **kwargs,
-    ) -> ListRulesResponse:
-        store = self.get_store(context)
-        event_bus_name = self._extract_event_bus_name(event_bus_name)
-        event_bus = self.get_event_bus(event_bus_name, store)
-        rules = (
-            self._get_filtered_dict(name_prefix, event_bus.rules)
-            if name_prefix
-            else event_bus.rules
-        )
-        rules_len = len(rules)
-        start_index = self._decode_next_token(next_token) if next_token is not None else 0
-        end_index = start_index + limit if limit is not None else rules_len
-        limited_rules = dict(list(rules.items())[start_index:end_index])
-
-        next_token = (
-            self._encode_next_token(end_index)
-            # return a next_token (encoded integer of next starting index) if not all rules are returned
-            if end_index < rules_len
-            else None
-        )
-
-        response = {"Rules": list(self._rule_dict_to_list(limited_rules))}
-        if next_token is not None:
-            response["NextToken"] = next_token
-        return response
-
-    @handler("ListRuleNamesByTarget")
-    def list_rule_names_by_target(
-        self,
-        context: RequestContext,
-        target_arn: TargetArn,
-        event_bus_name: EventBusNameOrArn = None,
-        next_token: NextToken = None,
-        limit: LimitMax100 = None,
-        **kwargs,
-    ) -> ListRuleNamesByTargetResponse:
-        raise NotImplementedError  # TODO implement
-
-    @handler("DescribeRule")
-    def describe_rule(
-        self,
-        context: RequestContext,
-        name: RuleName,
-        event_bus_name: EventBusNameOrArn = None,
-        **kwargs,
-    ) -> DescribeRuleResponse:
-        store = self.get_store(context)
-        event_bus_name = self._extract_event_bus_name(event_bus_name)
-        event_bus = self.get_event_bus(event_bus_name, store)
-        rule = self.get_rule(name, event_bus)
-        response = self._rule_dict_to_api_type_rule(rule)
-        if created_by := getattr(rule, "created_by", None):
-            response["CreatedBy"] = created_by
-        return response
-
-    @handler("DisableRule")
-    def disable_rule(
-        self,
-        context: RequestContext,
-        name: RuleName,
-        event_bus_name: EventBusNameOrArn = None,
-        **kwargs,
-    ) -> None:
-        store = self.get_store(context)
-        event_bus_name = self._extract_event_bus_name(event_bus_name)
-        event_bus = self.get_event_bus(event_bus_name, store)
-        rule = self.get_rule(name, event_bus)
-        rule.state = RuleState.DISABLED
-
-    @handler("EnableRule")
-    def enable_rule(
-        self,
-        context: RequestContext,
-        name: RuleName,
-        event_bus_name: EventBusNameOrArn = None,
-        **kwargs,
-    ) -> None:
-        store = self.get_store(context)
-        event_bus_name = self._extract_event_bus_name(event_bus_name)
-        event_bus = self.get_event_bus(event_bus_name, store)
-        rule = self.get_rule(name, event_bus)
-        rule.state = RuleState.ENABLED
-
     #########
     # Targets
     #########
-
-    @handler("PutTargets")
-    def put_targets(
-        self,
-        context: RequestContext,
-        rule: RuleName,
-        targets: TargetList,
-        event_bus_name: EventBusNameOrArn = None,
-        **kwargs,
-    ) -> PutTargetsResponse:
-        region = context.region
-        account_id = context.account_id
-        rule_worker = self.get_rule_worker(context, rule, event_bus_name)
-        failed_entries = rule_worker.validate_targets_input(targets)
-        rule_worker.add_targets(targets)
-        rule_arn = rule_worker.arn
-        for target in targets:
-            target_worker = TargetWorkerFactory(
-                region, account_id, target, rule_arn
-            ).get_target_worker()
-            self._target_workers[target_worker.arn] = target_worker
-        return {"FailedEntries": failed_entries, "FailedEntryCount": len(failed_entries)}
-
-    @handler("RemoveTargets")
-    def remove_targets(
-        self,
-        context: RequestContext,
-        rule: RuleName,
-        ids: TargetIdList,
-        event_bus_name: EventBusNameOrArn = None,
-        force: Boolean = None,
-        **kwargs,
-    ) -> RemoveTargetsResponse:
-        rule_worker = self.get_rule_worker(context, rule, event_bus_name)
-        failed_entries = rule_worker.remove_targets(ids)
-        self._delete_target_workers(ids, rule_worker.rule)
-        return {"FailedEntries": failed_entries, "FailedEntryCount": len(failed_entries)}
 
     @handler("ListTargetsByRule")
     def list_targets_by_rule(
@@ -363,22 +326,55 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus_name = self._extract_event_bus_name(event_bus_name)
         event_bus = self.get_event_bus(event_bus_name, store)
         rule = self.get_rule(rule, event_bus)
-        targets = rule.targets
-        targets_len = len(targets)
-        start_index = self._decode_next_token(next_token) if next_token is not None else 0
-        end_index = start_index + limit if limit is not None else targets_len
-        limited_targets = dict(list(targets.items())[start_index:end_index])
-
-        next_token = (
-            self._encode_next_token(end_index)
-            # return a next_token (encoded integer of next starting index) if not all targets are returned
-            if end_index < targets_len
-            else None
+        targets = getattr(rule, "targets", {})
+        limited_targets, next_token = self._get_limited_dict_and_next_token(
+            targets, next_token, limit
         )
 
-        response = {"Targets": list(limited_targets.values())}
+        response = ListTargetsByRuleResponse(Targets=list(limited_targets.values()))
         if next_token is not None:
             response["NextToken"] = next_token
+        return response
+
+    @handler("PutTargets")
+    def put_targets(
+        self,
+        context: RequestContext,
+        rule: RuleName,
+        targets: TargetList,
+        event_bus_name: EventBusNameOrArn = None,
+        **kwargs,
+    ) -> PutTargetsResponse:
+        region = context.region
+        account_id = context.account_id
+        rule_worker = self.get_rule_worker(context, rule, event_bus_name)
+        failed_entries = rule_worker.add_targets(targets)
+        rule_arn = rule_worker.arn
+        for target in targets:
+            self.create_target_worker(target, region, account_id, rule_arn)
+
+        response = PutTargetsResponse(
+            FailedEntryCount=len(failed_entries), FailedEntries=failed_entries
+        )
+        return response
+
+    @handler("RemoveTargets")
+    def remove_targets(
+        self,
+        context: RequestContext,
+        rule: RuleName,
+        ids: TargetIdList,
+        event_bus_name: EventBusNameOrArn = None,
+        force: Boolean = None,
+        **kwargs,
+    ) -> RemoveTargetsResponse:
+        rule_worker = self.get_rule_worker(context, rule, event_bus_name)
+        failed_entries = rule_worker.remove_targets(ids)
+        self._delete_target_workers(ids, rule_worker.rule)
+
+        response = RemoveTargetsResponse(
+            FailedEntryCount=len(failed_entries), FailedEntries=failed_entries
+        )
         return response
 
     ########
@@ -394,7 +390,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         **kwargs,
     ) -> PutEventsResponse:
         failed_entries = self._put_entries(context, entries)
-        return {"FailedEntries": failed_entries, "FailedEntryCount": len(failed_entries)}
+
+        response = PutEventsResponse(FailedEntryCount=len(failed_entries), Entries=failed_entries)
+        return response
 
     @handler("PutPartnerEvents")
     def put_partner_events(
@@ -402,22 +400,28 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> PutPartnerEventsResponse:
         raise NotImplementedError
 
+    #########
+    # Methods
+    #########
+
     def get_store(self, context: RequestContext) -> EventsStore:
+        """Returns the events store for the account and region.
+        On first call, creates the default event bus for the account region."""
         region = context.region
         account_id = context.account_id
         store = events_store[account_id][region]
-        # create default event bus on first call
-        name = "default"
-        if name not in store.event_buses.keys():
-            event_bus_worker = EventBusWorker(name, region, account_id)
+        # create default event bus for account region on first call
+        default_event_bus_name = "default"
+        if default_event_bus_name not in store.event_buses.keys():
+            event_bus_worker = EventBusWorker(default_event_bus_name, region, account_id)
             self._event_bus_workers[event_bus_worker.arn] = event_bus_worker
             store.event_buses[event_bus_worker.event_bus.name] = event_bus_worker.event_bus
         return store
 
     def get_event_bus(self, name: EventBusName, store: EventsStore) -> EventBus:
-        if name not in store.event_buses.keys():
-            raise ResourceNotFoundException(f"Event bus {name} does not exist.")
-        return store.event_buses[name]
+        if event_bus := store.event_buses.get(name):
+            return event_bus
+        raise ResourceNotFoundException(f"Event bus {name} does not exist.")
 
     def get_rule(self, name: RuleName, event_bus: EventBus) -> Rule:
         if rule := event_bus.rules.get(name):
@@ -430,12 +434,12 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         raise ResourceNotFoundException(f"Target {target_id} does not exist on Rule {rule.name}.")
 
     def get_rule_worker(
-        self, context: RequestContext, rule: RuleName, event_bus_name: EventBusName
+        self, context: RequestContext, rule_name: RuleName, event_bus_name: EventBusName
     ) -> RuleWorker:
         store = self.get_store(context)
         event_bus_name = self._extract_event_bus_name(event_bus_name)
         event_bus = self.get_event_bus(event_bus_name, store)
-        rule = self.get_rule(rule, event_bus)
+        rule = self.get_rule(rule_name, event_bus)
         return self._rule_workers[rule.arn]
 
     def create_event_bus_worker(
@@ -456,21 +460,83 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self._event_bus_workers[event_bus_worker.arn] = event_bus_worker
         return event_bus_worker
 
-    def _get_filtered_dict(self, name_prefix: str, input_dict: dict) -> dict:
+    def create_rule_worker(
+        self,
+        name: RuleName,
+        region: str,
+        account_id: str,
+        schedule_expression: Optional[ScheduleExpression],
+        event_pattern: Optional[EventPattern],
+        state: Optional[RuleState],
+        description: Optional[RuleDescription],
+        role_arn: Optional[RoleArn],
+        tags: Optional[TagList],
+        event_bus_name: Optional[EventBusName],
+        targets: Optional[TargetDict],
+    ) -> RuleWorker:
+        rule_worker = RuleWorker(
+            name,
+            region,
+            account_id,
+            schedule_expression,
+            event_pattern,
+            state,
+            description,
+            role_arn,
+            tags,
+            event_bus_name,
+            targets,
+        )
+        self._rule_workers[rule_worker.arn] = rule_worker
+        return rule_worker
+
+    def create_target_worker(
+        self, target: Target, region: str, account_id: str, rule_arn: Arn
+    ) -> TargetWorker:
+        target_worker = TargetWorkerFactory(
+            target, region, account_id, rule_arn
+        ).get_target_worker()
+        self._target_workers[target_worker.arn] = target_worker
+        return target_worker
+
+    @staticmethod
+    def get_filtered_dict(name_prefix: str, input_dict: dict) -> dict:
+        """Filter dictionary by prefix."""
         return {name: value for name, value in input_dict.items() if name.startswith(name_prefix)}
 
-    def _encode_next_token(self, token: int) -> NextToken:
-        return base64.b64encode(token.to_bytes(128, "big")).decode("utf-8")
+    def _get_limited_dict_and_next_token(
+        self, input_dict: dict, next_token: NextToken | None, limit: LimitMax100 | None
+    ) -> tuple[dict, NextToken]:
+        """Return a slice of the given dictionary starting from next_token with length of limit
+        and new last index encoded as a next_token for pagination."""
+        input_dict_len = len(input_dict)
+        start_index = decode_next_token(next_token) if next_token is not None else 0
+        end_index = start_index + limit if limit is not None else input_dict_len
+        limited_dict = dict(list(input_dict.items())[start_index:end_index])
 
-    def _decode_next_token(self, token: NextToken) -> int:
-        return int.from_bytes(base64.b64decode(token), "big")
+        next_token = (
+            encode_next_token(end_index)
+            # return a next_token (encoded integer of next starting index) if not all items are returned
+            if end_index < input_dict_len
+            else None
+        )
+        return limited_dict, next_token
 
     def _extract_event_bus_name(
         self, event_bus_name_or_arn: EventBusNameOrArn | None
     ) -> EventBusName:
+        """Return the event bus name. Input can be either an event bus name or ARN."""
         if not event_bus_name_or_arn:
             return "default"
         return event_bus_name_or_arn.split("/")[-1]
+
+    def _event_bust_dict_to_api_type_list(self, event_buses: EventBusDict) -> EventBusList:
+        """Return a converted dict of EventBus model objects as a list of event buses in API type EventBus format."""
+        event_bus_list = [
+            self._event_bus_dict_to_api_type_event_bus(event_bus)
+            for event_bus in event_buses.values()
+        ]
+        return event_bus_list
 
     def _event_bus_dict_to_api_type_event_bus(self, event_bus: EventBus) -> ApiTypeEventBus:
         if event_bus.policy:
@@ -486,18 +552,16 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             }
         return event_bus
 
-    def _event_bust_dict_to_list(self, event_buses: EventBusDict) -> EventBusList:
-        event_bus_list = [
-            self._event_bus_dict_to_api_type_event_bus(event_bus)
-            for event_bus in event_buses.values()
-        ]
-        return event_bus_list
-
     def _delete_rule_workers(self, rules: RuleDict | Rule) -> None:
         if isinstance(rules, Rule):
             rules = {rules.name: rules}
         for rule in rules.values():
             self._rule_workers.pop(rule.arn)
+
+    def _rule_dict_to_api_type_list(self, rules: RuleDict) -> RuleResponseList:
+        """Return a converted dict of Rule model objects as a list of rules in API type Rule format."""
+        rule_list = [self._rule_dict_to_api_type_rule(rule) for rule in rules.values()]
+        return rule_list
 
     def _rule_dict_to_api_type_rule(self, rule: Rule) -> ApiTypeRule:
         rule = {
@@ -512,10 +576,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             "EventBusName": rule.event_bus_name,
         }
         return {k: v for k, v in rule.items() if v is not None and v != {} and v != []}
-
-    def _rule_dict_to_list(self, rules: RuleDict) -> RuleResponseList:
-        rule_list = [self._rule_dict_to_api_type_rule(rule) for rule in rules.values()]
-        return rule_list
 
     def _delete_target_workers(self, ids: TargetIdList | TargetId, rule) -> None:
         if isinstance(ids, TargetId):

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -213,8 +213,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule = self.get_rule(name, event_bus)
 
         response = self._rule_dict_to_api_type_rule(rule)
-        if created_by := getattr(rule, "created_by", None):
-            response["CreatedBy"] = created_by
         return response
 
     @handler("DisableRule")
@@ -577,6 +575,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             "RoleArn": rule.role_arn,
             "ManagedBy": rule.managed_by,
             "EventBusName": rule.event_bus_name,
+            "CreatedBy": rule.created_by,
         }
         return {k: v for k, v in rule.items() if v is not None and v != {} and v != []}
 

--- a/localstack/services/events/rule.py
+++ b/localstack/services/events/rule.py
@@ -22,7 +22,7 @@ from localstack.aws.api.events import (
 from localstack.services.events.models_v2 import Rule, TargetDict, ValidationException
 
 
-class RuleWorker:
+class RuleService:
     def __init__(
         self,
         name: RuleName,
@@ -180,4 +180,4 @@ class RuleWorker:
         return False
 
 
-RuleWorkerDict = dict[Arn, RuleWorker]
+RuleServiceDict = dict[Arn, RuleService]

--- a/localstack/services/events/rule.py
+++ b/localstack/services/events/rule.py
@@ -5,6 +5,7 @@ from localstack.aws.api.events import (
     Arn,
     EventBusName,
     EventPattern,
+    ManagedBy,
     RoleArn,
     RuleDescription,
     RuleName,
@@ -29,6 +30,7 @@ class RuleWorker:
         tags: Optional[TagList] = None,
         event_bus_name: Optional[EventBusName] = None,
         targets: Optional[TagList] = None,
+        managed_by: Optional[ManagedBy] = None,
     ):
         self._validate_input(event_pattern, schedule_expression, event_bus_name)
         # required to keep data and functionality separate for persistence
@@ -44,6 +46,7 @@ class RuleWorker:
             tags,
             event_bus_name,
             targets,
+            managed_by,
         )
 
     @property

--- a/localstack/services/events/rule.py
+++ b/localstack/services/events/rule.py
@@ -1,29 +1,91 @@
+import re
+from typing import Optional
+
 from localstack.aws.api.events import (
+    Arn,
+    EventBusName,
+    EventPattern,
     RoleArn,
     RuleDescription,
     RuleName,
     RuleState,
+    ScheduleExpression,
+    TagList,
 )
+from localstack.services.events.models_v2 import Rule, ValidationException
 
 
-class Rule:
+class RuleWorker:
     def __init__(
         self,
         name: RuleName,
-        state: RuleState = RuleState.ENABLED,
-        description: RuleDescription | None = None,
-        role_arn: RoleArn = None,
+        region: Optional[str] = None,
+        account_id: Optional[str] = None,
+        schedule_expression: Optional[ScheduleExpression] = None,
+        event_pattern: Optional[EventPattern] = None,
+        state: Optional[RuleState] = None,
+        description: Optional[RuleDescription] = None,
+        role_arn: Optional[RoleArn] = None,
+        tags: Optional[TagList] = None,
+        event_bus_name: Optional[EventBusName] = None,
+        targets: Optional[TagList] = None,
     ):
-        self.name = name
-        self.state = state
-        self.description = description
-        self.role_arn = role_arn
+        self._validate_input(event_pattern, schedule_expression, event_bus_name)
+        # required to keep data and functionality separate for persistence
+        self.rule = Rule(
+            name,
+            region,
+            account_id,
+            schedule_expression,
+            event_pattern,
+            state,
+            description,
+            role_arn,
+            tags,
+            event_bus_name,
+            targets,
+        )
+
+    @property
+    def arn(self):
+        return self.rule.arn
+
+    @property
+    def state(self):
+        return self.rule.state
 
     def enable(self):
-        self.state = RuleState.ENABLED
+        self.rule.state = RuleState.ENABLED
 
     def disable(self):
-        self.state = RuleState.DISABLED
+        self.rule.state = RuleState.DISABLED
+
+    def delete(self):
+        if len(self.rule.targets) > 0:
+            raise ValidationException("Rule can't be deleted since it has targets.")
+        self.rule.state = RuleState.DISABLED
+
+    def _validate_input(
+        self,
+        event_pattern: Optional[EventPattern],
+        schedule_expression: Optional[ScheduleExpression],
+        event_bus_name: Optional[EventBusName] = "default",
+    ):
+        cron_regex = re.compile(r"^cron\(.*\)")
+        rate_regex = re.compile(r"^rate\(\d*\s(minute|minutes|hour|hours|day|days)\)")
+
+        if not event_pattern and not schedule_expression:
+            raise ValidationException(
+                "Parameter(s) EventPattern or ScheduleExpression must be specified."
+            )
+
+        if schedule_expression:
+            if event_bus_name != "default":
+                raise ValidationException(
+                    "ScheduleExpression is supported only on the default event bus."
+                )
+            if not (cron_regex.match(schedule_expression) or rate_regex.match(schedule_expression)):
+                raise ValidationException("Parameter ScheduleExpression is not valid.")
 
 
-RuleDict = dict[str, Rule]
+RuleWorkerDict = dict[Arn, RuleWorker]

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -307,20 +307,26 @@ class TargetWorkerFactory:
         # TODO api gateway & custom endpoints via http target
     }
 
-    def __init__(self, region: str, account_id: str, target: Target):
+    def __init__(self, region: str, account_id: str, target: Target, rule_arn: Arn):
         self.region = region
         self.account_id = account_id
         self.target = target
+        self.rule_arn = rule_arn
+
+    @staticmethod
+    def extract_service_from_arn(arn: Arn) -> str:
+        arn = parse_arn(arn)
+        return arn["service"]
 
     def get_target_worker(self) -> TargetWorker:
-        target_arn = self.target["Arn"]
-        arn = parse_arn(target_arn)
-        service = arn["service"]
+        service = TargetWorkerFactory.extract_service_from_arn(self.target["Arn"])
         if service in self.target_map:
             target_worker_class = self.target_map[service]
         else:
-            raise Exception(f"Unsupported target for Arn: {target_arn}")
-        target_worker = target_worker_class(self.region, self.account_id, self.target)
+            raise Exception(f"Unsupported target for Service: {service}")
+        target_worker = target_worker_class(
+            self.region, self.account_id, self.target, self.rule_arn, service
+        )
         return target_worker
 
 

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -29,15 +29,15 @@ class TargetWorker(ABC):
 
     def __init__(
         self,
+        target: Target,
         region: str,
         account_id: str,
-        target: Target,
         rule_arn: Arn,
         service: str,
     ):
+        self.target = target
         self.region = region
         self.account_id = account_id
-        self.target = target
         self.rule_arn = rule_arn
         self.service = service
 
@@ -86,6 +86,9 @@ class TargetWorker(ABC):
         else:
             clients = connect_to(aws_access_key_id=self.account_id, region_name=self.region)
         return clients
+
+
+TargetWorkerDict = dict[Arn, TargetWorker]
 
 
 class LambdaTargetWorker(TargetWorker):
@@ -306,10 +309,10 @@ class TargetWorkerFactory:
         # TODO api gateway & custom endpoints via http target
     }
 
-    def __init__(self, region: str, account_id: str, target: Target, rule_arn: Arn):
+    def __init__(self, target: Target, region: str, account_id: str, rule_arn: Arn):
+        self.target = target
         self.region = region
         self.account_id = account_id
-        self.target = target
         self.rule_arn = rule_arn
 
     @staticmethod
@@ -324,7 +327,7 @@ class TargetWorkerFactory:
         else:
             raise Exception(f"Unsupported target for Service: {service}")
         target_worker = target_worker_class(
-            self.region, self.account_id, self.target, self.rule_arn, service
+            self.target, self.region, self.account_id, self.rule_arn, service
         )
         return target_worker
 

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import uuid

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -10,8 +10,8 @@ from localstack.aws.api.events import (
 from localstack.aws.connect import ServiceLevelClientFactory, connect_to
 from localstack.utils import collections
 from localstack.utils.aws.arns import (
+    extract_service_from_arn,
     firehose_name,
-    parse_arn,
     sqs_queue_url_for_arn,
 )
 from localstack.utils.aws.client_types import ServicePrincipal
@@ -300,13 +300,8 @@ class TargetServiceFactory:
         self.account_id = account_id
         self.rule_arn = rule_arn
 
-    @staticmethod
-    def extract_service_from_arn(arn: Arn) -> str:
-        arn = parse_arn(arn)
-        return arn["service"]
-
     def get_target_service(self) -> TargetService:
-        service = TargetServiceFactory.extract_service_from_arn(self.target["Arn"])
+        service = extract_service_from_arn(self.target["Arn"])
         if service in self.target_map:
             target_service_class = self.target_map[service]
         else:

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from abc import ABC, abstractmethod
+
+from localstack.aws.api.events import (
+    Arn,
+    Target,
+    TargetId,
+)
+from localstack.aws.connect import ServiceLevelClientFactory, connect_to
+from localstack.utils import collections
+from localstack.utils.aws.arns import (
+    extract_service_from_arn,
+    firehose_name,
+    parse_arn,
+    sqs_queue_url_for_arn,
+)
+from localstack.utils.aws.client_types import ServicePrincipal
+from localstack.utils.strings import to_bytes
+from localstack.utils.time import now_utc
+
+LOG = logging.getLogger(__name__)
+
+
+class TargetWorker(ABC):
+    """https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html"""
+
+    def __init__(
+        self,
+        region: str,
+        account_id: str,
+        target: Target,
+    ):
+        self.region = region
+        self.account_id = account_id
+        self.target = target
+        self.service = self._extract_service_from_arn(self.arn)
+
+        self._validate_input(self.target)
+        self._client: ServiceLevelClientFactory | None = None
+
+    @property
+    def arn(self):
+        return self.target["Arn"]
+
+    @abstractmethod
+    def send_event(self):
+        pass
+
+    @abstractmethod
+    def _validate_input(self, target: Target):
+        pass
+
+    def _extract_service_from_arn(self, arn: Arn) -> str:
+        arn = parse_arn(arn)
+        return arn["resource"]
+
+    def _initialize_clients(self) -> ServiceLevelClientFactory:
+        """Initializes AWS service clients, with or without assuming a role of service source.
+        If a role from a source is provided, the client will be initialized with the assumed role.
+        If no role is provided e.g. calling put_events directly, the client will be initialized with the account ID and region."""
+        if self.role_arn and self.source_arn:
+            try:
+                source_service = self._get_source_service()
+                return connect_to.with_assumed_role(
+                    role_arn=self.role_arn,
+                    service_principal=source_service,
+                    region_name=self.region,
+                )
+            except ValueError:
+                LOG.debug("Could not extract service from source ARN {self.source_arn}")
+                return connect_to(aws_access_key_id=self.account_id, region_name=self.region)
+        else:
+            return connect_to(aws_access_key_id=self.account_id, region_name=self.region)
+
+    def _get_source_service(self) -> ServicePrincipal:
+        if not self.source_service:
+            source_service_name = extract_service_from_arn(self.source_arn)
+        if service_principal := getattr(ServicePrincipal, source_service_name, None):
+            return service_principal
+        else:
+            raise ValueError(f"Unsupported source service: {source_service_name}")
+
+    @property
+    def clients(self):
+        """Lazy initialization of AWS service clients."""
+        if self._client is None:
+            self._client = self._initialize_clients()
+        return self._client
+
+
+class LambdaTargetWorker(TargetWorker):
+    def send_event(self, event):
+        lambda_client = self.clients.lambda_.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        lambda_client.invoke(
+            FunctionName=self.target_arn,
+            Payload=to_bytes(json.dumps(event)),
+            InvocationType="Event" if self.asynchronous else "RequestResponse",
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class SnsTargetWorker(TargetWorker):
+    def send_event(self, event):
+        sns_client = self.clients.sns.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        sns_client.publish(TopicArn=self.target_arn, Message=json.dumps(event))
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class SqsTargetWorker(TargetWorker):
+    def send_event(self, event):
+        sqs_client = self.clients.sqs.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        queue_url = sqs_queue_url_for_arn(self.target_arn)
+        msg_group_id = collections.get_safe(
+            self.target_attributes, "$.SqsParameters.MessageGroupId"
+        )
+        kwargs = {"MessageGroupId": msg_group_id} if msg_group_id else {}
+        sqs_client.send_message(
+            QueueUrl=queue_url, MessageBody=json.dumps(event, separators=(",", ":")), **kwargs
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class StatesTargetWorker(TargetWorker):
+    """Step Functions Target Sender"""
+
+    def send_event(self, event):
+        stepfunctions_client = self.clients.stepfunctions.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        stepfunctions_client.start_execution(
+            stateMachineArn=self.target_arn, input=json.dumps(event)
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class FirehoseTargetWorker(TargetWorker):
+    def send_event(self, event):
+        firehose_client = self.clients.firehose.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        delivery_stream_name = firehose_name(self.target_arn)
+        firehose_client.put_record(
+            DeliveryStreamName=delivery_stream_name, Record={"Data": to_bytes(json.dumps(event))}
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class EventsTargetWorker(TargetWorker):
+    def send_event(self, event):
+        events_client = self.clients.events.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        eventbus_name = self.target_arn.split(":")[-1].split("/")[-1]
+        detail = event.get("detail") or event
+        resources = event.get("resources") or [self.source_arn] if self.source_arn else []
+        events_client.put_events(
+            Entries=[
+                {
+                    "EventBusName": eventbus_name,
+                    "Source": event.get("source", self.source_service) or "",
+                    "DetailType": event.get("detail-type", ""),
+                    "Detail": json.dumps(detail),
+                    "Resources": resources,
+                }
+            ]
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class KinesisTargetWorker(TargetWorker):
+    def send_event(self, event):
+        kinesis_client = self.clients.kinesis.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        partition_key_path = collections.get_safe(
+            self.target_attributes,
+            "$.KinesisParameters.PartitionKeyPath",
+            default_value="$.id",
+        )
+        stream_name = self.target_arn.split("/")[-1]
+        partition_key = collections.get_safe(event, partition_key_path, event["id"])
+        kinesis_client.put_record(
+            StreamName=stream_name,
+            Data=to_bytes(json.dumps(event)),
+            PartitionKey=partition_key,
+        )
+
+    def _validate_input(self, target: Target):
+        if not collections.get_safe(target, "$.KinesisParameters.PartitionKeyPath"):
+            raise ValueError("KinesisParameters.PartitionKeyPath is required for Kinesis target")
+        # TODO add more validation
+
+
+class LogsTargetWorker(TargetWorker):
+    def send_event(self, event):
+        logs_client = self.clients.logs.request_metadata(
+            service_principal=self.source_service, source_arn=self.source_arn
+        )
+        log_group_name = self.target_arn.split(":")[6]
+        log_stream_name = str(uuid.uuid4())  # Unique log stream name
+        logs_client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
+        logs_client.put_log_events(
+            logGroupName=log_group_name,
+            logStreamName=log_stream_name,
+            logEvents=[{"timestamp": now_utc(millis=True), "message": json.dumps(event)}],
+        )
+
+    def _validate_input(self, target: Target):
+        # TODO add more validation
+        pass
+
+
+class SystemsManagerWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("Systems Manager target is not yet implemented")
+
+    def _validate_input(self, target: Target):
+        if not collections.get_safe(target, "$.RunCommandParameters.RunCommandTargets"):
+            raise ValueError(
+                "RunCommandParameters.RunCommandTargets is required for Systems Manager target"
+            )
+        # TODO add more validation
+
+
+class ContainerTargetWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("ECS target is not yet implemented")
+
+    def _validate_input(self, target: Target):
+        if not collections.get_safe(target, "$.EcsParameters.TaskDefinitionArn"):
+            raise ValueError("EcsParameters.TaskDefinitionArn is required for ECS target")
+        # TODO add more validation
+
+
+class BatchTargetWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("Batch target is not yet implemented")
+
+    def _validate_input(self, target: Target):
+        if not collections.get_safe(target, "$.BatchParameters.JobDefinition"):
+            raise ValueError("BatchParameters.JobDefinition is required for Batch target")
+        if not collections.get_safe(target, "$.BatchParameters.JobName"):
+            raise ValueError("BatchParameters.JobName is required for Batch target")
+        # TODO add more validation
+
+
+class RedshiftTargetWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("Redshift target is not yet implemented")
+
+    def _validate_input(self, target: Target):
+        if not collections.get_safe(target, "$.RedshiftDataParameters.Database"):
+            raise ValueError("RedshiftDataParameters.Database is required for Redshift target")
+        # TODO add more validation
+
+
+class SagemakerTargetWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("Sagemaker target is not yet implemented")
+
+
+class AppSyncTargetWorker(TargetWorker):
+    def send_event(self, event):
+        raise NotImplementedError("AppSync target is not yet implemented")
+
+
+class TargetWorkerFactory:
+    # supported targets: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html
+    target_map = {
+        "lambda": LambdaTargetWorker,
+        "sqs": SqsTargetWorker,
+        "sns": SnsTargetWorker,
+        "kinesis": KinesisTargetWorker,
+        "firehose": FirehoseTargetWorker,
+        "logs": LogsTargetWorker,
+        "events": EventsTargetWorker,
+        "ssm": SystemsManagerWorker,
+        "ecs": ContainerTargetWorker,
+        "batch": BatchTargetWorker,
+        "redshift": RedshiftTargetWorker,
+        "sagemaker": SagemakerTargetWorker,
+        "appsync": AppSyncTargetWorker,
+        # TODO api gateway & custom endpoints via http target
+    }
+
+    def __init__(self, region: str, account_id: str, target: Target):
+        self.region = region
+        self.account_id = account_id
+        self.target = target
+
+    def get_target_worker(self) -> TargetWorker:
+        target_arn = self.target["Arn"]
+        arn = parse_arn(target_arn)
+        service = arn["service"]
+        if service in self.target_map:
+            target_worker_class = self.target_map[service]
+        else:
+            raise Exception(f"Unsupported target for Arn: {target_arn}")
+        target_worker = target_worker_class(self.region, self.account_id, self.target)
+        return target_worker
+
+
+TargetWorkerDict = dict[TargetId, TargetWorker]

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -190,7 +190,7 @@ class KinesisTargetService(TargetService):
 
 class LambdaTargetService(TargetService):
     def send_event(self, event):
-        asynchronous = True
+        asynchronous = True  # TODO clarify default behavior of AWS
         lambda_client = self.client.lambda_.request_metadata(
             service_principal=self.service, source_arn=self.rule_arn
         )

--- a/localstack/testing/aws/asf_utils.py
+++ b/localstack/testing/aws/asf_utils.py
@@ -125,7 +125,7 @@ def check_provider_signature(sub_class: type, base_class: type, method_name: str
         base_spec = inspect.getfullargspec(base_function)
         assert sub_spec == base_spec, (
             f"{sub_class.__name__}#{method_name} breaks with {base_class.__name__}#{method_name}. "
-            f"This can also be caused by 'from __future__ import annotations'!"
+            f"This can also be caused by 'from __future__ import annotations in a provider file'!"
         )
     except AttributeError:
         # the function is not defined in the superclass

--- a/localstack/testing/aws/asf_utils.py
+++ b/localstack/testing/aws/asf_utils.py
@@ -125,7 +125,7 @@ def check_provider_signature(sub_class: type, base_class: type, method_name: str
         base_spec = inspect.getfullargspec(base_function)
         assert sub_spec == base_spec, (
             f"{sub_class.__name__}#{method_name} breaks with {base_class.__name__}#{method_name}. "
-            f"This can also be caused by 'from __future__ import annotations in a provider file'!"
+            f"This can also be caused by 'from __future__ import annotations' in a provider file!"
         )
     except AttributeError:
         # the function is not defined in the superclass

--- a/localstack/testing/aws/asf_utils.py
+++ b/localstack/testing/aws/asf_utils.py
@@ -123,9 +123,10 @@ def check_provider_signature(sub_class: type, base_class: type, method_name: str
 
         sub_spec = inspect.getfullargspec(sub_function)
         base_spec = inspect.getfullargspec(base_function)
-        assert (
-            sub_spec == base_spec
-        ), f"{sub_class.__name__}#{method_name} breaks with {base_class.__name__}#{method_name}"
+        assert sub_spec == base_spec, (
+            f"{sub_class.__name__}#{method_name} breaks with {base_class.__name__}#{method_name}. "
+            f"This can also be caused by 'from __future__ import annotations'!"
+        )
     except AttributeError:
         # the function is not defined in the superclass
         pass

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -12,9 +12,9 @@ from localstack.utils.sync import retry
 def create_event_bus(aws_client):
     event_bus_names = []
 
-    def _create_event_bus(bus_name, **kwargs):
-        response = aws_client.events.create_event_bus(Name=bus_name, **kwargs)
-        event_bus_names.append(bus_name)
+    def _create_event_bus(**kwargs):
+        response = aws_client.events.create_event_bus(**kwargs)
+        event_bus_names.append(kwargs["Name"])
         return response
 
     yield _create_event_bus

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -759,6 +759,14 @@ class TestEventsEventBus:
         snapshot.match("delete-not-existing-event-bus", e)
 
     @markers.aws.validated
+    def test_delete_default_event_bus(self, aws_client, snapshot):
+        events = aws_client.events
+
+        with pytest.raises(aws_client.events.exceptions.ClientError) as e:
+            events.delete_event_bus(Name="default")
+        snapshot.match("delete-default-event-bus", e)
+
+    @markers.aws.validated
     def test_list_event_buses_with_prefix(self, create_event_bus, aws_client, snapshot):
         events = aws_client.events
         bus_name = "test-bus"

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1154,3 +1154,12 @@ class TestEventRule:
             Limit=int(count / 2) + 2, NextToken=response["NextToken"]
         )
         snapshot.match("list-rules-limit-next-token", response)
+
+    @markers.aws.validated
+    def test_describe_nonexistent_rule(self, aws_client, snapshot):
+        rule_name = f"this-rule-does-not-exist-1234567890-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule-name>"))
+
+        with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as e:
+            aws_client.events.describe_rule(Name=rule_name)
+        snapshot.match("describe-not-existing-rule", e)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -708,6 +708,10 @@ class TestEvents:
 
 class TestEventBus:
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider() and not is_aws_cloud(),
+        reason="V1 provider does not support this feature",
+    )
     @pytest.mark.parametrize("regions", [["us-east-1"], ["us-east-1", "us-west-1", "eu-central-1"]])
     def test_create_list_describe_delete_custom_event_buses(
         self, aws_client_factory, regions, snapshot

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -570,7 +570,7 @@ class TestEvents:
                 ],
             )
         snapshot.add_transformer(snapshot.transform.regex(target_id, "invalid-target-id"))
-        snapshot.match("put-targets--invalid-id-error", e.value.response)
+        snapshot.match("put-targets-invalid-id-error", e.value.response)
 
         target_id = f"{long_uid()}-{long_uid()}-extra"
         with pytest.raises(ClientError) as e:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -570,7 +570,7 @@ class TestEvents:
                 ],
             )
         snapshot.add_transformer(snapshot.transform.regex(target_id, "invalid-target-id"))
-        snapshot.match("error", e.value.response)
+        snapshot.match("put-targets--invalid-id-error", e.value.response)
 
         target_id = f"{long_uid()}-{long_uid()}-extra"
         with pytest.raises(ClientError) as e:
@@ -581,7 +581,7 @@ class TestEvents:
                 ],
             )
         snapshot.add_transformer(snapshot.transform.regex(target_id, "second-invalid-target-id"))
-        snapshot.match("length_error", e.value.response)
+        snapshot.match("put-targets-length-error", e.value.response)
 
         target_id = f"test-With_valid.Characters-{short_uid()}"
         aws_client.events.put_targets(
@@ -754,7 +754,7 @@ class TestEventsEventBus:
 
         with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as e:
             events.describe_event_bus(Name=bus_name)
-        snapshot.match("describe-not-existing-event-bus", e)
+        snapshot.match("describe-not-existing-event-bus-error", e)
 
         events.delete_event_bus(Name=bus_name)
         snapshot.match("delete-not-existing-event-bus", e)
@@ -765,7 +765,7 @@ class TestEventsEventBus:
 
         with pytest.raises(aws_client.events.exceptions.ClientError) as e:
             events.delete_event_bus(Name="default")
-        snapshot.match("delete-default-event-bus", e)
+        snapshot.match("delete-default-event-bus-error", e)
 
     @markers.aws.validated
     def test_list_event_buses_with_prefix(self, create_event_bus, aws_client, snapshot):
@@ -1084,7 +1084,7 @@ class TestEventsEventBus:
         # try to get the custom EventBus we passed the Event to
         with pytest.raises(ClientError) as e:
             aws_client.events.describe_event_bus(Name=nonexistent_event_bus)
-        snapshot.match("non-existent-bus", e.value.response)
+        snapshot.match("non-existent-bus-error", e.value.response)
 
 
 class TestEventRule:
@@ -1170,7 +1170,7 @@ class TestEventRule:
 
         with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as e:
             aws_client.events.describe_rule(Name=rule_name)
-        snapshot.match("describe-not-existing-rule", e)
+        snapshot.match("describe-not-existing-rule-error", e)
 
     @markers.aws.validated
     @pytest.mark.parametrize("bus_name", ["custom", "default"])
@@ -1232,7 +1232,7 @@ class TestEventRule:
 
         with pytest.raises(aws_client.events.exceptions.ClientError) as e:
             aws_client.events.delete_rule(Name=rule_name)
-        snapshot.match("delete-rule", e)
+        snapshot.match("delete-rule-with-targets-error", e)
 
 
 class TestEventTarget:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -720,6 +720,9 @@ class TestEventBus:
         snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus-name>"))
 
         for region in regions:
+            # overwriting randomized region https://docs.localstack.cloud/contributing/multi-account-region-testing/
+            # requires manually adding region replacement for snapshot
+            snapshot.add_transformer(snapshot.transform.regex(region, "<region>"))
             events = aws_client_factory(region_name=region).events
 
             response = events.create_event_bus(Name=bus_name)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -782,6 +782,7 @@ class TestEventsEventBus:
         snapshot.match("list-event-buses-prefix", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
     def test_list_event_buses_with_limit(self, create_event_bus, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.jsonpath("$..NextToken", "next_token"))
         events = aws_client.events
@@ -1164,6 +1165,7 @@ class TestEventRule:
         snapshot.match("list-rules-limit-next-token", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
     def test_describe_nonexistent_rule(self, aws_client, snapshot):
         rule_name = f"this-rule-does-not-exist-1234567890-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule-name>"))
@@ -1290,6 +1292,7 @@ class TestEventTarget:
         snapshot.match("list-targets-after-delete", response)
 
     @markers.aws.validated
+    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
     def test_add_exceed_fife_targets_per_rule(
         self, put_rule, sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
     ):
@@ -1311,6 +1314,7 @@ class TestEventTarget:
         snapshot.match("put-targets-client-error", error)
 
     @markers.aws.validated
+    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
     def test_list_target_by_rule_limit(
         self, put_rule, sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
     ):

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1131,9 +1131,6 @@ class TestEventRule:
         )
         snapshot.match("put-rule", response)
 
-        if is_aws_cloud():
-            time.sleep(10)
-
         # put_rule updates the rule if it already exists
         response = put_rule(
             Name=rule_name,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -738,7 +738,8 @@ class TestEventsEventBus:
 
     @markers.aws.validated
     def test_create_multiple_event_buses_same_name(self, create_event_bus, aws_client, snapshot):
-        bus_name = "test-bus"
+        bus_name = f"test-bus-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus-name>"))
         create_event_bus(Name=bus_name)
 
         with pytest.raises(aws_client.events.exceptions.ResourceAlreadyExistsException) as e:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -739,10 +739,10 @@ class TestEventsEventBus:
     @markers.aws.validated
     def test_create_multiple_event_buses_same_name(self, create_event_bus, aws_client, snapshot):
         bus_name = "test-bus"
-        create_event_bus(bus_name)
+        create_event_bus(Name=bus_name)
 
         with pytest.raises(aws_client.events.exceptions.ResourceAlreadyExistsException) as e:
-            create_event_bus(bus_name)
+            create_event_bus(Name=bus_name)
         snapshot.match("create-multiple-event-buses-same-name", e)
 
     @markers.aws.validated
@@ -759,15 +759,13 @@ class TestEventsEventBus:
         snapshot.match("delete-not-existing-event-bus", e)
 
     @markers.aws.validated
-    def test_list_event_buses_with_prefix(self, aws_client, cleanups, snapshot):
+    def test_list_event_buses_with_prefix(self, create_event_bus, aws_client, snapshot):
         events = aws_client.events
         bus_name = "test-bus"
         bus_name_not_match = "no-prefix-match"
 
-        events.create_event_bus(Name=bus_name)
-        cleanups.append(lambda: events.delete_event_bus(Name=bus_name))
-        events.create_event_bus(Name=bus_name_not_match)
-        cleanups.append(lambda: events.delete_event_bus(Name=bus_name_not_match))
+        create_event_bus(Name=bus_name)
+        create_event_bus(Name=bus_name_not_match)
 
         response = events.list_event_buses(NamePrefix=bus_name)
         snapshot.match("list-event-buses-prefix-complete-name", response)
@@ -784,7 +782,7 @@ class TestEventsEventBus:
 
         for i in range(count):
             bus_name = f"{bus_name_prefix}-{i}"
-            create_event_bus(bus_name)
+            create_event_bus(Name=bus_name)
 
         response = events.list_event_buses(Limit=int(count / 2))
         snapshot.match("list-event-buses-limit", response)

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -706,7 +706,7 @@ class TestEvents:
         assert message_body["time"] == "2022-01-01T00:00:00Z"
 
 
-class TestEventsEventBus:
+class TestEventBus:
     @markers.aws.validated
     @pytest.mark.parametrize("regions", [["us-east-1"], ["us-east-1", "us-west-1", "eu-central-1"]])
     def test_create_list_describe_delete_custom_event_buses(
@@ -1007,7 +1007,7 @@ class TestEventsEventBus:
 
         assert_valid_event(received_event)
 
-    @markers.aws.validated
+    @markers.aws.validated  # TODO fix condition for this test, only succeeds if run on its own
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_nonexistent_event_bus(
         self,

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -783,7 +783,10 @@ class TestEventsEventBus:
         snapshot.match("list-event-buses-prefix", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
+    @pytest.mark.skipif(
+        not is_v2_provider() and not is_aws_cloud(),
+        reason="V1 provider does not support this feature",
+    )
     def test_list_event_buses_with_limit(self, create_event_bus, aws_client, snapshot):
         snapshot.add_transformer(snapshot.transform.jsonpath("$..NextToken", "next_token"))
         events = aws_client.events
@@ -1163,7 +1166,10 @@ class TestEventRule:
         snapshot.match("list-rules-limit-next-token", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
+    @pytest.mark.skipif(
+        not is_v2_provider() and not is_aws_cloud(),
+        reason="V1 provider does not support this feature",
+    )
     def test_describe_nonexistent_rule(self, aws_client, snapshot):
         rule_name = f"this-rule-does-not-exist-1234567890-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule-name>"))
@@ -1290,7 +1296,10 @@ class TestEventTarget:
         snapshot.match("list-targets-after-delete", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
+    @pytest.mark.skipif(
+        not is_v2_provider() and not is_aws_cloud(),
+        reason="V1 provider does not support this feature",
+    )
     def test_add_exceed_fife_targets_per_rule(
         self, put_rule, sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
     ):
@@ -1312,7 +1321,10 @@ class TestEventTarget:
         snapshot.match("put-targets-client-error", error)
 
     @markers.aws.validated
-    @pytest.mark.skipif(not is_v2_provider(), reason="V1 provider does not support this feature")
+    @pytest.mark.skipif(
+        not is_v2_provider() and not is_aws_cloud(),
+        reason="V1 provider does not support this feature",
+    )
     def test_list_target_by_rule_limit(
         self, put_rule, sqs_create_queue, sqs_get_queue_arn, aws_client, snapshot
     ):

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1198,5 +1198,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
+    "recorded-date": "11-04-2024, 11:27:59",
+    "recorded-content": {
+      "delete-rule": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1156,5 +1156,47 @@
     "recorded-content": {
       "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
+    "recorded-date": "10-04-2024, 11:34:18",
+    "recorded-content": {
+      "list-targets-limit": {
+        "NextToken": "<next_token:1>",
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>0"
+          },
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>1"
+          },
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-limit-next-token": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>3"
+          },
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>4"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -576,5 +576,29 @@
     "recorded-content": {
       "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus test-bus already exists.') tblen=4>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
+    "recorded-date": "04-04-2024, 10:47:20",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
+    "recorded-date": "04-04-2024, 10:47:21",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1210,5 +1210,41 @@
     "recorded-content": {
       "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
+    "recorded-date": "17-04-2024, 10:42:59",
+    "recorded-content": {
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-after-update": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1204,5 +1204,11 @@
     "recorded-content": {
       "delete-rule": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
+    "recorded-date": "11-04-2024, 12:05:06",
+    "recorded-content": {
+      "delete-default-event-bus": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -105,7 +105,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "recorded-date": "08-04-2024, 16:36:38",
+    "recorded-date": "22-04-2024, 13:07:35",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
@@ -181,7 +181,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "recorded-date": "08-04-2024, 16:36:39",
+    "recorded-date": "22-04-2024, 13:07:36",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
@@ -257,17 +257,17 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "recorded-date": "08-04-2024, 17:27:57",
+    "recorded-date": "22-04-2024, 13:07:38",
     "recorded-content": {
       "put-rule": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
       },
       "re-put-rule": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -276,8 +276,8 @@
       "list-rules": {
         "Rules": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -303,14 +303,14 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "recorded-date": "08-04-2024, 17:29:40",
+    "recorded-date": "22-04-2024, 13:07:40",
     "recorded-content": {
       "list-rules-limit": {
         "NextToken": "<next_token:1>",
         "Rules": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-0",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-0",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -324,12 +324,12 @@
                 ]
               }
             },
-            "Name": "test-rule-0",
+            "Name": "<rule-name-prefix>-0",
             "State": "ENABLED"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-1",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-1",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -343,12 +343,12 @@
                 ]
               }
             },
-            "Name": "test-rule-1",
+            "Name": "<rule-name-prefix>-1",
             "State": "ENABLED"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-2",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-2",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -362,7 +362,7 @@
                 ]
               }
             },
-            "Name": "test-rule-2",
+            "Name": "<rule-name-prefix>-2",
             "State": "ENABLED"
           }
         ],
@@ -374,8 +374,8 @@
       "list-rules-limit-next-token": {
         "Rules": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-3",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-3",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -389,12 +389,12 @@
                 ]
               }
             },
-            "Name": "test-rule-3",
+            "Name": "<rule-name-prefix>-3",
             "State": "ENABLED"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-4",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-4",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -408,12 +408,12 @@
                 ]
               }
             },
-            "Name": "test-rule-4",
+            "Name": "<rule-name-prefix>-4",
             "State": "ENABLED"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-5",
-            "EventBusName": "default",
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name-prefix>-5",
+            "EventBusName": "<bus-name>",
             "EventPattern": {
               "source": [
                 "core.update-account-command"
@@ -427,7 +427,7 @@
                 ]
               }
             },
-            "Name": "test-rule-5",
+            "Name": "<rule-name-prefix>-5",
             "State": "ENABLED"
           }
         ],
@@ -439,13 +439,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "recorded-date": "16-04-2024, 15:12:50",
+    "recorded-date": "22-04-2024, 13:07:42",
     "recorded-content": {
       "describe-not-existing-rule-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "recorded-date": "08-04-2024, 17:37:18",
+    "recorded-date": "22-04-2024, 13:07:43",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -510,7 +510,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "recorded-date": "08-04-2024, 17:37:19",
+    "recorded-date": "22-04-2024, 13:07:45",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -575,7 +575,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "recorded-date": "09-04-2024, 16:21:04",
+    "recorded-date": "22-04-2024, 13:07:17",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -615,7 +615,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "recorded-date": "09-04-2024, 16:21:05",
+    "recorded-date": "22-04-2024, 13:07:18",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -655,13 +655,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "recorded-date": "16-04-2024, 15:14:29",
+    "recorded-date": "22-04-2024, 13:07:20",
     "recorded-content": {
       "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "recorded-date": "10-04-2024, 11:34:18",
+    "recorded-date": "22-04-2024, 13:07:22",
     "recorded-content": {
       "list-targets-limit": {
         "NextToken": "<next_token:1>",
@@ -703,7 +703,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "recorded-date": "16-04-2024, 15:13:31",
+    "recorded-date": "22-04-2024, 13:07:46",
     "recorded-content": {
       "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
     }
@@ -715,7 +715,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "recorded-date": "17-04-2024, 10:42:59",
+    "recorded-date": "22-04-2024, 13:07:48",
     "recorded-content": {
       "list-targets": {
         "Targets": [
@@ -751,7 +751,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "17-04-2024, 17:42:11",
+    "recorded-date": "22-04-2024, 13:11:07",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -762,10 +762,6 @@
       },
       "list-event-buses-after-create-us-east-1": {
         "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
@@ -791,12 +787,7 @@
         }
       },
       "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
+        "EventBuses": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -805,7 +796,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "17-04-2024, 17:42:13",
+    "recorded-date": "22-04-2024, 13:11:10",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -816,10 +807,6 @@
       },
       "list-event-buses-after-create-us-east-1": {
         "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
@@ -848,10 +835,6 @@
       "list-event-buses-after-create-us-west-1": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
             "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
           }
@@ -879,10 +862,6 @@
       "list-event-buses-after-create-eu-central-1": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
             "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
           }
@@ -907,12 +886,7 @@
         }
       },
       "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
+        "EventBuses": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -925,12 +899,7 @@
         }
       },
       "list-event-buses-after-delete-us-west-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
+        "EventBuses": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -943,12 +912,7 @@
         }
       },
       "list-event-buses-after-delete-eu-central-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
+        "EventBuses": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -957,26 +921,26 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "17-04-2024, 17:42:13",
+    "recorded-date": "22-04-2024, 13:11:10",
     "recorded-content": {
       "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "17-04-2024, 17:42:15",
+    "recorded-date": "22-04-2024, 13:11:12",
     "recorded-content": {
       "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
       "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "recorded-date": "17-04-2024, 17:42:15",
+    "recorded-date": "22-04-2024, 13:11:12",
     "recorded-content": {
       "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "recorded-date": "17-04-2024, 17:42:16",
+    "recorded-date": "22-04-2024, 13:19:19",
     "recorded-content": {
       "list-event-buses-prefix-complete-name": {
         "EventBuses": [
@@ -1005,14 +969,10 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "recorded-date": "17-04-2024, 17:42:18",
+    "recorded-date": "22-04-2024, 13:11:15",
     "recorded-content": {
       "list-event-buses-limit": {
         "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-0",
             "Name": "<bus-name-prefix>-0"
@@ -1020,6 +980,10 @@
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-1",
             "Name": "<bus-name-prefix>-1"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
+            "Name": "<bus-name-prefix>-2"
           }
         ],
         "NextToken": "<next_token:1>",
@@ -1030,10 +994,6 @@
       },
       "list-event-buses-limit-next-token": {
         "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
-            "Name": "<bus-name-prefix>-2"
-          },
           {
             "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-3",
             "Name": "<bus-name-prefix>-3"
@@ -1055,7 +1015,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "recorded-date": "17-04-2024, 17:42:46",
+    "recorded-date": "22-04-2024, 13:11:43",
     "recorded-content": {
       "create-custom-event-bus": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
@@ -1134,7 +1094,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "17-04-2024, 17:50:27",
+    "recorded-date": "22-04-2024, 13:12:23",
     "recorded-content": {
       "put-events": {
         "Entries": [

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1,8 +1,8 @@
 {
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "recorded-date": "26-03-2024, 14:07:18",
+    "recorded-date": "16-04-2024, 15:09:28",
     "recorded-content": {
-      "error": {
+      "put-targets--invalid-id-error": {
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value '!@#$@!#$' at 'targets.1.member.id' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_A-Za-z0-9]+"
@@ -12,7 +12,7 @@
           "HTTPStatusCode": 400
         }
       },
-      "length_error": {
+      "put-targets-length-error": {
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value 'second-invalid-target-id' at 'targets.1.member.id' failed to satisfy constraint: Member must have length less than or equal to 64"
@@ -160,7 +160,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "26-03-2024, 14:11:46",
+    "recorded-date": "16-04-2024, 15:10:30",
     "recorded-content": {
       "put-events": {
         "Entries": [
@@ -197,7 +197,7 @@
           }
         }
       ],
-      "non-existent-bus": {
+      "non-existent-bus-error": {
         "Error": {
           "Code": "ResourceNotFoundException",
           "Message": "Event bus <custom-event-bus> does not exist."
@@ -359,9 +359,9 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "03-04-2024, 15:19:23",
+    "recorded-date": "17-04-2024, 07:32:19",
     "recorded-content": {
-      "describe-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
+      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
       "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
     }
   },
@@ -572,7 +572,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "16-04-2024, 14:51:31",
+    "recorded-date": "16-04-2024, 15:09:51",
     "recorded-content": {
       "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
     }
@@ -936,9 +936,9 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "recorded-date": "08-04-2024, 17:32:17",
+    "recorded-date": "16-04-2024, 15:12:50",
     "recorded-content": {
-      "describe-not-existing-rule": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
+      "describe-not-existing-rule-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
@@ -1152,7 +1152,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "recorded-date": "09-04-2024, 14:43:41",
+    "recorded-date": "16-04-2024, 15:14:29",
     "recorded-content": {
       "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
     }
@@ -1200,15 +1200,15 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "recorded-date": "11-04-2024, 11:27:59",
+    "recorded-date": "16-04-2024, 15:13:31",
     "recorded-content": {
-      "delete-rule": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
+      "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
-    "recorded-date": "11-04-2024, 12:05:06",
+    "recorded-date": "16-04-2024, 15:10:07",
     "recorded-content": {
-      "delete-default-event-bus": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
+      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
     }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -752,5 +752,51 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
+    "recorded-date": "08-04-2024, 17:27:57",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "re-put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules": {
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "<rule-name>",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -934,5 +934,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
+    "recorded-date": "08-04-2024, 17:32:17",
+    "recorded-content": {
+      "describe-not-existing-rule": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -751,7 +751,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "22-04-2024, 13:11:07",
+    "recorded-date": "23-04-2024, 06:11:32",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -796,7 +796,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "22-04-2024, 13:11:10",
+    "recorded-date": "23-04-2024, 06:11:34",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -826,7 +826,7 @@
         }
       },
       "create-custom-event-bus-us-west-1": {
-        "EventBusArn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -835,7 +835,7 @@
       "list-event-buses-after-create-us-west-1": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
           }
         ],
@@ -845,7 +845,7 @@
         }
       },
       "describe-custom-event-bus-us-west-1": {
-        "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -853,7 +853,7 @@
         }
       },
       "create-custom-event-bus-eu-central-1": {
-        "EventBusArn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -862,7 +862,7 @@
       "list-event-buses-after-create-eu-central-1": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
             "Name": "<bus-name>"
           }
         ],
@@ -872,7 +872,7 @@
         }
       },
       "describe-custom-event-bus-eu-central-1": {
-        "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
         "Name": "<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -572,9 +572,9 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "03-04-2024, 15:30:52",
+    "recorded-date": "16-04-2024, 14:51:31",
     "recorded-content": {
-      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus test-bus already exists.') tblen=4>"
+      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1,8 +1,8 @@
 {
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "recorded-date": "16-04-2024, 15:09:28",
+    "recorded-date": "18-04-2024, 15:47:35",
     "recorded-content": {
-      "put-targets--invalid-id-error": {
+      "put-targets-invalid-id-error": {
         "Error": {
           "Code": "ValidationException",
           "Message": "1 validation error detected: Value '!@#$@!#$' at 'targets.1.member.id' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_A-Za-z0-9]+"

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -80,503 +80,6 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "recorded-date": "26-03-2024, 14:07:59",
-    "recorded-content": {
-      "create-custom-event-bus": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-rule-1": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-rule-2": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:1>/<resource:3>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-target-1": {
-        "FailedEntries": [],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-target-2": {
-        "FailedEntries": [],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-events": {
-        "Messages": [
-          {
-            "Body": {
-              "version": "0",
-              "id": "<uuid:1>",
-              "detail-type": "Object Created",
-              "source": "aws.s3",
-              "account": "111111111111",
-              "time": "date",
-              "region": "<region>",
-              "resources": [
-                "arn:aws:s3:::<bucket-name:1>"
-              ],
-              "detail": {
-                "version": "0",
-                "bucket": {
-                  "name": "<bucket-name:1>"
-                },
-                "object": {
-                  "key": "<key-name:1>",
-                  "size": 4,
-                  "etag": "8d777f385d3dfec8815d20f7496026dc",
-                  "sequencer": "object-sequencer"
-                },
-                "request-id": "request-id",
-                "requester": "<requester>",
-                "source-ip-address": "<ip-address:1>",
-                "reason": "PutObject"
-              }
-            },
-            "MD5OfBody": "<m-d5-of-body:1>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "16-04-2024, 15:10:30",
-    "recorded-content": {
-      "put-events": {
-        "Entries": [
-          {
-            "EventId": "<uuid:1>"
-          },
-          {
-            "EventId": "<uuid:2>"
-          }
-        ],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-events": [
-        {
-          "MessageId": "<uuid:3>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "version": "0",
-            "id": "<uuid:1>",
-            "detail-type": "CustomType",
-            "source": "MySource",
-            "account": "111111111111",
-            "time": "date",
-            "region": "<region>",
-            "resources": [],
-            "detail": {
-              "message": "for the default event bus"
-            }
-          }
-        }
-      ],
-      "non-existent-bus-error": {
-        "Error": {
-          "Code": "ResourceNotFoundException",
-          "Message": "Event bus <custom-event-bus> does not exist."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
-    "recorded-date": "27-03-2024, 09:15:34",
-    "recorded-content": {
-      "create-custom-event-bus": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_list_describe_delete_custom_event_bus": {
-    "recorded-date": "02-04-2024, 13:04:38",
-    "recorded-content": {
-      "create-custom-event-bus": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-create": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "Name": "test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-delete": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_desribe_delete_not_existing_event_bus": {
-    "recorded-date": "02-04-2024, 13:20:57",
-    "recorded-content": {}
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_list_event_buses_with_prefix": {
-    "recorded-date": "03-04-2024, 14:38:19",
-    "recorded-content": {
-      "list-event-buses-prefix-complete-name": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-prefix": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_list_event_buses_with_limit": {
-    "recorded-date": "03-04-2024, 14:53:31",
-    "recorded-content": {
-      "list-event-buses-limit": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-0",
-            "Name": "test-bus-0"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-1",
-            "Name": "test-bus-1"
-          }
-        ],
-        "NextToken": "<next_token:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-limit-next-token": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-2",
-            "Name": "test-bus-2"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-3",
-            "Name": "test-bus-3"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-4",
-            "Name": "test-bus-4"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-5",
-            "Name": "test-bus-5"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "17-04-2024, 07:32:19",
-    "recorded-content": {
-      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
-      "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "03-04-2024, 13:49:07",
-    "recorded-content": {
-      "create-custom-event-bus-us-east-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-east-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "Name": "test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-east-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "03-04-2024, 13:49:10",
-    "recorded-content": {
-      "create-custom-event-bus-us-east-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-east-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-        "Name": "test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-custom-event-bus-us-west-1": {
-        "EventBusArn": "arn:aws:events:us-west-1:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-west-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-west-1": {
-        "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/test-bus",
-        "Name": "test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-custom-event-bus-eu-central-1": {
-        "EventBusArn": "arn:aws:events:eu-central-1:111111111111:event-bus/test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-eu-central-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
-            "Name": "default"
-          },
-          {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-eu-central-1": {
-        "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/test-bus",
-        "Name": "test-bus",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-east-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-west-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-west-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-eu-central-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-eu-central-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
-            "Name": "default"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "16-04-2024, 15:09:51",
-    "recorded-content": {
-      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
-    }
-  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
     "recorded-date": "04-04-2024, 10:47:20",
     "recorded-content": {
@@ -1243,6 +746,416 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
+    "recorded-date": "17-04-2024, 17:31:45",
+    "recorded-content": {
+      "create-custom-event-bus-us-east-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
+            "Name": "default"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-east-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-east-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
+            "Name": "default"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
+    "recorded-date": "17-04-2024, 17:31:48",
+    "recorded-content": {
+      "create-custom-event-bus-us-east-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
+            "Name": "default"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-east-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-custom-event-bus-us-west-1": {
+        "EventBusArn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-west-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
+            "Name": "default"
+          },
+          {
+            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-west-1": {
+        "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-custom-event-bus-eu-central-1": {
+        "EventBusArn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-eu-central-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
+            "Name": "default"
+          },
+          {
+            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-eu-central-1": {
+        "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-east-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
+            "Name": "default"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-west-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-west-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:us-west-1:111111111111:event-bus/default",
+            "Name": "default"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-eu-central-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-eu-central-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:eu-central-1:111111111111:event-bus/default",
+            "Name": "default"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
+    "recorded-date": "17-04-2024, 17:31:48",
+    "recorded-content": {
+      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
+    "recorded-date": "17-04-2024, 17:31:49",
+    "recorded-content": {
+      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
+      "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
+    "recorded-date": "17-04-2024, 17:31:50",
+    "recorded-content": {
+      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
+    "recorded-date": "17-04-2024, 17:31:51",
+    "recorded-content": {
+      "list-event-buses-prefix-complete-name": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
+            "Name": "test-bus"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-prefix": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
+            "Name": "test-bus"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
+    "recorded-date": "17-04-2024, 17:31:52",
+    "recorded-content": {
+      "list-event-buses-limit": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/default",
+            "Name": "default"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-0",
+            "Name": "test-bus-0"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-1",
+            "Name": "test-bus-1"
+          }
+        ],
+        "NextToken": "<next_token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-limit-next-token": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-2",
+            "Name": "test-bus-2"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-3",
+            "Name": "test-bus-3"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-4",
+            "Name": "test-bus-4"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-5",
+            "Name": "test-bus-5"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
+    "recorded-date": "17-04-2024, 17:32:24",
+    "recorded-content": {
+      "create-custom-event-bus": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-1": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-2": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:1>/<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-1": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-2": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": {
+        "Messages": [
+          {
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "Object Created",
+              "source": "aws.s3",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [
+                "arn:aws:s3:::<bucket-name:1>"
+              ],
+              "detail": {
+                "version": "0",
+                "bucket": {
+                  "name": "<bucket-name:1>"
+                },
+                "object": {
+                  "key": "<key-name:1>",
+                  "size": 4,
+                  "etag": "8d777f385d3dfec8815d20f7496026dc",
+                  "sequencer": "object-sequencer"
+                },
+                "request-id": "request-id",
+                "requester": "<requester>",
+                "source-ip-address": "<ip-address:1>",
+                "reason": "PutObject"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
+    "recorded-date": "17-04-2024, 17:32:42",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "EventId": "b2fc49fa-6cbc-bd51-db5f-a40f011cae5e"
+          },
+          {
+            "EventId": "6c716ae3-582a-7fd1-ff87-d158f35e1c9d"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {
+            "content-length": "136",
+            "content-type": "application/x-amz-json-1.1",
+            "date": "Wed, 17 Apr 2024 17:32:28 GMT",
+            "x-amzn-requestid": "05af1f7d-17dc-4eca-a13d-7455bc3b315a"
+          },
+          "HTTPStatusCode": 200,
+          "RequestId": "05af1f7d-17dc-4eca-a13d-7455bc3b315a",
+          "RetryAttempts": 0
         }
       }
     }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1150,5 +1150,11 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
+    "recorded-date": "09-04-2024, 14:43:41",
+    "recorded-content": {
+      "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -751,7 +751,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "17-04-2024, 17:31:45",
+    "recorded-date": "17-04-2024, 17:42:11",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -805,7 +805,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "17-04-2024, 17:31:48",
+    "recorded-date": "17-04-2024, 17:42:13",
     "recorded-content": {
       "create-custom-event-bus-us-east-1": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
@@ -957,32 +957,32 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "17-04-2024, 17:31:48",
+    "recorded-date": "17-04-2024, 17:42:13",
     "recorded-content": {
       "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "17-04-2024, 17:31:49",
+    "recorded-date": "17-04-2024, 17:42:15",
     "recorded-content": {
       "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
       "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "recorded-date": "17-04-2024, 17:31:50",
+    "recorded-date": "17-04-2024, 17:42:15",
     "recorded-content": {
       "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "recorded-date": "17-04-2024, 17:31:51",
+    "recorded-date": "17-04-2024, 17:42:16",
     "recorded-content": {
       "list-event-buses-prefix-complete-name": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
           }
         ],
         "ResponseMetadata": {
@@ -993,8 +993,8 @@
       "list-event-buses-prefix": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus",
-            "Name": "test-bus"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
           }
         ],
         "ResponseMetadata": {
@@ -1005,7 +1005,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "recorded-date": "17-04-2024, 17:31:52",
+    "recorded-date": "17-04-2024, 17:42:18",
     "recorded-content": {
       "list-event-buses-limit": {
         "EventBuses": [
@@ -1014,12 +1014,12 @@
             "Name": "default"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-0",
-            "Name": "test-bus-0"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-0",
+            "Name": "<bus-name-prefix>-0"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-1",
-            "Name": "test-bus-1"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-1",
+            "Name": "<bus-name-prefix>-1"
           }
         ],
         "NextToken": "<next_token:1>",
@@ -1031,20 +1031,20 @@
       "list-event-buses-limit-next-token": {
         "EventBuses": [
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-2",
-            "Name": "test-bus-2"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
+            "Name": "<bus-name-prefix>-2"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-3",
-            "Name": "test-bus-3"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-3",
+            "Name": "<bus-name-prefix>-3"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-4",
-            "Name": "test-bus-4"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-4",
+            "Name": "<bus-name-prefix>-4"
           },
           {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/test-bus-5",
-            "Name": "test-bus-5"
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-5",
+            "Name": "<bus-name-prefix>-5"
           }
         ],
         "ResponseMetadata": {
@@ -1055,7 +1055,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "recorded-date": "17-04-2024, 17:32:24",
+    "recorded-date": "17-04-2024, 17:42:46",
     "recorded-content": {
       "create-custom-event-bus": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
@@ -1134,28 +1134,51 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "17-04-2024, 17:32:42",
+    "recorded-date": "17-04-2024, 17:50:27",
     "recorded-content": {
       "put-events": {
         "Entries": [
           {
-            "EventId": "b2fc49fa-6cbc-bd51-db5f-a40f011cae5e"
+            "EventId": "<uuid:1>"
           },
           {
-            "EventId": "6c716ae3-582a-7fd1-ff87-d158f35e1c9d"
+            "EventId": "<uuid:2>"
           }
         ],
         "FailedEntryCount": 0,
         "ResponseMetadata": {
-          "HTTPHeaders": {
-            "content-length": "136",
-            "content-type": "application/x-amz-json-1.1",
-            "date": "Wed, 17 Apr 2024 17:32:28 GMT",
-            "x-amzn-requestid": "05af1f7d-17dc-4eca-a13d-7455bc3b315a"
-          },
-          "HTTPStatusCode": 200,
-          "RequestId": "05af1f7d-17dc-4eca-a13d-7455bc3b315a",
-          "RetryAttempts": 0
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "for the default event bus"
+            }
+          }
+        }
+      ],
+      "non-existent-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <custom-event-bus> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1070,5 +1070,85 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
+    "recorded-date": "09-04-2024, 16:21:04",
+    "recorded-content": {
+      "put-target": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-target": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-after-delete": {
+        "Targets": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
+    "recorded-date": "09-04-2024, 16:21:05",
+    "recorded-content": {
+      "put-target": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-target": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-after-delete": {
+        "Targets": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -600,5 +600,157 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
+    "recorded-date": "08-04-2024, 16:36:38",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules": {
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+            "EventBusName": "<bus-name>",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "<rule-name>",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "<bus-name>",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules-after-delete": {
+        "Rules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
+    "recorded-date": "08-04-2024, 16:36:39",
+    "recorded-content": {
+      "put-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules": {
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "<rule-name>",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "default",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules-after-delete": {
+        "Rules": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -798,5 +798,141 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
+    "recorded-date": "08-04-2024, 17:29:40",
+    "recorded-content": {
+      "list-rules-limit": {
+        "NextToken": "<next_token:1>",
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-0",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-0",
+            "State": "ENABLED"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-1",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-1",
+            "State": "ENABLED"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-2",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-2",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-rules-limit-next-token": {
+        "Rules": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-3",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-3",
+            "State": "ENABLED"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-4",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-4",
+            "State": "ENABLED"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:rule/test-rule-5",
+            "EventBusName": "default",
+            "EventPattern": {
+              "source": [
+                "core.update-account-command"
+              ],
+              "detail-type": [
+                "core.update-account-command"
+              ],
+              "detail": {
+                "command": [
+                  "update-account"
+                ]
+              }
+            },
+            "Name": "test-rule-5",
+            "State": "ENABLED"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -940,5 +940,135 @@
     "recorded-content": {
       "describe-not-existing-rule": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
+    "recorded-date": "08-04-2024, 17:37:18",
+    "recorded-content": {
+      "disable-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule-disabled": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "<bus-name>",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "DISABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "enable-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule-enabled": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "<bus-name>",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
+    "recorded-date": "08-04-2024, 17:37:19",
+    "recorded-content": {
+      "disable-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule-disabled": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "default",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "DISABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "enable-rule": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-rule-enabled": {
+        "Arn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "CreatedBy": "111111111111",
+        "EventBusName": "default",
+        "EventPattern": {
+          "source": [
+            "core.update-account-command"
+          ],
+          "detail-type": [
+            "core.update-account-command"
+          ],
+          "detail": {
+            "command": [
+              "update-account"
+            ]
+          }
+        },
+        "Name": "<rule-name>",
+        "State": "ENABLED",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,54 +1,54 @@
 {
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-17T17:42:11+00:00"
+    "last_validated_date": "2024-04-22T13:11:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-17T17:42:13+00:00"
+    "last_validated_date": "2024-04-22T13:11:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-17T17:42:13+00:00"
+    "last_validated_date": "2024-04-22T13:11:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-17T17:42:15+00:00"
+    "last_validated_date": "2024-04-22T13:11:12+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-17T17:42:15+00:00"
+    "last_validated_date": "2024-04-22T13:11:12+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "last_validated_date": "2024-04-17T17:42:18+00:00"
+    "last_validated_date": "2024-04-22T13:11:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "last_validated_date": "2024-04-17T17:42:16+00:00"
+    "last_validated_date": "2024-04-22T13:19:19+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-04-17T17:50:27+00:00"
+    "last_validated_date": "2024-04-22T13:12:23+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "last_validated_date": "2024-04-17T17:42:46+00:00"
+    "last_validated_date": "2024-04-22T13:11:43+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "last_validated_date": "2024-04-16T15:13:31+00:00"
+    "last_validated_date": "2024-04-22T13:07:46+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "last_validated_date": "2024-04-16T15:12:50+00:00"
+    "last_validated_date": "2024-04-22T13:07:42+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "last_validated_date": "2024-04-08T17:37:18+00:00"
+    "last_validated_date": "2024-04-22T13:07:43+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "last_validated_date": "2024-04-08T17:37:19+00:00"
+    "last_validated_date": "2024-04-22T13:07:45+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "last_validated_date": "2024-04-08T17:29:40+00:00"
+    "last_validated_date": "2024-04-22T13:07:40+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "last_validated_date": "2024-04-08T16:36:38+00:00"
+    "last_validated_date": "2024-04-22T13:07:35+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "last_validated_date": "2024-04-08T16:36:39+00:00"
+    "last_validated_date": "2024-04-22T13:07:36+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "last_validated_date": "2024-04-08T17:27:57+00:00"
+    "last_validated_date": "2024-04-22T13:07:38+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
     "last_validated_date": "2024-04-04T10:47:20+00:00"
@@ -57,19 +57,19 @@
     "last_validated_date": "2024-04-04T10:47:21+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "last_validated_date": "2024-04-17T10:42:59+00:00"
+    "last_validated_date": "2024-04-22T13:07:48+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "last_validated_date": "2024-04-16T15:14:29+00:00"
+    "last_validated_date": "2024-04-22T13:07:20+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "last_validated_date": "2024-04-10T11:34:18+00:00"
+    "last_validated_date": "2024-04-22T13:07:22+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "last_validated_date": "2024-04-09T16:21:04+00:00"
+    "last_validated_date": "2024-04-22T13:07:17+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "last_validated_date": "2024-04-09T16:21:05+00:00"
+    "last_validated_date": "2024-04-22T13:07:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
     "last_validated_date": "2024-03-26T14:07:16+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
     "last_validated_date": "2024-04-04T10:47:21+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
+    "last_validated_date": "2024-04-17T10:42:59+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
     "last_validated_date": "2024-04-16T15:14:29+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
+    "last_validated_date": "2024-04-08T17:29:40+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
     "last_validated_date": "2024-04-08T16:36:38+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
+    "last_validated_date": "2024-04-08T16:36:38+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
+    "last_validated_date": "2024-04-08T16:36:39+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
     "last_validated_date": "2024-04-04T10:47:20+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -26,6 +26,12 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
     "last_validated_date": "2024-04-04T10:47:21+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
+    "last_validated_date": "2024-04-09T16:21:04+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
+    "last_validated_date": "2024-04-09T16:21:05+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
     "last_validated_date": "2024-03-26T14:07:16+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
+    "last_validated_date": "2024-04-04T10:47:20+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
+    "last_validated_date": "2024-04-04T10:47:21+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
     "last_validated_date": "2024-03-26T14:07:16+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
+    "last_validated_date": "2024-04-08T17:32:17+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
     "last_validated_date": "2024-04-08T17:29:40+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -96,7 +96,7 @@
     "last_validated_date": "2024-03-26T14:06:58+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "last_validated_date": "2024-04-16T15:09:28+00:00"
+    "last_validated_date": "2024-04-18T15:47:35+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
     "last_validated_date": "2024-03-27T09:15:34+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,30 +1,30 @@
 {
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-17T17:31:45+00:00"
+    "last_validated_date": "2024-04-17T17:42:11+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-17T17:31:48+00:00"
+    "last_validated_date": "2024-04-17T17:42:13+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-17T17:31:48+00:00"
+    "last_validated_date": "2024-04-17T17:42:13+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-17T17:31:50+00:00"
+    "last_validated_date": "2024-04-17T17:42:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-17T17:31:49+00:00"
+    "last_validated_date": "2024-04-17T17:42:15+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "last_validated_date": "2024-04-17T17:31:52+00:00"
+    "last_validated_date": "2024-04-17T17:42:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "last_validated_date": "2024-04-17T17:31:51+00:00"
+    "last_validated_date": "2024-04-17T17:42:16+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-04-17T17:25:08+00:00"
+    "last_validated_date": "2024-04-17T17:50:27+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "last_validated_date": "2024-04-17T17:32:24+00:00"
+    "last_validated_date": "2024-04-17T17:42:46+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
     "last_validated_date": "2024-04-16T15:13:31+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,31 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
+    "last_validated_date": "2024-04-17T17:31:45+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
+    "last_validated_date": "2024-04-17T17:31:48+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
+    "last_validated_date": "2024-04-17T17:31:48+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
+    "last_validated_date": "2024-04-17T17:31:50+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
+    "last_validated_date": "2024-04-17T17:31:49+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
+    "last_validated_date": "2024-04-17T17:31:52+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
+    "last_validated_date": "2024-04-17T17:31:51+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
+    "last_validated_date": "2024-04-17T17:25:08+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
+    "last_validated_date": "2024-04-17T17:32:24+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
     "last_validated_date": "2024-04-16T15:13:31+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,9 +1,9 @@
 {
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "last_validated_date": "2024-04-11T11:27:59+00:00"
+    "last_validated_date": "2024-04-16T15:13:31+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "last_validated_date": "2024-04-08T17:32:17+00:00"
+    "last_validated_date": "2024-04-16T15:12:50+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
     "last_validated_date": "2024-04-08T17:37:18+00:00"
@@ -30,7 +30,7 @@
     "last_validated_date": "2024-04-04T10:47:21+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "last_validated_date": "2024-04-09T14:43:41+00:00"
+    "last_validated_date": "2024-04-16T15:14:29+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
     "last_validated_date": "2024-04-10T11:34:18+00:00"
@@ -66,7 +66,7 @@
     "last_validated_date": "2024-03-26T14:06:58+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "last_validated_date": "2024-03-26T14:07:18+00:00"
+    "last_validated_date": "2024-04-16T15:09:28+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
     "last_validated_date": "2024-03-27T09:15:34+00:00"
@@ -78,19 +78,19 @@
     "last_validated_date": "2024-04-03T13:49:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-16T14:51:31+00:00"
+    "last_validated_date": "2024-04-16T15:09:51+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-11T12:05:06+00:00"
+    "last_validated_date": "2024-04-16T15:10:07+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-03T15:19:23+00:00"
+    "last_validated_date": "2024-04-17T07:32:19+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_list_event_buses_with_limit": {
     "last_validated_date": "2024-04-03T14:53:31+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-03-26T14:11:46+00:00"
+    "last_validated_date": "2024-04-16T15:10:30+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
     "last_validated_date": "2024-03-26T14:07:59+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
+    "last_validated_date": "2024-04-11T11:27:59+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
     "last_validated_date": "2024-04-08T17:32:17+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -78,7 +78,7 @@
     "last_validated_date": "2024-04-03T13:49:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-03T15:30:52+00:00"
+    "last_validated_date": "2024-04-16T14:51:31+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
     "last_validated_date": "2024-04-11T12:05:06+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -80,6 +80,9 @@
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
     "last_validated_date": "2024-04-03T15:30:52+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
+    "last_validated_date": "2024-04-11T12:05:06+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventsEventBus::test_describe_delete_not_existing_event_bus": {
     "last_validated_date": "2024-04-03T15:19:23+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,9 +1,9 @@
 {
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-22T13:11:07+00:00"
+    "last_validated_date": "2024-04-23T06:11:32+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-22T13:11:10+00:00"
+    "last_validated_date": "2024-04-23T06:11:34+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
     "last_validated_date": "2024-04-22T13:11:10+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -2,6 +2,12 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
     "last_validated_date": "2024-04-08T17:32:17+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
+    "last_validated_date": "2024-04-08T17:37:18+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
+    "last_validated_date": "2024-04-08T17:37:19+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
     "last_validated_date": "2024-04-08T17:29:40+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
     "last_validated_date": "2024-04-08T16:36:39+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
+    "last_validated_date": "2024-04-08T17:27:57+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
     "last_validated_date": "2024-04-04T10:47:20+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
     "last_validated_date": "2024-04-09T14:43:41+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
+    "last_validated_date": "2024-04-10T11:34:18+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
     "last_validated_date": "2024-04-09T16:21:04+00:00"
   },

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -26,6 +26,9 @@
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
     "last_validated_date": "2024-04-04T10:47:21+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
+    "last_validated_date": "2024-04-09T14:43:41+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
     "last_validated_date": "2024-04-09T16:21:04+00:00"
   },

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -20,7 +20,6 @@ from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
     entries = [
         {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR introduces the core structure of the new localstack native implementation of event bridge. 
Furthermore, it implements the CRUD functionality based on snapshots of verified AWS tests. A clean pattern for keeping data stored in the AccountRegionBundle store separate from related functionality is required. Separation of different sender functionality based on the target should be handled more efficiently than in a if else chain.
These API operations are implemented:

- create_event_bus
- delete_event_bus
- describe_event_bus
- list_event_buses
- enable_rule
- delete_rule
- describe_rule
- disable_rule
- list_rules
- list_rule_names_by_target
- put_rule
- list_targets_by_rule
- put_targets
- remove_targets
- put_events
- put_partner_events

<!-- What notable changes does this PR make? -->
## Changes
- Implement new provider, and crud API operations. API methods are grouped by resource type and sorted in hierarchical order, each group is sorted alphabetically.
- Implement new dataclass definitions for EventBus and Rule
- Implement service class composing the dataclass for EventBridgeService, RuleService and TargetService, encapsulating related functionality
- A TargetService is instantiated via a base class and a factory containing specific logic in respect to the defined target service
- Added multiple validated AWS tests for basic API functionality validation

## Limitations
No pattern matching is implemented yet, thus all events are matched to all rules and sed to all targets.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

