### PR TITLE
validate and add S3Control tests

### DIFF
--- a/tests/aws/services/s3control/test_s3control.py
+++ b/tests/aws/services/s3control/test_s3control.py
@@ -13,7 +13,9 @@ from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid
 from localstack.utils.urls import localstack_host
 
-s3_control_endpoint = f"http://s3-control.{localstack_host()}"
+# TODO: this fails in CI, not sure why yet
+# s3_control_endpoint = f"http://s3-control.{localstack_host()}"
+s3_control_endpoint = f"https://{localstack_host().host_and_port()}"
 
 
 @pytest.fixture

--- a/tests/aws/services/s3control/test_s3control.py
+++ b/tests/aws/services/s3control/test_s3control.py
@@ -1,65 +1,419 @@
+import contextlib
+
 import pytest
+from botocore.client import Config
 from botocore.exceptions import ClientError
 
-from localstack import config
 from localstack.constants import (
     TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from localstack.utils.urls import localstack_host
 
-remote_endpoint = config.external_service_url(protocol="https")
+s3_control_endpoint = f"http://s3-control.{localstack_host()}"
 
 
 @pytest.fixture
-def s3control_client(aws_client_factory):
-    return aws_client_factory(
-        aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
-        endpoint_url=remote_endpoint,
-    ).s3control
-
-
-@markers.aws.unknown
-def test_lifecycle_public_access_block(s3control_client, account_id):
-    with pytest.raises(ClientError) as ce:
-        s3control_client.get_public_access_block(AccountId=account_id)
-    assert ce.value.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration"
-
-    access_block_config = {
-        "BlockPublicAcls": True,
-        "IgnorePublicAcls": True,
-        "BlockPublicPolicy": True,
-        "RestrictPublicBuckets": True,
-    }
-
-    put_response = s3control_client.put_public_access_block(
-        AccountId=account_id, PublicAccessBlockConfiguration=access_block_config
+def s3control_snapshot(snapshot):
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.key_value("HostId", reference_replacement=False),
+            snapshot.transform.key_value("Name"),
+            snapshot.transform.key_value("Bucket"),
+            snapshot.transform.regex("amazonaws.com", "<endpoint-host>"),
+            snapshot.transform.regex(localstack_host().host_and_port(), "<endpoint-host>"),
+            snapshot.transform.regex(
+                '([a-z0-9]{34})(?=.*-s3alias")', replacement="<alias-random-part>"
+            ),
+        ]
     )
 
-    assert put_response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    get_response = s3control_client.get_public_access_block(AccountId=account_id)
-    assert access_block_config == get_response["PublicAccessBlockConfiguration"]
+@pytest.fixture
+def s3control_client(aws_client_factory, aws_client):
+    """
+    The endpoint for S3 Control looks like `http(s)://<account-id>.s3-control.<host>/v20180820/configuration/<path>
+    We need to manually set it to something else than `localhost` so that it is resolvable, as boto will prefix the host
+    with the account-id
+    """
+    if not is_aws_cloud():
+        return aws_client_factory(
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+            endpoint_url=s3_control_endpoint,
+        ).s3control
+    else:
+        return aws_client.s3control
 
-    s3control_client.delete_public_access_block(AccountId=account_id)
+
+@pytest.fixture
+def s3control_client_no_validation(aws_client_factory):
+    if not is_aws_cloud():
+        client = aws_client_factory(
+            config=Config(parameter_validation=False),
+            aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+            endpoint_url=s3_control_endpoint,
+        ).s3control
+    else:
+        client = aws_client_factory(config=Config(parameter_validation=False)).s3control
+
+    return client
 
 
-@markers.aws.unknown
-def test_public_access_block_validations(s3control_client, account_id):
-    with pytest.raises(ClientError) as error:
-        s3control_client.get_public_access_block(AccountId="111111111111")
-    assert error.value.response["Error"]["Code"] == "AccessDenied"
+@pytest.fixture
+def s3control_create_access_point(s3control_client):
+    access_points = []
 
