### PR TITLE
Feature: Eventbridge v2: Add tagging

### DIFF
--- a/localstack/services/events/models.py
+++ b/localstack/services/events/models.py
@@ -16,7 +16,6 @@ from localstack.aws.api.events import (
     RuleName,
     RuleState,
     ScheduleExpression,
-    Tag,
     TagList,
     Target,
     TargetId,
@@ -27,6 +26,7 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
+from localstack.utils.tagging import TaggingService
 
 TargetDict = dict[TargetId, Target]
 
@@ -86,15 +86,13 @@ class EventBus:
 
 EventBusDict = dict[EventBusName, EventBus]
 
-TagDict = dict[Arn, Tag]
-
 
 class EventsStore(BaseStore):
     # Map of eventbus names to eventbus objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     event_buses: EventBusDict = LocalAttribute(default=dict)
 
     # Maps resource ARN to tags
-    TAGS: TagDict = CrossRegionAttribute(default=dict)
+    TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 
 
 events_store = AccountRegionBundle("events", EventsStore)

--- a/localstack/services/events/models.py
+++ b/localstack/services/events/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Optional, TypeAlias, TypedDict
 
 from localstack.aws.api.core import ServiceException
@@ -15,6 +16,7 @@ from localstack.aws.api.events import (
     RuleName,
     RuleState,
     ScheduleExpression,
+    Tag,
     TagList,
     Target,
     TargetId,
@@ -22,6 +24,7 @@ from localstack.aws.api.events import (
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
+    CrossRegionAttribute,
     LocalAttribute,
 )
 
@@ -83,10 +86,15 @@ class EventBus:
 
 EventBusDict = dict[EventBusName, EventBus]
 
+TagDict = dict[Arn, Tag]
+
 
 class EventsStore(BaseStore):
     # Map of eventbus names to eventbus objects. The name MUST be unique per account and region (works with AccountRegionBundle)
     event_buses: EventBusDict = LocalAttribute(default=dict)
+
+    # Maps resource ARN to tags
+    TAGS: TagDict = CrossRegionAttribute(default=dict)
 
 
 events_store = AccountRegionBundle("events", EventsStore)
@@ -119,3 +127,8 @@ class FormattedEvent(TypedDict):
 
 
 TransformedEvent: TypeAlias = FormattedEvent | dict | str
+
+
+class ResourceType(Enum):
+    EVENT_BUS = "event_bus"
+    RULE = "rule"

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -159,7 +159,7 @@ def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> 
     return formatted_event
 
 
-def get_bus_or_rule(arn: Arn) -> ResourceType:
+def get_resource_type(arn: Arn) -> ResourceType:
     parsed_arn = parse_arn(arn)
     resource_type = parsed_arn["resource"].split("/", 1)[0]
     if resource_type == "event-bus":
@@ -537,7 +537,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self, context: RequestContext, resource_arn: Arn, **kwargs
     ) -> ListTagsForResourceResponse:
         store = self.get_store(context)
-        resource_type = get_bus_or_rule(resource_arn)
+        resource_type = get_resource_type(resource_arn)
         if not resource_type:
             pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
@@ -551,7 +551,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         # each tag key must be unique
         # https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-best-practices
         store = self.get_store(context)
-        resource_type = get_bus_or_rule(resource_arn)
+        resource_type = get_resource_type(resource_arn)
         if not resource_type:
             pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
@@ -563,7 +563,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         self, context: RequestContext, resource_arn: Arn, tag_keys: TagKeyList, **kwargs
     ) -> UntagResourceResponse:
         store = self.get_store(context)
-        resource_type = get_bus_or_rule(resource_arn)
+        resource_type = get_resource_type(resource_arn)
         if not resource_type:
             pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
@@ -695,7 +695,7 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             return "default"
         if "arn:aws:events" not in resource_arn_or_name:
             return resource_arn_or_name
-        resource_type = get_bus_or_rule(resource_arn_or_name)
+        resource_type = get_resource_type(resource_arn_or_name)
         # TODO how to deal with / in event bus name or rule name
         if resource_type == ResourceType.EVENT_BUS:
             return resource_arn_or_name.split("/")[-1]

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -166,6 +166,9 @@ def get_resource_type(arn: Arn) -> ResourceType:
         return ResourceType.EVENT_BUS
     if resource_type == "rule":
         return ResourceType.RULE
+    raise ValidationException(
+        f"Parameter {arn} is not valid. Reason: Provided Arn is not in correct format."
+    )
 
 
 def check_unique_tags(tags: TagsList) -> None:
@@ -538,8 +541,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> ListTagsForResourceResponse:
         store = self.get_store(context)
         resource_type = get_resource_type(resource_arn)
-        if not resource_type:
-            pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
         tags = store.TAGS.list_tags_for_resource(resource_arn)
         return ListTagsForResourceResponse(tags)
@@ -552,8 +553,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         # https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-best-practices
         store = self.get_store(context)
         resource_type = get_resource_type(resource_arn)
