### PR TITLE
fix serialization for sqs http calls

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1654,12 +1654,13 @@ class SqsQueryResponseSerializer(QueryResponseSerializer):
         # Undo the second escaping of the &
         # Undo the second escaping of the carriage return (\r)
         if mime_type == APPLICATION_JSON:
+            # At this point the json was already dumped and escaped, so we replace directly.
             generated_string = generated_string.replace(r"__marker__\"__marker__", r"\"").replace(
                 "__marker__-r__marker__", r"\r"
             )
         else:
-            generated_string = generated_string.replace('__marker__"__marker__', '"').replace(
-                "__marker__-r__marker__", "\r"
+            generated_string = generated_string.replace('__marker__"__marker__', "&quot;").replace(
+                "__marker__-r__marker__", "&#xD;"
             )
 
         return to_bytes(generated_string)

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1334,14 +1334,16 @@ class TestSqsProvider:
         kwargs = {"flags": re.MULTILINE | re.DOTALL}
         assert re.match(rf".*<QueueUrl>\s*{url}/[^<]+</QueueUrl>.*", content, **kwargs)
 
+    @pytest.mark.parametrize(
+        argnames="json_body",
+        argvalues=['{"foo": "ba\rr", "foo2": "ba&quot;r&quot;"}', json.dumps('{"foo": "ba\rr"}')],
+    )
     @markers.aws.validated
     def test_marker_serialization_json_protocol(
-        self, sqs_create_queue, aws_client, aws_http_client_factory
+        self, sqs_create_queue, aws_client, aws_http_client_factory, json_body
     ):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
-        # message_body = {"foo": "ba\rr", "foo2": "ba&quot;r&quot;"}
-        # aws_client.sqs.send_message(QueueUrl=queue_name, MessageBody=json.dumps(message_body))
         message_body = '{"foo": "ba\rr", "foo2": "ba&quot;r&quot;"}'
         aws_client.sqs.send_message(QueueUrl=queue_name, MessageBody=message_body)
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1344,7 +1344,7 @@ class TestSqsProvider:
     ):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
-        message_body = '{"foo": "ba\rr", "foo2": "ba&quot;r&quot;"}'
+        message_body = json_body
         aws_client.sqs.send_message(QueueUrl=queue_name, MessageBody=message_body)
 
         client = aws_http_client_factory("sqs", region="us-east-1")

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -1334,6 +1334,38 @@ class TestSqsProvider:
         kwargs = {"flags": re.MULTILINE | re.DOTALL}
         assert re.match(rf".*<QueueUrl>\s*{url}/[^<]+</QueueUrl>.*", content, **kwargs)
 
