### PR TITLE
add support for `CommaDelimitedList` in cloudformation macro

### DIFF
--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -205,7 +205,11 @@ def execute_macro(
 
     formatted_stack_parameters = {}
     for key, value in stack_parameters.items():
-        formatted_stack_parameters[key] = value.get("ParameterValue")
+        # TODO: we want to support other types of parameters
+        if value.get("ParameterType") == "CommaDelimitedList":
+            formatted_stack_parameters[key] = value.get("ParameterValue").split(",")
+        else:
+            formatted_stack_parameters[key] = value.get("ParameterValue")
 
     transformation_id = f"{account_id}::{macro['Name']}"
     event = {

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -1064,6 +1064,35 @@ class TestMacros:
         snapshot.add_transformer(snapshot.transform.cloudformation_api())
         snapshot.match("failed_description", failed_events_by_policy[0])
 
+    @markers.aws.validated
+    def test_pyplate_param_type_list(self, deploy_cfn_template, aws_client):
+        deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/pyplate_deploy_template.yml"
+            ),
+        )
+
+        tags = "Env=Prod,Application=MyApp,BU=ModernisationTeam"
+        param_tags = {pair.split("=")[0]: pair.split("=")[1] for pair in tags.split(",")}
+
+        stack_with_macro = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/pyplate_example.yml"
+            ),
+            parameters={"Tags": tags},
+        )
+
+        bucket_name_output = stack_with_macro.outputs["BucketName"]
+        assert bucket_name_output
+
+        tagging = aws_client.s3.get_bucket_tagging(Bucket=bucket_name_output)
+        tags_s3 = [tag for tag in tagging["TagSet"]]
+
+        for tag in tags_s3:
+            if tag["Key"] in param_tags:
+                assert tag["Value"] == param_tags[tag["Key"]]
+        assert len(tags_s3) >= len(param_tags)
+
 
 class TestStackEvents:
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -1065,7 +1065,7 @@ class TestMacros:
         snapshot.match("failed_description", failed_events_by_policy[0])
 
     @markers.aws.validated
