### PR TITLE
fixed exception handling in secretsmanager

### DIFF
--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pytest
 import requests
 from botocore.auth import SigV4Auth
+from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import Runtime
 from localstack.aws.api.secretsmanager import (
@@ -2352,13 +2353,13 @@ class TestSecretsManager:
 
         secret_arn = response["ARN"]
 
-        with pytest.raises(Exception) as ex:
+        with pytest.raises(ClientError) as ex:
             aws_client.secretsmanager.get_secret_value(
                 SecretId=secret_arn, VersionStage="AWSPREVIOUS"
             )
         sm_snapshot.match("error_get_secret_value_non_existing", ex.value.response)
 
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(ClientError) as exc:
             aws_client.secretsmanager.get_secret_value(
                 SecretId=secret_name, VersionId=version_id, VersionStage="AWSPREVIOUS"
             )

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4476,7 +4476,7 @@
     }
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
-    "recorded-date": "10-04-2024, 06:44:15",
+    "recorded-date": "11-04-2024, 05:37:47",
     "recorded-content": {
       "error_get_secret_value_non_existing": {
         "Error": {

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4474,5 +4474,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
+    "recorded-date": "10-04-2024, 06:44:15",
+    "recorded-content": {
+      "error_get_secret_value_non_existing": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Secrets Manager can't find the specified secret value for staging label: AWSPREVIOUS"
+        },
+        "Message": "Secrets Manager can't find the specified secret value for staging label: AWSPREVIOUS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "mismatch_version_id_and_stage": {
+        "Error": {
+          "Code": "InvalidRequestException",
+          "Message": "You provided a VersionStage that is not associated to the provided VersionId."
+        },
+        "Message": "You provided a VersionStage that is not associated to the provided VersionId.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_random_exclude_characters_and_symbols": {
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
+    "last_validated_date": "2024-04-10T06:44:15+00:00"
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
     "last_validated_date": "2024-03-15T08:12:44+00:00"
   },

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-03-15T08:12:01+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_get_secret_value_errors": {
-    "last_validated_date": "2024-04-10T06:44:15+00:00"
+    "last_validated_date": "2024-04-11T05:37:47+00:00"
   },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_invalid_secret_name[ Inv *?!]Name\\\\-]": {
     "last_validated_date": "2024-03-15T08:12:44+00:00"


### PR DESCRIPTION
## Motivation
This PR addresses the issue described in https://github.com/localstack/localstack/issues/10621.

## Changes
Updated moto exception handling in LocalStack.

## Testing

- Added aws validated test cases.
