### PR TITLE
Feat: Eventbridge v2:  Add pattern matching

### DIFF
--- a/localstack/services/events/event_ruler.py
+++ b/localstack/services/events/event_ruler.py
@@ -3,7 +3,6 @@ import os
 from functools import cache
 from pathlib import Path
 
-from localstack import config
 from localstack.services.events.packages import event_ruler_package
 from localstack.services.events.utils import InvalidEventPatternException
 from localstack.utils.objects import singleton_factory
@@ -43,8 +42,6 @@ def matches_rule(event: str, rule: str) -> bool:
     There is a single static boolean method Ruler.matchesRule(event, rule) -
     both arguments are provided as JSON strings.
     """
-    if config.EVENT_RULE_ENGINE != "java":
-        raise NotImplementedError("Set EVENT_RULE_ENGINE=java to enable the Java Event Ruler.")
 
     start_jvm()
     import jpype.imports  # noqa F401: required for importing Java modules

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -94,11 +94,3 @@ class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = True
     status_code: int = 400
-
-
-class InternalInvalidEventPatternException(Exception):
-    reason: str
-
-    def __init__(self, reason=None, message=None) -> None:
-        self.reason = reason
-        self.message = message or f"Event pattern is not valid. Reason: {reason}"

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
@@ -58,6 +58,8 @@ class Rule:
 
 
 RuleDict = dict[RuleName, Rule]
+
+EventPatternDict = dict[str, Any]
 
 
 @dataclass

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Optional
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
@@ -58,8 +58,6 @@ class Rule:
 
 
 RuleDict = dict[RuleName, Rule]
-
-EventPatternDict = dict[str, Any]
 
 
 @dataclass

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -94,3 +94,9 @@ class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = True
     status_code: int = 400
+
+
+class InvalidEventPatternException(ServiceException):
+    code: str = "InvalidEventPatternException"
+    sender_fault: bool = True
+    status_code: int = 400

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -96,3 +96,11 @@ class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = True
     status_code: int = 400
+
+
+class InternalInvalidEventPatternException(Exception):
+    reason: str
+
+    def __init__(self, reason=None, message=None) -> None:
+        self.reason = reason
+        self.message = message or f"Event pattern is not valid. Reason: {reason}"

--- a/localstack/services/events/models_v2.py
+++ b/localstack/services/events/models_v2.py
@@ -96,9 +96,3 @@ class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = True
     status_code: int = 400
-
-
-class InvalidEventPatternException(ServiceException):
-    code: str = "InvalidEventPatternException"
-    sender_fault: bool = True
-    status_code: int = 400

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -345,7 +345,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule_service = self.get_rule_service(context, rule, event_bus_name)
         failed_entries = rule_service.add_targets(targets)
         rule_arn = rule_service.arn
-        for target in targets:
+        for target in targets:  # TODO only add successful targets
             self.create_target_sender(target, region, account_id, rule_arn)
 
         response = PutTargetsResponse(

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -449,10 +449,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         processed_entries_uuids, failed_entries = self._process_entries(context, entries)
 
         response = PutEventsResponse(
-            Entries=[{"EventId": id} for id in processed_entries_uuids], FailedEntryCount=0
+            Entries=[{"EventId": id} for id in processed_entries_uuids],
+            FailedEntryCount=len(failed_entries),
         )
         if failed_entries:
-            response["FailedEntryCount"] = len(failed_entries)
             response["FailedEntries"] = failed_entries
         return response
 

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -59,7 +59,6 @@ from localstack.services.events.models_v2 import (
     EventBus,
     EventBusDict,
     EventsStore,
-    InternalInvalidEventPatternException,
     Rule,
     RuleDict,
     TargetDict,
@@ -68,6 +67,9 @@ from localstack.services.events.models_v2 import (
 )
 from localstack.services.events.rule import RuleService, RuleServiceDict
 from localstack.services.events.target import TargetSender, TargetSenderDict, TargetSenderFactory
+from localstack.services.events.utils import (
+    InvalidEventPatternException as InternalInvalidEventPatternException,
+)
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.strings import long_uid
 

--- a/localstack/services/events/provider_v2.py
+++ b/localstack/services/events/provider_v2.py
@@ -46,6 +46,7 @@ from localstack.aws.api.events import (
     TargetId,
     TargetIdList,
     TargetList,
+    TestEventPatternResponse,
 )
 from localstack.aws.api.events import EventBus as ApiTypeEventBus
 from localstack.aws.api.events import Rule as ApiTypeRule
@@ -340,6 +341,19 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         event_bus.rules[name] = rule_service.rule
         response = PutRuleResponse(RuleArn=rule_service.arn)
         return response
+
+    @handler("TestEventPattern")
+    def test_event_pattern(
+        self, context: RequestContext, event_pattern: EventPattern, event: str, **kwargs
+    ) -> TestEventPatternResponse:
+        """Test event pattern uses EventBridge event pattern matching:
+        https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+        """
+        event_pattern_dict = json.loads(event_pattern)
+        event_dict = json.loads(event)
+        result = matches_event(event_pattern_dict, event_dict)
+
+        return TestEventPatternResponse(Result=result)
 
     #########
     # Targets

--- a/localstack/services/events/rule.py
+++ b/localstack/services/events/rule.py
@@ -6,6 +6,7 @@ from localstack.aws.api.events import (
     Arn,
     EventBusName,
     EventPattern,
+    InvalidEventPatternException,
     LimitExceededException,
     ManagedBy,
     PutTargetsResultEntryList,
@@ -22,7 +23,6 @@ from localstack.aws.api.events import (
 )
 from localstack.services.events.models_v2 import (
     EventPatternDict,
-    InvalidEventPatternException,
     Rule,
     TargetDict,
     ValidationException,

--- a/localstack/services/events/rule.py
+++ b/localstack/services/events/rule.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import Optional
 
@@ -6,7 +5,6 @@ from localstack.aws.api.events import (
     Arn,
     EventBusName,
     EventPattern,
-    InvalidEventPatternException,
     LimitExceededException,
     ManagedBy,
     PutTargetsResultEntryList,
@@ -22,7 +20,6 @@ from localstack.aws.api.events import (
     TargetList,
 )
 from localstack.services.events.models_v2 import (
-    EventPatternDict,
     Rule,
     TargetDict,
     ValidationException,
@@ -66,7 +63,6 @@ class RuleService:
             targets,
             managed_by,
         )
-        self.event_pattern = self.load_event_pattern(event_pattern)
 
     @property
     def arn(self) -> Arn:
@@ -163,19 +159,6 @@ class RuleService:
 
         return validation_errors
 
-    def load_event_pattern(self, raw_pattern: Optional[str]) -> EventPatternDict:
-        """Loads and validates an event pattern from a JSON string."""
-        if raw_pattern is None:
-            return {}
-
-        try:
-            pattern = json.loads(raw_pattern)
-        except json.JSONDecodeError:
-            raise InvalidEventPatternException(reason="Invalid JSON")
-
-        self._validate_event_pattern(pattern)
-        return pattern
-
     def _validate_input(
         self,
         event_pattern: Optional[EventPattern],
@@ -202,21 +185,6 @@ class RuleService:
         if len(self.rule.targets) >= 5:
             return True
         return False
-
-    def _validate_event_pattern(self, pattern):
-        """Validates that the event pattern is correctly structured."""
-        for attr, value in pattern.items():
-            if isinstance(value, dict):
-                self._validate_event_pattern(value)
-            elif isinstance(value, list):
-                if not value:
-                    raise InvalidEventPatternException("Empty arrays are not allowed")
-                if not all(isinstance(item, (dict, str)) for item in value):
-                    raise InvalidEventPatternException(
-                        f"All items in '{attr}' array must be dictionaries or strings"
-                    )
-            else:
-                raise InvalidEventPatternException(f"'{attr}' must be an object or an array")
 
 
 RuleServiceDict = dict[Arn, RuleService]

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -175,6 +175,7 @@ class KinesisTargetSender(TargetSender):
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)
+        # TODO add validated test to check if RoleArn is mandatory
         if not collections.get_safe(target, "$.RoleArn"):
             raise ValueError("RoleArn is required for Kinesis target")
         if not collections.get_safe(target, "$.KinesisParameters.PartitionKeyPath"):

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -7,6 +7,7 @@ from botocore.client import BaseClient
 
 from localstack.aws.api.events import (
     Arn,
+    PutEventsRequestEntry,
     Target,
 )
 from localstack.aws.connect import connect_to
@@ -53,7 +54,7 @@ class TargetSender(ABC):
         return self._client
 
     @abstractmethod
-    def send_event(self):
+    def send_event(self, event: PutEventsRequestEntry):
         pass
 
     def _validate_input(self, target: Target):

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -84,6 +84,8 @@ class TargetSender(ABC):
 
 TargetSenderDict = dict[Arn, TargetSender]
 
+# Target Senders are ordered alphabetically by service name
+
 
 class ApiGatewayTargetSender(TargetSender):
     def send_event(self, event):

--- a/tests/aws/services/events/test_event_patterns.py
+++ b/tests/aws/services/events/test_event_patterns.py
@@ -8,7 +8,6 @@ import pytest
 
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
-from tests.aws.services.events.helper_functions import is_v2_provider
 
 THIS_FOLDER: str = os.path.dirname(os.path.realpath(__file__))
 REQUEST_TEMPLATE_DIR = os.path.join(THIS_FOLDER, "event_pattern_templates")
@@ -80,7 +79,6 @@ SKIP_LABELS = [
 # TODO: extend these test cases based on the open source docs + tests: https://github.com/aws/event-ruler
 #  For example, "JSON Array Matching", "And and Or Relationship among fields with Ruler", rule validation,
 #  and exception handling.
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 @pytest.mark.parametrize(
     "request_template,label", request_template_tuples, ids=[t[1] for t in request_template_tuples]
 )
@@ -118,7 +116,6 @@ def test_test_event_pattern(aws_client, snapshot, request_template, label):
             assert response["Result"]
 
 
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 @markers.aws.validated
 def test_test_event_pattern_with_multi_key(aws_client):
     """Test the special case of a duplicate JSON key separately because it requires working around the
