### PR TITLE
Add support for environment variable placeholders in hot-reloading paths

### DIFF
--- a/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack/services/lambda_/invocation/lambda_models.py
@@ -5,6 +5,7 @@ The actual function code is stored in S3 (see S3Code).
 
 import dataclasses
 import logging
+import os.path
 import shutil
 import tempfile
 import threading
@@ -257,7 +258,8 @@ class HotReloadingCode(ArchiveCode):
         return f"Code location: {self.host_path}"
 
     def get_unzipped_code_location(self) -> Path:
-        return Path(self.host_path)
+        path = os.path.expandvars(self.host_path)
+        return Path(path)
 
     def is_hot_reloading(self) -> bool:
         """

--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import dataclasses
 import io
 import logging
+import os.path
 import random
 import uuid
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
@@ -549,12 +550,26 @@ def store_lambda_archive(
     )
 
 
-def create_hot_reloading_code(path: str) -> HotReloadingCode:
-    # TODO extract into other function
-    if not PurePosixPath(path).is_absolute() and not PureWindowsPath(path).is_absolute():
+def assert_hot_reloading_path_absolute(path: str) -> None:
+    """
+    Check whether a given path is an absolute path, either posix or windows.
+    Will expand variables in the path before the check.
+
+    :param path: Posix or windows path, potentially containing environment variable placeholders.
+    """
+    # expand variables in path before checking for an absolute path
+    expanded_path = os.path.expandvars(path)
+    if (
+        not PurePosixPath(expanded_path).is_absolute()
+        and not PureWindowsPath(expanded_path).is_absolute()
+    ):
         raise InvalidParameterValueException(
             f"When using hot reloading, the archive key has to be an absolute path! Your archive key: {path}",
         )
+
+
+def create_hot_reloading_code(path: str) -> HotReloadingCode:
+    assert_hot_reloading_path_absolute(path)
     return HotReloadingCode(host_path=path)
 
 

--- a/localstack/services/lambda_/invocation/lambda_service.py
+++ b/localstack/services/lambda_/invocation/lambda_service.py
@@ -552,10 +552,12 @@ def store_lambda_archive(
 
 def assert_hot_reloading_path_absolute(path: str) -> None:
     """
-    Check whether a given path is an absolute path, either posix or windows.
-    Will expand variables in the path before the check.
+    Check whether a given path, after environment variable substitution, is an absolute path.
+    Accepts either posix or windows paths, with environment placeholders.
+    Example placeholders: $ENV_VAR, ${ENV_VAR}
 
     :param path: Posix or windows path, potentially containing environment variable placeholders.
+        Example: `$ENV_VAR/lambda/src` with `ENV_VAR=/home/user/test-repo` set.
     """
     # expand variables in path before checking for an absolute path
     expanded_path = os.path.expandvars(path)

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -135,6 +135,59 @@ class TestHotReloading:
         )
         aws_client.lambda_.publish_version(FunctionName=function_name, CodeSha256="zipfilehash")
 
+    @markers.aws.only_localstack
+    def test_hot_reloading_error_path_not_absolute(
+        self,
+        create_lambda_function_aws,
+        lambda_su_role,
+        cleanups,
+        aws_client,
+    ):
+        """Test hot reloading of lambda code"""
+        # Hot reloading is debounced with 500ms
+        # 0.6 works on Linux, but it takes slightly longer on macOS
+        function_name = f"test-hot-reloading-{short_uid()}"
+        hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
+        with pytest.raises(Exception):
+            aws_client.lambda_.create_function(
+                FunctionName=function_name,
+                Handler="handler.handler",
+                Code={"S3Bucket": hot_reloading_bucket, "S3Key": "not/an/absolute/path"},
+                Role=lambda_su_role,
+                Runtime=Runtime.python3_12,
+            )
+
+    @markers.aws.only_localstack
+    def test_hot_reloading_environment_placeholder(
+        self, create_lambda_function_aws, lambda_su_role, cleanups, aws_client, monkeypatch
+    ):
+        """Test hot reloading of lambda code when the S3Key containers an environment variable placeholder like $DIR"""
+        function_name = f"test-hot-reloading-{short_uid()}"
+        hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
+        tmp_path = config.dirs.mounted_tmp
+        hot_reloading_dir_path = os.path.join(tmp_path, f"hot-reload-{short_uid()}")
+        mkdir(hot_reloading_dir_path)
+        cleanups.append(lambda: rm_rf(hot_reloading_dir_path))
+        function_content = load_file(HOT_RELOADING_PYTHON_HANDLER)
+        with open(os.path.join(hot_reloading_dir_path, "handler.py"), mode="wt") as f:
+            f.write(function_content)
+
+        mount_path = get_host_path_for_path_in_docker(hot_reloading_dir_path)
+        head, tail = os.path.split(mount_path)
+        monkeypatch.setenv("HEAD_DIR", head)
+
+        create_lambda_function_aws(
+            FunctionName=function_name,
+            Handler="handler.handler",
+            Code={"S3Bucket": hot_reloading_bucket, "S3Key": f"$HEAD_DIR/{tail}"},
+            Role=lambda_su_role,
+            Runtime=Runtime.python3_12,
+        )
+        response = aws_client.lambda_.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.load(response["Payload"])
+        assert response_dict["counter"] == 1
+        assert response_dict["constant"] == "value1"
+
 
 class TestDockerFlags:
     @markers.aws.only_localstack

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -143,9 +143,7 @@ class TestHotReloading:
         cleanups,
         aws_client,
     ):
-        """Test hot reloading of lambda code"""
-        # Hot reloading is debounced with 500ms
-        # 0.6 works on Linux, but it takes slightly longer on macOS
+        """Tests validation of hot reloading paths"""
         function_name = f"test-hot-reloading-{short_uid()}"
         hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
         with pytest.raises(Exception):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When specifying a path for hot-reloading, we require an absolute path on the host, as it is expected for docker bind mounts.
However, this has an important limitation: Templates with a path defined or Cloudpods cannot be easily shared between systems where the code location differs.

For example, a checked out repository with the code at `/home/user1/shared-repository/src` could be checked out at `/home/user2/repositories/shared-repository/src` at another users machine.

To enable sharing of templates and cloudpods with hot-reloading paths between different machines without modification, this PR will add the option to use environment variables expansion within the hot-reloading paths. A hot-reloading path like `$HOST_DIR/src` can now be used in the templates or cloud pods, if an environment variable is set in each LocalStack instance using that path, with the concrete absolute path part as its value.

This variable could be defined relative to the docker compose project, for example, using a template like this:

```yaml
version: "3.8"

services:
  localstack:
    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
    image: localstack/localstack
    ports:
      - "127.0.0.1:4566:4566"            # LocalStack Gateway
      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
    environment:
      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
      - DEBUG=${DEBUG:-0}
      - HOST_DIR=${PWD}
    volumes:
      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
      - "/var/run/docker.sock:/var/run/docker.sock"
```


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* The S3Key for a hot-reloading path now accepts placeholders for environment variables using `$KEY` or `${KEY}`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
