### PR TITLE
Partitions: ARN's now contain correct partition

### DIFF
--- a/localstack-core/localstack/aws/api/core.py
+++ b/localstack-core/localstack/aws/api/core.py
@@ -80,6 +80,8 @@ class RequestContext(RoloRequestContext):
     """The botocore OperationModel of the AWS operation being invoked."""
     region: Optional[str]
     """The region the request is made to."""
+    partition: str
+    """The partition the request is made to."""
     account_id: Optional[str]
     """The account the request is made from."""
     request_id: Optional[str]
@@ -98,6 +100,7 @@ class RequestContext(RoloRequestContext):
         self.service = None
         self.operation = None
         self.region = None
+        self.partition = "aws"  # Sensible default - will be overwritten by region-handler
         self.account_id = None
         self.request_id = long_uid()
         self.service_request = None

--- a/localstack-core/localstack/aws/handlers/region.py
+++ b/localstack-core/localstack/aws/handlers/region.py
@@ -1,6 +1,7 @@
 import logging
 
 from localstack.http import Request, Response
+from localstack.utils.aws.arns import get_partition
 
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
@@ -15,6 +16,7 @@ class RegionContextEnricher(Handler):
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
         context.region = self.get_region(context.request)
+        context.partition = get_partition(context.region)
 
     @staticmethod
     def get_region(request: Request) -> str:

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -47,7 +47,7 @@ from localstack.services.apigateway.models import (
 )
 from localstack.utils import common
 from localstack.utils.aws import resources as resource_utils
-from localstack.utils.aws.arns import parse_arn
+from localstack.utils.aws.arns import get_partition, parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
 from localstack.utils.json import try_json
 from localstack.utils.numbers import is_number
@@ -865,6 +865,7 @@ def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, accoun
         sqs_account = account_id
         sqs_region = region_name
 
