### PR TITLE
CFn: Parametrize Fn::GetAZs test across all regions

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -966,7 +966,7 @@ def deploy_cfn_template(
         change_set_name: Optional[str] = None,
         template: Optional[str] = None,
         template_path: Optional[str | os.PathLike] = None,
-        template_mapping: Optional[Dict[str, any]] = None,
+        template_mapping: Optional[Dict[str, Any]] = None,
         parameters: Optional[Dict[str, str]] = None,
         role_arn: Optional[str] = None,
         max_wait: Optional[int] = None,

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -21,6 +21,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 from localstack import config
+from localstack.aws.connect import ServiceLevelClientFactory
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
     SECONDARY_TEST_AWS_ACCOUNT_ID,
@@ -955,9 +956,9 @@ class StackDeployError(Exception):
 
 @pytest.fixture
 def deploy_cfn_template(
-    aws_client,
+    aws_client: ServiceLevelClientFactory,
 ):
-    state = []
+    state: list[tuple[str, Callable]] = []
 
     def _deploy(
         *,
@@ -971,6 +972,7 @@ def deploy_cfn_template(
         role_arn: Optional[str] = None,
         max_wait: Optional[int] = None,
         delay_between_polls: Optional[int] = 2,
+        custom_aws_client: Optional[ServiceLevelClientFactory] = None,
     ) -> DeployResult:
         if is_update:
             assert stack_name
@@ -1001,17 +1003,18 @@ def deploy_cfn_template(
         if role_arn is not None:
             kwargs["RoleARN"] = role_arn
 
-        response = aws_client.cloudformation.create_change_set(**kwargs)
+        cfn_aws_client = custom_aws_client if custom_aws_client is not None else aws_client
+
+        response = cfn_aws_client.cloudformation.create_change_set(**kwargs)
 
         change_set_id = response["Id"]
         stack_id = response["StackId"]
-        state.append({"stack_id": stack_id, "change_set_id": change_set_id})
 
-        aws_client.cloudformation.get_waiter(WAITER_CHANGE_SET_CREATE_COMPLETE).wait(
+        cfn_aws_client.cloudformation.get_waiter(WAITER_CHANGE_SET_CREATE_COMPLETE).wait(
             ChangeSetName=change_set_id
         )
-        aws_client.cloudformation.execute_change_set(ChangeSetName=change_set_id)
-        stack_waiter = aws_client.cloudformation.get_waiter(
+        cfn_aws_client.cloudformation.execute_change_set(ChangeSetName=change_set_id)
+        stack_waiter = cfn_aws_client.cloudformation.get_waiter(
             WAITER_STACK_UPDATE_COMPLETE if is_update else WAITER_STACK_CREATE_COMPLETE
         )
 
@@ -1025,11 +1028,13 @@ def deploy_cfn_template(
             )
         except botocore.exceptions.WaiterError as e:
             raise StackDeployError(
-                aws_client.cloudformation.describe_stacks(StackName=stack_id)["Stacks"][0],
-                aws_client.cloudformation.describe_stack_events(StackName=stack_id)["StackEvents"],
+                cfn_aws_client.cloudformation.describe_stacks(StackName=stack_id)["Stacks"][0],
+                cfn_aws_client.cloudformation.describe_stack_events(StackName=stack_id)[
+                    "StackEvents"
+                ],
             ) from e
 
-        describe_stack_res = aws_client.cloudformation.describe_stacks(StackName=stack_id)[
+        describe_stack_res = cfn_aws_client.cloudformation.describe_stacks(StackName=stack_id)[
             "Stacks"
         ][0]
         outputs = describe_stack_res.get("Outputs", [])
@@ -1037,16 +1042,16 @@ def deploy_cfn_template(
         mapped_outputs = {o["OutputKey"]: o.get("OutputValue") for o in outputs}
 
         def _destroy_stack():
-            aws_client.cloudformation.delete_stack(StackName=stack_id)
-            aws_client.cloudformation.get_waiter(WAITER_STACK_DELETE_COMPLETE).wait(
+            cfn_aws_client.cloudformation.delete_stack(StackName=stack_id)
+            cfn_aws_client.cloudformation.get_waiter(WAITER_STACK_DELETE_COMPLETE).wait(
                 StackName=stack_id,
                 WaiterConfig={
                     "Delay": delay_between_polls,
                     "MaxAttempts": max_wait / delay_between_polls,
                 },
             )
-            # TODO: fix in localstack. stack should only be in DELETE_COMPLETE state after all resources have been deleted
-            time.sleep(2)
+
+        state.append((stack_id, _destroy_stack))
 
         return DeployResult(
             change_set_id, stack_id, stack_name, change_set_name, mapped_outputs, _destroy_stack
@@ -1055,20 +1060,11 @@ def deploy_cfn_template(
     yield _deploy
 
     # delete the stacks in the reverse order they were created in case of inter-stack dependencies
-    for entry in state[::-1]:
-        entry_stack_id = entry.get("stack_id")
+    for stack_id, teardown in state[::-1]:
         try:
-            if entry_stack_id:
-                aws_client.cloudformation.delete_stack(StackName=entry_stack_id)
-                aws_client.cloudformation.get_waiter(WAITER_STACK_DELETE_COMPLETE).wait(
-                    StackName=entry_stack_id,
-                    WaiterConfig={
-                        "Delay": 2,
-                        "MaxAttempts": 120,
-                    },
-                )
+            teardown()
         except Exception as e:
-            LOG.debug(f"Failed cleaning up stack {entry_stack_id=}: {e}")
+            LOG.debug(f"Failed cleaning up stack {stack_id=}: {e}")
 
 
 @pytest.fixture

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -955,10 +955,6 @@ class StackDeployError(Exception):
 
 @pytest.fixture
 def deploy_cfn_template(
-    cleanup_stacks,
-    cleanup_changesets,
-    is_change_set_created_and_available,
-    is_change_set_finished,
     aws_client,
 ):
     state = []

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -8,7 +8,6 @@ import pytest
 import yaml
 
 from localstack.aws.api.lambda_ import Runtime
-from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
 from localstack.testing.aws.cloudformation_utils import load_template_file, load_template_raw
 from localstack.testing.pytest import markers
@@ -234,24 +233,40 @@ class TestIntrinsicFunctions:
 
         assert deployed.outputs["Address"] == "10.0.0.0/24"
 
+    @pytest.mark.parametrize(
+        "region",
+        [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "ap-southeast-2",
+            "ap-northeast-1",
+            "eu-central-1",
+            "eu-west-1",
+        ],
+    )
     @markers.aws.validated
-    def test_get_azs_function(self, deploy_cfn_template, snapshot):
+    def test_get_azs_function(self, deploy_cfn_template, region, aws_client_factory, snapshot):
         """
         TODO parametrize this test.
         For that we need to be able to parametrize the client region. The docs show the we should be
         able to put any region in the parameters but it doesn't work. It only accepts the same region from the client config
         if you put anything else it just returns an empty list.
         """
+        snapshot.add_transformer(snapshot.transform.regex(region, "<region>"))
 
         template_path = os.path.join(
             os.path.dirname(__file__), "../../templates/functions_get_azs.yml"
         )
 
+        aws_client = aws_client_factory(region_name=region)
         deployed = deploy_cfn_template(
             template_path=template_path,
+            custom_aws_client=aws_client,
+            parameters={"DeployRegion": region},
         )
 
-        snapshot.add_transformer(snapshot.transform.regex(AWS_REGION_US_EAST_1, "<region>"))
         snapshot.match("azs", deployed.outputs["Zones"].split(";"))
 
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -600,19 +600,6 @@
       }
     }
   },
-  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
-    "recorded-date": "03-04-2024, 07:12:29",
-    "recorded-content": {
-      "azs": [
-        "<region>a",
-        "<region>b",
-        "<region>c",
-        "<region>d",
-        "<region>e",
-        "<region>f"
-      ]
-    }
-  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
     "recorded-date": "17-05-2024, 06:19:03",
     "recorded-content": {

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -3,28 +3,28 @@
     "last_validated_date": "2024-04-03T07:12:29+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[ap-northeast-1]": {
-    "last_validated_date": "2024-04-17T10:25:52+00:00"
+    "last_validated_date": "2024-05-09T08:34:23+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[ap-southeast-2]": {
-    "last_validated_date": "2024-04-17T10:25:33+00:00"
+    "last_validated_date": "2024-05-09T08:34:02+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[eu-central-1]": {
-    "last_validated_date": "2024-04-17T10:26:09+00:00"
+    "last_validated_date": "2024-05-09T08:34:39+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[eu-west-1]": {
-    "last_validated_date": "2024-04-17T10:26:24+00:00"
+    "last_validated_date": "2024-05-09T08:34:56+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-1]": {
-    "last_validated_date": "2024-04-17T10:24:29+00:00"
+    "last_validated_date": "2024-05-09T08:32:56+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-2]": {
-    "last_validated_date": "2024-04-17T10:24:45+00:00"
+    "last_validated_date": "2024-05-09T08:33:12+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-1]": {
-    "last_validated_date": "2024-04-17T10:24:59+00:00"
+    "last_validated_date": "2024-05-09T08:33:29+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-2]": {
-    "last_validated_date": "2024-04-17T10:25:14+00:00"
+    "last_validated_date": "2024-05-09T08:33:45+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -2,6 +2,30 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function": {
     "last_validated_date": "2024-04-03T07:12:29+00:00"
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[ap-northeast-1]": {
+    "last_validated_date": "2024-04-17T10:25:52+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[ap-southeast-2]": {
+    "last_validated_date": "2024-04-17T10:25:33+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[eu-central-1]": {
+    "last_validated_date": "2024-04-17T10:26:09+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[eu-west-1]": {
+    "last_validated_date": "2024-04-17T10:26:24+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-1]": {
+    "last_validated_date": "2024-04-17T10:24:29+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-east-2]": {
+    "last_validated_date": "2024-04-17T10:24:45+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-1]": {
+    "last_validated_date": "2024-04-17T10:24:59+00:00"
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestIntrinsicFunctions::test_get_azs_function[us-west-2]": {
+    "last_validated_date": "2024-04-17T10:25:14+00:00"
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_capabilities_requirements": {
     "last_validated_date": "2023-01-30T19:15:46+00:00"
   },

--- a/tests/aws/templates/functions_get_azs.yml
+++ b/tests/aws/templates/functions_get_azs.yml
@@ -1,18 +1,10 @@
 Parameters:
   DeployRegion:
     Type: String
-    Default: us-east-1
-
-Conditions:
-  DeployInUSEast1:
-    Fn::Equals:
-      - !Ref DeployRegion
-      - us-east-1
 
 Resources:
   SsmParameter:
     Type: AWS::SSM::Parameter
-    Condition: DeployInUSEast1
     Properties:
       Type: String
       Value:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We cannot currently run the `test_get_azs_function` test against any other region but us-east-1 due to snapshot capture, and the `deploy_cfn_template` fixture being locked to the current profile region. We do not get coverage of other regions with this test.

Note: the `Fn::GetAZs` intrinsic function _must_ be called with the stack region as its argument, otherwise it returns nothing.

<!-- What notable changes does this PR make? -->
## Changes

- Test cleanup
- Support custom AWS client for `deploy_cfn_template` including standardising the stack deletion process between the automatic fixture cleanup, and the `DeployResult.destroy` method, ensuring the correct region is used
- Parametrize `test_get_azs_function` to evaluate all regions. This basically ignores the chosen region for the cross-region tests, but in a sense we gain _more_ coverage as we are testing **all** regions each time.
- As a side-effect of the removal of a 2 second sleep after manual destroy in a kinesis test, the kinesis stream resource provider has been updated to asynchronously delete the resource

**This PR will fail until the list of AZs per region as been corrected in `moto`.**

/cc @sannya-singal

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

