### PR TITLE
Fix detection of docker image digest for diagnostic purposes

### DIFF
--- a/localstack-core/localstack/services/infra.py
+++ b/localstack-core/localstack/services/infra.py
@@ -209,7 +209,8 @@ def print_runtime_information(in_docker: bool = False):
             container_id = inspect_result["Id"]
             print("LocalStack Docker container id: %s" % container_id[:12])
             image_details = DOCKER_CLIENT.inspect_image(inspect_result["Image"])
-            print("LocalStack Docker image sha: %s" % image_details["RepoDigests"][0])
+            digests = image_details.get("RepoDigests") or ["Unavailable"]
+            print("LocalStack Docker image sha: %s" % digests[0])
         except ContainerException:
             print(
                 "LocalStack Docker container info: Failed to inspect the LocalStack docker container. "

--- a/localstack-core/localstack/services/infra.py
+++ b/localstack-core/localstack/services/infra.py
@@ -208,8 +208,8 @@ def print_runtime_information(in_docker: bool = False):
             inspect_result = DOCKER_CLIENT.inspect_container(container_name)
             container_id = inspect_result["Id"]
             print("LocalStack Docker container id: %s" % container_id[:12])
-            image_sha = inspect_result["Image"]
-            print("LocalStack Docker image sha: %s" % image_sha)
+            image_details = DOCKER_CLIENT.inspect_image(inspect_result["Image"])
+            print("LocalStack Docker image sha: %s" % image_details["RepoDigests"][0])
         except ContainerException:
             print(
                 "LocalStack Docker container info: Failed to inspect the LocalStack docker container. "

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -145,9 +145,11 @@ def get_docker_image_details(image_name: str = None) -> Dict[str, str]:
     except ContainerException:
         return {}
 
+    digests = result.get("RepoDigests")
+    sha256 = digests[0].rpartition(":")[2] if digests else "Unavailable"
     result = {
         "id": result["Id"].replace("sha256:", "")[:12],
-        "sha256": result["RepoDigests"][0].rpartition(":")[2],
+        "sha256": sha256,
         "tag": (result.get("RepoTags") or ["latest"])[0].split(":")[-1],
         "created": result["Created"].split(".")[0],
     }

--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -144,8 +144,10 @@ def get_docker_image_details(image_name: str = None) -> Dict[str, str]:
         result = DOCKER_CLIENT.inspect_image(image_name)
     except ContainerException:
         return {}
+
     result = {
         "id": result["Id"].replace("sha256:", "")[:12],
+        "sha256": result["RepoDigests"][0].rpartition(":")[2],
         "tag": (result.get("RepoTags") or ["latest"])[0].split(":")[-1],
         "created": result["Created"].split(".")[0],
     }


### PR DESCRIPTION
## Motivation

I was asked about the different meaning of localstack version/commit/image SHAs and coincidentally noticed that the digests we were showing were actually the local image ids and not the digest on docker hub that we can actually pull for reproducing the issue.

 
## Changes

- The diagnose endpoint now also outputs the image sha that can be used to pull from docker hub via `docker pull localstack/localstack@sha256:....`
- On startup the value of `LocalStack Docker image sha` is now the actual digest that can be pulled (see above). This was a bit unfortunate since we now also refer to this in our GitHub issue template. If there's no manifest yet, it returns the fallback value `Unavailable`


## Discussion

@dfangl I noticed that fortunately the docker client works correctly when called with `image_details = DOCKER_CLIENT.inspect_image(image_name='sha256:6dd80f78fdaa60bcf9dcc3a34a072d3be3f577350e9e46b91f538f54531eef81')
` even though the naming of the parameter in `inspect_image` might not suggest so. The `inspect_container` method calls the parameter `container_name_or_id`, maybe we should do t he same for `inspect_image`  as well? wdyt?