### PR TITLE
add S3 pre-signed POST test with credentials

### DIFF
--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10895,6 +10895,117 @@ class TestS3PresignedPost:
         final_object = aws_client.s3.get_object(Bucket=s3_bucket, Key=object_key)
         snapshot.match("final-object", final_object)
 
+    @pytest.mark.skipif(
+        condition=TEST_S3_IMAGE or LEGACY_V2_S3_PROVIDER,
+        reason="STS not enabled in S3 image / moto does not implement this",
+    )
+    @markers.aws.validated
+    def test_presigned_post_with_different_user_credentials(
+        self,
+        aws_client,
+        s3_create_bucket_with_client,
+        create_role_with_policy,
+        account_id,
+        wait_and_assume_role,
+        snapshot,
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value(
+                    "HostId", reference_replacement=False, value_replacement="<host-id>"
+                ),
+                snapshot.transform.key_value("RequestId"),
+            ]
+        )
+        bucket_name = f"bucket-{short_uid()}"
+        actions = [
+            "s3:CreateBucket",
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteBucket",
+            "s3:DeleteObject",
+        ]
+
+        assume_policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {"AWS": account_id},
+                    "Effect": "Allow",
+                }
+            ],
+        }
+        assume_policy_doc = json.dumps(assume_policy_doc)
+        role_name, role_arn = create_role_with_policy(
+            effect="Allow",
+            actions=actions,
+            assume_policy_doc=assume_policy_doc,
+            resource="*",
+        )
+
+        credentials = wait_and_assume_role(role_arn=role_arn)
+
+        client = boto3.client(
+            "s3",
+            config=Config(signature_version="s3v4"),
+            endpoint_url=_endpoint_url(),
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+
+        retry(
+            lambda: s3_create_bucket_with_client(s3_client=client, Bucket=bucket_name),
+            sleep=3 if is_aws_cloud() else 0.5,
+        )
+
+        object_key = "validate-policy-full-credentials"
+        presigned_request = client.generate_presigned_post(
+            Bucket=bucket_name,
+            Key=object_key,
+            ExpiresIn=60,
+            Conditions=[
+                {"bucket": bucket_name},
+            ],
+        )
+        # load the generated policy to assert that it kept the casing, and it is sent to AWS
+        generated_policy = json.loads(
+            base64.b64decode(presigned_request["fields"]["policy"]).decode("utf-8")
+        )
+        policy_conditions_fields = set()
+        token_condition = None
+        for condition in generated_policy["conditions"]:
+            if isinstance(condition, dict):
+                for k, v in condition.items():
+                    policy_conditions_fields.add(k)
+                    if k == "x-amz-security-token":
+                        token_condition = v
+            else:
+                # format is [operator, key, value]
+                policy_conditions_fields.add(condition[1])
+
+        assert policy_conditions_fields == {
+            "bucket",
+            "key",
+            "x-amz-security-token",
+            "x-amz-credential",
+            "x-amz-date",
+            "x-amz-algorithm",
+        }
+        assert token_condition == credentials["SessionToken"]
+
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": self.DEFAULT_FILE_VALUE},
+            verify=False,
+        )
+        assert response.status_code == 204
+
+        get_obj = aws_client.s3.get_object(Bucket=bucket_name, Key=object_key)
+        snapshot.match("get-obj", get_obj)
+
 
 def _s3_client_pre_signed_client(conf: Config, endpoint_url: str = None):
     if is_aws_cloud():

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11610,5 +11610,24 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_presigned_post_with_different_user_credentials": {
+    "recorded-date": "11-04-2024, 20:50:35",
+    "recorded-content": {
+      "get-obj": {
+        "AcceptRanges": "bytes",
+        "Body": "abcdef",
+        "ContentLength": 6,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e80b5017098950fc58aad83c8c14978e\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -572,6 +572,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_request_missing_signature[s3v4]": {
     "last_validated_date": "2023-08-04T21:58:54+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_presigned_post_with_different_user_credentials": {
+    "last_validated_date": "2024-04-11T20:50:35+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-False]": {
     "last_validated_date": "2023-08-04T22:00:25+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Just adding a sanity check that AWS properly validate all fields when using a fully created client with access key / secret key / session token, linked to the raised issue here: https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda/pull/24

<!-- What notable changes does this PR make? -->
## Changes
- add an AWS test with full credentials for a S3 pre-signed POST, validating the boto SDK automatically sets all the authorization fields as conditions

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