-    with pytest.raises(ClientError) as error:
-        s3control_client.put_public_access_block(
-            AccountId="111111111111",
+    def _create_access_point(**kwargs):
+        resp = s3control_client.create_access_point(**kwargs)
+        access_points.append((kwargs["Name"], kwargs["AccountId"]))
+        return resp
+
+    yield _create_access_point
+
+    for access_point_name, req_account_id in access_points:
+        with contextlib.suppress(ClientError):
+            s3control_client.delete_access_point(AccountId=req_account_id, Name=access_point_name)
+
+
+class TestLegacyS3Control:
+    @markers.aws.validated
+    def test_lifecycle_public_access_block(self, s3control_client, account_id):
+        with pytest.raises(ClientError) as ce:
+            s3control_client.get_public_access_block(AccountId=account_id)
+        assert ce.value.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration"
+
+        access_block_config = {
+            "BlockPublicAcls": True,
+            "IgnorePublicAcls": True,
+            "BlockPublicPolicy": True,
+            "RestrictPublicBuckets": True,
+        }
+
+        try:
+            put_response = s3control_client.put_public_access_block(
+                AccountId=account_id, PublicAccessBlockConfiguration=access_block_config
+            )
+
+            assert put_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            get_response = s3control_client.get_public_access_block(AccountId=account_id)
+            assert access_block_config == get_response["PublicAccessBlockConfiguration"]
+
+        finally:
+            s3control_client.delete_public_access_block(AccountId=account_id)
+
+    @markers.aws.only_localstack
+    def test_public_access_block_validations(self, s3control_client, account_id):
+        # Moto forces IAM use with the account id even when not enabled
+        with pytest.raises(ClientError) as error:
+            s3control_client.get_public_access_block(AccountId="111111111111")
+        assert error.value.response["Error"]["Code"] == "AccessDenied"
+
+        with pytest.raises(ClientError) as error:
+            s3control_client.put_public_access_block(
+                AccountId="111111111111",
+                PublicAccessBlockConfiguration={"BlockPublicAcls": True},
+            )
+        assert error.value.response["Error"]["Code"] == "AccessDenied"
+
+        with pytest.raises(ClientError) as error:
+            s3control_client.put_public_access_block(
+                AccountId=account_id, PublicAccessBlockConfiguration={}
+            )
+        assert error.value.response["Error"]["Code"] == "InvalidRequest"
+
+
+@pytest.mark.skip("Not implemented yet in LocalStack")
+class TestS3ControlPublicAccessBlock:
+    @markers.aws.validated
+    def test_crud_public_access_block(self, s3control_client, account_id, snapshot):
+        with pytest.raises(ClientError) as e:
+            s3control_client.get_public_access_block(AccountId=account_id)
+        snapshot.match("get-default-public-access-block", e.value.response)
+
+        put_public_access_block = s3control_client.put_public_access_block(
+            AccountId=account_id,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+            },
+        )
+        snapshot.match("put-public-access-block", put_public_access_block)
+
+        get_public_access_block = s3control_client.get_public_access_block(AccountId=account_id)
+        snapshot.match("get-public-access-block", get_public_access_block)
+
+        delete_public_access_block = s3control_client.delete_public_access_block(
+            AccountId=account_id
+        )
+        snapshot.match("delete-public-access-block", delete_public_access_block)
+
+        with pytest.raises(ClientError) as e:
+            s3control_client.get_public_access_block(AccountId=account_id)
+        snapshot.match("get-public-access-block-after-delete", e.value.response)
+
+        delete_public_access_block = s3control_client.delete_public_access_block(
+            AccountId=account_id
+        )
+        snapshot.match("idempotent-delete-public-access-block", delete_public_access_block)
+
+    @markers.aws.validated
+    def test_empty_public_access_block(self, s3control_client_no_validation, account_id, snapshot):
+        # we need to disable validation for this test
+
+        with pytest.raises(ClientError) as e:
+            s3control_client_no_validation.put_public_access_block(
+                AccountId=account_id,
+                PublicAccessBlockConfiguration={},
+            )
+        snapshot.match("put-public-access-block-empty", e.value.response)
+        # Wanted to try it with a wrong key in the PublicAccessBlockConfiguration but boto is unable to serialize
+
+
+@pytest.mark.skip("Not implemented yet in LocalStack, missing link with S3")
+class TestS3ControlAccessPoint:
+    @markers.aws.validated
+    def test_access_point_lifecycle(
+        self,
+        s3control_client,
+        s3control_create_access_point,
+        account_id,
+        s3_bucket,
+        snapshot,
+        s3control_snapshot,
+    ):
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("Name"),
+                snapshot.transform.key_value("Bucket"),
+                snapshot.transform.regex("amazonaws.com", "<endpoint-host>"),
+                snapshot.transform.regex(localstack_host().host_and_port(), "<endpoint-host>"),
+            ]
+        )
+
+        list_access_points = s3control_client.list_access_points(AccountId=account_id)
+        snapshot.match("list-access-points-start", list_access_points)
+
+        ap_name = short_uid()
+        create_access_point = s3control_create_access_point(
+            AccountId=account_id, Name=ap_name, Bucket=s3_bucket
+        )
+
+        alias_random_part = create_access_point["Alias"].split("-")[1]
+        assert len(alias_random_part) == 34
+
+        snapshot.match("create-access-point", create_access_point)
+
+        get_access_point = s3control_client.get_access_point(AccountId=account_id, Name=ap_name)
+        snapshot.match("get-access-point", get_access_point)
+
+        list_access_points = s3control_client.list_access_points(AccountId=account_id)
+        snapshot.match("list-access-points-after-create", list_access_points)
+
+        delete_access_point = s3control_client.delete_access_point(
+            AccountId=account_id, Name=ap_name
+        )
+        snapshot.match("delete-access-point", delete_access_point)
+
+        list_access_points = s3control_client.list_access_points(AccountId=account_id)
+        snapshot.match("list-access-points-after-delete", list_access_points)
+
+        with pytest.raises(ClientError) as e:
+            s3control_client.get_access_point(AccountId=account_id, Name=ap_name)
+        snapshot.match("get-delete-access-point", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            s3control_client.delete_access_point(AccountId=account_id, Name=ap_name)
+        snapshot.match("delete-already-deleted-access-point", e.value.response)
+
+    @markers.aws.validated
+    def test_access_point_bucket_not_exists(
+        self, s3control_create_access_point, account_id, snapshot, s3control_snapshot
+    ):
+        ap_name = short_uid()
+        with pytest.raises(ClientError) as e:
+            s3control_create_access_point(
+                AccountId=account_id,
+                Name=ap_name,
+                Bucket=f"fake-bucket-{short_uid()}-{short_uid()}",
+            )
+        snapshot.match("access-point-bucket-not-exists", e.value.response)
+
+    @markers.aws.validated
+    def test_access_point_name_validation(
+        self, s3control_client_no_validation, account_id, snapshot, s3_bucket, s3control_snapshot
+    ):
+        # not using parametrization because that would be a lot of snapshot.
+        # only validate the first one
+        wrong_name = "xn-_test-alias"
+        wrong_names = [
+            "-hyphen-start",
+            "cannot-end-s3alias",
+            "cannot-have.dot",
+        ]
+
+        with pytest.raises(ClientError) as e:
+            s3control_client_no_validation.create_access_point(
+                AccountId=account_id,
+                Name=wrong_name,
+                Bucket=s3_bucket,
+            )
+        snapshot.match("access-point-wrong-naming", e.value.response)
+
+        for name in wrong_names:
+            with pytest.raises(ClientError) as e:
+                s3control_client_no_validation.create_access_point(
+                    AccountId=account_id,
+                    Name=name,
+                    Bucket=s3_bucket,
+                )
+            assert e.match("Your Amazon S3 AccessPoint name is invalid"), (name, e.value.response)
+
+        # error is different for too short of a name
+        with pytest.raises(ClientError) as e:
+            s3control_client_no_validation.create_access_point(
+                AccountId=account_id,
+                Name="sa",
+                Bucket=s3_bucket,
+            )
+        snapshot.match("access-point-name-too-short", e.value.response)
+
+        uri_error_names = [
+            "a" * 51,
+            "WRONG-casing",
+            "cannot-have_underscore",
+        ]
+        for name in uri_error_names:
+            with pytest.raises(ClientError) as e:
+                s3control_client_no_validation.create_access_point(
+                    AccountId=account_id,
+                    Name="a" * 51,
+                    Bucket=s3_bucket,
+                )
+            assert e.match("InvalidURI"), (name, e.value.response)
+
+    @markers.aws.validated
+    def test_access_point_already_exists(
+        self, s3control_create_access_point, s3_bucket, account_id, snapshot, s3control_snapshot
+    ):
+        ap_name = short_uid()
+        s3control_create_access_point(AccountId=account_id, Name=ap_name, Bucket=s3_bucket)
+        with pytest.raises(ClientError) as e:
+            s3control_create_access_point(AccountId=account_id, Name=ap_name, Bucket=s3_bucket)
+        snapshot.match("access-point-already-exists", e.value.response)
+
+    @markers.aws.validated
+    def test_access_point_public_access_block_configuration(
+        self,
+        s3control_client,
+        s3control_create_access_point,
+        account_id,
+        snapshot,
+        s3_bucket,
+        s3control_snapshot,
+    ):
+        # set a letter in the name for ordering
+        ap_name_1 = f"a{short_uid()}"
+        response = s3control_create_access_point(
+            AccountId=account_id,
+            Name=ap_name_1,
+            Bucket=s3_bucket,
+            PublicAccessBlockConfiguration={},
+        )
+        snapshot.match("put-ap-empty-pabc", response)
+        get_ap = s3control_client.get_access_point(AccountId=account_id, Name=ap_name_1)
+        snapshot.match("get-ap-empty-pabc", get_ap)
+
+        ap_name_2 = f"b{short_uid()}"
+        response = s3control_create_access_point(
+            AccountId=account_id,
+            Name=ap_name_2,
+            Bucket=s3_bucket,
+            PublicAccessBlockConfiguration={"BlockPublicAcls": False},
+        )
+        snapshot.match("put-ap-partial-pabc", response)
+        get_ap = s3control_client.get_access_point(AccountId=account_id, Name=ap_name_2)
+        snapshot.match("get-ap-partial-pabc", get_ap)
+
+        ap_name_3 = f"c{short_uid()}"
+        response = s3control_create_access_point(
+            AccountId=account_id,
+            Name=ap_name_3,
+            Bucket=s3_bucket,
             PublicAccessBlockConfiguration={"BlockPublicAcls": True},
         )
-    assert error.value.response["Error"]["Code"] == "AccessDenied"
+        snapshot.match("put-ap-partial-true-pabc", response)
+        get_ap = s3control_client.get_access_point(AccountId=account_id, Name=ap_name_3)
+        snapshot.match("get-ap-partial-true-pabc", get_ap)
 
-    with pytest.raises(ClientError) as error:
-        s3control_client.put_public_access_block(
-            AccountId=account_id, PublicAccessBlockConfiguration={}
+        ap_name_4 = f"d{short_uid()}"
+        response = s3control_create_access_point(
+            AccountId=account_id,
+            Name=ap_name_4,
+            Bucket=s3_bucket,
         )
-    assert error.value.response["Error"]["Code"] == "InvalidRequest"
+        snapshot.match("put-ap-pabc-not-set", response)
+        get_ap = s3control_client.get_access_point(AccountId=account_id, Name=ap_name_4)
+        snapshot.match("get-ap-pabc-not-set", get_ap)
+
+        list_access_points = s3control_client.list_access_points(AccountId=account_id)
+        snapshot.match("list-access-points", list_access_points)
+
+    @markers.aws.validated
+    def test_access_point_pagination(
+        self,
+        s3control_client,
+        s3control_create_access_point,
+        account_id,
+        snapshot,
+        s3_create_bucket,
+        s3control_snapshot,
+    ):
+        # TODO: can you have 2 AP on one bucket?
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("Name"),
+                snapshot.transform.key_value("Bucket"),
+                snapshot.transform.key_value("NextToken"),
+                snapshot.transform.regex("amazonaws.com", "<endpoint-host>"),
+                snapshot.transform.regex(localstack_host().host_and_port(), "<endpoint-host>"),
+            ]
+        )
+
+        ap_names = []
+        bucket_1 = s3_create_bucket()
+        bucket_2 = s3_create_bucket()
+        for i in range(3):
+            ap_name = short_uid()
+            ap_names.append(ap_name)
+            create_access_point = s3control_create_access_point(
+                AccountId=account_id, Name=ap_name, Bucket=bucket_1 if i < 2 else bucket_2
+            )
+            snapshot.match(f"create-access-point-{i}", create_access_point)
+
+        list_all = s3control_client.list_access_points(AccountId=account_id)
+        snapshot.match("list-all", list_all)
+
+        list_one_max = s3control_client.list_access_points(AccountId=account_id, MaxResults=1)
+        snapshot.match("list-one-max", list_one_max)
+        next_token = list_one_max["NextToken"]
+
+        list_one_next = s3control_client.list_access_points(
+            AccountId=account_id, NextToken=next_token, MaxResults=1
+        )
+        snapshot.match("list-one-next", list_one_next)
+        next_token = list_one_next["NextToken"]
+
+        list_one_last = s3control_client.list_access_points(
+            AccountId=account_id, NextToken=next_token, MaxResults=1
+        )
+        snapshot.match("list-one-next-2", list_one_last)
+
+        list_by_bucket = s3control_client.list_access_points(AccountId=account_id, Bucket=bucket_1)
+        snapshot.match("list-by-bucket", list_by_bucket)

