### PR TITLE
fixed physical resource id for AWS::Glue::SchemaVersionMetadata

### DIFF
--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -30,6 +30,7 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::SSM::Parameter": "/properties/Name",
     "AWS::RDS::DBProxyTargetGroup": "/properties/TargetGroupName",
+    "AWS::Glue::SchemaVersionMetadata": "</properties/SchemaVersionId>|</properties/Key>|</properties/Value>",  # composite
 }
 
 # You can usually find the available GetAtt targets in the official resource documentation:


### PR DESCRIPTION
## Motivation
This PR addresses the issue with the `PhysicalResourceId` format for `AWS::Glue::SchemaVersionMetadata`. Previously, it was generated as `<uuid>-<key>-<value>`, whereas in AWS it should be `<uuid>|<key>|<value>`.

## Changes
Modified `PhysicalResourceId` to align with AWS.

## Testing
- This changes are validated (snapshot tested) in https://github.com/localstack/localstack-ext/pull/584.


