### PR TITLE
fix APIGW: add rootResourceId to REST API creation

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -937,9 +937,6 @@ def import_api_from_openapi_spec(
     # rest_api.name = resolved_schema.get("info", {}).get("title")
     rest_api.description = resolved_schema.get("info", {}).get("description")
 
-    # Remove default root, then add paths from API spec
-    # TODO: the default mode is now `merge`, not `overwrite` if using `PutRestApi`
-    rest_api.resources = {}
     # authorizers map to avoid duplication
     authorizers = {}
 
@@ -1355,7 +1352,14 @@ def import_api_from_openapi_spec(
         base_path = base_path.strip("/").partition("/")[-1]
         base_path = f"/{base_path}" if base_path else ""
 
-    for path in resolved_schema.get("paths", {}):
+    api_paths = resolved_schema.get("paths", {})
+    if api_paths:
+        # Remove default root, then add paths from API spec
+        # TODO: the default mode is now `merge`, not `overwrite` if using `PutRestApi`
+        # TODO: quick hack for now, but do not remove the rootResource if the OpenAPI file is empty
+        rest_api.resources = {}
+
+    for path in api_paths:
         get_or_create_path(base_path + path, base_path=base_path)
 
     # binary types

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -386,6 +386,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         remove_empty_attributes_from_rest_api(response)
         store = get_apigateway_store(context=context)
         store.rest_apis[request["restApiId"]].rest_api = response
+        # TODO: remove once this is fixed upstream
+        if "rootResourceId" not in response:
+            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
         # TODO: verify this
         response = to_rest_api_response_json(response)
         response.setdefault("tags", {})

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -246,6 +246,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         rest_api = get_moto_rest_api(context, rest_api_id=result["id"])
         rest_api.version = request.get("version")
         response: RestApi = rest_api.to_dict()
+        # TODO: remove once this is fixed upstream
+        if "rootResourceId" not in response:
+            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
         remove_empty_attributes_from_rest_api(response)
         store = get_apigateway_store(context=context)
         rest_api_container = RestApiContainer(rest_api=response)
@@ -281,6 +284,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def get_rest_api(self, context: RequestContext, rest_api_id: String, **kwargs) -> RestApi:
         rest_api: RestApi = call_moto(context)
         remove_empty_attributes_from_rest_api(rest_api)
+        # TODO: remove once this is fixed upstream
+        if "rootResourceId" not in rest_api:
+            moto_rest_api = get_moto_rest_api(context, rest_api_id=rest_api_id)
+            rest_api["rootResourceId"] = get_moto_rest_api_root_resource(moto_rest_api)
         return rest_api
 
     def update_rest_api(
@@ -326,7 +333,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             elif patch_op_path == "/minimumCompressionSize":
                 if patch_op["op"] != "replace":
                     raise BadRequestException(
-                        "Invalid patch operation specified. Must be 'add'|'remove'|'replace'"
+                        "Invalid patch operation specified. Must be one of: [replace]"
                     )
 
                 try:
@@ -358,6 +365,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             rest_api.minimum_compression_size = None
 
         response = rest_api.to_dict()
+        if "rootResourceId" not in response:
+            response["rootResourceId"] = get_moto_rest_api_root_resource(rest_api)
+
         remove_empty_attributes_from_rest_api(response, remove_tags=False)
         store = get_apigateway_store(context=context)
         store.rest_apis[rest_api_id].rest_api = response
@@ -475,6 +485,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response: RestApis = call_moto(context)
         for rest_api in response["items"]:
             remove_empty_attributes_from_rest_api(rest_api)
+            if "rootResourceId" not in rest_api:
+                moto_rest_api = get_moto_rest_api(context, rest_api_id=rest_api["id"])
+                rest_api["rootResourceId"] = get_moto_rest_api_root_resource(moto_rest_api)
         return response
 
     # resources
@@ -807,7 +820,24 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             # if the path is not supported by the operation, ignore it and skip
             op_supported_path = UPDATE_METHOD_PATCH_PATHS.get(op, [])
             if not any(path.startswith(s_path) for s_path in op_supported_path):
-                continue
+                available_ops = [
+                    available_op
+                    for available_op in ("add", "replace", "delete")
+                    if available_op != op
+                ]
+                supported_ops = ", ".join(
+                    [
+                        supported_op
+                        for supported_op in available_ops
+                        if any(
+                            path.startswith(s_path)
+                            for s_path in UPDATE_METHOD_PATCH_PATHS.get(supported_op, [])
+                        )
+                    ]
+                )
+                raise BadRequestException(
+                    f"Invalid patch operation specified. Must be one of: [{supported_ops}]"
+                )
 
             value = patch_operation.get("value")
             if op not in ("add", "replace"):
@@ -2510,6 +2540,13 @@ def validate_model_in_use(moto_rest_api: MotoRestAPI, model_name: str) -> None:
                 raise ConflictException(
                     f"Cannot delete model '{model_name}', is referenced in method request: {path}"
                 )
+
+
+def get_moto_rest_api_root_resource(moto_rest_api: MotoRestAPI) -> str:
+    for res_id, res_obj in moto_rest_api.resources.items():
+        if res_obj.path_part == "/" and not res_obj.parent_id:
+            return res_id
+    raise Exception(f"Unable to find root resource for API {moto_rest_api.id}")
 
 
 def create_custom_context(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1954,10 +1954,8 @@ def create_rest_apigw(aws_client_factory):
         response = apigateway_client.create_rest_api(**kwargs)
         api_id = response.get("id")
         rest_apis.append((api_id, region_name))
-        resources = apigateway_client.get_resources(restApiId=api_id)
-        root_id = next(item for item in resources["items"] if item["path"] == "/")["id"]
 
-        return api_id, response.get("name"), root_id
+        return api_id, response.get("name"), response.get("rootResourceId")
 
     yield _create_apigateway_function
 

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -156,6 +156,7 @@ class TransformerUtility:
             TransformerUtility.key_value("id"),
             TransformerUtility.key_value("name"),
             TransformerUtility.key_value("parentId"),
+            TransformerUtility.key_value("rootResourceId"),
         ]
 
     @staticmethod

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -116,9 +116,6 @@ class TestApiGatewayApiRestApi:
         response["items"].sort(key=itemgetter("createdDate"))
         snapshot.match("get-rest-api-before-delete", response)
 
-        if is_aws_cloud():
-            time.sleep(15)
-
         response = aws_client.apigateway.delete_rest_api(restApiId=api_id)
         snapshot.match("delete-rest-api", response)
 

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -761,8 +761,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing resource method lifecycle"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         put_base_method_response = aws_client.apigateway.put_method(
             restApiId=api_id,
@@ -798,8 +797,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing resource method request params"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         put_method_response = aws_client.apigateway.put_method(
             restApiId=api_id,
@@ -846,8 +844,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing resource method model"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         create_model = aws_client.apigateway.create_model(
             name="MySchema",
@@ -955,8 +952,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing resource method request params"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         # wrong RestApiId
         with pytest.raises(ClientError) as e:
@@ -1033,8 +1029,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing update method"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         put_method_response = aws_client.apigateway.put_method(
             restApiId=api_id,
@@ -1124,8 +1119,7 @@ class TestApiGatewayApiMethod:
             name=f"test-api-{short_uid()}", description="testing resource method request params"
         )
         api_id = response["id"]
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_id = response["rootResourceId"]
 
         with pytest.raises(ClientError) as e:
             aws_client.apigateway.update_method(

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -68,197 +68,37 @@ def delete_rest_api_retry(client, rest_api_id: str):
 
 
 @pytest.fixture
-def apigw_create_rest_api(aws_client):
+def apigw_create_rest_api(aws_client, aws_client_factory):
+    if is_aws_cloud():
+        client_config = (
+            Config(
+                # Api gateway can throttle requests pretty heavily. Leading to potentially undeleted apis
+                retries={"max_attempts": 10, "mode": "adaptive"}
+            )
+            if is_aws_cloud()
+            else None
+        )
+
+        apigateway_client = aws_client_factory(config=client_config).apigateway
+    else:
+        apigateway_client = aws_client.apigateway
+
     rest_apis = []
 
     def _factory(*args, **kwargs):
         if "name" not in kwargs:
             kwargs["name"] = f"test-api-{short_uid()}"
-        response = aws_client.apigateway.create_rest_api(*args, **kwargs)
+        response = apigateway_client.create_rest_api(*args, **kwargs)
         rest_apis.append(response["id"])
         return response
 
     yield _factory
 
     for rest_api_id in rest_apis:
-        delete_rest_api_retry(aws_client.apigateway, rest_api_id)
+        delete_rest_api_retry(apigateway_client, rest_api_id)
 
 
-class TestApiGatewayApi:
-    @markers.aws.validated
-    def test_invoke_test_method(self, create_rest_apigw, snapshot, aws_client):
-        snapshot.add_transformer(
-            KeyValueBasedTransformer(
-                lambda k, v: str(v) if k == "latency" else None, "latency", replace_reference=False
-            )
-        )
-        snapshot.add_transformer(
-            snapshot.transform.key_value("log", "log", reference_replacement=False)
-        )
-
-        api_id, _, root = create_rest_apigw(name="aws lambda api")
-
-        # Create the /pets resource
-        root_resource_id, _ = create_rest_resource(
-            aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="pets"
-        )
-        # Create the /pets/{petId} resource
-        resource_id, _ = create_rest_resource(
-            aws_client.apigateway, restApiId=api_id, parentId=root_resource_id, pathPart="{petId}"
-        )
-        # Create the GET method for /pets/{petId}
-        create_rest_resource_method(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            authorizationType="NONE",
-            requestParameters={
-                "method.request.path.petId": True,
-            },
-        )
-        # Create the POST method for /pets/{petId}
-        create_rest_resource_method(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            authorizationType="NONE",
-            requestParameters={
-                "method.request.path.petId": True,
-            },
-        )
-        # Create the response for method GET /pets/{petId}
-        create_rest_api_method_response(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            statusCode="200",
-        )
-        # Create the response for method POST /pets/{petId}
-        create_rest_api_method_response(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            statusCode="200",
-        )
-        # Create the integration to connect GET /pets/{petId} to a backend
-        create_rest_api_integration(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            type="MOCK",
-            integrationHttpMethod="GET",
-            requestParameters={
-                "integration.request.path.id": "method.request.path.petId",
-            },
-            requestTemplates={"application/json": json.dumps({"statusCode": 200})},
-        )
-        # Create the integration to connect POST /pets/{petId} to a backend
-        create_rest_api_integration(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            type="MOCK",
-            integrationHttpMethod="POST",
-            requestParameters={
-                "integration.request.path.id": "method.request.path.petId",
-            },
-            requestTemplates={"application/json": json.dumps({"statusCode": 200})},
-        )
-        # Create the 200 integration response for GET /pets/{petId}
-        create_rest_api_integration_response(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="GET",
-            statusCode="200",
-            responseTemplates={"application/json": json.dumps({"petId": "$input.params('petId')"})},
-        )
-        # Create the 200 integration response for POST /pets/{petId}
-        create_rest_api_integration_response(
-            aws_client.apigateway,
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            statusCode="200",
-            responseTemplates={"application/json": json.dumps({"petId": "$input.params('petId')"})},
-        )
-
-        def invoke_method(api_id, resource_id, path_with_query_string, method, body=""):
-            res = aws_client.apigateway.test_invoke_method(
-                restApiId=api_id,
-                resourceId=resource_id,
-                httpMethod=method,
-                pathWithQueryString=path_with_query_string,
-                body=body,
-            )
-            assert 200 == res.get("status")
-            return res
-
-        response = retry(
-            invoke_method,
-            retries=10,
-            sleep=5,
-            api_id=api_id,
-            resource_id=resource_id,
-            path_with_query_string="/pets/123",
-            method="GET",
-        )
-        assert "HTTP Method: GET, Resource Path: /pets/123" in response["log"]
-        snapshot.match("test-invoke-method-get", response)
-
-        response = retry(
-            invoke_method,
-            retries=10,
-            sleep=5,
-            api_id=api_id,
-            resource_id=resource_id,
-            path_with_query_string="/pets/123?foo=bar",
-            method="GET",
-        )
-        snapshot.match("test-invoke-method-get-with-qs", response)
-
-        response = retry(
-            invoke_method,
-            retries=10,
-            sleep=5,
-            api_id=api_id,
-            resource_id=resource_id,
-            path_with_query_string="/pets/123",
-            method="POST",
-            body=json.dumps({"foo": "bar"}),
-        )
-        assert "HTTP Method: POST, Resource Path: /pets/123" in response["log"]
-        snapshot.match("test-invoke-method-post-with-body", response)
-
-        # assert resource and rest api doesn't exist
-        with pytest.raises(ClientError) as ex:
-            aws_client.apigateway.test_invoke_method(
-                restApiId=api_id,
-                resourceId="invalid_res",
-                httpMethod="POST",
-                pathWithQueryString="/pets/123",
-                body=json.dumps({"foo": "bar"}),
-            )
-        snapshot.match("resource-id-not-found", ex.value.response)
-        assert ex.value.response["Error"]["Code"] == "NotFoundException"
-
-        with pytest.raises(ClientError) as ex:
-            aws_client.apigateway.test_invoke_method(
-                restApiId=api_id,
-                resourceId="invalid_res",
-                httpMethod="POST",
-                pathWithQueryString="/pets/123",
-                body=json.dumps({"foo": "bar"}),
-            )
-        snapshot.match("rest-api-not-found", ex.value.response)
-        assert ex.value.response["Error"]["Code"] == "NotFoundException"
-
+class TestApiGatewayApiRestApi:
     @markers.aws.validated
     def test_list_and_delete_apis(self, apigw_create_rest_api, snapshot, aws_client):
         api_name1 = f"test-list-and-delete-apis-{short_uid()}"
@@ -275,6 +115,9 @@ class TestApiGatewayApi:
         # sort the response by creation date, to ensure order for snapshot matching
         response["items"].sort(key=itemgetter("createdDate"))
         snapshot.match("get-rest-api-before-delete", response)
+
+        if is_aws_cloud():
+            time.sleep(15)
 
         response = aws_client.apigateway.delete_rest_api(restApiId=api_id)
         snapshot.match("delete-rest-api", response)
@@ -529,6 +372,8 @@ class TestApiGatewayApi:
         snapshot.match("not-found-update-rest-api", ex.value.response)
         assert ex.value.response["Error"]["Code"] == "NotFoundException"
 
+
+class TestApiGatewayApiResource:
     @markers.aws.validated
     def test_resource_lifecycle(self, apigw_create_rest_api, snapshot, aws_client):
         snapshot.add_transformer(SortingTransformer("items", lambda x: x["path"]))
@@ -888,6 +733,8 @@ class TestApiGatewayApi:
         )
         snapshot.match("create-greedy-child-resource", greedy_child_response)
 
+
+class TestApiGatewayApiAuthorizer:
     @markers.aws.validated
     def test_authorizer_crud_no_api(self, snapshot, aws_client):
         # maybe move this test to a full lifecycle one
@@ -906,37 +753,8 @@ class TestApiGatewayApi:
             aws_client.apigateway.get_authorizers(restApiId="test-fake-rest-id")
         snapshot.match("wrong-rest-api-id-get-authorizers", e.value.response)
 
-    @markers.aws.validated
-    def test_doc_arts_crud_no_api(self, snapshot, aws_client):
-        # maybe move this test to a full lifecycle one
-        with pytest.raises(ClientError) as e:
-            aws_client.apigateway.create_documentation_part(
-                restApiId="test-fake-rest-id",
-                location={"type": "API"},
-                properties='{\n\t"info": {\n\t\t"description" : "Your first API with Amazon API Gateway."\n\t}\n}',
-            )
-        snapshot.match("wrong-rest-api-id-create-doc-part", e.value.response)
 
-        with pytest.raises(ClientError) as e:
-            aws_client.apigateway.get_documentation_parts(restApiId="test-fake-rest-id")
-        snapshot.match("wrong-rest-api-id-get-doc-parts", e.value.response)
-
-    @markers.aws.validated
-    def test_validators_crud_no_api(self, snapshot, aws_client):
-        # maybe move this test to a full lifecycle one
-        with pytest.raises(ClientError) as e:
-            aws_client.apigateway.create_request_validator(
-                restApiId="test-fake-rest-id",
-                name="test-validator",
-                validateRequestBody=True,
-                validateRequestParameters=False,
-            )
-        snapshot.match("wrong-rest-api-id-create-validator", e.value.response)
-
-        with pytest.raises(ClientError) as e:
-            aws_client.apigateway.get_request_validators(restApiId="test-fake-rest-id")
-        snapshot.match("wrong-rest-api-id-get-validators", e.value.response)
-
+class TestApiGatewayApiMethod:
     @markers.aws.validated
     def test_method_lifecycle(self, apigw_create_rest_api, snapshot, aws_client):
         response = apigw_create_rest_api(
@@ -1349,17 +1167,31 @@ class TestApiGatewayApi:
         )
         snapshot.match("put-method-response", put_method_response)
 
-        # unsupported operation ?
+        # unsupported operation
         patch_operations_add = [
             {"op": "add", "path": "/operationName", "value": "operationName"},
         ]
-        unsupported_operation_resp = aws_client.apigateway.update_method(
-            restApiId=api_id,
-            resourceId=root_id,
-            httpMethod="ANY",
-            patchOperations=patch_operations_add,
-        )
-        snapshot.match("unsupported-operation", unsupported_operation_resp)
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("unsupported-operation", e.value.response)
+
+        # unsupported operation
+        patch_operations_add_2 = [
+            {"op": "add", "path": "/requestValidatorId", "value": "wrong-id"},
+        ]
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add_2,
+            )
+        snapshot.match("unsupported-operation-2", e.value.response)
 
         # unsupported path
         with pytest.raises(ClientError) as e:
@@ -1468,9 +1300,10 @@ class TestApiGatewayApi:
             )
         snapshot.match("wrong-req-validator-id", e.value.response)
 
