### PR TITLE
Fix dev run container exiting from raw mode

### DIFF
--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -158,42 +158,7 @@ def run_interactive(command: List[str]):
 
     :param command: the command to pass to subprocess.Popen
     """
-    # save original tty setting then set it to raw mode
-    import pty
-    import termios
-    import tty
-
-    old_tty = termios.tcgetattr(sys.stdin)
-    tty.setraw(sys.stdin.fileno())
-
-    # open pseudo-terminal to interact with subprocess
-    master_fd, slave_fd = pty.openpty()
-
-    try:
-        # use os.setsid() make it run in a new process group, or bash job control will not be enabled
-        p = subprocess.Popen(
-            command,
-            preexec_fn=os.setsid,
-            stdin=slave_fd,
-            stdout=slave_fd,
-            stderr=slave_fd,
-            universal_newlines=True,
-        )
-
-        while p.poll() is None:
-            r, w, e = select.select([sys.stdin, master_fd], [], [])
-            if sys.stdin in r:
-                d = os.read(sys.stdin.fileno(), 10240)
-                os.write(master_fd, d)
-                if d == b"\x04":
-                    break
-            elif master_fd in r:
-                o = os.read(master_fd, 10240)
-                if o:
-                    os.write(sys.stdout.fileno(), o)
-    finally:
-        # restore tty settings back
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_tty)
+    subprocess.check_call(command)
 
 
 def is_command_available(cmd: str) -> bool:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Running a dev container with `python -m localstack.dev.run` does not return the terminal to "cooked" mode correctly. This means the user has to press Enter multiple times to get their prompt back.


<!-- What notable changes does this PR make? -->
## Changes

Swap out `run_interactive` for `subprocess.check_call` since I think all functionality implemented in `run_interactive` is performed by `check_call`. TBC

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

