### PR TITLE
fix pre-signed POST str type for content-length-range

### DIFF
--- a/localstack-core/localstack/services/s3/presigned_url.py
+++ b/localstack-core/localstack/services/s3/presigned_url.py
@@ -790,8 +790,9 @@ def validate_post_policy(
     form_dict = {k.lower(): v for k, v in request_form.items()}
     for condition in conditions:
         if not _verify_condition(condition, form_dict, additional_policy_metadata):
+            str_condition = str(condition).replace("'", '"')
             raise AccessDenied(
-                f"Invalid according to Policy: Policy Condition failed: {condition}",
+                f"Invalid according to Policy: Policy Condition failed: {str_condition}",
                 HostId=FAKE_HOST_ID,
             )
 
@@ -829,6 +830,11 @@ def _verify_condition(condition: list | dict, form: dict, additional_policy_meta
 
         case ["content-length-range", start, end]:
             size = additional_policy_metadata.get("content_length", 0)
+            try:
+                start, end = int(start), int(end)
+            except ValueError:
+                return False
+
             if size < start:
                 raise EntityTooSmall(
                     "Your proposed upload is smaller than the minimum allowed size",

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10140,13 +10140,6 @@ class TestS3PresignedPost:
             allow_redirects=False,
         )
 
-    @staticmethod
-    def parse_response_xml(content: bytes) -> dict:
-        if not is_aws_cloud():
-            # AWS use double quotes in error messages and LocalStack uses single. Try to unify before snapshotting
-            content = content.replace(b"'", b'"')
-        return xmltodict.parse(content)
-
     @markers.aws.validated
     @pytest.mark.xfail(
         reason="failing sporadically with new HTTP gateway (only in CI)",
@@ -10763,8 +10756,7 @@ class TestS3PresignedPost:
 
         # assert that it's rejected
         assert response.status_code == 403
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-eq", resp_content)
+        snapshot.match("invalid-condition-eq", xmltodict.parse(response.content))
 
         # PostObject with a wrong condition (missing $ prefix)
         presigned_request = aws_client.s3.generate_presigned_post(
@@ -10781,8 +10773,7 @@ class TestS3PresignedPost:
 
         # assert that it's rejected
         assert response.status_code == 403
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-missing-prefix", resp_content)
+        snapshot.match("invalid-condition-missing-prefix", xmltodict.parse(response.content))
 
         # PostObject with a wrong condition (multiple condition in one dict)
         presigned_request = aws_client.s3.generate_presigned_post(
@@ -10799,8 +10790,7 @@ class TestS3PresignedPost:
 
         # assert that it's rejected
         assert response.status_code == 400
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-wrong-condition", resp_content)
+        snapshot.match("invalid-condition-wrong-condition", xmltodict.parse(response.content))
 
         # PostObject with a wrong condition value casing
         presigned_request = aws_client.s3.generate_presigned_post(
@@ -10815,8 +10805,7 @@ class TestS3PresignedPost:
         response = self.post_generated_presigned_post_with_default_file(presigned_request)
         # assert that it's rejected
         assert response.status_code == 403
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-wrong-value-casing", resp_content)
+        snapshot.match("invalid-condition-wrong-value-casing", xmltodict.parse(response.content))
 
         object_expires = rfc_1123_datetime(
             datetime.datetime.now(ZoneInfo("GMT")) + datetime.timedelta(minutes=10)
@@ -10948,8 +10937,7 @@ class TestS3PresignedPost:
 
         # assert that it's rejected
         assert response.status_code == 403
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-starts-with", resp_content)
+        snapshot.match("invalid-condition-starts-with", xmltodict.parse(response.content))
 
         # PostObject with a right redirect location start but wrong casing
         presigned_request["fields"]["success_action_redirect"] = "HTTP://localhost.test/random"
@@ -10957,8 +10945,7 @@ class TestS3PresignedPost:
 
         # assert that it's rejected
         assert response.status_code == 403
-        resp_content = self.parse_response_xml(response.content)
-        snapshot.match("invalid-condition-starts-with-casing", resp_content)
+        snapshot.match("invalid-condition-starts-with-casing", xmltodict.parse(response.content))
 
         # PostObject with a right redirect location start
         presigned_request["fields"]["success_action_redirect"] = redirect_location

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11526,7 +11526,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
-    "recorded-date": "08-04-2024, 17:29:34",
+    "recorded-date": "24-05-2024, 11:43:48",
     "recorded-content": {
       "invalid-content-length-too-big": {
         "Error": {
@@ -11560,6 +11560,14 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "invalid-content-length-wrong-type": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "<host-id>",
+          "Message": "Invalid according to Policy: Policy Condition failed: [\"content-length-range\", \"test\", \"10\"]",
+          "RequestId": "<request-id:4>"
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11573,7 +11573,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "recorded-date": "21-05-2024, 16:51:17",
+    "recorded-date": "24-05-2024, 15:10:58",
     "recorded-content": {
       "invalid-condition-eq": {
         "Error": {
@@ -11641,7 +11641,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
-    "recorded-date": "10-04-2024, 12:16:01",
+    "recorded-date": "24-05-2024, 15:11:14",
     "recorded-content": {
       "invalid-condition-starts-with": {
         "Error": {

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -528,7 +528,7 @@
     "last_validated_date": "2024-04-10T12:16:01+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
-    "last_validated_date": "2024-04-08T17:29:34+00:00"
+    "last_validated_date": "2024-05-24T11:43:48+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_with_file_as_string": {
     "last_validated_date": "2024-02-24T01:01:59+00:00"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -522,10 +522,10 @@
     "last_validated_date": "2023-08-09T15:58:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_eq": {
-    "last_validated_date": "2024-05-21T16:51:17+00:00"
+    "last_validated_date": "2024-05-24T15:10:58+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_conditions_validation_starts_with": {
-    "last_validated_date": "2024-04-10T12:16:01+00:00"
+    "last_validated_date": "2024-05-24T15:11:14+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3PresignedPost::test_post_object_policy_validation_size": {
     "last_validated_date": "2024-05-24T11:43:48+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As a follow up from #10862, the same user encounter an issue when the policy condition were the following:
`["content-length-range", "0", "104857600000"]]`, as being generated by https://docs.fineuploader.com/endpoint_handlers/amazon-s3.html

This was a hole in our validation, we didn't check that the content length range could be a string. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- added test cases for content length range with strings (valid and invalid)
- fixed the logic to properly handle strings

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
