### PR TITLE
Raise correct exceptions for simultaneous lambda function updates

### DIFF
--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -456,14 +456,13 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         # cache the result to save time upon every invocation.
         get_runtime_client_path()
         if function_version.config.code:
-            # FIXME parallelize could be a problem
             function_version.config.code.prepare_for_execution()
             image_name = resolver.get_image_for_runtime(function_version.config.runtime)
             platform = docker_platform(function_version.config.architectures[0])
             # Pull image for a given platform upon function creation such that invocations do not time out.
             if (image_name, platform) not in PULLED_IMAGES:
                 try:
-                    # FIXME not specific to update, kinda sucks, multiple parallel downloads
+                    # FIXME multiple concurrent pulls could take place, which will slow them all down
                     CONTAINER_CLIENT.pull_image(image_name, platform)
                     PULLED_IMAGES.add((image_name, platform))
                 except NoSuchImage as e:

--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -456,12 +456,14 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         # cache the result to save time upon every invocation.
         get_runtime_client_path()
         if function_version.config.code:
+            # FIXME parallelize could be a problem
             function_version.config.code.prepare_for_execution()
             image_name = resolver.get_image_for_runtime(function_version.config.runtime)
             platform = docker_platform(function_version.config.architectures[0])
             # Pull image for a given platform upon function creation such that invocations do not time out.
             if (image_name, platform) not in PULLED_IMAGES:
                 try:
+                    # FIXME not specific to update, kinda sucks, multiple parallel downloads
                     CONTAINER_CLIENT.pull_image(image_name, platform)
                     PULLED_IMAGES.add((image_name, platform))
                 except NoSuchImage as e:

--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -149,6 +149,16 @@ class LambdaService:
 
         return event_manager
 
+    def _start_lambda_version(self, version_manager: LambdaVersionManager) -> None:
+        with self.update_locks[version_manager.function_version.id.qualified_arn()]:
+            if update_context.is_cancelled:
+                update_context.stopped = True
+                return
+            new_state = version_manager.start()
+            self.update_version_state(
+                function_version=version_manager.function_version, new_state=new_state
+            )
+
     def create_function_version(self, function_version: FunctionVersion) -> Future[None]:
         """
         Creates a new function version (manager), and puts it in the startup dict
@@ -160,22 +170,19 @@ class LambdaService:
             version_manager = self.lambda_starting_versions.get(qualified_arn)
             if version_manager:
                 raise Exception(
-                    "Version '%s' already starting up and in state %s",
-                    qualified_arn,
-                    version_manager.state,
+                    f"Version '{qualified_arn}' already starting up and in state {version_manager.state}"
                 )
             state = lambda_stores[function_version.id.account][function_version.id.region]
             fn = state.functions.get(function_version.id.function_name)
             version_manager = LambdaVersionManager(
                 function_arn=qualified_arn,
                 function_version=function_version,
-                lambda_service=self,
                 function=fn,
                 counting_service=self.counting_service,
                 assignment_service=self.assignment_service,
             )
             self.lambda_starting_versions[qualified_arn] = version_manager
-        return self.task_executor.submit(version_manager.start)
+        return self.task_executor.submit(self._start_lambda_version, version_manager)
 
     def publish_version(self, function_version: FunctionVersion):
         """
@@ -201,13 +208,12 @@ class LambdaService:
             version_manager = LambdaVersionManager(
                 function_arn=qualified_arn,
                 function_version=function_version,
-                lambda_service=self,
                 function=fn,
                 counting_service=self.counting_service,
                 assignment_service=self.assignment_service,
             )
             self.lambda_starting_versions[qualified_arn] = version_manager
-        version_manager.start()
+        self._start_lambda_version(version_manager)
 
     # Commands
     def invoke(

--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -166,7 +166,8 @@ class LambdaService:
             version_manager = self.lambda_starting_versions.get(qualified_arn)
             if version_manager:
                 raise ResourceConflictException(
-                    f"The operation cannot be performed at this time. An update is in progress for resource: {function_version.id.unqualified_arn()}"
+                    f"The operation cannot be performed at this time. An update is in progress for resource: {function_version.id.unqualified_arn()}",
+                    Type="User",
                 )
             state = lambda_stores[function_version.id.account][function_version.id.region]
             fn = state.functions.get(function_version.id.function_name)

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -63,7 +63,6 @@ class LambdaVersionManager:
         function_arn: str,
         function_version: FunctionVersion,
         function: Function,
-        lambda_service: "LambdaService",
         counting_service: CountingService,
         assignment_service: AssignmentService,
     ):
