### PR TITLE
improve user request route detection for APIGW in CORS

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -154,7 +154,7 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
         # we don't check for service_name == "apigw" here because ``.execute-api.`` can be either apigw v1 or v2
         path = context.request.path
         is_user_request = ".execute-api." in context.request.host or (
-            path.startswith("/restapis") and f"/{PATH_USER_REQUEST}" in context.request.path
+            path.startswith("/restapis/") and f"/{PATH_USER_REQUEST}" in context.request.path
         )
         if is_user_request:
             return False

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -152,8 +152,9 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
 
     if not config.DISABLE_CUSTOM_CORS_APIGATEWAY:
         # we don't check for service_name == "apigw" here because ``.execute-api.`` can be either apigw v1 or v2
-        is_user_request = (
-            ".execute-api." in context.request.host or PATH_USER_REQUEST in context.request.path
+        path = context.request.path
+        is_user_request = ".execute-api." in context.request.host or (
+            path.startswith("/restapis") and f"/{PATH_USER_REQUEST}" in context.request.path
         )
         if is_user_request:
             return False

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -153,3 +153,69 @@ class TestCSRF:
         response = requests.get(f"{config.internal_service_url()}/2015-03-31/functions/")
         assert response.status_code == 200
         assert "access-control-allow-origin" not in response.headers
+
+    def test_cors_apigw_not_applied(self, aws_client):
+        # make sure the service is loaded and has registered routes
+        aws_client.apigateway.get_rest_apis()
+
+        cors_headers = [
+            "access-control-allow-headers",
+            "access-control-allow-methods",
+            "access-control-allow-origin",
+            "access-control-allow-credentials",
+        ]
+
+        # assert that the registered routes for APIGW are handled by themselves on the CORS/CRSF level
+        # note: we have tests for asserting proper return of CORS headers in APIGW itself when configured to do so
+        #
+        rest_api_url_user_request = (
+            f"{config.internal_service_url()}/restapis/myapiid/stage/_user_request_"
+        )
+        response = requests.get(
+            rest_api_url_user_request,
+            verify=False,
+            headers={
+                "Origin": "https://app.localstack.cloud",
+            },
+        )
+        assert response.status_code == 404
+        assert not any(response.headers.get(cors_header) for cors_header in cors_headers)
+
+        rest_api_url_host = f"{config.internal_service_url()}/stage"
+        host_header = "myapiid.execute-api.localhost.localstack.cloud:4566"
+        response = requests.get(
+            rest_api_url_host,
+            verify=False,
+            headers={
+                "Origin": "https://app.localstack.cloud",
+                "Host": host_header,
+            },
+        )
+
+        assert response.status_code == 404
+        assert not any(response.headers.get(cors_header) for cors_header in cors_headers)
+
+        # now we give it a try with a route from the provider defined in the specs: GetRestApi, and an authorized origin
+        rest_api_url = f"{config.internal_service_url()}/restapis/myapiid"
+        response = requests.get(
+            rest_api_url,
+            verify=False,
+            headers={
+                "Origin": "https://app.localstack.cloud",
+                "Authorization": "AWS4-HMAC-SHA256 Credential=test/20240418/us-east-1/apigateway/aws4_request, SignedHeaders=accept;host;x-amz-date, Signature=88259852931bc389bd7c2e1fb8b700b935e9d6b14bd2ef72efc3a9b20b415701",
+            },
+        )
+        assert response.status_code == 404
+        assert all(response.headers.get(cors_header) for cors_header in cors_headers)
+
+        # now do the same from an unauthorized Origin
+        response = requests.get(
+            rest_api_url,
+            verify=False,
+            headers={
+                "Origin": "http://localhost:4200",
+                "Authorization": "AWS4-HMAC-SHA256 Credential=test/20240418/us-east-1/apigateway/aws4_request, SignedHeaders=accept;host;x-amz-date, Signature=88259852931bc389bd7c2e1fb8b700b935e9d6b14bd2ef72efc3a9b20b415701",
+            },
+        )
+        assert response.status_code == 403
+        assert not any(response.headers.get(cors_header) for cors_header in cors_headers)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #10682, Alex has raised valid concerns that we were weakening the CORS/CRSF checks for APIGW by removing the service check.


<!-- What notable changes does this PR make? -->
## Changes
- I've added a bit stricter check than before, and added tests for APIGW CORS handling. 

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

