### PR TITLE
implement SNS Filter/operators $or, suffix, equals-ignore-case, anything-but

### DIFF
--- a/localstack/services/sns/filter.py
+++ b/localstack/services/sns/filter.py
@@ -8,15 +8,22 @@ class SubscriptionFilter:
     def check_filter_policy_on_message_attributes(
         self, filter_policy: dict, message_attributes: dict
     ):
-        for criteria, conditions in filter_policy.items():
-            if not self._evaluate_filter_policy_conditions_on_attribute(
-                conditions,
-                message_attributes.get(criteria),
-                field_exists=criteria in message_attributes,
-            ):
-                return False
+        if not filter_policy:
+            return True
 
-        return True
+        flat_policy_conditions = self.flatten_policy(filter_policy)
+
+        return any(
+            all(
+                self._evaluate_filter_policy_conditions_on_attribute(
+                    conditions,
+                    message_attributes.get(criteria),
+                    field_exists=criteria in message_attributes,
+                )
+                for criteria, conditions in flat_policy.items()
+            )
+            for flat_policy in flat_policy_conditions
+        )
 
     def check_filter_policy_on_message_body(self, filter_policy: dict, message_body: str):
         try:
@@ -45,18 +52,26 @@ class SubscriptionFilter:
         :param payload: a dict, starting at the MessageBody
         :return: True if the payload respect the filter policy, otherwise False
         """
-        flat_policy = self._flatten_dict(filter_policy)
-        flat_payloads = self._flatten_dict_with_list(payload)
-        for key, values in flat_policy.items():
-            if not any(
-                self._evaluate_condition(
-                    flat_payload.get(key), condition, field_exists=key in flat_payload
+        if not filter_policy:
+            return True
+
+        # TODO: maybe save/cache the flattened/expanded policy?
+        flat_policy_conditions = self.flatten_policy(filter_policy)
+        flat_payloads = self.flatten_payload(payload)
+
+        return any(
+            all(
+                any(
+                    self._evaluate_condition(
+                        flat_payload.get(key), condition, field_exists=key in flat_payload
+                    )
+                    for condition in values
+                    for flat_payload in flat_payloads
                 )
-                for condition in values
-                for flat_payload in flat_payloads
-            ):
-                return False
-        return True
+                for key, values in flat_policy.items()
+            )
+            for flat_policy in flat_policy_conditions
+        )
 
     def _evaluate_filter_policy_conditions_on_attribute(
         self, conditions, attribute, field_exists: bool
@@ -94,11 +109,16 @@ class SubscriptionFilter:
             # the remaining conditions require the value to not be None
             return False
         elif anything_but := condition.get("anything-but"):
-            # TODO: support with `prefix`
-            # https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-anything-but-matching-prefix
+            # TODO: anything-but can be combined with prefix (and maybe others) by putting another condition in
+            #  > "event":[{"anything-but": {"prefix": "order-"}}]
+            # > https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-anything-but-matching-prefix
             return value not in anything_but
-        elif prefix := (condition.get("prefix")):
+        elif prefix := condition.get("prefix"):
             return value.startswith(prefix)
+        elif suffix := condition.get("suffix"):
+            return value.endswith(suffix)
+        elif equal_ignore_case := condition.get("equals-ignore-case"):
+            return equal_ignore_case.lower() == value.lower()
         elif numeric_condition := condition.get("numeric"):
             return self._evaluate_numeric_condition(numeric_condition, value)
         return False
@@ -135,35 +155,59 @@ class SubscriptionFilter:
         return True
 
     @staticmethod
-    def _flatten_dict(nested_dict: dict):
+    def flatten_policy(nested_dict: dict) -> list[dict]:
         """
         Takes a dictionary as input and will output the dictionary on a single level.
         Input:
-        `{"field1": {"field2: {"field3: "val1", "field4": "val2"}}}`
+        `{"field1": {"field2": {"field3": "val1", "field4": "val2"}}}`
         Output:
