### PR TITLE
Parametrize test selection scripts for usage in dependent repositories

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -7,11 +7,11 @@ on:
         required: false
         type: boolean
         default: false
-      disableTestSelection:
-        description: 'Disable Test Selection'
+      enableTestSelection:
+        description: 'Enable Test Selection'
         required: false
         type: boolean
-        default: false
+        default: true
       targetRef:
         description: 'LocalStack Pro Ref'
         required: false
@@ -23,11 +23,11 @@ on:
         required: false
         type: boolean
         default: false
-      disableTestSelection:
-        description: 'Disable Test Selection'
+      enableTestSelection:
+        description: 'Enable Test Selection'
         required: false
         type: boolean
-        default: false
+        default: true
       targetRef:
         description: 'LocalStack Pro Ref'
         required: false
@@ -91,7 +91,8 @@ env:
   CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
   # report to tinybird if executed on master
   TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
-  TESTSELECTION_PYTEST_ARGS: "${{ github.event_name == 'pull_request' && inputs.disableTestSelection && '--path-filter=../localstack/target/testselection/test-selection.txt ' || '' }}"
+  # enable test selection if  not running on master and test selection is not explicitly disabled
+  TESTSELECTION_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && inputs.enableTestSelection != false && '--path-filter=../localstack/target/testselection/test-selection.txt ' || '' }}"
 
 jobs:
   test-pro:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,7 +92,7 @@
 /localstack/testing/pytest/container.py @dominikschubert @simonrw
 
 # Test Selection
-/localstack/testing/testselection @dominikschubert @alexrashed 
+/localstack/testing/testselection @dominikschubert @alexrashed @silv-io
 
 ######################
 ### SERVICE OWNERS ###

--- a/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
+++ b/localstack/testing/testselection/scripts/generate_test_selection_from_pr.py
@@ -5,17 +5,23 @@ USAGE: $ GITHUB_API_TOKEN=<your-token> python -m localstack.testing.testselectio
 import os
 import sys
 from pathlib import Path
+from typing import Iterable
 
 from localstack.testing.testselection.git import find_merge_base, get_changed_files_from_git_diff
 from localstack.testing.testselection.github import get_pr_details_from_url
+from localstack.testing.testselection.matching import MatchingRule
 from localstack.testing.testselection.opt_in import complies_with_opt_in
 from localstack.testing.testselection.testselection import get_affected_tests_from_changes
 
 
-def main():
+def generate_from_pr(
+    opt_in_rules: Iterable[str] | None = None,
+    matching_rules: list[MatchingRule] | None = None,
+    repo_name: str = "localstack",
+):
     if len(sys.argv) != 4:
         print(
-            "Usage: python -m localstack.testing.testselection.scripts.generate_test_selection_from_pr <git-root-dir> <pull-request-url> <output-file-path>",
+            f"Usage: python -m {repo_name}.testing.testselection.scripts.generate_test_selection_from_pr <git-root-dir> <pull-request-url> <output-file-path>",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -37,13 +43,13 @@ def main():
     )
     # opt-in guard, can be removed after initial testing phase
     print("Checking for confirming to opt-in guards")
-    if not complies_with_opt_in(changed_files):
+    if not complies_with_opt_in(changed_files, opt_in_rules=opt_in_rules):
         print(
-            "Change outside of opt-in guards. Extend the list at localstack/testing/testselection/opt_in.py"
+            f"Change outside of opt-in guards. Extend the list at {repo_name}/testing/testselection/opt_in.py"
         )
         test_files = ["SENTINEL_ALL_TESTS"]
     else:
-        test_files = get_affected_tests_from_changes(changed_files)
+        test_files = get_affected_tests_from_changes(changed_files, matching_rules=matching_rules)
 
     print(f"Number of changed files detected: {len(changed_files)}")
     for cf in sorted(changed_files):
@@ -68,4 +74,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    generate_from_pr()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Using the test selection scripts in repositories with slightly different requirements is difficult because of a lack of parametrization.

<!-- What notable changes does this PR make? -->
## Changes

This PR adds parametrization in regards to repository name, opt_in dictionary and matching rules for test selection.

/cc @alexrashed 


## Testing

The test selection should still work as before:

1. Create a dummy change commit where you only change a simple thing in one service
2. Run
`python -m localstack/testing/testselection/scripts/generate_test_selection_from_commits.py . <HEAD~> <HEAD> test-selection`

Output should be only the service tests (if it's opted in)

## TODO

What's left to do:

- [x] parametrize generic testing rule


