### PR TITLE
Fix deduplication scope for non-high-throughput FIFO messages

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -934,7 +934,7 @@ class FifoQueue(SqsQueue):
     message_groups: dict[str, MessageGroup]
     inflight_groups: set[MessageGroup]
     message_group_queue: Queue
-    high_throughput: bool
+    deduplication_scope: str
 
     def __init__(self, name: str, region: str, account_id: str, attributes=None, tags=None) -> None:
         super().__init__(name, region, account_id, attributes, tags)
@@ -943,15 +943,10 @@ class FifoQueue(SqsQueue):
         self.message_groups = {}
         self.inflight_groups = set()
         self.message_group_queue = Queue()
-        self.high_throughput = False
 
         # SQS does not seem to change the deduplication behaviour of fifo queues if you
-        # change to/from high-throughput mode after creation -> we need to set this on creation
-        if (
-            self.attributes[QueueAttributeName.DeduplicationScope] == "messageGroup"
-            and self.attributes[QueueAttributeName.FifoThroughputLimit] == "perMessageGroupId"
-        ):
-            self.high_throughput = True
+        # change to/from 'queue'/'messageGroup' scope after creation -> we need to set this on creation
+        self.deduplication_scope = attributes.get(QueueAttributeName.DeduplicationScope, "queue")
 
     @property
     def approx_number_of_messages(self):
@@ -1043,9 +1038,9 @@ class FifoQueue(SqsQueue):
             original_message
             and original_message.priority + sqs_constants.DEDUPLICATION_INTERVAL_IN_SEC
             > fifo_message.priority
-            # account for high-throughput-mode
+            # account for deduplication scope required for (but not restricted to) high-throughput-mode
             and (
-                not self.high_throughput
+                not self.deduplication_scope == "messageGroup"
                 or fifo_message.message_group_id == original_message.message_group_id
             )
         ):

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -1852,7 +1852,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {
-    "recorded-date": "30-04-2024, 13:34:32",
+    "recorded-date": "24-05-2024, 09:41:13",
     "recorded-content": {
       "same-dedup-different-grp-1": {
         "Messages": [
@@ -1905,6 +1905,26 @@
         }
       },
       "same-dedup-different-grp-high-throughput-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "new-dedup2-high-throughput": {
+        "Messages": [
+          {
+            "Body": "Test4",
+            "MD5OfBody": "41d5e808720c8ee71257214e952a6721",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup2-high-throughput": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1913,7 +1933,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs_query]": {
-    "recorded-date": "30-04-2024, 13:34:35",
+    "recorded-date": "24-05-2024, 09:41:19",
     "recorded-content": {
       "same-dedup-different-grp-1": {
         "Messages": [
@@ -1966,6 +1986,26 @@
         }
       },
       "same-dedup-different-grp-high-throughput-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "new-dedup2-high-throughput": {
+        "Messages": [
+          {
+            "Body": "Test4",
+            "MD5OfBody": "41d5e808720c8ee71257214e952a6721",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup2-high-throughput": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -3256,5 +3296,71 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs_query]": {
     "recorded-date": "21-05-2024, 13:48:14",
     "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_message_group_scope_no_throughput_setting[sqs]": {
+    "recorded-date": "24-05-2024, 09:03:33",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test",
+            "MD5OfBody": "0cbc6611f5540bd0809a388dc95a615b",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "Messages": [
+          {
+            "Body": "Test",
+            "MD5OfBody": "0cbc6611f5540bd0809a388dc95a615b",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_message_group_scope_no_throughput_setting[sqs_query]": {
+    "recorded-date": "24-05-2024, 09:03:35",
+    "recorded-content": {
+      "same-dedup-different-grp-1": {
+        "Messages": [
+          {
+            "Body": "Test",
+            "MD5OfBody": "0cbc6611f5540bd0809a388dc95a615b",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "same-dedup-different-grp-2": {
+        "Messages": [
+          {
+            "Body": "Test",
+            "MD5OfBody": "0cbc6611f5540bd0809a388dc95a615b",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -81,10 +81,10 @@
     "last_validated_date": "2024-04-30T13:49:31+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {
-    "last_validated_date": "2024-04-30T13:34:32+00:00"
+    "last_validated_date": "2024-05-24T10:00:47+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs_query]": {
-    "last_validated_date": "2024-04-30T13:34:35+00:00"
+    "last_validated_date": "2024-05-24T10:00:53+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_regular_throughput_after_creation[sqs]": {
     "last_validated_date": "2024-04-30T13:52:02+00:00"
@@ -301,6 +301,18 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_set_unsupported_attribute_standard[sqs_query]": {
     "last_validated_date": "2024-05-14T22:34:35+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_content_based_dedup_with_message_group_scope[sqs]": {
+    "last_validated_date": "2024-05-24T08:57:07+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_content_based_dedup_with_message_group_scope[sqs_query]": {
+    "last_validated_date": "2024-05-24T08:57:10+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_message_group_scope_no_throughput_setting[sqs]": {
+    "last_validated_date": "2024-05-24T09:03:32+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_message_group_scope_no_throughput_setting[sqs_query]": {
+    "last_validated_date": "2024-05-24T09:03:35+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_sqs_fifo_same_dedup_id_different_message_groups[sqs]": {
     "last_validated_date": "2024-04-30T13:51:17+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Apparently the deduplication scope for high-throughput queues is not restricted to said high-throughput queues, but can be used for any FIFO queue really. This PR addresses this issue.
Fixes #10460 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Change deduplication scope check to only consider said scope, and not if the queue is in HT mode
- Change the flag for tracking this to match the scope (I still haven't figured out why this cannot be changed on AWS after queue creation even though they specifically mention that you can do just that)
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
