### PR TITLE
Validate existing test apigw

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1940,7 +1940,15 @@ def create_rest_apigw(aws_client_factory):
 
     def _create_apigateway_function(**kwargs):
         region_name = kwargs.pop("region_name", None)
-        apigateway_client = aws_client_factory(region_name=region_name).apigateway
+        client_config = None
+        if is_aws_cloud():
+            client_config = botocore.config.Config(
+                # Api gateway can throttle requests pretty heavily. Leading to potentially undeleted apis
+                retries={"max_attempts": 10, "mode": "adaptive"}
+            )
+        apigateway_client = aws_client_factory(
+            region_name=region_name, config=client_config
+        ).apigateway
         kwargs.setdefault("name", f"api-{short_uid()}")
 
         response = apigateway_client.create_rest_api(**kwargs)

--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -78,7 +78,7 @@ class TestACM:
         result = aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
         snapshot.match("describe-certificate", result)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_boto_wait_for_certificate_validation(
         self, acm_request_certificate, aws_client, monkeypatch
     ):

--- a/tests/aws/services/acm/test_acm.snapshot.json
+++ b/tests/aws/services/acm/test_acm.snapshot.json
@@ -291,5 +291,46 @@
         }
       }
     }
+  },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_domain_validation": {
+    "recorded-date": "12-04-2024, 15:36:37",
+    "recorded-content": {
+      "describe-certificate": {
+        "Certificate": {
+          "CertificateArn": "<certificate-arn:1>",
+          "CreatedAt": "datetime",
+          "DomainName": "<domain-name:1>",
+          "DomainValidationOptions": [
+            {
+              "DomainName": "<domain-name:1>",
+              "ValidationDomain": "<domain-name:1>",
+              "ValidationEmails": [],
+              "ValidationMethod": "<validation-method:1>",
+              "ValidationStatus": "PENDING_VALIDATION"
+            }
+          ],
+          "ExtendedKeyUsages": [],
+          "InUseBy": [],
+          "Issuer": "Amazon",
+          "KeyAlgorithm": "RSA-2048",
+          "KeyUsages": [],
+          "Options": {
+            "CertificateTransparencyLoggingPreference": "ENABLED"
+          },
+          "RenewalEligibility": "INELIGIBLE",
+          "SignatureAlgorithm": "<signature-algorithm:1>",
+          "Status": "PENDING_VALIDATION",
+          "Subject": "CN=<domain-name:1>",
+          "SubjectAlternativeNames": [
+            "<domain-name:1>"
+          ],
+          "Type": "AMAZON_ISSUED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/acm/test_acm.validation.json
+++ b/tests/aws/services/acm/test_acm.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/acm/test_acm.py::TestACM::test_create_certificate_for_multiple_alternative_domains": {
     "last_validated_date": "2024-01-09T14:58:14+00:00"
   },
+  "tests/aws/services/acm/test_acm.py::TestACM::test_domain_validation": {
+    "last_validated_date": "2024-04-12T15:36:37+00:00"
+  },
   "tests/aws/services/acm/test_acm.py::TestACM::test_import_certificate": {
     "last_validated_date": "2024-02-22T17:41:15+00:00"
   }

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -158,6 +158,7 @@ class TestAPIGateway:
 
     @pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
     @markers.aws.only_localstack
+    # This is not a possible feature on aws.
     def test_create_rest_api_with_custom_id(self, create_rest_apigw, url_function, aws_client):
         apigw_name = f"gw-{short_uid()}"
         test_id = "testId123"

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -178,8 +178,10 @@ class TestAPIGateway:
         assert response.ok
         assert response._content == b'{"echo": "foobar", "response": "mocked"}'
 
-    @markers.aws.unknown
-    def test_update_rest_api_deployment(self, create_rest_apigw, aws_client):
+    @markers.aws.validated
+    def test_update_rest_api_deployment(self, create_rest_apigw, aws_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("id"))
+
         api_id, _, root = create_rest_apigw(name="test_gateway5")
 
         create_rest_resource_method(
@@ -219,7 +221,7 @@ class TestAPIGateway:
             deploymentId=deployment_id,
             patchOperations=patch_operations,
         )
-        assert deployment["description"] == "new-description"
+        snapshot.match("after-update", deployment)
 
     @markers.aws.validated
     def test_api_gateway_lambda_integration_aws_type(

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -637,7 +637,9 @@ class TestAPIGateway:
                 restApiId=get_api_gateway_id, authorizerId=authorizer_id
             )
 
-    @markers.aws.unknown
+    # This test fails as it tries to create a lambda locally?
+    # It then leaves some resources behind, apigateway and policies
+    @markers.aws.needs_fixing
     def test_malformed_response_apigw_invocation(
         self, create_lambda_function, aws_client, region_name
     ):

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -358,7 +358,9 @@ class TestAPIGateway:
             assert response.status_code == 200
             assert "http://test.com" in response.headers["Access-Control-Allow-Origin"]
 
-    @markers.aws.unknown
+    # This test fails as it tries to create a lambda locally?
+    # It then leaves some resources behind, apigateway and policies
+    @markers.aws.needs_fixing
     @pytest.mark.parametrize(
         "api_path", [API_PATH_LAMBDA_PROXY_BACKEND, API_PATH_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM]
     )

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -669,7 +669,9 @@ class TestAPIGateway:
         assert result.headers.get("Content-Type") == "application/json"
         assert json.loads(result.content)["message"] == "Internal server error"
 
-    @markers.aws.unknown
+    # Missing certificate creation to create a domain
+    # this might end up being a bigger issue to fix until we have a validated certificate we can use
+    @markers.aws.needs_fixing
     def test_api_gateway_handle_domain_name(self, aws_client):
         domain_name = f"{short_uid()}.example.com"
         apigw_client = aws_client.apigateway

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -157,8 +157,7 @@ class TestAPIGateway:
         assert "foobar" in e.value.response["Error"]["Message"]
 
     @pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
-    @markers.aws.needs_fixing
-    # This is not a possible feature on aws. Is there a reason for us to add that support?
+    @markers.aws.only_localstack
     def test_create_rest_api_with_custom_id(self, create_rest_apigw, url_function, aws_client):
         apigw_name = f"gw-{short_uid()}"
         test_id = "testId123"
@@ -539,13 +538,17 @@ class TestAPIGateway:
         assert "/yCqIBE=" == result_content["body"]
         assert ["isBase64Encoded"]
 
-    @markers.aws.unknown
+    # This test fails as it tries to create a lambda locally?
+    # It then leaves some resources behind, apigateway and policies
+    @markers.aws.needs_fixing
     def test_api_gateway_lambda_proxy_integration_any_method(self, integration_lambda):
         self._test_api_gateway_lambda_proxy_integration_any_method(
             integration_lambda, API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD
         )
 
-    @markers.aws.unknown
+    # This test fails as it tries to create a lambda locally?
+    # It then leaves some resources behind, apigateway and policies
+    @markers.aws.needs_fixing
     def test_api_gateway_lambda_proxy_integration_any_method_with_path_param(
         self, integration_lambda
     ):
@@ -637,9 +640,7 @@ class TestAPIGateway:
                 restApiId=get_api_gateway_id, authorizerId=authorizer_id
             )
 
-    # This test fails as it tries to create a lambda locally?
-    # It then leaves some resources behind, apigateway and policies
-    @markers.aws.needs_fixing
+    @markers.aws.unknown
     def test_malformed_response_apigw_invocation(
         self, create_lambda_function, aws_client, region_name
     ):

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -157,7 +157,8 @@ class TestAPIGateway:
         assert "foobar" in e.value.response["Error"]["Message"]
 
     @pytest.mark.parametrize("url_function", [path_based_url, host_based_url])
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
+    # This is not a possible feature on aws. Is there a reason for us to add that support?
     def test_create_rest_api_with_custom_id(self, create_rest_apigw, url_function, aws_client):
         apigw_name = f"gw-{short_uid()}"
         test_id = "testId123"

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -381,7 +381,9 @@ class TestAPIGateway:
             aws_client.apigateway,
         )
 
