### PR TITLE
fix metrics upload failure on community PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,8 +507,7 @@ jobs:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
             # check if a fork-only env var is set (https://circleci.com/docs/variables/)
-            # TODO revert to -z
-            if [ -n "$CIRCLE_PR_REPONAME" ]; then
+            if [ -z "$CIRCLE_PR_REPONAME" ]; then
               source .venv/bin/activate
               mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
               METRIC_REPORT_DIR_PATH=parity_metrics \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,7 +507,8 @@ jobs:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
             # check if a fork-only env var is set (https://circleci.com/docs/variables/)
-            if [ -z "$CIRCLE_PR_REPONAME" ]; then
+            # TODO revert to -z
+            if [ -n "$CIRCLE_PR_REPONAME" ]; then
               source .venv/bin/activate
               mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
               METRIC_REPORT_DIR_PATH=parity_metrics \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,12 +506,18 @@ jobs:
       - run:
           name: Upload test metrics and implemented coverage data to tinybird
           command: |
-            source .venv/bin/activate
-            mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
-            METRIC_REPORT_DIR_PATH=parity_metrics \
-            IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv \
-            SOURCE_TYPE=community \
-            python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
+            # check if a fork-only env var is set (https://circleci.com/docs/variables/)
+            if [ -z "$CIRCLE_PR_REPONAME" ]; then
+              source .venv/bin/activate
+              mkdir parity_metrics && mv target/metric_reports/metric-report-raw-data-*amd64*.csv parity_metrics
+              METRIC_REPORT_DIR_PATH=parity_metrics \
+              IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv \
+              SOURCE_TYPE=community \
+              python -m scripts.tinybird.upload_raw_test_metrics_and_coverage
+            else
+              echo "Skipping parity reporting to tinybird (no credentials, running on fork)..."
+            fi
+
       - run:
           name: Create Coverage Diff (Code Coverage)
           # pycobertura diff will return with exit code 0-3 -> we currently expect 2 (2: the changes worsened the overall coverage),


### PR DESCRIPTION
## Motivation
#10568 hardened the Tinybird Metrics Upload script such that it strictly fail in case the needed secret is not set (because we realized it silently broke before).

In a recent community contribution (https://github.com/localstack/localstack/pull/10625 🥳), we have seen the [`report` job in CircleCI fail](https://app.circleci.com/pipelines/github/localstack/localstack/24104/workflows/b6f652c4-42c7-4060-9bde-4bb21e6506ae/jobs/198814/parallel-runs/0/steps/0-107) because the secret is (due to security reasons) not set for workflow executions triggered on forks (untrusted code):
```
METRIC_REPORT_DIR_PATH=parity_metrics, IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv, SOURCE_TYPE=community
missing data, please check the available ENVs that are required to run the script
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/workspace/repo/scripts/tinybird/upload_raw_test_metrics_and_coverage.py", line 323, in <module>
    main()
  File "/tmp/workspace/repo/scripts/tinybird/upload_raw_test_metrics_and_coverage.py", line 313, in main
    raise Exception("missing TINYBIRD_PARITY_ANALYTICS_TOKEN")
Exception: missing TINYBIRD_PARITY_ANALYTICS_TOKEN

Exited with code exit status 1
```

Both is reasonable, the secrets need to be protected and the script needs to fail fast.
This PR fixes this issue by checking if the workflow is executed on a fork:
- If `$CIRCLE_PR_REPONAME` is set, gracefully skip the step.
  - According to the [CircleCI documentation](https://circleci.com/docs/variables/) this env var is only set on fork executions:
    > The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
- If `$CIRCLE_PR_REPONAME` is not set: Execute the upload. It's not a fork and the secret has to be available.

## Changes
- Only execute the Tinybird upload if the workflow is not executed on a fork.

## Testing
- 371b79a8ed548f7a5d08e768f8808ff9ea0eb77b reverts the check for the initial run to test that the variable really is not set for non-fork PRs.
  - [This run shows that the parity upload is correctly being skipped](https://app.circleci.com/pipelines/github/localstack/localstack/24114/workflows/b6ee1186-4f34-4f8c-929e-b805da55352b/jobs/198896):
    ```
    Skipping parity reporting to tinybird (no credentials, running on fork)...
    ```
- Afterwards a successful [run](https://app.circleci.com/pipelines/github/localstack/localstack/24115/workflows/b555975a-6c3e-4235-8bb5-911264af6c40/jobs/198914) the commit was reverted, testing the opposite:
  - [This run shows that the parity upload is correctly being executed](https://app.circleci.com/pipelines/github/localstack/localstack/24115/workflows/b555975a-6c3e-4235-8bb5-911264af6c40/jobs/198914):
    ```
    METRIC_REPORT_DIR_PATH=parity_metrics, 
    IMPLEMENTATION_COVERAGE_FILE=scripts/implementation_coverage_full.csv, SOURCE_TYPE=community
    sent data to tinybird, status code: ...
    ```

## TODO
- [x] Ensure that the [run](https://app.circleci.com/pipelines/github/localstack/localstack/24114/workflows/b6ee1186-4f34-4f8c-929e-b805da55352b/jobs/198896) on 371b79a8ed548f7a5d08e768f8808ff9ea0eb77b skips the Tinybird upload.
- [x] Ensure that the final [run](https://app.circleci.com/pipelines/github/localstack/localstack/24115/workflows/b555975a-6c3e-4235-8bb5-911264af6c40/jobs/198914) (after 371b79a8ed548f7a5d08e768f8808ff9ea0eb77b was reverted) performs the Tinybird upload.