### PR TITLE
Feature/eventbridge v2 add input transformer

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -423,8 +423,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         rule_service = self.get_rule_service(context, rule, event_bus_name)
         failed_entries = rule_service.add_targets(targets)
         rule_arn = rule_service.arn
+        rule_name = rule_service.rule.name
         for target in targets:  # TODO only add successful targets
-            self.create_target_sender(target, region, account_id, rule_arn)
+            self.create_target_sender(target, region, account_id, rule_arn, rule_name)
 
         response = PutTargetsResponse(
             FailedEntryCount=len(failed_entries), FailedEntries=failed_entries
@@ -568,10 +569,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         return rule_service
 
     def create_target_sender(
-        self, target: Target, region: str, account_id: str, rule_arn: Arn
+        self, target: Target, region: str, account_id: str, rule_arn: Arn, rule_name: RuleName
     ) -> TargetSender:
         target_sender = TargetSenderFactory(
-            target, region, account_id, rule_arn
+            target, region, account_id, rule_arn, rule_name
         ).get_target_sender()
         self._target_sender_store[target_sender.arn] = target_sender
         return target_sender

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -131,11 +131,11 @@ class TargetSender(ABC):
         template_replacements.update(predefined_template_replacements)
 
         is_json_format = input_template.strip().startswith(("{", "["))
-        formatted_template = replace_template_placeholders(
+        populated_template = replace_template_placeholders(
             input_template, template_replacements, is_json_format
         )
 
-        return formatted_template
+        return populated_template
 
     def _validate_input(self, target: Target):
         """Provide a default implementation extended for each target based on specifications."""

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -140,6 +140,10 @@ class TargetSender(ABC):
     def _validate_input(self, target: Target):
         """Provide a default implementation extended for each target based on specifications."""
         # TODO add For Lambda and Amazon SNS resources, EventBridge relies on resource-based policies.
+        if "InputPath" in target and "InputTransformer" in target:
+            raise ValidationException(
+                f"Only one of Input, InputPath, or InputTransformer must be provided for target {target.get('Id')}."
+            )
         if input_transformer := target.get("InputTransformer"):
             self._validate_input_transformer(input_transformer)
 

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -183,7 +183,9 @@ class TargetSender(ABC):
         predefined_template_replacements["aws.events.rule-name"] = self.rule_name
         predefined_template_replacements["aws.events.event.ingestion-time"] = event["time"]
         predefined_template_replacements["aws.events.event"] = {
-            "detailType" if k == "detail-type" else k: v for k, v in event.items() if k != "detail"
+            "detailType" if k == "detail-type" else k: v  # detail-type is is returned as detailType
+            for k, v in event.items()
+            if k != "detail"  # detail is not part of .event placeholder
         }
         predefined_template_replacements["aws.events.event.json"] = event
 

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -192,7 +192,6 @@ class KinesisTargetSender(TargetSender):
 
     def _validate_input(self, target: Target):
         super()._validate_input(target)
-        # TODO add validated test to check if RoleArn is mandatory
         if not collections.get_safe(target, "$.RoleArn"):
             raise ValueError("RoleArn is required for Kinesis target")
         if not collections.get_safe(target, "$.KinesisParameters.PartitionKeyPath"):

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -130,7 +130,7 @@ class TargetSender(ABC):
         predefined_template_replacements = self._get_predefined_template_replacements(event)
         template_replacements.update(predefined_template_replacements)
 
-        is_json_format = input_template.strip().startswith(("{", "["))
+        is_json_format = input_template.strip().startswith(("{"))
         populated_template = replace_template_placeholders(
             input_template, template_replacements, is_json_format
         )

--- a/localstack/services/events/target.py
+++ b/localstack/services/events/target.py
@@ -28,6 +28,7 @@ from localstack.utils.time import now_utc
 
 LOG = logging.getLogger(__name__)
 
+# https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html#eb-transform-input-predefined
 AWS_PREDEFINED_PLACEHOLDERS_STRING_VALUES = {
     "aws.events.rule-arn",
     "aws.events.rule-name",

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -429,9 +429,11 @@ class TestInputTransformer:
                 snapshot.transform.regex(rule_name, "<rule-name>"),
                 snapshot.transform.key_value("MD5OfBody"),
                 snapshot.transform.key_value("ReceiptHandle"),
-                # snapshot.transform.jsonpath(
-                #     "$.messages[*].Body.originalEvent.time", value_replacement="ingestion-time"
-                # ), # TODO fix error for int replacement value
+                snapshot.transform.jsonpath(
+                    "$.messages[*].Body.originalEvent.time",
+                    value_replacement="<ingestion-time>",
+                    reference_replacement=False,
+                ),
             ]
         )
         snapshot.match("messages", messages)

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -65,11 +65,7 @@ def test_put_event_input_path_and_input_transfomer(
             ],
         )
 
-    snapshot.add_transformer(
-        [
-            snapshot.transform.regex(target_id, "<target-id>"),
-        ]
-    )
+    snapshot.add_transformer(snapshot.transform.regex(target_id, "<target-id>"))
     snapshot.match("missing-key-exception", exception)
 
 
