### PR TITLE
implement new runtime framework for bootstrapping localstack

### DIFF
--- a/localstack-core/localstack/aws/components.py
+++ b/localstack-core/localstack/aws/components.py
@@ -1,0 +1,22 @@
+from functools import cached_property
+
+from rolo.gateway import Gateway
+
+from localstack.aws.app import LocalstackAwsGateway
+from localstack.runtime.components import BaseComponents
+
+
+class AwsComponents(BaseComponents):
+    """
+    Runtime components specific to the AWS emulator.
+    """
+
+    name = "aws"
+
+    @cached_property
+    def gateway(self) -> Gateway:
+        # FIXME: the ServiceManager should be reworked to be more generic, and then become part of the
+        #  components
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        return LocalstackAwsGateway(SERVICE_PLUGINS)

--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -660,6 +660,9 @@ GATEWAY_WORKER_COUNT = int(os.environ.get("GATEWAY_WORKER_COUNT") or 1000)
 # the gateway server that should be used (supported: hypercorn, twisted dev: werkzeug)
 GATEWAY_SERVER = os.environ.get("GATEWAY_SERVER", "").strip() or "twisted"
 
+# whether to use the legacy runtime (``localstack.service.infra``)
+LEGACY_RUNTIME = is_env_true("LEGACY_RUNTIME")
+
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
 
@@ -1188,6 +1191,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_SQS_EVENT_SOURCE_MAPPING_INTERVAL",
     "LEGACY_DOCKER_CLIENT",
     "LEGACY_SNS_GCM_PUBLISHING",
+    "LEGACY_RUNTIME",
     "LOCALSTACK_API_KEY",
     "LOCALSTACK_AUTH_TOKEN",
     "LOCALSTACK_HOST",

--- a/localstack-core/localstack/runtime/__init__.py
+++ b/localstack-core/localstack/runtime/__init__.py
@@ -1,0 +1,5 @@
+from .current import get_current_runtime
+
+__all__ = [
+    "get_current_runtime",
+]

--- a/localstack-core/localstack/runtime/components.py
+++ b/localstack-core/localstack/runtime/components.py
@@ -1,0 +1,56 @@
+"""
+This package contains code to define and manage the core components that make up a ``LocalstackRuntime``.
+These include:
+  - A ``Gateway``
+  - A ``RuntimeServer`` as the main control loop
+  - A ``ServiceManager`` to manage service plugins (TODO: once the Service concept has been generalized)
+  - ... ?
+
+Components can then be accessed via ``get_current_runtime()``.
+"""
+
+from functools import cached_property
+
+from plux import Plugin, PluginManager
+from rolo.gateway import Gateway
+
+from .server.core import RuntimeServer, RuntimeServerPlugin
+
+
+class Components(Plugin):
+    """
+    A Plugin that allows a specific localstack runtime implementation (aws, snowflake, ...) to expose its
+    own component factory.
+    """
+
+    namespace = "localstack.runtime.components"
+
+    @cached_property
+    def gateway(self) -> Gateway:
+        raise NotImplementedError
+
+    @cached_property
+    def runtime_server(self) -> RuntimeServer:
+        raise NotImplementedError
+
+
+class BaseComponents(Components):
+    """
+    A component base, which includes a ``RuntimeServer`` created from the config variable, and a default
+    ServicePluginManager as ServiceManager.
+    """
+
+    @cached_property
+    def runtime_server(self) -> RuntimeServer:
+        from localstack import config
+
+        # TODO: rename to RUNTIME_SERVER
+        server_type = config.GATEWAY_SERVER
+
+        plugins = PluginManager(RuntimeServerPlugin.namespace)
+
+        if not plugins.exists(server_type):
+            raise ValueError(f"Unknown gateway server type {server_type}")
+
+        plugins.load(server_type)
+        return plugins.get_container(server_type).load_value

--- a/localstack-core/localstack/runtime/current.py
+++ b/localstack-core/localstack/runtime/current.py
@@ -1,0 +1,40 @@
+"""This package gives access to the singleton ``LocalstackRuntime`` instance. This is the only global state
+that should exist within localstack, which contains the singleton ``LocalstackRuntime`` which is currently
+running."""
+
+import threading
+import typing
+
+if typing.TYPE_CHECKING:
+    # make sure we don't have any imports here at runtime, so it can be imported anywhere without conflicts
+    from .runtime import LocalstackRuntime
+
+_runtime: typing.Optional["LocalstackRuntime"] = None
+"""The singleton LocalStack Runtime"""
+_runtime_lock = threading.RLock()
+
+
+def get_current_runtime() -> "LocalstackRuntime":
+    with _runtime_lock:
+        if not _runtime:
+            raise ValueError("LocalStack runtime has not yet been set")
+        return _runtime
+
+
+def set_current_runtime(runtime: "LocalstackRuntime"):
+    with _runtime_lock:
+        global _runtime
+        _runtime = runtime
+
+
+def initialize_runtime() -> "LocalstackRuntime":
+    from localstack.runtime import runtime
+
+    with _runtime_lock:
+        try:
+            return get_current_runtime()
+        except ValueError:
+            pass
+        rt = runtime.create_from_environment()
+        set_current_runtime(rt)
+        return rt

