### PR TITLE
[SFN] Temporary Skip of Flaky Test Cases

### DIFF
--- a/tests/aws/services/stepfunctions/v2/callback/test_callback.py
+++ b/tests/aws/services/stepfunctions/v2/callback/test_callback.py
@@ -499,6 +499,7 @@ class TestCallback:
         )
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="Skipped until flaky behaviour can be rectified.")
     def test_multiple_heartbeat_notifications(
         self,
         aws_client,
@@ -546,6 +547,7 @@ class TestCallback:
         task_token_consumer_thread.join(timeout=300)
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="Skipped until flaky behaviour can be rectified.")
     def test_multiple_executions_and_heartbeat_notifications(
         self,
         aws_client,

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api.py
@@ -13,7 +13,6 @@ from tests.aws.services.stepfunctions.lambda_functions import lambda_functions
 from tests.aws.services.stepfunctions.templates.base.base_templates import BaseTemplate
 from tests.aws.services.stepfunctions.utils import (
     await_execution_aborted,
-    await_execution_started,
     await_execution_success,
     await_execution_terminated,
     await_list_execution_status,
@@ -506,10 +505,6 @@ class TestSnfApi:
             stepfunctions_client=aws_client.stepfunctions,
             execution_arn=execution_arn,
             check_func=_check_stated_entered,
-        )
-
-        await_execution_started(
-            stepfunctions_client=aws_client.stepfunctions, execution_arn=execution_arn
         )
 
         stop_res = aws_client.stepfunctions.stop_execution(executionArn=execution_arn)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently two test cases concerning heartbeat notifications appear to be flaky, this PR adds temporary skips to these tests until the root cause can be addressed.
The PR also removes a redundant check in a stop execution test.
https://app.circleci.com/pipelines/github/localstack/localstack/24756/workflows/5cf27d74-2876-4903-8510-1e31ee87541b/jobs/206021/parallel-runs/3?filterBy=FAILED
https://app.circleci.com/pipelines/github/localstack/localstack/24760/workflows/321dcfb5-ca16-46f8-a7a9-7ec3fbc871f6/jobs/206069
