### PR TITLE
fix banner link in READMEs

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/localstack/localstack/master/doc/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">
+  <img src="https://raw.githubusercontent.com/localstack/localstack/master/docs/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/localstack/localstack/master/doc/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">
+  <img src="https://raw.githubusercontent.com/localstack/localstack/master/docs/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10775 renamed the `doc` folder to `docs`.
The README of the repo and the DockerHub description references the banner in this directory.
This PR updates these links.

## Changes
- Updates the links to the README.

## Testing
- Tested the new links manually.