### PR TITLE
limit github token permissions, fix cli action for fork runs

### DIFF
--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -70,6 +70,9 @@ env:
   # report to tinybird if executed on master
   TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
 
+permissions: 
+  contents: read # checkout the repository
+
 jobs:
   cli-tests:
     runs-on: ubuntu-latest
@@ -103,9 +106,11 @@ jobs:
         run: make test
 
   push-to-tinybird:
-    if: always() && github.ref == 'refs/heads/master'
+    if: always() && github.ref == 'refs/heads/master' && github.repository == 'localstack/localstack'
     runs-on: ubuntu-latest
     needs: cli-tests
+    permissions: 
+      actions: read
     steps:
       - name: Push to Tinybird
         uses: localstack/tinybird-workflow-push@v3


### PR DESCRIPTION
Hey! 🙂
I've made the following changes to the workflow:

- Use permissions whenever using Github Token
  - Permissions should be used when using the GitHub token as this token full access to the whole repository otherwise meaning that malicious code can tamper with the whole repository.
- Run tests on multiple OS's
  - Running the tests on multiple OS's provides a better test suite as all the functionality will be tested on the supported OS's by the platform.
- Define permissions for workflows with external actions
  - Permissions should be used when running actions written by other developers because there may be security leaks exposed through these actions.
- Avoid uploading artefacts forks
  - Uploading artefacts from forks is usually unwanted behaviour, especially to places outside GitHub. Forks don't have the correct credentials to do this and will therefore fail whilst uploading.


(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->





<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
