### PR TITLE
Feature: Eventbridge v2: Add input path

### DIFF
--- a/localstack/services/events/models.py
+++ b/localstack/services/events/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, TypedDict
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
@@ -7,6 +7,8 @@ from localstack.aws.api.events import (
     CreatedBy,
     EventBusName,
     EventPattern,
+    EventResourceList,
+    EventSourceName,
     ManagedBy,
     RoleArn,
     RuleDescription,
@@ -102,3 +104,15 @@ class InvalidEventPatternException(Exception):
     def __init__(self, reason=None, message=None) -> None:
         self.reason = reason
         self.message = message or f"Event pattern is not valid. Reason: {reason}"
+
+
+class FormattedEvent(TypedDict):
+    version: str
+    id: str
+    detail_type: Optional[str]  # key "detail-type" is automatically interpreted as detail_type
+    source: Optional[EventSourceName]
+    account: str
+    time: str
+    region: str
+    resources: Optional[EventResourceList]
+    detail: dict[str, str | dict]

--- a/localstack/services/events/models.py
+++ b/localstack/services/events/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, TypedDict
+from typing import Optional, TypeAlias, TypedDict
 
 from localstack.aws.api.core import ServiceException
 from localstack.aws.api.events import (
@@ -116,3 +116,6 @@ class FormattedEvent(TypedDict):
     region: str
     resources: Optional[EventResourceList]
     detail: dict[str, str | dict]
+
+
+TransformedEvent: TypeAlias = FormattedEvent | dict | str

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -59,6 +59,7 @@ from localstack.services.events.models import (
     EventBus,
     EventBusDict,
     EventsStore,
+    FormattedEvent,
     Rule,
     RuleDict,
     TargetDict,
@@ -125,7 +126,7 @@ def validate_event(event: PutEventsRequestEntry) -> None | PutEventsResultEntry:
         }
 
 
-def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> dict:
+def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> FormattedEvent:
     # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
     formatted_event = {
         "version": "0",

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -685,7 +685,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                     for target in rule.targets.values():
                         target_sender = self._target_sender_store[target["Arn"]]
                         try:
-                            target_sender.send_event(event)
+                            target_sender.process_event(event)
                             processed_entries.append({"EventId": event["id"]})
                         except Exception as error:
                             processed_entries.append(

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -12,6 +12,7 @@ from localstack.aws.api.events import (
     TargetInputPath,
 )
 from localstack.aws.connect import connect_to
+from localstack.services.events.models import FormattedEvent
 from localstack.utils import collections
 from localstack.utils.aws.arns import (
     extract_service_from_arn,
@@ -27,10 +28,10 @@ LOG = logging.getLogger(__name__)
 
 
 def transform_event_with_target_input_path(
-    input_path: TargetInputPath, event: PutEventsRequestEntry
+    input_path: TargetInputPath, event: FormattedEvent
 ) -> PutEventsRequestEntry:
-    event = extract_jsonpath(event, input_path)
-    return event
+    formated_event = extract_jsonpath(event, input_path)
+    return formated_event
 
 
 class TargetSender(ABC):
@@ -66,7 +67,7 @@ class TargetSender(ABC):
     def send_event(self, event: PutEventsRequestEntry):
         pass
 
-    def process_event(self, event: PutEventsRequestEntry):
+    def process_event(self, event: FormattedEvent):
         """Processes the event and send it to the target."""
         if input_path := self.target.get("InputPath"):
             event = transform_event_with_target_input_path(input_path, event)

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -7,12 +7,11 @@ from botocore.client import BaseClient
 
 from localstack.aws.api.events import (
     Arn,
-    PutEventsRequestEntry,
     Target,
     TargetInputPath,
 )
 from localstack.aws.connect import connect_to
-from localstack.services.events.models import FormattedEvent
+from localstack.services.events.models import FormattedEvent, TransformedEvent
 from localstack.utils import collections
 from localstack.utils.aws.arns import (
     extract_service_from_arn,
@@ -29,9 +28,9 @@ LOG = logging.getLogger(__name__)
 
 def transform_event_with_target_input_path(
     input_path: TargetInputPath, event: FormattedEvent
-) -> PutEventsRequestEntry:
-    formated_event = extract_jsonpath(event, input_path)
-    return formated_event
+) -> TransformedEvent:
+    formatted_event = extract_jsonpath(event, input_path)
+    return formatted_event
 
 
 class TargetSender(ABC):
@@ -64,7 +63,7 @@ class TargetSender(ABC):
         return self._client
 
     @abstractmethod
-    def send_event(self, event: PutEventsRequestEntry):
+    def send_event(self, event: FormattedEvent | TransformedEvent):
         pass
 
     def process_event(self, event: FormattedEvent):

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -38,6 +38,30 @@ class TestEventsInputPath:
         )
         snapshot.match("message", messages)
 
+    @markers.aws.validated
+    def test_put_events_with_input_path_nested(self, put_events_with_filter_to_sqs, snapshot):
+        entries1 = [
+            {
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(EVENT_DETAIL),
+            }
+        ]
+        entries_asserts = [(entries1, True)]
+        messages = put_events_with_filter_to_sqs(
+            pattern=TEST_EVENT_PATTERN,
+            entries_asserts=entries_asserts,
+            input_path="$.detail.payload",
+        )
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("MD5OfBody"),
+                snapshot.transform.key_value("ReceiptHandle"),
+            ]
+        )
+        snapshot.match("message", messages)
+
     @markers.aws.unknown
     def test_put_events_with_input_path_multiple(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -10,6 +10,11 @@ from tests.aws.services.events.conftest import sqs_collect_messages
 from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
 
+EVENT_DETAIL_DUPLICATED_KEY = {
+    "command": "update-account",
+    "payload": {"acc_id": "0a787ecb-4015", "payload": {"message": "baz", "id": "123"}},
+}
+
 
 class TestEventsInputPath:
     @markers.aws.validated
@@ -37,12 +42,15 @@ class TestEventsInputPath:
         snapshot.match("message", messages)
 
     @markers.aws.validated
-    def test_put_events_with_input_path_nested(self, put_events_with_filter_to_sqs, snapshot):
+    @pytest.mark.parametrize("event_detail", [EVENT_DETAIL, EVENT_DETAIL_DUPLICATED_KEY])
+    def test_put_events_with_input_path_nested(
+        self, event_detail, put_events_with_filter_to_sqs, snapshot
+    ):
         entries1 = [
             {
                 "Source": TEST_EVENT_PATTERN["source"][0],
                 "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
-                "Detail": json.dumps(EVENT_DETAIL),
+                "Detail": json.dumps(event_detail),
             }
         ]
         entries_asserts = [(entries1, True)]

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -15,7 +15,6 @@ from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTE
 
 class TestEventsInputPath:
     @markers.aws.unknown
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_path(self, aws_client, clean_up):
         queue_name = f"queue-{short_uid()}"
         rule_name = f"rule-{short_uid()}"
@@ -69,7 +68,6 @@ class TestEventsInputPath:
         clean_up(bus_name=bus_name, rule_name=rule_name, target_ids=target_id, queue_url=queue_url)
 
     @markers.aws.unknown
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_path_multiple(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())
         queue_name_1 = "queue-{}".format(short_uid())

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -62,6 +62,32 @@ class TestEventsInputPath:
         )
         snapshot.match("message", messages)
 
+    @markers.aws.validated
+    def test_put_events_with_input_path_max_level_depth(
+        self, put_events_with_filter_to_sqs, snapshot
+    ):
+        entries1 = [
+            {
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(EVENT_DETAIL),
+            }
+        ]
+        entries_asserts = [(entries1, True)]
+        messages = put_events_with_filter_to_sqs(
+            pattern=TEST_EVENT_PATTERN,
+            entries_asserts=entries_asserts,
+            input_path="$.detail.payload.sf_id",
+        )
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("MD5OfBody"),
+                snapshot.transform.key_value("ReceiptHandle"),
+            ]
+        )
+        snapshot.match("message", messages)
+
     @markers.aws.unknown
     def test_put_events_with_input_path_multiple(self, aws_client, clean_up):
         queue_name = "queue-{}".format(short_uid())

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -38,5 +38,21 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
+    "recorded-date": "06-05-2024, 14:40:27",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "sf_id": "baz"
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -54,5 +54,18 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
+    "recorded-date": "06-05-2024, 14:50:25",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"baz\""
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -19,5 +19,24 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
+    "recorded-date": "06-05-2024, 14:55:52",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -21,7 +21,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "recorded-date": "06-05-2024, 15:11:50",
+    "recorded-date": "08-05-2024, 13:54:10",
     "recorded-content": {
       "message": [
         {
@@ -105,6 +105,41 @@
                 "acc_id": "0a787ecb-4015",
                 "sf_id": "baz"
               }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "recorded-date": "08-05-2024, 13:54:42",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "sf_id": "baz"
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "recorded-date": "08-05-2024, 13:54:44",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "payload": {
+              "message": "baz",
+              "id": "123"
             }
           }
         }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -21,7 +21,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "recorded-date": "06-05-2024, 14:55:52",
