### PR TITLE
fix Sqs fifo message group invisibility after triggering move to dlq

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -1221,7 +1221,14 @@ class FifoQueue(SqsQueue):
                 # in FIFO queues, this should not happen, as expired receipt handles cannot be used to
                 # delete a message.
                 pass
+            self.update_message_group_visibility(message_group)
 
+    def update_message_group_visibility(self, message_group: MessageGroup):
+        """
+        Check if the passed message group should be made visible again
+        """
+
+        with self.mutex:
             if message_group in self.inflight_groups:
                 # it becomes visible again only if there are no other in flight messages in that group
                 for message in self.inflight:

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -510,6 +510,8 @@ class SqsQueue:
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
+        *,
+        source_queue: "SqsQueue" = None,
     ) -> SqsMessage:
         raise NotImplementedError
 
@@ -539,7 +541,7 @@ class SqsQueue:
             self.delayed.clear()
             self.receipts.clear()
 
-    def _put_message(self, message: SqsMessage):
+    def _put_message(self, message: SqsMessage, source_queue: "SqsQueue" = None):
         """Low-level put operation to put messages into a queue and modify visibilities accordingly."""
         raise NotImplementedError
 
@@ -738,6 +740,7 @@ class StandardQueue(SqsQueue):
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
+        source_queue: "SqsQueue" = None,
     ):
         if message_deduplication_id:
             raise InvalidParameterValueException(
@@ -770,7 +773,7 @@ class StandardQueue(SqsQueue):
 
         return standard_message
 
-    def _put_message(self, message: SqsMessage):
+    def _put_message(self, message: SqsMessage, source_queue: "SqsQueue" = None):
         self.visible.put_nowait(message)
 
     def remove_expired_messages(self):
@@ -999,6 +1002,7 @@ class FifoQueue(SqsQueue):
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
+        source_queue: "SqsQueue" = None,
     ):
         if delay_seconds:
             # in fifo queues, delay is only applied on queue level. However, explicitly setting delay_seconds=0 is valid
@@ -1054,13 +1058,13 @@ class FifoQueue(SqsQueue):
             if fifo_message.is_delayed:
                 self.delayed.add(fifo_message)
             else:
-                self._put_message(fifo_message)
+                self._put_message(fifo_message, source_queue=source_queue)
 
             self.deduplication[dedup_id] = fifo_message
 
         return fifo_message
 
-    def _put_message(self, message: SqsMessage):
+    def _put_message(self, message: SqsMessage, source_queue: "SqsQueue" = None):
         """Once a message becomes visible in a FIFO queue, its message group also becomes visible."""
         message_group = self.get_message_group(message.message_group_id)
 
@@ -1070,8 +1074,15 @@ class FifoQueue(SqsQueue):
             message_group.push(message)
 
             # new messages should not make groups visible that are currently inflight
-            if message.receive_count < 1 and message_group in self.inflight_groups:
+            if (
+                not source_queue
+                and message.receive_count < 1
+                and message_group in self.inflight_groups
+            ):
                 return
+            if source_queue:
+                source_queue.inflight_groups.remove(message_group)
+                source_queue.message_group_queue.put_nowait(message_group)
             # if an older message becomes visible again in the queue, that message's group becomes visible also.
             if message_group in self.inflight_groups:
                 self.inflight_groups.remove(message_group)

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1231,6 +1231,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                     message=message,
                     message_deduplication_id=standard_message.message_deduplication_id,
                     message_group_id=standard_message.message_group_id,
+                    source_queue=queue,
                 )
 
         # prepare result

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1233,7 +1233,9 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                     message_group_id=standard_message.message_group_id,
                 )
 
-                queue._on_remove_message(standard_message)
+                if isinstance(queue, FifoQueue):
+                    message_group = queue.get_message_group(standard_message.message_group_id)
+                    queue.update_message_group_visibility(message_group)
 
         # prepare result
         messages = []

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1231,8 +1231,9 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                     message=message,
                     message_deduplication_id=standard_message.message_deduplication_id,
                     message_group_id=standard_message.message_group_id,
-                    source_queue=queue,
                 )
+
+                queue._on_remove_message(standard_message)
 
         # prepare result
         messages = []

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -2840,6 +2840,59 @@ class TestSqsProvider:
         assert message["Body"] == "foobar"
 
     @markers.aws.validated
