### PR TITLE
fix headers for empty S3 responses

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1501,7 +1501,6 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
                 request_id,
             )
         self._serialize_content_type(response, shape, shape_members, mime_type)
-        self._prepare_additional_traits_in_response(response, operation_model, request_id)
 
     def _serialize_error(
         self,

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -134,7 +134,11 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
 )
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError
-from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
+from localstack.aws.handlers import (
+    modify_service_response,
+    preprocess_request,
+    serve_custom_service_request_handlers,
+)
 from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
@@ -161,6 +165,7 @@ from localstack.services.s3.utils import (
     get_lifecycle_rule_from_object,
     get_object_checksum_for_algorithm,
     get_permission_from_header,
+    s3_response_handler,
     serialize_expiration_header,
     validate_kms_key_id,
     verify_checksum,
@@ -230,8 +235,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         preprocess_request.append(self._cors_handler)
         register_website_hosting_routes(router=ROUTER)
         serve_custom_service_request_handlers.append(s3_cors_request_handler)
+        modify_service_response.append(self.service, s3_response_handler)
         # registering of virtual host routes happens with the hook on_infra_ready in virtual_host.py
-        # create a AWS managed KMS key at start and save it in the store for persistence?
 
     def __init__(self) -> None:
         super().__init__()

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -46,7 +46,9 @@ from localstack.aws.api.s3 import (
     TagSet,
 )
 from localstack.aws.api.s3 import Type as GranteeType
+from localstack.aws.chain import HandlerChain
 from localstack.aws.connect import connect_to
+from localstack.http import Response
 from localstack.services.s3.constants import (
     ALL_USERS_ACL_GRANTEE,
     AUTHENTICATED_USERS_ACL_GRANTEE,
@@ -91,6 +93,29 @@ _s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"
 _gmt_zone_info = ZoneInfo("GMT")
+
+
+def s3_response_handler(chain: HandlerChain, context: RequestContext, response: Response):
+    """
+    This response handler is taking care of removing certain headers from S3 responses.
+    We cannot handle this in the serializer, because the serializer handler calls `Response.update_from`, which does
+    not allow you to remove headers, only add them.
+    This handler can delete headers from the response.
+    """
+    # if AWS returns 204, it will not return a body, Content-Length and Content-Type
+    # the web server is already taking care of deleting the body, but it's more explicit to remove it here
+    if response.status_code == 204:
+        response.data = b""
+        response.headers.pop("Content-Type", None)
+        response.headers.pop("Content-Length", None)
+
+    elif (
+        response.status_code == 200
+        and context.request.method == "PUT"
+        and response.headers.get("Content-Length") in (0, None)
+    ):
+        # AWS does not return a Content-Type if the Content-Length is 0
+        response.headers.pop("Content-Type", None)
 
 
 def get_owner_for_account_id(account_id: str):

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -102,6 +102,11 @@ def s3_response_handler(chain: HandlerChain, context: RequestContext, response: 
     not allow you to remove headers, only add them.
     This handler can delete headers from the response.
     """
+    # some requests, for example coming frome extensions, are flagged as S3 requests. This check confirms that it is
+    # indeed truly an S3 request by checking if it parsed properly as an S3 operation
+    if not context.service_operation:
+        return
+
     # if AWS returns 204, it will not return a body, Content-Length and Content-Type
     # the web server is already taking care of deleting the body, but it's more explicit to remove it here
     if response.status_code == 204:

--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -199,7 +199,11 @@ from localstack.aws.api.s3 import (
     VersioningConfiguration,
     WebsiteConfiguration,
 )
-from localstack.aws.handlers import preprocess_request, serve_custom_service_request_handlers
+from localstack.aws.handlers import (
+    modify_service_response,
+    preprocess_request,
+    serve_custom_service_request_handlers,
+)
 from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
@@ -244,6 +248,7 @@ from localstack.services.s3.utils import (
     parse_post_object_tagging_xml,
     parse_range_header,
     parse_tagging_header,
+    s3_response_handler,
     serialize_expiration_header,
     str_to_rfc_1123_datetime,
     validate_dict_fields,
@@ -306,6 +311,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def on_after_init(self):
         preprocess_request.append(self._cors_handler)
         serve_custom_service_request_handlers.append(s3_cors_request_handler)
+        modify_service_response.append(self.service, s3_response_handler)
         register_website_hosting_routes(router=ROUTER)
 
     def accept_state_visitor(self, visitor: StateVisitor):

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11612,7 +11612,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_presigned_post_with_different_user_credentials": {
-    "recorded-date": "11-04-2024, 20:50:35",
+    "recorded-date": "24-04-2024, 18:30:08",
     "recorded-content": {
       "get-obj": {
         "AcceptRanges": "bytes",

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -237,7 +237,7 @@
     "last_validated_date": "2024-03-21T08:05:13+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure": {
-    "last_validated_date": "2024-01-03T16:46:18+00:00"
+    "last_validated_date": "2024-04-24T18:48:32+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
     "last_validated_date": "2023-08-03T02:25:40+00:00"
@@ -573,7 +573,10 @@
     "last_validated_date": "2023-08-04T21:58:54+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_presigned_post_with_different_user_credentials": {
-    "last_validated_date": "2024-04-11T20:50:35+00:00"
+    "last_validated_date": "2024-04-24T18:30:08+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_delete_has_empty_content_length_header": {
+    "last_validated_date": "2024-04-24T18:42:46+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-False]": {
     "last_validated_date": "2023-08-04T22:00:25+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #10712, LocalStack would return some `Content-Type` headers when AWS would not. Even though this was still in line with HTTP specs, some client were relying on this behavior.

We could not put this in the serializer, as the serializer handler calls `Response.update_from`, which is only additive. We cannot remove headers from this, and a default `Content-Type` is set at the beginning of the handler chain. 

<!-- What notable changes does this PR make? -->
## Changes
- create a new simple handler for S3 responses, which will remove some headers to be in line with AWS
- modify some tests to validate the new changes


_fixes #10712_
<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

