### PR TITLE
Resolved issue where using CDK wouldn't generate SecretString value

### DIFF
--- a/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_secret.py
+++ b/localstack/services/secretsmanager/resource_providers/aws_secretsmanager_secret.py
@@ -94,8 +94,15 @@ class SecretsManagerSecretProvider(ResourceProvider[SecretsManagerSecretProperti
         attributes = ["Name", "Description", "KmsKeyId", "SecretString", "Tags"]
         params = util.select_attributes(model, attributes)
 
+        """
+        From CFn Docs:
+        If you omit both GenerateSecretString and SecretString, you create an empty secret.
+        When you make a change to this property, a new secret version is created.
+        CDK wil generate empty dict in which case we also need to generate SecretString
+        """
+
         gen_secret = model.get("GenerateSecretString")
-        if gen_secret:
+        if gen_secret is not None:
             secret_value = self._get_secret_value(gen_secret)
             template = gen_secret.get("SecretStringTemplate")
             if template:

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.py
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.py
@@ -174,7 +174,9 @@ def test_cdk_deployment_generates_secret_value_if_no_value_is_provided(
 
         response = aws_client.secretsmanager.get_secret_value(SecretId=secret_name)
 
-        snapshot.add_transformer(snapshot.transform.key_value("SecretString"))
+        snapshot.add_transformer(
+            snapshot.transform.key_value("SecretString", reference_replacement=False)
+        )
         snapshot.add_transformer(snapshot.transform.regex(secret_arn, "<secret_arn>"))
         snapshot.add_transformer(snapshot.transform.regex(secret_name, "<secret_name>"))
 

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
@@ -18,13 +18,13 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cdk_deployment_generates_secret_value_if_no_value_is_provided": {
-    "recorded-date": "23-05-2024, 11:04:06",
+    "recorded-date": "23-05-2024, 17:15:31",
     "recorded-content": {
       "generated_key": {
         "ARN": "<secret_arn>",
         "CreatedDate": "datetime",
         "Name": "<secret_name>",
-        "SecretString": "<secret-string:1>",
+        "SecretString": "secret-string",
         "VersionId": "<uuid:1>",
         "VersionStages": [
           "AWSCURRENT"

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.snapshot.json
@@ -16,5 +16,24 @@
         "SecretPolicyArn": "arn:aws:secretsmanager:<region>:111111111111:secret:<secret-name>"
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cdk_deployment_generates_secret_value_if_no_value_is_provided": {
+    "recorded-date": "23-05-2024, 11:04:06",
+    "recorded-content": {
+      "generated_key": {
+        "ARN": "<secret_arn>",
+        "CreatedDate": "datetime",
+        "Name": "<secret_name>",
+        "SecretString": "<secret-string:1>",
+        "VersionId": "<uuid:1>",
+        "VersionStages": [
+          "AWSCURRENT"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cdk_deployment_generates_secret_value_if_no_value_is_provided": {
+    "last_validated_date": "2024-05-23T11:04:06+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[default]": {
     "last_validated_date": "2024-05-20T13:01:20+00:00"
   },

--- a/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_secretsmanager.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cdk_deployment_generates_secret_value_if_no_value_is_provided": {
-    "last_validated_date": "2024-05-23T11:04:06+00:00"
+    "last_validated_date": "2024-05-23T17:15:31+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_secretsmanager.py::test_cfn_secret_policy[default]": {
     "last_validated_date": "2024-05-20T13:01:20+00:00"


### PR DESCRIPTION
## Motivation
Client has reported issue where using CDK would generate SecretString value on AWS but not on LS


## Changes
In CFn if you omit both GenerateSecretString and SecretString, you create an empty secret.

CDK wil generate empty dictionary, which means that CFn will receive value for GenrateSecretString (empty dictionary). 
In which case we also need to generate SecretString.

I've modified CFn provider for Secret, to also work with empty dictionary and added tests.
        