### PR TITLE
Revert "APIGW: Default to an empty dict when the provided body for an API Gateway step function is an empty string"

### DIFF
--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -190,7 +190,7 @@ class ApiGatewayVtlTemplate(VtlTemplate):
             namespace["stageVariables"] = stage_var
         input_var = variables.get("input") or {}
         variables = {
-            "input": VelocityInput(input_var.get("body") or {}, input_var.get("params")),
+            "input": VelocityInput(input_var.get("body"), input_var.get("params")),
             "util": VelocityUtilApiGateway(),
         }
         namespace.update(variables)

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -80,21 +80,6 @@ APIGW_TEMPLATE_CUSTOM_BODY = """
 }
 """
 
-APIGW_TEMPLATE_BODY_FORWARDING_ONLY = """
-## Template that attempts to forward the request body to the execution input of
-## the state machine.
-
-#set($inputString = '')
-#set($allParams = $input.params())
-{
-    #set($inputString = "$inputString,@@body@@: $input.body")
-    #set($inputString = "$inputString}")
-    #set($inputString = $inputString.replaceAll("@@",'"'))
-    #set($len = $inputString.length() - 1)
-    "input": "{$util.escapeJavaScript($inputString.substring(1,$len)).replaceAll("\\'","'")}"
-}
-"""
-
 
 class TestMessageTransformationBasic:
     def test_return_macro(self):
@@ -196,14 +181,6 @@ class TestMessageTransformationApiGateway:
 
         result = ApiGatewayVtlTemplate().render_vtl(template, variables)
         assert result == " 2"
-
-    def test_template_rendering_with_empty_string_body(self):
-        template = APIGW_TEMPLATE_BODY_FORWARDING_ONLY
-        variables = {"input": {"body": ""}}
-        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
-        result = re.sub(r"\s+", " ", result).strip()
-        result = json.loads(result)
-        assert result == {"input": '{"body": {}}'}
 
     def test_message_transformation(self):
         template = APIGW_TEMPLATE_TRANSFORM_KINESIS


### PR DESCRIPTION
Reverts localstack/localstack#10816

The reverted PR causes an -ext test to fail, which uses the following request template: `Action=SendMessage&MessageBody=$util.urlEncode($input.body)`.

An empty body is defaulted to a dict, which cannot be urlencoded. We either need special handling, a different default value, or a completely different fix for the original issue the PR tried to address.

cc @marcciosilva 