### PR TITLE
add s3 POST policy validation

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -932,6 +932,15 @@ class InvalidLocationConstraint(ServiceException):
     LocationConstraint: Optional[BucketRegion]
 
 
+class EntityTooLarge(ServiceException):
+    code: str = "EntityTooLarge"
+    sender_fault: bool = False
+    status_code: int = 400
+    MaxSizeAllowed: Optional[KeyLength]
+    HostId: Optional[HostId]
+    ProposedSize: Optional[ProposedSize]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1190,6 +1190,26 @@
         "documentation": "<p>The specified location-constraint is not valid</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/EntityTooLarge",
+      "value": {
+        "type": "structure",
+        "members": {
+          "MaxSizeAllowed": {
+            "shape": "KeyLength"
+          },
+          "HostId": {
+            "shape": "HostId"
+          },
+          "ProposedSize": {
+            "shape": "ProposedSize"
+          }
+        },
+        "documentation": "<p>Your proposed upload exceeds the maximum allowed size</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -789,24 +789,20 @@ def validate_post_policy(
 def _verify_condition(
     condition: list | dict, form: ImmutableMultiDict, additional_policy_metadata: dict
 ) -> bool:
+    if isinstance(condition, dict) and len(condition) > 1:
+        raise CommonServiceException(
+            code="InvalidPolicyDocument",
+            message="Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
+        )
+
     match condition:
         case ["eq", "$bucket", value]:
             return additional_policy_metadata.get("bucket") == value
 
-        case {"bucket": value, **kwargs}:
-            if kwargs:
-                raise CommonServiceException(
-                    code="InvalidPolicyDocument",
-                    message="Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
-                )
+        case {"bucket": value}:
             return additional_policy_metadata.get("bucket") == value
 
         case {**kwargs}:
-            if len(kwargs) != 1:
-                raise CommonServiceException(
-                    code="InvalidPolicyDocument",
-                    message="Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
-                )
             return all(form.get(key) == val for key, val in kwargs.items())
 
         case ["eq", key, value]:

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -772,6 +772,11 @@ def validate_post_policy(
     #  1. only support the kind of matching the field supports: `success_action_status` does not support `starts-with`
     #  matching
     #  2. if there are fields that are not defined in the policy, we should reject it
+
+    # Special case for LEGACY_V2: do not validate the conditions. Remove this check once we remove legacy_v2
+    if not additional_policy_metadata:
+        return
+
     conditions = policy_decoded.get("conditions", [])
     for condition in conditions:
         if not _verify_condition(condition, request_form, additional_policy_metadata):

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1447,7 +1447,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
         # TODO: signature validation is not implemented for pre-signed POST
         # policy validation is not implemented either, except expiration and mandatory fields
-        validate_post_policy(context.request.form)
+        validate_post_policy(context.request.form, additional_policy_metadata={})
 
         # Botocore has trouble parsing responses with status code in the 3XX range, it interprets them as exception
         # it then raises a nonsense one with a wrong code

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3686,7 +3686,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 # is recognized by all form fields.
                 object_key = object_key.replace("${filename}", fileobj.filename)
 
-        # TODO: also add specific headers as specified in the table under:
+        # TODO: see if we need to pass additional metadata not contained in the policy from the table under
         # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html#sigv4-PolicyConditions
         additional_policy_metadata = {
             "bucket": bucket,

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -3661,22 +3661,38 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
 
         form = context.request.form
-        validate_post_policy(form)
         object_key = context.request.form.get("key")
 
         if "file" in form:
             # in AWS, you can pass the file content as a string in the form field and not as a file object
-            stream = BytesIO(to_bytes(form["file"]))
+            file_data = to_bytes(form["file"])
+            object_content_length = len(file_data)
+            stream = BytesIO(file_data)
         else:
             # this is the default behaviour
             fileobj = context.request.files["file"]
             stream = fileobj.stream
+            # stream is a SpooledTemporaryFile, so we can seek the stream to know its length, necessary for policy
+            # validation
+            original_pos = stream.tell()
+            object_content_length = stream.seek(0, 2)
+            # reset the stream and put it back at its original position
+            stream.seek(original_pos, 0)
+
             if "${filename}" in object_key:
                 # TODO: ${filename} is actually usable in all form fields
                 # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/PresignedPost.html
                 # > The string ${filename} is automatically replaced with the name of the file provided by the user and
                 # is recognized by all form fields.
                 object_key = object_key.replace("${filename}", fileobj.filename)
+
+        # TODO: also add specific headers as specified in the table under:
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html#sigv4-PolicyConditions
+        additional_policy_metadata = {
+            "bucket": bucket,
+            "content_length": object_content_length,
+        }
+        validate_post_policy(form, additional_policy_metadata)
 
         if canned_acl := form.get("acl"):
             validate_canned_acl(canned_acl)

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -2,7 +2,7 @@ import abc
 from io import RawIOBase
 from typing import IO, Iterable, Iterator, Literal, Optional
 
-from localstack.aws.api.s3 import BucketName, MultipartUploadId, PartNumber
+from localstack.aws.api.s3 import BucketName, PartNumber
 from localstack.services.s3.utils import ObjectRange
 from localstack.services.s3.v3.models import S3Multipart, S3Object, S3Part
 
@@ -202,7 +202,7 @@ class S3ObjectStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_multipart(self, bucket: BucketName, upload_id: MultipartUploadId) -> S3StoredMultipart:
+    def get_multipart(self, bucket: BucketName, upload_id: S3Multipart) -> S3StoredMultipart:
         pass
 
     @abc.abstractmethod

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10650,7 +10650,7 @@ class TestS3PresignedPost:
             Key=object_key,
             Fields={"success_action_redirect": redirect_location},
             Conditions=[
-                ["eq", "$success_action_redirect", "HTTP://wrong.location/test"],
+                ["eq", "$success_action_redirect", redirect_location.replace("http://", "HTTP://")],
             ],
             ExpiresIn=60,
         )

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11454,5 +11454,73 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation": {
+    "recorded-date": "08-04-2024, 17:55:00",
+    "recorded-content": {
+      "invalid-condition-eq": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"http://localhost.test/random\"]",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "invalid-condition-missing-prefix": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Extra input fields: success_action_redirect",
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "invalid-condition-wrong-condition": {
+        "Error": {
+          "Code": "InvalidPolicyDocument",
+          "HostId": "<host-id>",
+          "Message": "Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
+          "RequestId": "<request-id:3>"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
+    "recorded-date": "08-04-2024, 17:29:34",
+    "recorded-content": {
+      "invalid-content-length-too-big": {
+        "Error": {
+          "Code": "EntityTooLarge",
+          "HostId": "<host-id>",
+          "MaxSizeAllowed": "10",
+          "Message": "Your proposed upload exceeds the maximum allowed size",
+          "ProposedSize": "12",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "invalid-content-length-too-small": {
+        "Error": {
+          "Code": "EntityTooSmall",
+          "HostId": "<host-id>",
+          "Message": "Your proposed upload is smaller than the minimum allowed size",
+          "MinSizeAllowed": "5",
+          "ProposedSize": "1",
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "final-object": {
+        "AcceptRanges": "bytes",
+        "Body": "aaaaaaaaaa",
+        "ContentLength": 10,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11495,7 +11495,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "recorded-date": "10-04-2024, 12:29:32",
+    "recorded-date": "10-04-2024, 15:09:48",
     "recorded-content": {
       "invalid-condition-eq": {
         "Error": {
@@ -11525,7 +11525,7 @@
         "Error": {
           "Code": "AccessDenied",
           "HostId": "<host-id>",
-          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"HTTP://wrong.location/test\"]",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"HTTP://localhost.test/random\"]",
           "RequestId": "<request-id:4>"
         }
       },

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11495,7 +11495,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "recorded-date": "10-04-2024, 12:05:22",
+    "recorded-date": "10-04-2024, 12:29:32",
     "recorded-content": {
       "invalid-condition-eq": {
         "Error": {
@@ -11503,6 +11503,61 @@
           "HostId": "<host-id>",
           "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"http://localhost.test/random\"]",
           "RequestId": "<request-id:1>"
+        }
+      },
+      "invalid-condition-missing-prefix": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"success_action_redirect\", \"http://localhost.test/random\"]",
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "invalid-condition-wrong-condition": {
+        "Error": {
+          "Code": "InvalidPolicyDocument",
+          "HostId": "<host-id>",
+          "Message": "Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "invalid-condition-wrong-value-casing": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"HTTP://wrong.location/test\"]",
+          "RequestId": "<request-id:4>"
+        }
+      },
+      "head-object-metadata": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 6,
+        "ContentType": "text/plain",
+        "ETag": "\"e80b5017098950fc58aad83c8c14978e\"",
+        "Expires": "datetime",
+        "LastModified": "datetime",
+        "Metadata": {
+          "test-1": "test-meta-1",
+          "test-2": "test-meta-2"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "final-object": {
+        "AcceptRanges": "bytes",
+        "Body": "abcdef",
+        "ContentLength": 6,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e80b5017098950fc58aad83c8c14978e\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11495,7 +11495,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "recorded-date": "10-04-2024, 11:55:12",
+    "recorded-date": "10-04-2024, 12:05:22",
     "recorded-content": {
       "invalid-condition-eq": {
         "Error": {
@@ -11504,37 +11504,48 @@
           "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"http://localhost.test/random\"]",
           "RequestId": "<request-id:1>"
         }
-      },
-      "invalid-condition-missing-prefix": {
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
+    "recorded-date": "10-04-2024, 12:16:01",
+    "recorded-content": {
+      "invalid-condition-starts-with": {
         "Error": {
           "Code": "AccessDenied",
           "HostId": "<host-id>",
-          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"success_action_redirect\", \"http://localhost.test/random\"]",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"starts-with\", \"$success_action_redirect\", \"http://localhost\"]",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "invalid-condition-starts-with-casing": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"starts-with\", \"$success_action_redirect\", \"http://localhost\"]",
           "RequestId": "<request-id:2>"
         }
       },
-      "invalid-condition-wrong-condition": {
-        "Error": {
-          "Code": "InvalidPolicyDocument",
-          "HostId": "<host-id>",
-          "Message": "Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
-          "RequestId": "<request-id:3>"
-        }
-      },
-      "invalid-condition-wrong-value-casing": {
-        "Error": {
-          "Code": "AccessDenied",
-          "HostId": "<host-id>",
-          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"HTTP://wrong.location/test\"]",
-          "RequestId": "<request-id:4>"
-        }
-      },
-      "final-object": {
+      "get-object-1": {
         "AcceptRanges": "bytes",
-        "Body": "aaaaaaaaaaaa",
-        "ContentLength": 12,
+        "Body": "abcdef",
+        "ContentLength": 6,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"45e4812014d83dde5666ebdf5a8ed1ed\"",
+        "ETag": "\"e80b5017098950fc58aad83c8c14978e\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-2": {
+        "AcceptRanges": "bytes",
+        "Body": "manual value to change ETag",
+        "ContentLength": 27,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"365cb4550a52593ad95c6b31242d7418\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11455,35 +11455,6 @@
       }
     }
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation": {
-    "recorded-date": "08-04-2024, 17:55:00",
-    "recorded-content": {
-      "invalid-condition-eq": {
-        "Error": {
-          "Code": "AccessDenied",
-          "HostId": "<host-id>",
-          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"http://localhost.test/random\"]",
-          "RequestId": "<request-id:1>"
-        }
-      },
-      "invalid-condition-missing-prefix": {
-        "Error": {
-          "Code": "AccessDenied",
-          "HostId": "<host-id>",
-          "Message": "Invalid according to Policy: Extra input fields: success_action_redirect",
-          "RequestId": "<request-id:2>"
-        }
-      },
-      "invalid-condition-wrong-condition": {
-        "Error": {
-          "Code": "InvalidPolicyDocument",
-          "HostId": "<host-id>",
-          "Message": "Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
-          "RequestId": "<request-id:3>"
-        }
-      }
-    }
-  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
     "recorded-date": "08-04-2024, 17:29:34",
     "recorded-content": {
@@ -11513,6 +11484,57 @@
         "ContentLength": 10,
         "ContentType": "binary/octet-stream",
         "ETag": "\"e09c80c42fda55f9d992e59ca6b3307d\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
+    "recorded-date": "10-04-2024, 11:55:12",
+    "recorded-content": {
+      "invalid-condition-eq": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"http://localhost.test/random\"]",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "invalid-condition-missing-prefix": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"success_action_redirect\", \"http://localhost.test/random\"]",
+          "RequestId": "<request-id:2>"
+        }
+      },
+      "invalid-condition-wrong-condition": {
+        "Error": {
+          "Code": "InvalidPolicyDocument",
+          "HostId": "<host-id>",
+          "Message": "Invalid Policy: Invalid Simple-Condition: Simple-Conditions must have exactly one property specified.",
+          "RequestId": "<request-id:3>"
+        }
+      },
+      "invalid-condition-wrong-value-casing": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"eq\", \"$success_action_redirect\", \"HTTP://wrong.location/test\"]",
+          "RequestId": "<request-id:4>"
+        }
+      },
+      "final-object": {
+        "AcceptRanges": "bytes",
+        "Body": "aaaaaaaaaaaa",
+        "ContentLength": 12,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"45e4812014d83dde5666ebdf5a8ed1ed\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ServerSideEncryption": "AES256",

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -519,7 +519,10 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "last_validated_date": "2024-04-10T11:55:12+00:00"
+    "last_validated_date": "2024-04-10T12:05:22+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
+    "last_validated_date": "2024-04-10T12:16:01+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
     "last_validated_date": "2024-04-08T17:29:34+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -519,7 +519,7 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "last_validated_date": "2024-04-10T12:05:22+00:00"
+    "last_validated_date": "2024-04-10T12:29:32+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
     "last_validated_date": "2024-04-10T12:16:01+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -519,7 +519,7 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "last_validated_date": "2024-04-10T12:29:32+00:00"
+    "last_validated_date": "2024-04-10T15:09:48+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
     "last_validated_date": "2024-04-10T12:16:01+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -518,8 +518,8 @@
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
-  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation": {
-    "last_validated_date": "2024-04-08T17:55:00+00:00"
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
+    "last_validated_date": "2024-04-10T11:55:12+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
     "last_validated_date": "2024-04-08T17:29:34+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -518,6 +518,12 @@
   "tests/aws/services/s3/test_s3.py::TestS3ObjectLockRetention::test_s3_object_retention_exc": {
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation": {
+    "last_validated_date": "2024-04-08T17:55:00+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
+    "last_validated_date": "2024-04-08T17:29:34+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
     "last_validated_date": "2024-02-24T01:01:59+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As requested with #10351, we did not implement specific policy validation for pre-signed POST. 
We were lacking validating the conditions specified in the policy. This PR will take a stab at implementing the requested ones with a general implementation. 

See: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
Some are still left to do: 
- AWS will reject a policy that has extra fields passed to it that are not defined in the `Conditions` field (for ex. if you set `success_action_redirect` without defining it as a condition, the request should fail). This is not implemented yet as we need to know and test exactly which fields are considered "extra", with help from the documentation but will need quite some tests
- some fields only support one kind of matching (usually "exact matching" and some support both exact and "starts-with" matching). Right now we do not make the distinction, we will need some kind of map to validate that. Can be done at the same time as the other missing feature listed right above

<!-- What notable changes does this PR make? -->
## Changes
Added validation of the conditions using structural pattern matching, which I hope make it more readable, otherwise we can fall back to some de-structuring + some if/else statements. 

Added tests around the defined use cases of the feature requests + some negative testing. 

_fixes #10351_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