-    def test_pyplate_param_type_list(self, deploy_cfn_template, aws_client):
+    def test_pyplate_param_type_list(self, deploy_cfn_template, aws_client, snapshot):
         deploy_cfn_template(
             template_path=os.path.join(
                 os.path.dirname(__file__), "../../templates/pyplate_deploy_template.yml"
@@ -1088,10 +1088,13 @@ class TestMacros:
         tagging = aws_client.s3.get_bucket_tagging(Bucket=bucket_name_output)
         tags_s3 = [tag for tag in tagging["TagSet"]]
 
+        resp = []
         for tag in tags_s3:
             if tag["Key"] in param_tags:
                 assert tag["Value"] == param_tags[tag["Key"]]
+                resp.append([tag["Key"], tag["Value"]])
         assert len(tags_s3) >= len(param_tags)
+        snapshot.match("tags", sorted(resp))
 
 
 class TestStackEvents:

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -612,5 +612,9 @@
         "<region>f"
       ]
     }
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
+    "recorded-date": "16-05-2024, 09:33:24",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -614,7 +614,22 @@
     }
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
-    "recorded-date": "16-05-2024, 09:33:24",
-    "recorded-content": {}
+    "recorded-date": "17-05-2024, 06:19:03",
+    "recorded-content": {
+      "tags": [
+        [
+          "Application",
+          "MyApp"
+        ],
+        [
+          "BU",
+          "ModernisationTeam"
+        ],
+        [
+          "Env",
+          "Prod"
+        ]
+      ]
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -29,6 +29,9 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_macro_deployment": {
     "last_validated_date": "2023-01-30T19:13:58+00:00"
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
+    "last_validated_date": "2024-05-16T09:33:24+00:00"
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_scope_order_and_parameters": {
     "last_validated_date": "2022-12-07T08:08:26+00:00"
   },

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2023-01-30T19:13:58+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
-    "last_validated_date": "2024-05-16T09:33:24+00:00"
+    "last_validated_date": "2024-05-16T11:13:53+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_scope_order_and_parameters": {
     "last_validated_date": "2022-12-07T08:08:26+00:00"

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -30,7 +30,7 @@
     "last_validated_date": "2023-01-30T19:13:58+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_pyplate_param_type_list": {
-    "last_validated_date": "2024-05-16T11:13:53+00:00"
+    "last_validated_date": "2024-05-17T06:19:03+00:00"
   },
   "tests/aws/services/cloudformation/test_template_engine.py::TestMacros::test_scope_order_and_parameters": {
     "last_validated_date": "2022-12-07T08:08:26+00:00"

--- a/tests/aws/templates/pyplate_deploy_template.yml
+++ b/tests/aws/templates/pyplate_deploy_template.yml
@@ -1,0 +1,108 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Macro allowing you to run arbitrary Python code in your CloudFormation templates
+
+Parameters:
+  LambdaTimeout:
+    Description: "Optional setting of the Lambda's execution timeout (in seconds). \nThe default of 3 seconds won't be enough if you call AWS services; \nthen at least 10 seconds is recommended, more depending on complexity.\n"
+    Type: Number
+    Default: 10
+    MinValue: 3
+
+Resources:
+  TransformExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:*
+                Resource: arn:aws:logs:*:*:*
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess
+
+  TransformFunction:
+    Type: AWS::Lambda::Function
+    Metadata:
+      guard:
+        SuppressedRules:
+          - LAMBDA_INSIDE_VPC
+    Properties:
+      Description: Support for the PyPlate CloudFormation macro
+      Code:
+        ZipFile: |
+          #pylint: disable=exec-used
+
+          import traceback
+          import json
+
+          def obj_iterate(obj, params):
+              "Iterate over template resources and execute any PyPlate directives"
+              if isinstance(obj, dict):
+                  for k in obj:
+                      obj[k] = obj_iterate(obj[k], params)
+              elif isinstance(obj, list):
+                  for i, v in enumerate(obj):
+                      obj[i] = obj_iterate(v, params)
+              elif isinstance(obj, str):
+                  if obj.startswith("#!PyPlate"):
+                      params["output"] = None
+                      exec(obj, params)
+                      obj = params["output"]
+              return obj
+
+          def handler(event, _):
+              "Lambda handler"
+              print(json.dumps(event))
+
+              macro_response = {"requestId": event["requestId"], "status": "success"}
+              try:
+                  params = {
+                      "params": event["templateParameterValues"],
+                      "template": event["fragment"],
+                      "account_id": event["accountId"],
+                      "region": event["region"],
+                  }
+                  response = event["fragment"]
+                  macro_response["fragment"] = obj_iterate(response, params)
+              except Exception as e:
+                  traceback.print_exc()
+                  macro_response["status"] = "failure"
+                  macro_response["errorMessage"] = str(e)
+              return macro_response
+      Handler: index.handler
+      Runtime: python3.11
+      Role: !GetAtt TransformExecutionRole.Arn
+      Timeout: !Ref LambdaTimeout
+
+  TransformFunctionPermissions:
+    Type: AWS::Lambda::Permission
+    Metadata:
+      guard:
+        SuppressedRules:
+          - LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt TransformFunction.Arn
+      Principal: cloudformation.amazonaws.com
+
+  Transform:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: !Sub PyPlate
+      Description: Processes inline python in templates
+      FunctionName: !GetAtt TransformFunction.Arn

--- a/tests/aws/templates/pyplate_example.yml
+++ b/tests/aws/templates/pyplate_example.yml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: tests String macro functions
+
+Parameters:
+  Tags:
+    Type: CommaDelimitedList
+    Default: Env=Prod
+
+Transform:
+  - PyPlate
+
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      Comment: Suppressing typical rules for sample purposes only
+      guard:
+        SuppressedRules:
+          - S3_BUCKET_LOGGING_ENABLED
+          - S3_BUCKET_PUBLIC_READ_PROHIBITED
+          - S3_BUCKET_PUBLIC_WRITE_PROHIBITED
+          - S3_BUCKET_REPLICATION_ENABLED
+          - S3_BUCKET_VERSIONING_ENABLED
+          - S3_BUCKET_DEFAULT_LOCK_ENABLED
+          - S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+    Properties:
+      Tags: |-
+        #!PyPlate
+        output = []
+        for tag in params['Tags']:
+           key, value = tag.split('=')
+           output.append({"Key": key, "Value": value})
+
+Outputs:
+  BucketName:
+    Value:
+      Ref: S3Bucket

--- a/tests/aws/templates/pyplate_example.yml
+++ b/tests/aws/templates/pyplate_example.yml
@@ -5,27 +5,15 @@ Description: tests String macro functions
 Parameters:
   Tags:
     Type: CommaDelimitedList
-    Default: Env=Prod
 
 Transform:
   - PyPlate
 
 Resources:
   S3Bucket:
-    Type: AWS::S3::Bucket
-    Metadata:
-      Comment: Suppressing typical rules for sample purposes only
-      guard:
-        SuppressedRules:
-          - S3_BUCKET_LOGGING_ENABLED
-          - S3_BUCKET_PUBLIC_READ_PROHIBITED
-          - S3_BUCKET_PUBLIC_WRITE_PROHIBITED
-          - S3_BUCKET_REPLICATION_ENABLED
-          - S3_BUCKET_VERSIONING_ENABLED
-          - S3_BUCKET_DEFAULT_LOCK_ENABLED
-          - S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+    Type: "AWS::S3::Bucket"
     Properties:
-      Tags: |-
+      Tags: |
         #!PyPlate
         output = []
         for tag in params['Tags']:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When creating resource from `AWS::CloudFormation::Macro`, there was a missing support of parameter type `CommaDelimitedList`. This was reported in https://github.com/localstack/localstack/issues/10794 where user is trying to create a nested template with the following parameter:

 ```
 Subnets:
    Type: CommaDelimitedList
    Description: The IDs of the public DMZ subnets
```
using PyPlate Macros: https://github.com/aws-cloudformation/aws-cloudformation-macros/tree/master/PyPlate.  

Sample template: 

```
AWSTemplateFormatVersion: "2010-09-09"
Description: tests String macro functions
Parameters:
  Tags:
    Default: "Env=Prod,Application=MyApp,BU=ModernisationTeam"
    Type: "CommaDelimitedList"
Resources:
  S3Bucket:
    Type: "AWS::S3::Bucket"
    Properties:
      Tags: |
        #!PyPlate
        output = []
        for tag in params['Tags']:
           key, value = tag.split('=')
           output.append({"Key": key, "Value": value})
Transform: [PyPlate]
```

This resulted in the following error: 

```
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e] Traceback (most recent call last):
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "/var/task/index.py", line 34, in handler
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]     macro_response["fragment"] = obj_iterate(response, params)
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "/var/task/index.py", line 10, in obj_iterate
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]     obj[k] = obj_iterate(obj[k], params)
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16T16:22:39.599 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "/var/task/index.py", line 10, in obj_iterate
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]     obj[k] = obj_iterate(obj[k], params)
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "/var/task/index.py", line 10, in obj_iterate
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]     obj[k] = obj_iterate(obj[k], params)
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   [Previous line repeated 1 more time]
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "/var/task/index.py", line 17, in obj_iterate
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]     exec(obj, params)
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e]   File "<string>", line 4, in <module>
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e] ValueError: not enough values to unpack (expected 2, got 1)
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e] END RequestId: 372f6a8b-d680-44ce-8787-32a9a06f9e7e
2024-05-16T16:22:39.600 DEBUG --- [et.reactor-0] l.s.l.i.version_manager    : [pyplate-macro-TransformFunction-cd8fc0aa-372f6a8b-d680-44ce-8787-32a9a06f9e7e] REPORT RequestId: 372f6a8b-d680-44ce-8787-32a9a06f9e7e    Duration: 12.25 ms      Billed Duration: 13 ms   Memory Size: 128 MB     Max Memory Used: 128 MB 
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR:
- adds support of `CommaDelimitedList` param type in cloudformation macro
- adds AWS validated test using `PyPlate` template to check the results. 

closes: https://github.com/localstack/localstack/issues/10794
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
