### PR TITLE
remove unknown markers from S3 tests 

### DIFF
--- a/localstack-core/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack-core/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -448,10 +448,11 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
             s3_client.put_bucket_notification_configuration(**put_config)
 
         if version_conf := model.get("VersioningConfiguration"):
+            # from the documentation, it seems we `Status` is a required parameter
             s3_client.put_bucket_versioning(
                 Bucket=model["BucketName"],
                 VersioningConfiguration={
-                    "Status": version_conf.get("Status", "Disabled"),
+                    "Status": version_conf.get("Status", "Suspended"),
                 },
             )
 

--- a/localstack-core/localstack/services/s3/resource_providers/aws_s3_bucket.py
+++ b/localstack-core/localstack/services/s3/resource_providers/aws_s3_bucket.py
@@ -448,7 +448,7 @@ class S3BucketProvider(ResourceProvider[S3BucketProperties]):
             s3_client.put_bucket_notification_configuration(**put_config)
 
         if version_conf := model.get("VersioningConfiguration"):
-            # from the documentation, it seems we `Status` is a required parameter
+            # from the documentation, it seems that `Status` is a required parameter
             s3_client.put_bucket_versioning(
                 Bucket=model["BucketName"],
                 VersioningConfiguration={

--- a/tests/aws/services/cloudformation/resources/test_s3.py
+++ b/tests/aws/services/cloudformation/resources/test_s3.py
@@ -35,8 +35,6 @@ def test_bucketpolicy(deploy_cfn_template, aws_client, snapshot):
         aws_client.s3.get_bucket_policy(Bucket=bucket_name)
     snapshot.match("no-policy", err.value.response)
 
-    # assert err.value.response["Error"]["Code"] == "NoSuchBucketPolicy"
-
 
 @markers.aws.validated
 def test_bucket_autoname(deploy_cfn_template, aws_client):

--- a/tests/aws/services/cloudformation/resources/test_s3.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_s3.snapshot.json
@@ -101,5 +101,44 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_s3.py::test_bucketpolicy": {
+    "recorded-date": "31-05-2024, 13:41:44",
+    "recorded-content": {
+      "bucket": {
+        "BucketName": "<bucket-name:1>"
+      },
+      "get-policy-true": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Action": [
+              "s3:GetObject*",
+              "s3:GetBucket*",
+              "s3:List*"
+            ],
+            "Resource": [
+              "arn:aws:s3:::<bucket-name:1>",
+              "arn:aws:s3:::<bucket-name:1>/*"
+            ]
+          }
+        ]
+      },
+      "no-policy": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucketPolicy",
+          "Message": "The bucket policy does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_s3.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_s3.validation.json
@@ -1,4 +1,10 @@
 {
+  "tests/aws/services/cloudformation/resources/test_s3.py::test_bucket_versioning": {
+    "last_validated_date": "2024-05-31T13:44:37+00:00"
+  },
+  "tests/aws/services/cloudformation/resources/test_s3.py::test_bucketpolicy": {
+    "last_validated_date": "2024-05-31T13:41:44+00:00"
+  },
   "tests/aws/services/cloudformation/resources/test_s3.py::test_cors_configuration": {
     "last_validated_date": "2023-04-20T18:17:17+00:00"
   },

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -6003,7 +6003,7 @@ class TestS3MultiAccounts:
         """
         return secondary_aws_client.s3
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_shared_bucket_namespace(self, primary_client, secondary_client, cleanups):
         bucket_name = short_uid()
 
@@ -6015,7 +6015,7 @@ class TestS3MultiAccounts:
             create_s3_bucket(bucket_name=bucket_name, s3_client=secondary_client)
         exc.match("BucketAlreadyExists")
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_cross_account_access(
         self, primary_client, secondary_client, cleanups, s3_empty_bucket
     ):
@@ -6056,7 +6056,7 @@ class TestS3MultiAccounts:
         response = primary_client.get_object(Bucket=bucket_name, Key=key_name)
         assert response["Body"].read() == body2
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_cross_account_copy_object(
         self, primary_client, secondary_client, cleanups, s3_empty_bucket
     ):

--- a/tests/aws/templates/s3_bucketpolicy.yaml
+++ b/tests/aws/templates/s3_bucketpolicy.yaml
@@ -6,6 +6,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref BucketName
+      PublicAccessBlockConfiguration:
+        BlockPublicPolicy: False
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
   {% if include_policy %}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is a part of removing `unknown` test markers.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
The only `unknown` markers were on the cross account tests. As those are simplified tests with no IAM permissions, verifying that we can access cross-account resources, those might be marked `only_localstack` for now.
It could also be considered `needs_fixing`, but I think we could move those tests as part of the IAM tests for cross buckets access? 
Also, I believe you would need a set of 2 AWS accounts to validate it, making use of the secondary account fixture, which not many people have? 

I've tried to look around what already existed for other services, and some are `only_localstack`, some `validated` and some `unknown`. Maybe @viren-nadkarni can chime in for how those tests should be considered? 


I've also taken the opportunity to validate the CloudFormation tests related to S3:
- `tests.aws.services.cloudformation.resources.test_s3.test_bucketpolicy`
- `tests.aws.services.cloudformation.resources.test_s3.test_bucket_versioning`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
