### PR TITLE
skip flaky tests.aws.services.firehose.test_firehose.TestFirehoseIntegration.test_kinesis_firehose_opensearch_s3_backup

### DIFF
--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -246,6 +246,7 @@ class TestFirehoseIntegration:
     @markers.skip_offline
     @pytest.mark.parametrize("opensearch_endpoint_strategy", ["domain", "path", "port"])
     @markers.aws.unknown
+    @pytest.mark.skip(reason="flaky")
     def test_kinesis_firehose_opensearch_s3_backup(
         self,
         s3_bucket,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We saw that the `tests.aws.services.firehose.test_firehose.TestFirehoseIntegration.test_kinesis_firehose_opensearch_s3_backup` is not stable in the pipeline. 

This can be seen in the following workflow [here](https://app.circleci.com/pipelines/github/localstack/localstack/25035/workflows/3b85a30f-79b8-43c8-b68c-4b038071a0f8/jobs/208800/tests), and a re-run [here](https://app.circleci.com/pipelines/github/localstack/localstack/25035/workflows/fa01e003-fa58-4361-bc76-dfa1942aa000) which fixed the pipeline. 

From the test insights on CircleCI its observed that the success rate of this test is 99%:

![image](https://github.com/localstack/localstack/assets/32308435/53fdc1ad-56bc-4c6c-bd82-f86967cb595e)
And has observed failures in past runs as well.  

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Skips flaky test: `tests.aws.services.firehose.test_firehose.TestFirehoseIntegration.test_kinesis_firehose_opensearch_s3_backup` in order to decrease the instability in pipelines. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
