### PR TITLE
mitigate CI timeouts by increasing parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
       image: << parameters.machine_image >>
     resource_class: << parameters.resource_class >>
     working_directory: /tmp/workspace/repo
-    parallelism: 4
+    parallelism: 5
     environment:
       PYTEST_LOGLEVEL: << pipeline.parameters.PYTEST_LOGLEVEL >>
     steps:


### PR DESCRIPTION
## Motivation
The run time of our pipeline increased dramatically somewhat around the time of our latest bump of moto (with https://github.com/localstack/localstack/pull/10742).
This is causing some timeouts in the pipeline due to the hard limit of 60 minutes for a job in CircleCI.
While we are still investigating the issue, this PR tries to unblock the pipeline by adding another parallel runner in the meantime.

## Changes
- Adds another runner to the CircleCI integration tests for until we identified the issue.

/cc @viren-nadkarni