### PR TITLE
CFn: add schema validation for resource providers

### DIFF
--- a/localstack/services/cloudformation/resource_provider.py
+++ b/localstack/services/cloudformation/resource_provider.py
@@ -425,6 +425,11 @@ class ResourceProviderExecutor:
                                 "A ResourceProvider should always have a SCHEMA property defined."
                             )
                         resource_type_schema = resource_provider.SCHEMA
+                        self.validate_model_properties(
+                            logical_resource_id=raw_payload["requestData"]["logicalResourceId"],
+                            schema=resource_type_schema,
+                            model=event.resource_model,
+                        )
                         physical_resource_id = (
                             self.extract_physical_resource_id_from_model_with_schema(
                                 event.resource_model,
@@ -594,6 +599,14 @@ class ResourceProviderExecutor:
                 physical_resource_id = resolve_json_pointer(resource_model, primary_id_paths[0])
 
         return physical_resource_id
+
+    def validate_model_properties(self, logical_resource_id: str, schema: dict, model: dict):
+        required_fields = schema.get("required", [])
+        for required_field in required_fields:
+            if required_field not in model or model[required_field] is None:
+                raise ValueError(
+                    f"Missing required field '{required_field}' in resource definition for resource '{logical_resource_id}'"
+                )
 
 
 plugin_manager = PluginManager(CloudFormationResourceProviderPlugin.namespace)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We use the CloudFormation resource provider schema to generate our scaffolded resources, but we don't make any assertions that what is returned by a resource provider conforms to the schema. Now that we have migrated all resources to the new resource provider API we should be stricter about the responses coming back from the resource providers. This will help us ensure parity with AWS CFn.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Implement a schema validation method in the `ResourceProviderExecutor`
    * at the moment, this only validates that all required fields are present, but will provide a place to put further validations in the future
    * the `PhysicalResourceId` is validated implicitly with the call to `extract_physical_resource_id_from_model_with_schema`, which raises an exception (in `resolve_json_pointer`) if the value is not present

## Testing

The green CI pipeline run shows that all community resource providers already conform to the schema (:tada:). To check that the validation works, pick a resource provider and comment out setting one of the `required` fields.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
