### PR TITLE
Fix CFn UpdateStack response on identical templates that include a transformation

### DIFF
--- a/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.snapshot.json
@@ -1165,5 +1165,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_update_stack_with_same_template_withoutchange": {
+    "recorded-date": "07-05-2024, 08:34:18",
+    "recorded-content": {
+      "no_change_exception": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "No updates are to be performed.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_stacks.validation.json
@@ -20,6 +20,12 @@
   "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_update_resources": {
     "last_validated_date": "2022-08-29T22:13:26+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_update_stack_with_same_template_withoutchange": {
+    "last_validated_date": "2024-05-07T08:35:29+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_stacks.py::TestStacksApi::test_update_stack_with_same_template_withoutchange_transformation": {
+    "last_validated_date": "2024-05-07T09:26:39+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_stacks.py::test_blocked_stack_deletion": {
     "last_validated_date": "2023-09-06T09:01:18+00:00"
   },

--- a/tests/aws/templates/simple_no_change.yaml
+++ b/tests/aws/templates/simple_no_change.yaml
@@ -1,0 +1,3 @@
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic

--- a/tests/aws/templates/simple_no_change_with_transformation.yaml
+++ b/tests/aws/templates/simple_no_change_with_transformation.yaml
@@ -1,0 +1,4 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic


### PR DESCRIPTION

## Motivation

Fixes #10562

The CloudFormation `UpdateStack` operation behaves differently in the case of no updates depending on if there's template processing involved or not (e.g. via transformation/macro). This is a sort of hotfix for #10562 and we might need to investigate a bit more *why* this happens, e.g. via also looking at the situation when using ChangeSets. 

## Changes

- If the template is undergoing a transformation on UpdateStack, we now don't raise an exception anymore to be in parity with AWS.


## Testing

See #10562. Two validated tests have been added as well (replacing one old `needs_fixing`).

