### PR TITLE
validate unknown dynamodb streams test and update behavior

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -1418,26 +1418,37 @@ class TestDynamoDB:
         retry(lambda: _get_records_amount(4), sleep=1, retries=3)
         snapshot.match("get-records", {"Records": records})
 
-    @pytest.mark.xfail(reason="this test flakes regularly in CI")
-    @markers.aws.unknown
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=[
+            "$..SizeBytes",
+            "$..ProvisionedThroughput.NumberOfDecreasesToday",
+            "$..StreamDescription.CreationRequestDateTime",
+        ]
+    )
     def test_dynamodb_stream_records_with_update_item(
-        self, dynamodb_create_table, wait_for_stream_ready, aws_client
+        self,
+        aws_client,
+        dynamodb_create_table_with_parameters,
+        wait_for_dynamodb_stream_ready,
+        snapshot,
+        dynamodbstreams_snapshot_transformers,
     ):
         table_name = f"test-ddb-table-{short_uid()}"
 
-        dynamodb_create_table(
-            table_name=table_name,
-            partition_key=PARTITION_KEY,
-            stream_view_type="NEW_AND_OLD_IMAGES",
+        create_table = dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": PARTITION_KEY, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": PARTITION_KEY, "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"},
         )
-        table = aws_client.dynamodb.describe_table(TableName=table_name)
-        stream_name = get_kinesis_stream_name(table_name)
+        snapshot.match("create-table", create_table)
+        stream_arn = create_table["TableDescription"]["LatestStreamArn"]
+        wait_for_dynamodb_stream_ready(stream_arn=stream_arn)
 
-        wait_for_stream_ready(stream_name)
-
-        response = aws_client.dynamodbstreams.describe_stream(StreamArn=table["LatestStreamArn"])
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert len(response["StreamDescription"]["Shards"]) == 1
+        response = aws_client.dynamodbstreams.describe_stream(StreamArn=stream_arn)
+        snapshot.match("describe-stream", response)
         shard_id = response["StreamDescription"]["Shards"][0]["ShardId"]
         starting_sequence_number = int(
             response["StreamDescription"]["Shards"][0]
@@ -1446,15 +1457,17 @@ class TestDynamoDB:
         )
 
         response = aws_client.dynamodbstreams.get_shard_iterator(
-            StreamArn=table["LatestStreamArn"],
+            StreamArn=stream_arn,
             ShardId=shard_id,
             ShardIteratorType="LATEST",
         )
+        snapshot.match("get-shard-iterator", response)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         assert "ShardIterator" in response
-        iterator_id = response["ShardIterator"]
+        shard_iterator = response["ShardIterator"]
 
-        item_id = short_uid()
+        item_id = "my-item-id"
+        # assert that when we insert/update the record with the same value, no event is sent
         for _ in range(2):
             aws_client.dynamodb.update_item(
                 TableName=table_name,
@@ -1464,38 +1477,57 @@ class TestDynamoDB:
                     ":v1": {"S": "value1"},
                     ":v2": {"S": "value2"},
                 },
-                ReturnValues="ALL_NEW",
-                ReturnConsumedCapacity="INDEXES",
             )
 
