### PR TITLE
fix missing href inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <p align="center">
   <a href="#overview">Overview</a> •
-  <a href="#installing">Install</a> •
+  <a href="#install">Install</a> •
   <a href="#quickstart">Quickstart</a> •
   <a href="#running">Run</a> •
   <a href="#usage">Usage</a> •
@@ -48,7 +48,7 @@ LocalStack supports a growing number of AWS services, like AWS Lambda, S3, Dynam
 
 LocalStack also provides additional features to make your life as a cloud developer easier! Check out LocalStack's [User Guides](https://docs.localstack.cloud/user-guide/) for more information.
 
-## Installation
+## Install
 
 The quickest way get started with LocalStack is by using the LocalStack CLI. It enables you to start and manage the LocalStack Docker container directly through your command line. Ensure that your machine has a functional [`docker` environment](https://docs.docker.com/get-docker/) installed before proceeding.
 


### PR DESCRIPTION

Previously: `install`, `installation`, and `installing` we're all used. Clicking on `Install` link inside README did nothing.
Currently: use `install` everywhere.

<!-- What notable changes does this PR make? -->
## Changes
- fix a link that is not working in README

