### PR TITLE
Automatically determine PR URL through branch name for test selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
                     circleci-agent step halt
                   else
                     source .venv/bin/activate
-                    PYTHONPATH=localstack-core python -m localstack.testing.testselection.scripts.generate_test_selection_from_pr /tmp/workspace/repo $CI_PULL_REQUEST target/testselection/test-selection.txt
+                    PYTHONPATH=localstack-core python -m localstack.testing.testselection.scripts.generate_test_selection_from_pr /tmp/workspace/repo target/testselection/test-selection.txt --pr $CI_PULL_REQUEST
                     cat target/testselection/test-selection.txt
                   fi
 

--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -104,7 +104,7 @@ env:
   # report to tinybird if executed on master
   TINYBIRD_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && '--report-to-tinybird ' || '' }}"
   # enable test selection if  not running on master and test selection is not explicitly disabled
-  TESTSELECTION_PYTEST_ARGS: "${{ github.ref == 'refs/heads/master' && inputs.enableTestSelection != false && '--path-filter=../localstack/target/testselection/test-selection.txt ' || '' }}"
+  TESTSELECTION_PYTEST_ARGS: "${{ inputs.enableTestSelection != false && '--path-filter=../localstack/target/testselection/test-selection.txt ' || '' }}"
 
 jobs:
   test-pro:

--- a/localstack-core/localstack/testing/testselection/git.py
+++ b/localstack-core/localstack/testing/testselection/git.py
@@ -15,3 +15,9 @@ def find_merge_base(repo: str, base_branch: str, head_branch: str) -> str:
     cmd = ["git", "-C", repo, "merge-base", base_branch, head_branch]
     output = subprocess.check_output(cmd, encoding="UTF-8")
     return output.strip()
+
+
+def get_branch_name(repo: str) -> str:
+    cmd = ["git", "-C", repo, "rev-parse", "--abbrev-ref", "HEAD"]
+    output = subprocess.check_output(cmd, encoding="UTF-8")
+    return output.strip()

--- a/localstack-core/localstack/testing/testselection/github.py
+++ b/localstack-core/localstack/testing/testselection/github.py
@@ -22,3 +22,15 @@ def get_pr_details_from_url(pr_url: str, token: str) -> (str, str):
     repo_name = f"{parts[-4]}/{parts[-3]}"
     pr_number = parts[-1]
     return get_pr_details(repo_name, pr_number, token)
+
+
+def get_pr_url_from_branch(repo_name: str, branch: str, token: str = None) -> str:
+    """
+    Fetch the pull request URL of a given branch from a GitHub repository.
+    """
+    url = f"https://api.github.com/repos/{repo_name}/pulls?head=localstack:{branch}"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token is not None:
+        headers["Authorization"] = f"token {token}"
+    pr_data = requests.get(url, headers=headers).json()
+    return pr_data[0]["html_url"]

--- a/localstack-core/localstack/testing/testselection/scripts/generate_test_selection_from_commits.py
+++ b/localstack-core/localstack/testing/testselection/scripts/generate_test_selection_from_commits.py
@@ -2,6 +2,7 @@
 USAGE: $ python -m localstack.testing.testselection.scripts.generate_test_selection_from_commits <repo_root_path> <base-commit-sha> <head-commit-sha> <output_file_path>
 """
 
+import argparse
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -17,17 +18,18 @@ def generate_from_commits(
     matching_rules: list[MatchingRule] | None = None,
     repo_name: str = "localstack",
 ):
-    if len(sys.argv) != 5:
-        print(
-            f"Usage: python -m {repo_name}.testing.testselection.scripts.generate_test_selection_from_commits <repo_root_path> <base-commit-sha> <head-commit-sha> <output_file_path>",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="Generate test selection from a range of commits")
+    parser.add_argument("repo_root_path", type=str, help="Path to the git repository root")
+    parser.add_argument("base_commit_sha", type=str, help="Base commit SHA")
+    parser.add_argument("head_commit_sha", type=str, help="Head commit SHA")
+    parser.add_argument("output_file_path", type=str, help="Path to the output file")
 
-    output_file_path = sys.argv[-1]
-    head_commit_sha = sys.argv[-2]
-    base_commit_sha = sys.argv[-3]
-    repo_root_path = sys.argv[-4]
+    args = parser.parse_args()
+
+    output_file_path = args.output_file_path
+    head_commit_sha = args.head_commit_sha
+    base_commit_sha = args.base_commit_sha
+    repo_root_path = args.repo_root_path
 
     print(f"Base Commit SHA: {base_commit_sha}")
     print(f"Head Commit SHA: {head_commit_sha}")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Currently, in order to do test selection without knowing base and head commit from the github pull request event, you have to manually give the PR number to get this info via the GitHub API. However, the PR number can also automatically be determined via the GitHub API.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Use argparse instead of manually checking `sys.argv`
- Make the PR url an optional flag
- When the PR url is not given, use the GitHub API to find the PR url based on the name of the checked out branch.
- Fix the condition for executing the integration tests against pro.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
