### PR TITLE
switch default gateway server from hypercorn to twisted

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -658,7 +658,7 @@ def populate_edge_configuration(
 GATEWAY_WORKER_COUNT = int(os.environ.get("GATEWAY_WORKER_COUNT") or 1000)
 
 # the gateway server that should be used (supported: hypercorn, twisted dev: werkzeug)
-GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "hypercorn"
+GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "twisted"
 
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()


### PR DESCRIPTION
## Motivation
@thrau added twisted as supported gateway server with #9834. Since then this was tested by selected users, and it turned out to be a great server. In reduced complexity and improved performance.

## Changes
- Switches the default for `GATEWAY_SERVER` from `hypercorn` to `twisted`.

## Testing
- Since the gateway is the foundation for every single request served in LocalStack, this change has an insane coverage. If all our tests are 💚, we should be good to go!
- We also need to execute tests for our downstream projects, to make sure other projects don't break.

## TODO
- [x] Execute tests in downstream projects.
- [x] Fix issues with streaming responses in our downstream usage.