+
+class TestApiGatewayApiModels:
     @markers.aws.validated
     def test_model_lifecycle(self, apigw_create_rest_api, snapshot, aws_client):
-        snapshot.add_transformer(SortingTransformer("items", lambda x: x["name"]))
         # taken from https://docs.aws.amazon.com/apigateway/latest/api/API_CreateModel.html#API_CreateModel_Examples
         response = apigw_create_rest_api(
             name=f"test-api-{short_uid()}", description="testing resource model lifecycle"
@@ -1487,6 +1320,7 @@ class TestApiGatewayApi:
         snapshot.match("create-model", create_model_response)
 
         get_models_response = aws_client.apigateway.get_models(restApiId=api_id)
+        get_models_response["items"].sort(key=lambda x: x["name"])
         snapshot.match("get-models", get_models_response)
 
         # manually assert the presence of 2 default models, Error and Empty, as snapshots will replace names
@@ -1671,6 +1505,22 @@ class TestApiGatewayApi:
 
 
 class TestApiGatewayApiRequestValidator:
+    @markers.aws.validated
+    def test_validators_crud_no_api(self, snapshot, aws_client):
+        # maybe move this test to a full lifecycle one
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.create_request_validator(
+                restApiId="test-fake-rest-id",
+                name="test-validator",
+                validateRequestBody=True,
+                validateRequestParameters=False,
+            )
+        snapshot.match("wrong-rest-api-id-create-validator", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.get_request_validators(restApiId="test-fake-rest-id")
+        snapshot.match("wrong-rest-api-id-get-validators", e.value.response)
+
     @markers.aws.validated
     def test_request_validator_lifecycle(self, apigw_create_rest_api, snapshot, aws_client):
         response = apigw_create_rest_api(
@@ -1858,6 +1708,21 @@ class TestApiGatewayApiRequestValidator:
 
 
 class TestApiGatewayApiDocumentationPart:
+    @markers.aws.validated
+    def test_doc_parts_crud_no_api(self, snapshot, aws_client):
+        # maybe move this test to a full lifecycle one
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.create_documentation_part(
+                restApiId="test-fake-rest-id",
+                location={"type": "API"},
+                properties='{\n\t"info": {\n\t\t"description" : "Your first API with Amazon API Gateway."\n\t}\n}',
+            )
+        snapshot.match("wrong-rest-api-id-create-doc-part", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            aws_client.apigateway.get_documentation_parts(restApiId="test-fake-rest-id")
+        snapshot.match("wrong-rest-api-id-get-doc-parts", e.value.response)
+
     @markers.aws.validated
     def test_documentation_part_lifecycle(self, apigw_create_rest_api, snapshot, aws_client):
         response = apigw_create_rest_api(
@@ -2362,6 +2227,182 @@ class TestApiGatewayGatewayResponse:
             )
 
 
+class TestApigatewayTestInvoke:
+    @markers.aws.validated
+    def test_invoke_test_method(self, create_rest_apigw, snapshot, aws_client):
+        snapshot.add_transformer(
+            KeyValueBasedTransformer(
+                lambda k, v: str(v) if k == "latency" else None, "latency", replace_reference=False
+            )
+        )
+        snapshot.add_transformer(
+            snapshot.transform.key_value("log", "log", reference_replacement=False)
+        )
+
+        api_id, _, root = create_rest_apigw(name="aws lambda api")
+
+        # Create the /pets resource
+        root_resource_id, _ = create_rest_resource(
+            aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="pets"
+        )
+        # Create the /pets/{petId} resource
+        resource_id, _ = create_rest_resource(
+            aws_client.apigateway, restApiId=api_id, parentId=root_resource_id, pathPart="{petId}"
+        )
+        # Create the GET method for /pets/{petId}
+        create_rest_resource_method(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            authorizationType="NONE",
+            requestParameters={
+                "method.request.path.petId": True,
+            },
+        )
+        # Create the POST method for /pets/{petId}
+        create_rest_resource_method(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+            requestParameters={
+                "method.request.path.petId": True,
+            },
+        )
+        # Create the response for method GET /pets/{petId}
+        create_rest_api_method_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            statusCode="200",
+        )
+        # Create the response for method POST /pets/{petId}
+        create_rest_api_method_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+        # Create the integration to connect GET /pets/{petId} to a backend
+        create_rest_api_integration(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            type="MOCK",
+            integrationHttpMethod="GET",
+            requestParameters={
+                "integration.request.path.id": "method.request.path.petId",
+            },
+            requestTemplates={"application/json": json.dumps({"statusCode": 200})},
+        )
+        # Create the integration to connect POST /pets/{petId} to a backend
+        create_rest_api_integration(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            type="MOCK",
+            integrationHttpMethod="POST",
+            requestParameters={
+                "integration.request.path.id": "method.request.path.petId",
+            },
+            requestTemplates={"application/json": json.dumps({"statusCode": 200})},
+        )
+        # Create the 200 integration response for GET /pets/{petId}
+        create_rest_api_integration_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            statusCode="200",
+            responseTemplates={"application/json": json.dumps({"petId": "$input.params('petId')"})},
+        )
+        # Create the 200 integration response for POST /pets/{petId}
+        create_rest_api_integration_response(
+            aws_client.apigateway,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            responseTemplates={"application/json": json.dumps({"petId": "$input.params('petId')"})},
+        )
+
+        def invoke_method(api_id, resource_id, path_with_query_string, method, body=""):
+            res = aws_client.apigateway.test_invoke_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=method,
+                pathWithQueryString=path_with_query_string,
+                body=body,
+            )
+            assert 200 == res.get("status")
+            return res
+
+        response = retry(
+            invoke_method,
+            retries=10,
+            sleep=5,
+            api_id=api_id,
+            resource_id=resource_id,
+            path_with_query_string="/pets/123",
+            method="GET",
+        )
+        assert "HTTP Method: GET, Resource Path: /pets/123" in response["log"]
+        snapshot.match("test-invoke-method-get", response)
+
+        response = retry(
+            invoke_method,
+            retries=10,
+            sleep=5,
+            api_id=api_id,
+            resource_id=resource_id,
+            path_with_query_string="/pets/123?foo=bar",
+            method="GET",
+        )
+        snapshot.match("test-invoke-method-get-with-qs", response)
+
+        response = retry(
+            invoke_method,
+            retries=10,
+            sleep=5,
+            api_id=api_id,
+            resource_id=resource_id,
+            path_with_query_string="/pets/123",
+            method="POST",
+            body=json.dumps({"foo": "bar"}),
+        )
+        assert "HTTP Method: POST, Resource Path: /pets/123" in response["log"]
+        snapshot.match("test-invoke-method-post-with-body", response)
+
+        # assert resource and rest api doesn't exist
+        with pytest.raises(ClientError) as ex:
+            aws_client.apigateway.test_invoke_method(
+                restApiId=api_id,
+                resourceId="invalid_res",
+                httpMethod="POST",
+                pathWithQueryString="/pets/123",
+                body=json.dumps({"foo": "bar"}),
+            )
+        snapshot.match("resource-id-not-found", ex.value.response)
+        assert ex.value.response["Error"]["Code"] == "NotFoundException"
+
+        with pytest.raises(ClientError) as ex:
+            aws_client.apigateway.test_invoke_method(
+                restApiId=api_id,
+                resourceId="invalid_res",
+                httpMethod="POST",
+                pathWithQueryString="/pets/123",
+                body=json.dumps({"foo": "bar"}),
+            )
+        snapshot.match("rest-api-not-found", ex.value.response)
+        assert ex.value.response["Error"]["Code"] == "NotFoundException"
+
+
 class TestApigatewayIntegration:
     @markers.aws.validated
     def test_put_integration_wrong_type(
@@ -2373,13 +2414,10 @@ class TestApigatewayIntegration:
             description="APIGW test PutIntegration Types",
         )
         api_id = response["id"]
-
-        root_rest_api_resource = aws_client.apigateway.get_resources(restApiId=api_id)
-
-        root_id = root_rest_api_resource["items"][0]["id"]
+        root_resource_id = response["rootResourceId"]
 
         with pytest.raises(ClientError) as e:
             apigw_client.put_integration(
-                restApiId=api_id, resourceId=root_id, httpMethod="GET", type="HTTPS_PROXY"
+                restApiId=api_id, resourceId=root_resource_id, httpMethod="GET", type="HTTPS_PROXY"
             )
         snapshot.match("put-integration-wrong-type", e.value.response)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_list_and_delete_apis": {
-    "recorded-date": "01-02-2023, 20:16:52",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_list_and_delete_apis": {
+    "recorded-date": "15-04-2024, 15:09:48",
     "recorded-content": {
       "create-rest-api-1": {
         "apiKeySource": "HEADER",
@@ -14,6 +14,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -31,6 +32,7 @@
         },
         "id": "<id:2>",
         "name": "<name:2>",
+        "rootResourceId": "<root-resource-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -49,7 +51,8 @@
               ]
             },
             "id": "<id:1>",
