### PR TITLE
Fix SubtypesInstanceManager not loading subtypes lazily

### DIFF
--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -94,7 +94,7 @@ class SubtypesInstanceManager:
             # lazily load subtype instance (required if new plugins are dynamically loaded at runtime)
             for clazz in get_all_subclasses(base_type):
                 impl_name = clazz.impl_name()
-                if impl_name not in instances:
+                if impl_name not in instances and subtype_name == impl_name:
                     instances[impl_name] = clazz()
             instance = instances.get(subtype_name)
         if not instance and raise_if_missing:


### PR DESCRIPTION
## Background

`SubtypesInstanceManager` is supposed to lazily create a singleton instance of subtypes and return it. However a bug caused all subtypes to be instantiated eagerly if any subtype was requested.

This was identified when the Libvirt EC2 VM manager was being instantiated in the CI (which would fail since CI runners do not have a Libvirt socket) despite not being enabled explicitly in code or configuration.

## Changes

Fix `SubtypesInstanceManager` so that only the requested subtype is instantiated.