### PR TITLE
Ensure container clients return the same format for container labels on list call

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -833,7 +833,7 @@ class CmdDockerClient(ContainerClient):
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
 
-    def _transform_container_labels(self, labels: str) -> dict[str, str]:
+    def _transform_container_labels(self, labels: str) -> Dict[str, str]:
         """
         Transforms the container labels returned by the docker command from the key-value pair format to a dict
         :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -237,6 +237,7 @@ class CmdDockerClient(ContainerClient):
                 container_list = [json.loads(line) for line in cmd_result.splitlines()]
         result = []
         for container in container_list:
+            labels = self._transform_container_labels(container["Labels"])
             result.append(
                 {
                     # support both, Docker and podman API response formats (`ID` vs `Id`)
@@ -245,7 +246,7 @@ class CmdDockerClient(ContainerClient):
                     # Docker returns a single string for `Names`, whereas podman returns a list of names
                     "name": ensure_list(container["Names"])[0],
                     "status": container["State"],
-                    "labels": container["Labels"],
+                    "labels": labels,
                 }
             )
         return result
@@ -831,3 +832,13 @@ class CmdDockerClient(ContainerClient):
         process_stdout_lower = to_str(error.stdout).lower()
         if any(msg.lower() in process_stdout_lower for msg in error_messages):
             raise NoSuchContainer(container_name_or_id, stdout=error.stdout, stderr=error.stderr)
+
+    def _transform_container_labels(self, labels: str) -> dict[str, str]:
+        """
+        Transforms the container labels returned by the docker command from the key-value pair format to a dict
+        :param labels: Input string, comma separated key value pairs. Example: key1=value1,key2=value2
+        :return: Dict representation of the passed values, example: {"key1": "value1", "key2": "value2"}
+        """
+        labels = labels.split(",")
+        labels = [label.partition("=") for label in labels]
+        return {label[0]: label[2] for label in labels}

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1816,6 +1816,18 @@ class TestDockerLabels:
         finally:
             docker_client.remove_container(container_name=container_name, force=True)
 
+    def test_list_containers_with_labels(self, docker_client, create_container):
+        labels = {"foo": "bar", short_uid(): short_uid()}
+        container = create_container(
+            "alpine", command=["sh", "-c", "while true; do sleep 1; done"], labels=labels
+        )
+        docker_client.start_container(container.container_id)
+
+        containers = docker_client.list_containers(filter=f"id={container.container_id}")
+        assert len(containers) == 1
+        container = containers[0]
+        assert container["labels"] == labels
+
 
 def _pull_image_if_not_exists(docker_client: ContainerClient, image_name: str):
     if image_name not in docker_client.get_docker_image_names():

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -37,7 +37,7 @@ class TestDockerClient:
             "id": mock_container["ID"],
             "image": mock_container["Image"],
             "name": mock_container["Names"],
-            "labels": mock_container["Labels"],
+            "labels": {"authors": "LocalStack Contributors"},
             "status": mock_container["State"],
         }
         run_mock.return_value = json.dumps(mock_container)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, the `docker_cmd_client` returns labels on the `list_container` operations in this format: `key1=value1,key2=value2`
The SDK based client however returns a dict: `{"key1": "label1", "key2": "label2"}`

As they should behave identical, we need to change the CMD client to use the same dict format (as it is easier to use).

<!-- What notable changes does this PR make? -->
## Changes
* Change the CMD docker client to return a dict of labels, instead of a comma separated list of key-value pairs
* Add a test asserting that format

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

