### PR TITLE
move cloudformation deploy ui to cloudformation provider

### DIFF
--- a/localstack-core/localstack/services/cloudformation/deploy_ui.py
+++ b/localstack-core/localstack/services/cloudformation/deploy_ui.py
@@ -1,0 +1,47 @@
+import json
+import logging
+import os
+
+import requests
+from rolo import Response
+
+from localstack import constants
+from localstack.utils.files import load_file
+from localstack.utils.json import parse_json_or_yaml
+
+LOG = logging.getLogger(__name__)
+
+
+class CloudFormationUi:
+    def on_get(self, request):
+        from localstack.utils.aws.aws_stack import get_valid_regions
+
+        deploy_html_file = os.path.join(
+            constants.MODULE_MAIN_PATH, "services", "cloudformation", "deploy.html"
+        )
+        deploy_html = load_file(deploy_html_file)
+        req_params = request.values
+        params = {
+            "stackName": "stack1",
+            "templateBody": "{}",
+            "errorMessage": "''",
+            "regions": json.dumps(sorted(get_valid_regions())),
+        }
+
+        download_url = req_params.get("templateURL")
+        if download_url:
+            try:
+                LOG.debug("Attempting to download CloudFormation template URL: %s", download_url)
+                template_body = requests.get(download_url).text
+                template_body = parse_json_or_yaml(template_body)
+                params["templateBody"] = json.dumps(template_body)
+            except Exception as e:
+                msg = f"Unable to download CloudFormation template URL: {e}"
+                LOG.info(msg)
+                params["errorMessage"] = json.dumps(msg.replace("\n", " - "))
+
+        # using simple string replacement here, for simplicity (could be replaced with, e.g., jinja)
+        for key, value in params.items():
+            deploy_html = deploy_html.replace(f"<{key}>", value)
+
+        return Response(deploy_html, mimetype="text/html")

--- a/localstack-core/localstack/services/cloudformation/plugins.py
+++ b/localstack-core/localstack/services/cloudformation/plugins.py
@@ -1,0 +1,12 @@
+from rolo import Resource
+
+from localstack.runtime import hooks
+
+
+@hooks.on_infra_start()
+def register_cloudformation_deploy_ui():
+    from localstack.services.internal import get_internal_apis
+
+    from .deploy_ui import CloudFormationUi
+
+    get_internal_apis().add(Resource("/_localstack/cloudformation/deploy", CloudFormationUi()))

--- a/localstack-core/localstack/services/internal.py
+++ b/localstack-core/localstack/services/internal.py
@@ -8,12 +8,12 @@ from collections import defaultdict
 from datetime import datetime
 from typing import List
 
-from rolo import Request, Resource, Response, Router
-from rolo.dispatcher import handler_dispatcher
 from werkzeug.exceptions import NotFound
 
 from localstack import config, constants
 from localstack.deprecations import deprecated_endpoint
+from localstack.http import Request, Resource, Response, Router
+from localstack.http.dispatcher import handler_dispatcher
 from localstack.services.infra import exit_infra, signal_supervisor_restart
 from localstack.utils.analytics.metadata import (
     get_client_metadata,

--- a/tests/unit/services/cloudformation/test_deploy_ui.py
+++ b/tests/unit/services/cloudformation/test_deploy_ui.py
@@ -1,0 +1,12 @@
+from rolo import Request
+
+from localstack.services.cloudformation.deploy_ui import CloudFormationUi
+
+
+class TestCloudFormationUiResource:
+    def test_get(self):
+        resource = CloudFormationUi()
+        response = resource.on_get(Request("GET", "/", body=b"None"))
+        assert response.status == "200 OK"
+        assert "</html>" in response.get_data(as_text=True), "deploy UI did not render HTML"
+        assert "text/html" in response.headers.get("content-type", "")

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from localstack.constants import VERSION
 from localstack.http import Request
-from localstack.services.internal import CloudFormationUi, HealthResource
+from localstack.services.internal import HealthResource
 from localstack.services.plugins import ServiceManager, ServiceState
 
 
@@ -65,12 +65,3 @@ class TestHealthResource:
             },
             "version": VERSION,
         }
-
-
-class TestCloudFormationUiResource:
-    def test_get(self):
-        resource = CloudFormationUi()
-        response = resource.on_get(Request("GET", "/", body=b"None"))
-        assert response.status == "200 OK"
-        assert "</html>" in response.get_data(as_text=True), "deploy UI did not render HTML"
-        assert "text/html" in response.headers.get("content-type", "")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In an effort to reduce coupling between generic and aws-specific runtime components #10946, I'm moving the cloudformation deploy UI `/_localstack/cloudformation/deploy` to the cloudformation provider package, and registering it into the internal resources with a hook.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* The `CloudFormationUi` now lives in the cloudformation provider package, and is registered with a runtime hook instead of a static import


<!--
## Testing

* run `make entrypoints`
* `python -m localstack.runtime.main`
* Visit http://localhost:4566/_localstack/cloudformation/deploy it still works!

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