--- a/localstack-core/localstack/runtime/events.py
+++ b/localstack-core/localstack/runtime/events.py
@@ -1,5 +1,6 @@
 import threading
 
+# TODO: deprecate and replace access with ``get_current_runtime().starting``, ...
 infra_starting = threading.Event()
 infra_ready = threading.Event()
 infra_stopping = threading.Event()

--- a/localstack-core/localstack/runtime/hooks.py
+++ b/localstack-core/localstack/runtime/hooks.py
@@ -4,6 +4,7 @@ from plux import PluginManager, plugin
 
 # plugin namespace constants
 HOOKS_CONFIGURE_LOCALSTACK_CONTAINER = "localstack.hooks.configure_localstack_container"
+HOOKS_ON_RUNTIME_CREATE = "localstack.hooks.on_runtime_create"
 HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
 HOOKS_ON_PRO_INFRA_START = "localstack.hooks.on_pro_infra_start"
@@ -78,6 +79,10 @@ prepare_host = hook_spec(HOOKS_PREPARE_HOST)
 
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
 """Hooks that are executed right before starting the LocalStack infrastructure."""
+
+on_runtime_create = hook_spec(HOOKS_ON_RUNTIME_CREATE)
+"""Hooks that are executed right before the LocalstackRuntime is created. These can be used to apply
+patches or otherwise configure the interpreter before any other code is imported."""
 
 on_runtime_start = on_infra_start
 """Alias for on_infra_start. TODO: switch and deprecated `infra` naming."""

--- a/localstack-core/localstack/runtime/hooks.py
+++ b/localstack-core/localstack/runtime/hooks.py
@@ -79,6 +79,9 @@ prepare_host = hook_spec(HOOKS_PREPARE_HOST)
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
 """Hooks that are executed right before starting the LocalStack infrastructure."""
 
+on_runtime_start = on_infra_start
+"""Alias for on_infra_start. TODO: switch and deprecated `infra` naming."""
+
 on_pro_infra_start = hook_spec(HOOKS_ON_PRO_INFRA_START)
 """Hooks that are executed after on_infra_start hooks, and only if LocalStack pro has been activated."""
 
@@ -86,5 +89,11 @@ on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
 """Hooks that are execute after all startup hooks have been executed, and the LocalStack infrastructure has become
 available."""
 
+on_runtime_ready = on_infra_ready
+"""Alias for on_infra_ready. TODO: switch and deprecated `infra` naming."""
+
 on_infra_shutdown = hook_spec(HOOKS_ON_INFRA_SHUTDOWN)
 """Hooks that are execute when localstack shuts down."""
+
+on_runtime_shutdown = on_infra_shutdown
+"""Alias for on_infra_shutdown. TODO: switch and deprecated `infra` naming."""

--- a/localstack-core/localstack/runtime/legacy.py
+++ b/localstack-core/localstack/runtime/legacy.py
@@ -1,0 +1,40 @@
+"""Adapter code for the legacy runtime to make sure the new runtime is compatible with the old one,
+and at the same time doesn't need ``localstack.services.infra``, which imports AWS-specific modules."""
+
+import logging
+import os
+import signal
+import threading
+
+from localstack.runtime import events
+from localstack.utils import objects
+
+LOG = logging.getLogger(__name__)
+
+# event flag indicating the infrastructure has been started and that the ready marker has been printed
+# TODO: deprecated, use events.infra_ready
+INFRA_READY = events.infra_ready
+
+# event flag indicating that the infrastructure has been shut down
+SHUTDOWN_INFRA = threading.Event()
+
+# can be set
+EXIT_CODE: objects.Value[int] = objects.Value(0)
+
+
+def signal_supervisor_restart():
+    if pid := os.environ.get("SUPERVISOR_PID"):
+        os.kill(int(pid), signal.SIGUSR1)
+    else:
+        LOG.warning("could not signal supervisor to restart localstack")
+
+
+def exit_infra(code: int):
+    """
+    Triggers an orderly shutdown of the localstack infrastructure and sets the code the main process should
+    exit with to a specific value.
+
+    :param code: the exit code the main process should return with
+    """
+    EXIT_CODE.set(code)
+    SHUTDOWN_INFRA.set()

