### PR TITLE
Add container labels to container configuration and container run methods

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -839,6 +839,7 @@ class ContainerClient(metaclass=ABCMeta):
             workdir=container_config.workdir,
             privileged=container_config.privileged,
             platform=container_config.platform,
+            labels=container_config.labels,
         )
 
     @abstractmethod

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -463,6 +463,7 @@ class ContainerConfiguration:
     workdir: Optional[str] = None
     platform: Optional[str] = None
     ulimits: Optional[List[Ulimit]] = None
+    labels: Optional[Dict[str, str]] = None
 
 
 class ContainerConfigurator(Protocol):
@@ -898,6 +899,7 @@ class ContainerClient(metaclass=ABCMeta):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
         platform: Optional[DockerPlatform] = None,
         privileged: Optional[bool] = None,
         ulimits: Optional[List[Ulimit]] = None,

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -736,6 +736,7 @@ class SdkDockerClient(ContainerClient):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
         platform: Optional[DockerPlatform] = None,
         privileged: Optional[bool] = None,
         ulimits: Optional[List[Ulimit]] = None,
@@ -776,6 +777,7 @@ class SdkDockerClient(ContainerClient):
                 privileged=privileged,
                 platform=platform,
                 init=init,
+                labels=labels,
                 **kwargs,
             )
             result = self.start_container(

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1799,6 +1799,23 @@ class TestDockerLabels:
         result_labels = result.get("Config", {}).get("Labels")
         assert result_labels == labels
 
+    def test_run_container_with_labels(self, docker_client):
+        labels = {"foo": "bar", short_uid(): short_uid()}
+        container_name = _random_container_name()
+        try:
+            docker_client.run_container(
+                image_name="alpine",
+                command=["sh", "-c", "while true; do sleep 1; done"],
+                labels=labels,
+                name=container_name,
+                detach=True,
+            )
+            result = docker_client.inspect_container(container_name_or_id=container_name)
+            result_labels = result.get("Config", {}).get("Labels")
+            assert result_labels == labels
+        finally:
+            docker_client.remove_container(container_name=container_name, force=True)
+
 
 def _pull_image_if_not_exists(docker_client: ContainerClient, image_name: str):
     if image_name not in docker_client.get_docker_image_names():


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We are currently not supporting container labels the `run_container` method and the `ContainerConfiguration` class.
Since we want to make use of labels more often, to allow grouping containers and adding additional information, we should allow setting labels for these options to create containers.

<!-- What notable changes does this PR make? -->
## Changes
* Add `labels` parameter to `run_container` methods
* Add `labels` as a new field in the `ContainerConfiguration` class
* Add small test assuring `labels` to be correctly set during the `run_container` call


## Testing

We currently have no explicit tests for the `ContainerConfiguration` class, but test it rather implicitly. The `labels` field of it will be tested while testing new `ecs` changes.

<!-- The following sections are optional, but can be useful! 


## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

