### PR TITLE
Using ARN_PARTITION_REWRITING flag causes s3api head-object to provide invalid content-length

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -167,7 +167,10 @@ class ArnPartitionRewriteHandler(Handler):
         response.headers = self._adjust_partition(
             dict(response.headers), request_region=request_region
         )
-        response.data = self._adjust_partition(response.data, request_region=request_region)
+        # setting data also causes content-length to be re-calculated in WerkzeugResponse class
+        # so bellow is a quick and dirty fix
+        if response.data:
+            response.data = self._adjust_partition(response.data, request_region=request_region)
         self._post_process_response_headers(response)
 
     def modify_response_guard(self, response: Response):


### PR DESCRIPTION
## Motivation
Client using ARN_PARTITION_REWRITING flag has reported that content-length provided by head-object method in s3api is always invalid.

## Changes
Since in WerkzeugResponse class, setting data also causes header content-length to be invalid, I've added skip for partition adjustment of response data if it is empty.

Since we are working on new solution for partitions and this is a temporary fix until then,  I've only did manual tests.