### PR TITLE
Fix entrypoint script configurator encoding and line endings in windows

### DIFF
--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -98,7 +98,8 @@ class CustomEntryPointConfigurator:
         file = Path(tempdir, file_name)
         if not file.exists():
             # newline separator should be '\n' independent of the os, since the entrypoint is executed in the container
-            file.write_text(self.script, newline="\n")
+            # encoding needs to be "utf-8" since scripts could include emojis
+            file.write_text(self.script, newline="\n", encoding="utf-8")
             file.chmod(0o777)
         cfg.volumes.add(VolumeBind(str(file), f"/tmp/{file.name}"))
         cfg.entrypoint = f"/tmp/{file.name}"

--- a/localstack/dev/run/configurators.py
+++ b/localstack/dev/run/configurators.py
@@ -97,7 +97,8 @@ class CustomEntryPointConfigurator:
 
         file = Path(tempdir, file_name)
         if not file.exists():
-            file.write_text(self.script)
+            # newline separator should be '\n' independent of the os, since the entrypoint is executed in the container
+            file.write_text(self.script, newline="\n")
             file.chmod(0o777)
         cfg.volumes.add(VolumeBind(str(file), f"/tmp/{file.name}"))
         cfg.entrypoint = f"/tmp/{file.name}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When using the CLI in extension dev mode under windows, the custom container entrypoint file gets generated using windows file endings (`\r\n`).
This file is then mounted into the linux container, and fails to execute due to the wrong line endings.

To avoid this, we now force linux file endings for container entrypoints, and in addition utf-8 encoding, since some entrypoints (for example the extension dev mode one) contains unicode characters.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- LocalStack now starts in extension dev mode under windows without additional intervention


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
