### PR TITLE
[SFN] Add Generic Resolver for Unsupported Optimised Service Integrations

### DIFF
--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_factory.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_factory.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Final
+
+from antlr4 import RecognitionException
+
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.state_task_service import (
     StateTaskService,
 )
@@ -33,6 +37,23 @@ from localstack.services.stepfunctions.asl.component.state.state_execution.state
 from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.state_task_service_sqs import (
     StateTaskServiceSqs,
 )
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.state_task_service_unsupported import (
+    StateTaskServiceUnsupported,
+)
+
+_UNSUPPORTED_SERVICE_NAMES: Final[set[str]] = {
+    "athena",
+    "batch",
+    "bedrock",
+    "codebuild",
+    "eks",
+    "elasticmapreduce",
+    "emr-containers",
+    "emr-serverless",
+    "databrew",
+    "mediaconvert",
+    "sagemaker",
+}
 
 
 # TODO: improve on factory constructor (don't use SubtypeManager: cannot reuse state task instances).
@@ -58,5 +79,7 @@ def state_task_service_for(service_name: str) -> StateTaskService:
             return StateTaskServiceEcs()
         case "glue":
             return StateTaskServiceGlue()
+        case _ if service_name in _UNSUPPORTED_SERVICE_NAMES:
+            return StateTaskServiceUnsupported()
         case unknown:
-            raise NotImplementedError(f"Unsupported service: '{unknown}'.")  # noqa
+            raise RecognitionException(f"Unknown service '{unknown}'")

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
@@ -34,12 +34,12 @@ class StateTaskServiceUnsupported(StateTaskServiceCallback):
         # and relays the call to the target service with the computed parameters.
         self._log_unsupported_warning()
         service_name = self._get_boto_service_name()
-        api_action = self._get_boto_service_action()
-        sqs_client = boto_client_for(
+        boto_action = self._get_boto_service_action()
+        boto_client = boto_client_for(
             region=resource_runtime_part.region,
             account=resource_runtime_part.account,
             service=service_name,
         )
-        response = getattr(sqs_client, api_action)(**normalised_parameters)
+        response = getattr(boto_client, boto_action)(**normalised_parameters)
         response.pop("ResponseMetadata", None)
         env.stack.append(response)

--- a/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
+++ b/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_unsupported.py
@@ -1,0 +1,45 @@
+import logging
+
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.resource import (
+    ResourceRuntimePart,
+)
+from localstack.services.stepfunctions.asl.component.state.state_execution.state_task.service.state_task_service_callback import (
+    StateTaskServiceCallback,
+)
+from localstack.services.stepfunctions.asl.eval.environment import Environment
+from localstack.services.stepfunctions.asl.utils.boto_client import boto_client_for
+
+LOG = logging.getLogger(__name__)
+
+
+class StateTaskServiceUnsupported(StateTaskServiceCallback):
+    def _log_unsupported_warning(self):
+        # Logs that the optimised service integration is not supported,
+        # however the request is being forwarded to the service.
+        service_name = self._get_boto_service_name()
+        resource_arn = self.resource.resource_arn
+        LOG.warning(
+            f"Unsupported Optimised service integration for service_name '{service_name}' "
+            f"in resource: '{resource_arn}'."
+            "Attempting to forward request to service."
+        )
+
+    def _eval_service_task(
+        self,
+        env: Environment,
+        resource_runtime_part: ResourceRuntimePart,
+        normalised_parameters: dict,
+    ):
+        # Logs that the evaluation of this optimised service integration is not supported
+        # and relays the call to the target service with the computed parameters.
+        self._log_unsupported_warning()
+        service_name = self._get_boto_service_name()
+        api_action = self._get_boto_service_action()
+        sqs_client = boto_client_for(
+            region=resource_runtime_part.region,
+            account=resource_runtime_part.account,
+            service=service_name,
+        )
+        response = getattr(sqs_client, api_action)(**normalised_parameters)
+        response.pop("ResponseMetadata", None)
+        env.stack.append(response)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the SFN v2 interpreter lacks support for a subset of the (stepfunctions optimised service integrations)[https://docs.aws.amazon.com/step-functions/latest/dg/connect-supported-services.html]. This results in state machine that define unsupported service integrations to fail on creation. However, this prevents the execution of state machines that may never execute such logic, or prevents the execution in circumstances in which a simple forward to the target service with support for `.waitForTaskToken` may be required. This PR addresses such behaviour by logging the incident and attempting to relay the call to the target service, and also expose support for `.waitForTaskToken` workflows.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Added generic resolver for unsupported service integrations.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
