### PR TITLE
[SFN] Add Normalisation of Service Response Values

### DIFF
--- a/tests/aws/services/stepfunctions/templates/services/services_templates.py
+++ b/tests/aws/services/stepfunctions/templates/services/services_templates.py
@@ -32,6 +32,9 @@ class ServicesTemplates(TemplateLoader):
     AWS_SDK_SFN_START_EXECUTION_IMPLICIT_JSON_SERIALISATION: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/aws_sdk_sfn_start_execution_implicit_json_serialisation.json5"
     )
+    AWS_SDK_S3_GET_OBJECT: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/aws_sdk_s3_get_object.json5"
+    )
     API_GATEWAY_INVOKE_BASE: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/api_gateway_invoke_base.json5"
     )

--- a/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_s3_get_object.json5
+++ b/tests/aws/services/stepfunctions/templates/services/statemachines/aws_sdk_s3_get_object.json5
@@ -1,0 +1,15 @@
+{
+  "Comment": "AWS_SDK_S3_GET_OBJECT",
+  "StartAt": "S3GetObject",
+  "States": {
+    "S3GetObject": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObject",
+      "Parameters": {
+        "Bucket.$": "$.Bucket",
+        "Key.$": "$.Key"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.snapshot.json
@@ -1666,5 +1666,685 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[empty_str]": {
+    "recorded-date": "23-05-2024, 19:11:31",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3GetObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3GetObject",
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[str]": {
+    "recorded-date": "23-05-2024, 19:11:47",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3GetObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 9,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"332eec544317a6d340b8e77da7fe54ad\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "text data"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3GetObject",
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 9,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"332eec544317a6d340b8e77da7fe54ad\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "text data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 9,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"332eec544317a6d340b8e77da7fe54ad\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "text data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[empty_binary]": {
+    "recorded-date": "23-05-2024, 19:12:03",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3GetObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3GetObject",
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 0,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": ""
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[binary]": {
+    "recorded-date": "23-05-2024, 19:12:25",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3GetObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 11,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"e1a49b59e0c42e4fd3735ad644f25d57\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "binary data"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3GetObject",
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 11,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"e1a49b59e0c42e4fd3735ad644f25d57\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "binary data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 11,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"e1a49b59e0c42e4fd3735ad644f25d57\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "binary data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[bytearray]": {
+    "recorded-date": "23-05-2024, 19:12:51",
+    "recorded-content": {
+      "get_execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "snf_role_arn"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "S3GetObject"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "Bucket": "bucket-name",
+                "Key": "file_key"
+              },
+              "region": "<region>",
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 15,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"383fd42bdf94a2ab38cbeb1d8eb7e53f\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "byte array data"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "getObject",
+              "resourceType": "aws-sdk:s3"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "stateExitedEventDetails": {
+              "name": "S3GetObject",
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 15,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"383fd42bdf94a2ab38cbeb1d8eb7e53f\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "byte array data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "AcceptRanges": "bytes",
+                "ContentLength": 15,
+                "ContentType": "binary/octet-stream",
+                "ETag": "\"383fd42bdf94a2ab38cbeb1d8eb7e53f\"",
+                "LastModified": "date",
+                "Metadata": {},
+                "ServerSideEncryption": "AES256",
+                "Body": "byte array data"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 7,
+            "previousEventId": 6,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
+++ b/tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.validation.json
@@ -11,6 +11,21 @@
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_list_secrets": {
     "last_validated_date": "2023-06-22T11:59:49+00:00"
   },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[binary]": {
+    "last_validated_date": "2024-05-23T19:12:25+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[bytearray]": {
+    "last_validated_date": "2024-05-23T19:12:51+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[empty_binary]": {
+    "last_validated_date": "2024-05-23T19:12:03+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[empty_str]": {
+    "last_validated_date": "2024-05-23T19:11:31+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_s3_get_object[str]": {
+    "last_validated_date": "2024-05-23T19:11:47+00:00"
+  },
   "tests/aws/services/stepfunctions/v2/services/test_aws_sdk_task_service.py::TestTaskServiceAwsSdk::test_sfn_send_task_outcome_with_no_such_token[state_machine_template0]": {
     "last_validated_date": "2024-04-10T18:55:26+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Currently the StepFunctions interpreter does not perform normalisation steps to the output values of service responses. This is observable whenever the response type is not json inferable. For example responses of `s3` `GetObject` that include StreamingBody data types. This PR addresses such issue by adding a normalisation step for the response values, and uses this pattern to normalise StreamingBody data types. Addresses: #10787 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Add a response value normalisation step to the response normalisation workflow
- Add normalisation of StreamingBody data types
- Add related tests using `aws-sdk:s3:getObject`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
