### PR TITLE
Fix Lambda async invocation queue namespace

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -763,9 +763,9 @@ if not DOCKER_BRIDGE_IP:
 INTERNAL_RESOURCE_ACCOUNT = os.environ.get("INTERNAL_RESOURCE_ACCOUNT") or "949334387222"
 
 # Determine which implementation to use for the event rule / event filtering engine used by multiple services:
-# EventBridge, EventBridge Pipes, Lambda Event Source Mapping, SNS
-# Options: provider (default) | java
-EVENT_RULE_ENGINE = os.environ.get("EVENT_RULE_ENGINE", "").strip()
+# EventBridge, EventBridge Pipes, Lambda Event Source Mapping
+# Options: python (default) | java (preview)
+EVENT_RULE_ENGINE = os.environ.get("EVENT_RULE_ENGINE", "python").strip()
 
 # -----
 # SERVICE-SPECIFIC CONFIGS BELOW

--- a/localstack/services/lambda_/invocation/docker_runtime_executor.py
+++ b/localstack/services/lambda_/invocation/docker_runtime_executor.py
@@ -363,7 +363,8 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             container_config.dns = config.LAMBDA_DOCKER_DNS
         else:
             if dns_server.is_server_running():
-                # Enable transparent endpoint injection by setting DNS to the embedded DNS re-writer in the Go init.
+                # Set the container DNS to LocalStack to resolve localhost.localstack.cloud and
+                # enable transparent endpoint injection (Pro image only).
                 container_config.dns = self.get_endpoint_from_executor()
 
         lambda_hooks.start_docker_executor.run(container_config, self.function_version)

--- a/localstack/services/lambda_/invocation/event_manager.py
+++ b/localstack/services/lambda_/invocation/event_manager.py
@@ -141,41 +141,16 @@ class Poller:
         function_timeout = self.version_manager.function_version.config.timeout
         while not self._shutdown_event.is_set():
             try:
-                try:
-                    response = sqs_client.receive_message(
-                        QueueUrl=self.event_queue_url,
-                        # TODO: consider replacing with short polling instead of long polling to prevent keeping connections open
-                        # however, we had some serious performance issues when tried out, so those have to be investigated first
-                        WaitTimeSeconds=2,
-                        # Related: SQS event source mapping batches up to 10 messages:
-                        # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
-                        MaxNumberOfMessages=10,
-                        VisibilityTimeout=function_timeout + 60,
-                    )
-                except Exception as e:
-                    # TODO: fix exception parity in internal SQS implementation
-                    # except sqs_client.exceptions.QueueDoesNotExist as e:
-                    # TODO: remove debug log
-                    LOG.debug(f"Queue does not exist: {e}")
-                    # recreate the queue (extract into helper)
-                    function_id = self.version_manager.function_version.id
-                    # Truncate function name to ensure queue name limit of max 80 characters
-                    function_name_short = function_id.function_name[:47]
-                    queue_name = f"{function_name_short}-{md5(function_id.qualified_arn())}"
-                    create_queue_response = sqs_client.create_queue(QueueName=queue_name)
-                    self.event_queue_url = create_queue_response["QueueUrl"]
-
-                    # retry
-                    response = sqs_client.receive_message(
-                        QueueUrl=self.event_queue_url,
-                        # TODO: consider replacing with short polling instead of long polling to prevent keeping connections open
-                        # however, we had some serious performance issues when tried out, so those have to be investigated first
-                        WaitTimeSeconds=2,
-                        # Related: SQS event source mapping batches up to 10 messages:
-                        # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
-                        MaxNumberOfMessages=10,
-                        VisibilityTimeout=function_timeout + 60,
-                    )
+                response = sqs_client.receive_message(
+                    QueueUrl=self.event_queue_url,
+                    # TODO: consider replacing with short polling instead of long polling to prevent keeping connections open
+                    # however, we had some serious performance issues when tried out, so those have to be investigated first
+                    WaitTimeSeconds=2,
+                    # Related: SQS event source mapping batches up to 10 messages:
+                    # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+                    MaxNumberOfMessages=10,
+                    VisibilityTimeout=function_timeout + 60,
+                )
                 if not response.get("Messages"):
                     continue
                 LOG.debug("[%s] Got %d messages", self.event_queue_url, len(response["Messages"]))
