### PR TITLE
fix Checksum validation and assumptions for S3

### DIFF
--- a/localstack-core/localstack/services/s3/constants.py
+++ b/localstack-core/localstack/services/s3/constants.py
@@ -1,4 +1,5 @@
 from localstack.aws.api.s3 import (
+    ChecksumAlgorithm,
     Grantee,
     Permission,
     PublicAccessBlockConfiguration,
@@ -52,6 +53,13 @@ VALID_STORAGE_CLASSES = [
 ARCHIVES_STORAGE_CLASSES = [
     StorageClass.GLACIER,
     StorageClass.DEEP_ARCHIVE,
+]
+
+CHECKSUM_ALGORITHMS: list[ChecksumAlgorithm] = [
+    ChecksumAlgorithm.SHA1,
+    ChecksumAlgorithm.SHA256,
+    ChecksumAlgorithm.CRC32,
+    ChecksumAlgorithm.CRC32C,
 ]
 
 # response header overrides the client may request

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -41,9 +41,11 @@ from localstack.aws.api.s3 import (
     Owner,
     Permission,
     PreconditionFailed,
+    PutObjectRequest,
     SSEKMSKeyId,
     TaggingHeader,
     TagSet,
+    UploadPartRequest,
 )
 from localstack.aws.api.s3 import Type as GranteeType
 from localstack.aws.chain import HandlerChain
@@ -52,6 +54,7 @@ from localstack.http import Response
 from localstack.services.s3.constants import (
     ALL_USERS_ACL_GRANTEE,
     AUTHENTICATED_USERS_ACL_GRANTEE,
+    CHECKSUM_ALGORITHMS,
     LOG_DELIVERY_ACL_GRANTEE,
     S3_CHUNK_SIZE,
     S3_VIRTUAL_HOST_FORWARDED_HEADER,
@@ -73,8 +76,6 @@ from localstack.utils.strings import (
 from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
-
-checksum_keys = ["ChecksumSHA1", "ChecksumSHA256", "ChecksumCRC32", "ChecksumCRC32C"]
 
 BUCKET_NAME_REGEX = (
     r"(?=^.{3,63}$)(?!^(\d+\.)+\d+$)"
@@ -172,6 +173,23 @@ class ChecksumHash(Protocol):
     def digest(self) -> bytes: ...
 
     def update(self, value: bytes): ...
+
+
+def get_s3_checksum_algorithm_from_request(
+    request: PutObjectRequest | UploadPartRequest,
+) -> ChecksumAlgorithm | None:
+    checksum_algorithm: list[ChecksumAlgorithm] = [
+        algo for algo in CHECKSUM_ALGORITHMS if request.get(f"Checksum{algo}")
+    ]
+    if not checksum_algorithm:
+        return None
+
+    if len(checksum_algorithm) > 1:
+        raise InvalidRequest(
+            "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed."
+        )
+
+    return checksum_algorithm[0]
 
 
 def get_s3_checksum(algorithm) -> ChecksumHash:

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -192,6 +192,23 @@ def get_s3_checksum_algorithm_from_request(
     return checksum_algorithm[0]
 
 
+def get_s3_checksum_algorithm_from_trailing_headers(
+    trailing_headers: str,
+) -> ChecksumAlgorithm | None:
+    checksum_algorithm: list[ChecksumAlgorithm] = [
+        algo for algo in CHECKSUM_ALGORITHMS if f"x-amz-checksum-{algo.lower()}" in trailing_headers
+    ]
+    if not checksum_algorithm:
+        return None
+
+    if len(checksum_algorithm) > 1:
+        raise InvalidRequest(
+            "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed."
+        )
+
+    return checksum_algorithm[0]
+
+
 def get_s3_checksum(algorithm) -> ChecksumHash:
     match algorithm:
         case ChecksumAlgorithm.CRC32:

--- a/localstack-core/localstack/services/s3/v3/models.py
+++ b/localstack-core/localstack/services/s3/v3/models.py
@@ -335,10 +335,6 @@ class S3Object:
         for metadata_key, metadata_value in self.system_metadata.items():
             headers[metadata_key] = metadata_value
 
-        # this is a bug in AWS: it sets the content encoding header to an empty string (parity tested)
-        if "ContentEncoding" not in headers and self.checksum_algorithm and not self.parts:
-            headers["ContentEncoding"] = ""
-
         if self.storage_class != StorageClass.STANDARD:
             headers["StorageClass"] = self.storage_class
 

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -3145,7 +3145,6 @@ class TestS3:
             "X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
             "X-Amz-Date": "20190918T051509Z",
             "X-Amz-Decoded-Content-Length": str(len(body)),
-            "x-amz-sdk-checksum-algorithm": "SHA256",
             "x-amz-trailer": "x-amz-checksum-sha256",
             "Content-Encoding": "aws-chunked",
         }

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -487,7 +487,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
-    "recorded-date": "05-10-2023, 20:33:28",
+    "recorded-date": "04-06-2024, 14:28:10",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -557,7 +557,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
-    "recorded-date": "05-10-2023, 20:33:33",
+    "recorded-date": "04-06-2024, 14:28:13",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -627,7 +627,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
-    "recorded-date": "05-10-2023, 20:33:38",
+    "recorded-date": "04-06-2024, 14:28:16",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -697,7 +697,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
-    "recorded-date": "05-10-2023, 20:33:43",
+    "recorded-date": "04-06-2024, 14:28:19",
     "recorded-content": {
       "put-wrong-checksum": {
         "Error": {
@@ -4614,7 +4614,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA256]": {
-    "recorded-date": "03-08-2023, 04:14:55",
+    "recorded-date": "04-06-2024, 14:41:58",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA256": "1YQo81vx2VFUl0q5ccWISq8AkSBQQ0WO80S82TmfdIQ=",
@@ -4685,7 +4685,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[None]": {
-    "recorded-date": "03-08-2023, 04:14:59",
+    "recorded-date": "04-06-2024, 14:42:01",
     "recorded-content": {
       "put-object": {
         "ETag": "\"f2081dd61dfa700a0fd5e29b9c3cc23d\"",
@@ -4747,7 +4747,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_with_content_encoding": {
-    "recorded-date": "03-08-2023, 04:15:01",
+    "recorded-date": "04-06-2024, 14:25:58",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA256": "WO7lLNG8Mn/d4GkX4DqZXqeaVHJCN+BxvMNJXLOhukg=",
@@ -4966,8 +4966,18 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "recorded-date": "28-05-2024, 17:27:37",
+    "recorded-date": "04-06-2024, 14:03:55",
     "recorded-content": {
+      "create-mpu-wrong-checksum-algo": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, SHA1, SHA256]"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "create-mpu-no-checksum": {
         "Bucket": "bucket",
         "Key": "test-multipart-checksum-exc",
@@ -4979,6 +4989,16 @@
         }
       },
       "upload-part-with-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Checksum Type mismatch occurred, expected checksum Type: null, actual checksum Type: sha256"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "upload-part-with-checksum-calc": {
         "Error": {
           "Code": "InvalidRequest",
           "Message": "Checksum Type mismatch occurred, expected checksum Type: null, actual checksum Type: sha256"
@@ -6385,7 +6405,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32]": {
-    "recorded-date": "03-08-2023, 04:14:45",
+    "recorded-date": "04-06-2024, 14:41:49",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32": "lVk/nw==",
@@ -6456,7 +6476,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32C]": {
-    "recorded-date": "03-08-2023, 04:14:48",
+    "recorded-date": "04-06-2024, 14:41:52",
     "recorded-content": {
       "put-object": {
         "ChecksumCRC32C": "Fz3epA==",
@@ -6527,7 +6547,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA1]": {
-    "recorded-date": "03-08-2023, 04:14:52",
+    "recorded-date": "04-06-2024, 14:41:55",
     "recorded-content": {
       "put-object": {
         "ChecksumSHA1": "jbXkHAsXUrubtL3dqDQ4w+7WXc0=",
@@ -11932,6 +11952,108 @@
           "ETag": "70b68ae721a61941a1a62724dde5d5e4",
           "ObjectSize": "9",
           "StorageClass": "STANDARD"
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_no_automatic_sdk_calculation": {
+    "recorded-date": "04-06-2024, 14:22:53",
+    "recorded-content": {
+      "wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "HostId": "<host-id:1>",
+          "Message": "Value for x-amz-checksum-sha256 header is invalid.",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "head-obj-right-checksum": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-obj-only-checksum-algo": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-obj-diff-checksum-algo": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_no_algorithm": {
+    "recorded-date": "04-06-2024, 14:33:49",
+    "recorded-content": {
+      "put-wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-sha256 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-2-checksums": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-right-checksum": {
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-obj": {
+        "AcceptRanges": "bytes",
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -132,7 +132,7 @@
     "last_validated_date": "2023-10-18T15:40:12+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_multipart_parts_checksum_exceptions": {
-    "last_validated_date": "2024-05-28T17:27:37+00:00"
+    "last_validated_date": "2024-06-04T14:03:55+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_object_with_slashes_in_key[False]": {
     "last_validated_date": "2023-11-24T10:11:04+00:00"
@@ -186,16 +186,16 @@
     "last_validated_date": "2023-08-13T00:27:00+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
-    "last_validated_date": "2023-10-05T18:33:33+00:00"
+    "last_validated_date": "2024-06-04T14:28:13+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
-    "last_validated_date": "2023-10-05T18:33:28+00:00"
+    "last_validated_date": "2024-06-04T14:28:10+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
-    "last_validated_date": "2023-10-05T18:33:38+00:00"
+    "last_validated_date": "2024-06-04T14:28:16+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
-    "last_validated_date": "2023-10-05T18:33:43+00:00"
+    "last_validated_date": "2024-06-04T14:28:19+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE-False]": {
     "last_validated_date": "2024-03-05T17:17:44+00:00"
@@ -260,8 +260,14 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_bucket_acl_exceptions": {
     "last_validated_date": "2023-08-03T02:16:13+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_no_algorithm": {
+    "last_validated_date": "2024-06-04T14:33:49+00:00"
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_no_automatic_sdk_calculation": {
+    "last_validated_date": "2024-06-04T14:22:53+00:00"
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_checksum_with_content_encoding": {
-    "last_validated_date": "2023-08-03T02:15:01+00:00"
+    "last_validated_date": "2024-06-04T14:25:58+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_copy_content_type_and_metadata": {
     "last_validated_date": "2023-08-03T02:15:17+00:00"
@@ -327,19 +333,19 @@
     "last_validated_date": "2023-08-03T02:23:32+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32C]": {
-    "last_validated_date": "2023-08-03T02:14:48+00:00"
+    "last_validated_date": "2024-06-04T14:41:52+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[CRC32]": {
-    "last_validated_date": "2023-08-03T02:14:45+00:00"
+    "last_validated_date": "2024-06-04T14:41:49+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[None]": {
-    "last_validated_date": "2023-08-03T02:14:59+00:00"
+    "last_validated_date": "2024-06-04T14:42:01+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA1]": {
-    "last_validated_date": "2023-08-03T02:14:52+00:00"
+    "last_validated_date": "2024-06-04T14:41:55+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_checksum[SHA256]": {
-    "last_validated_date": "2023-08-03T02:14:55+00:00"
+    "last_validated_date": "2024-06-04T14:41:58+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_s3_get_object_header_overrides": {
     "last_validated_date": "2023-08-03T02:23:46+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by #10914, we had an issue with Checksum validation for S3. We would rely on the `x-amz-sdk-checksum-algorithm` header, but this one is not considered for `PutObject` and `UploadPart`, AWS does not use it. It is only internally used by the SDK to know it needs to automatically calculate the right `x-amz-checksum-{checksum_algorithm}` value to send along. 

This is only valid for `UploadPart` and `PutObject`. Some other requests like `CreateMultipartUpload` uses only the `ChecksumAlgorithm` parameter with no value (same headers but different purposes). 

The logic was then a bit flawed, because when the client would send a checksum we would not properly consider it if the SDK `x-amz-sdk-checksum-algorithm` was not sent. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add multiple tests related to the change:
  - add a test with no SDK interaction, raw requests sent to understand what is the relation between the 2 headers (result: none, AWS does not consider it at all)
  - add a test with the SDK, but no automatic calculation, just manual, to check the different raised errors
  - add a small check in an existing test regarding `ChecksumAlgorithm` validation for `CreateMultipartUpload`
  - add a small check regarding `UploadPart` to see if it follows the same logic as `PutObject`
  - modify the logic around checksum validation and introduce new helper method to retrieve the right algorithm name from the 4 possibles parameters/headers
  - remove an AWS bug behavior that was introduced in LocalStack as well following snapshots for parity. I've tracked it down to 2 botocore / global AWS SDK issues with empty `ContentEncoding` issue, so we just snapshot skip for now
  - also fix checksum check, taking the checksum algorithm from the trailing headers, to know what algorithm is used and set it to the object so that the `AwsChunkedDecoder` correctly picks the value


_fixes #10914_

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