--- a/tests/aws/services/s3control/test_s3control.py
+++ b/tests/aws/services/s3control/test_s3control.py
@@ -83,6 +83,11 @@ def s3control_create_access_point(s3control_client):
 
 
 class TestLegacyS3Control:
+    """
+    This class is related to the current Moto implementation, which is quite limited and not linked with S3
+    anymore. Remove these tests in favor of the currently skipped ones, once we migrate to the new provider.
+    """
+
     @markers.aws.validated
     def test_lifecycle_public_access_block(self, s3control_client, account_id):
         with pytest.raises(ClientError) as ce:

--- a/tests/aws/services/s3control/test_s3control.snapshot.json
+++ b/tests/aws/services/s3control/test_s3control.snapshot.json
@@ -1,0 +1,593 @@
+{
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlPublicAccessBlock::test_crud_public_access_block": {
+    "recorded-date": "30-05-2024, 17:32:58",
+    "recorded-content": {
+      "get-default-public-access-block": {
+        "Error": {
+          "AccountId": "111111111111",
+          "Code": "NoSuchPublicAccessBlockConfiguration",
+          "Message": "The public access block configuration was not found"
+        },
+        "HostId": "host-id",
+        "Message": "The public access block configuration was not found",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-public-access-block": {
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-public-access-block-after-delete": {
+        "Error": {
+          "AccountId": "111111111111",
+          "Code": "NoSuchPublicAccessBlockConfiguration",
+          "Message": "The public access block configuration was not found"
+        },
+        "HostId": "host-id",
+        "Message": "The public access block configuration was not found",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "idempotent-delete-public-access-block": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlPublicAccessBlock::test_empty_public_access_block": {
+    "recorded-date": "30-05-2024, 17:32:59",
+    "recorded-content": {
+      "put-public-access-block-empty": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Must specify at least one configuration."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_lifecycle": {
+    "recorded-date": "30-05-2024, 17:37:58",
+    "recorded-content": {
+      "list-access-points-start": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-access-point": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+        "Alias": "<name:2>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-access-point": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+        "Alias": "<name:2>-<alias-random-part>-s3alias",
+        "Bucket": "<bucket:2>",
+        "BucketAccountId": "111111111111",
+        "CreationDate": "datetime",
+        "Endpoints": {
+          "dualstack": "s3-accesspoint.dualstack.<region>.<endpoint-host>",
+          "fips": "s3-accesspoint-fips.<region>.<endpoint-host>",
+          "fips_dualstack": "s3-accesspoint-fips.dualstack.<region>.<endpoint-host>",
+          "ipv4": "s3-accesspoint.<region>.<endpoint-host>"
+        },
+        "Name": "<name:2>",
+        "NetworkOrigin": "Internet",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-access-points-after-create": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+            "Alias": "<name:2>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:2>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:2>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-access-point": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-access-points-after-delete": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-delete-access-point": {
+        "Error": {
+          "AccessPointName": "<name:2>",
+          "Code": "NoSuchAccessPoint",
+          "Message": "The specified accesspoint does not exist"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-already-deleted-access-point": {
+        "Error": {
+          "AccessPointName": "<name:2>",
+          "Code": "NoSuchAccessPoint",
+          "Message": "The specified accesspoint does not exist"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_bucket_not_exists": {
+    "recorded-date": "30-05-2024, 17:37:59",
+    "recorded-content": {
+      "access-point-bucket-not-exists": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Amazon S3 AccessPoint can only be created for existing bucket"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_name_validation": {
+    "recorded-date": "30-05-2024, 17:38:04",
+    "recorded-content": {
+      "access-point-wrong-naming": {
+        "Error": {
+          "Code": "InvalidURI",
+          "Message": "Couldn't parse the specified URI.",
+          "URI": "accesspoint/xn-_test-alias"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "access-point-name-too-short": {
+        "Error": {
+          "Code": "InvalidURI",
+          "Message": "Couldn't parse the specified URI.",
+          "URI": "accesspoint/sa"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_already_exists": {
+    "recorded-date": "30-05-2024, 17:38:05",
+    "recorded-content": {
+      "access-point-already-exists": {
+        "Error": {
+          "Code": "AccessPointAlreadyOwnedByYou",
+          "Message": "Your previous request to create the named accesspoint succeeded and you already own it."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_public_access_block_configuration": {
+    "recorded-date": "30-05-2024, 17:38:08",
+    "recorded-content": {
+      "put-ap-empty-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+        "Alias": "<name:1>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-ap-empty-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+        "Alias": "<name:1>-<alias-random-part>-s3alias",
+        "Bucket": "<bucket:1>",
+        "BucketAccountId": "111111111111",
+        "CreationDate": "datetime",
+        "Endpoints": {
+          "dualstack": "s3-accesspoint.dualstack.<region>.<endpoint-host>",
+          "fips": "s3-accesspoint-fips.<region>.<endpoint-host>",
+          "fips_dualstack": "s3-accesspoint-fips.dualstack.<region>.<endpoint-host>",
+          "ipv4": "s3-accesspoint.<region>.<endpoint-host>"
+        },
+        "Name": "<name:1>",
+        "NetworkOrigin": "Internet",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-ap-partial-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+        "Alias": "<name:2>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-ap-partial-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+        "Alias": "<name:2>-<alias-random-part>-s3alias",
+        "Bucket": "<bucket:1>",
+        "BucketAccountId": "111111111111",
+        "CreationDate": "datetime",
+        "Endpoints": {
+          "dualstack": "s3-accesspoint.dualstack.<region>.<endpoint-host>",
+          "fips": "s3-accesspoint-fips.<region>.<endpoint-host>",
+          "fips_dualstack": "s3-accesspoint-fips.dualstack.<region>.<endpoint-host>",
+          "ipv4": "s3-accesspoint.<region>.<endpoint-host>"
+        },
+        "Name": "<name:2>",
+        "NetworkOrigin": "Internet",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-ap-partial-true-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+        "Alias": "<name:3>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-ap-partial-true-pabc": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+        "Alias": "<name:3>-<alias-random-part>-s3alias",
+        "Bucket": "<bucket:1>",
+        "BucketAccountId": "111111111111",
+        "CreationDate": "datetime",
+        "Endpoints": {
+          "dualstack": "s3-accesspoint.dualstack.<region>.<endpoint-host>",
+          "fips": "s3-accesspoint-fips.<region>.<endpoint-host>",
+          "fips_dualstack": "s3-accesspoint-fips.dualstack.<region>.<endpoint-host>",
+          "ipv4": "s3-accesspoint.<region>.<endpoint-host>"
+        },
+        "Name": "<name:3>",
+        "NetworkOrigin": "Internet",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-ap-pabc-not-set": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:4>",
+        "Alias": "<name:4>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-ap-pabc-not-set": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:4>",
+        "Alias": "<name:4>-<alias-random-part>-s3alias",
+        "Bucket": "<bucket:1>",
+        "BucketAccountId": "111111111111",
+        "CreationDate": "datetime",
+        "Endpoints": {
+          "dualstack": "s3-accesspoint.dualstack.<region>.<endpoint-host>",
+          "fips": "s3-accesspoint-fips.<region>.<endpoint-host>",
+          "fips_dualstack": "s3-accesspoint-fips.dualstack.<region>.<endpoint-host>",
+          "ipv4": "s3-accesspoint.<region>.<endpoint-host>"
+        },
+        "Name": "<name:4>",
+        "NetworkOrigin": "Internet",
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-access-points": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+            "Alias": "<name:2>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:2>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+            "Alias": "<name:3>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:3>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:4>",
+            "Alias": "<name:4>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:4>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:5>",
+            "Alias": "<name:5>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:2>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:5>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_pagination": {
+    "recorded-date": "30-05-2024, 17:42:07",
+    "recorded-content": {
+      "create-access-point-0": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+        "Alias": "<name:2>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-access-point-1": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+        "Alias": "<name:1>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-access-point-2": {
+        "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+        "Alias": "<name:3>-<alias-random-part>-s3alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-all": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+            "Alias": "<name:2>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:2>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+            "Alias": "<name:3>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:2>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:3>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:4>",
+            "Alias": "<name:4>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:3>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:4>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-one-max": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "NextToken": "<next-token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-one-next": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+            "Alias": "<name:2>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:2>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "NextToken": "<next-token:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-one-next-2": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:3>",
+            "Alias": "<name:3>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:2>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:3>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "NextToken": "<next-token:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-by-bucket": {
+        "AccessPointList": [
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:1>",
+            "Alias": "<name:1>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:1>",
+            "NetworkOrigin": "Internet"
+          },
+          {
+            "AccessPointArn": "arn:aws:s3:<region>:111111111111:accesspoint/<name:2>",
+            "Alias": "<name:2>-<alias-random-part>-s3alias",
+            "Bucket": "<bucket:1>",
+            "BucketAccountId": "111111111111",
+            "Name": "<name:2>",
+            "NetworkOrigin": "Internet"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/s3control/test_s3control.validation.json
+++ b/tests/aws/services/s3control/test_s3control.validation.json
@@ -1,0 +1,29 @@
+{
+  "tests/aws/services/s3control/test_s3control.py::TestLegacyS3Control::test_lifecycle_public_access_block": {
+    "last_validated_date": "2024-05-30T17:31:18+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_already_exists": {
+    "last_validated_date": "2024-05-30T17:38:05+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_bucket_not_exists": {
+    "last_validated_date": "2024-05-30T17:37:59+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_lifecycle": {
+    "last_validated_date": "2024-05-30T17:37:58+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_name_validation": {
+    "last_validated_date": "2024-05-30T17:38:03+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_pagination": {
+    "last_validated_date": "2024-05-30T17:42:06+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlAccessPoint::test_access_point_public_access_block_configuration": {
+    "last_validated_date": "2024-05-30T17:38:08+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlPublicAccessBlock::test_crud_public_access_block": {
+    "last_validated_date": "2024-05-30T17:32:58+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlPublicAccessBlock::test_empty_public_access_block": {
+    "last_validated_date": "2024-05-30T17:32:59+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of the S3 Control provider migration, I had started to add more tests with #9730.
Sadly, I didn't have the time to fully go through with the migration, and we didn't get a request yet for it. I'll focus more on it if we have then, it only needs a bit more work which should be fine (+ integration with S3 itself). 

But as part of validating and removing `aws.unknown` test markers, I'm already cherry picking the tests.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- validate existing tests for S3 Control
- add more tests regarding S3 Control resources, but those are skipped for now as we don't implement the logic yet

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
