### PR TITLE
fix S3 Pre-signed POST policy condition casing

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -812,7 +812,7 @@ def _verify_condition(condition: list | dict, form: dict, additional_policy_meta
                 if k == "bucket":
                     return additional_policy_metadata.get("bucket") == val
                 else:
-                    return form.get(key) == val
+                    return form.get(k) == val
 
         case ["eq", key, value]:
             k = key.lower()

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11495,7 +11495,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "recorded-date": "10-04-2024, 15:09:48",
+    "recorded-date": "21-05-2024, 16:51:17",
     "recorded-content": {
       "invalid-condition-eq": {
         "Error": {

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -519,7 +519,7 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "last_validated_date": "2024-04-10T15:09:48+00:00"
+    "last_validated_date": "2024-05-21T16:51:17+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
     "last_validated_date": "2024-04-10T12:16:01+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in [our Slack community](https://localstack-community.slack.com/archives/CMAFN2KSP/p1716214732559039), we had an issue validating a S3 Pre-signed POST request containing the following condition in the policy: `{"Content-Type": "text/plain"}`. This was due to an issue in the condition matching where we would lower all the form keys, but tried to get the original casing condition key in the form. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- use the lowered condition key to fetch the value from the form
- add a test validating the use case for this condition format (using `dict` format instead of list with `eq`). 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
