### PR TITLE
CFn: handle `OperationStatus.PENDING` events from resource providers

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -444,6 +444,9 @@ class ResourceProviderExecutor:
                             time.sleep(0)
                         else:
                             time.sleep(sleep_time)
+                    case OperationStatus.PENDING:
+                        # come back to this resource in another iteration
+                        return event
                     case invalid_status:
                         raise ValueError(
                             f"Invalid OperationStatus ({invalid_status}) returned for resource {raw_payload['requestData']['logicalResourceId']} (type {raw_payload['resourceType']})"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

CloudFormation resource providers are able to return the `PENDING` status from operations such as `create` or `delete`, indicating that the operation is in progress. We can use this status in our CloudFormation engine to signal to the `do_apply_changes_in_loop` loop (and equivalent in `delete_stack`) that the operation is _knowingly_ not going to work at the moment, and we should come back to the operation and try again after continuing to attempt to operate on the other resources in the stack.

Specific example:

* Resource `A` depends on resources `B` and `C` (e.g. `A` = `AWS::RDS::DBCluster` and `B` and `C` are `AWS::RDS::DBInstance`s)
* CFn tries to delete `A` before deleting `B` and `C`, which raises an exception from the service

We can use the `PENDING` status to tell CloudFormation to give up trying to delete `A` until `B` and `C` have been deleted.

<!-- What notable changes does this PR make? -->
## Changes

* Handle `PENDING` status in `do_apply_changes_in_loop`
* Handle `PENDING` status in `delete_stack`

No specific tests have been added at this point, as it is part of the core engine and testing would be artificial.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