-        if not resource_type:
-            pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
         check_unique_tags(tags)
         store.TAGS.tag_resource(resource_arn, tags)
@@ -564,8 +563,6 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
     ) -> UntagResourceResponse:
         store = self.get_store(context)
         resource_type = get_resource_type(resource_arn)
-        if not resource_type:
-            pass  # TODO handle error for tagging not rule or event_bus
         self._check_resource_exists(resource_arn, resource_type, store)
         store.TAGS.untag_resource(resource_arn, tag_keys)
 

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -161,10 +161,10 @@ def format_event(event: PutEventsRequestEntry, region: str, account_id: str) -> 
 
 def get_bus_or_rule(arn: Arn) -> ResourceType:
     parsed_arn = parse_arn(arn)
-    service = parsed_arn["resource"].split("/", 1)[0]
-    if service == "event-bus":
+    resource_type = parsed_arn["resource"].split("/", 1)[0]
+    if resource_type == "event-bus":
         return ResourceType.EVENT_BUS
-    if service == "rule":
+    if resource_type == "rule":
         return ResourceType.RULE
 
 

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -211,6 +211,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
         )
         store.event_buses[event_bus_service.event_bus.name] = event_bus_service.event_bus
 
+        if tags:
+            self.tag_resource(context, event_bus_service.arn, tags)
+
         response = CreateEventBusResponse(
             EventBusArn=event_bus_service.arn,
         )

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -230,9 +230,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 if rules := event_bus.rules:
                     self._delete_rule_services(rules)
                 del store.event_buses[name]
+                del store.TAGS[event_bus.arn]
         except ResourceNotFoundException as error:
             return error
-        # TODO remove tags
 
     @handler("DescribeEventBus")
     def describe_event_bus(
@@ -304,9 +304,9 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
                 raise ValidationException("Rule can't be deleted since it has targets.")
             self._delete_rule_services(rule)
             del event_bus.rules[name]
+            del store.TAGS[rule.arn]
         except ResourceNotFoundException as error:
             return error
-        # TODO remove tags
 
     @handler("DescribeRule")
     def describe_rule(

--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -403,6 +403,10 @@ class EventsProvider(EventsApi, ServiceLifecycleHook):
             targets,
         )
         event_bus.rules[name] = rule_service.rule
+
+        if tags:
+            self.tag_resource(context, rule_service.arn, tags)
+
         response = PutRuleResponse(RuleArn=rule_service.arn)
         return response
 

--- a/localstack/utils/tagging.py
+++ b/localstack/utils/tagging.py
@@ -25,3 +25,10 @@ class TaggingService:
         tags = self.tags.get(arn, {})
         for name in tag_names:
             tags.pop(name, None)
+
+    def del_resource(self, arn: str):
+        if arn in self.tags:
+            del self.tags[arn]
+
+    def __delitem__(self, arn: str):
+        self.del_resource(arn)

--- a/tests/aws/services/events/conftest.py
+++ b/tests/aws/services/events/conftest.py
@@ -125,15 +125,18 @@ def events_put_rule(aws_client):
     yield _factory
 
     for rule, event_bus_name in rules:
-        targets_response = aws_client.events.list_targets_by_rule(
-            Rule=rule, EventBusName=event_bus_name
-        )
-        if targets := targets_response["Targets"]:
-            targets_ids = [target["Id"] for target in targets]
-            aws_client.events.remove_targets(
-                Rule=rule, EventBusName=event_bus_name, Ids=targets_ids
+        try:
+            targets_response = aws_client.events.list_targets_by_rule(
+                Rule=rule, EventBusName=event_bus_name
             )
-        aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
+            if targets := targets_response["Targets"]:
+                targets_ids = [target["Id"] for target in targets]
+                aws_client.events.remove_targets(
+                    Rule=rule, EventBusName=event_bus_name, Ids=targets_ids
+                )
+            aws_client.events.delete_rule(Name=rule, EventBusName=event_bus_name)
+        except Exception as e:
+            LOG.debug("error cleaning up rule %s: %s", rule, e)
 
 
 @pytest.fixture

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -190,35 +190,8 @@ class TestEvents:
 
         assert [json.loads(event["Detail"]) for event in sorted_events] == event_details_to_publish
 
-    @markers.aws.validated
-    @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
-    def test_list_tags_for_resource(self, aws_client, clean_up):
-        rule_name = "rule-{}".format(short_uid())
-
-        rule = aws_client.events.put_rule(
-            Name=rule_name, EventPattern=json.dumps(TEST_EVENT_PATTERN)
-        )
-        rule_arn = rule["RuleArn"]
-        expected = [
-            {"Key": "key1", "Value": "value1"},
-            {"Key": "key2", "Value": "value2"},
-        ]
-
-        # insert two tags, verify both are visible
-        aws_client.events.tag_resource(ResourceARN=rule_arn, Tags=expected)
-        actual = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)["Tags"]
-        assert actual == expected
-
-        # remove 'key2', verify only 'key1' remains
-        expected = [{"Key": "key1", "Value": "value1"}]
-        aws_client.events.untag_resource(ResourceARN=rule_arn, TagKeys=["key2"])
-        actual = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)["Tags"]
-        assert actual == expected
-
-        # clean up
-        clean_up(rule_name=rule_name)
-
     @markers.aws.unknown
