### PR TITLE
Use single character wildcard when matching the source distribution to avoid breaking with yanked setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ dist: entrypoints        ## Build source and built (wheel) distributions of the 
 
 publish: clean-dist dist  ## Publish the library to the central PyPi repository
 	# make sure the dist archive contains a non-empty entry_points.txt file before uploading
-	tar --wildcards --to-stdout -xf dist/localstack_core*.tar.gz "localstack_core*/localstack_core.egg-info/entry_points.txt" | grep . > /dev/null 2>&1 || (echo "Refusing upload, localstack-core dist does not contain entrypoints." && exit 1)
+	tar --wildcards --to-stdout -xf dist/localstack?core*.tar.gz "localstack?core*/localstack_core.egg-info/entry_points.txt" | grep . > /dev/null 2>&1 || (echo "Refusing upload, localstack-core dist does not contain entrypoints." && exit 1)
 	$(VENV_RUN); twine upload dist/*
 
 coveralls:         		  ## Publish coveralls metrics


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The setuptools upgrade which necessitated #10652 was yanked due to issues with the name normalization, but it is expected that the change will be re-released soon.
To avoid waiting for that release, and to avoid reverting now and reintroducing the changes when it happens, we should make the pattern more resilient.

<!-- What notable changes does this PR make? -->
## Changes
* Use a `?` (single character wildcard) instead of `-` or `_` in the publish operation, to always match the name, no matter the setuptools version.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

