### PR TITLE
fix: add Opensearch analysis-phonetic plugin

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -121,6 +121,7 @@ OPENSEARCH_DEFAULT_VERSION = "OpenSearch_2.11"
 OPENSEARCH_PLUGIN_LIST = [
     "ingest-attachment",
     "analysis-kuromoji",
+    "analysis-phonetic",
 ]
 
 # API endpoint for analytics events


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Install the `analysis-phonetic` plugin for Opensearch by default.

I provide [more detail in this issue](https://github.com/localstack/localstack/issues/10745). This plugin, along with others, [comes installed by default in AWS](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html), but that is not the case with localstack. Based on some old PR's I found, the reason to not include them all by default in localstack is down to concerns around install download & setup time. In my opinion, it would be better for localstack to match the defaults, but that change is out of scope for me - I only need one of the default plugins.

I require this plugin because I cannot use [elasticdump](https://github.com/elasticsearch-dump/elasticsearch-dump) to copy indexes from my actual Opensearch clusters into localstack unless this default plugin is installed. I feel like this might be a common scenario for others because they may want to populate Opensearch locally with some indexes\documents.

<!-- What notable changes does this PR make? -->
## Changes
- Adds `analysis-phonetic` plugin to the list of plugins installed for OpenSearch
This just involves updating a constant. No other logic changes required.

## Testing

- [This test already covers it.](https://github.com/localstack/localstack/blob/master/tests/aws/services/opensearch/test_opensearch.py#L362-L369) It checks that the installed plugins matches the plugins specified by this constant