-        `{
-            "field1.field2.field3": "val1",
-            "field1.field2.field4": "val1"
-        }`
+        `[
+            {
+                "field1.field2.field3": "val1",
+                "field1.field2.field4": "val2"
+            }
+        ]`
+        Input with $or will create multiple outputs:
+        `{"$or": [{"field1": "val1"}, {"field2": "val2"}], "field3": "val3"}`
+        Output:
+        `[
+            {"field1": "val1", "field3": "val3"},
+            {"field2": "val2", "field3": "val3"}
+        ]`
         :param nested_dict: a (nested) dictionary
         :return: a list of flattened dictionaries with no nested dict or list inside, flattened to a
         single level, one list item for every list item encountered
         """
-        flatten = {}
 
-        def _traverse(_policy: dict, parent_key=None):
-            for key, values in _policy.items():
-                flattened_parent_key = key if not parent_key else f"{parent_key}.{key}"
-                if not isinstance(values, dict):
-                    flatten[flattened_parent_key] = values
+        def _traverse_policy(obj, array=None, parent_key=None) -> list:
+            if array is None:
+                array = [{}]
+
+            for key, values in obj.items():
+                if key == "$or" and isinstance(values, list) and len(values) > 1:
+                    # $or will create multiple new branches in the array.
+                    # Each current branch will traverse with each choice in $or
+                    array = [
+                        i for value in values for i in _traverse_policy(value, array, parent_key)
+                    ]
                 else:
-                    _traverse(values, parent_key=flattened_parent_key)
+                    # We update the parent key do that {"key1": {"key2": ""}} becomes "key1.key2"
+                    _parent_key = f"{parent_key}.{key}" if parent_key else key
+                    if isinstance(values, dict):
+                        # If the current key has child dict -- key: "key1", child: {"key2": ["val1", val2"]}
+                        # We only update the parent_key and traverse its children with the current branches
+                        array = _traverse_policy(values, array, _parent_key)
+                    else:
+                        # If the current key has no child, this means we found the values to match -- child: ["val1", val2"]
+                        # we update the branches with the parent chain and the values -- {"key1.key2": ["val1, val2"]}
+                        array = [{**item, _parent_key: values} for item in array]
 
-        _traverse(nested_dict)
-        return flatten
+            return array
+
+        return _traverse_policy(nested_dict)
 
     @staticmethod
-    def _flatten_dict_with_list(nested_dict: dict) -> list[dict]:
+    def flatten_payload(nested_dict: dict) -> list[dict]:
         """
         Takes a dictionary as input and will output the dictionary on a single level.
         The dictionary can have lists containing other dictionaries, and one root level entry will be created for every

