### PR TITLE
[SFN] Fix Unknown Service sfn errors

### DIFF
--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -24,7 +24,8 @@ from localstack.services.stepfunctions.asl.utils.boto_client import boto_client_
 
 
 class StateTaskServiceAwsSdk(StateTaskServiceCallback):
-    _NORMALISED_SERVICE_NAMES = {"dynamodb": "DynamoDb"}
+    # Defines bindings of lower-cased service names to the StepFunctions service name included in error messages.
+    _SERVICE_ERROR_NAMES = {"dynamodb": "DynamoDb", "sfn": "Sfn"}
 
     def from_state_props(self, state_props: StateProps) -> None:
         super().from_state_props(state_props=state_props)
@@ -33,10 +34,11 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
         return f"{self.resource.service_name}:{self.resource.api_name}"
 
     @staticmethod
-    def _normalise_service_name(service_name: str) -> str:
+    def _normalise_service_error_name(service_name: str) -> str:
+        # Computes the normalised service error name for the given service.
         service_name_lower = service_name.lower()
-        if service_name_lower in StateTaskServiceAwsSdk._NORMALISED_SERVICE_NAMES:
-            return StateTaskServiceAwsSdk._NORMALISED_SERVICE_NAMES[service_name_lower]
+        if service_name_lower in StateTaskServiceAwsSdk._SERVICE_ERROR_NAMES:
+            return StateTaskServiceAwsSdk._SERVICE_ERROR_NAMES[service_name_lower]
         return get_service_catalog().get(service_name).service_id.replace(" ", "")
 
     @staticmethod
@@ -66,7 +68,7 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
         if isinstance(ex, ClientError):
-            norm_service_name: str = self._normalise_service_name(self.resource.api_name)
+            norm_service_name: str = self._normalise_service_error_name(self.resource.api_name)
             error: str = self._normalise_exception_name(norm_service_name, ex)
 
             error_message: str = ex.response["Error"]["Message"]

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_aws_sdk.py
@@ -1,4 +1,6 @@
-from botocore.exceptions import ClientError
+import logging
+
+from botocore.exceptions import ClientError, UnknownServiceError
 
 from localstack.aws.api.stepfunctions import HistoryEventType, TaskFailedEventDetails
 from localstack.aws.protocol.service_router import get_service_catalog
@@ -22,6 +24,8 @@ from localstack.services.stepfunctions.asl.eval.environment import Environment
 from localstack.services.stepfunctions.asl.eval.event.event_detail import EventDetails
 from localstack.services.stepfunctions.asl.utils.boto_client import boto_client_for
 
+LOG = logging.getLogger(__name__)
+
 
 class StateTaskServiceAwsSdk(StateTaskServiceCallback):
     # Defines bindings of lower-cased service names to the StepFunctions service name included in error messages.
@@ -36,10 +40,28 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
     @staticmethod
     def _normalise_service_error_name(service_name: str) -> str:
         # Computes the normalised service error name for the given service.
+
+        # Return the explicit binding if one exists.
         service_name_lower = service_name.lower()
         if service_name_lower in StateTaskServiceAwsSdk._SERVICE_ERROR_NAMES:
             return StateTaskServiceAwsSdk._SERVICE_ERROR_NAMES[service_name_lower]
-        return get_service_catalog().get(service_name).service_id.replace(" ", "")
+
+        # Attempt to retrieve the service name from the catalog.
+        try:
+            service_model = get_service_catalog().get(service_name)
+            if service_model is not None:
+                sfn_normalised_service_name = service_model.service_id.replace(" ", "")
+                return sfn_normalised_service_name
+        except UnknownServiceError:
+            LOG.warning(
+                f"No service for name '{service_name}' when building aws-sdk service error name."
+            )
+
+        # Revert to returning the resource's service name and log the missing binding.
+        LOG.error(
+            f"No normalised service error name for aws-sdk integration was found for service: '{service_name}'"
+        )
+        return service_name
 
     @staticmethod
     def _normalise_exception_name(norm_service_name: str, ex: Exception) -> str:

--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -373,7 +373,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                     raise TaskTimedOut()
                 else:
                     raise TaskDoesNotExist()