-            "name": "<name:1>"
+            "name": "<name:1>",
+            "rootResourceId": "<root-resource-id:1>"
           },
           {
             "apiKeySource": "HEADER",
@@ -62,7 +65,8 @@
               ]
             },
             "id": "<id:2>",
-            "name": "<name:2>"
+            "name": "<name:2>",
+            "rootResourceId": "<root-resource-id:2>"
           }
         ],
         "ResponseMetadata": {
@@ -89,7 +93,8 @@
               ]
             },
             "id": "<id:2>",
-            "name": "<name:2>"
+            "name": "<name:2>",
+            "rootResourceId": "<root-resource-id:2>"
           }
         ],
         "ResponseMetadata": {
@@ -99,8 +104,121 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_tags": {
-    "recorded-date": "01-02-2023, 20:11:19",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_get_api_case_insensitive": {
+    "recorded-date": "15-04-2024, 15:10:18",
+    "recorded-content": {
+      "create-rest-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "lower case api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-api-upper-case": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:<upper-id>"
+        },
+        "message": "Invalid API identifier specified 111111111111:<upper-id>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_optional_params": {
+    "recorded-date": "15-04-2024, 15:11:50",
+    "recorded-content": {
+      "create-only-name": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-empty-desc": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Description cannot be an empty string"
+        },
+        "message": "Description cannot be an empty string",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-with-version": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:2>",
+        "name": "<name:2>",
+        "rootResourceId": "<root-resource-id:2>",
+        "version": "v1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-with-empty-binary-media": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:3>",
+        "name": "<name:3>",
+        "rootResourceId": "<root-resource-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "string-compression-size": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_tags": {
+    "recorded-date": "15-04-2024, 15:12:32",
     "recorded-content": {
       "create-rest-api-w-tags": {
         "apiKeySource": "HEADER",
@@ -114,6 +232,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {
           "MY_TAG1": "MY_VALUE1"
         },
@@ -134,6 +253,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {
           "MY_TAG1": "MY_VALUE1"
         },
@@ -156,6 +276,7 @@
             },
             "id": "<id:1>",
             "name": "<name:1>",
+            "rootResourceId": "<root-resource-id:1>",
             "tags": {
               "MY_TAG1": "MY_VALUE1"
             }
@@ -168,8 +289,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_operation_add_remove": {
-    "recorded-date": "01-02-2023, 20:11:40",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_operation_add_remove": {
+    "recorded-date": "15-04-2024, 15:12:34",
     "recorded-content": {
       "update-rest-api-add": {
         "apiKeySource": "HEADER",
@@ -187,6 +308,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -209,6 +331,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -229,6 +352,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -237,8 +361,105 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_behaviour": {
-    "recorded-date": "01-02-2023, 20:27:17",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_compression": {
+    "recorded-date": "15-04-2024, 15:13:28",
+    "recorded-content": {
+      "enable-compression": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "minimumCompressionSize": 10,
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "disable-compression": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-compression-zero": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "minimumCompressionSize": 0,
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-negative-compression": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "set-string-compression": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
+        },
+        "message": "Invalid minimum compression size, must be between 0 and 10485760",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "unsupported-operation": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch operation specified. Must be one of: [replace]"
+        },
+        "message": "Invalid patch operation specified. Must be one of: [replace]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_behaviour": {
+    "recorded-date": "15-04-2024, 15:14:15",
     "recorded-content": {
       "update-rest-api-array": {
         "apiKeySource": "HEADER",
@@ -255,6 +476,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -296,8 +518,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_invalid_api_id": {
-    "recorded-date": "01-02-2023, 22:26:45",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_invalid_api_id": {
+    "recorded-date": "15-04-2024, 15:14:15",
     "recorded-content": {
       "not-found-update-rest-api": {
         "Error": {
@@ -312,84 +534,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_optional_params": {
-    "recorded-date": "04-04-2023, 17:58:40",
-    "recorded-content": {
-      "create-only-name": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:1>",
-        "name": "<name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "create-empty-desc": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Description cannot be an empty string"
-        },
-        "message": "Description cannot be an empty string",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "create-with-version": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:2>",
-        "name": "<name:2>",
-        "version": "v1",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "create-with-empty-binary-media": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:3>",
-        "name": "<name:3>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "string-compression-size": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
-        },
-        "message": "Invalid minimum compression size, must be between 0 and 10485760",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_resource_lifecycle": {
-    "recorded-date": "23-02-2023, 22:08:31",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_resource_lifecycle": {
+    "recorded-date": "15-04-2024, 17:29:03",
     "recorded-content": {
       "rest-api-root-resource": {
         "items": [
@@ -505,8 +651,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
-    "recorded-date": "24-02-2023, 17:56:07",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_behaviour": {
+    "recorded-date": "15-04-2024, 17:29:39",
     "recorded-content": {
       "nonexistent-resource": {
         "Error": {
@@ -646,8 +792,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_delete_resource": {
-    "recorded-date": "23-02-2023, 20:41:28",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_delete_resource": {
+    "recorded-date": "15-04-2024, 17:30:24",
     "recorded-content": {
       "delete-resource": {
         "ResponseMetadata": {
@@ -680,8 +826,24 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource": {
-    "recorded-date": "24-02-2023, 15:56:43",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_resource_parent_invalid": {
+    "recorded-date": "15-04-2024, 17:31:16",
+    "recorded-content": {
+      "wrong-resource-parent-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_proxy_resource": {
+    "recorded-date": "15-04-2024, 17:31:31",
     "recorded-content": {
       "create-base-proxy-resource": {
         "id": "<id:1>",
@@ -836,8 +998,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource_validation": {
-    "recorded-date": "24-02-2023, 16:17:00",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_proxy_resource_validation": {
+    "recorded-date": "15-04-2024, 17:32:33",
     "recorded-content": {
       "create-base-proxy-resource": {
         "id": "<id:1>",
@@ -894,24 +1056,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_resource_parent_invalid": {
-    "recorded-date": "24-02-2023, 16:39:00",
-    "recorded-content": {
-      "wrong-resource-parent-id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Resource identifier specified"
-        },
-        "message": "Invalid Resource identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_authorizer_crud_no_api": {
-    "recorded-date": "28-02-2023, 20:06:16",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiAuthorizer::test_authorizer_crud_no_api": {
+    "recorded-date": "15-04-2024, 18:43:45",
     "recorded-content": {
       "wrong-rest-api-id-create-authorizer": {
         "Error": {
@@ -937,95 +1083,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_doc_arts_crud_no_api": {
-    "recorded-date": "28-02-2023, 20:11:32",
-    "recorded-content": {
-      "wrong-rest-api-id-create-doc-part": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
-        },
-        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "wrong-rest-api-id-get-doc-parts": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
-        },
-        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_validators_crud_no_api": {
-    "recorded-date": "28-02-2023, 20:18:59",
-    "recorded-content": {
-      "wrong-rest-api-id-create-validator": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid REST API identifier specified"
-        },
-        "message": "Invalid REST API identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "wrong-rest-api-id-get-validators": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
-        },
-        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_get_api_case_insensitive": {
-    "recorded-date": "01-03-2023, 16:26:45",
-    "recorded-content": {
-      "create-rest-api": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "description": "lower case api",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:1>",
-        "name": "<name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get-api-upper-case": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:<upper-id>"
-        },
-        "message": "Invalid API identifier specified 111111111111:<upper-id>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_lifecycle": {
-    "recorded-date": "15-03-2023, 12:06:26",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_lifecycle": {
+    "recorded-date": "15-04-2024, 18:44:02",
     "recorded-content": {
       "put-base-method-response": {
         "apiKeyRequired": false,
@@ -1075,8 +1134,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_request_parameters": {
-    "recorded-date": "24-02-2023, 19:25:22",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_request_parameters": {
+    "recorded-date": "15-04-2024, 18:44:40",
     "recorded-content": {
       "put-method-request-params-response": {
         "apiKeyRequired": false,
@@ -1121,8 +1180,146 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_validation": {
-    "recorded-date": "25-02-2023, 17:49:08",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_model": {
+    "recorded-date": "15-04-2024, 18:45:11",
+    "recorded-content": {
+      "create-model": {
+        "contentType": "application/json",
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "schema": {
+          "title": "<name:1>",
+          "type": "object"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-model-2": {
+        "contentType": "application/json",
+        "id": "<id:2>",
+        "name": "<name:1>Two",
+        "schema": {
+          "title": "<name:1>Two",
+          "type": "object"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-method-request-models": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "delete-model-used": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "update-method-model": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>Two"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-model-unused": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "delete-model-used-2": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "put-method-2-request-models": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>Two"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "delete-model-used-by-2-method": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "update-method-model-2": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-model-used-by-method-1": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "delete-method-using-model-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-model-unused-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_validation": {
+    "recorded-date": "15-04-2024, 18:45:43",
     "recorded-content": {
       "wrong-api": {
         "Error": {
@@ -1192,8 +1389,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method": {
-    "recorded-date": "13-03-2023, 23:31:44",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method": {
+    "recorded-date": "15-04-2024, 18:46:01",
     "recorded-content": {
       "put-method-response": {
         "apiKeyRequired": false,
@@ -1265,8 +1462,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method_validation": {
-    "recorded-date": "13-03-2023, 23:36:56",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method_validation": {
+    "recorded-date": "15-04-2024, 21:11:41",
     "recorded-content": {
       "wrong-rest-api": {
         "Error": {
@@ -1311,12 +1508,25 @@
         }
       },
       "unsupported-operation": {
-        "apiKeyRequired": true,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch operation specified. Must be one of: [replace]"
+        },
+        "message": "Invalid patch operation specified. Must be one of: [replace]",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 400
+        }
+      },
+      "unsupported-operation-2": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch operation specified. Must be one of: [replace]"
+        },
+        "message": "Invalid patch operation specified. Must be one of: [replace]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       },
       "unsupported-path": {
@@ -1405,8 +1615,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_model_lifecycle": {
-    "recorded-date": "26-05-2023, 04:30:31",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_model_lifecycle": {
+    "recorded-date": "15-04-2024, 21:02:34",
     "recorded-content": {
       "create-model": {
         "contentType": "application/json",
@@ -1549,8 +1759,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_model_validation": {
-    "recorded-date": "09-03-2023, 19:13:20",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_model_validation": {
+    "recorded-date": "15-04-2024, 20:33:53",
     "recorded-content": {
       "create-model-wrong-id": {
         "Error": {
@@ -1653,8 +1863,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_model": {
-    "recorded-date": "09-03-2023, 19:39:34",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_update_model": {
+    "recorded-date": "15-04-2024, 20:34:09",
     "recorded-content": {
       "update-model-wrong-id": {
         "Error": {
@@ -1728,146 +1938,35 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_model": {
-    "recorded-date": "15-03-2023, 12:12:59",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_validators_crud_no_api": {
+    "recorded-date": "15-04-2024, 20:44:19",
     "recorded-content": {
-      "create-model": {
-        "contentType": "application/json",
-        "id": "<id:1>",
-        "name": "<name:1>",
-        "schema": {
-          "title": "<name:1>",
-          "type": "object"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "create-model-2": {
-        "contentType": "application/json",
-        "id": "<id:2>",
-        "name": "<name:1>Two",
-        "schema": {
-          "title": "<name:1>Two",
-          "type": "object"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put-method-request-models": {
-        "apiKeyRequired": false,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
-        "requestModels": {
-          "application/json": "<name:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "delete-model-used": {
+      "wrong-rest-api-id-create-validator": {
         "Error": {
-          "Code": "ConflictException",
-          "Message": "Cannot delete model '<name:1>', is referenced in method request: //ANY"
+          "Code": "BadRequestException",
+          "Message": "Invalid REST API identifier specified"
         },
-        "message": "Cannot delete model '<name:1>', is referenced in method request: //ANY",
+        "message": "Invalid REST API identifier specified",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 409
+          "HTTPStatusCode": 400
         }
       },
-      "update-method-model": {
-        "apiKeyRequired": false,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
-        "requestModels": {
-          "application/json": "<name:1>Two"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-model-unused": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        }
-      },
-      "delete-model-used-2": {
+      "wrong-rest-api-id-get-validators": {
         "Error": {
-          "Code": "ConflictException",
-          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
         },
-        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "put-method-2-request-models": {
-        "apiKeyRequired": false,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
-        "requestModels": {
-          "application/json": "<name:1>Two"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "delete-model-used-by-2-method": {
-        "Error": {
-          "Code": "ConflictException",
-          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY"
-        },
-        "message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "update-method-model-2": {
-        "apiKeyRequired": false,
-        "authorizationType": "NONE",
-        "httpMethod": "ANY",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete-model-used-by-method-1": {
-        "Error": {
-          "Code": "ConflictException",
-          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
-        },
-        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "delete-method-using-model-2": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "delete-model-unused-2": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
+          "HTTPStatusCode": 404
         }
       }
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_request_validator_lifecycle": {
-    "recorded-date": "22-03-2023, 13:07:42",
+    "recorded-date": "15-04-2024, 20:44:21",
     "recorded-content": {
       "create-rest-api": {
         "apiKeySource": "HEADER",
@@ -1881,6 +1980,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -1977,7 +2077,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_get_request_validator": {
-    "recorded-date": "22-03-2023, 13:08:19",
+    "recorded-date": "15-04-2024, 20:44:55",
     "recorded-content": {
       "get-request-validators-invalid-api-id": {
         "Error": {
@@ -2004,7 +2104,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_get_request_validators": {
-    "recorded-date": "22-03-2023, 13:08:19",
+    "recorded-date": "15-04-2024, 20:44:55",
     "recorded-content": {
       "get-invalid-request-validators": {
         "Error": {
@@ -2020,7 +2120,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_delete_request_validator": {
-    "recorded-date": "22-03-2023, 13:08:44",
+    "recorded-date": "15-04-2024, 20:45:24",
     "recorded-content": {
       "delete-request-validator-invalid-api-id": {
         "Error": {
@@ -2047,7 +2147,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_create_request_validator_invalid_api_id": {
-    "recorded-date": "22-03-2023, 13:08:44",
+    "recorded-date": "15-04-2024, 20:45:24",
     "recorded-content": {
       "invalid-create-request-validator": {
         "Error": {
@@ -2063,7 +2163,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_update_request_validator_operations": {
-    "recorded-date": "22-03-2023, 13:08:58",
+    "recorded-date": "15-04-2024, 20:46:01",
     "recorded-content": {
       "create-rest-api": {
         "apiKeySource": "HEADER",
@@ -2077,6 +2177,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -2138,474 +2239,8 @@
       }
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_documentation_part_lifecycle": {
-    "recorded-date": "23-03-2023, 17:50:40",
-    "recorded-content": {
-      "create-documentation-part": {
-        "id": "<id:1>",
-        "location": {
-          "type": "API"
-        },
-        "properties": {
-          "description": "Sample API description"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "get-documentation-part": {
-        "id": "<id:1>",
-        "location": {
-          "type": "API"
-        },
-        "properties": {
-          "description": "Sample API description"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-documentation-parts": {
-        "items": [
-          {
-            "id": "<id:1>",
-            "location": {
-              "type": "API"
-            },
-            "properties": {
-              "description": "Sample API description"
-            }
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "update-documentation-part": {
-        "id": "<id:1>",
-        "location": {
-          "type": "API"
-        },
-        "properties": {
-          "description": "Updated Sample API description"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-documentation-part-after-update": {
-        "id": "<id:1>",
-        "location": {
-          "type": "API"
-        },
-        "properties": {
-          "description": "Updated Sample API description"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_documentation_part": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_part": {
-    "recorded-date": "23-03-2023, 17:51:12",
-    "recorded-content": {
-      "get-documentation-part-invalid-api-id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Documentation part identifier specified"
-        },
-        "message": "Invalid Documentation part identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "get-documentation-part-invalid-doc-id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Documentation part identifier specified"
-        },
-        "message": "Invalid Documentation part identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_parts": {
-    "recorded-date": "23-03-2023, 17:51:12",
-    "recorded-content": {
-      "get-inavlid-documentation-parts": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:api_id"
-        },
-        "message": "Invalid API identifier specified 111111111111:api_id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_update_documentation_part": {
-    "recorded-date": "23-03-2023, 17:51:42",
-    "recorded-content": {
-      "update-documentation-part-invalid-api-id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Documentation part identifier specified"
-        },
-        "message": "Invalid Documentation part identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "update-documentation-part-invalid-add-operation": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid patch path  '/properties' specified for op 'add'. Please choose supported operations"
-        },
-        "message": "Invalid patch path  '/properties' specified for op 'add'. Please choose supported operations",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "update-documentation-part-invalid-path": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid patch path  '/invalidPath' specified for op 'replace'. Must be one of: [/properties]"
-        },
-        "message": "Invalid patch path  '/invalidPath' specified for op 'replace'. Must be one of: [/properties]",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_create_documentation_part_operations": {
-    "recorded-date": "23-03-2023, 17:52:11",
-    "recorded-content": {
-      "create_documentation_part_invalid_api_id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:api_id"
-        },
-        "message": "Invalid API identifier specified 111111111111:api_id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "create_documentation_part_invalid_location_type": {
-        "Error": {
-          "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'INVALID' at 'createDocumentationPartInput.location.type' failed to satisfy constraint: Member must satisfy enum value set: [RESPONSE_BODY, RESPONSE, METHOD, MODEL, AUTHORIZER, RESPONSE_HEADER, RESOURCE, PATH_PARAMETER, REQUEST_BODY, QUERY_PARAMETER, API, REQUEST_HEADER]"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_delete_documentation_part": {
-    "recorded-date": "23-03-2023, 17:52:31",
-    "recorded-content": {
-      "delete_documentation_part_wrong_api_id": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid API identifier specified 111111111111:api_id"
-        },
-        "message": "Invalid API identifier specified 111111111111:api_id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "delete_documentation_part": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        }
-      },
-      "delete_already_deleted_documentation_part": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Documentation part identifier specified"
-        },
-        "message": "Invalid Documentation part identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_compression": {
-    "recorded-date": "04-04-2023, 17:35:05",
-    "recorded-content": {
-      "enable-compression": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "description": "this is my api",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:1>",
-        "minimumCompressionSize": 10,
-        "name": "<name:1>",
-        "tags": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "disable-compression": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "description": "this is my api",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:1>",
-        "name": "<name:1>",
-        "tags": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "set-compression-zero": {
-        "apiKeySource": "HEADER",
-        "createdDate": "datetime",
-        "description": "this is my api",
-        "disableExecuteApiEndpoint": false,
-        "endpointConfiguration": {
-          "types": [
-            "EDGE"
-          ]
-        },
-        "id": "<id:1>",
-        "minimumCompressionSize": 0,
-        "name": "<name:1>",
-        "tags": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "set-negative-compression": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
-        },
-        "message": "Invalid minimum compression size, must be between 0 and 10485760",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "set-string-compression": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid minimum compression size, must be between 0 and 10485760"
-        },
-        "message": "Invalid minimum compression size, must be between 0 and 10485760",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "unsupported-operation": {
-        "Error": {
-          "Code": "BadRequestException",
-          "Message": "Invalid patch operation specified. Must be 'add'|'remove'|'replace'"
-        },
-        "message": "Invalid patch operation specified. Must be 'add'|'remove'|'replace'",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_invoke_test_method": {
-    "recorded-date": "01-07-2023, 18:52:50",
-    "recorded-content": {
-      "test-invoke-method-get": {
-        "body": {
-          "petId": "123"
-        },
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "latency": "latency",
-        "log": "log",
-        "multiValueHeaders": {
-          "Content-Type": [
-            "application/json"
-          ]
-        },
-        "status": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "test-invoke-method-get-with-qs": {
-        "body": {
-          "petId": "123"
-        },
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "latency": "latency",
-        "log": "log",
-        "multiValueHeaders": {
-          "Content-Type": [
-            "application/json"
-          ]
-        },
-        "status": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "test-invoke-method-post-with-body": {
-        "body": {
-          "petId": "123"
-        },
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "latency": "latency",
-        "log": "log",
-        "multiValueHeaders": {
-          "Content-Type": [
-            "application/json"
-          ]
-        },
-        "status": 200,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "resource-id-not-found": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Resource identifier specified"
-        },
-        "message": "Invalid Resource identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "rest-api-not-found": {
-        "Error": {
-          "Code": "NotFoundException",
-          "Message": "Invalid Resource identifier specified"
-        },
-        "message": "Invalid Resource identifier specified",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts": {
-    "recorded-date": "26-06-2023, 12:01:38",
-    "recorded-content": {
-      "create-import-documentations_parts": [
-        {
-          "id": "<id:1>",
-          "location": {
-            "type": "API"
-          },
-          "properties": {
-            "description": "API description",
-            "info": {
-              "description": "API info description 4",
-              "version": "API info version 3"
-            }
-          }
-        },
-        {
-          "id": "<id:2>",
-          "location": {
-            "type": "METHOD",
-            "path": "/",
-            "method": "GET"
-          },
-          "properties": {
-            "description": "Method description."
-          }
-        },
-        {
-          "id": "<id:3>",
-          "location": {
-            "type": "MODEL",
-            "name": "<name:1>"
-          },
-          "properties": {
-            "title": "<name:1> Schema"
-          }
-        },
-        {
-          "id": "<id:4>",
-          "location": {
-            "type": "RESPONSE",
-            "path": "/",
-            "method": "GET",
-            "statusCode": "200"
-          },
-          "properties": {
-            "description": "200 response"
-          }
-        }
-      ],
-      "import-documentation-parts": {
-        "ids": [
-          "<id:5>",
-          "<id:6>",
-          "<id:7>",
-          "<id:8>"
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_crud": {
-    "recorded-date": "04-09-2023, 20:13:20",
+    "recorded-date": "15-04-2024, 20:46:20",
     "recorded-content": {
       "get-gateway-response-default": {
         "defaultResponse": true,
@@ -2878,7 +2513,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_validation": {
-    "recorded-date": "04-09-2023, 20:32:34",
+    "recorded-date": "15-04-2024, 20:47:08",
     "recorded-content": {
       "get-gateway-responses-no-api": {
         "Error": {
@@ -2978,7 +2613,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
-    "recorded-date": "05-09-2023, 01:58:33",
+    "recorded-date": "15-04-2024, 20:47:51",
     "recorded-content": {
       "update-gateway-response-not-set": {
         "defaultResponse": false,
@@ -3157,8 +2792,95 @@
       }
     }
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
+    "recorded-date": "15-04-2024, 20:48:35",
+    "recorded-content": {
+      "test-invoke-method-get": {
+        "body": {
+          "petId": "123"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "latency",
+        "log": "log",
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-get-with-qs": {
+        "body": {
+          "petId": "123"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "latency",
+        "log": "log",
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "test-invoke-method-post-with-body": {
+        "body": {
+          "petId": "123"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "latency": "latency",
+        "log": "log",
+        "multiValueHeaders": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "status": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "resource-id-not-found": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "rest-api-not-found": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_wrong_type": {
-    "recorded-date": "28-11-2023, 20:15:11",
+    "recorded-date": "15-04-2024, 20:49:25",
     "recorded-content": {
       "put-integration-wrong-type": {
         "Error": {
@@ -3168,6 +2890,318 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_doc_parts_crud_no_api": {
+    "recorded-date": "15-04-2024, 20:52:33",
+    "recorded-content": {
+      "wrong-rest-api-id-create-doc-part": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "wrong-rest-api-id-get-doc-parts": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_documentation_part_lifecycle": {
+    "recorded-date": "15-04-2024, 20:52:35",
+    "recorded-content": {
+      "create-documentation-part": {
+        "id": "<id:1>",
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "description": "Sample API description"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-documentation-part": {
+        "id": "<id:1>",
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "description": "Sample API description"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-documentation-parts": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "location": {
+              "type": "API"
+            },
+            "properties": {
+              "description": "Sample API description"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-documentation-part": {
+        "id": "<id:1>",
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "description": "Updated Sample API description"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-documentation-part-after-update": {
+        "id": "<id:1>",
+        "location": {
+          "type": "API"
+        },
+        "properties": {
+          "description": "Updated Sample API description"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_documentation_part": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_part": {
+    "recorded-date": "15-04-2024, 20:53:15",
+    "recorded-content": {
+      "get-documentation-part-invalid-api-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Documentation part identifier specified"
+        },
+        "message": "Invalid Documentation part identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-documentation-part-invalid-doc-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Documentation part identifier specified"
+        },
+        "message": "Invalid Documentation part identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_parts": {
+    "recorded-date": "15-04-2024, 20:53:15",
+    "recorded-content": {
+      "get-inavlid-documentation-parts": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:api_id"
+        },
+        "message": "Invalid API identifier specified 111111111111:api_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_update_documentation_part": {
+    "recorded-date": "15-04-2024, 20:53:47",
+    "recorded-content": {
+      "update-documentation-part-invalid-api-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Documentation part identifier specified"
+        },
+        "message": "Invalid Documentation part identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "update-documentation-part-invalid-add-operation": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path  '/properties' specified for op 'add'. Please choose supported operations"
+        },
+        "message": "Invalid patch path  '/properties' specified for op 'add'. Please choose supported operations",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-documentation-part-invalid-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path  '/invalidPath' specified for op 'replace'. Must be one of: [/properties]"
+        },
+        "message": "Invalid patch path  '/invalidPath' specified for op 'replace'. Must be one of: [/properties]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_create_documentation_part_operations": {
+    "recorded-date": "15-04-2024, 20:54:19",
+    "recorded-content": {
+      "create_documentation_part_invalid_api_id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:api_id"
+        },
+        "message": "Invalid API identifier specified 111111111111:api_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "create_documentation_part_invalid_location_type": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'INVALID' at 'createDocumentationPartInput.location.type' failed to satisfy constraint: Member must satisfy enum value set: [RESPONSE_BODY, RESPONSE, METHOD, MODEL, AUTHORIZER, RESPONSE_HEADER, RESOURCE, PATH_PARAMETER, REQUEST_BODY, QUERY_PARAMETER, API, REQUEST_HEADER]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_delete_documentation_part": {
+    "recorded-date": "15-04-2024, 20:54:32",
+    "recorded-content": {
+      "delete_documentation_part_wrong_api_id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:api_id"
+        },
+        "message": "Invalid API identifier specified 111111111111:api_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete_documentation_part": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "delete_already_deleted_documentation_part": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Documentation part identifier specified"
+        },
+        "message": "Invalid Documentation part identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts": {
+    "recorded-date": "15-04-2024, 20:57:15",
+    "recorded-content": {
+      "create-import-documentations_parts": [
+        {
+          "id": "<id:1>",
+          "location": {
+            "type": "API"
+          },
+          "properties": {
+            "description": "API description",
+            "info": {
+              "description": "API info description 4",
+              "version": "API info version 3"
+            }
+          }
+        },
+        {
+          "id": "<id:2>",
+          "location": {
+            "type": "METHOD",
+            "path": "/",
+            "method": "GET"
+          },
+          "properties": {
+            "description": "Method description."
+          }
+        },
+        {
+          "id": "<id:3>",
+          "location": {
+            "type": "MODEL",
+            "name": "<name:1>"
+          },
+          "properties": {
+            "title": "<name:1> Schema"
+          }
+        },
+        {
+          "id": "<id:4>",
+          "location": {
+            "type": "RESPONSE",
+            "path": "/",
+            "method": "GET",
+            "statusCode": "200"
+          },
+          "properties": {
+            "description": "200 response"
+          }
+        }
+      ],
+      "import-documentation-parts": {
+        "ids": [
+          "<id:5>",
+          "<id:6>",
+          "<id:7>",
+          "<id:8>"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -1084,7 +1084,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_lifecycle": {
-    "recorded-date": "15-04-2024, 18:44:02",
+    "recorded-date": "15-04-2024, 21:22:46",
     "recorded-content": {
       "put-base-method-response": {
         "apiKeyRequired": false,
@@ -1135,7 +1135,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_request_parameters": {
-    "recorded-date": "15-04-2024, 18:44:40",
+    "recorded-date": "15-04-2024, 21:23:23",
     "recorded-content": {
       "put-method-request-params-response": {
         "apiKeyRequired": false,
@@ -1181,7 +1181,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_model": {
-    "recorded-date": "15-04-2024, 18:45:11",
+    "recorded-date": "15-04-2024, 21:23:48",
     "recorded-content": {
       "create-model": {
         "contentType": "application/json",
@@ -1276,9 +1276,9 @@
       "delete-model-used-by-2-method": {
         "Error": {
           "Code": "ConflictException",
-          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY"
         },
-        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
@@ -1319,7 +1319,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_validation": {
-    "recorded-date": "15-04-2024, 18:45:43",
+    "recorded-date": "15-04-2024, 21:24:40",
     "recorded-content": {
       "wrong-api": {
         "Error": {
@@ -1390,7 +1390,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method": {
-    "recorded-date": "15-04-2024, 18:46:01",
+    "recorded-date": "15-04-2024, 21:26:26",
     "recorded-content": {
       "put-method-response": {
         "apiKeyRequired": false,
@@ -1463,7 +1463,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method_validation": {
-    "recorded-date": "15-04-2024, 21:11:41",
+    "recorded-date": "15-04-2024, 21:26:43",
     "recorded-content": {
       "wrong-rest-api": {
         "Error": {

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -27,22 +27,22 @@
     "last_validated_date": "2024-04-15T20:53:16+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_lifecycle": {
-    "last_validated_date": "2024-04-15T18:44:02+00:00"
+    "last_validated_date": "2024-04-15T21:22:46+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_request_parameters": {
-    "last_validated_date": "2024-04-15T18:44:06+00:00"
+    "last_validated_date": "2024-04-15T21:22:51+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_model": {
-    "last_validated_date": "2024-04-15T18:44:46+00:00"
+    "last_validated_date": "2024-04-15T21:23:29+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_validation": {
-    "last_validated_date": "2024-04-15T18:45:12+00:00"
+    "last_validated_date": "2024-04-15T21:23:49+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method": {
-    "last_validated_date": "2024-04-15T18:45:45+00:00"
+    "last_validated_date": "2024-04-15T21:24:42+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method_validation": {
-    "last_validated_date": "2024-04-15T21:11:41+00:00"
+    "last_validated_date": "2024-04-15T21:26:29+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_model_lifecycle": {
     "last_validated_date": "2024-04-15T21:02:18+00:00"

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -1,134 +1,134 @@
 {
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_authorizer_crud_no_api": {
-    "last_validated_date": "2023-02-28T19:06:16+00:00"
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiAuthorizer::test_authorizer_crud_no_api": {
+    "last_validated_date": "2024-04-15T18:43:45+00:00"
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource": {
-    "last_validated_date": "2023-02-24T14:56:43+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource_validation": {
-    "last_validated_date": "2023-02-24T15:17:00+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_resource_parent_invalid": {
-    "last_validated_date": "2023-02-24T15:39:00+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_optional_params": {
-    "last_validated_date": "2023-04-04T15:58:40+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_tags": {
-    "last_validated_date": "2023-02-01T19:11:19+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_delete_resource": {
-    "last_validated_date": "2023-02-23T19:41:28+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_doc_arts_crud_no_api": {
-    "last_validated_date": "2023-02-28T19:11:32+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_get_api_case_insensitive": {
-    "last_validated_date": "2023-03-01T15:26:45+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_invoke_test_method": {
-    "last_validated_date": "2023-07-01T16:52:50+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_list_and_delete_apis": {
-    "last_validated_date": "2023-02-01T19:16:52+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_lifecycle": {
-    "last_validated_date": "2023-03-15T11:06:26+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_request_parameters": {
-    "last_validated_date": "2023-02-24T18:25:22+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_model_lifecycle": {
-    "last_validated_date": "2023-05-26T02:30:31+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_model_validation": {
-    "last_validated_date": "2023-03-09T18:13:20+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_model": {
-    "last_validated_date": "2023-03-15T11:12:59+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_validation": {
-    "last_validated_date": "2023-02-25T16:49:08+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_resource_lifecycle": {
-    "last_validated_date": "2023-02-23T21:08:31+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method": {
-    "last_validated_date": "2023-03-13T22:31:44+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method_validation": {
-    "last_validated_date": "2023-03-13T22:36:56+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_model": {
-    "last_validated_date": "2023-03-09T18:39:34+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
-    "last_validated_date": "2023-02-24T16:56:07+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_behaviour": {
-    "last_validated_date": "2023-02-01T19:27:17+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_compression": {
-    "last_validated_date": "2023-04-04T15:35:05+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_invalid_api_id": {
-    "last_validated_date": "2023-02-01T21:26:45+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_operation_add_remove": {
-    "last_validated_date": "2023-02-01T19:11:40+00:00"
-  },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_validators_crud_no_api": {
-    "last_validated_date": "2023-02-28T19:18:59+00:00"
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_doc_parts_crud_no_api": {
+    "last_validated_date": "2024-04-15T20:52:33+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_documentation_part_lifecycle": {
-    "last_validated_date": "2023-03-23T16:50:40+00:00"
+    "last_validated_date": "2024-04-15T20:52:34+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts": {
-    "last_validated_date": "2023-06-26T10:01:38+00:00"
+    "last_validated_date": "2024-04-15T20:56:45+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_create_documentation_part_operations": {
-    "last_validated_date": "2023-03-23T16:52:11+00:00"
+    "last_validated_date": "2024-04-15T20:53:48+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_delete_documentation_part": {
-    "last_validated_date": "2023-03-23T16:52:31+00:00"
+    "last_validated_date": "2024-04-15T20:54:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_part": {
-    "last_validated_date": "2023-03-23T16:51:12+00:00"
+    "last_validated_date": "2024-04-15T20:52:39+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_get_documentation_parts": {
-    "last_validated_date": "2023-03-23T16:51:12+00:00"
+    "last_validated_date": "2024-04-15T20:53:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_update_documentation_part": {
-    "last_validated_date": "2023-03-23T16:51:42+00:00"
+    "last_validated_date": "2024-04-15T20:53:16+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_lifecycle": {
+    "last_validated_date": "2024-04-15T18:44:02+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_method_request_parameters": {
+    "last_validated_date": "2024-04-15T18:44:06+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_model": {
+    "last_validated_date": "2024-04-15T18:44:46+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_put_method_validation": {
+    "last_validated_date": "2024-04-15T18:45:12+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method": {
+    "last_validated_date": "2024-04-15T18:45:45+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiMethod::test_update_method_validation": {
+    "last_validated_date": "2024-04-15T21:11:41+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_model_lifecycle": {
+    "last_validated_date": "2024-04-15T21:02:18+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_model_validation": {
+    "last_validated_date": "2024-04-15T20:33:07+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiModels::test_update_model": {
+    "last_validated_date": "2024-04-15T20:33:55+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_create_request_validator_invalid_api_id": {
-    "last_validated_date": "2023-03-22T12:08:44+00:00"
+    "last_validated_date": "2024-04-15T20:45:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_delete_request_validator": {
-    "last_validated_date": "2023-03-22T12:08:44+00:00"
+    "last_validated_date": "2024-04-15T20:44:56+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_get_request_validator": {
-    "last_validated_date": "2023-03-22T12:08:19+00:00"
+    "last_validated_date": "2024-04-15T20:44:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_get_request_validators": {
-    "last_validated_date": "2023-03-22T12:08:19+00:00"
+    "last_validated_date": "2024-04-15T20:44:55+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_invalid_update_request_validator_operations": {
-    "last_validated_date": "2023-03-22T12:08:58+00:00"
+    "last_validated_date": "2024-04-15T20:45:26+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_request_validator_lifecycle": {
-    "last_validated_date": "2023-03-22T12:07:42+00:00"
+    "last_validated_date": "2024-04-15T20:44:21+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRequestValidator::test_validators_crud_no_api": {
+    "last_validated_date": "2024-04-15T20:44:19+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_proxy_resource": {
+    "last_validated_date": "2024-04-15T17:31:19+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_proxy_resource_validation": {
+    "last_validated_date": "2024-04-15T17:31:32+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_create_resource_parent_invalid": {
+    "last_validated_date": "2024-04-15T17:30:24+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_delete_resource": {
+    "last_validated_date": "2024-04-15T17:29:41+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_resource_lifecycle": {
+    "last_validated_date": "2024-04-15T17:29:03+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_behaviour": {
+    "last_validated_date": "2024-04-15T17:29:08+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_optional_params": {
+    "last_validated_date": "2024-04-15T15:10:32+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_with_tags": {
+    "last_validated_date": "2024-04-15T15:11:51+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_get_api_case_insensitive": {
+    "last_validated_date": "2024-04-15T15:09:49+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_list_and_delete_apis": {
+    "last_validated_date": "2024-04-15T15:08:47+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_behaviour": {
+    "last_validated_date": "2024-04-15T15:13:30+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_compression": {
+    "last_validated_date": "2024-04-15T15:12:36+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_invalid_api_id": {
+    "last_validated_date": "2024-04-15T15:14:15+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_update_rest_api_operation_add_remove": {
+    "last_validated_date": "2024-04-15T15:12:34+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_crud": {
-    "last_validated_date": "2023-09-04T18:13:20+00:00"
+    "last_validated_date": "2024-04-15T20:46:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_gateway_response_validation": {
-    "last_validated_date": "2023-09-04T18:32:34+00:00"
+    "last_validated_date": "2024-04-15T20:46:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
-    "last_validated_date": "2023-09-04T23:58:33+00:00"
+    "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_put_integration_wrong_type": {
-    "last_validated_date": "2023-11-28T19:15:11+00:00"
+    "last_validated_date": "2024-04-15T20:48:47+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
+    "last_validated_date": "2024-04-15T20:48:35+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_extended.py
+++ b/tests/aws/services/apigateway/test_apigateway_extended.py
@@ -19,12 +19,7 @@ TEST_IMPORT_PETS = os.path.join(THIS_FOLDER, "../../files/pets.json")
     [TEST_IMPORT_PETSTORE_SWAGGER, TEST_IMPORT_PETS],
     ids=["TEST_IMPORT_PETSTORE_SWAGGER", "TEST_IMPORT_PETS"],
 )
-@markers.snapshot.skip_snapshot_verify(
-    paths=[
-        "$..body.host",
-        "$..rootResourceId",
-    ]
-)
+@markers.snapshot.skip_snapshot_verify(paths=["$..body.host"])
 def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file, region_name):
     snapshot.add_transformer(
         [
@@ -63,15 +58,13 @@ def test_export_swagger_openapi(aws_client, snapshot, import_apigw, import_file,
     [TEST_IMPORT_PETSTORE_SWAGGER, TEST_IMPORT_PETS],
     ids=["TEST_IMPORT_PETSTORE_SWAGGER", "TEST_IMPORT_PETS"],
 )
-@markers.snapshot.skip_snapshot_verify(
-    paths=[
-        "$..body.servers..url",
-        "$..rootResourceId",
-    ]
-)
+@markers.snapshot.skip_snapshot_verify(paths=["$..body.servers..url"])
 def test_export_oas30_openapi(aws_client, snapshot, import_apigw, region_name, import_file):
     snapshot.add_transformer(
-        snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id")
+        [
+            snapshot.transform.jsonpath("$.import-api.id", value_replacement="api-id"),
+            snapshot.transform.key_value("rootResourceId"),
+        ]
     )
 
     spec_file = load_file(import_file)

--- a/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "26-03-2024, 11:32:19",
+    "recorded-date": "15-04-2024, 21:43:25",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -638,7 +638,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "26-03-2024, 11:32:36",
+    "recorded-date": "15-04-2024, 21:43:56",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -782,7 +782,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "recorded-date": "26-03-2024, 11:32:50",
+    "recorded-date": "15-04-2024, 21:45:03",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -796,7 +796,7 @@
         },
         "id": "<api-id:1>",
         "name": "PetStore",
-        "rootResourceId": "kb57q8ij35",
+        "rootResourceId": "<root-resource-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -1140,7 +1140,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1155,7 +1154,8 @@
                     "integration.request.querystring.page": "method.request.querystring.page",
                     "integration.request.querystring.type": "method.request.querystring.type"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               },
               "post": {
@@ -1190,7 +1190,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "POST",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets",
                   "responses": {
@@ -1201,7 +1200,8 @@
                       }
                     }
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               },
               "options": {
@@ -1235,7 +1235,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1249,7 +1248,8 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
                 }
               }
             },
@@ -1286,7 +1286,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "http",
                   "httpMethod": "GET",
                   "uri": "http://petstore.execute-api.<region>.amazonaws.com/petstore/pets/{petId}",
                   "responses": {
@@ -1300,7 +1299,8 @@
                   "requestParameters": {
                     "integration.request.path.petId": "method.request.path.petId"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "http"
                 }
               },
               "options": {
@@ -1344,7 +1344,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1358,7 +1357,8 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
                 }
               }
             },
@@ -1378,7 +1378,6 @@
                   }
                 },
                 "x-amazon-apigateway-integration": {
-                  "type": "mock",
                   "responses": {
                     "default": {
                       "statusCode": "200",
@@ -1393,7 +1392,8 @@
                   "requestTemplates": {
                     "application/json": "{\"statusCode\": 200}"
                   },
-                  "passthroughBehavior": "when_no_match"
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
                 }
               }
             }
@@ -1468,7 +1468,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "recorded-date": "26-03-2024, 11:32:58",
+    "recorded-date": "15-04-2024, 21:45:07",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -1481,7 +1481,7 @@
         },
         "id": "<api-id:1>",
         "name": "Simple PetStore (Swagger)",
-        "rootResourceId": "vp8w0yxukk",
+        "rootResourceId": "<root-resource-id:1>",
         "version": "1.0.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/apigateway/test_apigateway_extended.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_extended.validation.json
@@ -1,14 +1,14 @@
 {
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-03-26T11:32:49+00:00"
+    "last_validated_date": "2024-04-15T21:45:02+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_oas30_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-03-26T11:32:53+00:00"
+    "last_validated_date": "2024-04-15T21:45:04+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETSTORE_SWAGGER]": {
-    "last_validated_date": "2024-03-26T11:32:19+00:00"
+    "last_validated_date": "2024-04-15T21:43:24+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_extended.py::test_export_swagger_openapi[TEST_IMPORT_PETS]": {
-    "last_validated_date": "2024-03-26T11:32:24+00:00"
+    "last_validated_date": "2024-04-15T21:43:30+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -272,7 +272,6 @@ class TestApiGatewayImportRestApi:
             "$.resources.items..resourceMethods.GET",  # TODO: this is really weird, after importing, AWS returns them empty?
             "$.resources.items..resourceMethods.OPTIONS",
             "$.resources.items..resourceMethods.POST",
-            "$..rootResourceId",
             "$.get-authorizers.items[1].authorizerResultTtlInSeconds",
         ]
     )
@@ -470,6 +469,7 @@ class TestApiGatewayImportRestApi:
             "$..cacheNamespace",  # TODO: investigate why it's different
             "$.get-resources-oas30-srv-url.items..id",  # TODO: even in overwrite, APIGW keeps the same ID if same path
             "$.get-resources-oas30-srv-url.items..parentId",  # TODO: even in overwrite, APIGW keeps the same ID if same path
+            "$.put-rest-api-oas30-srv-url..rootResourceId",  # TODO: because APIGW keeps the same above, id counting is different
         ]
     )
     def test_import_rest_api_with_base_path_oas30(
@@ -652,7 +652,6 @@ class TestApiGatewayImportRestApi:
         paths=[
             "$.resources.items..resourceMethods.POST",
             # TODO: this is really weird, after importing, AWS returns them empty?
-            "$..rootResourceId",  # TODO: newly added
         ]
     )
     @markers.aws.validated

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api": {
-    "recorded-date": "03-06-2023, 13:16:32",
+    "recorded-date": "15-04-2024, 21:30:21",
     "recorded-content": {
       "import_rest_api": {
         "apiKeySource": "HEADER",
@@ -16,6 +16,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -25,7 +26,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "recorded-date": "22-03-2024, 07:03:04",
+    "recorded-date": "15-04-2024, 21:31:02",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "HEADER",
@@ -771,7 +772,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_and_validate_rest_api[openapi.spec.tf.json]": {
-    "recorded-date": "03-06-2023, 13:29:17",
+    "recorded-date": "15-04-2024, 21:31:22",
     "recorded-content": {
       "import_tf_rest_api": {
         "apiKeySource": "HEADER",
@@ -784,6 +785,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:3>",
         "version": "1",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1006,7 +1008,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_and_validate_rest_api[swagger-mock-cors.json]": {
-    "recorded-date": "03-06-2023, 13:29:35",
+    "recorded-date": "15-04-2024, 21:31:41",
     "recorded-content": {
       "import_tf_rest_api": {
         "apiKeySource": "HEADER",
@@ -1019,6 +1021,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1379,7 +1382,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[ignore]": {
-    "recorded-date": "03-06-2023, 14:10:55",
+    "recorded-date": "15-04-2024, 21:33:04",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
@@ -1392,6 +1395,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2",
         "ResponseMetadata": {
@@ -1761,7 +1765,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[prepend]": {
-    "recorded-date": "03-06-2023, 14:12:12",
+    "recorded-date": "15-04-2024, 21:34:01",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
@@ -1774,6 +1778,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2",
         "ResponseMetadata": {
@@ -2149,7 +2154,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[split]": {
-    "recorded-date": "03-06-2023, 14:14:07",
+    "recorded-date": "15-04-2024, 21:34:50",
     "recorded-content": {
       "put-rest-api-swagger-json": {
         "apiKeySource": "HEADER",
@@ -2162,6 +2167,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2",
         "ResponseMetadata": {
@@ -2531,7 +2537,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[prepend]": {
-    "recorded-date": "04-06-2023, 00:45:31",
+    "recorded-date": "15-04-2024, 21:36:04",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -2544,6 +2550,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -2780,6 +2787,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -3014,7 +3022,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[split]": {
-    "recorded-date": "04-06-2023, 00:46:41",
+    "recorded-date": "15-04-2024, 21:36:26",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -3027,6 +3035,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -3257,6 +3266,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -3485,7 +3495,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[ignore]": {
-    "recorded-date": "04-06-2023, 00:45:06",
+    "recorded-date": "15-04-2024, 21:35:47",
     "recorded-content": {
       "put-rest-api-oas30-srv-var": {
         "apiKeySource": "HEADER",
@@ -3498,6 +3508,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -3728,6 +3739,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {},
         "version": "2.0",
         "ResponseMetadata": {
@@ -3763,7 +3775,7 @@
         "httpMethod": "GET",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9zjs21",
+          "cacheNamespace": "<cache-namespace:1>",
           "integrationResponses": {
             "200": {
               "responseParameters": {
@@ -3815,7 +3827,7 @@
       },
       "srv-url-integration-test-get": {
         "cacheKeyParameters": [],
-        "cacheNamespace": "9zjs21",
+        "cacheNamespace": "<cache-namespace:1>",
         "integrationResponses": {
           "200": {
             "responseParameters": {
@@ -3856,7 +3868,7 @@
         "httpMethod": "OPTIONS",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9zjs21",
+          "cacheNamespace": "<cache-namespace:1>",
           "integrationResponses": {
             "200": {
               "responseParameters": {
@@ -3911,7 +3923,7 @@
       },
       "srv-url-integration-test-options": {
         "cacheKeyParameters": [],
-        "cacheNamespace": "9zjs21",
+        "cacheNamespace": "<cache-namespace:1>",
         "integrationResponses": {
           "200": {
             "responseParameters": {
@@ -3950,7 +3962,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
-    "recorded-date": "07-06-2023, 03:16:37",
+    "recorded-date": "15-04-2024, 21:37:12",
     "recorded-content": {
       "import-swagger": {
         "apiKeySource": "AUTHORIZER",
@@ -3963,6 +3975,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:3>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4182,7 +4195,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models": {
-    "recorded-date": "07-06-2023, 02:26:07",
+    "recorded-date": "15-04-2024, 21:37:35",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -4195,6 +4208,7 @@
         },
         "id": "<rest-id:1>",
         "name": "Circular model reference",
+        "rootResourceId": "<resource-id:1>",
         "version": "1.0",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4378,7 +4392,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models_and_request_validation": {
-    "recorded-date": "09-01-2024, 22:35:27",
+    "recorded-date": "15-04-2024, 21:38:12",
     "recorded-content": {
       "import-api": {
         "apiKeySource": "HEADER",
@@ -4590,7 +4604,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_http_method_integration": {
-    "recorded-date": "05-12-2023, 22:27:16",
+    "recorded-date": "15-04-2024, 21:39:47",
     "recorded-content": {
       "resources": {
         "items": [
@@ -4776,5 +4790,9 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
+    "recorded-date": "15-04-2024, 21:38:55",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -1,44 +1,47 @@
 {
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_and_validate_rest_api[openapi.spec.tf.json]": {
-    "last_validated_date": "2023-06-03T11:29:17+00:00"
+    "last_validated_date": "2024-04-15T21:31:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_and_validate_rest_api[swagger-mock-cors.json]": {
-    "last_validated_date": "2023-06-03T11:29:35+00:00"
+    "last_validated_date": "2024-04-15T21:31:41+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api": {
-    "last_validated_date": "2023-06-03T11:16:32+00:00"
+    "last_validated_date": "2024-04-15T21:30:20+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[ignore]": {
-    "last_validated_date": "2023-06-03T22:45:06+00:00"
+    "last_validated_date": "2024-04-15T21:35:08+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[prepend]": {
-    "last_validated_date": "2023-06-03T22:45:31+00:00"
+    "last_validated_date": "2024-04-15T21:36:02+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api_with_base_path_oas30[split]": {
-    "last_validated_date": "2023-06-03T22:46:41+00:00"
+    "last_validated_date": "2024-04-15T21:36:22+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[ignore]": {
-    "last_validated_date": "2023-06-03T12:10:55+00:00"
+    "last_validated_date": "2024-04-15T21:32:25+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[prepend]": {
-    "last_validated_date": "2023-06-03T12:12:12+00:00"
+    "last_validated_date": "2024-04-15T21:33:49+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_apis_with_base_path_swagger[split]": {
-    "last_validated_date": "2023-06-03T12:14:07+00:00"
+    "last_validated_date": "2024-04-15T21:34:46+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_swagger_api": {
-    "last_validated_date": "2024-03-22T07:03:03+00:00"
+    "last_validated_date": "2024-04-15T21:30:39+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models": {
-    "last_validated_date": "2023-06-07T00:26:07+00:00"
+    "last_validated_date": "2024-04-15T21:37:14+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_circular_models_and_request_validation": {
-    "last_validated_date": "2024-01-09T22:35:26+00:00"
+    "last_validated_date": "2024-04-15T21:37:44+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_global_api_key_authorizer": {
-    "last_validated_date": "2023-06-07T01:16:37+00:00"
+    "last_validated_date": "2024-04-15T21:36:29+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_http_method_integration": {
-    "last_validated_date": "2023-12-05T21:27:16+00:00"
+    "last_validated_date": "2024-04-15T21:38:57+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
+    "last_validated_date": "2024-04-15T21:38:14+00:00"
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -501,16 +501,18 @@ def test_create_execute_api_vpc_endpoint(
 ):
     poll_sleep = 5 if is_aws_cloud() else 1
     # TODO: create a re-usable ec2_api() transformer
-    snapshot.add_transformer(snapshot.transform.key_value("DnsName"))
-    snapshot.add_transformer(snapshot.transform.key_value("GroupId"))
-    snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
-    snapshot.add_transformer(snapshot.transform.key_value("SubnetIds"))
-    snapshot.add_transformer(snapshot.transform.key_value("VpcId"))
-    snapshot.add_transformer(snapshot.transform.key_value("VpcEndpointId"))
-    snapshot.add_transformer(snapshot.transform.key_value("HostedZoneId"))
-    snapshot.add_transformer(snapshot.transform.key_value("id"))
-    snapshot.add_transformer(snapshot.transform.key_value("name"))
-    snapshot.add_transformer(snapshot.transform.key_value("rootResourceId"))
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("DnsName"),
+            snapshot.transform.key_value("GroupId"),
+            snapshot.transform.key_value("GroupName"),
+            snapshot.transform.key_value("SubnetIds"),
+            snapshot.transform.key_value("VpcId"),
+            snapshot.transform.key_value("VpcEndpointId"),
+            snapshot.transform.key_value("HostedZoneId"),
+            *snapshot.transform.apigateway_api(),
+        ]
+    )
 
     # create table
     table = dynamodb_create_table()["TableDescription"]

--- a/tests/aws/services/apigateway/test_apigateway_integrations.py
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.py
@@ -510,6 +510,7 @@ def test_create_execute_api_vpc_endpoint(
     snapshot.add_transformer(snapshot.transform.key_value("HostedZoneId"))
     snapshot.add_transformer(snapshot.transform.key_value("id"))
     snapshot.add_transformer(snapshot.transform.key_value("name"))
+    snapshot.add_transformer(snapshot.transform.key_value("rootResourceId"))
 
     # create table
     table = dynamodb_create_table()["TableDescription"]

--- a/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
-    "recorded-date": "18-03-2023, 22:01:10",
+    "recorded-date": "15-04-2024, 23:07:07",
     "recorded-content": {
       "endpoint-details": {
         "CreationTimestamp": "timestamp",
@@ -66,6 +66,7 @@
           ],
           "Version": "2012-10-17"
         },
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_integrations.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_create_execute_api_vpc_endpoint": {
-    "last_validated_date": "2023-03-18T21:01:10+00:00"
+    "last_validated_date": "2024-04-15T23:07:07+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_integrations.py::test_put_integration_responses": {
     "last_validated_date": "2023-05-26T17:44:45+00:00"

--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -7,6 +7,7 @@ from localstack.utils.strings import short_uid, to_bytes
 def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_client):
     snapshot.add_transformer(snapshot.transform.key_value("id"))
     snapshot.add_transformer(snapshot.transform.key_value("name"))
+    snapshot.add_transformer(snapshot.transform.key_value("rootResourceId"))
     snapshot.add_transformer(snapshot.transform.key_value("aws:cloudformation:stack-id"))
     snapshot.add_transformer(snapshot.transform.key_value("aws:cloudformation:stack-name"))
 
@@ -52,3 +53,6 @@ def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_clien
     result = aws_client.apigateway.get_rest_api(restApiId=api_id)
     assert result
     snapshot.match("api-details", result)
+
+    resources = aws_client.apigateway.get_resources(restApiId=api_id)
+    snapshot.match("api-resources", resources)

--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -5,11 +5,13 @@ from localstack.utils.strings import short_uid, to_bytes
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(paths=["$..tags"])
 def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_client):
-    snapshot.add_transformer(snapshot.transform.key_value("id"))
-    snapshot.add_transformer(snapshot.transform.key_value("name"))
-    snapshot.add_transformer(snapshot.transform.key_value("rootResourceId"))
-    snapshot.add_transformer(snapshot.transform.key_value("aws:cloudformation:stack-id"))
-    snapshot.add_transformer(snapshot.transform.key_value("aws:cloudformation:stack-name"))
+    snapshot.add_transformers_list(
+        [
+            *snapshot.transform.apigateway_api(),
+            snapshot.transform.key_value("aws:cloudformation:stack-id"),
+            snapshot.transform.key_value("aws:cloudformation:stack-name"),
+        ]
+    )
 
     # put API spec to S3
     api_spec = """

--- a/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
-    "recorded-date": "21-02-2023, 09:45:29",
+    "recorded-date": "15-04-2024, 22:51:13",
     "recorded-content": {
       "api-details": {
         "apiKeySource": "HEADER",
@@ -13,12 +13,25 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {
           "aws:cloudformation:logical-id": "RestApi",
           "aws:cloudformation:stack-id": "<aws:cloudformation:stack-id:1>",
           "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
         },
         "version": "1.2.3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "api-resources": {
+        "items": [
+          {
+            "id": "<id:2>",
+            "path": "/"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
-    "last_validated_date": "2023-02-21T08:45:29+00:00"
+    "last_validated_date": "2024-04-15T22:51:13+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -66,7 +66,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "recorded-date": "01-03-2023, 23:36:31",
+    "recorded-date": "15-04-2024, 22:59:53",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
@@ -93,6 +93,7 @@
           ],
           "Version": "2012-10-17"
         },
+        "rootResourceId": "<root-resource-id:1>",
         "tags": {
           "aws:cloudformation:logical-id": "MyApi",
           "aws:cloudformation:stack-id": "arn:aws:cloudformation:<region>:111111111111:stack/stack-name/<resource:1>",
@@ -106,7 +107,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "recorded-date": "02-06-2023, 18:26:01",
+    "recorded-date": "15-04-2024, 22:59:18",
     "recorded-content": {
       "rest-api": {
         "apiKeySource": "HEADER",
@@ -119,6 +120,7 @@
         },
         "id": "<id:1>",
         "name": "<name:1>",
+        "rootResourceId": "<id:2>",
         "tags": {
           "aws:cloudformation:logical-id": "ApiGatewayRestApi",
           "aws:cloudformation:stack-id": "arn:aws:cloudformation:<region>:111111111111:stack/stack-name/<resource:1>",

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -3,10 +3,10 @@
     "last_validated_date": "2024-02-19T08:55:12+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_api_gateway_with_policy_as_dict": {
-    "last_validated_date": "2023-03-01T22:36:31+00:00"
+    "last_validated_date": "2024-04-15T22:59:53+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_from_s3_swagger": {
-    "last_validated_date": "2023-06-02T16:26:01+00:00"
+    "last_validated_date": "2024-04-15T22:59:17+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::test_cfn_deploy_apigateway_integration": {
     "last_validated_date": "2024-02-21T12:54:34+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've had a report with #10657 that the latest Terraform AWS provider would fail with LocalStack because APIGW is not returning the `rootResourceId` field from APIGW REST API creation. 

A lot of our tests will snapshot the rest API creation, so we need to regenerate a lot of snapshots to avoid this fix breaking the test suite.

<!-- What notable changes does this PR make? -->
## Changes
- add the `rootResourceId` field to `CreateRestApi`, `PutRestApi`, `GetRestApi`, `GetRestApis` and `ImportRestApi`
- update some of the tests to try to make use of this new field
- update all the snapshots that might fail (regenerated all `test_apigateway_api.py` file
- above uncovered a new validation, last snapshot validation was from March 2023, so added a quick fix
- refactored `test_apigateway_api.py` file to be more contained in class, because regenerating snapshots against AWS takes a lot of time, and what type of resource the class is testing is clearer
- add a quick hacky fix for import, used by CFN, because it would overwrite even the root resource. We skip that if there are no defined path in the OpenAPI spec. 


_fixes #10657_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