--- a/localstack-core/localstack/runtime/main.py
+++ b/localstack-core/localstack/runtime/main.py
@@ -4,10 +4,11 @@ manages the interaction with the operating system - mostly signal handlers for n
 import signal
 import sys
 
+from localstack import config
 from localstack.runtime.exceptions import LocalstackExit
 
 
-def main():
+def main_legacy():
     from localstack.services import infra
 
     # signal handler to make sure SIGTERM properly shuts down localstack
@@ -23,6 +24,56 @@ def main():
         sys.exit(e.code)
 
     sys.exit(infra.EXIT_CODE.get())
+
+
+def print_runtime_information():
+    # FIXME: refactor legacy code
+    from localstack.services.infra import print_runtime_information
+
+    print_runtime_information()
+
+
+def main_v2():
+    from localstack.logging.setup import setup_logging_from_config
+    from localstack.runtime import current
+
+    try:
+        setup_logging_from_config()
+        runtime = current.initialize_runtime()
+    except Exception as e:
+        sys.stdout.write(f"ERROR: The LocalStack Runtime could not be initialized: {e}\n")
+        sys.stdout.flush()
+        raise
+
+    # TODO: where should this go?
+    print_runtime_information()
+
+    # signal handler to make sure SIGTERM properly shuts down localstack
+    def _terminate_localstack(sig: int, frame):
+        sys.stdout.write(f"Localstack runtime received signal {sig}\n")
+        sys.stdout.flush()
+        runtime.exit(0)
+
+    signal.signal(signal.SIGINT, _terminate_localstack)
+    signal.signal(signal.SIGTERM, _terminate_localstack)
+
+    try:
+        runtime.run()
+    except LocalstackExit as e:
+        sys.exit(e.code)
+    except Exception as e:
+        sys.stdout.write(f"ERROR: the LocalStack runtime exited unexpectedly: {e}\n")
+        sys.stdout.flush()
+        raise
+
+    sys.exit(runtime.exit_code)
+
+
+def main():
+    if config.LEGACY_RUNTIME:
+        main_legacy()
+    else:
+        main_v2()
 
 
 if __name__ == "__main__":

--- a/localstack-core/localstack/runtime/patches.py
+++ b/localstack-core/localstack/runtime/patches.py
@@ -39,7 +39,9 @@ def apply_runtime_patches():
         return
     _applied = True
 
+    from localstack.http.duplex_socket import enable_duplex_socket
     from localstack.services.infra import patch_urllib3_connection_pool
 
     patch_urllib3_connection_pool(maxsize=128)
     patch_thread_pool()
+    enable_duplex_socket()

--- a/localstack-core/localstack/runtime/patches.py
+++ b/localstack-core/localstack/runtime/patches.py
@@ -1,0 +1,45 @@
+"""
+System-wide patches that should be applied.
+"""
+
+from localstack.runtime import hooks
+from localstack.utils.patch import patch
+
+
+def patch_thread_pool():
+    """
+    This patch to ThreadPoolExecutor makes the executor remove the threads it creates from the global
+    ``_thread_queues`` of ``concurrent.futures.thread``, which joins all created threads at python exit and
+    will block interpreter shutdown if any threads are still running, even if they are daemon threads.
+    """
+
+    import concurrent.futures.thread
+
+    @patch(concurrent.futures.thread.ThreadPoolExecutor._adjust_thread_count)
+    def _adjust_thread_count(fn, self) -> None:
+        fn(self)
+
+        for t in self._threads:
+            if not t.daemon:
+                continue
+            try:
+                del concurrent.futures.thread._threads_queues[t]
+            except KeyError:
+                pass
+
+
+_applied = False
+
+
+@hooks.on_runtime_start(priority=100)  # apply patches earlier than other hooks
+def apply_runtime_patches():
+    # FIXME: find a better way to apply system-wide patches
+    global _applied
+    if _applied:
+        return
+    _applied = True
+
+    from localstack.services.infra import patch_urllib3_connection_pool
+
+    patch_urllib3_connection_pool(maxsize=128)
+    patch_thread_pool()

--- a/localstack-core/localstack/runtime/runtime.py
+++ b/localstack-core/localstack/runtime/runtime.py
@@ -164,23 +164,23 @@ class LocalstackRuntime:
     @property
     def exit_code(self):
         # FIXME: legacy compatibility code
-        from localstack.services.infra import EXIT_CODE
+        from localstack.runtime import legacy
 
-        return EXIT_CODE.get()
+        return legacy.EXIT_CODE.get()
 
     @exit_code.setter
     def exit_code(self, value):
         # FIXME: legacy compatibility code
-        from localstack.services.infra import EXIT_CODE
+        from localstack.runtime import legacy
 
