### PR TITLE
add small quirks for new resource providers

### DIFF
--- a/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack/services/cloudformation/engine/quirks.py
@@ -31,6 +31,10 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::SSM::Parameter": "/properties/Name",
     "AWS::RDS::DBProxyTargetGroup": "/properties/TargetGroupName",
     "AWS::Glue::SchemaVersionMetadata": "</properties/SchemaVersionId>|</properties/Key>|</properties/Value>",  # composite
+    "AWS::WAFv2::WebACL": "</properties/Name>|</properties/Id>|</properties/Scope>",
+    "AWS::WAFv2::WebACLAssociation": "</properties/ResourceArn>|</properties/WebACLArn>",
+    "AWS::WAFv2::IPSet": "</properties/Name>|</properties/Id>|</properties/Scope>",
+    # composite
 }
 
 # You can usually find the available GetAtt targets in the official resource documentation:

--- a/localstack/services/cloudformation/scaffolding/propgen.py
+++ b/localstack/services/cloudformation/scaffolding/propgen.py
@@ -178,8 +178,11 @@ class PropertyTypeScaffolding:
                 case "object":
                     resolved_type = "dict"  # TODO: any cases where we need to continue here?
                 case "array":
-                    item_type = self.resolve_type_of_property(property_def["items"])
-                    resolved_type = f"list[{item_type}]"
+                    try:
+                        item_type = self.resolve_type_of_property(property_def["items"])
+                        resolved_type = f"list[{item_type}]"
+                    except RecursionError:
+                        resolved_type = "list[Any]"
                 case _:
                     # TODO: allOf, anyOf, patternProperties (?)
                     # AWS::ApiGateway::RestApi passes a ["object", "string"] here for the "Body" property


### PR DESCRIPTION
## Motivation
This PR adds changes to allow the correct deployment of WAFv2 resource providers. These resources physical ids are composed like: Name|Id|Scope. 

Also, trying to use the scaffolding tool to generate the files for WAFv2::WebACL throws a RecursionError. 

## Changes
- CFn quirks added for WAFv2 resources
- Scaffolding changes for correct WebACL scaffolding