### PR TITLE
More consistent CFn logging for individual resources

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -895,7 +895,7 @@ class TemplateDeployer:
             }
             if len(resources) == 0:
                 break
-            for resource_id, resource in resources.items():
+            for i, (resource_id, resource) in enumerate(resources.items()):
                 try:
                     # TODO: cache condition value in resource details on deployment and use cached value here
                     if evaluate_resource_condition(
@@ -907,6 +907,14 @@ class TemplateDeployer:
                             "Remove", logical_resource_id=resource_id
                         )
                         # TODO: check actual return value
+                        LOG.debug(
+                            'Handling "Remove" for resource "%s" (%s/%s) type "%s" in loop iteration %s',
+                            resource_id,
+                            i + 1,
+                            len(resources),
+                            resource["ResourceType"],
+                            iteration_cycle + 1,
+                        )
                         executor.deploy_loop(resource, resource_provider_payload)
                         self.stack.set_resource_status(resource_id, "DELETE_COMPLETE")
                 except Exception as e:

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1256,6 +1256,15 @@ class TemplateDeployer:
                         if not should_remove:
                             del changes[j]
                             continue
+                        LOG.debug(
+                            'Handling "%s" for resource "%s" (%s/%s) type "%s" in loop iteration %s',
+                            action,
+                            resource_id,
+                            j + 1,
+                            len(changes),
+                            res_change["ResourceType"],
+                            i + 1,
+                        )
                     self.apply_change(change, stack=stack)
                     changes_done.append(change)
                     del changes[j]

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -913,7 +913,7 @@ class TemplateDeployer:
                             i + 1,
                             len(resources),
                             resource["ResourceType"],
-                            iteration_cycle + 1,
+                            iteration_cycle,
                         )
                         executor.deploy_loop(resource, resource_provider_payload)
                         self.stack.set_resource_status(resource_id, "DELETE_COMPLETE")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When adding new resources, CFn logs a message like:

```
Handling "Add" for resource "V1MysqlClusterSecretAttachment649A3B90" (1/1) type "AWS::SecretsManager::SecretTargetAttachment" in loop iteration 2
```

Which is useful context.

When deleting resources, CFn does not print anything 😥

<!-- What notable changes does this PR make? -->
## Changes

- Add log message for handling removes during stack deletes
- Add logging for _resource_ removal


<!-- The following sections are optional, but can be useful! 


Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

