### PR TITLE
Increase performance for first store creation per account/service

### DIFF
--- a/localstack-core/localstack/utils/aws/aws_stack.py
+++ b/localstack-core/localstack/utils/aws/aws_stack.py
@@ -11,7 +11,6 @@ from localstack.config import S3_VIRTUAL_HOSTNAME
 from localstack.constants import (
     LOCALHOST,
 )
-from localstack.utils.bootstrap import log_duration
 from localstack.utils.strings import is_string_or_bytes, to_str
 
 # set up logger
@@ -33,7 +32,6 @@ def get_valid_regions():
 
 # FIXME: AWS recommends use of SSM parameter store to determine per region availability
 # https://github.com/aws/aws-sdk/issues/206#issuecomment-1471354853
-@log_duration(min_ms=0)
 @lru_cache()
 def get_valid_regions_for_service(service_name):
     session = boto3.Session()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We currently create the boto3 session multiple times for checking available regions in the RegionBundle.
This code is called on the first store access per account for every service.

The changes in this PR should cache the result, and reduce the initial store instantiation time from around 200ms to around 50ms.
Due to the caching, the first request in additional accounts will be instantenous.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* LocalStack should respond ~150ms (depending on the system) faster on the first store-accessing call for each service for a new account.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
