### PR TITLE
update plux to 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools', 'wheel', 'plux>=1.7']
+requires = ['setuptools', 'wheel', 'plux>=1.10']
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,7 +18,7 @@ dependencies = [
     "dill==0.3.6",
     "dnslib>=0.9.10",
     "dnspython>=1.16.0",
-    "plux>=1.7",
+    "plux>=1.10",
     "psutil>=5.4.8",
     "python-dotenv>=0.19.1",
     "pyyaml>=5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "rich>=12.3.0",
     "requests>=2.20.0",
     "semver>=2.10",
-    "stevedore>=3.4.0",
     "tailer>=0.4.1",
 ]
 dynamic = ["version"]

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -114,7 +114,7 @@ packaging==24.0
     #   docker
 pbr==6.0.0
     # via stevedore
-plux==1.9.0
+plux==1.10.0
     # via localstack-core (pyproject.toml)
 priority==1.3.0
     # via
@@ -163,9 +163,7 @@ six==1.16.0
     #   python-dateutil
     #   requests-aws4auth
 stevedore==5.2.0
-    # via
-    #   localstack-core (pyproject.toml)
-    #   plux
+    # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
 typing-extensions==4.11.0

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -112,8 +112,6 @@ packaging==24.0
     # via
     #   build
     #   docker
-pbr==6.0.0
-    # via stevedore
 plux==1.10.0
     # via localstack-core (pyproject.toml)
 priority==1.3.0
@@ -162,8 +160,6 @@ six==1.16.0
     # via
     #   python-dateutil
     #   requests-aws4auth
-stevedore==5.2.0
-    # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
 typing-extensions==4.11.0

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -32,8 +32,6 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==24.0
     # via build
-pbr==6.0.0
-    # via stevedore
 plux==1.10.0
     # via localstack-core (pyproject.toml)
 psutil==5.9.8
@@ -53,8 +51,6 @@ requests==2.31.0
 rich==13.7.1
     # via localstack-core (pyproject.toml)
 semver==3.0.2
-    # via localstack-core (pyproject.toml)
-stevedore==5.2.0
     # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -34,7 +34,7 @@ packaging==24.0
     # via build
 pbr==6.0.0
     # via stevedore
-plux==1.9.0
+plux==1.10.0
     # via localstack-core (pyproject.toml)
 psutil==5.9.8
     # via localstack-core (pyproject.toml)
@@ -55,9 +55,7 @@ rich==13.7.1
 semver==3.0.2
     # via localstack-core (pyproject.toml)
 stevedore==5.2.0
-    # via
-    #   localstack-core (pyproject.toml)
-    #   plux
+    # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
 urllib3==2.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -320,7 +320,7 @@ pluggy==1.5.0
     #   pytest
 plumbum==1.8.3
     # via pandoc
-plux==1.9.0
+plux==1.10.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -478,7 +478,6 @@ stevedore==5.2.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-    #   plux
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -311,7 +311,6 @@ pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-    #   stevedore
 platformdirs==4.2.1
     # via virtualenv
 pluggy==1.5.0
@@ -474,10 +473,6 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-stevedore==5.2.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -238,7 +238,6 @@ pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-    #   stevedore
 plux==1.10.0
     # via
     #   localstack-core
@@ -355,10 +354,6 @@ six==1.16.0
     #   python-dateutil
     #   requests-aws4auth
     #   rfc3339-validator
-stevedore==5.2.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -239,7 +239,7 @@ pbr==6.0.0
     #   jschema-to-python
     #   sarif-om
     #   stevedore
-plux==1.9.0
+plux==1.10.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -359,7 +359,6 @@ stevedore==5.2.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-    #   plux
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -294,7 +294,7 @@ pluggy==1.5.0
     # via
     #   localstack-core (pyproject.toml)
     #   pytest
-plux==1.9.0
+plux==1.10.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -441,7 +441,6 @@ stevedore==5.2.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-    #   plux
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -289,7 +289,6 @@ pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-    #   stevedore
 pluggy==1.5.0
     # via
     #   localstack-core (pyproject.toml)
@@ -437,10 +436,6 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-stevedore==5.2.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -507,7 +507,6 @@ pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-    #   stevedore
 platformdirs==4.2.1
     # via virtualenv
 pluggy==1.5.0
@@ -670,10 +669,6 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-stevedore==5.2.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -516,7 +516,7 @@ pluggy==1.5.0
     #   pytest
 plumbum==1.8.3
     # via pandoc
-plux==1.9.0
+plux==1.10.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
@@ -674,7 +674,6 @@ stevedore==5.2.0
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-    #   plux
 sympy==1.12
     # via cfn-lint
 tailer==0.4.1


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Plux 1.10.0 now properly supports entry point resolution for editable wheels, the lack of which has caused headaches in the past, and also blocks #10800.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* localstack now uses plux 1.10.0 and no longer needs stevedore

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
