### PR TITLE
Add missing library for transcribe on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
         # Install dependencies to add additional repos
         apt-get install -y --no-install-recommends \
             # Runtime packages (groff-base is necessary for AWS CLI help)
-            ca-certificates curl gnupg git make openssl tar pixz zip unzip groff-base iputils-ping nss-passwords procps iproute2 xz-utils
+            ca-certificates curl gnupg git make openssl tar pixz zip unzip groff-base iputils-ping nss-passwords procps iproute2 xz-utils libatomic1
 
 # FIXME Node 18 actually shouldn't be necessary in Community, but we assume its presence in lots of tests
 # Install nodejs package from the dist release server. Note: we're installing from dist binaries, and not via

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -9,7 +9,6 @@ from localstack.aws.api.transcribe import BadRequestException, ConflictException
 from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.testing.pytest import markers
 from localstack.utils.files import new_tmp_file
-from localstack.utils.platform import get_arch
 from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import poll_condition, retry
 
@@ -23,10 +22,6 @@ def transcribe_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.transcribe_api())
 
 
-@pytest.mark.skipif(
-    "arm" in get_arch(),
-    reason="Vosk transcription library has issues running on Circle CI arm64 executors.",
-)
 class TestTranscribe:
     @staticmethod
     def _wait_transcription_job(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In Transcribe, when executing on ARM, we receive errors of a missing shared object (#10522). This is because the `libvosk.so` depends on `libatomic1.so`, which is not present in the ARM image. Installing `libatomic1` via `apt` in the running container fixes this issue.

<!-- What notable changes does this PR make? -->
## Changes

This PR adds `libatomic1` as a dependency in the apt installation step of the `Dockerfile`. 

## Testing

Removed the skip marker for ARM on the Transcribe tests. If they're green on this build, the issue should be resolved

## TODO

What's left to do:

- [x] Green Pipeline
- [x] Add this change to the pro image as well
- [ ] Remove notice in docs repo that ARM does not work (https://github.com/localstack/docs/pull/1171)


