### PR TITLE
fix S3 CopyObject in place deadlock for Suspended buckets

### DIFF
--- a/localstack/services/s3/v3/provider.py
+++ b/localstack/services/s3/v3/provider.py
@@ -1313,7 +1313,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         add_encryption_to_response(response, s3_object=s3_object)
 
-        if src_s3_bucket.versioning_status and src_s3_object.version_id:
+        if (
+            src_s3_bucket.versioning_status
+            and src_s3_object.version_id
+            and src_s3_object.version_id != "null"
+        ):
             response["CopySourceVersionId"] = src_s3_object.version_id
 
         # RequestCharged: Optional[RequestCharged] # TODO

--- a/localstack/services/s3/v3/storage/core.py
+++ b/localstack/services/s3/v3/storage/core.py
@@ -255,9 +255,13 @@ def should_copy_in_place(
     if src_object.key != dest_object.key:
         return False
 
-    # if the objects have version id, the bucket is versioned, and we should not copy in place: the new destination
-    # object will be a new version of the source object
-    if src_object.version_id or dest_object.version_id:
+    # if the objects are versioned, we should not copy in place: the new destination
+    # object will be a new version of the source object, with a different version id (both can be fetched)
+    if _is_object_versioned(src_object) or _is_object_versioned(dest_object):
         return False
 
     return True
+
+
+def _is_object_versioned(s3_object: S3Object) -> bool:
+    return s3_object.version_id and s3_object.version_id != "null"

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11363,7 +11363,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_versioned": {
-    "recorded-date": "19-03-2024, 18:12:57",
+    "recorded-date": "23-05-2024, 19:05:18",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -11448,6 +11448,76 @@
         "Metadata": {},
         "ServerSideEncryption": "AES256",
         "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-in-place-versioned-suspended": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "CopySourceVersionId": "<version-id:2>",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-copied-suspended": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-copied-suspended": {
+        "AcceptRanges": "bytes",
+        "Body": {
+          "key": "value"
+        },
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-previous-version-suspended": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-in-place-versioned-re-enabled": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -11639,6 +11709,129 @@
           "HostId": "host-id",
           "Message": "Error parsing the X-Amz-Credential parameter; the Credential is mal-formed; expecting \"<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request\".",
           "RequestId": "<request-id:1>"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_suspended_only": {
+    "recorded-date": "23-05-2024, 19:02:15",
+    "recorded-content": {
+      "put_object": {
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "application/json",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {
+          "key": "value"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-in-place-non-versioned": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-copied": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-copied": {
+        "AcceptRanges": "bytes",
+        "Body": {
+          "key": "value"
+        },
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-in-place-versioned-suspended": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-copied-suspended": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-copied-suspended": {
+        "AcceptRanges": "bytes",
+        "Body": {
+          "key": "value"
+        },
+        "ContentLength": 16,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-in-place-versioned-suspended-twice": {
+        "CopyObjectResult": {
+          "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -278,8 +278,11 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_storage_class": {
     "last_validated_date": "2023-08-03T02:15:24+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_suspended_only": {
+    "last_validated_date": "2024-05-23T19:02:15+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_versioned": {
-    "last_validated_date": "2024-03-19T18:12:57+00:00"
+    "last_validated_date": "2024-05-23T19:05:18+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_object_in_place_website_redirect_location": {
     "last_validated_date": "2023-08-03T02:15:36+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10881, we hit a deadlock in S3 when copying in place from a never versioned bucket into a `Suspended` bucket. This was due to a missing check in the copy in-place detection. We only ever checked if the object did not have a `version_id`, but `version_id = None` give the same result as `version_id = "null"`. 

This part of the code was then responsible for the deadlock:
```python
if should_copy_in_place(src_bucket, src_object, dest_bucket, dest_object):
    return self.open(dest_bucket, dest_object, mode="r")

with self.open(src_bucket, src_object, mode="r") as src_stored_object:
    dest_stored_object = self.open(dest_bucket, dest_object, mode="w")
    dest_stored_object.write(src_stored_object)
```

As the copy was not flagged as "in-place" when it should, we would not return early and try to open the same underlying object both in `write` and `read` mode 😅 
(We had an S3 object with `version_id = None` and the other was `version_id = "null"`, effectively being the same thing).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- added more tests around copy in place behavior in AWS regarding `Suspended` buckets
- fixed the condition by adding a small helper method to verify that the object is non-versioned

_fixes #10881_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