@@ -373,11 +369,7 @@ class TestInputTransformer:
                 ],
             )
 
-        snapshot.add_transformer(
-            [
-                snapshot.transform.regex(target_id, "<target-id>"),
-            ]
-        )
+        snapshot.add_transformer(snapshot.transform.regex(target_id, "<target-id>"))
         snapshot.match("missing-key-exception", exception)
 
     @markers.aws.validated

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -8,6 +8,7 @@ from botocore.client import Config
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from tests.aws.services.events.conftest import sqs_collect_messages
+from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import EVENT_DETAIL, TEST_EVENT_PATTERN
 
 EVENT_DETAIL_DUPLICATED_KEY = {
@@ -21,6 +22,10 @@ INPUT_TEMPLATE_PREDEFINED_VARIABLES_JSON = '{"originalEvent": <aws.events.event>
 
 
 @markers.aws.validated
+@pytest.mark.skipif(
+    not is_v2_provider(),
+    reason="V1 provider does not support this feature",
+)
 def test_put_event_input_path_and_input_transfomer(
     create_sqs_events_target, events_create_event_bus, events_put_rule, aws_client, snapshot
 ):
@@ -261,6 +266,10 @@ class TestInputTransformer:
         snapshot.match("custom-variables-not-match-all", messages_not_match_all)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_events_with_input_transformer_input_template_json(
         self, put_events_with_filter_to_sqs, snapshot
     ):
@@ -316,6 +325,10 @@ class TestInputTransformer:
         snapshot.match("custom-variables-not-match-all", messages_not_match_all)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_put_events_with_input_transformer_missing_keys(
         self,
         create_sqs_events_target,
@@ -368,6 +381,10 @@ class TestInputTransformer:
         snapshot.match("missing-key-exception", exception)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     @pytest.mark.parametrize(
         "input_template",
         [INPUT_TEMPLATE_PREDEFINE_VARIABLES_STR, INPUT_TEMPLATE_PREDEFINED_VARIABLES_JSON],

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -406,7 +406,7 @@ class TestInputTransformer:
         bus_name = f"test-bus-{short_uid()}"
         events_create_event_bus(Name=bus_name)
 
-        rule_name = f"test-rule-{short_uid()}"
+        rule_name = f"test-rule-/slash-{short_uid()}"
         events_put_rule(
             Name=rule_name,
             EventBusName=bus_name,

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -155,16 +155,12 @@ class TestEventsInputPath:
 class TestEventsInputTransformers:
     @markers.aws.validated
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
-    def test_put_events_with_input_transformation_to_sqs(
-        self, put_events_with_filter_to_sqs, snapshot
-    ):
-        pattern = {"detail-type": ["customerCreated"]}
-        event_detail = {"command": "display-message", "payload": "baz"}
+    def test_put_events_with_input_transformer(self, put_events_with_filter_to_sqs, snapshot):
         entries = [
             {
-                "Source": "com.mycompany.myapp",
-                "DetailType": "customerCreated",
-                "Detail": json.dumps(event_detail),
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(EVENT_DETAIL),
             }
         ]
         entries_asserts = [(entries, True)]
@@ -181,7 +177,7 @@ class TestEventsInputTransformers:
             "InputTemplate": input_template,
         }
         messages_match_all = put_events_with_filter_to_sqs(
-            pattern=pattern,
+            pattern=TEST_EVENT_PATTERN,
             entries_asserts=entries_asserts,
             input_transformer=input_transformer_match_all,
         )
@@ -197,7 +193,7 @@ class TestEventsInputTransformers:
             "InputTemplate": input_template,
         }
         messages_not_match_all = put_events_with_filter_to_sqs(
-            pattern=pattern,
+            pattern=TEST_EVENT_PATTERN,
             entries_asserts=entries_asserts,
             input_transformer=input_transformer_not_match_all,
         )

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -207,8 +207,15 @@ class TestInputPath:
 
 class TestInputTransformer:
     @markers.aws.validated
+    @pytest.mark.parametrize(
+        "input_template",
+        [
+            '"Event of <detail-type> type, at time <timestamp>, info extracted from detail <command>"',
+            '"{[/Check with special starting characters for event of <detail-type> type"',
+        ],
+    )
     def test_put_events_with_input_transformer_input_template_string(
-        self, put_events_with_filter_to_sqs, snapshot
+        self, input_template, put_events_with_filter_to_sqs, snapshot
     ):
         entries = [
             {
@@ -225,7 +232,7 @@ class TestInputTransformer:
             "timestamp": "$.time",
             "command": "$.detail.command",
         }
-        input_template = '"Event of <detail-type> type, at time <timestamp>, info extracted from detail <command>"'
+        input_template = input_template
         input_transformer_match_all = {
             "InputPathsMap": input_path_map,
             "InputTemplate": input_template,

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -20,7 +20,7 @@ INPUT_TEMPLATE_PREDEFINE_VARIABLES_STR = '"Message containing all pre defined va
 INPUT_TEMPLATE_PREDEFINED_VARIABLES_JSON = '{"originalEvent": <aws.events.event>, "originalEventJson": <aws.events.event.json>}'  # important to not quote the predefined variables
 
 
-class TestEventsInputPath:  # TODO rename
+class TestInputPath:
     @markers.aws.validated
     def test_put_events_with_input_path(self, put_events_with_filter_to_sqs, snapshot):
         entries1 = [

--- a/tests/aws/services/events/test_events_inputs.py
+++ b/tests/aws/services/events/test_events_inputs.py
@@ -156,7 +156,7 @@ class TestInputPath:
         snapshot.match("message-queue-2", messages_queue_2)
 
 
-class TestEventsInputTransformers:  # TODO rename
+class TestInputTransformer:
     @markers.aws.validated
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_put_events_with_input_transformer(self, put_events_with_filter_to_sqs, snapshot):

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -185,7 +185,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "recorded-date": "08-05-2024, 14:38:59",
+    "recorded-date": "08-05-2024, 14:40:07",
     "recorded-content": {
       "message": [
         {
@@ -204,7 +204,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "recorded-date": "08-05-2024, 14:39:01",
+    "recorded-date": "08-05-2024, 14:40:09",
     "recorded-content": {
       "message": [
         {
@@ -220,7 +220,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "recorded-date": "08-05-2024, 14:39:03",
+    "recorded-date": "08-05-2024, 14:40:11",
     "recorded-content": {
       "message": [
         {
@@ -239,7 +239,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "08-05-2024, 14:39:05",
+    "recorded-date": "08-05-2024, 14:40:13",
     "recorded-content": {
       "message": [
         {
@@ -252,7 +252,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "recorded-date": "08-05-2024, 14:39:08",
+    "recorded-date": "08-05-2024, 14:40:16",
     "recorded-content": {
       "message-queue-1": [
         {
@@ -287,6 +287,81 @@
               "payload": {
                 "acc_id": "0a787ecb-4015",
                 "sf_id": "baz"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
+    "recorded-date": "08-05-2024, 14:40:20",
+    "recorded-content": {
+      "custom-variables-match-all": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
+    "recorded-date": "08-05-2024, 14:40:23",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Message containing all pre defined variables arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name> <rule-name> date\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
+    "recorded-date": "08-05-2024, 14:40:25",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "originalEvent": {
+              "id": "<uuid:2>",
+              "account": "111111111111",
+              "detailType": "core.update-account-command",
+              "time": 1715179225000,
+              "source": "core.update-account-command",
+              "region": "<region>",
+              "resources": [],
+              "version": "0"
+            },
+            "originalEventJson": {
+              "version": "0",
+              "id": "<uuid:2>",
+              "detail-type": "core.update-account-command",
+              "source": "core.update-account-command",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "command": "update-account",
+                "payload": {
+                  "acc_id": "0a787ecb-4015",
+                  "sf_id": "baz"
+                }
               }
             }
           }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -368,5 +368,55 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
+    "recorded-date": "08-05-2024, 14:43:04",
+    "recorded-content": {
+      "custom-variables-match-all": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
+    "recorded-date": "08-05-2024, 14:43:08",
+    "recorded-content": {
+      "custom-variables-match-all": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "detailType": "core.update-account-command",
+            "time": "date",
+            "command": "update-account"
+          }
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "detailType": "core.update-account-command",
+            "time": "date",
+            "command": ""
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -1,27 +1,6 @@
 {
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "recorded-date": "07-05-2024, 08:44:39",
-    "recorded-content": {
-      "custom-variables-match-all": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
-        }
-      ],
-      "custom-variables-not-match-all": [
-        {
-          "MessageId": "<uuid:2>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
-        }
-      ]
-    }
-  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "recorded-date": "08-05-2024, 13:54:10",
+    "recorded-date": "08-05-2024, 14:37:28",
     "recorded-content": {
       "message": [
         {
@@ -39,8 +18,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
-    "recorded-date": "06-05-2024, 15:11:52",
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "recorded-date": "08-05-2024, 14:37:30",
     "recorded-content": {
       "message": [
         {
@@ -55,8 +34,27 @@
       ]
     }
   },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "recorded-date": "08-05-2024, 14:37:32",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "payload": {
+              "message": "baz",
+              "id": "123"
+            }
+          }
+        }
+      ]
+    }
+  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "06-05-2024, 15:11:54",
+    "recorded-date": "08-05-2024, 14:37:34",
     "recorded-content": {
       "message": [
         {
@@ -69,7 +67,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
-    "recorded-date": "06-05-2024, 15:22:58",
+    "recorded-date": "08-05-2024, 14:37:36",
     "recorded-content": {
       "message-queue-1": [
         {
@@ -111,35 +109,75 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "recorded-date": "08-05-2024, 13:54:42",
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
+    "recorded-date": "08-05-2024, 14:37:40",
     "recorded-content": {
-      "message": [
+      "custom-variables-match-all": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "acc_id": "0a787ecb-4015",
-            "sf_id": "baz"
-          }
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
         }
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "recorded-date": "08-05-2024, 13:54:44",
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
+    "recorded-date": "08-05-2024, 14:37:43",
     "recorded-content": {
-      "message": [
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Message containing all pre defined variables arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name> <rule-name> date\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
+    "recorded-date": "08-05-2024, 14:37:46",
+    "recorded-content": {
+      "messages": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
           "Body": {
-            "acc_id": "0a787ecb-4015",
-            "payload": {
-              "message": "baz",
-              "id": "123"
+            "originalEvent": {
+              "id": "<uuid:2>",
+              "account": "111111111111",
+              "detailType": "core.update-account-command",
+              "time": 1715179065000,
+              "source": "core.update-account-command",
+              "region": "<region>",
+              "resources": [],
+              "version": "0"
+            },
+            "originalEventJson": {
+              "version": "0",
+              "id": "<uuid:2>",
+              "detail-type": "core.update-account-command",
+              "source": "core.update-account-command",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "command": "update-account",
+                "payload": {
+                  "acc_id": "0a787ecb-4015",
+                  "sf_id": "baz"
+                }
+              }
             }
           }
         }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -1,13 +1,13 @@
 {
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "recorded-date": "26-03-2024, 15:48:35",
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
+    "recorded-date": "07-05-2024, 08:44:39",
     "recorded-content": {
       "custom-variables-match-all": [
         {
           "MessageId": "<uuid:1>",
           "ReceiptHandle": "<receipt-handle:1>",
           "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Event of customerCreated type, at time date, info extracted from detail display-message\""
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
         }
       ],
       "custom-variables-not-match-all": [
@@ -15,7 +15,7 @@
           "MessageId": "<uuid:2>",
           "ReceiptHandle": "<receipt-handle:2>",
           "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": "\"Event of customerCreated type, at time date, info extracted from detail \""
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
         }
       ]
     }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -1,191 +1,6 @@
 {
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "recorded-date": "08-05-2024, 14:37:28",
-    "recorded-content": {
-      "message": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "command": "update-account",
-            "payload": {
-              "acc_id": "0a787ecb-4015",
-              "sf_id": "baz"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "recorded-date": "08-05-2024, 14:37:30",
-    "recorded-content": {
-      "message": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "acc_id": "0a787ecb-4015",
-            "sf_id": "baz"
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "recorded-date": "08-05-2024, 14:37:32",
-    "recorded-content": {
-      "message": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "acc_id": "0a787ecb-4015",
-            "payload": {
-              "message": "baz",
-              "id": "123"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "08-05-2024, 14:37:34",
-    "recorded-content": {
-      "message": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"baz\""
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
-    "recorded-date": "08-05-2024, 14:37:36",
-    "recorded-content": {
-      "message-queue-1": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "command": "update-account",
-            "payload": {
-              "acc_id": "0a787ecb-4015",
-              "sf_id": "baz"
-            }
-          }
-        }
-      ],
-      "message-queue-2": [
-        {
-          "MessageId": "<uuid:2>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": {
-            "version": "0",
-            "id": "<uuid:3>",
-            "detail-type": "core.update-account-command",
-            "source": "core.update-account-command",
-            "account": "111111111111",
-            "time": "date",
-            "region": "<region>",
-            "resources": [],
-            "detail": {
-              "command": "update-account",
-              "payload": {
-                "acc_id": "0a787ecb-4015",
-                "sf_id": "baz"
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "recorded-date": "08-05-2024, 14:39:12",
-    "recorded-content": {
-      "custom-variables-match-all": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
-        }
-      ],
-      "custom-variables-not-match-all": [
-        {
-          "MessageId": "<uuid:2>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "recorded-date": "08-05-2024, 14:39:15",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Message containing all pre defined variables arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name> <rule-name> date\""
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "recorded-date": "08-05-2024, 14:39:17",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "originalEvent": {
-              "id": "<uuid:2>",
-              "account": "111111111111",
-              "detailType": "core.update-account-command",
-              "time": 1715179157000,
-              "source": "core.update-account-command",
-              "region": "<region>",
-              "resources": [],
-              "version": "0"
-            },
-            "originalEventJson": {
-              "version": "0",
-              "id": "<uuid:2>",
-              "detail-type": "core.update-account-command",
-              "source": "core.update-account-command",
-              "account": "111111111111",
-              "time": "date",
-              "region": "<region>",
-              "resources": [],
-              "detail": {
-                "command": "update-account",
-                "payload": {
-                  "acc_id": "0a787ecb-4015",
-                  "sf_id": "baz"
-                }
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "recorded-date": "08-05-2024, 14:40:07",
+    "recorded-date": "13-05-2024, 11:15:11",
     "recorded-content": {
       "message": [
         {
@@ -204,7 +19,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "recorded-date": "08-05-2024, 14:40:09",
+    "recorded-date": "13-05-2024, 11:15:14",
     "recorded-content": {
       "message": [
         {
@@ -220,7 +35,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "recorded-date": "08-05-2024, 14:40:11",
+    "recorded-date": "13-05-2024, 11:15:16",
     "recorded-content": {
       "message": [
         {
@@ -239,7 +54,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "08-05-2024, 14:40:13",
+    "recorded-date": "13-05-2024, 11:15:18",
     "recorded-content": {
       "message": [
         {
@@ -252,7 +67,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "recorded-date": "08-05-2024, 14:40:16",
+    "recorded-date": "13-05-2024, 11:15:22",
     "recorded-content": {
       "message-queue-1": [
         {
@@ -294,29 +109,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
-    "recorded-date": "08-05-2024, 14:40:20",
-    "recorded-content": {
-      "custom-variables-match-all": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
-        }
-      ],
-      "custom-variables-not-match-all": [
-        {
-          "MessageId": "<uuid:2>",
-          "ReceiptHandle": "<receipt-handle:2>",
-          "MD5OfBody": "<m-d5-of-body:2>",
-          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
-        }
-      ]
-    }
-  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "recorded-date": "08-05-2024, 14:40:23",
+    "recorded-date": "13-05-2024, 11:15:35",
     "recorded-content": {
       "messages": [
         {
@@ -329,7 +123,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "recorded-date": "08-05-2024, 14:40:25",
+    "recorded-date": "13-05-2024, 11:15:38",
     "recorded-content": {
       "messages": [
         {
@@ -341,7 +135,7 @@
               "id": "<uuid:2>",
               "account": "111111111111",
               "detailType": "core.update-account-command",
-              "time": 1715179225000,
+              "time": 1715598938000,
               "source": "core.update-account-command",
               "region": "<region>",
               "resources": [],
@@ -370,7 +164,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
-    "recorded-date": "08-05-2024, 14:43:04",
+    "recorded-date": "13-05-2024, 11:15:26",
     "recorded-content": {
       "custom-variables-match-all": [
         {
@@ -391,7 +185,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
-    "recorded-date": "08-05-2024, 14:43:08",
+    "recorded-date": "13-05-2024, 11:15:30",
     "recorded-content": {
       "custom-variables-match-all": [
         {
@@ -417,6 +211,12 @@
           }
         }
       ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
+    "recorded-date": "13-05-2024, 11:15:33",
+    "recorded-content": {
+      "missing-key-exception": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: InputTemplate for target <target-id> contains invalid placeholder notdefinedkey.') tblen=3>"
     }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -218,5 +218,11 @@
         }
       ]
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::test_put_event_input_path_and_input_transfomer": {
+    "recorded-date": "13-05-2024, 13:01:15",
+    "recorded-content": {
+      "missing-key-exception": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: Only one of Input, InputPath, or InputTransformer must be provided for target <target-id>.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "recorded-date": "13-05-2024, 11:15:11",
+    "recorded-date": "13-05-2024, 12:27:07",
     "recorded-content": {
       "message": [
         {
@@ -19,7 +19,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "recorded-date": "13-05-2024, 11:15:14",
+    "recorded-date": "13-05-2024, 12:27:09",
     "recorded-content": {
       "message": [
         {
@@ -35,7 +35,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "recorded-date": "13-05-2024, 11:15:16",
+    "recorded-date": "13-05-2024, 12:27:11",
     "recorded-content": {
       "message": [
         {
@@ -54,7 +54,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "recorded-date": "13-05-2024, 11:15:18",
+    "recorded-date": "13-05-2024, 12:27:13",
     "recorded-content": {
       "message": [
         {
@@ -67,7 +67,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "recorded-date": "13-05-2024, 11:15:22",
+    "recorded-date": "13-05-2024, 12:27:16",
     "recorded-content": {
       "message-queue-1": [
         {
@@ -109,62 +109,8 @@
       ]
     }
   },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "recorded-date": "13-05-2024, 11:15:35",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": "\"Message containing all pre defined variables arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name> <rule-name> date\""
-        }
-      ]
-    }
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "recorded-date": "13-05-2024, 11:15:38",
-    "recorded-content": {
-      "messages": [
-        {
-          "MessageId": "<uuid:1>",
-          "ReceiptHandle": "<receipt-handle:1>",
-          "MD5OfBody": "<m-d5-of-body:1>",
-          "Body": {
-            "originalEvent": {
-              "id": "<uuid:2>",
-              "account": "111111111111",
-              "detailType": "core.update-account-command",
-              "time": 1715598938000,
-              "source": "core.update-account-command",
-              "region": "<region>",
-              "resources": [],
-              "version": "0"
-            },
-            "originalEventJson": {
-              "version": "0",
-              "id": "<uuid:2>",
-              "detail-type": "core.update-account-command",
-              "source": "core.update-account-command",
-              "account": "111111111111",
-              "time": "date",
-              "region": "<region>",
-              "resources": [],
-              "detail": {
-                "command": "update-account",
-                "payload": {
-                  "acc_id": "0a787ecb-4015",
-                  "sf_id": "baz"
-                }
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
-    "recorded-date": "13-05-2024, 11:15:26",
+    "recorded-date": "13-05-2024, 12:27:20",
     "recorded-content": {
       "custom-variables-match-all": [
         {
@@ -185,7 +131,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
-    "recorded-date": "13-05-2024, 11:15:30",
+    "recorded-date": "13-05-2024, 12:27:25",
     "recorded-content": {
       "custom-variables-match-all": [
         {
@@ -214,9 +160,63 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
-    "recorded-date": "13-05-2024, 11:15:33",
+    "recorded-date": "13-05-2024, 12:27:28",
     "recorded-content": {
       "missing-key-exception": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: InputTemplate for target <target-id> contains invalid placeholder notdefinedkey.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
+    "recorded-date": "13-05-2024, 12:27:30",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Message containing all pre defined variables arn:aws:events:<region>:111111111111:rule/<bus-name>/<rule-name> <rule-name> date\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
+    "recorded-date": "13-05-2024, 12:27:33",
+    "recorded-content": {
+      "messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "originalEvent": {
+              "id": "<uuid:2>",
+              "account": "111111111111",
+              "detailType": "core.update-account-command",
+              "time": 1715603252000,
+              "source": "core.update-account-command",
+              "region": "<region>",
+              "resources": [],
+              "version": "0"
+            },
+            "originalEventJson": {
+              "version": "0",
+              "id": "<uuid:2>",
+              "detail-type": "core.update-account-command",
+              "source": "core.update-account-command",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [],
+              "detail": {
+                "command": "update-account",
+                "payload": {
+                  "acc_id": "0a787ecb-4015",
+                  "sf_id": "baz"
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -110,7 +110,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "recorded-date": "08-05-2024, 14:37:40",
+    "recorded-date": "08-05-2024, 14:39:12",
     "recorded-content": {
       "custom-variables-match-all": [
         {
@@ -131,7 +131,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "recorded-date": "08-05-2024, 14:37:43",
+    "recorded-date": "08-05-2024, 14:39:15",
     "recorded-content": {
       "messages": [
         {
@@ -144,7 +144,7 @@
     }
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "recorded-date": "08-05-2024, 14:37:46",
+    "recorded-date": "08-05-2024, 14:39:17",
     "recorded-content": {
       "messages": [
         {
@@ -156,7 +156,7 @@
               "id": "<uuid:2>",
               "account": "111111111111",
               "detailType": "core.update-account-command",
-              "time": 1715179065000,
+              "time": 1715179157000,
               "source": "core.update-account-command",
               "region": "<region>",
               "resources": [],
@@ -177,6 +177,116 @@
                   "acc_id": "0a787ecb-4015",
                   "sf_id": "baz"
                 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
+    "recorded-date": "08-05-2024, 14:38:59",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "recorded-date": "08-05-2024, 14:39:01",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "sf_id": "baz"
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "recorded-date": "08-05-2024, 14:39:03",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "acc_id": "0a787ecb-4015",
+            "payload": {
+              "message": "baz",
+              "id": "123"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
+    "recorded-date": "08-05-2024, 14:39:05",
+    "recorded-content": {
+      "message": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"baz\""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
+    "recorded-date": "08-05-2024, 14:39:08",
+    "recorded-content": {
+      "message-queue-1": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": {
+            "command": "update-account",
+            "payload": {
+              "acc_id": "0a787ecb-4015",
+              "sf_id": "baz"
+            }
+          }
+        }
+      ],
+      "message-queue-2": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "version": "0",
+            "id": "<uuid:3>",
+            "detail-type": "core.update-account-command",
+            "source": "core.update-account-command",
+            "account": "111111111111",
+            "time": "date",
+            "region": "<region>",
+            "resources": [],
+            "detail": {
+              "command": "update-account",
+              "payload": {
+                "acc_id": "0a787ecb-4015",
+                "sf_id": "baz"
               }
             }
           }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -224,5 +224,47 @@
     "recorded-content": {
       "missing-key-exception": "<ExceptionInfo ClientError('An error occurred (ValidationException) when calling the PutTargets operation: Only one of Input, InputPath, or InputTransformer must be provided for target <target-id>.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string[\"Event of <detail-type> type, at time <timestamp>, info extracted from detail <command>\"]": {
+    "recorded-date": "14-05-2024, 17:01:50",
+    "recorded-content": {
+      "custom-variables-match-all": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail update-account\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": "\"Event of core.update-account-command type, at time date, info extracted from detail \""
+        }
+      ]
+    }
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string[\"{[/Check with special starting characters for event of <detail-type> type\"]": {
+    "recorded-date": "14-05-2024, 17:01:54",
+    "recorded-content": {
+      "custom-variables-match-all": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"{[/Check with special starting characters for event of core.update-account-command type\""
+        }
+      ],
+      "custom-variables-not-match-all": [
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "\"{[/Check with special starting characters for event of core.update-account-command type\""
+        }
+      ]
+    }
   }
 }

--- a/tests/aws/services/events/test_events_inputs.snapshot.json
+++ b/tests/aws/services/events/test_events_inputs.snapshot.json
@@ -191,7 +191,7 @@
               "id": "<uuid:2>",
               "account": "111111111111",
               "detailType": "core.update-account-command",
-              "time": 1715603252000,
+              "time": "<ingestion-time>",
               "source": "core.update-account-command",
               "region": "<region>",
               "resources": [],

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -64,5 +64,11 @@
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
     "last_validated_date": "2024-05-08T14:40:20+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
+    "last_validated_date": "2024-05-08T14:43:08+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
+    "last_validated_date": "2024-05-08T14:43:04+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -42,18 +42,27 @@
     "last_validated_date": "2024-05-08T14:39:12+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-08T14:38:59+00:00"
+    "last_validated_date": "2024-05-08T14:40:07+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-08T14:39:05+00:00"
+    "last_validated_date": "2024-05-08T14:40:13+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-08T14:39:08+00:00"
+    "last_validated_date": "2024-05-08T14:40:16+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-08T14:39:01+00:00"
+    "last_validated_date": "2024-05-08T14:40:09+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-08T14:39:03+00:00"
+    "last_validated_date": "2024-05-08T14:40:11+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
+    "last_validated_date": "2024-05-08T14:40:23+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
+    "last_validated_date": "2024-05-08T14:40:25+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
+    "last_validated_date": "2024-05-08T14:40:20+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -42,33 +42,36 @@
     "last_validated_date": "2024-05-08T14:39:12+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-08T14:40:07+00:00"
+    "last_validated_date": "2024-05-13T11:15:11+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-08T14:40:13+00:00"
+    "last_validated_date": "2024-05-13T11:15:18+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-08T14:40:16+00:00"
+    "last_validated_date": "2024-05-13T11:15:22+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-08T14:40:09+00:00"
+    "last_validated_date": "2024-05-13T11:15:14+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-08T14:40:11+00:00"
+    "last_validated_date": "2024-05-13T11:15:16+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "last_validated_date": "2024-05-08T14:40:23+00:00"
+    "last_validated_date": "2024-05-13T11:15:35+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "last_validated_date": "2024-05-08T14:40:25+00:00"
+    "last_validated_date": "2024-05-13T11:15:38+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
     "last_validated_date": "2024-05-08T14:40:20+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
-    "last_validated_date": "2024-05-08T14:43:08+00:00"
+    "last_validated_date": "2024-05-13T11:15:30+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
-    "last_validated_date": "2024-05-08T14:43:04+00:00"
+    "last_validated_date": "2024-05-13T11:15:26+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
+    "last_validated_date": "2024-05-13T11:15:33+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -26,6 +26,12 @@
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
     "last_validated_date": "2024-05-13T12:27:20+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string[\"Event of <detail-type> type, at time <timestamp>, info extracted from detail <command>\"]": {
+    "last_validated_date": "2024-05-14T17:01:49+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string[\"{[/Check with special starting characters for event of <detail-type> type\"]": {
+    "last_validated_date": "2024-05-14T17:01:54+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
     "last_validated_date": "2024-05-13T12:27:28+00:00"
   },

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -15,10 +15,10 @@
     "last_validated_date": "2024-05-08T14:37:32+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "last_validated_date": "2024-05-08T14:37:43+00:00"
+    "last_validated_date": "2024-05-08T14:39:15+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "last_validated_date": "2024-05-08T14:37:46+00:00"
+    "last_validated_date": "2024-05-08T14:39:17+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
     "last_validated_date": "2024-05-06T15:11:54+00:00"
@@ -39,6 +39,21 @@
     "last_validated_date": "2024-03-26T15:48:35+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "last_validated_date": "2024-05-08T14:37:40+00:00"
+    "last_validated_date": "2024-05-08T14:39:12+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
+    "last_validated_date": "2024-05-08T14:38:59+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
+    "last_validated_date": "2024-05-08T14:39:05+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
+    "last_validated_date": "2024-05-08T14:39:08+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "last_validated_date": "2024-05-08T14:39:01+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "last_validated_date": "2024-05-08T14:39:03+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -8,9 +8,6 @@
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
     "last_validated_date": "2024-05-06T15:22:58+00:00"
   },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
-    "last_validated_date": "2024-05-06T15:11:52+00:00"
-  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
     "last_validated_date": "2024-05-08T13:54:42+00:00"
   },
@@ -34,5 +31,8 @@
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
+    "last_validated_date": "2024-05-07T08:44:39+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -17,6 +17,21 @@
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
     "last_validated_date": "2024-05-08T13:54:44+00:00"
   },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
+    "last_validated_date": "2024-05-06T15:11:54+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
+    "last_validated_date": "2024-05-06T15:22:58+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
+    "last_validated_date": "2024-05-06T15:11:52+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
+    "last_validated_date": "2024-05-08T13:54:42+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
+    "last_validated_date": "2024-05-08T13:54:44+00:00"
+  },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
     "last_validated_date": "2024-03-26T15:48:35+00:00"
   }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -1,18 +1,24 @@
 {
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-08T13:54:10+00:00"
+    "last_validated_date": "2024-05-08T14:37:28+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-06T15:11:54+00:00"
+    "last_validated_date": "2024-05-08T14:37:34+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-06T15:22:58+00:00"
+    "last_validated_date": "2024-05-08T14:37:36+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-08T13:54:42+00:00"
+    "last_validated_date": "2024-05-08T14:37:30+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-08T13:54:44+00:00"
+    "last_validated_date": "2024-05-08T14:37:32+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
+    "last_validated_date": "2024-05-08T14:37:43+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
+    "last_validated_date": "2024-05-08T14:37:46+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
     "last_validated_date": "2024-05-06T15:11:54+00:00"
@@ -33,6 +39,6 @@
     "last_validated_date": "2024-03-26T15:48:35+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "last_validated_date": "2024-05-07T08:44:39+00:00"
+    "last_validated_date": "2024-05-08T14:37:40+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -1,77 +1,32 @@
 {
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-08T14:37:28+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-08T14:37:34+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-08T14:37:36+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-08T14:37:30+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-08T14:37:32+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "last_validated_date": "2024-05-08T14:39:15+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "last_validated_date": "2024-05-08T14:39:17+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-06T15:11:54+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-06T15:22:58+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested": {
-    "last_validated_date": "2024-05-06T15:11:52+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-08T13:54:42+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-08T13:54:44+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformation_to_sqs": {
-    "last_validated_date": "2024-03-26T15:48:35+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestEventsInputTransformers::test_put_events_with_input_transformer": {
-    "last_validated_date": "2024-05-08T14:39:12+00:00"
-  },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path": {
-    "last_validated_date": "2024-05-13T11:15:11+00:00"
+    "last_validated_date": "2024-05-13T12:27:07+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_max_level_depth": {
-    "last_validated_date": "2024-05-13T11:15:18+00:00"
+    "last_validated_date": "2024-05-13T12:27:13+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_multiple_targets": {
-    "last_validated_date": "2024-05-13T11:15:22+00:00"
+    "last_validated_date": "2024-05-13T12:27:16+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail0]": {
-    "last_validated_date": "2024-05-13T11:15:14+00:00"
+    "last_validated_date": "2024-05-13T12:27:09+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputPath::test_put_events_with_input_path_nested[event_detail1]": {
-    "last_validated_date": "2024-05-13T11:15:16+00:00"
+    "last_validated_date": "2024-05-13T12:27:11+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[\"Message containing all pre defined variables <aws.events.rule-arn> <aws.events.rule-name> <aws.events.event.ingestion-time>\"]": {
-    "last_validated_date": "2024-05-13T11:15:35+00:00"
+    "last_validated_date": "2024-05-13T12:27:30+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_input_transformer_predefined_variables[{\"originalEvent\": <aws.events.event>, \"originalEventJson\": <aws.events.event.json>}]": {
-    "last_validated_date": "2024-05-13T11:15:38+00:00"
-  },
-  "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer": {
-    "last_validated_date": "2024-05-08T14:40:20+00:00"
+    "last_validated_date": "2024-05-13T12:27:33+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_json": {
-    "last_validated_date": "2024-05-13T11:15:30+00:00"
+    "last_validated_date": "2024-05-13T12:27:25+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_input_template_string": {
-    "last_validated_date": "2024-05-13T11:15:26+00:00"
+    "last_validated_date": "2024-05-13T12:27:20+00:00"
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
-    "last_validated_date": "2024-05-13T11:15:33+00:00"
+    "last_validated_date": "2024-05-13T12:27:28+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_inputs.validation.json
+++ b/tests/aws/services/events/test_events_inputs.validation.json
@@ -28,5 +28,8 @@
   },
   "tests/aws/services/events/test_events_inputs.py::TestInputTransformer::test_put_events_with_input_transformer_missing_keys": {
     "last_validated_date": "2024-05-13T12:27:28+00:00"
+  },
+  "tests/aws/services/events/test_events_inputs.py::test_put_event_input_path_and_input_transfomer": {
+    "last_validated_date": "2024-05-13T13:01:15+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR adds input transformers https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html to the v2 provider. Input transformers use either predefined placeholders or custom placeholders defined in input template or a combination of both, that are used to re-write the returned event. 
Predefined placeholders can return either a string or a dict ( dicts are only allowed in json input maps)

The event that is returned is the input map that gets populated with the placeholders described before with the variables from the original event and rule. The input map can be either a plain string or a json string that results in a return dict. 

<!-- What notable changes does this PR make? -->
## Changes
Add input transformer to transform incoming event based on input path and input map.
Add predefined placeholders.
Add tests for input path string and json.
Add test for predefined placeholders.
Add test for combining input path and input transfomrer.

<!-- The following sections are optional, but can be useful! 

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...
- [ ] ...

-->

