### PR TITLE
Remove CloudFormation moto backend from persisted state

### DIFF
--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -5,8 +5,6 @@ import re
 from collections import defaultdict
 from copy import deepcopy
 
-from moto.cloudformation import cloudformation_backends
-
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudformation import (
     AlreadyExistsException,
@@ -170,7 +168,6 @@ class CloudformationProvider(CloudformationApi):
 
     def accept_state_visitor(self, visitor: StateVisitor):
         visitor.visit(cloudformation_stores)
-        visitor.visit(cloudformation_backends)
 
     @handler("CreateStack", expand=False)
     def create_stack(self, context: RequestContext, request: CreateStackInput) -> CreateStackOutput:


### PR DESCRIPTION
## Motivation

For some reason the moto backend was probably unintentionally added last year to the persisted CFn state even though we don't actually use moto in the service.

Saw this by chance when trying to debug persistence. It shouldn't have any actual effect on persistence tests since we're not using moto in the service but still good to clean this up.

## Changes

- Only our internal CloudFormation store will be persisted now