-        raise InvalidToken()
+        raise InvalidToken("Invalid token")
 
     def send_task_failure(
         self,
@@ -396,7 +396,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
                     raise TaskTimedOut()
                 else:
                     raise TaskDoesNotExist()
-        raise InvalidToken()
+        raise InvalidToken("Invalid token")
 
     def start_execution(
         self,

--- a/tests/aws/services/stepfunctions/templates/services/services_templates.py
+++ b/tests/aws/services/stepfunctions/templates/services/services_templates.py
@@ -20,6 +20,12 @@ class ServicesTemplates(TemplateLoader):
     AWS_SDK_DYNAMODB_PUT_UPDATE_GET_ITEM: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/aws_sdk_dynamodb_put_update_get_item.json5"
     )
+    AWS_SDK_SFN_SEND_TASK_FAILURE: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/aws_sdk_sfn_send_task_failure.json5"
+    )
+    AWS_SDK_SFN_SEND_TASK_SUCCESS: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/aws_sdk_sfn_send_task_success.json5"
+    )
     AWS_SDK_SFN_START_EXECUTION: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/aws_sdk_sfn_start_execution.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_sfn_send_task_failure.json5
+++ b/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_sfn_send_task_failure.json5
@@ -1,0 +1,14 @@
+{
+  "Comment": "AWS_SDK_SFN_SEND_TASK_FAILURE",
+  "StartAt": "StartExecution",
+  "States": {
+    "StartExecution": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskFailure",
+      "Parameters": {
+        "TaskToken.$": "$$.Execution.Input.TaskToken"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_sfn_send_task_success.json5
+++ b/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_sfn_send_task_success.json5
@@ -1,0 +1,15 @@
+{
+  "Comment": "AWS_SDK_SFN_SEND_TASK_SUCCESS",
+  "StartAt": "StartExecution",
+  "States": {
+    "StartExecution": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskSuccess",
+      "Parameters": {
+        "Output": "ParameterOutput",
+        "TaskToken.$": "$$.Execution.Input.TaskToken"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -139,6 +139,63 @@ class TestTaskServiceAwsSdk:
             exec_input,
         )
 
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # TODO: aws-sdk SFN integration now appears to be inserting decorated error names into the cause messages.
+            #  Upcoming work should collect more failure snapshot involving other aws-sdk integrations and trace a
+            #  picture of generalisability of this behaviour.
+            #  Hence insert this into the logic of the aws-sdk integration.
+            "$..cause"
+        ]
+    )
+    @markers.aws.validated
+    def test_sfn_send_task_success_no_such_token(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_SUCCESS)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"TaskToken": "NoSuchTaskToken"})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            # TODO: see reasoning for test `test_sfn_send_task_success_no_such_token` in this suite.
+            "$..cause"
+        ]
+    )
+    @markers.aws.validated
+    def test_sfn_send_task_failure_no_such_token(
+        self,
+        aws_client,
+        create_iam_role_for_sfn,
+        create_state_machine,
+        sfn_snapshot,
+    ):
+        template = ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_FAILURE)
+        definition = json.dumps(template)
+
+        exec_input = json.dumps({"TaskToken": "NoSuchTaskToken"})
+        create_and_record_execution(
+            aws_client.stepfunctions,
+            create_iam_role_for_sfn,
+            create_state_machine,
+            sfn_snapshot,
+            definition,
+            exec_input,
+        )
+
     @markers.aws.validated
     def test_sfn_start_execution(
         self,

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer
 
 from localstack.testing.pytest import markers
@@ -148,43 +149,23 @@ class TestTaskServiceAwsSdk:
             "$..cause"
         ]
     )
-    @markers.aws.validated
-    def test_sfn_send_task_success_no_such_token(
-        self,
-        aws_client,
-        create_iam_role_for_sfn,
-        create_state_machine,
-        sfn_snapshot,
-    ):
-        template = ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_SUCCESS)
-        definition = json.dumps(template)
-
-        exec_input = json.dumps({"TaskToken": "NoSuchTaskToken"})
-        create_and_record_execution(
-            aws_client.stepfunctions,
-            create_iam_role_for_sfn,
-            create_state_machine,
-            sfn_snapshot,
-            definition,
-            exec_input,
-        )
-
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            # TODO: see reasoning for test `test_sfn_send_task_success_no_such_token` in this suite.
-            "$..cause"
-        ]
+    @pytest.mark.parametrize(
+        "state_machine_template",
+        [
+            ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_SUCCESS),
+            ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_FAILURE),
+        ],
     )
     @markers.aws.validated
