### PR TITLE
Fix lambda persistence restore

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
+++ b/localstack-core/localstack/services/lambda_/invocation/lambda_models.py
@@ -620,6 +620,12 @@ class Function:
         del state["instance_id"]
         return state
 
+    def __setstate__(self, state):
+        # Inject persistent state
+        self.__dict__.update(state)
+        # Create new instance id
+        self.__post_init__()
+
 
 class ValidationException(CommonServiceException):
     def __init__(self, message: str):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #10831 we introduced an function instance id, which should not be persisted.
However, on persistence restore we do not set the instance_id again, so the restored state does not contain the attribute, which leads to errors down the road.

We need to explicitly set the instance id after restore, `__post_init__` is not called by default on unpickling.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack Lambda persistence should be fixed, no more `AttributeError` thrown after persistence restore

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