+    partition = get_partition(region_name)
     resources[resource_path] = [
         {
             "httpMethod": "POST",
@@ -872,8 +873,8 @@ def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, accoun
             "integrations": [
                 {
                     "type": "AWS",
-                    "uri": "arn:aws:apigateway:%s:sqs:path/%s/%s"
-                    % (sqs_region, sqs_account, queue_name),
+                    "uri": "arn:%s:apigateway:%s:sqs:path/%s/%s"
+                    % (partition, sqs_region, sqs_account, queue_name),
                     "requestTemplates": {"application/json": template},
                     "requestParameters": {
                         "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"

--- a/localstack-core/localstack/services/apigateway/integration.py
+++ b/localstack-core/localstack/services/apigateway/integration.py
@@ -41,7 +41,7 @@ from localstack.services.apigateway.templates import (
 )
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
-from localstack.utils.aws.arns import extract_region_from_arn
+from localstack.utils.aws.arns import ARN_PARTITION_REGEX, extract_region_from_arn, get_partition
 from localstack.utils.aws.aws_responses import (
     LambdaResponse,
     request_response_stream,
@@ -188,7 +188,7 @@ def get_internal_mocked_headers(
 
 
 def get_source_arn(invocation_context: ApiInvocationContext):
-    return f"arn:aws:execute-api:{invocation_context.region_name}:{invocation_context.account_id}:{invocation_context.api_id}/{invocation_context.stage}/{invocation_context.method}{invocation_context.path}"
+    return f"arn:{get_partition(invocation_context.region_name)}:execute-api:{invocation_context.region_name}:{invocation_context.account_id}:{invocation_context.api_id}/{invocation_context.stage}/{invocation_context.method}{invocation_context.path}"
 
 
 def call_lambda(
@@ -686,10 +686,8 @@ class DynamoDBIntegration(BackendIntegration):
 
 class S3Integration(BackendIntegration):
     # target ARN patterns
-    TARGET_REGEX_PATH_S3_URI = (
-        r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
-    )
-    TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
+    TARGET_REGEX_PATH_S3_URI = rf"{ARN_PARTITION_REGEX}:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
+    TARGET_REGEX_ACTION_S3_URI = rf"{ARN_PARTITION_REGEX}:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
 
     def invoke(self, invocation_context: ApiInvocationContext):
         invocation_path = invocation_context.path_with_query_string

--- a/localstack-core/localstack/services/apigateway/models.py
+++ b/localstack-core/localstack/services/apigateway/models.py
@@ -14,7 +14,6 @@ from localstack.aws.api.apigateway import (
     Resource,
     RestApi,
 )
-from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -106,7 +105,7 @@ class ApiGatewayStore(BaseStore):
     rest_apis: Dict[str, RestApiContainer] = LocalAttribute(default=CaseInsensitiveDict)
 
     # account details
-    account: Dict[str, Any] = LocalAttribute(default=dict)
+    _account: Dict[str, Any] = LocalAttribute(default=dict)
 
     # maps (domain_name) -> [path_mappings]
     base_path_mappings: Dict[str, List[Dict]] = LocalAttribute(default=dict)
@@ -135,16 +134,20 @@ class ApiGatewayStore(BaseStore):
     def __init__(self):
         super().__init__()
 
-        self.account.update(
-            {
-                "cloudwatchRoleArn": arns.iam_role_arn(
-                    "api-gw-cw-role", DEFAULT_AWS_ACCOUNT_ID
-                ),  # FIXME: account ID must be of the current store
-                "throttleSettings": {"burstLimit": 1000, "rateLimit": 500},
-                "features": ["UsagePlans"],
-                "apiKeyVersion": "1",
-            }
-        )
+    @property
+    def account(self):
+        if not self._account:
+            self._account.update(
+                {
+                    "cloudwatchRoleArn": arns.iam_role_arn(
+                        "api-gw-cw-role", self._account_id, self._region_name
+                    ),
+                    "throttleSettings": {"burstLimit": 1000, "rateLimit": 500},
+                    "features": ["UsagePlans"],
+                    "apiKeyVersion": "1",
+                }
+            )
+        return self._account
 
 
 apigateway_stores = AccountRegionBundle("apigateway", ApiGatewayStore)

--- a/localstack-core/localstack/services/dynamodb/provider.py
+++ b/localstack-core/localstack/services/dynamodb/provider.py
@@ -146,7 +146,11 @@ from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws import arns
-from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
+from localstack.utils.aws.arns import (
+    extract_account_id_from_arn,
+    extract_region_from_arn,
+    get_partition,
+)
 from localstack.utils.aws.aws_stack import get_valid_regions_for_service
 from localstack.utils.aws.request_context import (
     extract_account_id_from_headers,
@@ -565,17 +569,23 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def _modify_ddblocal_arns(self, chain, context: RequestContext, response: Response):
         """A service response handler that modifies the dynamodb backend response."""
         if response_content := response.get_data(as_text=True):
+
+            def _convert_arn(matchobj):
+                key = matchobj.group(1)
+                partition = get_partition(context.region)
+                table_name = matchobj.group(2)
+                return f'{key}: "arn:{partition}:dynamodb:{context.region}:{context.account_id}:{table_name}"'
+
             # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
             content_replaced = re.sub(
-                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:([a-z-]+):dynamodb:ddblocal:000000000000:([^"]+)"',
-                rf'\1: "arn:\2:dynamodb:{context.region}:{context.account_id}:\3"',
+                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:[a-z-]+:dynamodb:ddblocal:000000000000:([^"]+)"',
+                _convert_arn,
                 response_content,
             )
             if content_replaced != response_content:
                 response.data = content_replaced
-                context.service_response = (
-                    None  # make sure the service response is parsed again later
-                )
+                # make sure the service response is parsed again later
+                context.service_response = None
 
         # update x-amz-crc32 header required by some clients
         response.headers["x-amz-crc32"] = crc32(response.data) & 0xFFFFFFFF
@@ -1755,8 +1765,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         """
         Set the correct account ID and region in ARNs returned by DynamoDB Local.
         """
-        return arn.replace(":ddblocal:", f":{region_name}:").replace(
-            ":000000000000:", f":{account_id}:"
+        partition = get_partition(region_name)
+        return (
+            arn.replace("arn:aws:", f"arn:{partition}:")
+            .replace(":ddblocal:", f":{region_name}:")
+            .replace(":000000000000:", f":{account_id}:")
         )
 
     def prepare_transact_write_item_records(

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -33,10 +33,10 @@ RULE_ARN_CUSTOM_EVENT_BUS_PATTERN = re.compile(
 )
 
 RULE_ARN_ARCHIVE_PATTERN = re.compile(
-    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{12}:archive/[a-zA-Z0-9_-]+$"
+    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{{12}}:archive/[a-zA-Z0-9_-]+$"
 )
 ARCHIVE_NAME_ARN_PATTERN = re.compile(
-    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{12}:archive/(?P<name>.+)$"
+    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{{12}}:archive/(?P<name>.+)$"
 )
 
 

--- a/localstack-core/localstack/services/events/utils.py
+++ b/localstack-core/localstack/services/events/utils.py
@@ -23,17 +23,21 @@ from localstack.services.events.models import (
     TransformedEvent,
     ValidationException,
 )
-from localstack.utils.aws.arns import parse_arn
+from localstack.utils.aws.arns import ARN_PARTITION_REGEX, parse_arn
 from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
 
 RULE_ARN_CUSTOM_EVENT_BUS_PATTERN = re.compile(
-    r"^arn:aws:events:[a-z0-9-]+:\d{12}:rule/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$"
+    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{{12}}:rule/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$"
 )
 
-RULE_ARN_ARCHIVE_PATTERN = re.compile(r"^arn:aws:events:[a-z0-9-]+:\d{12}:archive/[a-zA-Z0-9_-]+$")
-ARCHIVE_NAME_ARN_PATTERN = re.compile(r"^arn:aws:events:[a-z0-9-]+:\d{12}:archive/(?P<name>.+)$")
+RULE_ARN_ARCHIVE_PATTERN = re.compile(
+    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{12}:archive/[a-zA-Z0-9_-]+$"
+)
+ARCHIVE_NAME_ARN_PATTERN = re.compile(
+    rf"{ARN_PARTITION_REGEX}:events:[a-z0-9-]+:\d{12}:archive/(?P<name>.+)$"
+)
 
 
 class EventJSONEncoder(json.JSONEncoder):
@@ -73,7 +77,7 @@ def extract_event_bus_name(
     """Return the event bus name. Input can be either an event bus name or ARN."""
     if not resource_arn_or_name:
         return "default"
-    if "arn:aws:events" not in resource_arn_or_name:
+    if not re.match(f"{ARN_PARTITION_REGEX}:events", resource_arn_or_name):
         return resource_arn_or_name
     resource_type = get_resource_type(resource_arn_or_name)
     if resource_type == ResourceType.EVENT_BUS:

--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -102,7 +102,7 @@ POLICY_ARN_REGEX = re.compile(r"arn:[^:]+:iam::(?:\d{12}|aws):policy/.*")
 
 
 def get_iam_backend(context: RequestContext) -> IAMBackend:
-    return iam_backends[context.account_id]["global"]
+    return iam_backends[context.account_id][context.partition]
 
 
 class IamProvider(IamApi):

--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -337,8 +337,8 @@ class IamProvider(IamApi):
             tags={},
             max_session_duration=3600,
         )
-        role.service_linked_role_arn = "arn:aws:iam::{0}:role/aws-service-role/{1}/{2}".format(
-            context.account_id, aws_service_name, role.name
+        role.service_linked_role_arn = "arn:{0}:iam::{1}:role/aws-service-role/{2}/{3}".format(
+            context.partition, context.account_id, aws_service_name, role.name
         )
 
         res_role = self.moto_role_to_role_type(role)

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -117,7 +117,7 @@ from localstack.services.kms.models import (
 )
 from localstack.services.kms.utils import is_valid_key_arn, parse_key_arn, validate_alias_name
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws.arns import kms_alias_arn, parse_arn
+from localstack.utils.aws.arns import get_partition, kms_alias_arn, parse_arn
 from localstack.utils.collections import PaginatedList
 from localstack.utils.common import select_attributes
 from localstack.utils.strings import short_uid, to_bytes, to_str
@@ -255,7 +255,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
 
         if key_id not in store.keys:
             if not key_arn:
-                key_arn = f"arn:aws:kms:{region_name}:{account_id}:key/{key_id}"
+                key_arn = (
+                    f"arn:{get_partition(region_name)}:kms:{region_name}:{account_id}:key/{key_id}"
+                )
             raise NotFoundException(f"Key '{key_arn}' does not exist")
 
         return key_id

--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -2,9 +2,10 @@ import re
 from typing import Tuple
 
 from localstack.services.kms.exceptions import ValidationException
+from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 
 KMS_KEY_ARN_PATTERN = re.compile(
-    r"^arn:aws:kms:(?P<region_name>[^:]+):(?P<account_id>\d{12}):key\/(?P<key_id>[^:]+)$"
+    rf"{ARN_PARTITION_REGEX}:kms:(?P<region_name>[^:]+):(?P<account_id>\d{{12}}):key\/(?P<key_id>[^:]+)$"
 )
 
 

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -202,7 +202,7 @@ from localstack.services.lambda_.runtimes import (
 from localstack.services.lambda_.urlrouter import FunctionUrlRouter
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import StateVisitor
-from localstack.utils.aws.arns import extract_service_from_arn
+from localstack.utils.aws.arns import extract_service_from_arn, get_partition
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import PaginatedList
 from localstack.utils.files import load_file
@@ -673,7 +673,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     # TODO: detect user or role from context when IAM users are implemented
                     user = "user/localstack-testing"
                     raise AccessDeniedException(
-                        f"User: arn:aws:iam::{account_id}:{user} is not authorized to perform: lambda:GetLayerVersion on resource: {layer_version_arn} because no resource-based policy allows the lambda:GetLayerVersion action"
+                        f"User: arn:{get_partition(region)}:iam::{account_id}:{user} is not authorized to perform: lambda:GetLayerVersion on resource: {layer_version_arn} because no resource-based policy allows the lambda:GetLayerVersion action"
                     )
                 if layer is None or layer_version is None:
                     # Limitation: cannot fetch external layers when using the same account id as the target layer
@@ -688,7 +688,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                         # TODO: detect user or role from context when IAM users are implemented
                         user = "user/localstack-testing"
                         raise AccessDeniedException(
-                            f"User: arn:aws:iam::{account_id}:{user} is not authorized to perform: lambda:GetLayerVersion on resource: {layer_version_arn} because no resource-based policy allows the lambda:GetLayerVersion action"
+                            f"User: arn:{get_partition(region)}:iam::{account_id}:{user} is not authorized to perform: lambda:GetLayerVersion on resource: {layer_version_arn} because no resource-based policy allows the lambda:GetLayerVersion action"
                         )
 
                     # Distinguish between new layer and new layer version
@@ -840,7 +840,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             runtime_version_config = RuntimeVersionConfig(
                 # Limitation: the runtime id (presumably sha256 of image) is currently hardcoded
                 # Potential implementation: provide (cached) sha256 hash of used Docker image
-                RuntimeVersionArn=f"arn:aws:lambda:{context_region}::runtime:8eeff65f6809a3ce81507fe733fe09b835899b99481ba22fd75b5a7338290ec1"
+                RuntimeVersionArn=f"arn:{context.partition}:lambda:{context_region}::runtime:8eeff65f6809a3ce81507fe733fe09b835899b99481ba22fd75b5a7338290ec1"
             )
             request_code = request.get("Code")
             if package_type == PackageType.Zip:
@@ -1492,9 +1492,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     Runtime=Runtime.nodejs20_x,
                     Handler="index.handler",
                     Code={"ZipFile": code},
-                    Role="arn:aws:iam::{account_id}:role/lambda-test-role".format(
-                        account_id=account_id
-                    ),  # TODO: proper role
+                    Role=f"arn:{get_partition(region)}:iam::{account_id}:role/lambda-test-role",  # TODO: proper role
                 )
 
         time_before = time.perf_counter()
@@ -2377,10 +2375,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 )
 
         permission_statement = api_utils.build_statement(
-            fn_arn,
-            request["StatementId"],
-            request["Action"],
-            request["Principal"],
+            partition=context.partition,
+            resource_arn=fn_arn,
+            statement_id=request["StatementId"],
+            action=request["Action"],
+            principal=request["Principal"],
             source_arn=request.get("SourceArn"),
             source_account=request.get("SourceAccount"),
             principal_org_id=request.get("PrincipalOrgID"),
@@ -2532,7 +2531,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         state = lambda_stores[account][region]
         # TODO: can there be duplicates?
         csc_id = f"csc-{get_random_hex(17)}"  # e.g. 'csc-077c33b4c19e26036'
-        csc_arn = f"arn:aws:lambda:{region}:{account}:code-signing-config:{csc_id}"
+        csc_arn = f"arn:{context.partition}:lambda:{region}:{account}:code-signing-config:{csc_id}"
         csc = CodeSigningConfig(
             csc_id=csc_id,
             arn=csc_arn,

--- a/localstack-core/localstack/services/opensearch/cluster_manager.py
+++ b/localstack-core/localstack/services/opensearch/cluster_manager.py
@@ -19,6 +19,7 @@ from localstack.services.opensearch.cluster import (
     OpensearchCluster,
     SecurityOptions,
 )
+from localstack.utils.aws.arns import get_partition
 from localstack.utils.common import (
     PortNotAvailableException,
     call_safe,
@@ -62,7 +63,7 @@ class DomainKey:
 
     @property
     def arn(self):
-        return f"arn:aws:es:{self.region}:{self.account}:domain/{self.domain_name}"
+        return f"arn:{get_partition(self.region)}:es:{self.region}:{self.account}:domain/{self.domain_name}"
 
     @staticmethod
     def from_arn(arn: str) -> "DomainKey":

--- a/localstack-core/localstack/services/route53/provider.py
+++ b/localstack-core/localstack/services/route53/provider.py
@@ -80,7 +80,7 @@ class Route53Provider(Route53Api, ServiceLifecycleHook):
         self, context: RequestContext, health_check_id: HealthCheckId, **kwargs
     ) -> GetHealthCheckResponse:
         health_check: Optional[route53_models.HealthCheck] = route53_backends[context.account_id][
-            "global"
+            context.partition
         ].health_checks.get(health_check_id, None)
         if not health_check:
             raise NoSuchHealthCheck(
@@ -111,10 +111,13 @@ class Route53Provider(Route53Api, ServiceLifecycleHook):
     def delete_health_check(
         self, context: RequestContext, health_check_id: HealthCheckId, **kwargs
     ) -> DeleteHealthCheckResponse:
-        if health_check_id not in route53_backends[context.account_id]["global"].health_checks:
+        if (
+            health_check_id
+            not in route53_backends[context.account_id][context.partition].health_checks
+        ):
             raise NoSuchHealthCheck(
                 f"No health check exists with the specified ID {health_check_id}"
             )
 
-        route53_backends[context.account_id]["global"].delete_health_check(health_check_id)
+        route53_backends[context.account_id][context.partition].delete_health_check(health_check_id)
         return {}

--- a/localstack-core/localstack/services/route53resolver/utils.py
+++ b/localstack-core/localstack/services/route53resolver/utils.py
@@ -2,6 +2,7 @@ import re
 
 from localstack.aws.api.route53resolver import ResourceNotFoundException, ValidationException
 from localstack.services.ec2.models import get_ec2_backend
+from localstack.utils.aws.arns import ARN_PARTITION_REGEX
 from localstack.utils.strings import get_random_hex
 
 
@@ -47,7 +48,7 @@ def validate_mutation_protection(mutation_protection):
 
 
 def validate_destination_arn(destination_arn):
-    arn_pattern = r"arn:aws:(kinesis|logs|s3):?(.*)"
+    arn_pattern = rf"{ARN_PARTITION_REGEX}:(kinesis|logs|s3):?(.*)"
     if not re.match(arn_pattern, destination_arn):
         raise ResourceNotFoundException(
             f"[RSLVR-01014] An Amazon Resource Name (ARN) for the destination is required. Trace Id: '{get_trace_id()}'"

--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -578,7 +578,7 @@ class SNSEmitter:
 
         if emit_source_arn:
             event_payload["mail"]["sourceArn"] = (
-                f"arn:aws:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}"
+                f"arn:{self.context.partition}:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}"
             )
 
         client = self._client_for_topic(sns_topic_arn)
@@ -603,7 +603,7 @@ class SNSEmitter:
             "mail": {
                 "timestamp": now.isoformat(),
                 "source": payload.sender_email,
-                "sourceArn": f"arn:aws:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}",
+                "sourceArn": f"arn:{self.context.partition}:ses:{self.context.region}:{self.context.account_id}:identity/{payload.sender_email}",
                 "sendingAccountId": self.context.account_id,
                 "destination": payload.destination_addresses,
                 "messageId": payload.message_id,

--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -30,6 +30,7 @@ from localstack.services.sns.models import (
     SnsSubscription,
 )
 from localstack.utils.aws.arns import (
+    PARTITION_NAMES,
     extract_account_id_from_arn,
     extract_region_from_arn,
     extract_resource_from_arn,
@@ -1055,7 +1056,10 @@ def store_delivery_log(
         )
         return
 
-    log_group_name = subscriber.get("TopicArn", "").replace("arn:aws:", "").replace(":", "/")
+    log_group_name = subscriber.get("TopicArn", "")
+    for partition in PARTITION_NAMES:
+        log_group_name = log_group_name.replace(f"arn:{partition}:", "")
+    log_group_name = log_group_name.replace(":", "/")
     log_stream_name = long_uid()
     invocation_time = int(time.time() * 1000)
 

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -37,6 +37,7 @@ from localstack.services.sqs.utils import (
     is_message_deduplication_id_required,
 )
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.utils.aws.arns import get_partition
 from localstack.utils.strings import long_uid
 from localstack.utils.time import now
 from localstack.utils.urls import localstack_host
@@ -341,7 +342,7 @@ class SqsQueue:
 
     @property
     def arn(self) -> str:
-        return f"arn:aws:sqs:{self.region}:{self.account_id}:{self.name}"
+        return f"arn:{get_partition(self.region)}:sqs:{self.region}:{self.account_id}:{self.name}"
 
     def url(self, context: RequestContext) -> str:
         """Return queue URL which depending on the endpoint strategy returns e.g.:
@@ -603,9 +604,12 @@ class SqsQueue:
             "Sid": label,
             "Effect": "Allow",
             "Principal": {
-                "AWS": [f"arn:aws:iam::{account_id}:root" for account_id in account_ids]
+                "AWS": [
+                    f"arn:{get_partition(self.region)}:iam::{account_id}:root"
+                    for account_id in account_ids
+                ]
                 if len(account_ids) > 1
-                else f"arn:aws:iam::{account_ids[0]}:root"
+                else f"arn:{get_partition(self.region)}:iam::{account_ids[0]}:root"
             },
             "Action": [f"SQS:{action}" for action in actions]
             if len(actions) > 1

--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -138,6 +138,7 @@ from localstack.services.stepfunctions.stepfunctions_utils import (
 )
 from localstack.state import StateVisitor
 from localstack.utils.aws.arns import (
+    ARN_PARTITION_REGEX,
     stepfunctions_activity_arn,
     stepfunctions_express_execution_arn,
     stepfunctions_standard_execution_arn,
@@ -160,15 +161,15 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         visitor.visit(sfn_stores)
 
     _STATE_MACHINE_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:stateMachine:[a-zA-Z0-9-_.]+(:\d+)?$"
+        rf"{ARN_PARTITION_REGEX}:states:[a-z0-9-]+:[0-9]{{12}}:stateMachine:[a-zA-Z0-9-_.]+(:\d+)?$"
     )
 
     _STATE_MACHINE_EXECUTION_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution|express):[a-zA-Z0-9-_.]+(:\d+)?(:[a-zA-Z0-9-_.]+)*$"
+        rf"^{ARN_PARTITION_REGEX}:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution|express):[a-zA-Z0-9-_.]+(:\d+)?(:[a-zA-Z0-9-_.]+)*$"
     )
 
     _ACTIVITY_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:activity:[a-zA-Z0-9-_]+$"
+        rf"{ARN_PARTITION_REGEX}:states:[a-z0-9-]+:[0-9]{{12}}:activity:[a-zA-Z0-9-_]+$"
     )
 
     @staticmethod

--- a/localstack-core/localstack/services/sts/provider.py
+++ b/localstack-core/localstack/services/sts/provider.py
@@ -30,7 +30,7 @@ class StsProvider(StsApi, ServiceLifecycleHook):
     def get_caller_identity(self, context: RequestContext, **kwargs) -> GetCallerIdentityResponse:
         response = call_moto(context)
         if "user/moto" in response["Arn"] and "sts" in response["Arn"]:
-            response["Arn"] = f"arn:aws:iam::{response['Account']}:root"
+            response["Arn"] = f"arn:{context.partition}:iam::{response['Account']}:root"
         return response
 
     def assume_role(

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -11,6 +11,32 @@ from localstack.utils.strings import long_uid
 
 LOG = logging.getLogger(__name__)
 
+#
+# Partition Utilities
+#
+
+DEFAULT_PARTITION = "aws"
+REGION_PREFIX_TO_PARTITION = {
+    # (region prefix, aws partition)
+    "cn-": "aws-cn",
+    "us-gov-": "aws-us-gov",
+    "us-iso-": "aws-iso",
+    "us-isob-": "aws-iso-b",
+}
+PARTITION_NAMES = list(REGION_PREFIX_TO_PARTITION.values()) + [DEFAULT_PARTITION]
+ARN_PARTITION_REGEX = r"^arn:(" + "|".join(sorted(PARTITION_NAMES)) + ")"
+
+
+def get_partition(region: Optional[str]) -> str:
+    if not region:
+        return DEFAULT_PARTITION
+    if region in PARTITION_NAMES:
+        return region
+    for prefix in REGION_PREFIX_TO_PARTITION:
+        if region.startswith(prefix):
+            return REGION_PREFIX_TO_PARTITION[prefix]
+    return DEFAULT_PARTITION
+
 
 #
 # ARN parsing utilities
@@ -75,9 +101,9 @@ def extract_resource_from_arn(arn: str) -> Optional[str]:
 def _resource_arn(name: str, pattern: str, account_id: str, region_name: str) -> str:
     if ":" in name:
         return name
-    if len(pattern.split("%s")) == 3:
-        return pattern % (account_id, name)
-    return pattern % (region_name, account_id, name)
+    if len(pattern.split("%s")) == 4:
+        return pattern % (get_partition(region_name), account_id, name)
+    return pattern % (get_partition(region_name), region_name, account_id, name)
 
 
 #
@@ -89,24 +115,19 @@ def _resource_arn(name: str, pattern: str, account_id: str, region_name: str) ->
 #
 
 
-def iam_role_arn(role_name: str, account_id: str) -> str:
+def iam_role_arn(role_name: str, account_id: str, region_name: str) -> str:
     if not role_name:
         return role_name
-    if role_name.startswith("arn:aws:iam::"):
+    if re.match(f"{ARN_PARTITION_REGEX}:iam::", role_name):
         return role_name
-    return "arn:aws:iam::%s:role/%s" % (account_id, role_name)
-
-
-def iam_policy_arn(policy_name: str, account_id: str) -> str:
-    if ":policy/" in policy_name:
-        return policy_name
-    return "arn:aws:iam::{}:policy/{}".format(account_id, policy_name)
+    return "arn:%s:iam::%s:role/%s" % (get_partition(region_name), account_id, role_name)
 
 
 def iam_resource_arn(resource: str, account_id: str, role: str = None) -> str:
     if not role:
         role = f"role-{resource}"
-    return iam_role_arn(role_name=role, account_id=account_id)
+    # Only used in tests, so we can hardcode the region for now
+    return iam_role_arn(role_name=role, account_id=account_id, region_name="us-east-1")
 
 
 #
@@ -119,7 +140,7 @@ def secretsmanager_secret_arn(
 ) -> str:
     if ":" in (secret_id or ""):
         return secret_id
-    pattern = "arn:aws:secretsmanager:%s:%s:secret:%s"
+    pattern = "arn:%s:secretsmanager:%s:%s:secret:%s"
     arn = _resource_arn(secret_id, pattern, account_id=account_id, region_name=region_name)
     if random_suffix:
         arn += f"-{random_suffix}"
@@ -134,14 +155,14 @@ def secretsmanager_secret_arn(
 def cloudformation_stack_arn(
     stack_name: str, stack_id: str, account_id: str, region_name: str
 ) -> str:
-    pattern = "arn:aws:cloudformation:%s:%s:stack/%s/{stack_id}".format(stack_id=stack_id)
+    pattern = "arn:%s:cloudformation:%s:%s:stack/%s/{stack_id}".format(stack_id=stack_id)
     return _resource_arn(stack_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def cloudformation_change_set_arn(
     change_set_name: str, change_set_id: str, account_id: str, region_name: str
 ) -> str:
-    pattern = "arn:aws:cloudformation:%s:%s:changeSet/%s/{cs_id}".format(cs_id=change_set_id)
+    pattern = "arn:%s:cloudformation:%s:%s:changeSet/%s/{cs_id}".format(cs_id=change_set_id)
     return _resource_arn(change_set_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -152,14 +173,15 @@ def cloudformation_change_set_arn(
 
 def dynamodb_table_arn(table_name: str, account_id: str, region_name: str) -> str:
     table_name = table_name.split(":table/")[-1]
-    pattern = "arn:aws:dynamodb:%s:%s:table/%s"
+    pattern = "arn:%s:dynamodb:%s:%s:table/%s"
     return _resource_arn(table_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def dynamodb_stream_arn(
     table_name: str, latest_stream_label: str, account_id: str, region_name: str
 ) -> str:
-    return "arn:aws:dynamodb:%s:%s:table/%s/stream/%s" % (
+    return "arn:%s:dynamodb:%s:%s:table/%s/stream/%s" % (
+        get_partition(region_name),
         region_name,
         account_id,
         table_name,
@@ -173,12 +195,12 @@ def dynamodb_stream_arn(
 
 
 def cloudwatch_alarm_arn(alarm_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:cloudwatch:%s:%s:alarm:%s"
+    pattern = "arn:%s:cloudwatch:%s:%s:alarm:%s"
     return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def cloudwatch_dashboard_arn(alarm_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:cloudwatch::%s:dashboard/%s"
+    pattern = "arn:%s:cloudwatch::%s:dashboard/%s"
     return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -188,7 +210,7 @@ def cloudwatch_dashboard_arn(alarm_name: str, account_id: str, region_name: str)
 
 
 def log_group_arn(group_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:logs:%s:%s:log-group:%s"
+    pattern = "arn:%s:logs:%s:%s:log-group:%s"
     return _resource_arn(group_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -198,24 +220,24 @@ def log_group_arn(group_name: str, account_id: str, region_name: str) -> str:
 
 
 def events_archive_arn(archive_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:events:%s:%s:archive/%s"
+    pattern = "arn:%s:events:%s:%s:archive/%s"
     return _resource_arn(archive_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def event_bus_arn(bus_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:events:%s:%s:event-bus/%s"
+    pattern = "arn:%s:events:%s:%s:event-bus/%s"
     return _resource_arn(bus_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def events_replay_arn(replay_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:events:%s:%s:replay/%s"
+    pattern = "arn:%s:events:%s:%s:replay/%s"
     return _resource_arn(replay_name, pattern, account_id=account_id, region_name=region_name)
 
 
 def events_rule_arn(
     rule_name: str, account_id: str, region_name: str, event_bus_name: str = "default"
 ) -> str:
-    pattern = "arn:aws:events:%s:%s:rule/%s"
+    pattern = "arn:%s:events:%s:%s:rule/%s"
     if event_bus_name != "default":
         rule_name = f"{event_bus_name}/{rule_name}"
     return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
@@ -239,7 +261,7 @@ def lambda_layer_arn(layer_name: str, account_id: str, region_name: str) -> str:
 
 
 def lambda_code_signing_arn(code_signing_id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:lambda:%s:%s:code-signing-config:%s"
+    pattern = "arn:%s:lambda:%s:%s:code-signing-config:%s"
     return _resource_arn(code_signing_id, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -265,7 +287,9 @@ def lambda_function_or_layer_arn(
             LOG.info(f"{msg}: {e}")
             raise Exception(msg)
 
-    result = f"arn:aws:lambda:{region_name}:{account_id}:{type}:{entity_name}"
+    result = (
+        f"arn:{get_partition(region_name)}:lambda:{region_name}:{account_id}:{type}:{entity_name}"
+    )
     if version:
         result = f"{result}:{version}"
     return result
@@ -277,7 +301,7 @@ def lambda_function_or_layer_arn(
 
 
 def stepfunctions_state_machine_arn(name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:states:%s:%s:stateMachine:%s"
+    pattern = "arn:%s:states:%s:%s:stateMachine:%s"
     return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -317,7 +341,7 @@ def stepfunctions_express_execution_arn(state_machine_arn: str, execution_name: 
 
 
 def stepfunctions_activity_arn(name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:states:%s:%s:activity:%s"
+    pattern = "arn:%s:states:%s:%s:activity:%s"
     return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -327,7 +351,7 @@ def stepfunctions_activity_arn(name: str, account_id: str, region_name: str) -> 
 
 
 def cognito_user_pool_arn(user_pool_id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:cognito-idp:%s:%s:userpool/%s"
+    pattern = "arn:%s:cognito-idp:%s:%s:userpool/%s"
     return _resource_arn(user_pool_id, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -337,7 +361,7 @@ def cognito_user_pool_arn(user_pool_id: str, account_id: str, region_name: str) 
 
 
 def kinesis_stream_arn(stream_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:kinesis:%s:%s:stream/%s"
+    pattern = "arn:%s:kinesis:%s:%s:stream/%s"
     return _resource_arn(stream_name, pattern, account_id, region_name)
 
 
@@ -347,7 +371,7 @@ def kinesis_stream_arn(stream_name: str, account_id: str, region_name: str) -> s
 
 
 def elasticsearch_domain_arn(domain_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:es:%s:%s:domain/%s"
+    pattern = "arn:%s:es:%s:%s:domain/%s"
     return _resource_arn(domain_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -357,7 +381,7 @@ def elasticsearch_domain_arn(domain_name: str, account_id: str, region_name: str
 
 
 def firehose_stream_arn(stream_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:firehose:%s:%s:deliverystream/%s"
+    pattern = "arn:%s:firehose:%s:%s:deliverystream/%s"
     return _resource_arn(stream_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -367,14 +391,14 @@ def firehose_stream_arn(stream_name: str, account_id: str, region_name: str) -> 
 
 
 def kms_key_arn(key_id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:kms:%s:%s:key/%s"
+    pattern = "arn:%s:kms:%s:%s:key/%s"
     return _resource_arn(key_id, pattern, account_id=account_id, region_name=region_name)
 
 
 def kms_alias_arn(alias_name: str, account_id: str, region_name: str):
     if not alias_name.startswith("alias/"):
         alias_name = "alias/" + alias_name
-    pattern = "arn:aws:kms:%s:%s:%s"
+    pattern = "arn:%s:kms:%s:%s:%s"
     return _resource_arn(alias_name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -384,7 +408,7 @@ def kms_alias_arn(alias_name: str, account_id: str, region_name: str):
 
 
 def ssm_parameter_arn(param_name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:ssm:%s:%s:parameter/%s"
+    pattern = "arn:%s:ssm:%s:%s:parameter/%s"
     param_name = param_name.lstrip("/")
     return _resource_arn(param_name, pattern, account_id=account_id, region_name=region_name)
 
@@ -394,9 +418,9 @@ def ssm_parameter_arn(param_name: str, account_id: str, region_name: str) -> str
 #
 
 
-def s3_bucket_arn(bucket_name_or_arn: str) -> str:
+def s3_bucket_arn(bucket_name_or_arn: str, region="us-east-1") -> str:
     bucket_name = s3_bucket_name(bucket_name_or_arn)
-    return f"arn:aws:s3:::{bucket_name}"
+    return f"arn:{get_partition(region)}:s3:::{bucket_name}"
 
 
 #
@@ -406,7 +430,7 @@ def s3_bucket_arn(bucket_name_or_arn: str) -> str:
 
 def sqs_queue_arn(queue_name: str, account_id: str, region_name: str) -> str:
     queue_name = queue_name.split("/")[-1]
-    return "arn:aws:sqs:%s:%s:%s" % (region_name, account_id, queue_name)
+    return "arn:%s:sqs:%s:%s:%s" % (get_partition(region_name), region_name, account_id, queue_name)
 
 
 #
@@ -415,11 +439,17 @@ def sqs_queue_arn(queue_name: str, account_id: str, region_name: str) -> str:
 
 
 def apigateway_restapi_arn(api_id: str, account_id: str, region_name: str) -> str:
-    return "arn:aws:apigateway:%s:%s:/restapis/%s" % (region_name, account_id, api_id)
+    return "arn:%s:apigateway:%s:%s:/restapis/%s" % (
+        get_partition(region_name),
+        region_name,
+        account_id,
+        api_id,
+    )
 
 
 def apigateway_invocations_arn(lambda_uri: str, region_name: str) -> str:
-    return "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (
+    return "arn:%s:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (
+        get_partition(region_name),
         region_name,
         lambda_uri,
     )
@@ -431,7 +461,7 @@ def apigateway_invocations_arn(lambda_uri: str, region_name: str) -> str:
 
 
 def sns_topic_arn(topic_name: str, account_id: str, region_name: str) -> str:
-    return f"arn:aws:sns:{region_name}:{account_id}:{topic_name}"
+    return f"arn:{get_partition(region_name)}:sns:{region_name}:{account_id}:{topic_name}"
 
 
 #
@@ -440,7 +470,7 @@ def sns_topic_arn(topic_name: str, account_id: str, region_name: str) -> str:
 
 
 def ecr_repository_arn(name: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:ecr:%s:%s:repository/%s"
+    pattern = "arn:%s:ecr:%s:%s:repository/%s"
     return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
 
 
@@ -450,44 +480,30 @@ def ecr_repository_arn(name: str, account_id: str, region_name: str) -> str:
 
 
 def route53_resolver_firewall_rule_group_arn(id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group/%s"
+    pattern = "arn:%s:route53resolver:%s:%s:firewall-rule-group/%s"
     return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
 
 
 def route53_resolver_firewall_domain_list_arn(id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-domain-list/%s"
+    pattern = "arn:%s:route53resolver:%s:%s:firewall-domain-list/%s"
     return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
 
 
 def route53_resolver_firewall_rule_group_associations_arn(
     id: str, account_id: str, region_name: str
 ) -> str:
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group-association/%s"
+    pattern = "arn:%s:route53resolver:%s:%s:firewall-rule-group-association/%s"
     return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
 
 
 def route53_resolver_query_log_config_arn(id: str, account_id: str, region_name: str) -> str:
-    pattern = "arn:aws:route53resolver:%s:%s:resolver-query-log-config/%s"
+    pattern = "arn:%s:route53resolver:%s:%s:resolver-query-log-config/%s"
     return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
 
 
 #
 # Other ARN related helpers
 #
-
-
-def fix_arn(arn: str):
-    """Function that attempts to "canonicalize" the given ARN. This includes converting
-    resource names to ARNs, replacing incorrect regions, account IDs, etc."""
-    if arn.startswith("arn:aws:lambda"):
-        arn_data = parse_arn(arn)
-        return lambda_function_arn(
-            lambda_function_name(arn),
-            account_id=arn_data["account"],
-            region_name=arn_data["region"],
-        )
-    LOG.warning("Unable to fix/canonicalize ARN: %s", arn)
-    return arn
 
 
 def opensearch_domain_name(domain_arn: str) -> str:

--- a/tests/aws/services/apigateway/test_apigateway_partitions.py
+++ b/tests/aws/services/apigateway/test_apigateway_partitions.py
@@ -40,7 +40,4 @@ class TestApiGatewayApiPartitions:
         apigw = aws_client_factory(region_name=region).apigateway
 
         response = apigw.get_account()
-        assert (
-            response["cloudwatchRoleArn"]
-            == f"arn:{partition}:iam::{account_id}:role/api-gw-cw-role"
-        )
+        assert response["cloudwatchRoleArn"].startswith(f"arn:{partition}:iam::{account_id}:role/")

--- a/tests/aws/services/apigateway/test_apigateway_partitions.py
+++ b/tests/aws/services/apigateway/test_apigateway_partitions.py
@@ -1,0 +1,46 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestApiGatewayApiPartitions:
+    # We only have access to the AWS partition not to CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_put_integration_validation(self, account_id, aws_client_factory, region, partition):
+        apigw = aws_client_factory(region_name=region).apigateway
+
+        response = apigw.create_rest_api(name=f"api{short_uid()}", description="no")
+        api_id = response["id"]
+        resources = apigw.get_resources(restApiId=api_id)
+        root_id = [resource for resource in resources["items"] if resource["path"] == "/"][0]["id"]
+
+        apigw.put_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+        )
+        apigw.put_method_response(
+            restApiId=api_id, resourceId=root_id, httpMethod="GET", statusCode="200"
+        )
+        resp = apigw.put_integration(
+            restApiId=api_id,
+            resourceId=root_id,
+            credentials=f"arn:{partition}:iam::{account_id}:role/service-role/testfunction-role-oe783psq",
+            httpMethod="GET",
+            type="AWS",
+            uri=f"arn:{partition}:apigateway:{region}:s3:path/b/k",
+            integrationHttpMethod="POST",
+        )
+        # We just want to validate that the partitioned Credentials/URI was accepted
+        assert resp["uri"] == f"arn:{partition}:apigateway:{region}:s3:path/b/k"
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_get_account(self, account_id, aws_client_factory, region, partition):
+        apigw = aws_client_factory(region_name=region).apigateway
+
+        response = apigw.get_account()
+        assert (
+            response["cloudwatchRoleArn"]
+            == f"arn:{partition}:iam::{account_id}:role/api-gw-cw-role"
+        )

--- a/tests/aws/services/cloudformation/resources/test_events.py
+++ b/tests/aws/services/cloudformation/resources/test_events.py
@@ -290,12 +290,15 @@ def test_cfn_handle_events_rule(deploy_cfn_template, aws_client):
 
 # {"LogicalResourceId": "TestStateMachine", "ResourceType": "AWS::StepFunctions::StateMachine", "ResourceStatus": "CREATE_FAILED", "ResourceStatusReason": "Resource handler returned message: \"Cross-account pass role is not allowed."}
 @markers.aws.needs_fixing
-def test_cfn_handle_events_rule_without_name(deploy_cfn_template, aws_client, account_id):
+def test_cfn_handle_events_rule_without_name(
+    deploy_cfn_template, aws_client, account_id, region_name
+):
     rs = aws_client.events.list_rules()
     rule_names = [rule["Name"] for rule in rs["Rules"]]
 
     stack = deploy_cfn_template(
-        template=TEST_TEMPLATE_18 % arns.iam_role_arn("sfn_role", account_id=account_id),
+        template=TEST_TEMPLATE_18
+        % arns.iam_role_arn("sfn_role", account_id=account_id, region_name=region_name),
     )
 
     rs = aws_client.events.list_rules()

--- a/tests/aws/services/dynamodb/test_dynamodb_partitions.py
+++ b/tests/aws/services/dynamodb/test_dynamodb_partitions.py
@@ -1,0 +1,26 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.aws.resources import create_dynamodb_table
+from localstack.utils.strings import short_uid
+
+
+class TestDynamoDBPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition", [("us-east-2", "aws"), ("us-gov-east-1", "aws-us-gov")]
+    )
+    def test_dynamodb_table_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        dynamodb = aws_client_factory(region_name=region).dynamodb
+
+        table_name = f"table-{short_uid()}"
+        table = create_dynamodb_table(table_name, partition_key="id", client=dynamodb)
+        table_arn = table["TableDescription"]["TableArn"]
+        assert table_arn == f"arn:{partition}:dynamodb:{region}:{account_id}:table/{table_name}"
+
+        table = dynamodb.describe_table(TableName=table_name)
+        table_arn = table["Table"]["TableArn"]
+        assert table_arn == f"arn:{partition}:dynamodb:{region}:{account_id}:table/{table_name}"

--- a/tests/aws/services/dynamodbstreams/test_dynamodb_streams_partitions.py
+++ b/tests/aws/services/dynamodbstreams/test_dynamodb_streams_partitions.py
@@ -1,0 +1,32 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.aws.resources import create_dynamodb_table
+from localstack.utils.strings import short_uid
+
+
+class TestDynamoDBStreamsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition", [("us-east-2", "aws"), ("us-gov-east-1", "aws-us-gov")]
+    )
+    def test_dynamodb_stream_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        dynamodb = aws_client_factory(region_name=region).dynamodb
+        dynamodbstreams = aws_client_factory(region_name=region).dynamodbstreams
+
+        table_name = f"table-{short_uid()}"
+        create_dynamodb_table(
+            table_name, partition_key="id", stream_view_type="NEW_AND_OLD_IMAGES", client=dynamodb
+        )
+
+        table = dynamodb.describe_table(TableName=table_name)
+        stream_arn = table["Table"]["LatestStreamArn"]
+        assert stream_arn.startswith(
+            f"arn:{partition}:dynamodb:{region}:{account_id}:table/{table_name}/stream/"
+        )
+
+        result = dynamodbstreams.describe_stream(StreamArn=stream_arn)["StreamDescription"]
+        assert result["StreamArn"] == stream_arn

--- a/tests/aws/services/events/test_events.py
+++ b/tests/aws/services/events/test_events.py
@@ -244,7 +244,7 @@ class TestEvents:
         queue_name = f"queue-{short_uid()}"
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         rule_name = f"rule-{short_uid()}"
-        sm_role_arn = arns.iam_role_arn("sfn_role", account_id=account_id)
+        sm_role_arn = arns.iam_role_arn("sfn_role", account_id=account_id, region_name=region_name)
         sm_name = f"state-machine-{short_uid()}"
         topic_target_id = f"target-{short_uid()}"
         sm_target_id = f"target-{short_uid()}"

--- a/tests/aws/services/events/test_events_partitions.py
+++ b/tests/aws/services/events/test_events_partitions.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from tests.aws.services.events.test_events import TEST_EVENT_PATTERN
+
+
+class TestEventsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_event_bus_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        events_client = aws_client_factory(region_name=region).events
+        bus_name = f"bus-{short_uid()}"
+        arn = events_client.create_event_bus(
+            Name=bus_name,
+            Tags=[{"Key": "name", "Value": bus_name}],
+        )["EventBusArn"]
+        assert arn == f"arn:{partition}:events:{region}:{account_id}:event-bus/{bus_name}"
+
+        tags = events_client.list_tags_for_resource(ResourceARN=arn)["Tags"]
+        assert tags == [{"Key": "name", "Value": bus_name}]
+
+        events_client.delete_event_bus(Name=bus_name)
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_event_rules_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        events_client = aws_client_factory(region_name=region).events
+        bus_name = f"bus-{short_uid()}"
+        events_client.create_event_bus(Name=bus_name)["EventBusArn"]
+
+        rule_name = f"test-rule-{short_uid()}"
+        rule_arn = events_client.put_rule(
+            Name=rule_name,
+            EventBusName=bus_name,
+            EventPattern=json.dumps(TEST_EVENT_PATTERN),
+            Tags=[{"Key": "name", "Value": rule_name}],
+        )["RuleArn"]
+        assert (
+            rule_arn == f"arn:{partition}:events:{region}:{account_id}:rule/{bus_name}/{rule_name}"
+        )
+
+        tags = events_client.list_tags_for_resource(ResourceARN=rule_arn)["Tags"]
+        assert tags == [{"Key": "name", "Value": rule_name}]
+
+        rule_name = f"test-rule-{short_uid()}"
+        rule_arn = events_client.put_rule(
+            Name=rule_name,
+            EventBusName="default",
+            EventPattern=json.dumps(TEST_EVENT_PATTERN),
+            Tags=[{"Key": "name", "Value": "default"}],
+        )["RuleArn"]
+        assert rule_arn == f"arn:{partition}:events:{region}:{account_id}:rule/{rule_name}"
+
+        tags = events_client.list_tags_for_resource(ResourceARN=rule_arn)["Tags"]
+        assert tags == [{"Key": "name", "Value": "default"}]
+
+        events_client.delete_event_bus(Name=bus_name)

--- a/tests/aws/services/iam/test_iam_partitions.py
+++ b/tests/aws/services/iam/test_iam_partitions.py
@@ -1,0 +1,20 @@
+import pytest
+
+from localstack.testing.pytest import markers
+
+
+class TestIamPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition", [("us-east-2", "aws"), ("us-gov-east-1", "aws-us-gov")]
+    )
+    def test_service_linked_role_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        iam = aws_client_factory(region_name=region).iam
+
+        arn = iam.create_service_linked_role(AWSServiceName="elasticbeanstalk")["Role"]["Arn"]
+        assert arn.startswith(
+            f"arn:{partition}:iam::{account_id}:role/aws-service-role/elasticbeanstalk/r-"
+        )

--- a/tests/aws/services/kinesis/test_kinesis_partitions.py
+++ b/tests/aws/services/kinesis/test_kinesis_partitions.py
@@ -1,0 +1,26 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestKinesisPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition",
+        [("us-east-1", "aws"), ("cn-north-1", "aws-cn"), ("us-gov-east-1", "aws-us-gov")],
+    )
+    def test_stream_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        kinesis = aws_client_factory(region_name=region).kinesis
+
+        stream_name = f"stream-{short_uid()}"
+        kinesis.create_stream(StreamName=stream_name)
+
+        stream = kinesis.describe_stream(StreamName=stream_name)["StreamDescription"]
+        assert (
+            stream["StreamARN"]
+            == f"arn:{partition}:kinesis:{region}:{account_id}:stream/{stream_name}"
+        )

--- a/tests/aws/services/kms/test_kms_partitions.py
+++ b/tests/aws/services/kms/test_kms_partitions.py
@@ -1,0 +1,59 @@
+import json
+from uuid import uuid4
+
+import pytest
+from botocore.exceptions import ClientError
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestKmsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_key_in_different_partitions(self, account_id, aws_client_factory, region, partition):
+        kms_client = aws_client_factory(region_name=region).kms
+
+        key = kms_client.create_key(Description="test", KeyUsage="ENCRYPT_DECRYPT")["KeyMetadata"]
+        assert key["Arn"] == f"arn:{partition}:kms:{region}:{account_id}:key/{key['KeyId']}"
+
+        key_policy = json.loads(
+            kms_client.get_key_policy(KeyId=key["KeyId"], PolicyName="default")["Policy"]
+        )
+        principal = key_policy["Statement"][0]["Principal"]["AWS"]
+        assert principal == f"arn:{partition}:iam::{account_id}:root"
+
+        # Just validate it can be found
+        kms_client.describe_key(KeyId=key["KeyId"])
+        kms_client.describe_key(KeyId=key["Arn"])
+
+        # Create/list grants
+        kms_client.create_grant(
+            KeyId=key["Arn"], GranteePrincipal="someone", Operations=["Decrypt"]
+        )
+        grants = kms_client.list_grants(KeyId=key["Arn"])["Grants"]
+        assert len(grants) == 1
+
+        # DescribeKey should throw a partition-aware error for unknown keys
+        unknown_key_id = str(uuid4())
+        with pytest.raises(ClientError) as exc:
+            kms_client.describe_key(KeyId=unknown_key_id)
+        err = exc.value.response["Error"]
+        assert (
+            err["Message"]
+            == f"Key 'arn:{partition}:kms:{region}:{account_id}:key/{unknown_key_id}' does not exist"
+        )
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_alias_in_different_partitions(self, account_id, aws_client_factory, region, partition):
+        kms_client = aws_client_factory(region_name=region).kms
+
+        key = kms_client.create_key(Description="test", KeyUsage="ENCRYPT_DECRYPT")["KeyMetadata"]
+
+        alias_name = f"alias/{short_uid()}"
+        kms_client.create_alias(AliasName=alias_name, TargetKeyId=key["KeyId"])
+
+        alias = kms_client.list_aliases(KeyId=key["KeyId"])["Aliases"][0]
+        assert alias["AliasArn"] == f"arn:{partition}:kms:{region}:{account_id}:{alias_name}"

--- a/tests/aws/services/lambda_/test_lambda_partitions.py
+++ b/tests/aws/services/lambda_/test_lambda_partitions.py
@@ -1,0 +1,129 @@
+import json
+
+import pytest
+
+from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+from .test_lambda import TEST_LAMBDA_PYTHON_ECHO
+
+
+class TestLambdaPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_function_in_different_partitions(
+        self,
+        account_id,
+        aws_client_factory,
+        create_lambda_function,
+        region,
+        partition,
+        dummylayer,
+    ):
+        lambda_client = aws_client_factory(region_name=region).lambda_
+
+        function_name = f"test-region-{short_uid()}"
+        function = create_lambda_function(
+            client=lambda_client,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+        )["CreateFunctionResponse"]
+
+        function_arn = function["FunctionArn"]
+        assert (
+            function_arn == f"arn:{partition}:lambda:{region}:{account_id}:function:{function_name}"
+        )
+
+        runtime_version_config_arn = function["RuntimeVersionConfig"]["RuntimeVersionArn"]
+        assert (
+            runtime_version_config_arn
+            == f"arn:{partition}:lambda:{region}::runtime:8eeff65f6809a3ce81507fe733fe09b835899b99481ba22fd75b5a7338290ec1"
+        )
+
+        alias_arn = lambda_client.create_alias(
+            FunctionName=function_arn,
+            Name="my-alias",
+            FunctionVersion="$LATEST",
+        )["AliasArn"]
+        assert (
+            alias_arn
+            == f"arn:{partition}:lambda:{region}:{account_id}:function:{function_name}:my-alias"
+        )
+
+        layer_name = f"test-layer-{short_uid()}"
+        layer = lambda_client.publish_layer_version(
+            LayerName=layer_name, Content={"ZipFile": dummylayer}
+        )
+        assert (
+            layer["LayerArn"] == f"arn:{partition}:lambda:{region}:{account_id}:layer:{layer_name}"
+        )
+        assert (
+            layer["LayerVersionArn"]
+            == f"arn:{partition}:lambda:{region}:{account_id}:layer:{layer_name}:1"
+        )
+
+        layer = lambda_client.get_layer_version(LayerName=layer_name, VersionNumber=1)
+        assert (
+            layer["LayerArn"] == f"arn:{partition}:lambda:{region}:{account_id}:layer:{layer_name}"
+        )
+
+        # tags
+        lambda_client.tag_resource(Resource=function_arn, Tags={"fn": "yes"})
+
+        assert lambda_client.list_tags(Resource=function_arn)["Tags"] == {"fn": "yes"}
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_code_signing_config_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        lambda_client = aws_client_factory(region_name=region).lambda_
+
+        arn = lambda_client.create_code_signing_config(
+            Description="Testing CodeSigning Config",
+            AllowedPublishers={
+                "SigningProfileVersionArns": [
+                    f"arn:aws:signer:{region}:{account_id}:/signing-profiles/test",
+                ]
+            },
+            CodeSigningPolicies={"UntrustedArtifactOnDeployment": "Enforce"},
+        )["CodeSigningConfig"]["CodeSigningConfigArn"]
+        assert arn.startswith(
+            f"arn:{partition}:lambda:{region}:{account_id}:code-signing-config:csc-"
+        )
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_permissions_in_different_partitions(
+        self, account_id, create_lambda_function, aws_client_factory, region, partition
+    ):
+        lambda_client = aws_client_factory(region_name=region).lambda_
+
+        function_name = f"test-region-{short_uid()}"
+        create_lambda_function(
+            client=lambda_client,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_12,
+        )
+
+        resp = lambda_client.add_permission(
+            FunctionName=function_name,
+            StatementId="1",
+            Action="lambda:GetFunction",
+            Principal=f"arn:{partition}:iam:some_user",
+        )["Statement"]
+        statement = json.loads(resp)
+        assert statement["Principal"] == {"AWS": f"arn:{partition}:iam:some_user"}
+
+        resp = lambda_client.add_permission(
+            FunctionName=function_name,
+            StatementId="2",
+            Action="lambda:GetFunction",
+            Principal="111122223333",
+        )["Statement"]
+        statement = json.loads(resp)
+        assert statement["Principal"] == {"AWS": f"arn:{partition}:iam::111122223333:root"}

--- a/tests/aws/services/opensearch/test_opensearch_partitions.py
+++ b/tests/aws/services/opensearch/test_opensearch_partitions.py
@@ -1,0 +1,18 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestOpenSearchPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_domain_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        opensearch_client = aws_client_factory(region_name=region).opensearch
+
+        domain_name = f"opensearch-domain-{short_uid()}"
+        domain_arn = opensearch_client.create_domain(DomainName=domain_name)["DomainStatus"]["ARN"]
+        assert domain_arn == f"arn:{partition}:es:{region}:{account_id}:domain/{domain_name}"

--- a/tests/aws/services/route53resolver/test_route53resolver_partitions.py
+++ b/tests/aws/services/route53resolver/test_route53resolver_partitions.py
@@ -1,0 +1,30 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestRoute53ResolverPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition", [("us-east-2", "aws"), ("us-gov-east-1", "aws-us-gov")]
+    )
+    def test_query_log_config_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        logs = aws_client_factory(region_name=region).logs
+        route53_resolver = aws_client_factory(region_name=region).route53resolver
+
+        log_group_name = f"test-r53resolver-lg-{short_uid()}"
+        logs.create_log_group(logGroupName=log_group_name)
+        lg_arn = logs.describe_log_groups(logGroupNamePrefix=log_group_name)["logGroups"][0]["arn"]
+
+        query_log_config_arn = route53_resolver.create_resolver_query_log_config(
+            Name=f"test-{short_uid()}",
+            DestinationArn=lg_arn,
+            CreatorRequestId=short_uid(),
+        )["ResolverQueryLogConfig"]["Arn"]
+        assert query_log_config_arn.startswith(
+            f"arn:{partition}:route53resolver:{region}:{account_id}:resolver-query-log-config/"
+        )

--- a/tests/aws/services/s3/test_s3_partitions.py
+++ b/tests/aws/services/s3/test_s3_partitions.py
@@ -1,0 +1,38 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestS3Partitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_sns_notifications_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        s3 = aws_client_factory(region_name=region).s3
+        sns = aws_client_factory(region_name=region).sns
+
+        topic_name = f"topic-{short_uid()}"
+        topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+
+        bucket_name = f"test-bucket-{short_uid()}"
+        s3.create_bucket(
+            Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
+        )
+
+        s3.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "TopicConfigurations": [
+                    {
+                        "TopicArn": topic_arn,
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ]
+            },
+        )
+
+        resp = s3.get_bucket_notification_configuration(Bucket=bucket_name)
+        assert resp["TopicConfigurations"][0]["TopicArn"] == topic_arn

--- a/tests/aws/services/s3/test_s3_partitions.py
+++ b/tests/aws/services/s3/test_s3_partitions.py
@@ -2,8 +2,10 @@ import pytest
 
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
+from tests.aws.services.s3.conftest import TEST_S3_IMAGE
 
 
+@pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="SNS not enabled in S3 image")
 class TestS3Partitions:
     # We only have access to the AWS partition, not CHINA/US-GOV/etc
     @markers.aws.manual_setup_required

--- a/tests/aws/services/s3/test_s3_partitions.py
+++ b/tests/aws/services/s3/test_s3_partitions.py
@@ -1,11 +1,16 @@
 import pytest
 
+from localstack.config import LEGACY_V2_S3_PROVIDER
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from tests.aws.services.s3.conftest import TEST_S3_IMAGE
 
 
 @pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="SNS not enabled in S3 image")
+@pytest.mark.skipif(
+    condition=LEGACY_V2_S3_PROVIDER,
+    reason="Will be fixed in a future Moto release (https://github.com/getmoto/moto/pull/7731)",
+)
 class TestS3Partitions:
     # We only have access to the AWS partition, not CHINA/US-GOV/etc
     @markers.aws.manual_setup_required

--- a/tests/aws/services/ses/test_ses_partitions.py
+++ b/tests/aws/services/ses/test_ses_partitions.py
@@ -1,0 +1,78 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+
+class TestSesPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize(
+        "region,partition", [("us-east-2", "aws"), ("us-gov-east-1", "aws-us-gov")]
+    )
+    def test_configuration_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        ses = aws_client_factory(region_name=region).ses
+        sns = aws_client_factory(region_name=region).sns
+        sqs = aws_client_factory(region_name=region).sqs
+
+        topic_name = f"topic-{short_uid()}"
+        topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+
+        queue_name = f"queue-{short_uid()}"
+        queue_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+        queue_arn = sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])[
+            "Attributes"
+        ]["QueueArn"]
+        sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
+
+        config_set = f"config-{short_uid()}"
+        ses.create_configuration_set(ConfigurationSet={"Name": config_set})
+        ses.create_configuration_set_event_destination(
+            ConfigurationSetName=config_set,
+            EventDestination={
+                "Name": f"destination_{short_uid()}",
+                "Enabled": True,
+                "MatchingEventTypes": ["send", "delivery"],
+                "SNSDestination": {
+                    "TopicARN": topic_arn,
+                },
+            },
+        )
+
+        ses.verify_email_address(EmailAddress="source@localstack.cloud")
+        ses.send_email(
+            Source="source@localstack.cloud",
+            Destination={"ToAddresses": ["target@localstack.cloud"]},
+            Message={"Subject": {"Data": "subj"}, "Body": {"Text": {"Data": "body"}}},
+        )
+
+        message_bodies = []
+
+        def _collect_messages():
+            messages = sqs.receive_message(
+                QueueUrl=queue_url,
+                MessageAttributeNames=["All"],
+                VisibilityTimeout=1,
+                WaitTimeSeconds=4,
+            )["Messages"]
+
+            for msg in messages:
+                body = json.loads(msg["Body"])
+                message = json.loads(body["Message"])
+
+                if message["eventType"] in ["Send", "Delivery"]:
+                    message_bodies.append(message)
+                assert len(message_bodies) == 2
+
+        retry(_collect_messages, retries=5, sleep=0.5)
+
+        for message in message_bodies:
+            assert (
+                message["mail"]["sourceArn"]
+                == f"arn:{partition}:ses:{region}:{account_id}:identity/source@localstack.cloud"
+            )

--- a/tests/aws/services/sns/test_sns_partitions.py
+++ b/tests/aws/services/sns/test_sns_partitions.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+
+class TestSnsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_topic_in_different_partitions(self, account_id, aws_client_factory, region, partition):
+        sns = aws_client_factory(region_name=region).sns
+
+        topic_name = f"topic-{short_uid()}"
+        topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+        assert topic_arn == f"arn:{partition}:sns:{region}:{account_id}:{topic_name}"
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_platform_app_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        key = "mock_server_key"
+        token = "mock_token"
+
+        sns = aws_client_factory(region_name=region).sns
+
+        platform_name = f"platform-{short_uid()}"
+        platform_app_arn = sns.create_platform_application(
+            Name=platform_name, Platform="GCM", Attributes={"PlatformCredential": key}
+        )["PlatformApplicationArn"]
+        assert (
+            platform_app_arn == f"arn:{partition}:sns:{region}:{account_id}:app/GCM/{platform_name}"
+        )
+
+        endpoint_arn = sns.create_platform_endpoint(
+            PlatformApplicationArn=platform_app_arn,
+            Token=token,
+        )["EndpointArn"]
+        assert endpoint_arn.startswith(
+            f"arn:{partition}:sns:{region}:{account_id}:endpoint/GCM/{platform_name}"
+        )
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_sqs_delivery_logs_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        topic_name = f"topic_{short_uid()}"
+        queue_name = f"queue_{short_uid()}"
+
+        sns = aws_client_factory(region_name=region).sns
+        sqs = aws_client_factory(region_name=region).sqs
+        logs = aws_client_factory(region_name=region).logs
+
+        topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+        sns.set_topic_attributes(
+            TopicArn=topic_arn, AttributeName="SQSSuccessFeedbackRoleArn", AttributeValue="sth"
+        )
+        queue_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+        queue_arn = sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])[
+            "Attributes"
+        ]["QueueArn"]
+        sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
+
+        sns.publish(TopicArn=topic_arn, Message="test-msg-1")
+
+        log_group_name = f"sns/{region}/{account_id}/{topic_name}"
+
+        def assert_invocations():
+            groups = logs.describe_log_groups()["logGroups"]
+            assert len(groups) > 0
+
+            streams = logs.describe_log_streams(logGroupName=log_group_name)["logStreams"]
+            stream_name = streams[0]["logStreamName"]
+            events = logs.get_log_events(logGroupName=log_group_name, logStreamName=stream_name)[
+                "events"
+            ]
+            message = json.loads(events[0]["message"])
+            assert (
+                message["notification"]["topicArn"]
+                == f"arn:{partition}:sns:{region}:{account_id}:{topic_name}"
+            )
+            assert (
+                message["delivery"]["destination"]
+                == f"arn:{partition}:sqs:{region}:{account_id}:{queue_name}"
+            )
+
+        retry(assert_invocations, sleep=1, retries=5)

--- a/tests/aws/services/sqs/test_sqs_partitions.py
+++ b/tests/aws/services/sqs/test_sqs_partitions.py
@@ -1,0 +1,47 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestSqsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_queue_in_different_partitions(self, account_id, aws_client_factory, region, partition):
+        sqs = aws_client_factory(region_name=region).sqs
+
+        queue_name = f"queue_{short_uid()}"
+        queue_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+        queue_arn = sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])[
+            "Attributes"
+        ]["QueueArn"]
+        assert queue_arn == f"arn:{partition}:sqs:{region}:{account_id}:{queue_name}"
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_permission_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        sqs = aws_client_factory(region_name=region).sqs
+
+        queue_name = f"queue_{short_uid()}"
+        queue_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+
+        sqs.add_permission(
+            QueueUrl=queue_url, Label="Yes", AWSAccountIds=[account_id], Actions=["*"]
+        )
+
+        policy = sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])["Attributes"][
+            "Policy"
+        ]
+        policy = json.loads(policy)
+        assert (
+            policy["Id"]
+            == f"arn:{partition}:sqs:{region}:{account_id}:{queue_name}/SQSDefaultPolicy"
+        )
+        assert (
+            policy["Statement"][0]["Principal"]["AWS"] == f"arn:{partition}:iam::{account_id}:root"
+        )

--- a/tests/aws/services/stepfunctions/test_stepfunctions_partitions.py
+++ b/tests/aws/services/stepfunctions/test_stepfunctions_partitions.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+STATE_MACHINE_ERROR = {
+    "Comment": "An example of the Amazon States Language using a choice state.",
+    "StartAt": "DefaultState",
+    "States": {
+        "DefaultState": {"Type": "Fail", "Error": "DefaultStateError", "Cause": "No Matches!"}
+    },
+}
+
+
+class TestStepFunctionsPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-2", "aws"), ("cn-north-1", "aws-cn")])
+    def test_state_machine_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        sfn = aws_client_factory(region_name=region).stepfunctions
+
+        name = f"state-machine-{short_uid()}"
+        state_machine_arn = sfn.create_state_machine(
+            name=name,
+            definition=json.dumps(STATE_MACHINE_ERROR),
+            roleArn="sth",
+        )["stateMachineArn"]
+        assert (
+            state_machine_arn == f"arn:{partition}:states:{region}:{account_id}:stateMachine:{name}"
+        )
+
+        assert (
+            sfn.describe_state_machine(stateMachineArn=state_machine_arn)["stateMachineArn"]
+            == state_machine_arn
+        )

--- a/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
+++ b/tests/aws/services/stepfunctions/v2/test_stepfunctions_v2.py
@@ -281,7 +281,7 @@ class TestStateMachine:
     @markers.aws.needs_fixing
     def test_create_choice_state_machine(self, aws_client, account_id, region_name):
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
 
         definition = clone(STATE_MACHINE_CHOICE)
         lambda_arn_4 = arns.lambda_function_arn(TEST_LAMBDA_NAME_4, account_id, region_name)
@@ -323,7 +323,7 @@ class TestStateMachine:
         test_output = [{"Hello": name} for name in names]
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         definition = clone(STATE_MACHINE_MAP)
         lambda_arn_3 = arns.lambda_function_arn(TEST_LAMBDA_NAME_3, account_id, region_name)
         definition["States"]["ExampleMapState"]["ItemProcessor"]["States"]["CallLambda"][
@@ -361,7 +361,7 @@ class TestStateMachine:
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         definition = clone(STATE_MACHINE_BASIC)
         lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_1, account_id, region_name)
         lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_2, account_id, region_name)
@@ -397,7 +397,7 @@ class TestStateMachine:
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         definition = clone(STATE_MACHINE_CATCH)
         lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_1, account_id, region_name)
         lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_2, account_id, region_name)
@@ -431,7 +431,7 @@ class TestStateMachine:
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         definition = clone(STATE_MACHINE_INTRINSIC_FUNCS)
         lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5, account_id, region_name)
         lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5, account_id, region_name)
@@ -469,7 +469,7 @@ class TestStateMachine:
         condition=not is_aws_cloud(), reason="Accurate events reporting not yet supported."
     )
     @markers.aws.needs_fixing
-    def test_events_state_machine(self, aws_client, account_id):
+    def test_events_state_machine(self, aws_client, account_id, region_name):
         events = aws_client.events
         state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
@@ -482,7 +482,7 @@ class TestStateMachine:
         definition["States"]["step1"]["Parameters"]["Entries"][0]["EventBusName"] = bus_name
         definition = json.dumps(definition)
         sm_name = f"events-{short_uid()}"
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         aws_client.stepfunctions.create_state_machine(
             name=sm_name, definition=definition, roleArn=role_arn
         )
@@ -519,7 +519,7 @@ class TestStateMachine:
         CreateStateMachine operation: Invalid State Machine Definition: ''DUPLICATE_STATE_NAME: Duplicate State name:
         MissingValue at /States/MissingValue', 'DUPLICATE_STATE_NAME: Duplicate State name: Add at /States/Add''
         """
-        role_arn = arns.iam_role_arn("sfn_role", account_id)
+        role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
         definition = clone(STATE_MACHINE_CHOICE)
         lambda_arn_4 = arns.lambda_function_arn(TEST_LAMBDA_NAME_4, account_id, region_name)
         definition["States"]["Add"]["Resource"] = lambda_arn_4
@@ -612,7 +612,7 @@ def test_multiregion_nested(aws_client_factory, account_id, region_name, statema
     )
     # create state machine
     child_machine_name = f"sf-child-{short_uid()}"
-    role = arns.iam_role_arn("sfn_role", account_id)
+    role = arns.iam_role_arn("sfn_role", account_id, region_name)
     child_machine_result = client1.create_state_machine(
         name=child_machine_name, definition=json.dumps(TEST_STATE_MACHINE), roleArn=role
     )
@@ -620,7 +620,7 @@ def test_multiregion_nested(aws_client_factory, account_id, region_name, statema
 
     # create parent state machine
     name = f"sf-parent-{short_uid()}"
-    role = arns.iam_role_arn("sfn_role", account_id)
+    role = arns.iam_role_arn("sfn_role", account_id, region_name)
     result = client1.create_state_machine(
         name=name,
         definition=json.dumps(statemachine_definition).replace(
@@ -778,11 +778,11 @@ def test_aws_sdk_task(aws_client):
 
 
 @markers.aws.needs_fixing
-def test_run_aws_sdk_secrets_manager(aws_client, account_id):
+def test_run_aws_sdk_secrets_manager(aws_client, account_id, region_name):
     state_machines_before = aws_client.stepfunctions.list_state_machines()["stateMachines"]
 
     # create state machine
-    role_arn = arns.iam_role_arn("sfn_role", account_id)
+    role_arn = arns.iam_role_arn("sfn_role", account_id, region_name)
     definition = {
         "StartAt": "StateCreateSecret",
         "States": {

--- a/tests/aws/services/sts/test_sts_partitions.py
+++ b/tests/aws/services/sts/test_sts_partitions.py
@@ -1,0 +1,33 @@
+import pytest
+
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+
+
+class TestSTSPartitions:
+    # We only have access to the AWS partition, not CHINA/US-GOV/etc
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_sts_caller_identity_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        sts_client = aws_client_factory(region_name=region).sts
+
+        assert sts_client.get_caller_identity()["Arn"] == f"arn:{partition}:iam::{account_id}:root"
+
+    @markers.aws.manual_setup_required
+    @pytest.mark.parametrize("region,partition", [("us-east-1", "aws"), ("cn-north-1", "aws-cn")])
+    def test_caller_identity_with_custom_creds_in_different_partitions(
+        self, account_id, aws_client_factory, region, partition
+    ):
+        iam_client = aws_client_factory(
+            region_name=region, aws_access_key_id=f"random-{short_uid()}"
+        ).iam
+        user = iam_client.create_user(UserName=f"test-user-{short_uid()}")["User"]
+        user_name = user["UserName"]
+
+        access_key = iam_client.create_access_key(UserName=user_name)["AccessKey"]["AccessKeyId"]
+
+        sts_user_client = aws_client_factory(region_name=region, aws_access_key_id=access_key).sts
+        user_arn = sts_user_client.get_caller_identity()["Arn"]
+        assert user_arn == f"arn:{partition}:iam::{account_id}:user/{user_name}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Users should be able to use LocalStack in any region. That includes the regular AWS regions, but also regions in the China, GovCloud and ISO-partitions. 

One of the major implications of  using a region in a non-standard partition is the fact that ARN's should reflect the correct partitions. For example:
 - `"arn:aws:apigateway:us-east-1:s3:path/"` for the regular `aws` partition
 - `"arn:aws-cn:apigateway:cn-north-1:s3:path/"` for the China partition
 - etc.

The current implementation uses a regex to rewrite any mention of `arn:aws` to `arn:aws-cn` in the raw response. This is a fragile hack, breaks frequently, doesn't consider inter-service comunication scenarios, and has a host of other issues.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR changes all ARN's to include the correct partition on creation.


## Tests

Tests were added to verify the following:
 - ARN's generated by LocalStack have the correct partition
 - ARN's generated by Moto have the correct partition
 - ARN's are correctly validated, in case of inter-service communication

## TODO

What's left to do before merging:

- [x] Wait for the latest Moto-bump, as that includes native partition-support in Moto
- [x] Rebase to include the multi-distribution refactoring

What's left to to  after merging:
- [ ] Make the same changes in LocalstackPro
- [ ]  Remove the current ArnPartitionRewriter
