### PR TITLE
Avoid failing host_path_for_path_in_docker if no docker daemon is available

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -464,6 +464,7 @@ class ContainerConfiguration:
     platform: Optional[str] = None
     ulimits: Optional[List[Ulimit]] = None
     labels: Optional[Dict[str, str]] = None
+    init: Optional[bool] = None
 
 
 class ContainerConfigurator(Protocol):
@@ -841,6 +842,7 @@ class ContainerClient(metaclass=ABCMeta):
             platform=container_config.platform,
             labels=container_config.labels,
             ulimits=container_config.ulimits,
+            init=container_config.init,
         )
 
     @abstractmethod
@@ -944,6 +946,7 @@ class ContainerClient(metaclass=ABCMeta):
             platform=container_config.platform,
             privileged=container_config.privileged,
             ulimits=container_config.ulimits,
+            init=container_config.init,
         )
 
     @abstractmethod

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -840,6 +840,7 @@ class ContainerClient(metaclass=ABCMeta):
             privileged=container_config.privileged,
             platform=container_config.platform,
             labels=container_config.labels,
+            ulimits=container_config.ulimits,
         )
 
     @abstractmethod
@@ -869,6 +870,8 @@ class ContainerClient(metaclass=ABCMeta):
         privileged: Optional[bool] = None,
         labels: Optional[Dict[str, str]] = None,
         platform: Optional[DockerPlatform] = None,
+        ulimits: Optional[List[Ulimit]] = None,
+        init: Optional[bool] = None,
     ) -> str:
         """Creates a container with the given image
 

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -6,6 +6,7 @@ import queue
 import re
 import socket
 import threading
+from functools import lru_cache
 from time import sleep
 from typing import Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import quote
@@ -468,6 +469,7 @@ class SdkDockerClient(ContainerClient):
             LOG.info("Container has more than one assigned network. Picking the first one...")
         return networks[network_names[0]]["IPAddress"]
 
+    @lru_cache(maxsize=None)
     def has_docker(self) -> bool:
         try:
             if not self.docker_client:

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -102,7 +102,7 @@ def get_host_path_for_path_in_docker(path):
     :param path: Path to be replaced (subpath of DEFAULT_VOLUME_DIR)
     :return: Path on the host
     """
-    if config.is_in_docker:
+    if config.is_in_docker and DOCKER_CLIENT.has_docker():
         volume = get_default_volume_dir_mount()
 
         if volume:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The `get_host_path_for_path_in_docker` function should not fail if we have no docker daemon available.
If docker is required later, we can still fail there. If not, because there are other options available, we should not fail.

This is a bandaid fix, we need to have a bigger refactoring for this method in the future.

<!-- What notable changes does this PR make? -->
## Changes
* Check if we have access to the docker socket before executing operations for it
* Check `has_docker` call for the sdk client as well, similar to the cmd client.
* Properly pass ulimit configuration from `ContainerConfiguration` to `create_container`.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

