### PR TITLE
Collect analytics on error probability config options

### DIFF
--- a/localstack/runtime/analytics.py
+++ b/localstack/runtime/analytics.py
@@ -13,11 +13,13 @@ TRACKED_ENV_VAR = [
     "DISABLE_CORS_CHECK",
     "DISABLE_CORS_HEADERS",
     "DNS_ADDRESS",
+    "DYNAMODB_ERROR_PROBABILITY",
     "EAGER_SERVICE_LOADING",
     "EDGE_PORT",
     "ENFORCE_IAM",
     "IAM_SOFT_MODE",
     "KINESIS_PROVIDER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
+    "KINESIS_ERROR_PROBABILITY",
     "KMS_PROVIDER",
     "LAMBDA_DOWNLOAD_AWS_LAYERS",
     "LAMBDA_EXECUTOR",  # Not functional; deprecated in 2.0.0, removed in 3.0.0


### PR DESCRIPTION
## Background

With the current push on developing the chaos engineering suite, we want to gain an insight on how existing chaos features are being used.

## Changes

This PR adds the following env config options to analytics collection:

- [`DYNAMODB_ERROR_PROBABILITY`](https://docs.localstack.cloud/references/configuration/#dynamodb)
- [`KINESIS_ERROR_PROBABILITY`](https://docs.localstack.cloud/references/configuration/#kinesis)