### PR TITLE
fix postgress install in ci

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -232,7 +232,7 @@ jobs:
           sudo apt-get update
           # libvirt-dev is required by the libvirt-python Python package
           # postgresql-14 pin is required to make explicit install of the version from the Ubuntu repos and not PGDG repos
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.11-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.12-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
       - name: Cache Ext Dependencies (venv)
         if: inputs.disableCaching != true
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A new [security patch](https://packages.ubuntu.com/search?keywords=postgresql-14) was release for postgresql-14. `14.11-0ubuntu0*` is no longer available and we should use the latest `14.12-0ubuntu0*` instead. 

Currently broken [Community Integration Tests against Pro](https://github.com/localstack/localstack/actions/runs/9306747645/job/25616582221#logs)

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This is a quick fix. We should probably consider an approach that would not break the build when security patches are released.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
