### PR TITLE
Include old resolv.conf contents without nameservers

### DIFF
--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -809,8 +809,14 @@ def add_resolv_entry(file_path: Path | str = Path("/etc/resolv.conf")):
     try:
         with file_path.open("r+") as outfile:
             PREVIOUS_RESOLV_CONF_FILE = outfile.read()
+            previous_resolv_conf_without_nameservers = [
+                line
+                for line in PREVIOUS_RESOLV_CONF_FILE.splitlines()
+                if not line.startswith("nameserver")
+            ]
             outfile.seek(0)
             outfile.write(content)
+            outfile.write("\n".join(previous_resolv_conf_without_nameservers))
             outfile.truncate()
     except Exception:
         LOG.warning(

--- a/tests/unit/test_dns_server.py
+++ b/tests/unit/test_dns_server.py
@@ -417,6 +417,30 @@ class TestDnsUtils:
 
         assert "nameserver 127.0.0.1" in new_contents.splitlines()
 
+    def test_exising_resolv_conf_contents(self, tmp_path: Path, monkeypatch):
+        from localstack.dns import server
+
+        monkeypatch.setattr(server, "in_docker", lambda: True)
+
+        file = tmp_path.joinpath("resolv.conf")
+        with file.open("w") as outfile:
+            print(
+                "nameserver 127.0.0.11\n"
+                "search default.svc.cluster.local svc.cluster.local cluster.local\n"
+                "options ndots:5",
+                file=outfile,
+            )
+
+        add_resolv_entry(file)
+
+        with file.open() as infile:
+            new_contents = infile.read()
+
+        lines = new_contents.splitlines()
+        assert "nameserver 127.0.0.1" in lines
+        assert "search default.svc.cluster.local svc.cluster.local cluster.local" in lines
+        assert "options ndots:5" in lines
+
     def test_no_resolv_conf_overwriting_on_host(self, tmp_path: Path, monkeypatch):
         from localstack.dns import server
 

--- a/tests/unit/test_dns_server.py
+++ b/tests/unit/test_dns_server.py
@@ -441,6 +441,9 @@ class TestDnsUtils:
         assert "search default.svc.cluster.local svc.cluster.local cluster.local" in lines
         assert "options ndots:5" in lines
 
+        # check the previous value is _not_ in the file
+        assert "nameserver 127.0.0.11" not in lines
+
     def test_no_resolv_conf_overwriting_on_host(self, tmp_path: Path, monkeypatch):
         from localstack.dns import server
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A user mentioned that their DNS lookups within their Kubernetes cluster did not work with "simple" names, e.g. looking up a service by its name only - not specifying `.cluster.local` or `.<namespace>.svc.cluster.local` etc.

<!-- What notable changes does this PR make? -->
## Changes

* Rather than clobbering the entire `/etc/resolv.conf` we only update the `nameservers` fields, leaving the `search` and `ndots` (and others) at their original values

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->