### PR TITLE
CFN_PER_RESOURCE_TIMEOUT env variable

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1041,6 +1041,9 @@ PARITY_AWS_ACCESS_KEY_ID = is_env_true("PARITY_AWS_ACCESS_KEY_ID")
 # Show exceptions for CloudFormation deploy errors
 CFN_VERBOSE_ERRORS = is_env_true("CFN_VERBOSE_ERRORS")
 
+# Set the timeout for CloudFormation resources
+CFN_PER_RESOURCE_TIMEOUT = int(os.environ.get("CFN_PER_RESOURCE_TIMEOUT") or 150)
+
 # How localstack will react to encountering unsupported resource types.
 # By default unsupported resource types will be ignored.
 # EXPERIMENTAL

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1041,8 +1041,8 @@ PARITY_AWS_ACCESS_KEY_ID = is_env_true("PARITY_AWS_ACCESS_KEY_ID")
 # Show exceptions for CloudFormation deploy errors
 CFN_VERBOSE_ERRORS = is_env_true("CFN_VERBOSE_ERRORS")
 
-# Set the timeout for CloudFormation resources
-CFN_PER_RESOURCE_TIMEOUT = int(os.environ.get("CFN_PER_RESOURCE_TIMEOUT") or 150)
+# Set the timeout to deploy each individual CloudFormation resource
+CFN_PER_RESOURCE_TIMEOUT = int(os.environ.get("CFN_PER_RESOURCE_TIMEOUT") or 300)
 
 # How localstack will react to encountering unsupported resource types.
 # By default unsupported resource types will be ignored.

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -8,6 +8,7 @@ import uuid
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from logging import Logger
+from math import ceil
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypedDict, TypeVar
 
 import botocore
@@ -397,10 +398,12 @@ class ResourceProviderExecutor:
         self,
         resource: dict,
         raw_payload: ResourceProviderPayload,
-        max_iterations: int = 30,
+        max_timeout: int = config.CFN_PER_RESOURCE_TIMEOUT,
         sleep_time: float = 5,
     ) -> ProgressEvent[Properties]:
         payload = copy.deepcopy(raw_payload)
+
+        max_iterations = ceil(max_timeout/sleep_time)
 
         for current_iteration in range(max_iterations):
             resource_type = get_resource_type(

--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -403,7 +403,7 @@ class ResourceProviderExecutor:
     ) -> ProgressEvent[Properties]:
         payload = copy.deepcopy(raw_payload)
 
-        max_iterations = ceil(max_timeout/sleep_time)
+        max_iterations = max(ceil(max_timeout / sleep_time), 2)
 
         for current_iteration in range(max_iterations):
             resource_type = get_resource_type(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
LocalStack's CloudFormation implementation has a hard limit of 2.5 mins to deploy a single resource which is not always enough for bigger resource deployments like nested stacks.

<!-- What notable changes does this PR make? -->
## Changes
- Add CFN_PER_RESOURCE_TIMEOUT env variable
- Increase default value to 300s

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

