### PR TITLE
fix flaky TestServerless.test_kinesis_stream_handler_deployed

### DIFF
--- a/tests/aws/test_serverless.py
+++ b/tests/aws/test_serverless.py
@@ -98,6 +98,7 @@ class TestServerless:
 
     @markers.skip_offline
     @markers.aws.unknown
+    @pytest.mark.skip(reason="flaky")
     def test_kinesis_stream_handler_deployed(self, aws_client, setup_and_teardown):
         function_name = "sls-test-local-kinesisStreamHandler"
         function_name2 = "sls-test-local-kinesisConsumerHandler"


### PR DESCRIPTION
## Motivation
We have seen some flakes due to `test_kinesis_stream_handler_deployed (tests.aws.test_serverless.TestServerless)`.
This PR disables this test.

## Changes
- Skip `test_kinesis_stream_handler_deployed`.