### PR TITLE
CFn: handle secretsmanager policy BlockPublicPolicy

### DIFF
--- a/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_resourcepolicy.py
+++ b/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_resourcepolicy.py
@@ -57,7 +57,7 @@ class SecretsManagerResourcePolicyProvider(
         params = {
             "SecretId": model["SecretId"],
             "ResourcePolicy": json.dumps(model["ResourcePolicy"]),
-            "BlockPublicPolicy": model.get("BlockPublicPolicy"),
+            "BlockPublicPolicy": model.get("BlockPublicPolicy") or True,
         }
         response = secret_manager.put_resource_policy(**params)
 

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
@@ -1,6 +1,15 @@
 {
-  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy": {
-    "recorded-date": "06-07-2023, 23:05:38",
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[true]": {
+    "recorded-date": "20-05-2024, 13:00:56",
+    "recorded-content": {
+      "outputs": {
+        "SecretId": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-name>",
+        "SecretPolicyArn": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-name>"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[default]": {
+    "recorded-date": "20-05-2024, 13:01:20",
     "recorded-content": {
       "outputs": {
         "SecretId": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-name>",

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
@@ -1,5 +1,8 @@
 {
-  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy": {
-    "last_validated_date": "2023-07-06T21:05:38+00:00"
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[default]": {
+    "last_validated_date": "2024-05-20T13:01:20+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[true]": {
+    "last_validated_date": "2024-05-20T13:00:56+00:00"
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When deploying an `AWS::SecretsManager::ResourcePolicy` resource with CloudFormation, if `BlockPublicPolicy` is not specified, it should default to `True` however in LocalStack it is represented as `None` which is not a valid type for this property.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Default the property to `True` if not specified
* Update existing test that creates a ResourcePolicy to either specify the value, or use `AWS::NoValue` to _not_ provide a value

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