--- a/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.snapshot.json
@@ -41,7 +41,7 @@
     }
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "recorded-date": "14-05-2024, 16:51:03",
+    "recorded-date": "15-05-2024, 14:39:23",
     "recorded-content": {
       "error-condition-is-numeric": {
         "Error": {
@@ -73,6 +73,30 @@
           "Message": "Invalid parameter: Attributes Reason: FilterPolicy: \"suffix\" must be an object or an array\n at [Source: (String)\"{\"key\":{\"suffix\":\"value\"}}\"; line: 1, column: 19]",
           "Type": "Sender",
           "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: \"suffix\" must be an object or an array"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-empty-list": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: suffix match pattern must be a string\n at [Source: (String)\"{\"key\":[{\"suffix\":[]}]}\"; line: 1, column: 20]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: suffix match pattern must be a string"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-list-wrong-type": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: suffix match pattern must be a string\n at [Source: (String)\"{\"key\":[{\"suffix\":[\"test\",\"test2\"]}]}\"; line: 1, column: 20]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: suffix match pattern must be a string"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1529,5 +1553,58 @@
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyBody::test_filter_policy_on_message_body_or_attribute": {
     "recorded-date": "14-05-2024, 16:51:02",
     "recorded-content": {}
+  },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_nested_anything_but_operator": {
+    "recorded-date": "15-05-2024, 14:39:32",
+    "recorded-content": {
+      "error-condition-wrong-operator": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: wrong-operator\n at [Source: (String)\"{\"key\":[{\"anything-but\":{\"wrong-operator\":null}}]}\"; line: 1, column: 47]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: wrong-operator"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-anything-but-suffix": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: suffix\n at [Source: (String)\"{\"key\":[{\"anything-but\":{\"suffix\":\"test\"}}]}\"; line: 1, column: 36]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: suffix"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-anything-but-exists": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: exists\n at [Source: (String)\"{\"key\":[{\"anything-but\":{\"exists\":false}}]}\"; line: 1, column: 40]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: Unsupported anything-but pattern: exists"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "error-condition-anything-but-prefix-wrong-type": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: FilterPolicy: prefix match pattern must be a string\n at [Source: (String)\"{\"key\":[{\"anything-but\":{\"prefix\":false}}]}\"; line: 1, column: 40]",
+          "Type": "Sender",
+          "_normalized": "Invalid parameter: Attributes Reason: FilterPolicy: prefix match pattern must be a string"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns_filter_policy.validation.json
+++ b/tests/aws/services/sns/test_sns_filter_policy.validation.json
@@ -41,11 +41,14 @@
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_exists_operator": {
     "last_validated_date": "2024-05-14T16:51:06+00:00"
   },
+  "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_nested_anything_but_operator": {
+    "last_validated_date": "2024-05-15T14:39:32+00:00"
+  },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_numeric_operator": {
     "last_validated_date": "2024-05-14T16:51:06+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyConditions::test_validate_policy_string_operators": {
-    "last_validated_date": "2024-05-14T16:51:03+00:00"
+    "last_validated_date": "2024-05-15T14:39:23+00:00"
   },
   "tests/aws/services/sns/test_sns_filter_policy.py::TestSNSFilterPolicyCrud::test_set_subscription_filter_policy_scope": {
     "last_validated_date": "2024-05-14T16:49:11+00:00"

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -889,3 +889,27 @@ class TestSns:
         }
         rules, combinations = validator_flat.aggregate_rules(filter_policy)
         assert combinations == 150
+
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            (
+                {"f3": ["v3"], "f1": {"f2": "v2"}},
+                [{"f3": "v3", "f1.f2": "v2"}],
+            ),
+            (
+                {"f3": ["v3", "v4"], "f1": {"f2": "v2"}},
+                [{"f3": "v3", "f1.f2": "v2"}, {"f3": "v4", "f1.f2": "v2"}],
+            ),
+        ],
+    )
+    def test_filter_flatten_payload(self, payload, expected):
+        sub_filter = SubscriptionFilter()
+        # payload = {"f3": ["v3"], "f1": {"f2": "v2"}}
+        # expected = [
+        #     {
+        #         "f3": "v3",
+        #         "f1.f2": "v2",
+        #     }
+        # ]
+        assert sub_filter.flatten_payload(payload) == expected


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #9738, AWS launched new operators for SNS filtering. `suffix` and `equals-ignore-case` are pretty simple to implement, but `$or` necessitated a quite consequent rewrite, as the logic can get quite convoluted pretty fast. It quickly creates a lot of different forks, where one rule can have multiple branches and a payload can have multiple branches too if it contains array. 

Also included better support for `anything-but`, which can accept any regular "plain" values like string, numbers and list of string & number. It can also accept the `prefix` operator, see https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html#string-anything-but-matching-prefix

Also, we still had an issue with some ordering of complex payload with arrays, see https://github.com/localstack/localstack/issues/10567#issuecomment-2096128740

<!-- What notable changes does this PR make? -->
## Changes
- switched the model for the policy, making it a list where each item of the list is an OR condition. This comes from the documentation of AWS: https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html
  - this is done via the improved `flatten_policy`, thanks a lot @cloutierMat for the great pairing session we've had, and you providing the final solution fixing all our issues! 🥳 
- added support for `suffix` and `equals-ignore-case`
- improved support for `anything-but`
- added a lot of unit tests for filtering
- added a few AWS tests to validate the new behavior
- remove the `skip` for the AWS validated `$or` test
- fix the recursive function `flatten_payload`


_fixes #10567, fixes #9738_