-        EXIT_CODE.set(value)
+        legacy.EXIT_CODE.set(value)
 
     def _run_shutdown_monitor(self):
         # FIXME: legacy compatibility code. this can be removed once we replace access to the
         #  ``SHUTDOWN_INFRA`` event with ``get_current_runtime().shutdown()``.
-        from localstack.services import infra
+        from localstack.runtime import legacy
 
-        infra.SHUTDOWN_INFRA.wait()
+        legacy.SHUTDOWN_INFRA.wait()
         self.shutdown()
 
 
@@ -193,6 +193,8 @@ def create_from_environment() -> LocalstackRuntime:
 
     :return: a new LocalstackRuntime instance
     """
+    hooks.on_runtime_create.run()
+
     plugin_manager = PluginManager(Components.namespace)
     components = plugin_manager.load_all()
 

--- a/localstack-core/localstack/runtime/runtime.py
+++ b/localstack-core/localstack/runtime/runtime.py
@@ -1,0 +1,211 @@
+import logging
+import os
+import threading
+
+from plux import PluginManager
+
+from localstack import config, constants
+from localstack.runtime import events, hooks
+from localstack.utils import files, net, sync, threads
+
+from .components import Components
+
+LOG = logging.getLogger(__name__)
+
+
+class LocalstackRuntime:
+    """
+    The localstack runtime. It has the following responsibilities:
+
+      - Manage localstack filesystem directories
+      - Execute runtime lifecycle hook plugins from ``localstack.runtime.hooks``.
+      - Manage the localstack SSL certificate
+      - Serve the gateway (It uses a ``RuntimeServer`` to serve a ``Gateway`` instance coming from the
+        ``Components`` factory.)
+    """
+
+    def __init__(self, components: Components):
+        self.components = components
+
+        # at some point, far far in the future, we should no longer access a global config object, but rather
+        # the one from the current runtime. This will allow us to truly instantiate multiple localstack
+        # runtime instances in one process, which can be useful for many different things. but there is too
+        # much global state at the moment think about this seriously. however, this assignment here can
+        # serve as a reminder to avoid global state in general.
+        self.config = config
+
+        # TODO: move away from `localstack.runtime.events` and instantiate new `threading.Event()` here
+        #  instead
+        self.starting = events.infra_starting
+        self.ready = events.infra_ready
+        self.stopping = events.infra_stopping
+        self.stopped = events.infra_stopped
+
+    def run(self):
+        """
+        Start the main control loop of the runtime and block the thread. This will initialize the
+        filesystem, run all lifecycle hooks, initialize the gateway server, and then serve the
+        ``RuntimeServer`` until ``shutdown()`` is called.
+        """
+        # indicates to the environment that this is an "infra process" (old terminology referring to the
+        # localstack runtime). this is necessary for disabling certain hooks that may run in the context of
+        # the CLI host mode. TODO: should not be needed over time.
+        os.environ[constants.LOCALSTACK_INFRA_PROCESS] = "1"
+
+        self._init_filesystem()
+        self._on_starting()
+        self._init_gateway_server()
+
+        # since we are blocking the main thread with the runtime server, we need to run the monitor that
+        # prints the ready marker asynchronously. this is different from how the runtime was started in the
+        # past, where the server was running in a thread.
+        # TODO: ideally we pass down a `shutdown` event that can be waited on so we can cancel the thread
+        #  if the runtime shuts down beforehand
+        threading.Thread(target=self._run_ready_monitor, daemon=True).start()
+        # FIXME: legacy compatibility code
+        threading.Thread(target=self._run_shutdown_monitor, daemon=True).start()
+
+        # run the main control loop of the server and block execution
+        try:
+            self.components.runtime_server.run()
+        finally:
+            self._on_return()
+
+    def exit(self, code: int = 0):
+        """
+        Sets the exit code and runs ``shutdown``. It does not actually call ``sys.exit``, this is for the
+        caller to do.
+
+        :param code: the exit code to be set
+        """
+        self.exit_code = code
+        self.shutdown()
+
+    def shutdown(self):
+        """
+        Initiates an orderly shutdown of the runtime by stopping the main control loop of the
+        ``RuntimeServer``. The shutdown hooks are actually called by the main control loop (in the main
+        thread) after it returns.
+        """
+        if self.stopping.is_set():
+            return
+        self.stopping.set()
+        self.components.runtime_server.shutdown()
+
+    def is_ready(self) -> bool:
+        return self.ready.is_set()
+
+    def _init_filesystem(self):
+        self._clear_tmp_directory()
+        self.config.dirs.mkdirs()
+
+    def _init_gateway_server(self):
+        from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
+
+        install_predefined_cert_if_available()
+        serial_number = self.config.GATEWAY_LISTEN[0].port
+        _, cert_file_name, key_file_name = create_ssl_cert(serial_number=serial_number)
+        ssl_creds = (cert_file_name, key_file_name)
+
+        self.components.runtime_server.register(
+            self.components.gateway, self.config.GATEWAY_LISTEN, ssl_creds
+        )
+
+    def _on_starting(self):
+        self.starting.set()
+        hooks.on_runtime_start.run()
+
+    def _on_ready(self):
+        hooks.on_runtime_ready.run()
+        print(constants.READY_MARKER_OUTPUT, flush=True)
+        self.ready.set()
+
+    def _on_return(self):
+        LOG.debug("[shutdown] Running shutdown hooks ...")
+        hooks.on_runtime_shutdown.run()
+        LOG.debug("[shutdown] Cleaning up resources ...")
+        self._cleanup_resources()
+        self.stopped.set()
+        LOG.debug("[shutdown] Completed, bye!")
+
+    def _run_ready_monitor(self):
+        self._wait_for_gateway()
+        self._on_ready()
+
+    def _wait_for_gateway(self):
+        host_and_port = self.config.GATEWAY_LISTEN[0]
+
+        if not sync.poll_condition(
+            lambda: net.is_port_open(host_and_port.port), timeout=15, interval=0.3
+        ):
+            if LOG.isEnabledFor(logging.DEBUG):
+                # make another call with quiet=False to print detailed error logs
+                net.is_port_open(host_and_port.port, quiet=False)
+            raise TimeoutError(f"gave up waiting for gateway server to start on {host_and_port}")
+
+    def _clear_tmp_directory(self):
+        if self.config.CLEAR_TMP_FOLDER:
+            # try to clear temp dir on startup
+            try:
+                files.rm_rf(self.config.dirs.tmp)
+            except PermissionError as e:
+                LOG.error(
+                    "unable to delete temp folder %s: %s, please delete manually or you will "
+                    "keep seeing these errors.",
+                    self.config.dirs.tmp,
+                    e,
+                )
+
+    def _cleanup_resources(self):
+        threads.cleanup_threads_and_processes()
+        self._clear_tmp_directory()
+
+    # more legacy compatibility code
+    @property
+    def exit_code(self):
+        # FIXME: legacy compatibility code
+        from localstack.services.infra import EXIT_CODE
+
+        return EXIT_CODE.get()
+
+    @exit_code.setter
+    def exit_code(self, value):
+        # FIXME: legacy compatibility code
+        from localstack.services.infra import EXIT_CODE
+
+        EXIT_CODE.set(value)
+
+    def _run_shutdown_monitor(self):
+        # FIXME: legacy compatibility code. this can be removed once we replace access to the
+        #  ``SHUTDOWN_INFRA`` event with ``get_current_runtime().shutdown()``.
+        from localstack.services import infra
+
+        infra.SHUTDOWN_INFRA.wait()
+        self.shutdown()
+
+
+def create_from_environment() -> LocalstackRuntime:
+    """
+    Creates a new runtime instance from the current environment. It uses a plugin manager to resolve the
+    necessary components from the ``localstack.runtime.components`` plugin namespace to start the runtime.
+
+    TODO: perhaps we could control which components should be instantiated with a config variable/constant
+
+    :return: a new LocalstackRuntime instance
+    """
+    plugin_manager = PluginManager(Components.namespace)
+    components = plugin_manager.load_all()
+
+    if not components:
+        raise ValueError(
+            f"No component plugins found in namespace {Components.namespace}. Are entry points created "
+            f"correctly?"
+        )
+
+    if len(components) > 1:
+        LOG.warning(
+            "There are more than one component plugins, using the first one which is %s",
+            components[0].name,
+        )
+
+    return LocalstackRuntime(components[0])

--- a/localstack-core/localstack/runtime/server/__init__.py
+++ b/localstack-core/localstack/runtime/server/__init__.py
@@ -1,0 +1,5 @@
+from localstack.runtime.server.core import RuntimeServer
+
+__all__ = [
+    "RuntimeServer",
+]

--- a/localstack-core/localstack/runtime/server/core.py
+++ b/localstack-core/localstack/runtime/server/core.py
@@ -42,7 +42,7 @@ class RuntimeServer:
 
 class RuntimeServerPlugin(Plugin):
     """
