### PR TITLE
fix lambda function URLs when they don't exist or the service is not loaded

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -3,7 +3,7 @@ from localstack.aws import handlers
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.handlers.metric_handler import MetricHandler
-from localstack.aws.handlers.service_plugin import ServiceLoader
+from localstack.aws.handlers.service_plugin import ServiceLoader, ServiceLoaderForDataPlane
 from localstack.aws.trace import TracingHandlerChain
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceManager, ServicePluginManager
 from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
@@ -22,6 +22,7 @@ class LocalstackAwsGateway(Gateway):
         self.service_request_router = ServiceRequestRouter()
         # lazy-loads services into the router
         load_service = ServiceLoader(self.service_manager, self.service_request_router)
+        load_service_for_data_plane = ServiceLoaderForDataPlane(load_service)
 
         metric_collector = MetricHandler()
         # the main request handler chain
@@ -31,6 +32,7 @@ class LocalstackAwsGateway(Gateway):
                 handlers.add_internal_request_params,
                 handlers.handle_runtime_shutdown,
                 metric_collector.create_metric_handler_item,
+                load_service_for_data_plane,
                 handlers.preprocess_request,
                 handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
                 handlers.enforce_cors,

--- a/localstack/aws/handlers/service_plugin.py
+++ b/localstack/aws/handlers/service_plugin.py
@@ -40,15 +40,15 @@ class ServiceLoader(Handler):
             return
 
         service_name: str = context.service.service_name
+        if service_name in self.loaded_services:
+            return
+
         if not self.service_manager.exists(service_name):
             raise NotImplementedError
         elif not is_api_enabled(service_name):
             raise NotImplementedError(
                 f"Service '{service_name}' is not enabled. Please check your 'SERVICES' configuration variable."
             )