-    def test_sfn_send_task_failure_no_such_token(
+    def test_sfn_send_task_outcome_with_no_such_token(
         self,
         aws_client,
         create_iam_role_for_sfn,
         create_state_machine,
         sfn_snapshot,
+        state_machine_template,
     ):
-        template = ST.load_sfn_template(ST.AWS_SDK_SFN_SEND_TASK_FAILURE)
-        definition = json.dumps(template)
+        definition = json.dumps(state_machine_template)
 
         exec_input = json.dumps({"TaskToken": "NoSuchTaskToken"})
         create_and_record_execution(

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
@@ -1488,8 +1488,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_success_no_such_token": {
-    "recorded-date": "10-04-2024, 11:39:42",
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template0]": {
+    "recorded-date": "10-04-2024, 18:55:26",
     "recorded-content": {
       "get_execution_history": {
         "events": [
@@ -1578,8 +1578,8 @@
       }
     }
   },
-  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_failure_no_such_token": {
-    "recorded-date": "10-04-2024, 11:45:49",
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template1]": {
+    "recorded-date": "10-04-2024, 18:55:40",
     "recorded-content": {
       "get_execution_history": {
         "events": [

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
@@ -1487,5 +1487,184 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_success_no_such_token": {
+    "recorded-date": "10-04-2024, 11:39:42",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "StartExecution"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Output": "ParameterOutput",
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "region": "<region>",
+              "resource": "sendTaskSuccess",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendTaskSuccess",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": "Invalid Token: 'Invalid token' (Service: Sfn, Status Code: 400, Request ID: <request_id>)",
+              "error": "Sfn.InvalidTokenException",
+              "resource": "sendTaskSuccess",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "Invalid Token: 'Invalid token' (Service: Sfn, Status Code: 400, Request ID: <request_id>)",
+              "error": "Sfn.InvalidTokenException"
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_failure_no_such_token": {
+    "recorded-date": "10-04-2024, 11:45:49",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "StartExecution"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "TaskToken": "NoSuchTaskToken"
+              },
+              "region": "<region>",
+              "resource": "sendTaskFailure",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendTaskFailure",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskFailedEventDetails": {
+              "cause": "Invalid Token: 'Invalid token' (Service: Sfn, Status Code: 400, Request ID: <request_id>)",
+              "error": "Sfn.InvalidTokenException",
+              "resource": "sendTaskFailure",
+              "resourceType": "aws-sdk:sfn"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "executionFailedEventDetails": {
+              "cause": "Invalid Token: 'Invalid token' (Service: Sfn, Status Code: 400, Request ID: <request_id>)",
+              "error": "Sfn.InvalidTokenException"
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
@@ -11,6 +11,12 @@
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_list_secrets": {
     "last_validated_date": "2023-06-22T11:59:49+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_failure_no_such_token": {
+    "last_validated_date": "2024-04-10T11:45:49+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_success_no_such_token": {
+    "last_validated_date": "2024-04-10T11:39:42+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_start_execution_implicit_json_serialisation": {
     "last_validated_date": "2024-02-05T11:29:16+00:00"
   }

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
@@ -11,11 +11,11 @@
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_list_secrets": {
     "last_validated_date": "2023-06-22T11:59:49+00:00"
   },
-  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_failure_no_such_token": {
-    "last_validated_date": "2024-04-10T11:45:49+00:00"
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template0]": {
+    "last_validated_date": "2024-04-10T18:55:26+00:00"
   },
-  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_success_no_such_token": {
-    "last_validated_date": "2024-04-10T11:39:42+00:00"
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template1]": {
+    "last_validated_date": "2024-04-10T18:55:40+00:00"
   },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_start_execution_implicit_json_serialisation": {
     "last_validated_date": "2024-02-05T11:29:16+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The current version of the SFN v2 interpreter lacks the capability to enhance aws-sdk failures if the service name of the resource isn't associated with any explicit bindings or isn't available in boto's service catalog. As a result, it generates unknown service error messages, causing the interpreter to fail without reporting the decorated aws-sdk source error.

This pull request aims to resolve this issue by refining the logic for decorating service error names to accurately search for a normalised error name. In cases where none is found, it logs such incidents and returns the original service name as an error. This adjustment is intended to enable the computation to continue, albeit with slightly different cause and error string formatting, while also emphasising the necessity for more explicit normalised error name bindings.

Furthermore, the PR includes bindings for aws-sdk stepfunctions error names along with relevant snapshot tests, addressing issue #10622.

<!-- What notable changes does this PR make? -->
## Changes
- revised logic for decorating aws-sdk service error names
- added normalised error name binding for aws-sdk stepfunctions
- added relevant aws-sdk stepfunctions snapshot tests

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

