### PR TITLE
fix header list parsing in ASF

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -236,7 +236,9 @@ class RequestParser(abc.ABC):
                 if payload and shape.type_name == "list":
                     # headers may contain a comma separated list of values (e.g., the ObjectAttributes member in
                     # s3.GetObjectAttributes), so we prepare it here for the handler, which will be `_parse_list`.
-                    payload = payload.split(",")
+                    # Header lists can contain optional whitespace, so we strip it
+                    # https://www.rfc-editor.org/rfc/rfc9110.html#name-lists-rule-abnf-extension
+                    payload = [value.strip() for value in payload.split(",")]
             elif location == "headers":
                 payload = self._parse_header_map(shape, request.headers)
                 # shapes with the location trait "headers" only contain strings and are not further processed

--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -1453,6 +1453,7 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         "GetObjectLockConfigurationOutput": "ObjectLockConfiguration",
         "GetObjectRetentionOutput": "Retention",
         "GetObjectTaggingOutput": "Tagging",
+        "GetObjectAttributesOutput": "GetObjectAttributesResponse",
         "GetPublicAccessBlockOutput": "PublicAccessBlockConfiguration",
         "ListBucketAnalyticsConfigurationsOutput": "ListBucketAnalyticsConfigurationResult",
         "ListBucketInventoryConfigurationsOutput": "ListInventoryConfigurationsResult",

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -11908,5 +11908,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes_with_space": {
+    "recorded-date": "31-05-2024, 12:44:23",
+    "recorded-content": {
+      "get-attrs-with-whitespace": {
+        "GetObjectAttributesResponse": {
+          "@xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+          "Checksum": {
+            "ChecksumSHA256": "2dhlzFTsYGePGxGQhK15rn+TV9HEUZxkV94zFLf7uoo="
+          },
+          "ETag": "70b68ae721a61941a1a62724dde5d5e4",
+          "ObjectSize": "9",
+          "StorageClass": "STANDARD"
+        }
+      },
+      "get-attrs-without-whitespace": {
+        "GetObjectAttributesResponse": {
+          "@xmlns": "http://s3.amazonaws.com/doc/2006-03-01/",
+          "Checksum": {
+            "ChecksumSHA256": "2dhlzFTsYGePGxGQhK15rn+TV9HEUZxkV94zFLf7uoo="
+          },
+          "ETag": "70b68ae721a61941a1a62724dde5d5e4",
+          "ObjectSize": "9",
+          "StorageClass": "STANDARD"
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -86,6 +86,9 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes_versioned": {
     "last_validated_date": "2023-08-03T02:14:03+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_attributes_with_space": {
+    "last_validated_date": "2024-05-31T12:44:23+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_get_object_content_length_with_virtual_host[False]": {
     "last_validated_date": "2023-08-07T17:56:13+00:00"
   },

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1171,6 +1171,48 @@ def test_s3_list_buckets_with_localhost():
     assert parsed_operation_model.name == "ListBuckets"
 
 
+def test_s3_get_object_attributes_with_whitespace():
+    # optional whitespace is accepted for ObjectAttributesList, a list of strings with location:"header"
+    request = HttpRequest(
+        "GET",
+        "/bucket/key?attributes",
+        query_string="attributes",
+        headers={
+            "x-amz-object-attributes": "ETag, Checksum, ObjectParts, StorageClass, ObjectSize",
+        },
+    )
+    parser = create_parser(load_service("s3"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "GetObjectAttributes"
+    assert parsed_request["ObjectAttributes"] == [
+        "ETag",
+        "Checksum",
+        "ObjectParts",
+        "StorageClass",
+        "ObjectSize",
+    ]
+
+    # assert that with no whitespace, it is identical
+    request = HttpRequest(
+        "GET",
+        "/bucket/key",
+        query_string="attributes",
+        headers={
+            "x-amz-object-attributes": "ETag,Checksum,ObjectParts,StorageClass,ObjectSize",
+        },
+    )
+    parser = create_parser(load_service("s3"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "GetObjectAttributes"
+    assert parsed_request["ObjectAttributes"] == [
+        "ETag",
+        "Checksum",
+        "ObjectParts",
+        "StorageClass",
+        "ObjectSize",
+    ]
+
+
 def test_s3_list_buckets_with_localhost_and_port():
     # this is the canonical request of `awslocal s3 ls`
     request = HttpRequest("GET", "/", headers={"host": "localhost:4566"})


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #10925, we've had an issue parsing header list for the `GetObjectAttributes` S3 operation, following some updates in the Ruby SDK. The reporter also opened an issue in the ruby SDK repo, where they linked the RFC regarding header list and that optional whitespace is indeed accepted. 
RFC: https://www.rfc-editor.org/rfc/rfc9110.html#name-lists-rule-abnf-extension

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- create an AWS validated test to validate the change
- add test for the parser
- add the fix in the parser: stripping the whitespace of header list values

_fixes #10925_
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
