### PR TITLE
Add support for the --env-file flag in docker flags

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -1142,6 +1142,12 @@ class Util:
             "--env", "-e", help="Set environment variables", dest="envs", action="append"
         )
         parser.add_argument(
+            "--env-file",
+            help="Set environment variables via a file",
+            dest="env_files",
+            action="append",
+        )
+        parser.add_argument(
             "--label", "-l", help="Add container meta data", dest="labels", action="append"
         )
         parser.add_argument("--network", help="Connect a container to a network")
@@ -1182,6 +1188,20 @@ class Util:
                 extra_hosts = extra_hosts if extra_hosts is not None else {}
                 hosts_split = add_host.split(":")
                 extra_hosts[hosts_split[0]] = hosts_split[1]
+
+        # set env file values before env values, as the latter override the earlier
+        if args.env_files:
+            env_vars = env_vars if env_vars is not None else {}
+            for env_file in args.env_files:
+                with open(env_file, mode="rt") as f:
+                    env_file_lines = f.readlines()
+                for idx, line in enumerate(env_file_lines):
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        # skip comments or empty lines
+                        continue
+                    lhs, _, rhs = line.partition("=")
+                    env_vars[lhs] = rhs
 
         if args.envs:
             env_vars = env_vars if env_vars is not None else {}

--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -1193,8 +1193,23 @@ class Util:
         if args.env_files:
             env_vars = env_vars if env_vars is not None else {}
             for env_file in args.env_files:
-                with open(env_file, mode="rt") as f:
-                    env_file_lines = f.readlines()
+                try:
+                    with open(env_file, mode="rt") as f:
+                        env_file_lines = f.readlines()
+                except FileNotFoundError as e:
+                    LOG.error(
+                        "Specified env file '%s' not found. Please make sure the file is properly mounted into the LocalStack container. Error: %s",
+                        env_file,
+                        e,
+                    )
+                    raise
+                except OSError as e:
+                    LOG.error(
+                        "Could not read env file '%s'. Please make sure the LocalStack container has the permissions to read it. Error: %s",
+                        env_file,
+                        e,
+                    )
+                    raise
                 for idx, line in enumerate(env_file_lines):
                     line = line.strip()
                     if not line or line.startswith("#") or "=" not in line:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 import os
 import re
+import textwrap
 import time
 from typing import NamedTuple, Type
 
@@ -1443,6 +1444,49 @@ class TestRunWithAdditionalArgs:
             ulimits=[Ulimit(name="nofile", soft_limit=1024, hard_limit=1024)],
         )
         assert stdout.decode(config.DEFAULT_ENCODING).strip() == "1024"
+
+    def test_run_with_additional_arguments_env_files(
+        self, docker_client: ContainerClient, tmp_path
+    ):
+        env_variable = "TEST1=VAL1"
+        env_file = tmp_path / "env1"
+        env_vars = textwrap.dedent("""
+            # Some comment
+            TEST1=OVERRIDDEN
+            TEST2=VAL2
+            TEST3=${TEST2}
+            TEST4=VAL # end comment
+            """)
+        env_file.write_text(env_vars)
+
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            remove=True,
+            command=["env"],
+            additional_flags=f"-e {env_variable} --env-file {env_file}",
+        )
+        env_output = stdout.decode(config.DEFAULT_ENCODING)
+        # behavior differs here from more advanced env file parsers
+        assert env_variable in env_output
+        assert "TEST1=VAL1" in env_output
+        assert "TEST2=VAL2" in env_output
+        assert "TEST3=${TEST2}" in env_output
+        assert "TEST4=VAL # end comment" in env_output
+
+        env_vars = textwrap.dedent("""
+            # Some comment
+            TEST1
+            """)
+        env_file.write_text(env_vars)
+
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            remove=True,
+            command=["env"],
+            additional_flags=f"--env-file {env_file}",
+        )
+        env_output = stdout.decode(config.DEFAULT_ENCODING)
+        assert "TEST1" not in env_output
 
 
 class TestDockerImages:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently do not support `--env-file` specification in the `DOCKER_FLAGS` variables.
It has, however, been requested by a customer to support this flag.

Please note that in the case of `--env-file`, the path to the env file has to be inside the LocalStack docker container.
This means, that the file has to be copied or mounted into the container before its usage, in essence before an affected container is spawned.

I avoided the usage of `docker-dotenv` (even though already installed) and wrote a simple manual parser of the environment files here, since the docker environment file parsing is quite limited. It for example does not respect comments at the end of a line (only when the line starts with a #) and also does not support referencing existing variables.
The usage of `docker-dotenv` would not allow us to be in parity with this restrictions of docker, even though it would be simpler and more powerful.

As context, we need to parse all the docker flags manually, as we do not simply forward them to a command line client, but use the docker sdk, which only accepts already parsed arguments and no command line flags.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* `DOCKER_FLAGS` variables, like `LAMBDA_DOCKER_FLAGS` now support the docker `--env-file` parameter with all its limitations.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
