### PR TITLE
Avoid concurrent pulling of identical images in lambda

### DIFF
--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -3,6 +3,8 @@ import json
 import logging
 import shutil
 import tempfile
+import threading
+from collections import defaultdict
 from functools import cache
 from pathlib import Path
 from typing import Callable, Dict, Literal, Optional
@@ -60,6 +62,7 @@ COPY code/ /var/task
 """
 
 PULLED_IMAGES: set[(str, DockerPlatform)] = set()
+PULL_LOCKS: dict[(str, DockerPlatform), threading.RLock] = defaultdict(threading.RLock)
 
 HOT_RELOADING_ENV_VARIABLE = "LOCALSTACK_HOT_RELOADING_PATHS"
 
@@ -89,11 +92,35 @@ def get_image_name_for_function(function_version: FunctionVersion) -> str:
     return f"localstack/prebuild-lambda-{function_version.id.qualified_arn().replace(':', '_').replace('$', '_').lower()}"
 
 
-def get_default_image_for_runtime(runtime: str) -> str:
+def get_default_image_for_runtime(runtime: Runtime) -> str:
     postfix = IMAGE_MAPPING.get(runtime)
     if not postfix:
         raise ValueError(f"Unsupported runtime {runtime}!")
     return f"{IMAGE_PREFIX}{postfix}"
+
+
+def _ensure_runtime_image_present(image: str, platform: DockerPlatform) -> None:
+    # Pull image for a given platform upon function creation such that invocations do not time out.
+    if (image, platform) in PULLED_IMAGES:
+        return
+    # use a lock to avoid concurrent pulling of the same image
+    with PULL_LOCKS[(image, platform)]:
+        if (image, platform) in PULLED_IMAGES:
+            return
+        try:
+            CONTAINER_CLIENT.pull_image(image, platform)
+            PULLED_IMAGES.add((image, platform))
+        except NoSuchImage as e:
+            LOG.debug("Unable to pull image %s for runtime executor preparation.", image)
+            raise e
+        except DockerNotAvailable as e:
+            HINT_LOG.error(
+                "Failed to pull Docker image because Docker is not available in the LocalStack container "
+                "but required to run Lambda functions. Please add the Docker volume mount "
+                '"/var/run/docker.sock:/var/run/docker.sock" to your LocalStack startup. '
+                "https://docs.localstack.cloud/user-guide/aws/lambda/#docker-not-available"
+            )
+            raise e
 
 
 class RuntimeImageResolver:
@@ -459,25 +486,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             function_version.config.code.prepare_for_execution()
             image_name = resolver.get_image_for_runtime(function_version.config.runtime)
             platform = docker_platform(function_version.config.architectures[0])
-            # Pull image for a given platform upon function creation such that invocations do not time out.
-            if (image_name, platform) not in PULLED_IMAGES:
-                try:
-                    # FIXME multiple concurrent pulls could take place, which will slow them all down
-                    CONTAINER_CLIENT.pull_image(image_name, platform)
-                    PULLED_IMAGES.add((image_name, platform))
-                except NoSuchImage as e:
-                    LOG.debug(
-                        "Unable to pull image %s for runtime executor preparation.", image_name
-                    )
-                    raise e
-                except DockerNotAvailable as e:
-                    HINT_LOG.error(
-                        "Failed to pull Docker image because Docker is not available in the LocalStack container "
-                        "but required to run Lambda functions. Please add the Docker volume mount "
-                        '"/var/run/docker.sock:/var/run/docker.sock" to your LocalStack startup. '
-                        "https://docs.localstack.cloud/user-guide/aws/lambda/#docker-not-available"
-                    )
-                    raise e
+            _ensure_runtime_image_present(image_name, platform)
             if config.LAMBDA_PREBUILD_IMAGES:
                 prepare_image(function_version, platform)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently, if multiple lambda functions are created at the same time, with the same runtime, the image is pulled multiple times, concurrently.
Only after the images has been successfully pulled once, the image will not be pulled anymore.
In an extreme case, this could lead to a lot of lambdas pulling images concurrently, with the operation being slowed down for all of them (due to parallel downloads).

We need a solution where all the lambdas wait for the image, but it is only pulled once.

<!-- What notable changes does this PR make? -->
## Changes
* Add method to pull images with lock to avoid concurrent pulls of the same image (different images can still be pulled concurrently)

Old behavior:
```
2024-04-25T11:16:08.109  INFO --- [   asgi_gw_0] l.request.internal.aws     : AWS s3.GetObject => 200
2024-04-25T11:16:08.119 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['which', 'unzip']
2024-04-25T11:16:08.122 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['unzip', '-o', '-q', '/tmp/tmpwrpigzi3']
2024-04-25T11:16:08.125 DEBUG --- [rvice-task_0] l.u.c.docker_cmd_client    : Pulling image with cmd: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T11:16:08.125 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T11:16:08.125 DEBUG --- [rvice-task_1] l.u.c.docker_cmd_client    : Pulling image with cmd: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T11:16:08.125 DEBUG --- [rvice-task_1] localstack.utils.run       : Executing command: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T11:16:09.713 DEBUG --- [rvice-task_0] l.s.l.i.version_manager    : Version preparation of function arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST took 1637.74ms
2024-04-25T11:16:09.713 DEBUG --- [rvice-task_0] l.s.l.i.version_manager    : Changing Lambda arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST (id f88cfd04) to active
2024-04-25T11:16:09.713 DEBUG --- [rvice-task_0] l.s.l.i.event_manager      : Starting event manager arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST id 137697323769040
2024-04-25T11:16:09.716 DEBUG --- [rvice-task_1] l.s.l.i.version_manager    : Version preparation of function arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 took 1638.27ms
2024-04-25T11:16:09.716 DEBUG --- [rvice-task_1] l.s.l.i.version_manager    : Changing Lambda arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 (id f88cfd04) to active
2024-04-25T11:16:09.716 DEBUG --- [rvice-task_1] l.s.l.i.event_manager      : Starting event manager arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 id 137697047831184
```

New behavior:
```
2024-04-25T10:56:17.697  INFO --- [   asgi_gw_0] l.request.internal.aws     : AWS s3.GetObject => 200
2024-04-25T10:56:17.709 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['which', 'unzip']
2024-04-25T10:56:17.714 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['unzip', '-o', '-q', '/tmp/tmpj93oy90x']
2024-04-25T10:56:17.717 DEBUG --- [rvice-task_0] l.u.c.docker_cmd_client    : Pulling image with cmd: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T10:56:17.717 DEBUG --- [rvice-task_0] localstack.utils.run       : Executing command: ['docker', 'pull', 'public.ecr.aws/lambda/python:3.11', '--platform', 'linux/amd64']
2024-04-25T10:56:19.272 DEBUG --- [rvice-task_0] l.s.l.i.version_manager    : Version preparation of function arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST took 1612.24ms
2024-04-25T10:56:19.272 DEBUG --- [rvice-task_0] l.s.l.i.version_manager    : Changing Lambda arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST (id 675a1696) to active
2024-04-25T10:56:19.273 DEBUG --- [rvice-task_0] l.s.l.i.event_manager      : Starting event manager arn:aws:lambda:us-east-1:000000000000:function:test-function-1:$LATEST id 131335534222800
2024-04-25T10:56:19.273 DEBUG --- [rvice-task_1] l.s.l.i.version_manager    : Version preparation of function arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 took 1609.05ms
2024-04-25T10:56:19.273 DEBUG --- [rvice-task_1] l.s.l.i.version_manager    : Changing Lambda arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 (id 675a1696) to active
2024-04-25T10:56:19.274 DEBUG --- [rvice-task_1] l.s.l.i.event_manager      : Starting event manager arn:aws:lambda:us-east-1:000000000000:function:test-function-1:1 id 131335695833680
```

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

