### PR TITLE
fix ListObjectVersions field order

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2588,7 +2588,6 @@ class ListObjectVersionsOutput(TypedDict, total=False):
     VersionIdMarker: Optional[VersionIdMarker]
     NextKeyMarker: Optional[NextKeyMarker]
     NextVersionIdMarker: Optional[NextVersionIdMarker]
-    Versions: Optional[ObjectVersionList]
     DeleteMarkers: Optional[DeleteMarkers]
     Name: Optional[BucketName]
     Prefix: Optional[Prefix]
@@ -2597,6 +2596,7 @@ class ListObjectVersionsOutput(TypedDict, total=False):
     CommonPrefixes: Optional[CommonPrefixList]
     EncodingType: Optional[EncodingType]
     RequestCharged: Optional[RequestCharged]
+    Versions: Optional[ObjectVersionList]
 
 
 OptionalObjectAttributesList = List[OptionalObjectAttributes]

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1210,6 +1210,19 @@
         "documentation": "<p>Your proposed upload exceeds the maximum allowed size</p>",
         "exception": true
       }
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/ListObjectVersionsOutput/members/Versions"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ListObjectVersionsOutput/members/Versions",
+      "value": {
+        "shape":"ObjectVersionList",
+        "documentation":"<p>Container for version information.</p>",
+        "locationName":"Version"
+      }
     }
   ]
 }

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -4835,6 +4835,22 @@ class TestS3:
         key_name = "test-key"
         aws_client.s3.put_object(Bucket=s3_bucket, Key=key_name, Tagging="tag1=tag1")
 
+        # Lists all objects versions in a bucket
+        list_objects_version_url = f"{bucket_url}?versions"
+        resp = s3_http_client.get(list_objects_version_url, headers=headers)
+        assert b'<?xml version="1.0" encoding="UTF-8"?>\n' in get_xml_content(resp.content)
+        resp_dict = xmltodict.parse(resp.content)
+        assert "ListVersionsResult" in resp_dict
+        assert (
+            resp_dict["ListVersionsResult"]["@xmlns"] == "http://s3.amazonaws.com/doc/2006-03-01/"
+        )
+        # same as ListObjects
+        list_objects_versions_tags = list(resp_dict["ListVersionsResult"].keys())
+        assert list_objects_versions_tags.index("Name") < list_objects_versions_tags.index(
+            "Version"
+        )
+        assert list_objects_versions_tags[-1] == "Version"
+
         # GetObjectTagging
         get_object_tagging_url = f"{bucket_url}/{key_name}?tagging"
         resp = s3_http_client.get(get_object_tagging_url, headers=headers)

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -237,7 +237,7 @@
     "last_validated_date": "2024-03-21T08:05:13+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_response_structure": {
-    "last_validated_date": "2024-04-24T18:48:32+00:00"
+    "last_validated_date": "2024-05-15T16:13:26+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_analytics_configurations": {
     "last_validated_date": "2023-08-03T02:25:40+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Similar to #8329, we had a report with #10801 where the AWS Java SDK v1 could not properly parse the Bucket name out of the field. The reporter added very useful information about `AmazonS3.xsd`, we quickly communicated with @alexrashed about it, especially the fact that the S3 fields are reported as `<xsd:sequence>`, meaning the order is required/important. We will need to think about how we could add such specs, but also keep them in sync. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- similar to #8329, removing the `Versions` field from the spec and re-adding it, counting of Python dictionary ordering to make it last
- added a test to verify the fix

_fixes #10801_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