@@ -140,7 +137,6 @@ def test_test_event_pattern_with_multi_key(aws_client):
         assert response["Result"]
 
 
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 @markers.aws.validated
 def test_test_event_pattern_with_escape_characters(aws_client):
     r"""Test the special case of using escape characters separately because it requires working around JSON escaping.

--- a/tests/aws/services/events/test_event_patterns.snapshot.json
+++ b/tests/aws/services/events/test_event_patterns.snapshot.json
@@ -430,5 +430,24 @@
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[exists_dynamodb_NEG]": {
     "recorded-date": "09-04-2024, 16:51:59",
     "recorded-content": {}
+  },
+  "tests/aws/services/events/test_event_patterns.py::test_event_pattern_source": {
+    "recorded-date": "29-04-2024, 14:12:14",
+    "recorded-content": {
+      "eventbridge-test-event-pattern-response": {
+        "Result": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "eventbridge-test-event-pattern-response-no-match": {
+        "Result": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_event_patterns.validation.json
+++ b/tests/aws/services/events/test_event_patterns.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_event_patterns.py::test_event_pattern_source": {
+    "last_validated_date": "2024-04-29T14:12:14+00:00"
+  },
   "tests/aws/services/events/test_event_patterns.py::test_test_event_pattern[arrays]": {
     "last_validated_date": "2024-04-08T19:33:55+00:00"
   },

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -1130,6 +1130,7 @@ class TestEventRule:
 
 class TestEventPattern:
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_pattern_with_values_in_array(self, put_events_with_filter_to_sqs, snapshot):
         pattern = {"detail": {"event": {"data": {"type": ["1", "2"]}}}}
         entries1 = [
@@ -1169,6 +1170,7 @@ class TestEventPattern:
         snapshot.match("messages", messages)
 
     @markers.aws.validated
+    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_pattern_nested(self, put_events_with_filter_to_sqs, snapshot):
         pattern = {"detail": {"event": {"data": {"type": ["1"]}}}}
         entries1 = [

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -651,7 +651,7 @@ class TestEventBus:
         )
         snapshot.match("list-event-buses-limit-next-token", response)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing  # TODO use fixture setup_sqs_queue_as_event_target to simplify
     @pytest.mark.skipif(is_aws_cloud(), reason="not validated")
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
     def test_put_events_into_event_bus(

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -648,73 +648,50 @@ class TestEvents:
         snapshot.match("eventbridge-test-event-pattern-response-no-match", response)
 
     @markers.aws.validated
-    def test_put_events_time(
-        self,
-        aws_client,
-        sqs_create_queue,
-        sqs_get_queue_arn,
-        events_put_rule,
-        snapshot,
-    ):
-        default_bus_rule_name = f"rule-{short_uid()}"
-        default_bus_target_id = f"test-target-default-b-{short_uid()}"
+    def test_put_events_time(self, put_events_with_filter_to_sqs, snapshot):
+        pattern = {"source": ["MySource"], "detail-type": ["CustomType"]}
+        entries1 = [
+            {
+                "Source": pattern["source"][0],
+                "DetailType": pattern["detail-type"][0],
+                "Detail": json.dumps({"message": "short time"}),
+                "Time": "2022-01-01",
+            },
+        ]
+        entries2 = [
+            {
+                "Source": pattern["source"][0],
+                "DetailType": pattern["detail-type"][0],
+                "Detail": json.dumps({"message": "new time"}),
+                "Time": "01-01-2022T00:00:00Z",
+            },
+        ]
+        entries3 = [
+            {
+                "Source": pattern["source"][0],
+                "DetailType": pattern["detail-type"][0],
+                "Detail": json.dumps({"message": "long time"}),
+                "Time": "2022-01-01 00:00:00Z",
+            },
+        ]
+        entries_asserts = [(entries1, True), (entries2, True), (entries3, True)]
+        messages = put_events_with_filter_to_sqs(
+            pattern=pattern,
+            entries_asserts=entries_asserts,
+        )
 
         snapshot.add_transformer(
             [
-                snapshot.transform.key_value("MD5OfBody"),  # the event contains a timestamp
+                snapshot.transform.key_value("MD5OfBody"),
                 snapshot.transform.key_value("ReceiptHandle"),
             ]
         )
+        snapshot.match("messages", messages)
 
-        queue_url = sqs_create_queue()
-        queue_arn = sqs_get_queue_arn(queue_url)
-
-        rule_on_default_bus = events_put_rule(
-            Name=default_bus_rule_name,
-            EventPattern=json.dumps({"detail-type": ["CustomType"], "source": ["MySource"]}),
-            State="ENABLED",
-        )
-
-        allow_event_rule_to_sqs_queue(
-            aws_client=aws_client,
-            event_rule_arn=rule_on_default_bus["RuleArn"],
-            sqs_queue_arn=queue_arn,
-            sqs_queue_url=queue_url,
-        )
-
-        aws_client.events.put_targets(
-            Rule=default_bus_rule_name,
-            Targets=[{"Id": default_bus_target_id, "Arn": queue_arn}],
-        )
-
-        # create an entry with a defined time
-        entries = [
-            {
-                "Source": "MySource",
-                "DetailType": "CustomType",
-                "Detail": json.dumps({"message": "for the default event bus"}),
-                "Time": datetime(year=2022, day=1, month=1),
-            }
-        ]
-        response = aws_client.events.put_events(Entries=entries)
-        snapshot.match("put-events", response)
-
-        def _get_sqs_messages():
-            resp = aws_client.sqs.receive_message(
-                QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=1
-            )
-            msgs = resp.get("Messages")
-            assert len(msgs) == 1
-            aws_client.sqs.delete_message(
-                QueueUrl=queue_url, ReceiptHandle=msgs[0]["ReceiptHandle"]
-            )
-            return msgs
-
-        messages = retry(_get_sqs_messages, retries=5, sleep=0.1)
-        snapshot.match("get-events", messages)
-
-        message_body = json.loads(messages[0]["Body"])
-        assert message_body["time"] == "2022-01-01T00:00:00Z"
+        # check for correct time strings in the messages
+        for message in messages:
+            message_body = json.loads(message["Body"])
+            assert message_body["time"] == "2022-01-01T00:00:00Z"
 
 
 class TestEventBus:

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -82,6 +82,10 @@ EVENT_BUS_ROLE = {
 
 class TestEvents:
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_events_without_source(self, snapshot, aws_client):
         entries = [
             {
@@ -93,6 +97,10 @@ class TestEvents:
         snapshot.match("put-events", response)
 
     @markers.aws.unknown
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_event_without_detail(self, snapshot, aws_client):
         entries = [
             {

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -139,7 +139,6 @@ class TestEvents:
         clean_up(rule_name=rule_name)
 
     @markers.aws.unknown
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_values_in_array(self, put_events_with_filter_to_sqs):
         pattern = {"detail": {"event": {"data": {"type": ["1", "2"]}}}}
         entries1 = [
@@ -171,7 +170,6 @@ class TestEvents:
         )
 
     @markers.aws.validated
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_nested_event_pattern(self, put_events_with_filter_to_sqs):
         pattern = {"detail": {"event": {"data": {"type": ["1"]}}}}
         entries1 = [
@@ -527,7 +525,6 @@ class TestEvents:
         assert "must satisfy enum value set: [BASIC, OAUTH_CLIENT_CREDENTIALS, API_KEY]" in message
 
     @markers.aws.unknown
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_event_without_source(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
@@ -535,7 +532,6 @@ class TestEvents:
         assert response.get("Entries")
 
     @markers.aws.unknown
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_event_without_detail(self, aws_client_factory):
         events_client = aws_client_factory(region_name="eu-west-1").events
 
@@ -591,7 +587,7 @@ class TestEvents:
             ],
         )
 
-    @markers.aws.validated
+    @markers.aws.validated  # TODO move to tests_event_patterns
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_event_pattern(self, aws_client, snapshot, account_id, region_name):
         response = aws_client.events.test_event_pattern(
@@ -636,7 +632,6 @@ class TestEvents:
         snapshot.match("eventbridge-test-event-pattern-response-no-match", response)
 
     @markers.aws.validated
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_time(
         self,
         aws_client,
@@ -817,7 +812,6 @@ class TestEventBus:
     @markers.aws.unknown
     @pytest.mark.skipif(is_aws_cloud(), reason="not validated")
     @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_into_event_bus(
         self,
         monkeypatch,
@@ -885,7 +879,6 @@ class TestEventBus:
         aws_client.sqs.delete_queue(QueueUrl=queue_url)
 
     @markers.aws.validated
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     # TODO simplify and use sqs as target
     def test_put_events_to_default_eventbus_for_custom_eventbus(
         self,
@@ -1019,7 +1012,6 @@ class TestEventBus:
         assert_valid_event(received_event)
 
     @markers.aws.validated  # TODO fix condition for this test, only succeeds if run on its own
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_nonexistent_event_bus(
         self,
         aws_client,

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -44,28 +44,16 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "recorded-date": "26-03-2024, 14:09:45",
+    "recorded-date": "29-04-2024, 12:11:50",
     "recorded-content": {
-      "put-events": {
-        "Entries": [
-          {
-            "EventId": "<uuid:1>"
-          }
-        ],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-events": [
+      "messages": [
         {
-          "MessageId": "<uuid:2>",
+          "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": {
             "version": "0",
-            "id": "<uuid:1>",
+            "id": "<uuid:2>",
             "detail-type": "CustomType",
             "source": "MySource",
             "account": "111111111111",
@@ -73,7 +61,43 @@
             "region": "<region>",
             "resources": [],
             "detail": {
-              "message": "for the default event bus"
+              "message": "short time"
+            }
+          }
+        },
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:4>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "new time"
+            }
+          }
+        },
+        {
+          "MessageId": "<uuid:5>",
+          "ReceiptHandle": "<receipt-handle:3>",
+          "MD5OfBody": "<m-d5-of-body:3>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:6>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "long time"
             }
           }
         }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1,41 +1,33 @@
 {
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "recorded-date": "18-04-2024, 15:47:35",
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
+    "recorded-date": "29-04-2024, 13:15:31",
     "recorded-content": {
-      "put-targets-invalid-id-error": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "1 validation error detected: Value '!@#$@!#$' at 'targets.1.member.id' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_A-Za-z0-9]+"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-targets-length-error": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'second-invalid-target-id' at 'targets.1.member.id' failed to satisfy constraint: Member must have length less than or equal to 64"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_event_pattern": {
-    "recorded-date": "26-03-2024, 14:07:19",
-    "recorded-content": {
-      "eventbridge-test-event-pattern-response": {
-        "Result": true,
+      "put-events": {
+        "Entries": [
+          {
+            "ErrorCode": "InvalidArgument",
+            "ErrorMessage": "Parameter Source is not valid. Reason: Source is a required argument."
+          }
+        ],
+        "FailedEntryCount": 1,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "eventbridge-test-event-pattern-response-no-match": {
-        "Result": false,
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
+    "recorded-date": "29-04-2024, 13:15:31",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "ErrorCode": "InvalidArgument",
+            "ErrorMessage": "Parameter Detail is not valid. Reason: Detail is a required argument."
+          }
+        ],
+        "FailedEntryCount": 1,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -44,7 +36,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "recorded-date": "29-04-2024, 12:11:50",
+    "recorded-date": "29-04-2024, 13:15:34",
     "recorded-content": {
       "messages": [
         {
@@ -54,8 +46,8 @@
           "Body": {
             "version": "0",
             "id": "<uuid:2>",
-            "detail-type": "CustomType",
-            "source": "MySource",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
             "account": "111111111111",
             "time": "date",
             "region": "<region>",
@@ -72,8 +64,8 @@
           "Body": {
             "version": "0",
             "id": "<uuid:4>",
-            "detail-type": "CustomType",
-            "source": "MySource",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
             "account": "111111111111",
             "time": "date",
             "region": "<region>",
@@ -90,8 +82,8 @@
           "Body": {
             "version": "0",
             "id": "<uuid:6>",
-            "detail-type": "CustomType",
-            "source": "MySource",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
             "account": "111111111111",
             "time": "date",
             "region": "<region>",
@@ -104,11 +96,44 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
-    "recorded-date": "04-04-2024, 10:47:20",
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
+    "recorded-date": "29-04-2024, 13:15:44",
     "recorded-content": {
-      "put-rule": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
+      "create-custom-event-bus-us-east-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-east-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-east-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-east-1": {
+        "EventBuses": [],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -116,20 +141,356 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
-    "recorded-date": "04-04-2024, 10:47:21",
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
+    "recorded-date": "29-04-2024, 13:15:47",
     "recorded-content": {
-      "put-rule": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+      "create-custom-event-bus-us-east-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-east-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-east-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-custom-event-bus-us-west-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-us-west-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-us-west-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-custom-event-bus-eu-central-1": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-create-eu-central-1": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-custom-event-bus-eu-central-1": {
+        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+        "Name": "<bus-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-east-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-east-1": {
+        "EventBuses": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-us-west-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-us-west-1": {
+        "EventBuses": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-custom-event-bus-eu-central-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-after-delete-eu-central-1": {
+        "EventBuses": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
+    "recorded-date": "29-04-2024, 13:15:47",
+    "recorded-content": {
+      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
+    "recorded-date": "29-04-2024, 13:15:49",
+    "recorded-content": {
+      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
+      "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
+    "recorded-date": "29-04-2024, 13:15:49",
+    "recorded-content": {
+      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
+    "recorded-date": "29-04-2024, 13:15:50",
+    "recorded-content": {
+      "list-event-buses-prefix-complete-name": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-prefix": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
+            "Name": "<bus-name>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
+    "recorded-date": "29-04-2024, 13:15:52",
+    "recorded-content": {
+      "list-event-buses-limit": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-0",
+            "Name": "<bus-name-prefix>-0"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-1",
+            "Name": "<bus-name-prefix>-1"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
+            "Name": "<bus-name-prefix>-2"
+          }
+        ],
+        "NextToken": "<next_token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-event-buses-limit-next-token": {
+        "EventBuses": [
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-3",
+            "Name": "<bus-name-prefix>-3"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-4",
+            "Name": "<bus-name-prefix>-4"
+          },
+          {
+            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-5",
+            "Name": "<bus-name-prefix>-5"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
+    "recorded-date": "29-04-2024, 13:16:20",
+    "recorded-content": {
+      "create-custom-event-bus": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-1": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-2": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:1>/<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-1": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-2": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": {
+        "Messages": [
+          {
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "Object Created",
+              "source": "aws.s3",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [
+                "arn:aws:s3:::<bucket-name:1>"
+              ],
+              "detail": {
+                "version": "0",
+                "bucket": {
+                  "name": "<bucket-name:1>"
+                },
+                "object": {
+                  "key": "<key-name:1>",
+                  "size": 4,
+                  "etag": "8d777f385d3dfec8815d20f7496026dc",
+                  "sequencer": "object-sequencer"
+                },
+                "request-id": "request-id",
+                "requester": "<requester>",
+                "source-ip-address": "<ip-address:1>",
+                "reason": "PutObject"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ]
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
+    "recorded-date": "29-04-2024, 13:18:57",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          },
+          {
+            "EventId": "<uuid:2>"
+          }
+        ],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": [
+        {
+          "MessageId": "<uuid:3>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:1>",
+            "detail-type": "CustomType",
+            "source": "MySource",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "message": "for the default event bus"
+            }
+          }
+        }
+      ],
+      "non-existent-bus-error": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Event bus <custom-event-bus> does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "recorded-date": "22-04-2024, 13:07:35",
+    "recorded-date": "29-04-2024, 13:16:41",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
@@ -205,7 +566,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "recorded-date": "22-04-2024, 13:07:36",
+    "recorded-date": "29-04-2024, 13:16:43",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
@@ -281,7 +642,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "recorded-date": "22-04-2024, 13:07:38",
+    "recorded-date": "29-04-2024, 13:16:44",
     "recorded-content": {
       "put-rule": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name>",
@@ -327,7 +688,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "recorded-date": "22-04-2024, 13:07:40",
+    "recorded-date": "29-04-2024, 13:16:47",
     "recorded-content": {
       "list-rules-limit": {
         "NextToken": "<next_token:1>",
@@ -463,13 +824,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "recorded-date": "22-04-2024, 13:07:42",
+    "recorded-date": "29-04-2024, 13:16:49",
     "recorded-content": {
       "describe-not-existing-rule-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeRule operation: Rule <rule-name> does not exist on EventBus default.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "recorded-date": "22-04-2024, 13:07:43",
+    "recorded-date": "29-04-2024, 13:16:50",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -534,7 +895,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "recorded-date": "22-04-2024, 13:07:45",
+    "recorded-date": "29-04-2024, 13:16:52",
     "recorded-content": {
       "disable-rule": {
         "ResponseMetadata": {
@@ -598,8 +959,105 @@
       }
     }
   },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
+    "recorded-date": "29-04-2024, 13:16:53",
+    "recorded-content": {
+      "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
+    "recorded-date": "29-04-2024, 13:16:55",
+    "recorded-content": {
+      "list-targets": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-rule": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-targets-after-update": {
+        "Targets": [
+          {
+            "Arn": "<queue-arn>",
+            "Id": "<target-id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_with_values_in_array": {
+    "recorded-date": "29-04-2024, 13:17:04",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": [
+                  "3",
+                  "1"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": [
+                  "2"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
+    "recorded-date": "29-04-2024, 13:17:16",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": "1"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "recorded-date": "22-04-2024, 13:07:17",
+    "recorded-date": "29-04-2024, 13:17:18",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -639,7 +1097,7 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "recorded-date": "22-04-2024, 13:07:18",
+    "recorded-date": "29-04-2024, 13:17:20",
     "recorded-content": {
       "put-target": {
         "FailedEntries": [],
@@ -679,13 +1137,13 @@
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "recorded-date": "22-04-2024, 13:07:20",
+    "recorded-date": "29-04-2024, 13:17:21",
     "recorded-content": {
       "put-targets-client-error": "<ExceptionInfo LimitExceededException('An error occurred (LimitExceededException) when calling the PutTargets operation: The requested resource exceeds the maximum number allowed.') tblen=3>"
     }
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "recorded-date": "22-04-2024, 13:07:22",
+    "recorded-date": "29-04-2024, 13:17:23",
     "recorded-content": {
       "list-targets-limit": {
         "NextToken": "<next_token:1>",
@@ -726,516 +1184,27 @@
       }
     }
   },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "recorded-date": "22-04-2024, 13:07:46",
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_target_id_validation": {
+    "recorded-date": "29-04-2024, 13:17:26",
     "recorded-content": {
-      "delete-rule-with-targets-error": "<ExceptionInfo ClientError(\"An error occurred (ValidationException) when calling the DeleteRule operation: Rule can't be deleted since it has targets.\") tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
-    "recorded-date": "16-04-2024, 15:10:07",
-    "recorded-content": {
-      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "recorded-date": "22-04-2024, 13:07:48",
-    "recorded-content": {
-      "list-targets": {
-        "Targets": [
-          {
-            "Arn": "<queue-arn>",
-            "Id": "<target-id>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "update-rule": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-targets-after-update": {
-        "Targets": [
-          {
-            "Arn": "<queue-arn>",
-            "Id": "<target-id>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "recorded-date": "23-04-2024, 06:11:32",
-    "recorded-content": {
-      "create-custom-event-bus-us-east-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-east-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-east-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "recorded-date": "23-04-2024, 06:11:34",
-    "recorded-content": {
-      "create-custom-event-bus-us-east-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-east-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-east-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-custom-event-bus-us-west-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-us-west-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-us-west-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-custom-event-bus-eu-central-1": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-create-eu-central-1": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-custom-event-bus-eu-central-1": {
-        "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-        "Name": "<bus-name>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-east-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-east-1": {
-        "EventBuses": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-us-west-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-us-west-1": {
-        "EventBuses": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-custom-event-bus-eu-central-1": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-after-delete-eu-central-1": {
-        "EventBuses": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "recorded-date": "22-04-2024, 13:11:10",
-    "recorded-content": {
-      "create-multiple-event-buses-same-name": "<ExceptionInfo ResourceAlreadyExistsException('An error occurred (ResourceAlreadyExistsException) when calling the CreateEventBus operation: Event bus <bus-name> already exists.') tblen=4>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "recorded-date": "22-04-2024, 13:11:12",
-    "recorded-content": {
-      "describe-not-existing-event-bus-error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>",
-      "delete-not-existing-event-bus": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the DescribeEventBus operation: Event bus <bus-name> does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "recorded-date": "22-04-2024, 13:11:12",
-    "recorded-content": {
-      "delete-default-event-bus-error": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the DeleteEventBus operation: Cannot delete event bus default.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "recorded-date": "22-04-2024, 13:19:19",
-    "recorded-content": {
-      "list-event-buses-prefix-complete-name": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-prefix": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name>",
-            "Name": "<bus-name>"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "recorded-date": "22-04-2024, 13:11:15",
-    "recorded-content": {
-      "list-event-buses-limit": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-0",
-            "Name": "<bus-name-prefix>-0"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-1",
-            "Name": "<bus-name-prefix>-1"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-2",
-            "Name": "<bus-name-prefix>-2"
-          }
-        ],
-        "NextToken": "<next_token:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "list-event-buses-limit-next-token": {
-        "EventBuses": [
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-3",
-            "Name": "<bus-name-prefix>-3"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-4",
-            "Name": "<bus-name-prefix>-4"
-          },
-          {
-            "Arn": "arn:aws:events:<region>:111111111111:event-bus/<bus-name-prefix>-5",
-            "Name": "<bus-name-prefix>-5"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "recorded-date": "22-04-2024, 13:11:43",
-    "recorded-content": {
-      "create-custom-event-bus": {
-        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-rule-1": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:2>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-rule-2": {
-        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:1>/<resource:3>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-target-1": {
-        "FailedEntries": [],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-target-2": {
-        "FailedEntries": [],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-events": {
-        "Messages": [
-          {
-            "Body": {
-              "version": "0",
-              "id": "<uuid:1>",
-              "detail-type": "Object Created",
-              "source": "aws.s3",
-              "account": "111111111111",
-              "time": "date",
-              "region": "<region>",
-              "resources": [
-                "arn:aws:s3:::<bucket-name:1>"
-              ],
-              "detail": {
-                "version": "0",
-                "bucket": {
-                  "name": "<bucket-name:1>"
-                },
-                "object": {
-                  "key": "<key-name:1>",
-                  "size": 4,
-                  "etag": "8d777f385d3dfec8815d20f7496026dc",
-                  "sequencer": "object-sequencer"
-                },
-                "request-id": "request-id",
-                "requester": "<requester>",
-                "source-ip-address": "<ip-address:1>",
-                "reason": "PutObject"
-              }
-            },
-            "MD5OfBody": "<m-d5-of-body:1>",
-            "MessageId": "<uuid:2>",
-            "ReceiptHandle": "<receipt-handle:1>"
-          }
-        ]
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "recorded-date": "22-04-2024, 13:12:23",
-    "recorded-content": {
-      "put-events": {
-        "Entries": [
-          {
-            "EventId": "<uuid:1>"
-          },
-          {
-            "EventId": "<uuid:2>"
-          }
-        ],
-        "FailedEntryCount": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-events": [
-        {
-          "MessageId": "<uuid:3>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "version": "0",
-            "id": "<uuid:1>",
-            "detail-type": "CustomType",
-            "source": "MySource",
-            "account": "111111111111",
-            "time": "date",
-            "region": "<region>",
-            "resources": [],
-            "detail": {
-              "message": "for the default event bus"
-            }
-          }
-        }
-      ],
-      "non-existent-bus-error": {
+      "put-targets-invalid-id-error": {
         "Error": {
-          "Code": "ResourceNotFoundException",
-          "Message": "Event bus <custom-event-bus> does not exist."
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '!@#$@!#$' at 'targets.1.member.id' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\.\\-_A-Za-z0-9]+"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
-      }
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_values_in_array": {
-    "recorded-date": "29-04-2024, 11:47:10",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "event": {
-              "data": {
-                "type": [
-                  "3",
-                  "1"
-                ]
-              }
-            }
-          }
+      },
+      "put-targets-length-error": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'second-invalid-target-id' at 'targets.1.member.id' failed to satisfy constraint: Member must have length less than or equal to 64"
         },
-        {
-          "MessageId": "<uuid:2>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": {
-            "event": {
-              "data": {
-                "type": [
-                  "2"
-                ]
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_nested_event_pattern": {
-    "recorded-date": "29-04-2024, 11:48:23",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "event": {
-              "data": {
-                "type": "1"
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
-    "recorded-date": "29-04-2024, 12:47:09",
-    "recorded-content": {
-      "put-events": {
-        "Entries": [
-          {
-            "ErrorCode": "InvalidArgument",
-            "ErrorMessage": "Parameter Source is not valid. Reason: Source is a required argument."
-          }
-        ],
-        "FailedEntryCount": 1,
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 400
         }
       }
     }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1142,5 +1142,60 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_values_in_array": {
+    "recorded-date": "29-04-2024, 11:47:10",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": [
+                  "3",
+                  "1"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": [
+                  "2"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_nested_event_pattern": {
+    "recorded-date": "29-04-2024, 11:48:23",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "event": {
+              "data": {
+                "type": "1"
+              }
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events.snapshot.json
+++ b/tests/aws/services/events/test_events.snapshot.json
@@ -1221,5 +1221,23 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
+    "recorded-date": "29-04-2024, 12:47:09",
+    "recorded-content": {
+      "put-events": {
+        "Entries": [
+          {
+            "ErrorCode": "InvalidArgument",
+            "ErrorMessage": "Parameter Source is not valid. Reason: Source is a required argument."
+          }
+        ],
+        "FailedEntryCount": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -1,131 +1,92 @@
 {
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-23T06:11:32+00:00"
+    "last_validated_date": "2024-04-29T13:15:44+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-23T06:11:34+00:00"
+    "last_validated_date": "2024-04-29T13:15:47+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-22T13:11:10+00:00"
+    "last_validated_date": "2024-04-29T13:15:47+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-22T13:11:12+00:00"
+    "last_validated_date": "2024-04-29T13:15:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-22T13:11:12+00:00"
+    "last_validated_date": "2024-04-29T13:15:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_limit": {
-    "last_validated_date": "2024-04-22T13:11:15+00:00"
+    "last_validated_date": "2024-04-29T13:15:52+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_list_event_buses_with_prefix": {
-    "last_validated_date": "2024-04-22T13:19:19+00:00"
+    "last_validated_date": "2024-04-29T13:15:50+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-04-22T13:12:23+00:00"
+    "last_validated_date": "2024-04-29T13:18:57+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "last_validated_date": "2024-04-22T13:11:43+00:00"
+    "last_validated_date": "2024-04-29T13:16:20+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_nested": {
+    "last_validated_date": "2024-04-29T13:17:16+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventPattern::test_put_events_pattern_with_values_in_array": {
+    "last_validated_date": "2024-04-29T13:17:04+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_delete_rule_with_targets": {
-    "last_validated_date": "2024-04-22T13:07:46+00:00"
+    "last_validated_date": "2024-04-29T13:16:53+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_describe_nonexistent_rule": {
-    "last_validated_date": "2024-04-22T13:07:42+00:00"
+    "last_validated_date": "2024-04-29T13:16:49+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[custom]": {
-    "last_validated_date": "2024-04-22T13:07:43+00:00"
+    "last_validated_date": "2024-04-29T13:16:50+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_disable_re_enable_rule[default]": {
-    "last_validated_date": "2024-04-22T13:07:45+00:00"
+    "last_validated_date": "2024-04-29T13:16:52+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_list_rule_with_limit": {
-    "last_validated_date": "2024-04-22T13:07:40+00:00"
+    "last_validated_date": "2024-04-29T13:16:47+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[custom]": {
-    "last_validated_date": "2024-04-22T13:07:35+00:00"
+    "last_validated_date": "2024-04-29T13:16:41+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_list_with_prefix_describe_delete_rule[default]": {
-    "last_validated_date": "2024-04-22T13:07:36+00:00"
+    "last_validated_date": "2024-04-29T13:16:43+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_put_multiple_rules_with_same_name": {
-    "last_validated_date": "2024-04-22T13:07:38+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[custom]": {
-    "last_validated_date": "2024-04-04T10:47:20+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventRule::test_put_rule[default]": {
-    "last_validated_date": "2024-04-04T10:47:21+00:00"
+    "last_validated_date": "2024-04-29T13:16:44+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventRule::test_update_rule_with_targets": {
-    "last_validated_date": "2024-04-22T13:07:48+00:00"
+    "last_validated_date": "2024-04-29T13:16:55+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_add_exceed_fife_targets_per_rule": {
-    "last_validated_date": "2024-04-22T13:07:20+00:00"
+    "last_validated_date": "2024-04-29T13:17:21+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_list_target_by_rule_limit": {
-    "last_validated_date": "2024-04-22T13:07:22+00:00"
+    "last_validated_date": "2024-04-29T13:17:23+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[custom]": {
-    "last_validated_date": "2024-04-22T13:07:17+00:00"
+    "last_validated_date": "2024-04-29T13:17:18+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEventTarget::test_put_list_remove_target[default]": {
-    "last_validated_date": "2024-04-22T13:07:18+00:00"
+    "last_validated_date": "2024-04-29T13:17:20+00:00"
+  },
+  "tests/aws/services/events/test_events.py::TestEventTarget::test_put_target_id_validation": {
+    "last_validated_date": "2024-04-29T13:17:26+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_create_connection_validations": {
-    "last_validated_date": "2024-03-26T14:07:16+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_event_pattern": {
-    "last_validated_date": "2024-03-26T14:07:19+00:00"
+    "last_validated_date": "2024-04-29T13:15:43+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_list_tags_for_resource": {
-    "last_validated_date": "2024-03-26T14:06:51+00:00"
+    "last_validated_date": "2024-04-29T13:15:38+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_detail": {
-    "last_validated_date": "2024-03-26T14:07:16+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_event_without_source": {
-    "last_validated_date": "2024-03-26T14:07:16+00:00"
+    "last_validated_date": "2024-04-29T13:15:31+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "last_validated_date": "2024-04-29T12:11:50+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_nested_event_pattern": {
-    "last_validated_date": "2024-04-29T11:48:23+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_values_in_array": {
-    "last_validated_date": "2024-04-29T11:47:10+00:00"
+    "last_validated_date": "2024-04-29T13:15:34+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
-    "last_validated_date": "2024-04-29T12:47:09+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
-    "last_validated_date": "2024-04-18T15:47:35+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_custom_event_bus": {
-    "last_validated_date": "2024-03-27T09:15:34+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_list_describe_delete_custom_event_buses[regions0]": {
-    "last_validated_date": "2024-04-03T13:49:07+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_list_describe_delete_custom_event_buses[regions1]": {
-    "last_validated_date": "2024-04-03T13:49:10+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_create_multiple_event_buses_same_name": {
-    "last_validated_date": "2024-04-16T15:09:51+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_delete_default_event_bus": {
-    "last_validated_date": "2024-04-16T15:10:07+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_describe_delete_not_existing_event_bus": {
-    "last_validated_date": "2024-04-17T07:32:19+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_list_event_buses_with_limit": {
-    "last_validated_date": "2024-04-03T14:53:31+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_nonexistent_event_bus": {
-    "last_validated_date": "2024-04-16T15:10:30+00:00"
-  },
-  "tests/aws/services/events/test_events.py::TestEventsEventBus::test_put_events_to_default_eventbus_for_custom_eventbus": {
-    "last_validated_date": "2024-03-26T14:07:59+00:00"
+    "last_validated_date": "2024-04-29T13:15:31+00:00"
   }
 }

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -90,10 +90,10 @@
     "last_validated_date": "2024-03-26T14:09:45+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_nested_event_pattern": {
-    "last_validated_date": "2024-03-26T14:07:10+00:00"
+    "last_validated_date": "2024-04-29T11:48:23+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_values_in_array": {
-    "last_validated_date": "2024-03-26T14:06:58+00:00"
+    "last_validated_date": "2024-04-29T11:47:10+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
     "last_validated_date": "2024-04-18T15:47:35+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -87,7 +87,7 @@
     "last_validated_date": "2024-03-26T14:07:16+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_time": {
-    "last_validated_date": "2024-03-26T14:09:45+00:00"
+    "last_validated_date": "2024-04-29T12:11:50+00:00"
   },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_nested_event_pattern": {
     "last_validated_date": "2024-04-29T11:48:23+00:00"

--- a/tests/aws/services/events/test_events.validation.json
+++ b/tests/aws/services/events/test_events.validation.json
@@ -95,6 +95,9 @@
   "tests/aws/services/events/test_events.py::TestEvents::test_put_events_with_values_in_array": {
     "last_validated_date": "2024-04-29T11:47:10+00:00"
   },
+  "tests/aws/services/events/test_events.py::TestEvents::test_put_events_without_source": {
+    "last_validated_date": "2024-04-29T12:47:09+00:00"
+  },
   "tests/aws/services/events/test_events.py::TestEvents::test_put_target_id_validation": {
     "last_validated_date": "2024-04-18T15:47:35+00:00"
   },

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -20,7 +20,7 @@ from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO
 
 
 @markers.aws.validated
-def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
+def test_put_events_with_target_sqs(put_events_with_filter_to_sqs, snapshot):
     entries = [
         {
             "Source": TEST_EVENT_PATTERN["source"][0],
@@ -28,10 +28,17 @@ def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
             "Detail": json.dumps(EVENT_DETAIL),
         }
     ]
-    put_events_with_filter_to_sqs(
+    message = put_events_with_filter_to_sqs(
         pattern=TEST_EVENT_PATTERN,
         entries_asserts=[(entries, True)],
     )
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("ReceiptHandle", reference_replacement=False),
+            snapshot.transform.key_value("MD5OfBody", reference_replacement=False),
+        ],
+    )
+    snapshot.match("message", message)
 
 
 @markers.aws.unknown

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -42,6 +42,7 @@ def test_put_events_with_target_sqs(put_events_with_filter_to_sqs, snapshot):
 
 
 @markers.aws.unknown
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs_new_region(aws_client_factory):
     events_client = aws_client_factory(region_name="eu-west-1").events
     queue_name = "queue-{}".format(short_uid())

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -35,7 +35,6 @@ def test_put_events_with_target_sqs(put_events_with_filter_to_sqs):
 
 
 @markers.aws.unknown
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs_new_region(aws_client_factory):
     events_client = aws_client_factory(region_name="eu-west-1").events
     queue_name = "queue-{}".format(short_uid())
@@ -77,7 +76,6 @@ def test_put_events_with_target_sqs_new_region(aws_client_factory):
 
 
 @markers.aws.unknown
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sqs_event_detail_match(put_events_with_filter_to_sqs):
     entries1 = [
         {
@@ -106,7 +104,6 @@ def test_put_events_with_target_sqs_event_detail_match(put_events_with_filter_to
 
 @markers.aws.unknown
 @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_sns(
     monkeypatch,
     sns_subscription,
@@ -175,7 +172,6 @@ def test_put_events_with_target_sns(
 
 
 @markers.aws.unknown
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_lambda(create_lambda_function, cleanups, aws_client, clean_up):
     rule_name = f"rule-{short_uid()}"
     function_name = f"lambda-func-{short_uid()}"
@@ -237,7 +233,6 @@ def test_put_events_with_target_lambda(create_lambda_function, cleanups, aws_cli
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_lambda_list_entry(
     create_lambda_function, cleanups, aws_client, clean_up, snapshot
 ):
@@ -334,7 +329,6 @@ def test_put_events_with_target_lambda_list_entry(
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_lambda_list_entries_partial_match(
     create_lambda_function, cleanups, aws_client, clean_up, snapshot
 ):
@@ -483,7 +477,6 @@ def test_should_ignore_schedules_for_put_event(create_lambda_function, cleanups,
 
 
 @markers.aws.unknown
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_target_firehose(aws_client, clean_up):
     s3_bucket = "s3-{}".format(short_uid())
     s3_prefix = "testeventdata"

--- a/tests/aws/services/events/test_events_integrations.snapshot.json
+++ b/tests/aws/services/events/test_events_integrations.snapshot.json
@@ -100,5 +100,34 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs": {
+    "recorded-date": "26-04-2024, 08:43:27",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:2>",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_integrations.snapshot.json
+++ b/tests/aws/services/events/test_events_integrations.snapshot.json
@@ -129,5 +129,20 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs_event_detail_match": {
+    "recorded-date": "07-05-2024, 10:40:38",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "receipt-handle",
+          "MD5OfBody": "m-d5-of-body",
+          "Body": {
+            "EventType": "1"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_integrations.validation.json
+++ b/tests/aws/services/events/test_events_integrations.validation.json
@@ -9,7 +9,7 @@
     "last_validated_date": "2024-04-26T08:43:27+00:00"
   },
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs_event_detail_match": {
-    "last_validated_date": "2024-03-26T15:50:07+00:00"
+    "last_validated_date": "2024-05-07T10:40:38+00:00"
   },
   "tests/aws/services/events/test_events_integrations.py::test_should_ignore_schedules_for_put_event": {
     "last_validated_date": "2024-03-26T15:51:47+00:00"

--- a/tests/aws/services/events/test_events_integrations.validation.json
+++ b/tests/aws/services/events/test_events_integrations.validation.json
@@ -6,7 +6,7 @@
     "last_validated_date": "2024-04-08T17:33:44+00:00"
   },
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs": {
-    "last_validated_date": "2024-03-26T15:49:59+00:00"
+    "last_validated_date": "2024-04-26T08:43:27+00:00"
   },
   "tests/aws/services/events/test_events_integrations.py::test_put_events_with_target_sqs_event_detail_match": {
     "last_validated_date": "2024-03-26T15:50:07+00:00"

--- a/tests/aws/services/events/test_events_rules.py
+++ b/tests/aws/services/events/test_events_rules.py
@@ -18,7 +18,6 @@ from tests.aws.services.events.test_events import TEST_EVENT_BUS_NAME, TEST_EVEN
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_rule(aws_client, snapshot, clean_up):
     rule_name = f"rule-{short_uid()}"
     snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule-name>"))
@@ -38,7 +37,6 @@ def test_put_rule(aws_client, snapshot, clean_up):
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_rule_disable(aws_client, clean_up):
     rule_name = f"rule-{short_uid()}"
     aws_client.events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)")
@@ -54,6 +52,8 @@ def test_rule_disable(aws_client, clean_up):
 
 
 @markers.aws.validated
+# TODO move to test_events_schedules.py
+@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 @pytest.mark.parametrize(
     "expression",
     [
@@ -76,7 +76,6 @@ def test_rule_disable(aws_client, clean_up):
         " rate(10 minutes)",
     ],
 )
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_rule_invalid_rate_schedule_expression(expression, aws_client):
     with pytest.raises(ClientError) as e:
         aws_client.events.put_rule(Name=f"rule-{short_uid()}", ScheduleExpression=expression)
@@ -88,7 +87,6 @@ def test_put_rule_invalid_rate_schedule_expression(expression, aws_client):
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_anything_but_to_sqs(put_events_with_filter_to_sqs, snapshot):
     snapshot.add_transformer(
         [
@@ -142,7 +140,6 @@ def test_put_events_with_rule_anything_but_to_sqs(put_events_with_filter_to_sqs,
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_exists_true_to_sqs(put_events_with_filter_to_sqs, snapshot):
     """
     Exists matching True condition: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-exists-matching
