### PR TITLE
CFn: add simple template validations

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -39,6 +39,42 @@ def outputs_have_values(template: dict):
             raise ValidationError(f"[{key}] 'null' values are not allowed in templates")
 
 
+def resources_top_level_keys(template: dict):
+    """
+    Validate that each resource
+    - there is a resources key
+    - includes the `Properties` key
+    - does not include any other keys that should not be there
+    """
+    resources = template.get("Resources")
+    if resources is None:
+        raise ValidationError(
+            "Template format error: At least one Resources member must be defined."
+        )
+
+    allowed_keys = {
+        "Type",
+        "Properties",
+        "DependsOn",
+        "CreationPolicy",
+        "DeletionPolicy",
+        "Metadata",
+        "UpdatePolicy",
+        "UpdateReplacePolicy",
+    }
+    for resource_id, resource in resources.items():
+        if "Type" not in resource:
+            raise ValidationError(
+                f"Template format error: [/Resources/{resource_id}] Every Resources object must contain a Type member."
+            )
+
+        # check for invalid keys
+        for key in resource:
+            if key not in allowed_keys:
+                raise ValidationError(f"Invalid template resource property '{key}'")
+
+
 DEFAULT_TEMPLATE_VALIDATIONS: list[TemplateValidationStep] = [
     outputs_have_values,
+    resources_top_level_keys,
 ]

--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -1,0 +1,44 @@
+"""
+Provide validations for use within the CFn engine
+"""
+
+from typing import Protocol
+
+from localstack.aws.api import CommonServiceException
+
+
+class ValidationError(CommonServiceException):
+    """General validation error type (defined in the AWS docs, but not part of the botocore spec)"""
+
+    def __init__(self, message=None):
+        super().__init__("ValidationError", message=message, sender_fault=True)
+
+
+class TemplateValidationStep(Protocol):
+    """
+    Base class for static analysis of the template
+    """
+
+    def __call__(self, template: dict):
+        """
+        Execute a specific validation on the template
+        """
+
+
+def outputs_have_values(template: dict):
+    outputs: dict[str, dict] = template.get("Outputs", {})
+
+    for output_name, output_defn in outputs.items():
+        if "Value" not in output_defn:
+            raise ValidationError(
+                "Template format error: Every Outputs member must contain a Value object"
+            )
+
+        if output_defn["Value"] is None:
+            key = f"/Outputs/{output_name}/Value"
+            raise ValidationError(f"[{key}] 'null' values are not allowed in templates")
+
+
+DEFAULT_TEMPLATE_VALIDATIONS: list[TemplateValidationStep] = [
+    outputs_have_values,
+]

--- a/localstack-core/localstack/services/cloudformation/engine/validations.py
+++ b/localstack-core/localstack/services/cloudformation/engine/validations.py
@@ -61,6 +61,7 @@ def resources_top_level_keys(template: dict):
         "Metadata",
         "UpdatePolicy",
         "UpdateReplacePolicy",
+        "Condition",
     }
     for resource_id, resource in resources.items():
         if "Type" not in resource:

--- a/localstack-core/localstack/services/cloudformation/resource_providers/aws_cloudformation_stack.py
+++ b/localstack-core/localstack/services/cloudformation/resource_providers/aws_cloudformation_stack.py
@@ -104,9 +104,12 @@ class CloudFormationStackProvider(ResourceProvider[CloudFormationStackProperties
         stack = request.aws_client_factory.cloudformation.describe_stacks(StackName=model["Id"])[
             "Stacks"
         ][0]
-        model["Outputs"] = {o["OutputKey"]: o["OutputValue"] for o in stack.get("Outputs", [])}
         match stack["StackStatus"]:
             case "CREATE_COMPLETE":
+                # only store nested stack outputs when we know the deploy has completed
+                model["Outputs"] = {
+                    o["OutputKey"]: o["OutputValue"] for o in stack.get("Outputs", [])
+                }
                 return ProgressEvent(
                     status=OperationStatus.SUCCESS,
                     resource_model=model,

--- a/tests/aws/services/cloudformation/api/test_validations.py
+++ b/tests/aws/services/cloudformation/api/test_validations.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+
+from localstack.testing.pytest import markers
+
+
+@markers.aws.validated
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        {
+            "MyOutput": {
+                "Value": None,
+            },
+        },
+        {
+            "MyOutput": {
+                "Value": None,
+                "AnotherValue": None,
+            },
+        },
+        {
+            "MyOutput": {},
+        },
+    ],
+    ids=["none-value", "missing-def", "multiple-nones"],
+)
+def test_validations_for_invalid_output_structure(
+    deploy_cfn_template, snapshot, aws_client, outputs
+):
+    template = {
+        "Resources": {
+            "Foo": {
+                "Type": "AWS::SNS::Topic",
+            },
+        },
+        "Outputs": outputs,
+    }
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        deploy_cfn_template(template=json.dumps(template))
+
+    snapshot.match("validation-error", e.value.response)

--- a/tests/aws/services/cloudformation/api/test_validations.py
+++ b/tests/aws/services/cloudformation/api/test_validations.py
@@ -26,9 +26,7 @@ from localstack.testing.pytest import markers
     ],
     ids=["none-value", "missing-def", "multiple-nones"],
 )
