### PR TITLE
Refine optional Lambda dependencies

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -71,7 +71,17 @@ API_DEPENDENCIES = {
 API_DEPENDENCIES_OPTIONAL = {
     # firehose's optional dependencies are supported delivery stream destinations
     "firehose": ["es", "opensearch", "s3", "redshift"],
-    "lambda": ["cloudwatch", "dynamodbstreams", "logs", "kafka", "kinesis", "msk", "sqs"],
+    "lambda": [
+        "cloudwatch",  # Lambda metrics
+        "dynamodbstreams",  # Event source mapping source
+        "events",  # Lambda destination
+        "logs",  # Function logging
+        "kinesis",  # Event source mapping source
+        "sqs",  # Event source mapping source + Lambda destination
+        "sns",  # Lambda destination
+        "sts",  # Credentials injection
+        # Additional dependencies to Pro-only services are defined in ext
+    ],
     "ses": ["sns"],
     "sns": ["sqs", "lambda", "firehose", "ses", "logs"],
     "sqs": ["cloudwatch"],


### PR DESCRIPTION
Introduce test selection: https://github.com/localstack/localstack/pull/10301

## Motivation

As discussed in our Lambda service owner sync (2024-06-03), we missed some optional dependencies and should split the definitions between community + Pro since merging is now supported.

## Changes

* Add missing optional dependencies for Lambda destinations
* Add comments to clarify the integration type
* Move Pro services into ext