-        def check_expected_records():
-            records = aws_client.dynamodbstreams.get_records(ShardIterator=iterator_id)
-            assert records["ResponseMetadata"]["HTTPStatusCode"] == 200
-            assert len(records["Records"]) == 2
-            assert isinstance(
-                records["Records"][0]["dynamodb"]["ApproximateCreationDateTime"],
-                datetime,
-            )
-            assert records["Records"][0]["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
-            assert records["Records"][0]["eventVersion"] == "1.1"
-            assert records["Records"][0]["eventName"] == "INSERT"
-            assert "OldImage" not in records["Records"][0]["dynamodb"]
-            assert (
-                int(records["Records"][0]["dynamodb"]["SequenceNumber"]) > starting_sequence_number
-            )
-            assert isinstance(
-                records["Records"][1]["dynamodb"]["ApproximateCreationDateTime"],
-                datetime,
-            )
-            assert records["Records"][1]["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
-            assert records["Records"][1]["eventVersion"] == "1.1"
-            assert records["Records"][1]["eventName"] == "MODIFY"
-            assert "OldImage" in records["Records"][1]["dynamodb"]
-            assert (
-                int(records["Records"][1]["dynamodb"]["SequenceNumber"]) > starting_sequence_number
-            )
+        aws_client.dynamodb.update_item(
+            TableName=table_name,
+            Key={PARTITION_KEY: {"S": item_id}},
+            UpdateExpression="SET attr1 = :v1, attr2 = :v2",
+            ExpressionAttributeValues={
+                ":v1": {"S": "value2"},
+                ":v2": {"S": "value3"},
+            },
+        )
+        records = []
 
-        retry(check_expected_records, retries=5, sleep=1, sleep_before=2)
+        def _get_records_amount(record_amount: int):
+            nonlocal shard_iterator
+            if len(records) < record_amount:
+                _resp = aws_client.dynamodbstreams.get_records(ShardIterator=shard_iterator)
+                records.extend(_resp["Records"])
+                if next_shard_iterator := _resp.get("NextShardIterator"):
+                    shard_iterator = next_shard_iterator
+
+            assert len(records) >= record_amount
+
+        retry(lambda: _get_records_amount(2), sleep=1, retries=3)
+        snapshot.match("get-records", {"Records": records})
+
+        assert len(records) == 2
+        event_insert, event_update = records
+        assert isinstance(
+            event_insert["dynamodb"]["ApproximateCreationDateTime"],
+            datetime,
+        )
+        assert event_insert["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
+        assert event_insert["eventVersion"] == "1.1"
+        assert event_insert["eventName"] == "INSERT"
+        assert "OldImage" not in event_insert["dynamodb"]
+        insert_seq_number = int(event_insert["dynamodb"]["SequenceNumber"])
+        # TODO: maybe fix sequence number, seems something related to Kinesis
+        if is_aws_cloud():
+            assert insert_seq_number > starting_sequence_number
+        else:
+            assert insert_seq_number >= starting_sequence_number
+        assert isinstance(
+            event_update["dynamodb"]["ApproximateCreationDateTime"],
+            datetime,
+        )
+        assert event_update["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
+        assert event_update["eventVersion"] == "1.1"
+        assert event_update["eventName"] == "MODIFY"
+        assert "OldImage" in event_update["dynamodb"]
+        assert int(event_update["dynamodb"]["SequenceNumber"]) > starting_sequence_number
 
     @markers.aws.only_localstack
     def test_query_on_deleted_resource(self, dynamodb_create_table, aws_client):

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -818,6 +818,9 @@ class TestDynamoDB:
 
         # put item in table - INSERT event
         dynamodb.put_item(TableName=table_name, Item={"Username": {"S": "Fred"}})
+        # put item again in table - no event as it is the same valur
+        dynamodb.put_item(TableName=table_name, Item={"Username": {"S": "Fred"}})
+
         # update item in table - MODIFY event
         dynamodb.update_item(
             TableName=table_name,

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -818,7 +818,7 @@ class TestDynamoDB:
 
         # put item in table - INSERT event
         dynamodb.put_item(TableName=table_name, Item={"Username": {"S": "Fred"}})
-        # put item again in table - no event as it is the same valur
+        # put item again in table - no event as it is the same value
         dynamodb.put_item(TableName=table_name, Item={"Username": {"S": "Fred"}})
 
         # update item in table - MODIFY event
@@ -1513,9 +1513,6 @@ class TestDynamoDB:
             datetime,
         )
         assert event_insert["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
-        assert event_insert["eventVersion"] == "1.1"
-        assert event_insert["eventName"] == "INSERT"
-        assert "OldImage" not in event_insert["dynamodb"]
         insert_seq_number = int(event_insert["dynamodb"]["SequenceNumber"])
         # TODO: maybe fix sequence number, seems something related to Kinesis
         if is_aws_cloud():
@@ -1527,9 +1524,6 @@ class TestDynamoDB:
             datetime,
         )
         assert event_update["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
-        assert event_update["eventVersion"] == "1.1"
-        assert event_update["eventName"] == "MODIFY"
-        assert "OldImage" in event_update["dynamodb"]
         assert int(event_update["dynamodb"]["SequenceNumber"]) > starting_sequence_number
 
     @markers.aws.only_localstack

--- a/tests/aws/services/dynamodb/test_dynamodb.py
+++ b/tests/aws/services/dynamodb/test_dynamodb.py
@@ -2128,6 +2128,16 @@ class TestDynamoDB:
                         "Item": {"id": {"S": "Fred"}, "name": {"S": "Fred"}},
                     }
                 },
+                {
+                    "Update": {
+                        "TableName": table_name,
+                        "Key": {"id": {"S": "NonExistentKey"}},
+                        "UpdateExpression": "SET attr1 = :v1",
+                        "ExpressionAttributeValues": {
+                            ":v1": {"S": "value1"},
+                        },
+                    }
+                },
             ]
         )
         snapshot.match("transact-write-response-delete", response)
@@ -2139,7 +2149,8 @@ class TestDynamoDB:
         # - TransactWriteItem on NonExistentKey insert
         # - TransactWriteItem on NewKey delete
         # - TransactWriteItem on Fred modify via Put
-        # don't send an event when Fred is overwritten with the same value
+        # don't send an event when Fred is overwritten with the same value with Put
+        # or when NonExistentKey is overwritte with Update
         # get all records:
         records = []
 

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1265,5 +1265,157 @@
         ]
       }
     }