-    Plugin to expose RuntimeServer plugins to the
+    Plugin that serves as a factory for specific ```RuntimeServer`` implementations.
     """
 
     namespace = "localstack.runtime.server"

--- a/localstack-core/localstack/runtime/server/core.py
+++ b/localstack-core/localstack/runtime/server/core.py
@@ -1,0 +1,51 @@
+from plux import Plugin
+from rolo.gateway import Gateway
+
+from localstack import config
+
+
+class RuntimeServer:
+    """
+    The main network IO loop of LocalStack. This could be twisted, hypercorn, or any other server
+    implementation.
+    """
+
+    def register(
+        self,
+        gateway: Gateway,
+        listen: list[config.HostAndPort],
+        ssl_creds: tuple[str, str] | None = None,
+    ):
+        """
+        Registers the Gateway and the port configuration into the server. Some servers like ``twisted`` or
+        ``hypercorn`` support multiple calls to ``register``, allowing you to serve several Gateways
+        through a single event loop.
+
+        :param gateway: the gateway to serve
+        :param listen: the host and port configuration
+        :param ssl_creds: ssl credentials (certificate file path, key file path)
+        """
+        raise NotImplementedError
+
+    def run(self):
+        """
+        Run the server and block the thread.
+        """
+        raise NotImplementedError
+
+    def shutdown(self):
+        """
+        Shutdown the running server.
+        """
+        raise NotImplementedError
+
+
+class RuntimeServerPlugin(Plugin):
+    """
+    Plugin to expose RuntimeServer plugins to the
+    """
+
+    namespace = "localstack.runtime.server"
+
+    def load(self, *args, **kwargs) -> RuntimeServer:
+        raise NotImplementedError

--- a/localstack-core/localstack/runtime/server/hypercorn.py
+++ b/localstack-core/localstack/runtime/server/hypercorn.py
@@ -1,0 +1,68 @@
+import asyncio
+import threading
+
+from hypercorn import Config
+from hypercorn.asyncio import serve
+from rolo.gateway import Gateway
+from rolo.gateway.asgi import AsgiGateway
+
+from localstack import config
+from localstack.logging.setup import setup_hypercorn_logger
+
+from .core import RuntimeServer
+
+
+class HypercornRuntimeServer(RuntimeServer):
+    def __init__(self):
+        self.loop = asyncio.get_event_loop()
+
+        self._close = asyncio.Event()
+        self._closed = threading.Event()
+
+        self._futures = []
+
+    def register(
+        self,
+        gateway: Gateway,
+        listen: list[config.HostAndPort],
+        ssl_creds: tuple[str, str] | None = None,
+    ):
+        hypercorn_config = Config()
+        hypercorn_config.h11_pass_raw_headers = True
+        hypercorn_config.bind = [str(host_and_port) for host_and_port in listen]
+        # hypercorn_config.use_reloader = use_reloader
+
+        setup_hypercorn_logger(hypercorn_config)
+
+        if ssl_creds:
+            cert_file_name, key_file_name = ssl_creds
+            hypercorn_config.certfile = cert_file_name
+            hypercorn_config.keyfile = key_file_name
+
+        app = AsgiGateway(gateway, event_loop=self.loop)
+
+        future = asyncio.run_coroutine_threadsafe(
+            serve(app, hypercorn_config, shutdown_trigger=self._shutdown_trigger),
+            self.loop,
+        )
+        self._futures.append(future)
+
+    def run(self):
+        self.loop.run_forever()
+
+    def shutdown(self):
+        self._close.set()
+        asyncio.run_coroutine_threadsafe(self._set_closed(), self.loop)
+        # TODO: correctly wait for all hypercorn serve coroutines to finish
+        asyncio.run_coroutine_threadsafe(self.loop.shutdown_asyncgens(), self.loop)
+        self.loop.shutdown_default_executor()
+        self.loop.stop()
+
+    async def _wait_server_stopped(self):
+        self._closed.set()
+
+    async def _set_closed(self):
+        self._close.set()
+
+    async def _shutdown_trigger(self):
+        await self._close.wait()

--- a/localstack-core/localstack/runtime/server/plugins.py
+++ b/localstack-core/localstack/runtime/server/plugins.py
@@ -1,0 +1,19 @@
+from localstack.runtime.server.core import RuntimeServer, RuntimeServerPlugin
+
+
+class TwistedRuntimeServerPlugin(RuntimeServerPlugin):
+    name = "twisted"
+
+    def load(self, *args, **kwargs) -> RuntimeServer:
+        from .twisted import TwistedRuntimeServer
+
+        return TwistedRuntimeServer()
+
+
+class HypercornRuntimeServerPlugin(RuntimeServerPlugin):
+    name = "hypercorn"
+
+    def load(self, *args, **kwargs) -> RuntimeServer:
+        from .hypercorn import HypercornRuntimeServer
+
+        return HypercornRuntimeServer()

--- a/localstack-core/localstack/runtime/server/twisted.py
+++ b/localstack-core/localstack/runtime/server/twisted.py
@@ -1,0 +1,52 @@
+from rolo.gateway import Gateway
+from rolo.serving.twisted import TwistedGateway
+from twisted.internet import endpoints, reactor, ssl
+
+from localstack import config
+from localstack.aws.serving.twisted import TLSMultiplexerFactory, stop_thread_pool
+from localstack.utils import patch
+
+from .core import RuntimeServer
+
+
+class TwistedRuntimeServer(RuntimeServer):
+    def __init__(self):
+        self.thread_pool = None
+
+    def register(
+        self,
+        gateway: Gateway,
+        listen: list[config.HostAndPort],
+        ssl_creds: tuple[str, str] | None = None,
+    ):
+        # setup twisted webserver Site
+        site = TwistedGateway(gateway)
+
+        # configure ssl
+        if ssl_creds:
+            cert_file_name, key_file_name = ssl_creds
+            context_factory = ssl.DefaultOpenSSLContextFactory(key_file_name, cert_file_name)
+            context_factory.getContext().use_certificate_chain_file(cert_file_name)
+            protocol_factory = TLSMultiplexerFactory(context_factory, False, site)
+        else:
+            protocol_factory = site
+
+        # add endpoint for each host/port combination
+        for host_and_port in listen:
+            # TODO: interface = host?
+            endpoint = endpoints.TCP4ServerEndpoint(reactor, host_and_port.port)
+            endpoint.listen(protocol_factory)
+
+    def run(self):
+        reactor.suggestThreadPoolSize(config.GATEWAY_WORKER_COUNT)
+        self.thread_pool = reactor.getThreadPool()
+        patch.patch(self.thread_pool.stop)(stop_thread_pool)
+
+        # we don't need signal handlers, since all they do is call ``reactor`` stop, which we expect the
+        # caller to do via ``shutdown``.
+        return reactor.run(installSignalHandlers=False)
+
+    def shutdown(self):
+        if self.thread_pool:
+            self.thread_pool.stop(timeout=10)
+        reactor.stop()

--- a/localstack-core/localstack/services/internal.py
+++ b/localstack-core/localstack/services/internal.py
@@ -14,7 +14,7 @@ from localstack import config, constants
 from localstack.deprecations import deprecated_endpoint
 from localstack.http import Request, Resource, Response, Router
 from localstack.http.dispatcher import handler_dispatcher
-from localstack.services.infra import exit_infra, signal_supervisor_restart
+from localstack.runtime.legacy import exit_infra, signal_supervisor_restart
 from localstack.utils.analytics.metadata import (
     get_client_metadata,
     get_localstack_edition,

--- a/localstack-core/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack-core/localstack/testing/pytest/in_memory_localstack.py
@@ -44,6 +44,10 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtestloop(session: Session):
+    # avoid starting up localstack if we only collect the tests (-co / --collect-only)
+    if session.config.option.collectonly:
+        return
+
     if not session.config.option.start_localstack:
         return
 

--- a/localstack-core/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack-core/localstack/testing/pytest/in_memory_localstack.py
@@ -83,6 +83,12 @@ def pytest_sessionfinish(session: Session):
 
     from localstack.runtime import get_current_runtime
 
+    try:
+        get_current_runtime()
+    except ValueError:
+        LOG.warning("Could not access the current runtime in a pytest sessionfinish hook.")
+        return
+
     get_current_runtime().shutdown()
     LOG.info("waiting for runtime to stop")
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This is part of the effort to generalize certain aspects of the codebase to make them more re-usable (see #10946). One concept that was difficult to re-use was `infra.py`, which is responsible for starting what we now call the localstack _Runtime_. The reason is that it imports all sorts of aws-specific code.

The Runtime is roughly responsible for
- running runtime lifecycle hooks
- managing the localstack filesystem (creating directories and cleaning up afterwards)
- clean up thread and process pools
- serving the main Gateway

Another annoying thing with the previous runtime is that the server (either hypercorn or twisted), couldn't properly register signal handlers, such as a code reloader, because it can only do that from the main thread, and we were starting the server in a separate thread. Now the runtime server, i.e., the control/event loop of the underlying I/O framework, now (imo correctly) blocks the main thread.

:bulb: The primary change though is that you now have a dynamic and re-usable `python -m localstack.runtime.main` bootstrapping procedure, which follows the open-closed principle.

## Usage

Here is an example to build a new localstack runtime distribution without needing to define a new main or new bootstrapping procedure. All you need to do is expose a Components plugin, and (provisionally) disable AWS plugins that the currently leaking from localstack-core using https://github.com/localstack/plux/pull/22.

Then, in your distribution, you can `python -m localstack.runtime.main`, and instead of starting AWS, it will start the ``my-emulator``.

```python
from functools import cached_property

