### PR TITLE
fix apigw data plane service matching

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -145,19 +145,19 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
                     the targeting service
     :return: True if the CORS rules should be enforced in here.
     """
-    if config.DISABLE_CUSTOM_CORS_S3 and config.DISABLE_CUSTOM_CORS_APIGATEWAY:
-        return True
     # allow only certain api calls without checking origin
-    if context.service:
-        service_name = context.service.service_name
-        if not config.DISABLE_CUSTOM_CORS_S3 and service_name == "s3":
+    if not config.DISABLE_CUSTOM_CORS_S3:
+        if context.service and context.service.service_name == "s3":
             return False
-        if not config.DISABLE_CUSTOM_CORS_APIGATEWAY and service_name == "apigateway":
-            is_user_request = (
-                PATH_USER_REQUEST in context.request.path or ".execute-api." in context.request.host
-            )
-            if is_user_request:
-                return False
+
+    if not config.DISABLE_CUSTOM_CORS_APIGATEWAY:
+        # we don't check for service_name == "apigw" here because ``.execute-api.`` can be either apigw v1 or v2
+        is_user_request = (
+            ".execute-api." in context.request.host or PATH_USER_REQUEST in context.request.path
+        )
+        if is_user_request:
+            return False
+
     return True
 
 

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -140,10 +140,13 @@ def custom_host_addressing_rules(host: str) -> Optional[ServiceModelIdentifier]:
     """
     Rules based on the host header of the request, which is typically the data plane of a service.
 
-    # TODO: ELB, AppSync, CloudFront, ...
+    Some services are added through a patch in ext.
     """
-    if ".execute-api." in host:
-        return ServiceModelIdentifier("apigateway")
+
+    # a note on ``.execute-api.`` and why it shouldn't be added as a check here: ``.execute-api.`` was previously
+    # mapped distinctly to ``apigateway``, but this assumption is too strong, since the URL can be apigw v1, v2,
+    # or apigw management api. so in short, simply based on the host header, it's not possibly to unambiguously
+    # associate a specific apigw service to the request.
 
     if ".lambda-url." in host:
         return ServiceModelIdentifier("lambda")

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -145,7 +145,7 @@ def custom_host_addressing_rules(host: str) -> Optional[ServiceModelIdentifier]:
 
     # a note on ``.execute-api.`` and why it shouldn't be added as a check here: ``.execute-api.`` was previously
     # mapped distinctly to ``apigateway``, but this assumption is too strong, since the URL can be apigw v1, v2,
-    # or apigw management api. so in short, simply based on the host header, it's not possibly to unambiguously
+    # or apigw management api. so in short, simply based on the host header, it's not possible to unambiguously
     # associate a specific apigw service to the request.
 
     if ".lambda-url." in host:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

After merging https://github.com/localstack/localstack/pull/10640, we noticed an issue in ext that a request to apigwv2 websockets would mistakenly go into the service parser, which would fail because the request was detected as "apigateway" when it really should have been "apigatewaymanagementapi". It turns out setting `apigateway` as a service simply based on the condition `if `.execute-api. in request.host` is much too strong, because it's ambiguous.

however, we were relying on this (wrong) behavior in the CORS handler, to trigger the custom apigw cors check, so we had to weaken the condition for that control path as well, now that we're no longer setting the service name in the request to `apigateway`.

Moving forward, we have the option to handle data plane service loading without setting `context.service` (which at the end of the day is just an optimization, not a necessity for loading the service), and we can load more than one service in the `if `.execute-api. in request.host` case (namely apigw v1, v2 and management API). the decision whether we want to do that i've left to @bentsku who will give it some thought.

until then we accept the limitation that pre-loading the service from data-plane URLs will not work for api gateway.


<!-- What notable changes does this PR make? -->
## Changes

* apigateway is no longer set automatically as service when `.execute-api. in request.host`
* custom cors check for APIGW is now done independently on whether the service is set or not (TODO: we could probably optimize and skip the check completely if the service is already set to something that's not APIGW)


## TODO

What's left to do:

- [x] Run the ext pipeline on this change