@@ -190,7 +187,6 @@ def test_put_events_with_rule_exists_true_to_sqs(put_events_with_filter_to_sqs, 
 
 
 @markers.aws.validated
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_put_events_with_rule_exists_false_to_sqs(put_events_with_filter_to_sqs, snapshot):
     """
     Exists matching False condition: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-exists-matching
@@ -339,8 +335,9 @@ def test_put_event_with_content_base_rule_in_pattern(aws_client, clean_up):
 
 
 @markers.aws.validated
-@pytest.mark.parametrize("schedule_expression", ["rate(1 minute)", "rate(1 day)", "rate(1 hour)"])
+# TODO move to test_events_schedules.py
 @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
+@pytest.mark.parametrize("schedule_expression", ["rate(1 minute)", "rate(1 day)", "rate(1 hour)"])
 def test_create_rule_with_one_unit_in_singular_should_succeed(
     schedule_expression, aws_client, clean_up
 ):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds pattern matching to distribute incoming events based on event bus specified in the event, rules in the matching event bus and matches the patterns in the rules. 
It uses the existing rule matching algorithm from v1, which is limited, e.g. patterns with `anything but` or `exists = True`. 

<!-- What notable changes does this PR make? -->
## Changes
Add parsing for event pattern to a dictionary, and add validating of pattern.
Add correct formatting of events and add additional keys. 
Add API method to test event pattern using same matching algorithm as for distributing events to targets.
Remove skip markers from now passing tests.



## Testing
Set the env variable `PROVIDER_OVERRIDE_EVENTS=v2` and run tests in events folder. All unsupported tests have the appropriate skip markers. 

<!-- The following sections are optional, but can be useful! 


Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