from localstack.runtime import components, hooks
from plux.runtime.filter import global_plugin_filter
from rolo import Response
from rolo.gateway import Gateway, HandlerChain, RequestContext


@hooks.on_runtime_create()  # <- new hook that this PR introduces
def _disable_aws_plugins():
    # disable unwanted plugins from localstack aws
    global_plugin_filter.add_exclusion(namespace="localstack.runtime.components", name="aws")
    global_plugin_filter.add_exclusion(namespace="localstack.aws.*")
    global_plugin_filter.add_exclusion(value="localstack.aws.*")
    global_plugin_filter.add_exclusion(value="localstack.services*")


class MyEmulatorComponents(components.BaseComponents):
    namespace = "localstack.runtime.components"
    name = "my-emulator"

    @cached_property
    def gateway(self) -> Gateway:
        def _dummy_handler(chain: HandlerChain, context: RequestContext, response: Response):
            chain.respond(200, "ok")

        return Gateway(request_handlers=[
            _dummy_handler
        ])
```


## Architecture

This is a high-level diagram to help explain the components. It's an ad-hoc notation, I hope it helps to get the gist though :sweat_smile: 

![localstack-runtime](https://github.com/localstack/localstack/assets/3996682/1d32be3e-610d-4d89-aa58-8c6e72ba11ba)

### Components

One critical aspect to add was an IoC mechanism to dynamically load, specifically the `Gateway` instance, but more generally a type of application context (now the `Components`).
We assume that, within a runtime, there is only one `Components` plugin. For instance, there are now `AwsComponents` which is a `Components` plugin. Within the context of the AWS emulator, only this plugin should be available and loaded.

### RuntimeServer

The `RuntimeServer` represents the lower-level IO control loop that should block the main thread. In the case of twisted, this is the twisted reactor. In the case of hypercorn, this is the asyncio event loop.
There was no need to limit the `RuntimeServer` to serve only one Gateway instance. Basically an IO control loop should be able to serve multiple server sockets, so in the future we could serve TCP proxies for instance through the main control loop, rather than instantiating new threads. Thus, the `register(Gateway, ...)` method was conceived. Other than `register`, the `RuntimeServer` only has a `run` and a `shutdown` method.

#### Instantiation

Which type of `RuntimeServer` is instantiated is currently governed by `config.GATEWAY_SERVER`. The different server implementations are now registered as plugins instead of using static imports as we do in `serve_gateway`.

### Global access

There are situations where you need global access to the runtime and runtime components (for instance in the in-memory client, we need access to the `Gateway` instance we inject the request into).
To this end, the runtime package provides a `localstack.runtime.get_current_runtime()` method, that represents global (or in the future: scoped) access to the current `LocalstackRuntime` object.
### Bootstrapping

Bootstrapping (the process of creating a localstack runtime and starting it), is done by `localstack.runtime.main`. The idea is that this is generalized. Whether we start AWS, Snowflake, or Azure, we always run the generalized `localstack.runtime.main`, which gets its application context from the `Components` explained above.
Bootstrapping also involves setting the current runtime (as described above), and registering exit handlers. The runtime and subsequently the `RuntimeServer`'s event loop, should now always block the main thread.

A special case is the `in_memory_localstack.py` for testing, which works similarly, only that it creates a new runtime running in a thread, which still works.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Introduce a new runtime that can be enabled with `LEGACY_RUNTIME=0` (changed in the future)
* The runtime server (twisted reactor or hypercorn eventloop) now blocks the main thread.
* Integration tests already use the new runtime

<!-- Optional section: How to test these changes? -->
## Testing

* Simply run `make entrypoints` and then `python -m localstack.runtime.main` - should already use the new runtime.
* You can also test that different gateway servers are instantiated correctly by setting `GATEWAY_SERVER=hypercorn`

<!-- Optional section: What's left to do before it can be merged? -->

## Limitations / Future work

* We still have a lot of import errors when running the example in "Usage". This is mostly because of `localstack.services.plugins` which contains the `Service` and `ServiceManager` framework, but also imports from botocore. In a second step, we need to generalize the `Service` concept similar to what I've done in this PR.
* There are a few provisional concepts like `localstack.runtime.legacy` that I don't like, but were necessary to decouple the new runtime from `localstack.services.infra` while maintaining backwards compatibility
* I would like to remove the legacy runtime very soon, and start replacing global access to it with `get_current_runtime()`. maybe we can make the switch to the new runtime with 3.5, and then remove `LEGACY_RUNTIME` with 3.6

## TODO

What's left to do:

- [x] Extend PR description
- [x] Greenify pipeline
- [ ] Set default config back to `LEGACY_RUNTIME` (maybe?)

