### PR TITLE
implement S3 checksum for Multipart uploads

### DIFF
--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -196,7 +196,7 @@ def get_s3_checksum(algorithm) -> ChecksumHash:
 
 
 class S3CRC32Checksum:
-    """Implements a unified way of using zlib.crc32 compatibl with hashlib.sha and botocore CrtCrc32cChecksum"""
+    """Implements a unified way of using zlib.crc32 compatible with hashlib.sha and botocore CrtCrc32cChecksum"""
 
     __slots__ = ["checksum"]
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -665,6 +665,10 @@ class TestS3:
         snapshot.match("expected_error", e.value.response)
 
     @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        condition=is_v2_provider,
+        paths=["$.object-attrs-multiparts-2-parts-checksum.ObjectParts"],
+    )
     def test_get_object_attributes(self, s3_bucket, snapshot, s3_multipart_upload, aws_client):
         aws_client.s3.put_object(Bucket=s3_bucket, Key="data.txt", Body=b"69\n420\n")
         response = aws_client.s3.get_object_attributes(
@@ -852,7 +856,6 @@ class TestS3:
         snapshot.match("abort-exc", e.value.response)
 
     @pytest.mark.skipif(condition=LEGACY_V2_S3_PROVIDER, reason="not implemented in moto")
-    @markers.snapshot.skip_snapshot_verify(paths=["$..ServerSideEncryption"])
     @markers.aws.validated
     def test_multipart_complete_multipart_too_small(self, s3_bucket, snapshot, aws_client):
         key_name = "test-upload-part-exc"

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -280,7 +280,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes": {
-    "recorded-date": "03-08-2023, 04:14:00",
+    "recorded-date": "28-05-2024, 16:02:03",
     "recorded-content": {
       "object-attrs": {
         "ETag": "e92499db864217242396e8ef766079a9",
@@ -311,6 +311,16 @@
         "ObjectParts": {
           "TotalPartsCount": 2
         },
+        "ObjectSize": 5242965,
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-multiparts-2-parts-checksum": {
+        "ETag": "5389a7fb9c7e4b97c90255e2ee5e57f7-2",
+        "LastModified": "datetime",
         "ObjectSize": 5242965,
         "StorageClass": "STANDARD",
         "ResponseMetadata": {
@@ -3751,7 +3761,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
-    "recorded-date": "03-08-2023, 04:14:05",
+    "recorded-date": "28-05-2024, 17:32:52",
     "recorded-content": {
       "create-multipart": {
         "Bucket": "bucket",
@@ -3911,6 +3921,33 @@
         "NextKeyMarker": "",
         "NextUploadIdMarker": "",
         "UploadIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-multipart-checksum": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 65,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e747540af6911dbc890f8d3e0b48549b-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-multipart-checksum": {
+        "AcceptRanges": "bytes",
+        "Body": "upload-part-1upload-part-1upload-part-1upload-part-1upload-part-1",
+        "ContentLength": 65,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e747540af6911dbc890f8d3e0b48549b-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -4765,7 +4802,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_complete_multipart_parts_checksum": {
-    "recorded-date": "03-08-2023, 04:25:24",
+    "recorded-date": "28-05-2024, 16:09:21",
     "recorded-content": {
       "create-mpu-checksum": {
         "Bucket": "bucket",
@@ -4851,7 +4888,20 @@
           "HTTPStatusCode": 200
         }
       },
-      "complete-multipart-without-checksum": {
+      "complete-multipart-wrong-parts-checksum": {
+        "Error": {
+          "Code": "InvalidPart",
+          "ETag": "c4c753e69bb853187f5854c46cf801c6",
+          "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+          "PartNumber": "1",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-wrong-checksum": {
         "Error": {
           "Code": "InvalidRequest",
           "Message": "The upload was created using a sha256 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request."
@@ -4888,10 +4938,25 @@
           "HTTPStatusCode": 200
         }
       },
+      "head-object-with-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg=-3",
+        "ContentLength": 15728643,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "get-object-attrs": {
         "Checksum": {
           "ChecksumSHA256": "dVAleH1OmqkLvByTMLIWSjNCz3x2Ul1KJEZw3eQ2Fqg="
         },
+        "ETag": "c7cb0938a47e31f70cf07028d22e6913-3",
         "LastModified": "datetime",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4901,7 +4966,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "recorded-date": "03-08-2023, 04:25:28",
+    "recorded-date": "28-05-2024, 17:27:37",
     "recorded-content": {
       "create-mpu-no-checksum": {
         "Bucket": "bucket",
@@ -4924,7 +4989,7 @@
         }
       },
       "upload-part-no-checksum-ok": {
-        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "ETag": "\"900150983cd24fb0d6963f7d28e17f72\"",
         "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -4934,7 +4999,7 @@
       "complete-part-with-checksum": {
         "Error": {
           "Code": "InvalidPart",
-          "ETag": "d41d8cd98f00b204e9800998ecf8427e",
+          "ETag": "900150983cd24fb0d6963f7d28e17f72",
           "Message": "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
           "PartNumber": "1",
           "UploadId": "<upload-id:1>"

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2023-09-12T12:35:39+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_complete_multipart_parts_checksum": {
-    "last_validated_date": "2023-08-03T02:25:24+00:00"
+    "last_validated_date": "2024-05-28T16:09:21+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_complete_multipart_parts_order": {
     "last_validated_date": "2023-08-03T02:24:38+00:00"
@@ -81,7 +81,7 @@
     "last_validated_date": "2023-08-03T02:14:29+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes": {
-    "last_validated_date": "2023-08-03T02:14:00+00:00"
+    "last_validated_date": "2024-05-28T16:02:03+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes_versioned": {
     "last_validated_date": "2023-08-03T02:14:03+00:00"
@@ -111,7 +111,7 @@
     "last_validated_date": "2023-08-03T02:13:29+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
-    "last_validated_date": "2023-08-03T02:14:05+00:00"
+    "last_validated_date": "2024-05-28T17:32:52+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_complete_multipart_too_small": {
     "last_validated_date": "2023-08-03T02:14:10+00:00"
@@ -129,7 +129,7 @@
     "last_validated_date": "2023-10-18T15:40:12+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "last_validated_date": "2023-08-03T02:25:28+00:00"
+    "last_validated_date": "2024-05-28T17:27:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_object_with_slashes_in_key[False]": {
     "last_validated_date": "2023-11-24T10:11:04+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10898, multipart uploads still did not have checksum implemented. This was left as a TODO during the migration of S3, and I've now implemented it. 

See https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- enable and regenerate tests for this feature
- implement logic in the models for checksum logic, properly checking if the checksum provided are there, and if we're providing checksum or not depending on what was done during `CreateMultipartUpload`
- additional fixes around `PartsCount` for `HeadObject`

_fixes #10898_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