@@ -495,12 +470,14 @@ class LambdaEventManager:
             function_id = self.version_manager.function_version.id
             # Truncate function name to ensure queue name limit of max 80 characters
             function_name_short = function_id.function_name[:47]
-            queue_name = f"{function_name_short}-{md5(function_id.qualified_arn())}"
+            # The instance id MUST be unique to the function and a given LocalStack instance
+            queue_namespace = (
+                f"{function_id.qualified_arn()}-{self.version_manager.function.instance_id}"
+            )
+            queue_name = f"{function_name_short}-{md5(queue_namespace)}"
             create_queue_response = sqs_client.create_queue(QueueName=queue_name)
             self.event_queue_url = create_queue_response["QueueUrl"]
-            # TODO: add try/catch because a race condition upon re-create could potentially delete the queue in between here!
-            # Ensure no events are in new queues due to persistence and cloud pods
-            sqs_client.purge_queue(QueueUrl=self.event_queue_url)
+            # We don't need to purge the queue for persistence or cloud pods because the instance id is MUST be unique
 
             self.poller = Poller(self.version_manager, self.event_queue_url)
             self.poller_thread = FuncThread(

--- a/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack/services/lambda_/invocation/lambda_models.py
@@ -41,7 +41,7 @@ from localstack.aws.connect import connect_to
 from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.lambda_.api_utils import qualified_lambda_arn, unqualified_lambda_arn
 from localstack.utils.archives import unzip
-from localstack.utils.strings import long_uid
+from localstack.utils.strings import long_uid, short_uid
 
 LOG = logging.getLogger(__name__)
 
@@ -598,6 +598,13 @@ class Function:
 
     def latest(self) -> FunctionVersion:
         return self.versions["$LATEST"]
+
+    # HACK to model a volatile variable that should be ignored for persistence
+    def __post_init__(self):
+        # Identifier unique to this function and LocalStack instance.
+        # A LocalStack restart or persistence load should create a new instance id.
+        # Used for retaining invoke queues across version updates for $LATEST, but separate unrelated instances.
+        self.instance_id = short_uid()
 
 
 class ValidationException(CommonServiceException):

--- a/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack/services/lambda_/invocation/lambda_models.py
@@ -606,6 +606,18 @@ class Function:
         # Used for retaining invoke queues across version updates for $LATEST, but separate unrelated instances.
         self.instance_id = short_uid()
 
+    def __getstate__(self):
+        """Ignore certain volatile fields for pickling.
+        # https://docs.python.org/3/library/pickle.html#handling-stateful-objects
+        """
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        # Remove the volatile entries.
+        del state["instance_id"]
+        return state
+
 
 class ValidationException(CommonServiceException):
     def __init__(self, message: str):

--- a/localstack/services/lambda_/invocation/version_manager.py
+++ b/localstack/services/lambda_/invocation/version_manager.py
@@ -3,7 +3,6 @@ import logging
 import threading
 import time
 from concurrent.futures import Future
-from typing import TYPE_CHECKING
 
 from localstack import config
 from localstack.aws.api.lambda_ import (
@@ -33,9 +32,6 @@ from localstack.services.lambda_.invocation.runtime_executor import get_runtime_
 from localstack.utils.strings import long_uid, truncate
 from localstack.utils.threads import FuncThread, start_thread
 
-if TYPE_CHECKING:
-    from localstack.services.lambda_.invocation.lambda_service import LambdaService
-
 LOG = logging.getLogger(__name__)
 
 
@@ -53,8 +49,6 @@ class LambdaVersionManager:
     state: VersionState | None
     provisioned_state: ProvisionedConcurrencyState | None  # TODO: remove?
     log_handler: LogHandler
-    # TODO not sure about this backlink, maybe a callback is better?
-    lambda_service: "LambdaService"
     counting_service: CountingService
     assignment_service: AssignmentService
 

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1277,6 +1277,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 destroy_code_if_not_used(code=version.config.code, function=function)
         else:
             # delete the whole function
+            # TODO: move that down / add locking because we could create a new version before the old one gets cleaned up in the internal lambda services
+            # => we need some locking or safe status
             function = store.functions.pop(function_name)
             for version in function.versions.values():
                 self.lambda_service.stop_version(qualified_arn=version.id.qualified_arn())

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -1277,8 +1277,8 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 destroy_code_if_not_used(code=version.config.code, function=function)
         else:
             # delete the whole function
-            # TODO: move that down / add locking because we could create a new version before the old one gets cleaned up in the internal lambda services
-            # => we need some locking or safe status
+            # TODO: introduce locking for safe deletion: We could create a new version at the API layer before
+            #  the old version gets cleaned up in the internal lambda service.
             function = store.functions.pop(function_name)
             for version in function.versions.values():
                 self.lambda_service.stop_version(qualified_arn=version.id.qualified_arn())

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
@@ -1,0 +1,33 @@
+import json
+import os
+import time
+
+import boto3
+
+s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"))
+S3_BUCKET_NAME = os.environ["S3_BUCKET_NAME"]
+# Configurable identifier to test function updates
+FUNCTION_VARIANT = os.environ.get("FUNCTION_VARIANT")
+
+
+def handler(event, context):
+    sleep_duration = int(event.get("sleep_seconds", 0))
+    print(f"Sleeping for {sleep_duration} seconds ...")
+    time.sleep(sleep_duration)
+    print("... done sleeping")
+
+    request_prefix = event.get("request_prefix")
+    response = {
+        "function_version": context.function_version,
+        "request_id": context.aws_request_id,
+        "request_prefix": request_prefix,
+        "function_variant": FUNCTION_VARIANT,
+    }
+
+    # The side effect is required to test async invokes
+    if S3_BUCKET_NAME:
+        s3_key = f"{request_prefix}--{FUNCTION_VARIANT}"
+        response["s3_key"] = s3_key
+        s3.put_object(Bucket=S3_BUCKET_NAME, Key=s3_key, Body=json.dumps(response))
+
+    return response

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
@@ -5,7 +5,7 @@ import time
 import boto3
 
 s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL"))
-S3_BUCKET_NAME = os.environ["S3_BUCKET_NAME"]
+S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME")
 # Configurable identifier to test function updates
 FUNCTION_VARIANT = os.environ.get("FUNCTION_VARIANT")
 

--- a/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
+++ b/tests/aws/services/lambda_/functions/lambda_s3_integration_function_version.py
@@ -12,9 +12,10 @@ FUNCTION_VARIANT = os.environ.get("FUNCTION_VARIANT")
 
 def handler(event, context):
     sleep_duration = int(event.get("sleep_seconds", 0))
-    print(f"Sleeping for {sleep_duration} seconds ...")
-    time.sleep(sleep_duration)
-    print("... done sleeping")
+    if sleep_duration > 0:
+        print(f"Sleeping for {sleep_duration} seconds ...")
+        time.sleep(sleep_duration)
+        print("... done sleeping")
 
     request_prefix = event.get("request_prefix")
     response = {

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2652,7 +2652,7 @@ class TestLambdaVersions:
                   the current implementation stops all running invokes upon update."""
     )
     @markers.aws.validated
-    def test_handler_update_during_invoke(self, aws_client, create_lambda_function, snapshot):
+    def test_function_update_during_invoke(self, aws_client, create_lambda_function, snapshot):
         function_name = f"test-function-{short_uid()}"
         environment_v1 = {"Variables": {"FUNCTION_VARIANT": "variant-1"}}
         create_lambda_function(

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -2667,9 +2667,8 @@ class TestLambdaVersions:
         def _update_function():
             nonlocal errored
             try:
-                # Make it very likely that the invocation is being processed
-                # In LocalStack, Lambda image pulling could potentially affect the exact timing,
-                # but at least the invocation runtime startup should be in progress.
+                # Make it very likely that the invocation is being processed because the incoming invocation acquires
+                # an invocation lease quickly.
                 time.sleep(5)
 
                 environment_v2 = environment_v1.copy()
@@ -2750,9 +2749,8 @@ class TestLambdaVersions:
             InvocationType="Event",
             Payload=json.dumps(payload),
         )
-        # Make it very likely that the first request is being processed before sending further requests without sleeps.
-        # We could use a side effect (e.g., via S3) to signal a status update if Lambda image pulling causes flakiness,
-        # but the poller should have already picked up the async invocation such that a sleep works reliably.
+        # Make it very likely that the invocation is being processed because the Lambda poller should pick up queued
+        # async invokes quickly using long polling.
         time.sleep(2)
 
         # Send async invocation, which should queue up before we update the function

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4266,7 +4266,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
-    "recorded-date": "15-05-2024, 15:11:30",
+    "recorded-date": "15-05-2024, 17:38:05",
     "recorded-content": {
       "async_invoke_history_sorted": [
         "01-sleep--variant-1",

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3522,7 +3522,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_mixed_architecture": {
-    "recorded-date": "08-04-2024, 16:55:53",
+    "recorded-date": "15-05-2024, 12:55:53",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -3573,7 +3573,7 @@
           }
         }
       },
-      "update_function_configuration_response": {
+      "update_function_code_response": {
         "Architectures": [
           "arm64"
         ],
@@ -4263,6 +4263,28 @@
           }
         }
       }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
+    "recorded-date": "15-05-2024, 15:11:30",
+    "recorded-content": {
+      "async_invoke_history_sorted": [
+        "01-sleep--variant-1",
+        "02-before--variant-2",
+        "03-before--variant-2",
+        "04-before--variant-2",
+        "05-before--variant-2",
+        "06-before--variant-2",
+        "07-before--variant-2",
+        "08-before--variant-2",
+        "09-before--variant-2",
+        "10-before--variant-2",
+        "11-after--variant-2",
+        "12-after--variant-2",
+        "13-after--variant-2",
+        "14-after--variant-2",
+        "15-after--variant-2"
+      ]
     }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4161,5 +4161,108 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaMultiAccounts::test_cross_account_access": {
     "recorded-date": "08-04-2024, 16:59:40",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaCleanup::test_recreate_function": {
+    "recorded-date": "15-05-2024, 10:16:45",
+    "recorded-content": {
+      "create_function_response_one": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "lambda_echo.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "create_function_response_two": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "lambda_echo.handler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.12",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4286,5 +4286,24 @@
         "15-after--variant-2"
       ]
     }
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_handler_update_during_invoke": {
+    "recorded-date": "15-05-2024, 19:05:05",
+    "recorded-content": {
+      "invoke_response_before": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "function_version": "$LATEST",
+          "request_id": "<uuid:1>",
+          "request_prefix": "1-sleep",
+          "function_variant": "variant-1"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4287,7 +4287,7 @@
       ]
     }
   },
-  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_handler_update_during_invoke": {
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_function_update_during_invoke": {
     "recorded-date": "15-05-2024, 19:05:05",
     "recorded-content": {
       "invoke_response_before": {

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2024-04-08T16:56:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_mixed_architecture": {
-    "last_validated_date": "2024-04-08T16:55:52+00:00"
+    "last_validated_date": "2024-05-15T12:55:52+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
     "last_validated_date": "2024-04-08T16:55:44+00:00"
@@ -205,6 +205,9 @@
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_non_existing_url": {
     "last_validated_date": "2024-04-11T17:16:39+00:00"
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
+    "last_validated_date": "2024-05-15T15:11:27+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
     "last_validated_date": "2024-04-08T17:10:58+00:00"

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -209,7 +209,7 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
     "last_validated_date": "2024-05-15T18:29:38+00:00"
   },
-  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_handler_update_during_invoke": {
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_function_update_during_invoke": {
     "last_validated_date": "2024-05-15T19:05:04+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -209,6 +209,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
     "last_validated_date": "2024-05-15T18:29:38+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_handler_update_during_invoke": {
+    "last_validated_date": "2024-05-15T19:05:04+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
     "last_validated_date": "2024-04-08T17:10:58+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -56,6 +56,9 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_runtime_ulimits": {
     "last_validated_date": "2024-04-16T08:12:11+00:00"
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaCleanup::test_recreate_function": {
+    "last_validated_date": "2024-05-15T10:16:44+00:00"
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_block": {
     "last_validated_date": "2024-04-08T17:02:06+00:00"
   },

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -207,7 +207,7 @@
     "last_validated_date": "2024-04-11T17:16:39+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_async_invoke_queue_upon_function_update": {
-    "last_validated_date": "2024-05-15T15:11:27+00:00"
+    "last_validated_date": "2024-05-15T18:29:38+00:00"
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaVersions::test_lambda_handler_update": {
     "last_validated_date": "2024-04-08T17:10:58+00:00"

--- a/tests/aws/services/lambda_/test_lambda_performance.py
+++ b/tests/aws/services/lambda_/test_lambda_performance.py
@@ -32,6 +32,7 @@ from tests.aws.services.lambda_.test_lambda import (
     TEST_LAMBDA_PYTHON_ECHO,
     TEST_LAMBDA_PYTHON_S3_INTEGRATION,
 )
+from tests.aws.services.lambda_.utils import get_s3_keys
 
 # These performance tests are opt-in because we currently do not track performance systematically.
 if not is_env_true("TEST_PERFORMANCE"):
@@ -688,16 +689,6 @@ def test_sns_subscription_lambda(
         num_invocations,
         num_invocations,
     ]
-
-
-def get_s3_keys(aws_client, s3_bucket) -> [str]:
-    s3_keys_output = []
-    paginator = aws_client.s3.get_paginator("list_objects_v2")
-    page_iterator = paginator.paginate(Bucket=s3_bucket)
-    for page in page_iterator:
-        for obj in page.get("Contents", []):
-            s3_keys_output.append(obj["Key"])
-    return s3_keys_output
 
 
 def format_summary(timings: [float]) -> str:

--- a/tests/aws/services/lambda_/utils.py
+++ b/tests/aws/services/lambda_/utils.py
@@ -1,0 +1,13 @@
+"""Test utils for Lambda."""
+
+from localstack.aws.connect import ServiceLevelClientFactory
+
+
+def get_s3_keys(aws_client: ServiceLevelClientFactory, s3_bucket: str) -> list[str]:
+    s3_keys_output = []
+    paginator = aws_client.s3.get_paginator("list_objects_v2")
+    page_iterator = paginator.paginate(Bucket=s3_bucket)
+    for page in page_iterator:
+        for obj in page.get("Contents", []):
+            s3_keys_output.append(obj["Key"])
+    return s3_keys_output


### PR DESCRIPTION
## Motivation

Addresses https://github.com/localstack/localstack/issues/10280

Re-creating a Lambda function immediately after deleting it, triggers a race condition and deletes the internal async invoke queue. This causes continuous error logs and breaks async invokes.
The namespace clash also causes further issues because queued invokes can get deleted.

## Changes

* Introduce a volatile (i.e., non-persisted) function instance id unique to a running LocalStack installation that can be used for the async queue namespace
* Add test `test_recreate_function` to reproduce the reported function recreate issue
* Add test `test_function_update_during_invoke` to validate the AWS behavior of function updates during a running invocation => Currently broken on LocalStack ⚠️ 
* Add test `test_async_invoke_queue_upon_function_update` to validate the queuing behavior of async invokes when a function update happens => kinda works but the first invoke fails and gets retried due function updates aborting all running invokes (even for $LATEST)

Unrelated changes sneaked in:
* Fix config default for event rule engine (align with docs)
* Remove unnecessary `lambda_service` backlink in Lambda service manager (missing declaration cleanup from [this PR](https://github.com/localstack/localstack/pull/10614/files#diff-056f8f1dc9188bf87729941f6be9805c0caf16189dafa882f16fb259676f79daL66))
* Fix an outdated comment in the Docker runtime executor
* Fix misleading name in test and snapshot

## Testing

State pickling testing whether the `instance_id` attribute is persisted or not:

1. Debug `tests.aws.services.lambda_.test_lambda.TestLambdaCleanup.test_recreate_function` with a breakpoint at the end of the tests
2. Export the state using `localstack-pro state export --format json lambda-state`
3. Load the pickled file in a scratch file:

```python
import pickle
import pprint

with open("/Users/joe/Downloads/lambda-state/api_states/000000000000/lambda/us-east-1/store.state", "rb") as f:
    lambda_store = pickle.load(f)

    pprint.pp(lambda_store)
    print("attr_functions".center(80, "="))
    pprint.pp(lambda_store.attr_functions)
    print("functions".center(80, "="))
    pprint.pp(lambda_store.functions)

```

## Discussion

* I'm not really happy with the volatile variable hack in the lambda model. Maybe, we can find some better solution here 🤔 
* We should not abort running executions for updates of $LATEST. That seems like a common scenario.

