### PR TITLE
Adapt source distribution glob to new PEP 625 canonicalized name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ dist: entrypoints        ## Build source and built (wheel) distributions of the 
 
 publish: clean-dist dist  ## Publish the library to the central PyPi repository
 	# make sure the dist archive contains a non-empty entry_points.txt file before uploading
-	tar --wildcards --to-stdout -xf dist/localstack-core*.tar.gz "localstack-core*/localstack_core.egg-info/entry_points.txt" | grep . > /dev/null 2>&1 || (echo "Refusing upload, localstack-core dist does not contain entrypoints." && exit 1)
+	tar --wildcards --to-stdout -xf dist/localstack_core*.tar.gz "localstack_core*/localstack_core.egg-info/entry_points.txt" | grep . > /dev/null 2>&1 || (echo "Refusing upload, localstack-core dist does not contain entrypoints." && exit 1)
 	$(VENV_RUN); twine upload dist/*
 
 coveralls:         		  ## Publish coveralls metrics


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With the recently released setuptools version `69.3.0` (https://setuptools.pypa.io/en/latest/history.html#v69-3-0), setuptools normalizes the source distribution name to conform with [PEP 625](https://peps.python.org/pep-0625/).

In summary, source distribution names should be named as followed: `{distribution}-{version}.tar.gz`.
Only a single hypen is now allowed:
> Conforming sdist files can be recognised by the presence of the .tar.gz suffix and a single hyphen in the filename.

Since our package was named `localstack-core-{version}.tar.gz`, it is now normalized to the above format with `localstack_core-{version}.tar.gz`.

In our Makefile we look for the source distribution when checking the source distribution for valid entrypoints using a glob, which has to be adapted.

<!-- What notable changes does this PR make? -->
## Changes
* Adapt glob for checking the to-be-uploaded the localstack-core source distribution to new normalized name.

<!-- The following sections are optional, but can be useful!

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->
