### PR TITLE
add S3 pre-signed credentials validation

### DIFF
--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11629,5 +11629,18 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_double_encoded_credentials": {
+    "recorded-date": "21-05-2024, 10:26:17",
+    "recorded-content": {
+      "error-malformed": {
+        "Error": {
+          "Code": "AuthorizationQueryParametersError",
+          "HostId": "host-id",
+          "Message": "Error parsing the X-Amz-Credential parameter; the Credential is mal-formed; expecting \"<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request\".",
+          "RequestId": "<request-id:1>"
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -578,6 +578,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_delete_has_empty_content_length_header": {
     "last_validated_date": "2024-04-24T18:42:46+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_double_encoded_credentials": {
+    "last_validated_date": "2024-05-21T10:26:17+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-False]": {
     "last_validated_date": "2023-08-04T22:00:25+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following #10844 where the request sent was malformed but the raised exception was an internal one:
```python
2024-05-17T09:08:44.719 ERROR --- [et.reactor-0] l.aws.handlers.logging     : exception during call chain
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/localstack/aws/handlers/presigned_url.py", line 23, in __call__
    handler(chain, context, response)
  File "/opt/code/localstack/localstack/services/s3/presigned_url.py", line 201, in __call__
    validate_presigned_url_s3v4(context)
  File "/opt/code/localstack/localstack/services/s3/presigned_url.py", line 425, in validate_presigned_url_s3v4
    sigv4_context, exception = _find_valid_signature_through_ports(context)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/localstack/services/s3/presigned_url.py", line 487, in _find_valid_signature_through_ports
    sigv4_context = S3SigV4SignatureContext(context=context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/localstack/services/s3/presigned_url.py", line 543, in __init__
    region = self._query_parameters["X-Amz-Credential"].split("/")[2]
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

I validated that AWS does not accept double URL encoded `X-Amz-Credential` and saw the proper exception raised, so wanted the error to be more descriptive and add parity to LocalStack. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add validation before splitting and getting data from `X-Amz-Credential` query string parameter in pre-signed URL. This was done in a non intrusive way, only done where we would directly access the data. We could maybe do a little parity push on pre-signed URL all around and do better validation of incoming mandatory parameters.
- added a test to check the exception on AWS

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
