### PR TITLE
Validate existing test acm

### DIFF
--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -78,7 +78,7 @@ class TestACM:
         result = aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
         snapshot.match("describe-certificate", result)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_boto_wait_for_certificate_validation(
         self, acm_request_certificate, aws_client, monkeypatch
     ):

--- a/tests/aws/services/acm/test_acm.snapshot.json
+++ b/tests/aws/services/acm/test_acm.snapshot.json
@@ -291,5 +291,46 @@
         }
       }
     }
+  },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_domain_validation": {
+    "recorded-date": "12-04-2024, 15:36:37",
+    "recorded-content": {
+      "describe-certificate": {
+        "Certificate": {
+          "CertificateArn": "<certificate-arn:1>",
+          "CreatedAt": "datetime",
+          "DomainName": "<domain-name:1>",
+          "DomainValidationOptions": [
+            {
+              "DomainName": "<domain-name:1>",
+              "ValidationDomain": "<domain-name:1>",
+              "ValidationEmails": [],
+              "ValidationMethod": "<validation-method:1>",
+              "ValidationStatus": "PENDING_VALIDATION"
+            }
+          ],
+          "ExtendedKeyUsages": [],
+          "InUseBy": [],
+          "Issuer": "Amazon",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [],
+          "Options": {
+            "CertificateTransparencyLoggingPreference": "ENABLED"
+          },
+          "RenewalEligibility": "INELIGIBLE",
+          "SignatureAlgorithm": "<signature-algorithm:1>",
+          "Status": "PENDING_VALIDATION",
+          "Subject": "CN=<domain-name:1>",
+          "SubjectAlternativeNames": [
+            "<domain-name:1>"
+          ],
+          "Type": "AMAZON_ISSUED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/acm/test_acm.validation.json
+++ b/tests/aws/services/acm/test_acm.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/acm/test_acm.py::TestACM::test_create_certificate_for_multiple_alternative_domains": {
     "last_validated_date": "2024-01-09T14:58:14+00:00"
   },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_domain_validation": {
+    "last_validated_date": "2024-04-12T15:36:37+00:00"
+  },
   "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
     "last_validated_date": "2024-02-22T17:41:15+00:00"
   }


### PR DESCRIPTION
<!-- What notable changes does this PR make? -->
## Motivation

Part of the effort to improve parity with aws. This first step sorts all `aws.unknown` tags and replaces them with `aws.validated` or `aws.needs_fixing`. 

## Changes

Removed all `unknown` markers from acm.

There is no comment on the `test_boto_wait_for_certificate_validation` as the TODO is already well captured by the comment preceding the `acm_request_certificate` fixtures

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

