### PR TITLE
add utility for resource providers

### DIFF
--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -6,7 +6,4 @@ class TestDictUtils:
         original = {"Parameter": "1", "SecondParameter": ["2", "2"], "ThirdParameter": "3"}
         transformed = utils.convert_values_to_numbers(original, ["ThirdParameter"])
 
-        assert original["Parameter"] == "1"
-        assert transformed["Parameter"] == 1
-        assert transformed["SecondParameter"][0] == 2
-        assert transformed["ThirdParameter"] == "3"
+        assert transformed == {"Parameter": 1, "SecondParameter": [2, 2], "ThirdParameter": "3"}

--- a/tests/unit/services/cloudformation/test_provider_utils.py
+++ b/tests/unit/services/cloudformation/test_provider_utils.py
@@ -1,0 +1,12 @@
+import localstack.services.cloudformation.provider_utils as utils
+
+
+class TestDictUtils:
+    def test_convert_values_to_numbers(self):
+        original = {"Parameter": "1", "SecondParameter": ["2", "2"], "ThirdParameter": "3"}
+        transformed = utils.convert_values_to_numbers(original, ["ThirdParameter"])
+
+        assert original["Parameter"] == "1"
+        assert transformed["Parameter"] == 1
+        assert transformed["SecondParameter"][0] == 2
+        assert transformed["ThirdParameter"] == "3"


### PR DESCRIPTION
## Motivation
The CloudFormation template engine passes values from attributes that are expected to be numbers as strings, resulting in potential parameter rejection by boto3 when numeric values are required.

## Changes
New utility to easily convert the values that are digits into numbers.

## Testing
New unit test for the function.

Notes: In the future all the resource provider utilities should have a test.