+    "recorded-date": "06-05-2024, 15:11:50",
     "recorded-content": {
       "message": [
         {
@@ -40,7 +40,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
-    "recorded-date": "06-05-2024, 14:40:27",
+    "recorded-date": "06-05-2024, 15:11:52",
     "recorded-content": {
       "message": [
         {
@@ -56,7 +56,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "06-05-2024, 14:50:25",
+    "recorded-date": "06-05-2024, 15:11:54",
     "recorded-content": {
       "message": [
         {
@@ -64,6 +64,49 @@
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": "\"baz\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
+    "recorded-date": "06-05-2024, 15:22:58",
+    "recorded-content": {
+      "message-queue-1": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ],
+      "message-queue-2": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:3>",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
+              }
+            }
+          }
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
+    "last_validated_date": "2024-05-06T14:55:52+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"
   }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
     "last_validated_date": "2024-05-06T14:55:52+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
+    "last_validated_date": "2024-05-06T14:50:25+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
     "last_validated_date": "2024-05-06T14:40:27+00:00"
   },

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
     "last_validated_date": "2024-05-06T14:55:52+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
+    "last_validated_date": "2024-05-06T14:40:27+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"
   }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -1,12 +1,15 @@
 {
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-06T14:55:52+00:00"
+    "last_validated_date": "2024-05-06T15:11:50+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-06T14:50:25+00:00"
+    "last_validated_date": "2024-05-06T15:11:54+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
+    "last_validated_date": "2024-05-06T15:22:58+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
-    "last_validated_date": "2024-05-06T14:40:27+00:00"
+    "last_validated_date": "2024-05-06T15:11:52+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-06T15:11:50+00:00"
+    "last_validated_date": "2024-05-08T13:54:10+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
     "last_validated_date": "2024-05-06T15:11:54+00:00"
@@ -10,6 +10,12 @@
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
     "last_validated_date": "2024-05-06T15:11:52+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "last_validated_date": "2024-05-08T13:54:42+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "last_validated_date": "2024-05-08T13:54:44+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"

--- a/tests/aws/services/events/test_events_integrations.py
+++ b/tests/aws/services/events/test_events_integrations.py
@@ -634,9 +634,8 @@ def test_put_events_with_target_kinesis(aws_client):
     assert_valid_event(data)
 
 
-@markers.aws.unknown
+@markers.aws.needs_fixing  # TODO: Reason add permission and correct policies
 @pytest.mark.parametrize("strategy", ["standard", "domain", "path"])
-@pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
 def test_trigger_event_on_ssm_change(monkeypatch, aws_client, clean_up, strategy):
     monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", strategy)
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Enable the input path (transformer) feature (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Target.html).
This allows to specify an input path for the target, the body of matching event is parsed based on the specified json path and only the filtered content is sent to the target.

<!-- What notable changes does this PR make? -->
## Changes
Add input transformer functionality to rule class. 
Add `process_event` method that transforms the event content with the input path transformer if an input path is specified in the target.
Change from `send_event` to `process_event` method invoced by the provider.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

