### PR TITLE
fix asf update action by updating ruff fix command

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           source .venv/bin/activate
           # explicitly perform an unsafe fix to remove unused imports in the generated ASF APIs
-          ruff check --select F401 --unsafe-fixes --fix . --config "lint.ignore-init-module-imports = false"
+          ruff check --select F401 --unsafe-fixes --fix . --config "lint.preview = true"
           make format-modified
 
       - name: Check for changes


### PR DESCRIPTION
## Motivation
Last week we upgraded to `ruff==0.4.3`.
With this release, the [ASF update action broke](https://github.com/localstack/localstack/actions/runs/9057484320) due to https://github.com/astral-sh/ruff/pull/11168.
This PR starts reworking the F401 fixes, and now `lint.ignore-init-module-imports = false` is ignored and `lint.preview = true` has to be set to enable the F401 fixer.

## Changes
- Updates the ruff command such that the linting fixes are working again (switching from `lint.ignore-init-module-imports = false` to `lint.preview = true`).

## Testing
- Tested the commands executed in the [ASF update action](https://github.com/localstack/localstack/blob/7917b4af501720cdff328b38298f6bd71245b307/.github/workflows/asf-updates.yml) locally:
  ```
  make install-dev
  source .venv/bin/activate
  pip install --upgrade botocore
  python3 -m localstack.aws.scaffold upgrade --path ../localstack-ext/localstack_ext/aws/api/
  ruff check --select F401 --unsafe-fixes --fix . --config "lint.preview = true"
  make format-modified
  ```