-def test_validations_for_invalid_output_structure(
-    deploy_cfn_template, snapshot, aws_client, outputs
-):
+def test_invalid_output_structure(deploy_cfn_template, snapshot, aws_client, outputs):
     template = {
         "Resources": {
             "Foo": {
@@ -37,6 +35,39 @@ def test_validations_for_invalid_output_structure(
         },
         "Outputs": outputs,
     }
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        deploy_cfn_template(template=json.dumps(template))
+
+    snapshot.match("validation-error", e.value.response)
+
+
+@markers.aws.validated
+def test_missing_resources_block(deploy_cfn_template, snapshot, aws_client):
+    with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
+        deploy_cfn_template(template=json.dumps({}))
+
+    snapshot.match("validation-error", e.value.response)
+
+
+@markers.aws.validated
+@pytest.mark.parametrize(
+    "properties",
+    [
+        {
+            "Properties": {},
+        },
+        {
+            "Type": "AWS::SNS::Topic",
+            "Invalid": 10,
+        },
+    ],
+    ids=[
+        "missing-type",
+        "invalid-key",
+    ],
+)
+def test_resources_blocks(deploy_cfn_template, snapshot, aws_client, properties):
+    template = {"Resources": {"A": properties}}
     with pytest.raises(aws_client.cloudformation.exceptions.ClientError) as e:
         deploy_cfn_template(template=json.dumps(template))
 

--- a/tests/aws/services/cloudformation/api/test_validations.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_validations.snapshot.json
@@ -46,5 +46,133 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[template0]": {
+    "recorded-date": "31-05-2024, 14:40:20",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: At least one Resources member must be defined.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[none-value]": {
+    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[missing-def]": {
+    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[multiple-nones]": {
+    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Every Outputs member must contain a Value object",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_missing_resources_block": {
+    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: At least one Resources member must be defined.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[resources0]": {
+    "recorded-date": "31-05-2024, 14:43:23",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Invalid template resource property 'Invalid'",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[missing-type]": {
+    "recorded-date": "31-05-2024, 14:48:08",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: [/Resources/A] Every Resources object must contain a Type member.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[invalid-key]": {
+    "recorded-date": "31-05-2024, 14:48:08",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Invalid template resource property 'Invalid'",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_validations.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_validations.snapshot.json
@@ -1,70 +1,6 @@
 {
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[none-value]": {
-    "recorded-date": "31-05-2024, 14:35:21",
-    "recorded-content": {
-      "validation-error": {
-        "Error": {
-          "Code": "ValidationError",
-          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[missing-def]": {
-    "recorded-date": "31-05-2024, 14:35:21",
-    "recorded-content": {
-      "validation-error": {
-        "Error": {
-          "Code": "ValidationError",
-          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[multiple-nones]": {
-    "recorded-date": "31-05-2024, 14:35:22",
-    "recorded-content": {
-      "validation-error": {
-        "Error": {
-          "Code": "ValidationError",
-          "Message": "Template format error: Every Outputs member must contain a Value object",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[template0]": {
-    "recorded-date": "31-05-2024, 14:40:20",
-    "recorded-content": {
-      "validation-error": {
-        "Error": {
-          "Code": "ValidationError",
-          "Message": "Template format error: At least one Resources member must be defined.",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[none-value]": {
-    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-date": "31-05-2024, 14:53:31",
     "recorded-content": {
       "validation-error": {
         "Error": {
@@ -80,7 +16,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[missing-def]": {
-    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-date": "31-05-2024, 14:53:31",
     "recorded-content": {
       "validation-error": {
         "Error": {
@@ -96,7 +32,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[multiple-nones]": {
-    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-date": "31-05-2024, 14:53:31",
     "recorded-content": {
       "validation-error": {
         "Error": {
@@ -112,7 +48,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_missing_resources_block": {
-    "recorded-date": "31-05-2024, 14:48:07",
+    "recorded-date": "31-05-2024, 14:53:31",
     "recorded-content": {
       "validation-error": {
         "Error": {
@@ -127,24 +63,8 @@
       }
     }
   },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[resources0]": {
-    "recorded-date": "31-05-2024, 14:43:23",
-    "recorded-content": {
-      "validation-error": {
-        "Error": {
-          "Code": "ValidationError",
-          "Message": "Invalid template resource property 'Invalid'",
-          "Type": "Sender"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
   "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[missing-type]": {
-    "recorded-date": "31-05-2024, 14:48:08",
+    "recorded-date": "31-05-2024, 14:53:32",
     "recorded-content": {
       "validation-error": {
         "Error": {
@@ -160,7 +80,7 @@
     }
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[invalid-key]": {
-    "recorded-date": "31-05-2024, 14:48:08",
+    "recorded-date": "31-05-2024, 14:53:32",
     "recorded-content": {
       "validation-error": {
         "Error": {

--- a/tests/aws/services/cloudformation/api/test_validations.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_validations.snapshot.json
@@ -1,0 +1,50 @@
+{
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[none-value]": {
+    "recorded-date": "31-05-2024, 14:35:21",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[missing-def]": {
+    "recorded-date": "31-05-2024, 14:35:21",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "[/Outputs/MyOutput/Value] 'null' values are not allowed in templates",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[multiple-nones]": {
+    "recorded-date": "31-05-2024, 14:35:22",
+    "recorded-content": {
+      "validation-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Every Outputs member must contain a Value object",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/api/test_validations.validation.json
+++ b/tests/aws/services/cloudformation/api/test_validations.validation.json
@@ -1,35 +1,20 @@
 {
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[missing-def]": {
-    "last_validated_date": "2024-05-31T14:48:07+00:00"
+    "last_validated_date": "2024-05-31T14:53:31+00:00"
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[multiple-nones]": {
-    "last_validated_date": "2024-05-31T14:48:07+00:00"
+    "last_validated_date": "2024-05-31T14:53:31+00:00"
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[none-value]": {
-    "last_validated_date": "2024-05-31T14:48:07+00:00"
+    "last_validated_date": "2024-05-31T14:53:31+00:00"
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_missing_resources_block": {
-    "last_validated_date": "2024-05-31T14:48:07+00:00"
+    "last_validated_date": "2024-05-31T14:53:31+00:00"
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[invalid-key]": {
-    "last_validated_date": "2024-05-31T14:48:08+00:00"
+    "last_validated_date": "2024-05-31T14:53:32+00:00"
   },
   "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[missing-type]": {
-    "last_validated_date": "2024-05-31T14:48:08+00:00"
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[resources0]": {
-    "last_validated_date": "2024-05-31T14:43:23+00:00"
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[template0]": {
-    "last_validated_date": "2024-05-31T14:40:20+00:00"
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[missing-def]": {
-    "last_validated_date": "2024-05-31T14:35:21+00:00"
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[multiple-nones]": {
-    "last_validated_date": "2024-05-31T14:35:22+00:00"
-  },
-  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[none-value]": {
-    "last_validated_date": "2024-05-31T14:35:21+00:00"
+    "last_validated_date": "2024-05-31T14:53:32+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/api/test_validations.validation.json
+++ b/tests/aws/services/cloudformation/api/test_validations.validation.json
@@ -1,4 +1,28 @@
 {
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[missing-def]": {
+    "last_validated_date": "2024-05-31T14:48:07+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[multiple-nones]": {
+    "last_validated_date": "2024-05-31T14:48:07+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_invalid_output_structure[none-value]": {
+    "last_validated_date": "2024-05-31T14:48:07+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_missing_resources_block": {
+    "last_validated_date": "2024-05-31T14:48:07+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[invalid-key]": {
+    "last_validated_date": "2024-05-31T14:48:08+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[missing-type]": {
+    "last_validated_date": "2024-05-31T14:48:08+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[resources0]": {
+    "last_validated_date": "2024-05-31T14:43:23+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_resources_blocks[template0]": {
+    "last_validated_date": "2024-05-31T14:40:20+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[missing-def]": {
     "last_validated_date": "2024-05-31T14:35:21+00:00"
   },

--- a/tests/aws/services/cloudformation/api/test_validations.validation.json
+++ b/tests/aws/services/cloudformation/api/test_validations.validation.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[missing-def]": {
+    "last_validated_date": "2024-05-31T14:35:21+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[multiple-nones]": {
+    "last_validated_date": "2024-05-31T14:35:22+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_validations.py::test_validations_for_invalid_output_structure[none-value]": {
+    "last_validated_date": "2024-05-31T14:35:21+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We currently allow templates that are not allowed on AWS. For example, extra top level fields for resources, or outputs without a `Value` field.

Users deploying these get a false sense of security when deploying CFn stacks. To make LocalStack more useful to users of CloudFormation, we should repliate AWS behaviour and perform template validations.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add new `validations` submodule to the CloudFormation service
* Define a "static" template validation type, which is performed on the template only
* Implement two checks
    * that the resources blocks are well formed
    * that the outputs all have a `Value`, and that it is not statically known to be `null`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