+    # TODO move to schedule
     @pytest.mark.skipif(is_v2_provider(), reason="V2 provider does not support this feature yet")
     def test_scheduled_expression_events(
         self,

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -133,7 +133,9 @@ class TestScheduleRate:
             json.loads(messages_second[0]["Body"])["time"]
         )
         time_delta = time_messages_second - time_messages_first
-        assert time_delta == timedelta(seconds=60)
+        expected_time_delta = timedelta(seconds=60)
+        tolerance = timedelta(seconds=5)
+        assert expected_time_delta - tolerance <= time_delta <= expected_time_delta + tolerance
 
     @markers.aws.validated
     def tests_schedule_rate_custom_input_target_sqs(

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -187,3 +187,17 @@ class TestEventBusTags:
         response_create_event_bus = aws_client.events.list_tags_for_resource(ResourceARN=bus_arn)
         snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus_name>"))
         snapshot.match("list_tags_for_event_bus", response_create_event_bus)
+
+    @markers.aws.validated
+    def test_list_tags_for_deleted_event_bus(self, events_create_event_bus, aws_client, snapshot):
+        bus_name = f"test_bus-{short_uid()}"
+        response = events_create_event_bus(Name=bus_name)
+        bus_arn = response["EventBusArn"]
+
+        aws_client.events.delete_event_bus(Name=bus_name)
+
+        with pytest.raises(aws_client.events.exceptions.ResourceNotFoundException) as error:
+            aws_client.events.list_tags_for_resource(ResourceARN=bus_arn)
+
+        snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus_name>"))
+        snapshot.match("list_tags_for_deleted_rule_error", error)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -56,3 +56,34 @@ def tests_tag_untag_resource(
 
     response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
     snapshot.match("list_untagged_rule", response)
+
+
+class TestRuleTags:
+    @markers.aws.validated
+    def test_put_rule_with_tags(
+        self, events_create_event_bus, events_put_rule, aws_client, snapshot
+    ):
+        bus_name = f"test_bus-{short_uid()}"
+        events_create_event_bus(Name=bus_name)
+
+        rule_name = f"test_rule-{short_uid()}"
+        response_put_rule = events_put_rule(
+            Name=rule_name,
+            EventPattern=json.dumps(TEST_EVENT_PATTERN),
+            Tags=[
+                {
+                    "Key": "tag1",
+                    "Value": "value1",
+                },
+                {
+                    "Key": "tag2",
+                    "Value": "value2",
+                },
+            ],
+        )
+        rule_arn = response_put_rule["RuleArn"]
+        snapshot.match("put_rule_with_tags", response_put_rule)
+
+        response_put_rule = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
+        snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule_name>"))
+        snapshot.match("list_tags_for_rule", response_put_rule)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -4,6 +4,7 @@ import pytest
 
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
+from tests.aws.services.events.helper_functions import is_v2_provider
 from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
 
 
@@ -62,6 +63,10 @@ def tests_tag_untag_resource(
 
 
 @markers.aws.validated
+@pytest.mark.skipif(
+    not is_v2_provider(),
+    reason="V1 provider does not support this feature",
+)
 @pytest.mark.parametrize("resource_to_tag", ["not_existing_rule", "not_existing_event_bus"])
 def tests_tag_list_untag_not_existing_resource(
     resource_to_tag,
@@ -136,6 +141,10 @@ class TestRuleTags:
         snapshot.match("list_tags_for_rule", response_put_rule)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_list_tags_for_deleted_rule(
         self, events_create_event_bus, events_put_rule, aws_client, snapshot
     ):
@@ -189,6 +198,10 @@ class TestEventBusTags:
         snapshot.match("list_tags_for_event_bus", response_create_event_bus)
 
     @markers.aws.validated
+    @pytest.mark.skipif(
+        not is_v2_provider(),
+        reason="V1 provider does not support this feature",
+    )
     def test_list_tags_for_deleted_event_bus(self, events_create_event_bus, aws_client, snapshot):
         bus_name = f"test_bus-{short_uid()}"
         response = events_create_event_bus(Name=bus_name)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -10,7 +10,11 @@ from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
 @markers.aws.validated
 @pytest.mark.parametrize("resource_to_tag", ["event_bus", "rule"])
 def tests_tag_untag_resource(
-    resource_to_tag, events_create_event_bus, events_put_rule, aws_client, snapshot
+    resource_to_tag,
+    events_create_event_bus,
+    events_put_rule,
+    aws_client,
+    snapshot,
 ):
     bus_name = f"test_bus-{short_uid()}"
     response = events_create_event_bus(Name=bus_name)
@@ -28,7 +32,6 @@ def tests_tag_untag_resource(
         resource_arn = event_bus_arn
     if resource_to_tag == "rule":
         resource_arn = rule_arn
-
     tag_key_2 = "tag2"
     response_tag_resource = aws_client.events.tag_resource(
         ResourceARN=resource_arn,
@@ -46,7 +49,7 @@ def tests_tag_untag_resource(
     snapshot.match("tag_resource", response_tag_resource)
 
     response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
-    snapshot.match("list_tagged_rule", response)
+    snapshot.match("list_tags_for_resource", response)
 
     response_untag_resource = aws_client.events.untag_resource(
         ResourceARN=resource_arn,
@@ -55,6 +58,7 @@ def tests_tag_untag_resource(
     snapshot.match("untag_resource", response_untag_resource)
 
     response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
+    snapshot.match("list_tags_for_untagged_resource", response)
 
 
 @markers.aws.validated

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -87,3 +87,28 @@ class TestRuleTags:
         response_put_rule = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
         snapshot.add_transformer(snapshot.transform.regex(rule_name, "<rule_name>"))
         snapshot.match("list_tags_for_rule", response_put_rule)
+
+
+class TestEventBusTags:
+    @markers.aws.validated
+    def test_create_event_bus_with_tags(self, events_create_event_bus, aws_client, snapshot):
+        bus_name = f"test_bus-{short_uid()}"
+        response_create_event_bus = events_create_event_bus(
+            Name=bus_name,
+            Tags=[
+                {
+                    "Key": "tag1",
+                    "Value": "value1",
+                },
+                {
+                    "Key": "tag2",
+                    "Value": "value2",
+                },
+            ],
+        )
+        bus_arn = response_create_event_bus["EventBusArn"]
+        snapshot.match("create_event_bus_with_tags", response_create_event_bus)
+
+        response_create_event_bus = aws_client.events.list_tags_for_resource(ResourceARN=bus_arn)
+        snapshot.add_transformer(snapshot.transform.regex(bus_name, "<bus_name>"))
+        snapshot.match("list_tags_for_event_bus", response_create_event_bus)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -1,0 +1,48 @@
+import json
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
+
+
+class TestRuleTags:
+    @markers.aws.validated
+    def tests_tag_untag_resource(self, events_put_rule, aws_client, snapshot):
+        bus_name = f"test_bus-{short_uid()}"
+        aws_client.events.create_event_bus(Name=bus_name)
+
+        rule_name = f"test_rule-{short_uid()}"
+        response = events_put_rule(
+            Name=rule_name,
+            EventBusName=bus_name,
+            EventPattern=json.dumps(TEST_EVENT_PATTERN),
+        )
+        rule_arn = response["RuleArn"]
+
+        tag_key_2 = "tag2"
+        response_tag_resource = aws_client.events.tag_resource(
+            ResourceARN=rule_arn,
+            Tags=[
+                {
+                    "Key": "tag1",
+                    "Value": "value1",
+                },
+                {
+                    "Key": tag_key_2,
+                    "Value": "value2",
+                },
+            ],
+        )
+        snapshot.match("tag_resource", response_tag_resource)
+
+        response = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
+        snapshot.match("list_tagged_rule", response)
+
+        response_untag_resource = aws_client.events.untag_resource(
+            ResourceARN=rule_arn,
+            TagKeys=[tag_key_2],
+        )
+        snapshot.match("untag_resource", response_untag_resource)
+
+        response = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
+        snapshot.match("list_untagged_rule", response)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -1,48 +1,58 @@
 import json
 
+import pytest
+
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
 
 
-class TestRuleTags:
-    @markers.aws.validated
-    def tests_tag_untag_resource(self, events_put_rule, aws_client, snapshot):
-        bus_name = f"test_bus-{short_uid()}"
-        aws_client.events.create_event_bus(Name=bus_name)
+@markers.aws.validated
+@pytest.mark.parametrize("resource_to_tag", ["event_bus", "rule"])
+def tests_tag_untag_resource(
+    resource_to_tag, events_create_event_bus, events_put_rule, aws_client, snapshot
+):
+    bus_name = f"test_bus-{short_uid()}"
+    response = events_create_event_bus(Name=bus_name)
+    event_bus_arn = response["EventBusArn"]
 
-        rule_name = f"test_rule-{short_uid()}"
-        response = events_put_rule(
-            Name=rule_name,
-            EventBusName=bus_name,
-            EventPattern=json.dumps(TEST_EVENT_PATTERN),
-        )
-        rule_arn = response["RuleArn"]
+    rule_name = f"test_rule-{short_uid()}"
+    response = events_put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps(TEST_EVENT_PATTERN),
+    )
+    rule_arn = response["RuleArn"]
 
-        tag_key_2 = "tag2"
-        response_tag_resource = aws_client.events.tag_resource(
-            ResourceARN=rule_arn,
-            Tags=[
-                {
-                    "Key": "tag1",
-                    "Value": "value1",
-                },
-                {
-                    "Key": tag_key_2,
-                    "Value": "value2",
-                },
-            ],
-        )
-        snapshot.match("tag_resource", response_tag_resource)
+    if resource_to_tag == "event_bus":
+        resource_arn = event_bus_arn
+    if resource_to_tag == "rule":
+        resource_arn = rule_arn
 
-        response = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
-        snapshot.match("list_tagged_rule", response)
+    tag_key_2 = "tag2"
+    response_tag_resource = aws_client.events.tag_resource(
+        ResourceARN=resource_arn,
+        Tags=[
+            {
+                "Key": "tag1",
+                "Value": "value1",
+            },
+            {
+                "Key": tag_key_2,
+                "Value": "value2",
+            },
+        ],
+    )
+    snapshot.match("tag_resource", response_tag_resource)
 
-        response_untag_resource = aws_client.events.untag_resource(
-            ResourceARN=rule_arn,
-            TagKeys=[tag_key_2],
-        )
-        snapshot.match("untag_resource", response_untag_resource)
+    response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
+    snapshot.match("list_tagged_rule", response)
 
-        response = aws_client.events.list_tags_for_resource(ResourceARN=rule_arn)
-        snapshot.match("list_untagged_rule", response)
+    response_untag_resource = aws_client.events.untag_resource(
+        ResourceARN=resource_arn,
+        TagKeys=[tag_key_2],
+    )
+    snapshot.match("untag_resource", response_untag_resource)
+
+    response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
+    snapshot.match("list_untagged_rule", response)

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -69,6 +69,12 @@ def tests_tag_untag_resource(
     response = aws_client.events.list_tags_for_resource(ResourceARN=resource_arn)
     snapshot.match("list_tags_for_untagged_resource", response)
 
+    response_untag_resource_not_existing_tag = aws_client.events.untag_resource(
+        ResourceARN=resource_arn,
+        TagKeys=[f"not_existing_tag-{short_uid()}"],
+    )
+    snapshot.match("untag_resource_not_existing_tag", response_untag_resource_not_existing_tag)
+
 
 @markers.aws.validated
 @pytest.mark.skipif(

--- a/tests/aws/services/events/test_events_tags.py
+++ b/tests/aws/services/events/test_events_tags.py
@@ -9,17 +9,25 @@ from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
 
 
 @markers.aws.validated
+@pytest.mark.parametrize("event_bus_name", ["event_bus_default", "event_bus_custom"])
 @pytest.mark.parametrize("resource_to_tag", ["event_bus", "rule"])
 def tests_tag_untag_resource(
+    event_bus_name,
     resource_to_tag,
+    region_name,
+    account_id,
     events_create_event_bus,
     events_put_rule,
     aws_client,
     snapshot,
 ):
-    bus_name = f"test_bus-{short_uid()}"
-    response = events_create_event_bus(Name=bus_name)
-    event_bus_arn = response["EventBusArn"]
+    if event_bus_name == "event_bus_default":
+        bus_name = "default"
+        event_bus_arn = f"arn:aws:events:{region_name}:{account_id}:event-bus/default"
+    if event_bus_name == "event_bus_custom":
+        bus_name = f"test_bus-{short_uid()}"
+        response = events_create_event_bus(Name=bus_name)
+        event_bus_arn = response["EventBusArn"]
 
     rule_name = f"test_rule-{short_uid()}"
     response = events_put_rule(

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -116,5 +116,33 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
+    "recorded-date": "15-05-2024, 14:01:46",
+    "recorded-content": {
+      "create_event_bus_with_tags": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus_name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_event_bus": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -1,6 +1,51 @@
 {
-  "tests/aws/services/events/test_events_tags.py::TestRuleTags::tests_tag_untag_resource": {
-    "recorded-date": "15-05-2024, 13:41:22",
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
+    "recorded-date": "15-05-2024, 13:47:52",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tagged_rule": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_untagged_rule": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
+    "recorded-date": "15-05-2024, 13:47:54",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "recorded-date": "15-05-2024, 14:23:15",
+    "recorded-date": "15-05-2024, 14:57:52",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -45,7 +45,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "recorded-date": "15-05-2024, 14:23:17",
+    "recorded-date": "15-05-2024, 14:57:54",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -89,8 +89,24 @@
       }
     }
   },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
+    "recorded-date": "15-05-2024, 14:57:57",
+    "recorded-content": {
+      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
+      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
+      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
+    "recorded-date": "15-05-2024, 14:58:00",
+    "recorded-content": {
+      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
+      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
+      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>"
+    }
+  },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
-    "recorded-date": "15-05-2024, 14:23:23",
+    "recorded-date": "15-05-2024, 14:58:01",
     "recorded-content": {
       "put_rule_with_tags": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule_name>",
@@ -117,8 +133,14 @@
       }
     }
   },
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
+    "recorded-date": "15-05-2024, 14:58:02",
+    "recorded-content": {
+      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <rule_name> does not exist on EventBus <bus_name>.') tblen=3>"
+    }
+  },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
-    "recorded-date": "15-05-2024, 14:23:25",
+    "recorded-date": "15-05-2024, 14:58:04",
     "recorded-content": {
       "create_event_bus_with_tags": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus_name>",
@@ -145,42 +167,8 @@
       }
     }
   },
-  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[not_existing_rule]": {
-    "recorded-date": "15-05-2024, 14:08:29",
-    "recorded-content": {}
-  },
-  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[not_existing_event_bus]": {
-    "recorded-date": "15-05-2024, 14:08:30",
-    "recorded-content": {}
-  },
-  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
-    "recorded-date": "15-05-2024, 14:31:38",
-    "recorded-content": {
-      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
-      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
-      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
-    "recorded-date": "15-05-2024, 14:31:40",
-    "recorded-content": {
-      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
-      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
-      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>"
-    }
-  },
-  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_resource": {
-    "recorded-date": "15-05-2024, 14:43:11",
-    "recorded-content": {}
-  },
-  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
-    "recorded-date": "15-05-2024, 14:53:08",
-    "recorded-content": {
-      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <rule_name> does not exist on EventBus <bus_name>.') tblen=3>"
-    }
-  },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
-    "recorded-date": "15-05-2024, 14:54:48",
+    "recorded-date": "15-05-2024, 14:58:05",
     "recorded-content": {
       "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <bus_name> does not exist.') tblen=3>"
     }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -174,7 +174,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_default]": {
-    "recorded-date": "16-05-2024, 09:49:39",
+    "recorded-date": "16-05-2024, 11:45:30",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -211,6 +211,12 @@
             "Value": "value1"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource_not_existing_tag": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -219,7 +225,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_custom]": {
-    "recorded-date": "16-05-2024, 09:49:40",
+    "recorded-date": "16-05-2024, 11:45:31",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -256,6 +262,12 @@
             "Value": "value1"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource_not_existing_tag": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -264,7 +276,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_default]": {
-    "recorded-date": "16-05-2024, 09:49:41",
+    "recorded-date": "16-05-2024, 11:45:32",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -301,6 +313,12 @@
             "Value": "value1"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource_not_existing_tag": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -309,7 +327,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_custom]": {
-    "recorded-date": "16-05-2024, 09:49:42",
+    "recorded-date": "16-05-2024, 11:45:34",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -346,6 +364,12 @@
             "Value": "value1"
           }
         ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource_not_existing_tag": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "recorded-date": "15-05-2024, 14:08:25",
+    "recorded-date": "15-05-2024, 14:23:15",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -8,7 +8,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_tagged_rule": {
+      "list_tags_for_resource": {
         "Tags": [
           {
             "Key": "tag1",
@@ -30,7 +30,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_untagged_rule": {
+      "list_tags_for_untagged_resource": {
         "Tags": [
           {
             "Key": "tag1",
@@ -45,7 +45,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "recorded-date": "15-05-2024, 14:08:27",
+    "recorded-date": "15-05-2024, 14:23:17",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -53,7 +53,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_tagged_rule": {
+      "list_tags_for_resource": {
         "Tags": [
           {
             "Key": "tag1",
@@ -75,7 +75,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "list_untagged_rule": {
+      "list_tags_for_untagged_resource": {
         "Tags": [
           {
             "Key": "tag1",
@@ -90,7 +90,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
-    "recorded-date": "15-05-2024, 14:00:25",
+    "recorded-date": "15-05-2024, 14:23:23",
     "recorded-content": {
       "put_rule_with_tags": {
         "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule_name>",
@@ -118,7 +118,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
-    "recorded-date": "15-05-2024, 14:01:46",
+    "recorded-date": "15-05-2024, 14:23:25",
     "recorded-content": {
       "create_event_bus_with_tags": {
         "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<bus_name>",

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -178,5 +178,11 @@
     "recorded-content": {
       "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <rule_name> does not exist on EventBus <bus_name>.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
+    "recorded-date": "15-05-2024, 14:54:48",
+    "recorded-content": {
+      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <bus_name> does not exist.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -168,5 +168,15 @@
       "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
       "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_resource": {
+    "recorded-date": "15-05-2024, 14:43:11",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
+    "recorded-date": "15-05-2024, 14:53:08",
+    "recorded-content": {
+      "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <rule_name> does not exist on EventBus <bus_name>.') tblen=3>"
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -1,0 +1,47 @@
+{
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::tests_tag_untag_resource": {
+    "recorded-date": "15-05-2024, 13:41:22",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tagged_rule": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_untagged_rule": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "recorded-date": "15-05-2024, 13:47:52",
+    "recorded-date": "15-05-2024, 14:08:25",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -45,7 +45,7 @@
     }
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "recorded-date": "15-05-2024, 13:47:54",
+    "recorded-date": "15-05-2024, 14:08:27",
     "recorded-content": {
       "tag_resource": {
         "ResponseMetadata": {
@@ -143,6 +143,30 @@
           "HTTPStatusCode": 200
         }
       }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[not_existing_rule]": {
+    "recorded-date": "15-05-2024, 14:08:29",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[not_existing_event_bus]": {
+    "recorded-date": "15-05-2024, 14:08:30",
+    "recorded-content": {}
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
+    "recorded-date": "15-05-2024, 14:31:38",
+    "recorded-content": {
+      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
+      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>",
+      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Rule <not-existing-resource-name> does not exist on EventBus default.') tblen=3>"
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
+    "recorded-date": "15-05-2024, 14:31:40",
+    "recorded-content": {
+      "tag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the TagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
+      "list_tags_for_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>",
+      "untag_not_existing_resource_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the UntagResource operation: Event bus <not-existing-resource-name> does not exist.') tblen=3>"
     }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -172,5 +172,185 @@
     "recorded-content": {
       "list_tags_for_deleted_rule_error": "<ExceptionInfo ResourceNotFoundException('An error occurred (ResourceNotFoundException) when calling the ListTagsForResource operation: Event bus <bus_name> does not exist.') tblen=3>"
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_default]": {
+    "recorded-date": "16-05-2024, 09:49:39",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_untagged_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_custom]": {
+    "recorded-date": "16-05-2024, 09:49:40",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_untagged_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_default]": {
+    "recorded-date": "16-05-2024, 09:49:41",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_untagged_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_custom]": {
+    "recorded-date": "16-05-2024, 09:49:42",
+    "recorded-content": {
+      "tag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag_resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_untagged_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -376,5 +376,58 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[event_bus-event_bus_default]": {
+    "recorded-date": "16-05-2024, 12:13:16",
+    "recorded-content": {
+      "list_tags_for_resource": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[event_bus-event_bus_custom]": {
+    "recorded-date": "16-05-2024, 12:13:17",
+    "recorded-content": {
+      "list_tags_for_resource": {
+        "Tags": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[rule-event_bus_default]": {
+    "recorded-date": "16-05-2024, 12:13:18",
+    "recorded-content": {
+      "list_tags_for_resource": {
+        "Tags": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[rule-event_bus_custom]": {
+    "recorded-date": "16-05-2024, 12:13:20",
+    "recorded-content": {
+      "list_tags_for_resource": {
+        "Tags": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.snapshot.json
+++ b/tests/aws/services/events/test_events_tags.snapshot.json
@@ -88,5 +88,33 @@
         }
       }
     }
+  },
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
+    "recorded-date": "15-05-2024, 14:00:25",
+    "recorded-content": {
+      "put_rule_with_tags": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<rule_name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_rule": {
+        "Tags": [
+          {
+            "Key": "tag1",
+            "Value": "value1"
+          },
+          {
+            "Key": "tag2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,26 +1,26 @@
 {
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
-    "last_validated_date": "2024-05-15T14:23:25+00:00"
+    "last_validated_date": "2024-05-15T14:58:04+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
-    "last_validated_date": "2024-05-15T14:54:48+00:00"
+    "last_validated_date": "2024-05-15T14:58:05+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
-    "last_validated_date": "2024-05-15T14:53:08+00:00"
+    "last_validated_date": "2024-05-15T14:58:02+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
-    "last_validated_date": "2024-05-15T14:23:23+00:00"
+    "last_validated_date": "2024-05-15T14:58:01+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
-    "last_validated_date": "2024-05-15T14:31:40+00:00"
+    "last_validated_date": "2024-05-15T14:58:00+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
-    "last_validated_date": "2024-05-15T14:31:38+00:00"
+    "last_validated_date": "2024-05-15T14:57:57+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "last_validated_date": "2024-05-15T14:23:15+00:00"
+    "last_validated_date": "2024-05-15T14:57:52+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "last_validated_date": "2024-05-15T14:23:17+00:00"
+    "last_validated_date": "2024-05-15T14:57:54+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -17,8 +17,20 @@
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
     "last_validated_date": "2024-05-15T14:57:57+00:00"
   },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_custom]": {
+    "last_validated_date": "2024-05-16T09:49:40+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_default]": {
+    "last_validated_date": "2024-05-16T09:49:39+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
     "last_validated_date": "2024-05-15T14:57:52+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_custom]": {
+    "last_validated_date": "2024-05-16T09:49:42+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_default]": {
+    "last_validated_date": "2024-05-16T09:49:41+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
     "last_validated_date": "2024-05-15T14:57:54+00:00"

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
+    "last_validated_date": "2024-05-15T14:01:46+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
     "last_validated_date": "2024-05-15T14:00:25+00:00"
   },

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::tests_tag_untag_resource": {
+    "last_validated_date": "2024-05-15T13:41:22+00:00"
+  }
+}

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,9 +1,9 @@
 {
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
-    "last_validated_date": "2024-05-15T14:01:46+00:00"
+    "last_validated_date": "2024-05-15T14:23:25+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
-    "last_validated_date": "2024-05-15T14:00:25+00:00"
+    "last_validated_date": "2024-05-15T14:23:23+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
     "last_validated_date": "2024-05-15T14:31:40+00:00"
@@ -12,9 +12,9 @@
     "last_validated_date": "2024-05-15T14:31:38+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "last_validated_date": "2024-05-15T14:08:25+00:00"
+    "last_validated_date": "2024-05-15T14:23:15+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "last_validated_date": "2024-05-15T14:08:27+00:00"
+    "last_validated_date": "2024-05-15T14:23:17+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,5 +1,8 @@
 {
-  "tests/aws/services/events/test_events_tags.py::TestRuleTags::tests_tag_untag_resource": {
-    "last_validated_date": "2024-05-15T13:41:22+00:00"
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
+    "last_validated_date": "2024-05-15T13:47:52+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
+    "last_validated_date": "2024-05-15T13:47:54+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -5,10 +5,16 @@
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
     "last_validated_date": "2024-05-15T14:00:25+00:00"
   },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
+    "last_validated_date": "2024-05-15T14:31:40+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_rule]": {
+    "last_validated_date": "2024-05-15T14:31:38+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
-    "last_validated_date": "2024-05-15T13:47:52+00:00"
+    "last_validated_date": "2024-05-15T14:08:25+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
-    "last_validated_date": "2024-05-15T13:47:54+00:00"
+    "last_validated_date": "2024-05-15T14:08:27+00:00"
   }
 }

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
     "last_validated_date": "2024-05-15T14:23:25+00:00"
   },
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
+    "last_validated_date": "2024-05-15T14:53:08+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
     "last_validated_date": "2024-05-15T14:23:23+00:00"
   },

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_create_event_bus_with_tags": {
     "last_validated_date": "2024-05-15T14:23:25+00:00"
   },
+  "tests/aws/services/events/test_events_tags.py::TestEventBusTags::test_list_tags_for_deleted_event_bus": {
+    "last_validated_date": "2024-05-15T14:54:48+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_list_tags_for_deleted_rule": {
     "last_validated_date": "2024-05-15T14:53:08+00:00"
   },

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -18,19 +18,19 @@
     "last_validated_date": "2024-05-15T14:57:57+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_custom]": {
-    "last_validated_date": "2024-05-16T09:49:40+00:00"
+    "last_validated_date": "2024-05-16T11:45:31+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus-event_bus_default]": {
-    "last_validated_date": "2024-05-16T09:49:39+00:00"
+    "last_validated_date": "2024-05-16T11:45:30+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
     "last_validated_date": "2024-05-15T14:57:52+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_custom]": {
-    "last_validated_date": "2024-05-16T09:49:42+00:00"
+    "last_validated_date": "2024-05-16T11:45:34+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule-event_bus_default]": {
-    "last_validated_date": "2024-05-16T09:49:41+00:00"
+    "last_validated_date": "2024-05-16T11:45:32+00:00"
   },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[rule]": {
     "last_validated_date": "2024-05-15T14:57:54+00:00"

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
+    "last_validated_date": "2024-05-15T14:00:25+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::tests_tag_untag_resource[event_bus]": {
     "last_validated_date": "2024-05-15T13:47:52+00:00"
   },

--- a/tests/aws/services/events/test_events_tags.validation.json
+++ b/tests/aws/services/events/test_events_tags.validation.json
@@ -11,6 +11,18 @@
   "tests/aws/services/events/test_events_tags.py::TestRuleTags::test_put_rule_with_tags": {
     "last_validated_date": "2024-05-15T14:58:01+00:00"
   },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[event_bus-event_bus_custom]": {
+    "last_validated_date": "2024-05-16T12:13:17+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[event_bus-event_bus_default]": {
+    "last_validated_date": "2024-05-16T12:13:16+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[rule-event_bus_custom]": {
+    "last_validated_date": "2024-05-16T12:13:20+00:00"
+  },
+  "tests/aws/services/events/test_events_tags.py::test_recreate_tagged_resource_without_tags[rule-event_bus_default]": {
+    "last_validated_date": "2024-05-16T12:13:18+00:00"
+  },
   "tests/aws/services/events/test_events_tags.py::tests_tag_list_untag_not_existing_resource[not_existing_event_bus]": {
     "last_validated_date": "2024-05-15T14:58:00+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Event bridge allows for adding tags to event buses and rules: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-tagging.html
This PR introduces the ability to create event buses and rules with tags, add and remove tags to existing buses or rules and list tags for buses and rules.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Use most widely used pattern of handling tags from multiple other services by extend store with TagDict mapping resource arn to the dictionary of tags.
Exten test suite to cover all different options of tagging.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
