### PR TITLE
fix docker client ulimits

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -790,7 +790,7 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--platform", platform]
         if ulimits:
             cmd += list(
-                itertools.chain.from_iterable(["--ulimits", str(ulimit)] for ulimit in ulimits)
+                itertools.chain.from_iterable(["--ulimit", str(ulimit)] for ulimit in ulimits)
             )
         if init:
             cmd += ["--init"]

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -745,14 +745,6 @@ class SdkDockerClient(ContainerClient):
         LOG.debug("Running container with image: %s", image_name)
         container = None
         try:
-            kwargs = {}
-            if ulimits:
-                kwargs["ulimits"] = [
-                    docker.types.Ulimit(
-                        name=ulimit.name, soft=ulimit.soft_limit, hard=ulimit.hard_limit
-                    )
-                    for ulimit in ulimits
-                ]
             container = self.create_container(
                 image_name,
                 name=name,
@@ -778,7 +770,7 @@ class SdkDockerClient(ContainerClient):
                 platform=platform,
                 init=init,
                 labels=labels,
-                **kwargs,
+                ulimits=ulimits,
             )
             result = self.start_container(
                 container_name_or_id=container,

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -25,6 +25,7 @@ from localstack.utils.container_utils.container_client import (
     NoSuchNetwork,
     PortMappings,
     RegistryConnectionError,
+    Ulimit,
     Util,
     VolumeInfo,
 )
@@ -1431,6 +1432,28 @@ class TestRunWithAdditionalArgs:
             inspect_result["NetworkSettings"]["Ports"]["80/tcp"][0]["HostPort"]
         )
         assert automatic_host_port > 0
+
+    def test_run_with_ulimit(self, docker_client: ContainerClient):
+        # test baseline without ulimit
+        container_name = f"c-{short_uid()}"
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            name=container_name,
+            remove=True,
+            command=["sh", "-c", "ulimit -n"],
+        )
+        assert stdout.decode(config.DEFAULT_ENCODING).strip() == "1073741816"
+
+        # Test with ulimit set
+        container_name = f"c-{short_uid()}"
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            name=container_name,
+            remove=True,
+            command=["sh", "-c", "ulimit -n"],
+            ulimits=[Ulimit(name="nofile", soft_limit=1024, hard_limit=1024)],
+        )
+        assert stdout.decode(config.DEFAULT_ENCODING).strip() == "1024"
 
 
 class TestDockerImages:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1434,17 +1434,6 @@ class TestRunWithAdditionalArgs:
         assert automatic_host_port > 0
 
     def test_run_with_ulimit(self, docker_client: ContainerClient):
-        # test baseline without ulimit
-        container_name = f"c-{short_uid()}"
-        stdout, _ = docker_client.run_container(
-            "alpine",
-            name=container_name,
-            remove=True,
-            command=["sh", "-c", "ulimit -n"],
-        )
-        assert stdout.decode(config.DEFAULT_ENCODING).strip() == "1073741816"
-
-        # Test with ulimit set
         container_name = f"c-{short_uid()}"
         stdout, _ = docker_client.run_container(
             "alpine",


### PR DESCRIPTION

## Motivation

Trying to setup ulimits for a container using the `ContainerClient.run_container()` method leads to invalid configuration. 

The sdk client tried to transform the Ulimit object twice. Once in `run_container` and then again in `start_container`. Removed it from `run_container` as it calls the `start_container`, which should keep it's interface.

The cmd client had a typo in ulimit.
