### PR TITLE
Opt in services to the test selection

### DIFF
--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -60,6 +60,9 @@ OPT_IN = [
     # route53resolver
     "localstack-core/localstack/services/route53resolver/**",
     "tests/aws/services/route53resolver/**",
+    # route53
+    "localstack-core/localstack/services/route53/**",
+    "tests/aws/services/route53/**",
 ]
 
 

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -42,6 +42,7 @@ OPT_IN = [
     # SQS
     "localstack/services/sqs/**",
     "tests/aws/services/sqs/**",
+    # TODO add more services
 ]
 
 

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -54,6 +54,9 @@ OPT_IN = [
     # transcribe
     "localstack/services/transcribe/**",
     "tests/aws/services/transcribe/**",
+    # secretsmanager
+    "localstack/services/secretsmanager/**",
+    "tests/aws/services/secretsmanager/**",
     # TODO add more services
 ]
 

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -57,6 +57,9 @@ OPT_IN = [
     # secretsmanager
     "localstack/services/secretsmanager/**",
     "tests/aws/services/secretsmanager/**",
+    # route53resolver
+    "localstack/services/route53resolver/**",
+    "tests/aws/services/route53resolver/**",
     # TODO add more services
 ]
 

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -42,6 +42,12 @@ OPT_IN = [
     # SQS
     "localstack/services/sqs/**",
     "tests/aws/services/sqs/**",
+    # KMS
+    "localstack/services/kms/**",
+    "tests/aws/services/kms/**",
+    # transcribe
+    "localstack/services/transcribe/**",
+    "tests/aws/services/transcribe/**",
     # TODO add more services
 ]
 

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -18,6 +18,9 @@ OPT_IN = [
     # elasticsearch
     "localstack/services/es/**",
     "tests/aws/services/es/**",
+    # IAM
+    "localstack/services/iam/**",
+    "tests/aws/services/iam/**",
     # lambda
     "localstack/services/lambda_/**",
     "tests/aws/services/lambda_/**",
@@ -42,6 +45,9 @@ OPT_IN = [
     # SQS
     "localstack/services/sqs/**",
     "tests/aws/services/sqs/**",
+    # STS
+    "localstack/services/sts/**",
+    "tests/aws/services/sts/**",
     # KMS
     "localstack/services/kms/**",
     "tests/aws/services/kms/**",

--- a/localstack-core/localstack/testing/testselection/opt_in.py
+++ b/localstack-core/localstack/testing/testselection/opt_in.py
@@ -9,58 +9,57 @@ from typing import Iterable, Optional
 
 OPT_IN = [
     # acm
-    "localstack/services/acm/**",
+    "localstack-core/localstack/services/acm/**",
     "tests/aws/services/acm/**",
     # cloudformation
     # probably the riskiest here since CFn tests are not as isolated as the rest
-    "localstack/services/cloudformation/**",
+    "localstack-core/localstack/services/cloudformation/**",
     "tests/aws/services/cloudformation/**",
     # elasticsearch
-    "localstack/services/es/**",
+    "localstack-core/localstack/services/es/**",
     "tests/aws/services/es/**",
     # IAM
-    "localstack/services/iam/**",
+    "localstack-core/localstack/services/iam/**",
     "tests/aws/services/iam/**",
     # lambda
-    "localstack/services/lambda_/**",
+    "localstack-core/localstack/services/lambda_/**",
     "tests/aws/services/lambda_/**",
     # sns
-    "localstack/services/sns/**",
+    "localstack-core/localstack/services/sns/**",
     "tests/aws/services/sns/**",
     # opensearch
-    "localstack/services/opensearch/**",
+    "localstack-core/localstack/services/opensearch/**",
     "tests/aws/services/opensearch/**",
     # stepfunctions
-    "localstack/services/stepfunctions/**",
+    "localstack-core/localstack/services/stepfunctions/**",
     "tests/aws/services/stepfunctions/**",
     # secretsmanager
-    "localstack/services/secretsmanager/**",
+    "localstack-core/localstack/services/secretsmanager/**",
     "tests/aws/services/secretsmanager/**",
     # events
-    "localstack/services/events/**",
+    "localstack-core/localstack/services/events/**",
     "tests/aws/services/events/**",
     # SSM
-    "localstack/services/ssm/**",
+    "localstack-core/localstack/services/ssm/**",
     "tests/aws/services/ssm/**",
     # SQS
-    "localstack/services/sqs/**",
+    "localstack-core/localstack/services/sqs/**",
     "tests/aws/services/sqs/**",
     # STS
-    "localstack/services/sts/**",
+    "localstack-core/localstack/services/sts/**",
     "tests/aws/services/sts/**",
     # KMS
-    "localstack/services/kms/**",
+    "localstack-core/localstack/services/kms/**",
     "tests/aws/services/kms/**",
     # transcribe
-    "localstack/services/transcribe/**",
+    "localstack-core/localstack/services/transcribe/**",
     "tests/aws/services/transcribe/**",
     # secretsmanager
-    "localstack/services/secretsmanager/**",
+    "localstack-core/localstack/services/secretsmanager/**",
     "tests/aws/services/secretsmanager/**",
     # route53resolver
-    "localstack/services/route53resolver/**",
+    "localstack-core/localstack/services/route53resolver/**",
     "tests/aws/services/route53resolver/**",
-    # TODO add more services
 ]
 
 

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -58,6 +58,8 @@ API_DEPENDENCIES = {
     # firehose currently only supports kinesis as source, this could become optional when more sources are supported
     "firehose": ["kinesis"],
     "transcribe": ["s3"],
+    # secretsmanager uses lambda for rotation
+    "secretsmanager": ["kms", "lambda"],
     # TODO: add more dependencies
 }
 

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -49,7 +49,7 @@ LOG = logging.getLogger(__name__)
 # - do not add "optional" dependencies of services here, use API_DEPENDENCIES_OPTIONAL instead
 API_DEPENDENCIES = {
     "dynamodb": ["dynamodbstreams"],
-    # dynamodbsteams uses kinesis under the hood
+    # dynamodbstreams uses kinesis under the hood
     "dynamodbstreams": ["kinesis"],
     # es forwards all requests to opensearch (basically an API deprecation path in AWS)
     "es": ["opensearch"],
@@ -78,6 +78,20 @@ API_DEPENDENCIES_OPTIONAL = {
     "cloudformation": ["secretsmanager", "ssm", "lambda"],
     "events": ["lambda", "kinesis", "firehose", "sns", "sqs", "stepfunctions", "logs"],
     "stepfunctions": ["logs", "lambda", "dynamodb", "ecs", "sns", "sqs", "apigateway", "events"],
+    "apigateway": [
+        "s3",
+        "sqs",
+        "sns",
+        "kinesis",
+        "route53",
+        "servicediscovery",
+        "lambda",
+        "dynamodb",
+        "stepfunctions",
+        "events",
+    ],
+    # This is for S3 notifications and S3 KMS key
+    "s3": ["events", "sqs", "sns", "lambda", "kms"],
     # TODO: add more dependencies
 }
 

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -92,6 +92,9 @@ API_DEPENDENCIES_OPTIONAL = {
     ],
     # This is for S3 notifications and S3 KMS key
     "s3": ["events", "sqs", "sns", "lambda", "kms"],
+    # IAM and STS are tightly coupled
+    "sts": ["iam"],
+    "iam": ["sts"],
     # TODO: add more dependencies
 }
 

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -60,7 +60,6 @@ API_DEPENDENCIES = {
     "transcribe": ["s3"],
     # secretsmanager uses lambda for rotation
     "secretsmanager": ["kms", "lambda"],
-    # TODO: add more dependencies
 }
 
 # Optional dependencies of services on other services
@@ -97,7 +96,6 @@ API_DEPENDENCIES_OPTIONAL = {
     # IAM and STS are tightly coupled
     "sts": ["iam"],
     "iam": ["sts"],
-    # TODO: add more dependencies
 }
 
 # composites define an abstract name like "serverless" that maps to a set of services

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -58,6 +58,7 @@ API_DEPENDENCIES = {
     # firehose currently only supports kinesis as source, this could become optional when more sources are supported
     "firehose": ["kinesis"],
     "transcribe": ["s3"],
+    # TODO: add more dependencies
 }
 
 # Optional dependencies of services on other services
@@ -77,6 +78,7 @@ API_DEPENDENCIES_OPTIONAL = {
     "cloudformation": ["secretsmanager", "ssm", "lambda"],
     "events": ["lambda", "kinesis", "firehose", "sns", "sqs", "stepfunctions", "logs"],
     "stepfunctions": ["logs", "lambda", "dynamodb", "ecs", "sns", "sqs", "apigateway", "events"],
+    # TODO: add more dependencies
 }
 
 # composites define an abstract name like "serverless" that maps to a set of services


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The test selection allows future PRs containing strictly service changes to only execute tests corresponding to those services and services that depend on them. However, to enable this, services need to opt in. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR offers the opportunity to opt in services to the test selection. These services are opting in with this PR:

- IAM
- STS
- KMS
- Transcribe
- Secretsmanager
- Route53 Resolver
- <add your service as needed>


Furthermore, paths are adjusted to the new structure, prefixed with `localstack-core/`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
