### PR TITLE
fix `connect` unit tests for cross-accounts 

### DIFF
--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -119,7 +119,7 @@ class TestClientFactory:
 
     @patch.object(ExternalAwsClientFactory, "_get_client")
     def test_external_aws_client_credentials_loaded_from_env_if_set_to_none(
-        self, mock, monkeypatch
+        self, mock, region_name, monkeypatch
     ):
         session = boto3.Session()
         connect_to = ExternalAwsClientFactory(use_ssl=True, session=session)
@@ -147,7 +147,7 @@ class TestClientFactory:
         )
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=region_name,
             use_ssl=True,
             verify=True,
             endpoint_url=None,

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -68,7 +68,7 @@ class TestClientFactory:
         mock.meta.events.register.assert_not_called()
 
     @patch.object(ExternalClientFactory, "_get_client")
-    def test_external_client_credentials_origin(self, region_name, mock, monkeypatch):
+    def test_external_client_credentials_origin(self, mock, region_name, monkeypatch):
         connect_to = ExternalClientFactory(use_ssl=True)
         connect_to.get_client(
             "abc", region_name="xx-south-1", aws_access_key_id="foo", aws_secret_access_key="bar"

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -68,7 +68,7 @@ class TestClientFactory:
         mock.meta.events.register.assert_not_called()
 
     @patch.object(ExternalClientFactory, "_get_client")
-    def test_external_client_credentials_origin(self, mock, monkeypatch):
+    def test_external_client_credentials_origin(self, region_name, mock, monkeypatch):
         connect_to = ExternalClientFactory(use_ssl=True)
         connect_to.get_client(
             "abc", region_name="xx-south-1", aws_access_key_id="foo", aws_secret_access_key="bar"
@@ -92,7 +92,7 @@ class TestClientFactory:
         )
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=region_name,
             use_ssl=True,
             verify=False,
             endpoint_url="http://localhost:4566",
@@ -107,7 +107,7 @@ class TestClientFactory:
         connect_to.get_client("def", region_name=None, aws_access_key_id=TEST_AWS_ACCESS_KEY_ID)
         mock.assert_called_once_with(
             service_name="def",
-            region_name="us-east-1",
+            region_name=region_name,
             use_ssl=True,
             verify=False,
             endpoint_url="http://localhost:4566",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
After the merge of #10253 the scheduled workflow for randomised AWS credentials started to fail [here](https://app.circleci.com/pipelines/github/localstack/localstack/24025/workflows/acdd44d3-7f7e-40f2-8c85-759ce17b1980/jobs/197842/tests). 

<!-- What notable changes does this PR make? -->
## Changes
This PR removes the hardcoded `us-east-1` region from `test_external_client_credentials_origin` and `test_external_aws_client_credentials_loaded_from_env_if_set_to_none` unit test cases and uses the `region_name` fixture instead. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

