### PR TITLE
remove unknown-markers in test_transcribe

### DIFF
--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -116,7 +116,7 @@ class TestTranscribe:
             content = to_str(data["Body"].read())
             assert speech in content
 
-        retry(_assert_transcript, retries=80, sleep=5, sleep_before=5)
+        retry(_assert_transcript, retries=30, sleep=2)
 
     @markers.aws.needs_fixing
     def test_transcribe_unsupported_media_format_failure(self, transcribe_create_job, aws_client):

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -92,7 +92,7 @@ class TestTranscribe:
             ("../../files/en-us_video.mp4", "one of the most vital"),
         ],
     )
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_transcribe_supported_media_formats(
         self, transcribe_create_job, media_file, speech, aws_client
     ):
@@ -116,9 +116,9 @@ class TestTranscribe:
             content = to_str(data["Body"].read())
             assert speech in content
 
-        retry(_assert_transcript, retries=30, sleep=2)
+        retry(_assert_transcript, retries=80, sleep=5, sleep_before=5)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_transcribe_unsupported_media_format_failure(self, transcribe_create_job, aws_client):
         # Ensure transcribing an empty file fails
         file_path = new_tmp_file()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to remove `markers.aws.unknown` in transcribe tests. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR updates the marker to `needs_fixing` if it didn't pass against AWS.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
