### PR TITLE
APIGW: Default to an empty dict when the provided body for an API Gateway step function is an empty string

### DIFF
--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -190,7 +190,7 @@ class ApiGatewayVtlTemplate(VtlTemplate):
             namespace["stageVariables"] = stage_var
         input_var = variables.get("input") or {}
         variables = {
-            "input": VelocityInput(input_var.get("body"), input_var.get("params")),
+            "input": VelocityInput(input_var.get("body") or {}, input_var.get("params")),
             "util": VelocityUtilApiGateway(),
         }
         namespace.update(variables)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This attempts to solve issue #10252 .

I created a CDK project following what the reporter of the issue added to its description, and when running `curl -X POST https://$APIID.execute-api.us-east-1.amazonaws.com/prod/`, I got the expected output:
```
"Hello.World"
```

When doing the same through cdklocal against a local instance of Localstack, I got the following output:
```
{"Type": "User", "message": "Error invoking integration for API Gateway ID 'fsbb50s4si': An error occurred (InvalidExecutionInput) when calling the StartExecution operation: Expecting value: line 1 column 10 (char 9)", "__type": "InvalidRequest"}%
```

This isn't exactly the same as what the user reported (which was probably partially fixed since February), but something was definitely wrong - so upon inspection, I found that when a request body was not provided, we ended up generating malformed JSON, which was in turn sent to the step function. With this fix, the output is now the expected one (added a small unit test for the templating logic, trying to mimic an actual velocity template with body forwarding).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

We now default to an empty dict when an empty body comes when executing a step function - this allows us to create a correct JSON.