### PR TITLE
Fix k8s dev script code locations

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -69,8 +69,7 @@ def generate_k8s_cluster_overrides(
         volumes.append(
             {
                 "name": name,
-                "hostPath": {"path": volume["volume"].split(":")[-1]},
-                "type": volume_type,
+                "hostPath": {"path": volume["volume"].split(":")[-1], "type": volume_type},
             }
         )
 

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -18,11 +18,15 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
     )
 
     egg_path = os.path.join(root_path, "localstack_core.egg-info/entry_points.txt")
+    volumes.append(
+        {
+            "volume": f"{os.path.normpath(egg_path)}:/code/entry_points_community",
+            "nodeFilters": ["server:*", "agent:*"],
+        }
+    )
     if pro:
         ext_path = os.path.join(root_path, "..", "localstack-ext")
         ext_code_path = os.path.join(ext_path, "localstack_ext")
-        egg_path = os.path.join(ext_path, "localstack_ext.egg-info/entry_points.txt")
-
         volumes.append(
             {
                 "volume": f"{os.path.normpath(ext_code_path)}:/code/localstack_ext",
@@ -30,12 +34,13 @@ def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, por
             }
         )
 
-    volumes.append(
-        {
-            "volume": f"{os.path.normpath(egg_path)}:/code/entry_points",
-            "nodeFilters": ["server:*", "agent:*"],
-        }
-    )
+        egg_path = os.path.join(ext_path, "localstack_ext.egg-info/entry_points.txt")
+        volumes.append(
+            {
+                "volume": f"{os.path.normpath(egg_path)}:/code/entry_points_ext",
+                "nodeFilters": ["server:*", "agent:*"],
+            }
+        )
 
     if mount_moto:
         moto_path = os.path.join(root_path, "..", "moto", "moto")

--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -8,8 +8,8 @@ from localstack import version as localstack_version
 
 def generate_k8s_cluster_config(pro: bool = False, mount_moto: bool = False, port: int = 4566):
     volumes = []
-    root_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
-    localstack_code_path = os.path.join(root_path, "localstack")
+    root_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    localstack_code_path = os.path.join(root_path, "localstack-core", "localstack")
     volumes.append(
         {
             "volume": f"{os.path.normpath(localstack_code_path)}:/code/localstack",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The kubernetes dev script generates incorrect templates. Specifically:
* paths have not been updated to account for the code restructuring from #10800, and
* the `hostPath` syntax is incorrect

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Update root path location after code relocation
- Mount community entry points
- Correct schema of hostPath mounts

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