+    def test_message_groups_with_dead_letter_queue_and_fifo(
+        self, sqs_create_queue, sqs_get_queue_arn, aws_sqs_client
+    ):
+        dlq_url = sqs_create_queue(
+            QueueName=f"test-dlq-{short_uid()}.fifo",
+            Attributes={
+                "FifoQueue": "true",
+                "ContentBasedDeduplication": "true",
+            },
+        )
+        dlq_arn = sqs_get_queue_arn(dlq_url)
+
+        queue_url = sqs_create_queue(
+            QueueName=f"test-queue-{short_uid()}.fifo",
+            Attributes={
+                "FifoQueue": "true",
+                "ContentBasedDeduplication": "true",
+                "RedrivePolicy": json.dumps({"deadLetterTargetArn": dlq_arn, "maxReceiveCount": 1}),
+            },
+        )
+
+        response = aws_sqs_client.send_message(
+            QueueUrl=queue_url, MessageBody="foobar", MessageGroupId="1"
+        )
+        message_id = response["MessageId"]
+
+        aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
+        # after this receive call the message should be in the DLQ
+        aws_sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1, VisibilityTimeout=0)
+
+        # send another message with the same messageGroupId
+        response = aws_sqs_client.send_message(
+            QueueUrl=queue_url, MessageBody="foobar2", MessageGroupId="1"
+        )
+        time.sleep(15)
+        # check if the new message arrived in the fifo queue
+        fifo_receive_response = aws_sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=1
+        )
+        assert len(fifo_receive_response["Messages"]) == 1
+        message = fifo_receive_response["Messages"][0]
+        assert message["Body"] == "foobar2"
+
+        # check the DLQ
+        response = aws_sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+        message = response["Messages"][0]
+        assert message["MessageId"] == message_id
+        assert message["Body"] == "foobar"
+
+    @markers.aws.validated
     def test_dead_letter_queue_max_receive_count(
         self, sqs_create_queue, aws_sqs_client, region_name
     ):

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3248,5 +3248,13 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs]": {
+    "recorded-date": "21-05-2024, 13:48:08",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs_query]": {
+    "recorded-date": "21-05-2024, 13:48:14",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -50,6 +50,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
     "last_validated_date": "2024-04-30T13:33:55+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs]": {
+    "last_validated_date": "2024-05-21T13:58:10+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs_query]": {
+    "last_validated_date": "2024-05-21T13:58:16+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-]": {
     "last_validated_date": "2024-04-30T13:48:34+00:00"
   },

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -164,6 +164,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_group_id_too_long": {
     "last_validated_date": "2024-04-30T13:35:35+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_groups_with_dead_letter_queue_and_fifo[sqs]": {
+    "last_validated_date": "2024-05-21T07:05:48+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_groups_with_dead_letter_queue_and_fifo[sqs_query]": {
+    "last_validated_date": "2024-05-21T07:05:53+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2024-04-30T13:35:47+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Users [raised the issue](https://github.com/localstack/localstack/issues/10107) that fifo queues become unusable after messages were moved to a DLQ.
After a fifo queue's message's receive count exceeds the maximum and is moved to a DLQ, its message group remains invisible. This PR addresses this issue.
fixes #10107 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add method to allow the provider to call the missing visibility changes to the message group after moving the message

I am not happy with how this change is implemented, but I am unsure what the best way is.
The root cause is that we simply never addressed the message group visibility when a dlq move is triggered, so obviously we need to address that. There are two main ways to do this that I see:
- Provider calls the necessary code in the "move to dlq" block directly. That's what's happening now
  -  Right now it contains an ugly `isinstance(queue,FifoQueue)` check, and the provider shouldn't care what kind of message it handles, the point of the different classes is to abstract that away.
  -  We could also leave the current method as is and simply call `queue._on_remove_message`, to get rid of the Fifo check. But this method seems to actually be "queue.\_on\_**delete**\_message" from a program-logic point of view and is expected to be called during deletion. Moving a message to a dlq is very similar, but not quite the same, and this approach would result in e.g. a re-heapifying for a standard queue every time (that's the reason why this solution was discarded).
- Since moving the message to a dlq is a put operation, we could do a "if dlq move, unlock source queue message group" during the `put` to the dlq. This options also has the advantage that we can add this message group visibility related change to the [place in the code](https://github.com/localstack/localstack/blob/master/localstack/services/sqs/models.py#L1063-L1081) where the other checks of this kind are. However we would need the source queue object for that:
  - We could pass the source queue object on the put operation as optional parameter. This means changing the signature of `put` for standard_queues too though, as well as passing it all the way down from the provider, and that doesn't seem that clean either.
  - We already pass the `DeadLetterQueueSourceArn` with the message, and could get the queue from said arn. This way, we would have the change exactly where it belongs (in my opinion) without touching other code from a program-logic point of view. However, the queues are not context aware, and we would need that to access the proper queue from the store. This comes with some medium sized refactoring and is therefore quite the architectural change, which was the reason why this was discarded.
Sorry for the wall of text, if something is unclear please ask ahead. The reason for it is that message group visibility has been quite the back and forth with patching so far, so I'd like to make extra sure that we do this the right way.
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
