### PR TITLE
fix external service ports manager unit test flakiness

### DIFF
--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -584,9 +584,12 @@ class TestExternalServicePortsManager:
     def test_reserve_port_all_reserved(
         self, external_service_ports_manager: ExternalServicePortsManager
     ):
-        external_service_ports_manager.reserve_port()
-        external_service_ports_manager.reserve_port()
+        # the external service ports manager fixture only has 2 ports available,
+        # reserving 3 has to raise an error, but this could also happen earlier
+        # (if one of the ports is blocked by something else, like a previous test)
         with pytest.raises(PortNotAvailableException):
+            external_service_ports_manager.reserve_port()
+            external_service_ports_manager.reserve_port()
             external_service_ports_manager.reserve_port()
 
     def test_reserve_same_port_twice(


### PR DESCRIPTION
## Motivation
According to our CI analytics, the `tests/unit/test_common.py::TestExternalServicePortsManager::test_reserve_port_all_reserved` failed with a flake in ~6.25% of the runs of the last week.
Here are some example runs with this test failing:
- https://app.circleci.com/pipelines/github/localstack/localstack/24295/workflows/5b1fe023-a6b9-4dc0-8172-5b76cf17e9cb/jobs/200959
- https://app.circleci.com/pipelines/github/localstack/localstack/24237/workflows/3f7cb5a1-416b-4cdb-8d5c-16301dc77346/jobs/200239
- https://app.circleci.com/pipelines/github/localstack/localstack/23899/workflows/4fb96fb0-be61-4a20-a719-1438685cd55b/jobs/196354
- https://app.circleci.com/pipelines/github/localstack/localstack/23884/workflows/8d5757b5-f794-4208-a605-579bc0219a61/jobs/196268
- https://app.circleci.com/pipelines/github/localstack/localstack/24295/workflows/5b1fe023-a6b9-4dc0-8172-5b76cf17e9cb/jobs/200959

## Changes
- Harden the test such that it is more resilient / doesn't fail if a port is already been taken.