+  },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
+    "recorded-date": "31-05-2024, 14:44:35",
+    "recorded-content": {
+      "create-table": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "DeletionProtectionEnabled": false,
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "LatestStreamLabel": "<latest-stream-label:1>",
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "StreamSpecification": {
+            "StreamEnabled": true,
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "<table-status:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-stream": {
+        "StreamDescription": {
+          "CreationRequestDateTime": "datetime",
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "Shards": [
+            {
+              "SequenceNumberRange": {
+                "StartingSequenceNumber": "starting-sequence-number"
+              },
+              "ShardId": "<shard-id:1>"
+            }
+          ],
+          "StreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>/stream/<latest-stream-label:1>",
+          "StreamLabel": "<latest-stream-label:1>",
+          "StreamStatus": "ENABLED",
+          "StreamViewType": "NEW_AND_OLD_IMAGES",
+          "TableName": "<table-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-shard-iterator": {
+        "ShardIterator": "<shard-iterator:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-records": {
+        "Records": [
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "my-item-id"
+                }
+              },
+              "NewImage": {
+                "attr1": {
+                  "S": "value1"
+                },
+                "attr2": {
+                  "S": "value2"
+                },
+                "id": {
+                  "S": "my-item-id"
+                }
+              },
+              "SequenceNumber": "<sequence-number:1>",
+              "SizeBytes": 46,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:1>",
+            "eventName": "INSERT",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          },
+          {
+            "awsRegion": "<region>",
+            "dynamodb": {
+              "ApproximateCreationDateTime": "datetime",
+              "Keys": {
+                "id": {
+                  "S": "my-item-id"
+                }
+              },
+              "NewImage": {
+                "attr1": {
+                  "S": "value2"
+                },
+                "attr2": {
+                  "S": "value3"
+                },
+                "id": {
+                  "S": "my-item-id"
+                }
+              },
+              "OldImage": {
+                "attr1": {
+                  "S": "value1"
+                },
+                "attr2": {
+                  "S": "value2"
+                },
+                "id": {
+                  "S": "my-item-id"
+                }
+              },
+              "SequenceNumber": "<sequence-number:2>",
+              "SizeBytes": 80,
+              "StreamViewType": "NEW_AND_OLD_IMAGES"
+            },
+            "eventID": "<event-i-d:2>",
+            "eventName": "MODIFY",
+            "eventSource": "aws:dynamodb",
+            "eventVersion": "1.1"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1267,7 +1267,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "recorded-date": "31-05-2024, 14:44:35",
+    "recorded-date": "06-06-2024, 09:08:30",
     "recorded-content": {
       "create-table": {
         "TableDescription": {

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -857,7 +857,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming": {
-    "recorded-date": "17-04-2024, 22:45:49",
+    "recorded-date": "31-05-2024, 14:47:04",
     "recorded-content": {
       "create-table": {
         "TableDescription": {

--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -640,7 +640,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
-    "recorded-date": "22-10-2023, 23:22:27",
+    "recorded-date": "31-05-2024, 14:49:57",
     "recorded-content": {
       "create-table": {
         "TableDescription": {

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -66,7 +66,7 @@
     "last_validated_date": "2023-08-23T14:33:37+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming": {
-    "last_validated_date": "2024-04-17T22:45:49+00:00"
+    "last_validated_date": "2024-05-31T14:47:04+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_transact_write_items_streaming_for_different_tables": {
     "last_validated_date": "2024-04-02T21:45:36+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2023-08-23T14:33:43+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "last_validated_date": "2024-05-31T14:44:35+00:00"
+    "last_validated_date": "2024-06-06T09:08:30+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
     "last_validated_date": "2024-05-31T14:49:56+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -48,7 +48,7 @@
     "last_validated_date": "2024-05-31T14:44:35+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
-    "last_validated_date": "2023-10-22T21:22:27+00:00"
+    "last_validated_date": "2024-05-31T14:49:56+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_streams_describe_with_exclusive_start_shard_id": {
     "last_validated_date": "2023-10-22T20:27:28+00:00"

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -44,6 +44,9 @@
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_pay_per_request": {
     "last_validated_date": "2023-08-23T14:33:43+00:00"
   },
+  "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
+    "last_validated_date": "2024-05-31T14:44:35+00:00"
+  },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
     "last_validated_date": "2023-10-22T21:22:27+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
`test_dynamodb_stream_records_with_update_item` still had the `unknown` marker. 
While AWS validating it, it showed that our implementation was not right: we would send an event if the update operation was not actually updating the record. So I quickly fixed it and add some validations in the test for this use-case.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- validated `test_dynamodb_stream_records_with_update_item`
- changed the logic in `update_item`, `put_item` and `transact_write_items` to not send events if the update operation did not actually update the record
- updated two test for `put_item` and `transact_write_items` validation of behavior 


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
