### PR TITLE
Add cdklocal package installer for lpm

### DIFF
--- a/localstack/packages/cdklocal.py
+++ b/localstack/packages/cdklocal.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+from typing import List
+
+from localstack.packages import Package, PackageInstaller
+from localstack.packages.core import NodePackageInstaller
+
+DEFAULT_CDKLOCAL_VERSION = "2.18.0"
+
+
+class CdkLocalPackage(Package):
+    def __init__(self, default_version: str = DEFAULT_CDKLOCAL_VERSION):
+        super().__init__(name="CDK Local", default_version=default_version)
+
+    @lru_cache
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return CdkLocalInstaller(version)
+
+    def get_versions(self) -> List[str]:
+        return [DEFAULT_CDKLOCAL_VERSION]
+
+
+class CdkLocalInstaller(NodePackageInstaller):
+    def __init__(self, version: str):
+        package_name = "aws-cdk-local"
+        super().__init__(
+            package_name=package_name,
+            package_spec=[f"{package_name}@{version}", "aws-cdk"],
+            version=version,
+        )
+
+
+cdklocal_package = CdkLocalPackage()

--- a/localstack/packages/cdklocal.py
+++ b/localstack/packages/cdklocal.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from typing import List
 
@@ -26,6 +27,15 @@ class CdkLocalInstaller(NodePackageInstaller):
             package_name=package_name,
             package_spec=[f"{package_name}@{version}", "aws-cdk"],
             version=version,
+        )
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(
+            install_dir,
+            "node_modules",
+            self.package_name,
+            "bin",
+            "cdklocal",
         )
 
 

--- a/localstack/packages/plugins.py
+++ b/localstack/packages/plugins.py
@@ -13,3 +13,10 @@ def ffmpeg_package() -> Package:
     from localstack.packages.ffmpeg import ffmpeg_package
 
     return ffmpeg_package
+
+
+@package(name="cdklocal")
+def cdklocal_package() -> Package:
+    from localstack.packages.cdklocal import cdklocal_package
+
+    return cdklocal_package


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

It would be nice to support using [`cdklocal`](https://github.com/localstack/aws-cdk-local) in [init hooks](https://docs.localstack.cloud/references/init-hooks/).


<!-- What notable changes does this PR make? -->
## Changes

- Add package installer for lpm

## Testing

Create a script with the following contents:

```bash
#!/bin/bash

set -euo pipefail

CDKLOCAL_VERSION=2.18.0
python -m localstack.cli.lpm install cdklocal --version ${CDKLOCAL_VERSION} --target var_libs
export PATH=/var/lib/localstack/lib/aws-cdk-local/${CDKLOCAL_VERSION}/node_modules/.bin:$PATH

cd /app
cdklocal bootstrap
cdklocal deploy --require-approval never --all
```

Then start LocalStack with the following additional settings:

1. Mount your CDK app into the LocalStack container at start time, e.g. to /opt/cdk in the container
2. Mount the script above into the container at `/etc/localstack/init/ready.d/00-cdk.sh` and make it executable

For example, using the CLI:

```bash
localstack start -v <path to cdk app>:/opt/cdk -v <path to init script>:/etc/localstack/init/ready.d/00-cdk.sh
```

Then LocalStack should start up, install `cdklocal` if it does not already exist, then proceed to bootstrap and deploy your application.
