### PR TITLE
Remove fix to relative persistence path for Kinesis

### DIFF
--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -86,9 +86,7 @@ class KinesisMockServer(Server):
 
         if self._data_dir and config.KINESIS_PERSISTENCE:
             env_vars["SHOULD_PERSIST_DATA"] = "true"
-            # FIXME use relative path to current working directory until
-            #  https://github.com/etspaceman/kinesis-mock/issues/554 is resolved
-            env_vars["PERSIST_PATH"] = os.path.relpath(self._data_dir)
+            env_vars["PERSIST_PATH"] = self._data_dir
             env_vars["PERSIST_FILE_NAME"] = self._data_filename
             env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I randomly came across this `FIXME` comment here. The use of the relative path should not be needed, as the upstream [issue](https://github.com/etspaceman/kinesis-mock/issues/554) has been resolved.
I also run the persistence tests in a [companion branch](https://github.com/localstack/localstack-ext/actions/runs/8929367616/job/24527310273?pr=2937).


<!-- What notable changes does this PR make? -->
## Changes
- Removed the use of `os.path.relpath` for the `PERSIST_PATH` env variable.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

