### PR TITLE
Add host addressing rule for IoT Data

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -154,6 +154,9 @@ def custom_host_addressing_rules(host: str) -> Optional[ServiceModelIdentifier]:
     if ".s3-website." in host:
         return ServiceModelIdentifier("s3")
 
+    if ".iot." in host:
+        return ServiceModelIdentifier("iot-data")
+
 
 def custom_path_addressing_rules(path: str) -> Optional[ServiceModelIdentifier]:
     """
@@ -289,7 +292,7 @@ def resolve_conflicts(
 ) -> ServiceModelIdentifier:
     """
     Some service definitions are overlapping to a point where they are _not_ distinguishable at all
-    (f.e. ``DescribeEndpints`` in timestream-query and timestream-write).
+    (f.e. ``DescribeEndpoints`` in timestream-query and timestream-write).
     These conflicts need to be resolved manually.
     """
     service_name_candidates = {service.name for service in candidates}


### PR DESCRIPTION
## Background

IoT Device Shadow supports a REST API at the endpoint exposed by `IoT:DescribeEndpoint`.

<https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-rest-api.html>

This PR implements this funcationality in LocalStack.

<!--
## Changes


## Tests


## Related

Closes:
-->