+    @markers.aws.unknown
+    def test_marker_serialization_query_protocol(
+        self, sqs_create_queue, aws_client, region_name, create_iam_role_with_policy
+    ):
+        queue_name = f"queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        message_body = {"foo": "bar"}
+        aws_client.sqs.send_message(QueueUrl=queue_name, MessageBody=json.dumps(message_body))
+
+        # edge_url = config.internal_service_url()
+        # headers = mock_aws_request_headers(
+        #     "sqs",
+        #     aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+        #     region_name=region_name,
+        # )
+        # payload = f"Action=SendMessage&QueueUrl={queue_url}&MessageBody={message_body}"
+        # result = requests.post(edge_url, data=payload, headers=headers)
+
+        response = requests.get(
+            queue_url,
+            params={"Action": "ReceiveMessage", "MaxNumberOfMessages": 2},
+            headers={"Accept": "application/json"},
+        )
+        parsed_content = json.loads(response.content.decode("utf-8"))
+        # TODO: this is an error in LocalStack. Usually it should be Messages[0]['Body']
+        assert (
+            json.loads(
+                parsed_content["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["Body"]
+            )
+            == message_body
+        )
+
     @markers.aws.only_localstack
     def test_external_host_via_header_complete_message_lifecycle(
         self, monkeypatch, account_id, region_name

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -143,6 +143,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_list_queues": {
     "last_validated_date": "2024-04-30T13:39:55+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_json_protocol[\"{\\\\\"foo\\\\\": \\\\\"ba\\\\rr\\\\\"}\"]": {
+    "last_validated_date": "2024-05-07T07:46:12+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_json_protocol[{\"foo\": \"ba\\rr\", \"foo2\": \"ba&quot;r&quot;\"}]": {
+    "last_validated_date": "2024-05-07T07:46:10+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_query_protocol": {
     "last_validated_date": "2024-04-29T06:07:04+00:00"
   },

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -144,10 +144,10 @@
     "last_validated_date": "2024-04-30T13:39:55+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_json_protocol[\"{\\\\\"foo\\\\\": \\\\\"ba\\\\rr\\\\\"}\"]": {
-    "last_validated_date": "2024-05-07T07:46:12+00:00"
+    "last_validated_date": "2024-05-07T13:33:39+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_json_protocol[{\"foo\": \"ba\\rr\", \"foo2\": \"ba&quot;r&quot;\"}]": {
-    "last_validated_date": "2024-05-07T07:46:10+00:00"
+    "last_validated_date": "2024-05-07T13:33:34+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_query_protocol": {
     "last_validated_date": "2024-04-29T06:07:04+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -144,7 +144,7 @@
     "last_validated_date": "2024-04-30T13:39:55+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_query_protocol": {
-    "last_validated_date": "2024-04-26T11:07:04+00:00"
+    "last_validated_date": "2024-04-29T06:07:04+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
     "last_validated_date": "2024-04-30T13:35:34+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -143,6 +143,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_list_queues": {
     "last_validated_date": "2024-04-30T13:39:55+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_marker_serialization_query_protocol": {
+    "last_validated_date": "2024-04-26T11:07:04+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_deduplication_id_too_long": {
     "last_validated_date": "2024-04-30T13:35:34+00:00"
   },

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -505,6 +505,7 @@ def test_query_protocol_error_serialization_plain():
     # - The original response does not define an encoding.
     # - There is no newline after the XML declaration.
     # - The response does not contain a Type nor Detail tag (since they aren't contained in the spec).
+    # - The original response uses double quotes for the xml declaration.
     # Most of these differences should be handled equally by parsing clients, however, we might adopt some of these
     # changes in the future.
     expected_response_body = (

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -505,7 +505,6 @@ def test_query_protocol_error_serialization_plain():
     # - The original response does not define an encoding.
     # - There is no newline after the XML declaration.
     # - The response does not contain a Type nor Detail tag (since they aren't contained in the spec).
-    # - The original response uses double quotes for the xml declaration.
     # Most of these differences should be handled equally by parsing clients, however, we might adopt some of these
     # changes in the future.
     expected_response_body = (
@@ -513,7 +512,7 @@ def test_query_protocol_error_serialization_plain():
         '<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">'
         "<Error>"
         "<Code>ReceiptHandleIsInvalid</Code>"
-        "<Message>The input receipt handle &quot;garbage&quot; is not a valid receipt handle."
+        '<Message>The input receipt handle "garbage" is not a valid receipt handle.'
         "</Message>"
         "</Error>"
         "<RequestId>static_request_id</RequestId>"

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -512,7 +512,7 @@ def test_query_protocol_error_serialization_plain():
         '<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">'
         "<Error>"
         "<Code>ReceiptHandleIsInvalid</Code>"
-        '<Message>The input receipt handle "garbage" is not a valid receipt handle.'
+        "<Message>The input receipt handle &quot;garbage&quot; is not a valid receipt handle."
         "</Message>"
         "</Error>"
         "<RequestId>static_request_id</RequestId>"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When performing API calls for sqs like "ReceiveMessage" directly via HTTP outside the CLI, the response was malformed. It was malformed in general, and had an additional error for json messages. This PR addresses these issues.

<!-- What notable changes does this PR make? -->
## Changes
- fixes the json parsing by taking into account the escaping of a potential json dump

## TODO

What's left to do:

- [x] clarify if the asymmetry between the marker conversions has a reason. It seems odd that the code goes to great lengths explaining the reason for all the conversion, only to have these two ways differ -> not doing this results in strange conversion errors for \r on non-json messages.
- [ ] while tackling this, I found another bug: the response for ReceiveMessage is potentially further malformed. A usual cli call returns ```{Messages:[{<msg_1>}, {<msg_2>}, ...]}``` but we return ```{Message:{<msg_1>}}``` if there is one message, and ```{Message:[{<msg_1>}, {<msg_2>}, ...]}``` if there are more than one (note the missing plural s of Message). AWS' response is also different with a "direct" http call, but it is only the case that is different ("Messages" vs "messages"). How to proceed here? It seems to be an error in the automatic response creation of LS


