### PR TITLE
Validate remaining unknown sqs tests

### DIFF
--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -2720,6 +2720,7 @@ class TestSqsProvider:
         send_invalid(invalid_attribute)
 
     @markers.aws.needs_fixing
+    @pytest.mark.skip
     def test_send_message_with_invalid_fifo_parameters(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(
@@ -2969,6 +2970,7 @@ class TestSqsProvider:
         snapshot.match("dlq-messages", messages)
 
     @markers.aws.needs_fixing
+    @pytest.mark.skip
     def test_dead_letter_queue_chain(
         self, sqs_create_queue, aws_sqs_client, account_id, region_name
     ):
@@ -3491,6 +3493,7 @@ class TestSqsProvider:
         assert "Messages" not in result_recv_2 or result_recv_2["Messages"] == []
 
     @markers.aws.needs_fixing
+    @pytest.mark.skip
     def test_dead_letter_queue_execution_lambda_mapping_preserves_id(
         self, sqs_create_queue, create_lambda_function, aws_sqs_client, aws_client, region_name
     ):

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -2720,7 +2720,6 @@ class TestSqsProvider:
         send_invalid(invalid_attribute)
 
     @markers.aws.needs_fixing
-    @markers.aws.validated
     def test_send_message_with_invalid_fifo_parameters(self, sqs_create_queue, aws_sqs_client):
         fifo_queue_name = f"queue-{short_uid()}.fifo"
         queue_url = sqs_create_queue(

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -48,10 +48,10 @@
     "last_validated_date": "2024-05-15T02:30:48+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_execution_lambda_mapping_preserves_id[sqs]": {
-    "last_validated_date": "2024-05-28T14:41:06+00:00"
+    "last_validated_date": "2024-05-29T14:12:29+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_execution_lambda_mapping_preserves_id[sqs_query]": {
-    "last_validated_date": "2024-05-28T14:53:13+00:00"
+    "last_validated_date": "2024-05-29T14:14:14+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
     "last_validated_date": "2024-04-30T13:33:55+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -47,6 +47,12 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_create_standard_queue_with_fifo_attribute_raises_error[sqs_query]": {
     "last_validated_date": "2024-05-15T02:30:48+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_execution_lambda_mapping_preserves_id[sqs]": {
+    "last_validated_date": "2024-05-28T14:41:06+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_execution_lambda_mapping_preserves_id[sqs_query]": {
+    "last_validated_date": "2024-05-28T14:53:13+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_message_attributes": {
     "last_validated_date": "2024-04-30T13:33:55+00:00"
   },
@@ -55,6 +61,12 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_dead_letter_queue_with_fifo_and_content_based_deduplication[sqs_query]": {
     "last_validated_date": "2024-05-21T13:58:16+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_deduplication_interval[sqs]": {
+    "last_validated_date": "2024-05-29T13:41:13+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_deduplication_interval[sqs_query]": {
+    "last_validated_date": "2024-05-29T13:47:36+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_delete_message_batch_invalid_msg_id[sqs-]": {
     "last_validated_date": "2024-04-30T13:48:34+00:00"
@@ -256,6 +268,12 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_empty_string_attribute[sqs_query]": {
     "last_validated_date": "2024-04-30T13:35:42+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_invalid_fifo_parameters[sqs]": {
+    "last_validated_date": "2024-05-28T14:27:55+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_invalid_fifo_parameters[sqs_query]": {
+    "last_validated_date": "2024-05-28T14:19:35+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_message_with_updated_maximum_message_size[sqs]": {
     "last_validated_date": "2024-04-30T13:33:02+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Support the ongoing initiative of #9141 and remove remaining unknown markers for sqs related tests.
Side note: the tests in test_notifications.py should probably be moved/deleted, they not seem special or complex enough to warrant its own test class

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- remove unknown markers and replace them with validated/needs_fixing
- fix all tests so that they at least work against AWS
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
