### PR TITLE
fix docker helper usage typo and push without force flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,9 +651,9 @@ jobs:
           name: Create multi-platform manifests
           command: |
             # Push to Docker Hub
-            ./bin/docker-helper.sh push-manifest
+            ./bin/docker-helper.sh push-manifests
             # Push to Amazon Public ECR
-            IMAGE_NAME="public.ecr.aws/localstack/localstack" ./bin/docker-helper.sh push-manifest
+            IMAGE_NAME="public.ecr.aws/localstack/localstack" ./bin/docker-helper.sh push-manifests
       - run:
           name: Publish a dev release
           command: |

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -188,10 +188,10 @@ function cmd-push() {
       docker push $TARGET_IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION-$PLATFORM
     }
 
-    if [ "$FORCE_VERSION_TAG_PUSH" -eq "1" ]; then
+    if [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "1" ]; then
       echo "Force-enabled version tag push."
       _push
-    elif [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
+    elif [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
       echo "Force-disabled version tag push. Not pushing any other tags."
     elif (git diff HEAD~1 ${VERSION_FILE} | grep -v '.dev'); then
       echo "Pushing version tags, version has changed in last commit."
@@ -251,13 +251,15 @@ function cmd-push-manifests() {
       docker manifest push $IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION
     }
 
-
-    if [ "$FORCE_VERSION_TAG_PUSH" -eq "1" ]; then
+    if [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "1" ]; then
       echo "Force-enabled version tag push."
       _push
-    elif [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
+    elif [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
       echo "Force-disabled version tag push. Not pushing any other tags."
     elif (git diff HEAD~1 ${VERSION_FILE} | grep -v '.dev'); then
+      echo "Pushing version tags, version has changed in last commit."
+      _push
+    else
       echo "Not pushing any other tags, version has not changed in last commit."
     fi
 }

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -193,7 +193,7 @@ function cmd-push() {
       _push
     elif [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
       echo "Force-disabled version tag push. Not pushing any other tags."
-    elif (git diff HEAD~1 ${VERSION_FILE} | grep -v '.dev'); then
+    elif (git diff HEAD^ ${VERSION_FILE} | tail -n 1 | grep -v '.dev'); then
       echo "Pushing version tags, version has changed in last commit."
       _push
     else
@@ -256,7 +256,7 @@ function cmd-push-manifests() {
       _push
     elif [ -n "$FORCE_VERSION_TAG_PUSH" ] && [ "$FORCE_VERSION_TAG_PUSH" -eq "0" ]; then
       echo "Force-disabled version tag push. Not pushing any other tags."
-    elif (git diff HEAD~1 ${VERSION_FILE} | grep -v '.dev'); then
+    elif (git diff HEAD^ ${VERSION_FILE} | tail -n 1 | grep -v '.dev'); then
       echo "Pushing version tags, version has changed in last commit."
       _push
     else

--- a/tests/bin/test.docker-helper.bats
+++ b/tests/bin/test.docker-helper.bats
@@ -152,6 +152,17 @@ setup_file() {
 
 # push-manifests
 
+@test "push-manifests works without FORCE_VERSION_TAG_PUSH" {
+  export IMAGE_NAME="localstack/test"
+  export MAIN_BRANCH="`git branch --show-current`"
+  export DOCKER_USERNAME=test
+  export DOCKER_PASSWORD=test
+  export VERSION_FILE="$BATS_TEST_DIRNAME/files/VERSION"
+  run bin/docker-helper.sh push-manifests
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "docker manifest push $IMAGE_NAME:latest" ]]
+}
+
 @test "push-manifests pushes built image wo versions" {
   export IMAGE_NAME="localstack/test"
   export MAIN_BRANCH="`git branch --show-current`"


### PR DESCRIPTION
## Motivation
#10872 migrated the make targets to push the Docker images to a separate helper script.
Unfortunately a few small issues sneaked into the script and its usage, which are fixed with this PR.

## Changes
- Fixes the usage of the docker-helper in the CircleCI workflow (small typo, `push-manifests` instead of `push-manifest`)
- Fix the push targets in case `FORCE_VERSION_TAG_PUSH` is not set.
- Fix the detection of a version bump.
  - There was still the old version detection from #10276, but this has changed by @silv-io with #10497 in the meantime.