### PR TITLE
fix DDB eventName for TransactWriteItems Update inserting data

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1807,10 +1807,10 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         record["dynamodb"]["StreamViewType"] = stream_type.stream_view_type
 
                     record["eventID"] = short_uid()
-                    record["eventName"] = "MODIFY" if updated_item else "INSERT"
+                    record["eventName"] = "MODIFY" if existing_item else "INSERT"
                     record["dynamodb"]["Keys"] = keys
 
-                    if stream_type.needs_old_image:
+                    if existing_item and stream_type.needs_old_image:
                         record["dynamodb"]["OldImage"] = existing_item
                     if stream_type.needs_new_image:
                         record["dynamodb"]["NewImage"] = updated_item

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -857,7 +857,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming": {
-    "recorded-date": "15-03-2024, 01:54:32",
+    "recorded-date": "17-04-2024, 22:45:49",
     "recorded-content": {
       "create-table": {
         "TableDescription": {
@@ -939,6 +939,12 @@
         }
       },
       "transact-write-response-update": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "transact-write-update-insert": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1038,6 +1044,32 @@
               "ApproximateCreationDateTime": "datetime",
               "Keys": {
                 "id": {
+                  "S": "NonExistentKey"
+                }
+              },
+              "NewImage": {
+                "attr1": {
+                  "S": "value1"
+                },
+                "id": {
+                  "S": "NonExistentKey"
+                }
+              },
+              "SequenceNumber": "<sequence-number:4>",
+              "SizeBytes": 43,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:4>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
                   "S": "NewKey"
                 }
               },
@@ -1052,11 +1084,11 @@
                   "S": "NewKey"
                 }
               },
-              "SequenceNumber": "<sequence-number:4>",
+              "SequenceNumber": "<sequence-number:5>",
               "SizeBytes": 38,
               "StreamViewType": "NEW_AND_OLD_IMAGES"
             },
-            "eventID": "<event-i-d:4>",
+            "eventID": "<event-i-d:5>",
             "eventName": "REMOVE",
             "eventSource": "aws:dynamodb",
             "eventVersion": "1.1"
@@ -1083,11 +1115,11 @@
                   "S": "Fred"
                 }
               },
-              "SequenceNumber": "<sequence-number:5>",
+              "SequenceNumber": "<sequence-number:6>",
               "SizeBytes": 26,
               "StreamViewType": "NEW_AND_OLD_IMAGES"
             },
-            "eventID": "<event-i-d:5>",
+            "eventID": "<event-i-d:6>",
             "eventName": "MODIFY",
             "eventSource": "aws:dynamodb",
             "eventVersion": "1.1"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -63,7 +63,7 @@
     "last_validated_date": "2023-08-23T14:33:37+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming": {
-    "last_validated_date": "2024-03-15T01:54:32+00:00"
+    "last_validated_date": "2024-04-17T22:45:49+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming_for_different_tables": {
     "last_validated_date": "2024-04-02T21:45:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported with #10679, we would return `MODIFY` when the call to `Update` would insert data that didn't exist.
A condition was wrong and was checking for the wrong value (`updated_item` instead of `existing_item`). 

<!-- What notable changes does this PR make? -->
## Changes
- added a new call in the `test_transact_write_items_streaming` test to test for an `Update` call which inserts data
- fix the condition check 

_fixes #10679_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

