### PR TITLE
Add libvirt as a build dependency

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -217,8 +217,9 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
+          # libvirt-dev is required by the libvirt-python Python package
           # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.11-0ubuntu0* postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.11-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true
         uses: actions/cache@v4


### PR DESCRIPTION
## Background

This PR prepares the community CI for the upcoming Libvirt virtualisation for EC2.

The `libvirt-dev` Debian package is required by `libvirt-python` Python package during the build time of Docker image.

## Changes

Adds `libvirt-dev` as a build-time dependency.