### PR TITLE
[SFN] Improve Handling of Empty SendTaskFailure Calls

### DIFF
--- a/localstack/services/stepfunctions/asl/component/common/catch/catcher_decl.py
+++ b/localstack/services/stepfunctions/asl/component/common/catch/catcher_decl.py
@@ -75,8 +75,8 @@ class CatcherDecl(EvalComponent):
             )
         spec_event_details: dict = list(failure_event.event_details.values())[0]
         # If no cause or error fields are given, AWS binds an empty string; otherwise it attaches the value.
-        error = str() if "error" not in spec_event_details else spec_event_details["error"]
-        cause = str() if "cause" not in spec_event_details else spec_event_details["cause"]
+        error = spec_event_details.get("error", "")
+        cause = spec_event_details.get("cause", "")
         # Stepfunctions renames these fields to capital in this scenario.
         return {
             "Error": error,

--- a/localstack/services/stepfunctions/asl/component/common/catch/catcher_decl.py
+++ b/localstack/services/stepfunctions/asl/component/common/catch/catcher_decl.py
@@ -74,8 +74,9 @@ class CatcherDecl(EvalComponent):
                 f"Internal Error: invalid event details declaration in FailureEvent: '{failure_event}'."
             )
         spec_event_details: dict = list(failure_event.event_details.values())[0]