@@ -71,7 +70,6 @@ class LambdaVersionManager:
         self.function_arn = function_arn
         self.function_version = function_version
         self.function = function
-        self.lambda_service = lambda_service
         self.counting_service = counting_service
         self.assignment_service = assignment_service
         self.log_handler = LogHandler(function_version.config.role, function_version.id.region)
@@ -85,8 +83,7 @@ class LambdaVersionManager:
         self.provisioned_state_lock = threading.RLock()
         self.state = None
 
-    def start(self) -> None:
-        new_state = None
+    def start(self) -> VersionState:
         try:
             self.log_handler.start_subscriber()
             time_before = time.perf_counter()
@@ -115,11 +112,7 @@ class LambdaVersionManager:
                 e,
                 exc_info=True,
             )
-        finally:
-            if new_state:
-                self.lambda_service.update_version_state(
-                    function_version=self.function_version, new_state=new_state
-                )
+        return new_state
 
     def stop(self) -> None:
         LOG.debug("Stopping lambda version '%s'", self.function_arn)

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -333,3 +333,7 @@ def _get_lambda_invocation_events(logs_client, function_name, expected_num_event
         return events
 
     return retry(get_events, retries=retries, sleep_before=5, sleep=5)
+
+
+def is_docker_runtime_executor():
+    return config.LAMBDA_RUNTIME_EXECUTOR in ["docker", ""]

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13788,7 +13788,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
-    "recorded-date": "08-04-2024, 12:53:58",
+    "recorded-date": "08-04-2024, 13:14:54",
     "recorded-content": {
       "create-function-response": {
         "CreateEventSourceMappingResponse": null,

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13854,7 +13854,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
-    "recorded-date": "08-04-2024, 12:54:46",
+    "recorded-date": "09-04-2024, 11:23:28",
     "recorded-content": {
       "create-function-response": {
         "Architectures": [

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -13786,5 +13786,131 @@
         }
       }
     }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
+    "recorded-date": "08-04-2024, 12:53:58",
+    "recorded-content": {
+      "create-function-response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "update-during-in-progress-update-exc": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:<region>:111111111111:function:<function-name:1>"
+        },
+        "Type": "User",
+        "message": "The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
+    "recorded-date": "08-04-2024, 12:54:46",
+    "recorded-content": {
+      "create-function-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.12",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-during-in-progress-update-exc": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:<region>:111111111111:function:<function-name:1>"
+        },
+        "Type": "User",
+        "message": "The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -86,6 +86,12 @@
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
     "last_validated_date": "2023-11-20T15:46:52+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
+    "last_validated_date": "2024-04-08T12:54:45+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
+    "last_validated_date": "2024-04-08T12:53:57+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
     "last_validated_date": "2023-11-20T15:47:16+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -90,7 +90,7 @@
     "last_validated_date": "2024-04-08T12:54:45+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
-    "last_validated_date": "2024-04-08T12:53:57+00:00"
+    "last_validated_date": "2024-04-08T13:14:54+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
     "last_validated_date": "2023-11-20T15:47:16+00:00"

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -87,7 +87,7 @@
     "last_validated_date": "2023-11-20T15:46:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_code_updates": {
-    "last_validated_date": "2024-04-08T12:54:45+00:00"
+    "last_validated_date": "2024-04-09T11:23:28+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_lambda_concurrent_config_updates": {
     "last_validated_date": "2024-04-08T13:14:54+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently raising a custom exception if an update cannot be performed yet, as another update is currently in progress. Instead, we should raise the correct exception AWS also raises.

This was planned as an investigation how to make updates concurrent, with the realization that this is currently not possible in AWS.

<!-- What notable changes does this PR make? -->
## Changes
* Remove callback after start, but add complete logic into the lambda service
* Adapt exception
* Add two test, one for config, one for code, to test the changes. They use a threading event to block the update if run against LocalStack, to avoid test flakyness when the updates are too fast.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

