### PR TITLE
[SFN] Fix Flaky Stop Execution Test

### DIFF
--- a/tests/aws/services/stepfunctions/utils.py
+++ b/tests/aws/services/stepfunctions/utils.py
@@ -120,7 +120,7 @@ def await_state_machine_version_listed(
         )
 
 
-def _await_on_execution_events(
+def await_on_execution_events(
     stepfunctions_client, execution_arn: str, check_func: Callable[[HistoryEventList], bool]
 ) -> None:
     def _run_check():
@@ -148,7 +148,7 @@ def await_execution_success(stepfunctions_client, execution_arn: str):
             return "executionSucceededEventDetails" in last_event
         return False
 
-    _await_on_execution_events(
+    await_on_execution_events(
         stepfunctions_client=stepfunctions_client,
         execution_arn=execution_arn,
         check_func=_check_last_is_success,
@@ -190,7 +190,7 @@ def await_execution_terminated(stepfunctions_client, execution_arn: str):
             }
         return False
 
-    _await_on_execution_events(
+    await_on_execution_events(
         stepfunctions_client=stepfunctions_client,
         execution_arn=execution_arn,
         check_func=_check_last_is_terminal,
@@ -221,7 +221,7 @@ def await_execution_started(stepfunctions_client, execution_arn: str):
             return "executionStartedEventDetails" in event
         return False
 
-    _await_on_execution_events(
+    await_on_execution_events(
         stepfunctions_client=stepfunctions_client,
         execution_arn=execution_arn,
         check_func=_check_stated_exists,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.snapshot.json
@@ -469,7 +469,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_stop_execution": {
-    "recorded-date": "22-06-2023, 13:53:24",
+    "recorded-date": "06-05-2024, 12:59:34",
     "recorded-content": {
       "creation_resp": {
         "creationDate": "datetime",

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.validation.json
@@ -93,6 +93,6 @@
     "last_validated_date": "2024-03-14T21:59:25+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api.py::TestSnfApi::test_stop_execution": {
-    "last_validated_date": "2023-06-22T11:53:24+00:00"
+    "last_validated_date": "2024-05-06T12:59:34+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the test `tests.aws.services.stepfunctions.v2.test_sfn_api.TestSnfApi.test_stop_execution` is flaky as the wait condition before sending the interrupt action does not wait on a (semi)terminal point, when the evaluation starts executing the wait state, but rather on the start of the program evaluation. This PR addresses this issue by defining the wait condition before sending the interrupt to be the execution of the wait state.

<!-- What notable changes does this PR make? -->
## Changes
- Changed the wait condition to be the wait state execution, not the execution start
- Exposes the wait on event logic as other test cases may benefit from this flexibility
- Regenerated snapshot test

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