-
-        if service_name in self.loaded_services:
-            return
 
         request_router = self.service_request_router
 

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -138,13 +138,18 @@ def custom_signing_name_rules(signing_name: str, path: str) -> Optional[ServiceM
 
 def custom_host_addressing_rules(host: str) -> Optional[ServiceModelIdentifier]:
     """
-    Rules based on the host header of the request.
+    Rules based on the host header of the request, which is typically the data plane of a service.
+
+    # TODO: ELB, AppSync, CloudFront, ...
     """
     if ".execute-api." in host:
         return ServiceModelIdentifier("apigateway")
 
     if ".lambda-url." in host:
         return ServiceModelIdentifier("lambda")
+
+    if ".s3-website." in host:
+        return ServiceModelIdentifier("s3")
 
 
 def custom_path_addressing_rules(path: str) -> Optional[ServiceModelIdentifier]:
@@ -303,6 +308,19 @@ def resolve_conflicts(
             if content_type == "application/x-amz-json-1.0"
             else ServiceModelIdentifier("sqs")
         )
+
+
+def determine_aws_service_model_for_data_plane(
+    request: Request, services: ServiceCatalog = None
+) -> Optional[ServiceModel]:
+    """
+    A stripped down version of ``determine_aws_service_model`` which only checks hostname indicators for
+    the AWS data plane, such as s3 websites, lambda function URLs, or API gateway routes.
+    """
+    services = services or get_service_catalog()
+    custom_host_match = custom_host_addressing_rules(request.host)
+    if custom_host_match:
+        return services.get(*custom_host_match)
 
 
 def determine_aws_service_model(

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -317,9 +317,9 @@ def determine_aws_service_model_for_data_plane(
     A stripped down version of ``determine_aws_service_model`` which only checks hostname indicators for
     the AWS data plane, such as s3 websites, lambda function URLs, or API gateway routes.
     """
-    services = services or get_service_catalog()
     custom_host_match = custom_host_addressing_rules(request.host)
     if custom_host_match:
+        services = services or get_service_catalog()
         return services.get(*custom_host_match)
 
 

--- a/localstack/services/lambda_/urlrouter.py
+++ b/localstack/services/lambda_/urlrouter.py
@@ -56,20 +56,25 @@ class FunctionUrlRouter:
     def handle_lambda_url_invocation(
         self, request: Request, api_id: str, region: str, **url_params: dict[str, str]
     ) -> HttpResponse:
-        response = HttpResponse(headers={"Content-type": "application/json"})
+        response = HttpResponse()
+        response.mimetype = "application/json"
 
         lambda_url_config = None
-        try:
-            for account_id in lambda_stores.keys():
-                store = lambda_stores[account_id][region]
-                for fn in store.functions.values():
-                    for url_config in fn.function_url_configs.values():
-                        if url_config.url_id == api_id:
-                            lambda_url_config = url_config
-        except IndexError as e:
-            LOG.warning(f"Lambda URL ({api_id}) not found: {e}")
-            response.set_json({"Message": None})
-            response.status = "404"
+
+        for account_id in lambda_stores.keys():
+            store = lambda_stores[account_id][region]
+            for fn in store.functions.values():
+                for url_config in fn.function_url_configs.values():
+                    if url_config.url_id == api_id:
+                        lambda_url_config = url_config
+
+        # TODO: check if errors are different when the URL has existed previously
+        if lambda_url_config is None:
+            LOG.info("Lambda URL %s does not exist", request.url)
+            response.data = '{"Message":null}'
+            response.status = 403
+            response.headers["x-amzn-ErrorType"] = "AccessDeniedException"
+            # TODO: x-amzn-requestid
             return response
 
         event = event_for_lambda_url(

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1128,6 +1128,21 @@ class TestLambdaURL:
             )
         snapshot.match("invoke_function_invalid_invoke_type", e.value.response)
 
+    @markers.aws.validated
+    def test_lambda_url_non_existing_url(self):
+        lambda_url_subdomain = "0123456789abcdefghijklmnopqrstuv.lambda-url.us-east-1"
+
+        if is_aws_cloud():
+            url = f"https://{lambda_url_subdomain}.on.aws"
+        else:
+            url = config.external_service_url(subdomains=lambda_url_subdomain)
+
+        response = requests.get(url)
+        assert response.text == '{"Message":null}'
+        assert response.status_code == 403
+        assert response.headers["Content-Type"] == "application/json"
+        assert response.headers["x-amzn-ErrorType"] == "AccessDeniedException"
+
     @markers.snapshot.skip_snapshot_verify(
         paths=[
             "$..headers.domain",  # TODO: LS Lambda should populate this value for AWS parity

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -200,6 +200,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
     "last_validated_date": "2023-11-20T21:05:44+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_non_existing_url": {
+    "last_validated_date": "2024-04-11T17:16:39+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
     "last_validated_date": "2024-02-14T14:32:31+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I noticed an error when calling non-existing lambda function URLs. The code we had was apparently faulty, and I got this error:

```
2024-04-11T17:20:40.966 ERROR --- [et.reactor-0] l.aws.handlers.logging     : exception during call chain
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/handlers.py", line 27, in __call__
    router_response = self.router.dispatch(context.request)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/router.py", line 378, in dispatch
    return self.dispatcher(request, handler, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/dispatcher.py", line 71, in _dispatch
    result = endpoint(request, **args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/localstack/services/lambda_/urlrouter.py", line 79, in handle_lambda_url_invocation
    match = FULL_FN_ARN_PATTERN.search(lambda_url_config.function_arn).groupdict()
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

After writing a test, I further ran into a problem that we've had in the past, which is that, services that have a data plane are not properly loaded based on calling URLs of the data plane, even though we could.

Previously localstack would behave like this when calling a lambda function URL without lambda being loaded first (e.g., by calling `awslocal lambda list-functions`.

```
 % curl http://a38wes0ubqxh7ipckjdl8ilptt40uiha.lambda-url.us-east-1.localhost.localstack.cloud:4566
{"__type": "InternalError", "message": "exception while calling lambda with unknown operation: Traceback (most recent call last):\n  File \"/opt/code/localstack/localstack/aws/protocol/parser.py\", line 557, in parse\n    operation, uri_params = self._operation_router.match(request)\n                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/code/localstack/localstack/aws/protocol/op_router.py\", line 321, in match\n    rule, args = matcher.match(path, method=method, return_rule=True)\n                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/code/localstack/.venv/lib/python3.11/site-packages/werkzeug/routing/map.py\", line 631, in match\n    raise NotFound() from None\nwerkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py\", line 166, in handle\n    handler(self, self.context, response)\n  File \"/opt/code/localstack/localstack/aws/handlers/service.py\", line 63, in __call__\n    return self.parse_and_enrich(context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/code/localstack/localstack/aws/handlers/service.py\", line 67, in parse_and_enrich\n    operation, instance = parser.parse(context.request)\n                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/code/localstack/localstack/aws/protocol/parser.py\", line 172, in wrapper\n    return func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/code/localstack/localstack/aws/protocol/parser.py\", line 559, in parse\n    raise OperationNotFoundParserError(\nlocalstack.aws.protocol.parser.OperationNotFoundParserError: Unable to find operation for request to service lambda: GET /\n"}%  
```

In this situation:
* the service is identified as "lambda" because of the hostname matching rule (`.lambda-url.`)
* the service hasn't been loaded yet, so the edge routes for lambda (i.e., the data plane) haven't been added yet either
* therefore, the request moves on to the service request parser, which fails because no operation is associated with the request.

bad and ugly!

instead, localstack now correctly loads the lambda service:

```
curl http://a38wes0ubqxh7ipckjdl8ilptt40uiha.lambda-url.us-east-1.localhost.localstack.cloud:4566
{"Message": null}
```

I had to
* adapt the service loader so it correctly loads services even when there is no api operation set (for the life of me i cannot remember why i thought it would be useful to check individual operations rather than just whole services).
* add a special type of service loader that only checks the hostname rules


<!-- What notable changes does this PR make? -->
## Changes

* A selected set of services are now properly loaded when calling data plane URLs. Specfically, URLs of APIGW (`.execute-api.`), S3 website (`.s3-website.`) (cc @bentsku) and lambda (`.lambda-url.`)
* Calling non-existing lambda function URLs now returns the correct HTTP response

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