-        error = spec_event_details["error"]
-        cause = spec_event_details.get("cause") or ""
+        # If no cause or error fields are given, AWS binds an empty string; otherwise it attaches the value.
+        error = str() if "error" not in spec_event_details else spec_event_details["error"]
+        cause = str() if "cause" not in spec_event_details else spec_event_details["cause"]
         # Stepfunctions renames these fields to capital in this scenario.
         return {
             "Error": error,

--- a/localstack/services/stepfunctions/asl/component/common/error_name/custom_error_name.py
+++ b/localstack/services/stepfunctions/asl/component/common/error_name/custom_error_name.py
@@ -1,6 +1,8 @@
-from typing import Final
+from typing import Final, Optional
 
 from localstack.services.stepfunctions.asl.component.common.error_name.error_name import ErrorName
+
+ILLEGAL_CUSTOM_ERROR_PREFIX: Final[str] = "States."
 
 
 class CustomErrorName(ErrorName):
@@ -8,10 +10,8 @@ class CustomErrorName(ErrorName):
     States MAY report errors with other names, which MUST NOT begin with the prefix "States.".
     """
 
-    _ILLEGAL_PREFIX: Final[str] = "States."
-
-    def __init__(self, error_name: str):
-        if error_name.startswith(CustomErrorName._ILLEGAL_PREFIX):
+    def __init__(self, error_name: Optional[str]):
+        if error_name is not None and error_name.startswith(ILLEGAL_CUSTOM_ERROR_PREFIX):
             raise ValueError(
                 f"Custom Error Names MUST NOT begin with the prefix 'States.', got '{error_name}'."
             )

--- a/localstack/services/stepfunctions/asl/component/common/error_name/error_name.py
+++ b/localstack/services/stepfunctions/asl/component/common/error_name/error_name.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import abc
-from typing import Final
+from typing import Final, Optional
 
 from localstack.services.stepfunctions.asl.component.component import Component
 
 
 class ErrorName(Component, abc.ABC):
-    def __init__(self, error_name: str):
-        self.error_name: Final[str] = error_name
+    error_name: Final[Optional[str]]
 
-    def matches(self, error_name: str) -> bool:
+    def __init__(self, error_name: Optional[str]):
+        self.error_name = error_name
+
+    def matches(self, error_name: Optional[str]) -> bool:
         return self.error_name == error_name
 
     def __eq__(self, other):

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import time
+from typing import Optional
 
 from localstack.aws.api.stepfunctions import (
     HistoryEventExecutionDataDetails,
@@ -120,10 +121,10 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         self, env: Environment, ex: CallbackOutcomeFailureError
     ) -> FailureEvent:
         callback_outcome_failure: CallbackOutcomeFailure = ex.callback_outcome_failure
-        error: str = callback_outcome_failure.error
+        error: Optional[str] = callback_outcome_failure.error
         return FailureEvent(
             env=env,
-            error_name=CustomErrorName(error_name=callback_outcome_failure.error),
+            error_name=CustomErrorName(error_name=error),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(
                 taskFailedEventDetails=TaskFailedEventDetails(

--- a/localstack/services/stepfunctions/asl/eval/callback/callback.py
+++ b/localstack/services/stepfunctions/asl/eval/callback/callback.py
@@ -26,10 +26,10 @@ class CallbackOutcomeSuccess(CallbackOutcome):
 
 
 class CallbackOutcomeFailure(CallbackOutcome):
-    error: Final[str]
-    cause: Final[str]
+    error: Final[Optional[str]]
+    cause: Final[Optional[str]]
 
-    def __init__(self, callback_id: CallbackId, error: str, cause: str):
+    def __init__(self, callback_id: CallbackId, error: Optional[str], cause: Optional[str]):
         super().__init__(callback_id=callback_id)
         self.error = error
         self.cause = cause

--- a/tests/aws/services/stepfunctions/templates/callbacks/callback_templates.py
+++ b/tests/aws/services/stepfunctions/templates/callbacks/callback_templates.py
@@ -37,3 +37,9 @@ class CallbackTemplates(TemplateLoader):
     SQS_HEARTBEAT_SUCCESS_ON_TASK_TOKEN: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/sqs_hearbeat_success_on_task_token.json5"
     )
+    SQS_PARALLEL_WAIT_FOR_TASK_TOKEN: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/sqs_parallel_wait_for_task_token.json5"
+    )
+    SQS_WAIT_FOR_TASK_TOKEN_CATCH: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/sqs_wait_for_task_token_catch.json5"
+    )

--- a/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_parallel_wait_for_task_token.json5
+++ b/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_parallel_wait_for_task_token.json5
@@ -1,0 +1,53 @@
+{
+  "Comment": "SQS_PARALLEL_WAIT_FOR_TASK_TOKEN",
+  "StartAt": "ParallelJob",
+  "States": {
+    "ParallelJob": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "SendMessageWithWait",
+          "States": {
+            "SendMessageWithWait": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+              "Parameters": {
+                "QueueUrl.$": "$.QueueUrl",
+                "MessageBody": {
+                  "Context.$": "$",
+                  "TaskToken.$": "$$.Task.Token"
+                }
+              },
+              "End": true
+            },
+          }
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.Runtime"
+          ],
+          "ResultPath": "$.states_runtime_error",
+          "Next": "CaughtRuntimeError"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.states_all_error",
+          "Next": "CaughtStatesALL"
+        }
+      ],
+      "End": true
+    },
+    "CaughtRuntimeError": {
+      "Type": "Pass",
+      "End": true
+    },
+    "CaughtStatesALL": {
+      "Type": "Pass",
+      "End": true
+    },
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_wait_for_task_token_catch.json5
+++ b/tests/aws/services/stepfunctions/templates/callbacks/statemachines/sqs_wait_for_task_token_catch.json5
@@ -1,0 +1,42 @@
+{
+  "Comment": "SQS_WAIT_FOR_TASK_TOKEN_CATCH",
+  "StartAt": "SendMessageWithWait",
+  "States": {
+    "SendMessageWithWait": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+      "Parameters": {
+        "QueueUrl.$": "$.QueueUrl",
+        "MessageBody": {
+          "Context.$": "$",
+          "TaskToken.$": "$$.Task.Token"
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.Runtime"
+          ],
+          "ResultPath": "$.states_runtime_error",
+          "Next": "CaughtRuntimeError"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.states_all_error",
+          "Next": "CaughtStatesALL"
+        }
+      ],
+      "End": true
+    },
+    "CaughtRuntimeError": {
+      "Type": "Pass",
+      "End": true
+    },
+    "CaughtStatesALL": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.py
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.py
@@ -750,7 +750,13 @@ class TestCallback:
             task_token = message_body["TaskToken"]
             aws_client.stepfunctions.send_task_failure(taskToken=task_token)
 
-        threading.Thread(target=_empty_send_task_failure_on_sqs_message, args=()).start()
+        thread_send_task_failure = threading.Thread(
+            target=_empty_send_task_failure_on_sqs_message,
+            args=(),
+            name="Thread_empty_send_task_failure_on_sqs_message",
+        )
+        thread_send_task_failure.daemon = True
+        thread_send_task_failure.start()
 
         template = CT.load_sfn_template(template)
         definition = json.dumps(template)

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.py
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.py
@@ -5,6 +5,7 @@ import pytest
 from localstack_snapshot.snapshots.transformer import JsonpathTransformer, RegexTransformer
 
 from localstack.services.stepfunctions.asl.eval.count_down_latch import CountDownLatch
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -716,7 +717,8 @@ class TestCallback:
         request,
     ):
         if (
-            request.node.name
+            not is_aws_cloud()
+            and request.node.name
             == "test_sqs_failure_in_wait_for_task_tok_no_error_field[SQS_PARALLEL_WAIT_FOR_TASK_TOKEN]"
         ):
             # TODO: The conditions in which TaskStateAborted error events are logged requires further investigations.

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.snapshot.json
@@ -3110,5 +3110,459 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_failure_in_wait_for_task_tok_no_error_field[SQS_PARALLEL_WAIT_FOR_TASK_TOKEN]": {
+    "recorded-date": "29-04-2024, 10:07:12",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<resource:1>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "ParallelJob"
+            },
+            "timestamp": "timestamp",
+            "type": "ParallelStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "timestamp": "timestamp",
+            "type": "ParallelStateStarted"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "SendMessageWithWait"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "MessageBody": {
+                  "Context": {
+                    "QueueUrl": "<sqs_queue_url>",
+                    "Message": "test_message_txt"
+                  },
+                  "TaskToken": "<task_token:1>"
+                },
+                "QueueUrl": "<sqs_queue_url>"
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "connection": [
+                      "keep-alive"
+                    ],
+                    "Content-Length": [
+                      "106"
+                    ],
+                    "Date": "date",
+                    "Content-Type": [
+                      "application/x-amz-json-1.0"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "Date": "date",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "taskFailedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "TaskStateAborted"
+          },
+          {
+            "id": 10,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ParallelStateFailed"
+          },
+          {
+            "id": 11,
+            "previousEventId": 10,
+            "stateExitedEventDetails": {
+              "name": "ParallelJob",
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ParallelStateExited"
+          },
+          {
+            "id": 12,
+            "previousEventId": 11,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "CaughtStatesALL"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 13,
+            "previousEventId": 12,
+            "stateExitedEventDetails": {
+              "name": "CaughtStatesALL",
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 14,
+            "previousEventId": 13,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_failure_in_wait_for_task_tok_no_error_field[SQS_WAIT_FOR_TASK_TOKEN_CATCH]": {
+    "recorded-date": "29-04-2024, 10:07:27",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<resource:1>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "SendMessageWithWait"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "MessageBody": {
+                  "Context": {
+                    "QueueUrl": "<sqs_queue_url>",
+                    "Message": "test_message_txt"
+                  },
+                  "TaskToken": "<task_token:1>"
+                },
+                "QueueUrl": "<sqs_queue_url>"
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "connection": [
+                      "keep-alive"
+                    ],
+                    "Content-Length": [
+                      "106"
+                    ],
+                    "Date": "date",
+                    "Content-Type": [
+                      "application/x-amz-json-1.0"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "connection": "keep-alive",
+                    "Content-Length": "106",
+                    "Content-Type": "application/x-amz-json-1.0",
+                    "Date": "date",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskFailedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "SendMessageWithWait",
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "CaughtStatesALL"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "stateExitedEventDetails": {
+              "name": "CaughtStatesALL",
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "QueueUrl": "<sqs_queue_url>",
+                "Message": "test_message_txt",
+                "states_all_error": {
+                  "Error": null,
+                  "Cause": null
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 10,
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.validation.json
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.validation.json
@@ -8,6 +8,12 @@
   "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sns_publish_wait_for_task_token": {
     "last_validated_date": "2024-02-01T20:51:35+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_failure_in_wait_for_task_tok_no_error_field[SQS_PARALLEL_WAIT_FOR_TASK_TOKEN]": {
+    "last_validated_date": "2024-04-29T10:07:12+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_failure_in_wait_for_task_tok_no_error_field[SQS_WAIT_FOR_TASK_TOKEN_CATCH]": {
+    "last_validated_date": "2024-04-29T10:07:27+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/callback/test_callback.py::TestCallback::test_sqs_failure_in_wait_for_task_token": {
     "last_validated_date": "2024-04-18T06:24:24+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the StepFunctions v2 interpreter is unable of handling empty SentTaskFailure api calls. These are SendTaskFailure messages for waitForTaskToken tasks which do not provide an error string. Such calls would result in internal States.Runtime errors, and misleading error messages such as `Custom Error Names MUST NOT begin with the prefix 'States.', got 'State.Runtime'`.  This PR adds snapshot tests replicating this occurrence and add support for CustomErrorNames to have nullable error strings. It also identifies need for future work on StateTaskAbort events logging.

<!-- What notable changes does this PR make? -->
## Changes
- Nullable error strings in CustomErrorName objects
- Related handling of null error strings
- Snapshot tests

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