-    @markers.aws.unknown
+    # This test fails as it tries to create a lambda locally?
+    # It then leaves some resources behind, apigateway and policies
+    @markers.aws.needs_fixing
     def test_api_gateway_lambda_proxy_integration_with_is_base_64_encoded(
         self, integration_lambda, aws_client, create_iam_role_with_policy
     ):

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -72,5 +72,19 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
+    "recorded-date": "12-04-2024, 21:24:49",
+    "recorded-content": {
+      "after-update": {
+        "createdDate": "datetime",
+        "description": "new-description",
+        "id": "<id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -86,5 +86,35 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigateway_with_custom_authorization_method": {
+    "recorded-date": "12-04-2024, 22:31:50",
+    "recorded-content": {
+      "api-id": {
+        "api_id": "<api_id:1>"
+      },
+      "authorizer": {
+        "authType": "custom",
+        "authorizerUri": "<authorizer-uri:1>",
+        "id": "<id:1>",
+        "identitySource": "method.request.header.Auth",
+        "name": "lambda_authorizer",
+        "type": "TOKEN",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-method-response": {
+        "apiKeyRequired": true,
+        "authorizationType": "CUSTOM",
+        "authorizerId": "<id:1>",
+        "httpMethod": "GET",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigateway_with_custom_authorization_method": {
+    "last_validated_date": "2024-04-12T22:31:50+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigateway_with_step_function_integration[DeleteStateMachine]": {
     "last_validated_date": "2023-09-07T20:40:38+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -7,5 +7,8 @@
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
     "last_validated_date": "2024-02-04T18:48:24+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
+    "last_validated_date": "2024-04-12T21:24:49+00:00"
   }
 }


### PR DESCRIPTION
## Motivation

Part of the effort to improve parity with aws. This first step sorts all `aws.unknown` tags and replaces them with `aws.validated` or `aws.needs_fixing`.

## Changes

Started to go through apigw
