### PR TITLE
fix SNS test with wrong base64 assumption

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -843,7 +843,7 @@ class TestSNSSubscriptionCrud:
         # not snapshotting the results, it contains 100 entries
         assert "NextToken" in response
         # seems to be b64 encoded
-        assert response["NextToken"].endswith("==")
+        assert base64.b64decode(response["NextToken"])
         assert len(response["Subscriptions"]) == 100
         # keep the page 1 subscriptions ARNs
         page_1_subs = {sub["SubscriptionArn"] for sub in response["Subscriptions"]}

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -4074,7 +4074,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_list_subscriptions_by_topic_pagination": {
-    "recorded-date": "13-05-2024, 12:50:25",
+    "recorded-date": "16-05-2024, 10:32:16",
     "recorded-content": {
       "list-sub-per-topic-page-2": {
         "Subscriptions": [

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -57,7 +57,7 @@
     "last_validated_date": "2023-08-25T14:23:53+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_list_subscriptions_by_topic_pagination": {
-    "last_validated_date": "2024-05-13T12:50:03+00:00"
+    "last_validated_date": "2024-05-16T10:31:56+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSubscriptionCrud::test_not_found_error_on_set_subscription_attributes": {
     "last_validated_date": "2023-08-24T21:27:55+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As shown by https://app.circleci.com/pipelines/github/localstack/localstack/24900/workflows/810d396a-b56e-4ad2-bb6c-ce6e4d73f4b4/jobs/207505/tests, there was a wrong assertion in `test_list_subscriptions_by_topic_pagination` and the base64 string finishing by `==`, which worked with the length of the ARN in `us-east-1` and against AWS and most probably needed padding. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- changed the assertion to just assert it is base64

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
