### PR TITLE
SQS: Add MessageSystemAttributeNames for receive-message

### DIFF
--- a/localstack-core/localstack/aws/data/sqs-query/2012-11-05/README.md
+++ b/localstack-core/localstack/aws/data/sqs-query/2012-11-05/README.md
@@ -6,3 +6,5 @@ This switch removed a lot of spec data which is necessary for the proper parsing
 - The file is licensed with Apache License 2.0.
 - Modifications:
   - Removal of documentation strings with the following regex: `(,)?\n\s+"documentation":".*"`
+  - Added `MessageSystemAttributeNames` to `ReceiveMessageRequest.members` with AWS deprecating `AttributeNames`.
+  The patches in `spec-patches.json` are not present in the boto client for our sqs-query tests right now because the custom loading is not fully integrated at the moment, so it is changed directly in the spec.

--- a/localstack-core/localstack/aws/data/sqs-query/2012-11-05/service-2.json
+++ b/localstack-core/localstack/aws/data/sqs-query/2012-11-05/service-2.json
@@ -1166,6 +1166,9 @@
         "AttributeNames":{
           "shape":"AttributeNameList"
         },
+        "MessageSystemAttributeNames":{
+          "shape":"AttributeNameList"
+        },
         "MessageAttributeNames":{
           "shape":"MessageAttributeNameList"
         },

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1239,8 +1239,11 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         # prepare result
         messages = []
+        message_system_attribute_names = message_system_attribute_names or attribute_names
         for i, standard_message in enumerate(result.successful):
-            message = to_sqs_api_message(standard_message, attribute_names, message_attribute_names)
+            message = to_sqs_api_message(
+                standard_message, message_system_attribute_names, message_attribute_names
+            )
             message["ReceiptHandle"] = result.receipt_handles[i]
             messages.append(message)
 

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -4271,14 +4271,10 @@ class TestSqsProvider:
         response = receive_message(["SenderId", "SequenceNumber"])
         assert snapshot.match("multiple_attributes", response)
 
-    @markers.aws.unknown
-    # @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SenderId"])
+    @markers.aws.validated
     def test_receive_message_message_system_attribute_names_filters(
         self, sqs_create_queue, snapshot, aws_sqs_client
     ):
-        # TODO -> senderId in LS == account ID, but on AWS it looks quite different: [A-Z]{21}:<email>
-        # account id is replaced with higher priority
-
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
 
         aws_sqs_client.send_message(
@@ -4309,14 +4305,10 @@ class TestSqsProvider:
         response = receive_message(["SenderId", "SequenceNumber"])
         assert snapshot.match("multiple_attributes", response)
 
-    @markers.aws.unknown
-    # @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SenderId"])
+    @markers.aws.validated
     def test_message_system_attribute_names_with_attribute_names(
         self, sqs_create_queue, snapshot, aws_sqs_client
     ):
-        # TODO -> senderId in LS == account ID, but on AWS it looks quite different: [A-Z]{21}:<email>
-        # account id is replaced with higher priority
-
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
 
         aws_sqs_client.send_message(

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -4271,6 +4271,76 @@ class TestSqsProvider:
         response = receive_message(["SenderId", "SequenceNumber"])
         assert snapshot.match("multiple_attributes", response)
 
+    @markers.aws.unknown
+    # @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SenderId"])
+    def test_receive_message_message_system_attribute_names_filters(
+        self, sqs_create_queue, snapshot, aws_sqs_client
+    ):
+        # TODO -> senderId in LS == account ID, but on AWS it looks quite different: [A-Z]{21}:<email>
+        # account id is replaced with higher priority
+
+        queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
+
+        aws_sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody="msg",
+            MessageAttributes={
+                "Foo": {"DataType": "String", "StringValue": "Bar"},
+            },
+        )
+
+        def receive_message(message_system_attribute_names, message_attribute_names=None):
+            return aws_sqs_client.receive_message(
+                QueueUrl=queue_url,
+                WaitTimeSeconds=5,
+                MessageSystemAttributeNames=message_system_attribute_names,
+                MessageAttributeNames=message_attribute_names or [],
+            )
+
+        response = receive_message(["All"])
+        assert snapshot.match("all_attributes", response)
+
+        response = receive_message(["All"], ["All"])
+        assert snapshot.match("all_system_and_message_attributes", response)
+
+        response = receive_message(["SenderId"])
+        assert snapshot.match("single_attribute", response)
+
+        response = receive_message(["SenderId", "SequenceNumber"])
+        assert snapshot.match("multiple_attributes", response)
+
+    @markers.aws.unknown
+    # @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SenderId"])
+    def test_message_system_attribute_names_with_attribute_names(
+        self, sqs_create_queue, snapshot, aws_sqs_client
+    ):
+        # TODO -> senderId in LS == account ID, but on AWS it looks quite different: [A-Z]{21}:<email>
+        # account id is replaced with higher priority
+
+        queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "0"})
+
+        aws_sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody="msg",
+            MessageAttributes={
+                "Foo": {"DataType": "String", "StringValue": "Bar"},
+            },
+        )
+
+        def receive_message(message_system_attribute_names, attribute_names):
+            return aws_sqs_client.receive_message(
+                QueueUrl=queue_url,
+                WaitTimeSeconds=5,
+                MessageSystemAttributeNames=message_system_attribute_names,
+                AttributeNames=attribute_names,
+            )
+
+        response = receive_message(["All"], attribute_names=["All"])
+        assert snapshot.match("same_values", response)
+
+        response = receive_message(["All"], attribute_names=["SenderId"])
+        assert snapshot.match("different_values", response)
+
     @markers.aws.validated
     def test_change_visibility_on_deleted_message_raises_invalid_parameter_value(
         self, sqs_queue, aws_sqs_client

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -2578,7 +2578,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs]": {
-    "recorded-date": "30-04-2024, 13:34:57",
+    "recorded-date": "04-06-2024, 11:54:31",
     "recorded-content": {
       "all_attributes": {
         "Messages": [
@@ -2664,7 +2664,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs_query]": {
-    "recorded-date": "30-04-2024, 13:34:58",
+    "recorded-date": "04-06-2024, 11:54:34",
     "recorded-content": {
       "all_attributes": {
         "Messages": [
@@ -3362,5 +3362,144 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs]": {
+    "recorded-date": "04-06-2024, 11:46:28",
+    "recorded-content": {
+      "all_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all_system_and_message_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MD5OfMessageAttributes": "ae7155c6026991b6d54b11589678bf9c",
+            "MessageAttributes": {
+              "Foo": {
+                "DataType": "String",
+                "StringValue": "Bar"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "single_attribute": {
+        "Messages": [
+          {
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "multiple_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs_query]": {
+    "recorded-date": "04-06-2024, 11:46:30",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
+    "recorded-date": "04-06-2024, 11:57:55",
+    "recorded-content": {
+      "same_values": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "different_values": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs_query]": {
+    "recorded-date": "04-06-2024, 11:57:57",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3364,7 +3364,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs]": {
-    "recorded-date": "04-06-2024, 11:46:28",
+    "recorded-date": "04-06-2024, 16:10:07",
     "recorded-content": {
       "all_attributes": {
         "Messages": [
@@ -3450,8 +3450,90 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs_query]": {
-    "recorded-date": "04-06-2024, 11:46:30",
-    "recorded-content": {}
+    "recorded-date": "04-06-2024, 16:10:10",
+    "recorded-content": {
+      "all_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "all_system_and_message_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MD5OfMessageAttributes": "ae7155c6026991b6d54b11589678bf9c",
+            "MessageAttributes": {
+              "Foo": {
+                "DataType": "String",
+                "StringValue": "Bar"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "single_attribute": {
+        "Messages": [
+          {
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "multiple_attributes": {
+        "Messages": [
+          {
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
     "recorded-date": "04-06-2024, 11:57:55",

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -3536,7 +3536,7 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
-    "recorded-date": "04-06-2024, 11:57:55",
+    "recorded-date": "04-06-2024, 17:43:13",
     "recorded-content": {
       "same_values": {
         "Messages": [
@@ -3581,7 +3581,45 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs_query]": {
-    "recorded-date": "04-06-2024, 11:57:57",
-    "recorded-content": {}
+    "recorded-date": "04-06-2024, 17:43:15",
+    "recorded-content": {
+      "same_values": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "different_values": {
+        "Messages": [
+          {
+            "Attributes": {
+              "SenderId": "<sender-id:1>"
+            },
+            "Body": "msg",
+            "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -219,7 +219,10 @@
     "last_validated_date": "2024-04-30T13:34:55+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs]": {
-    "last_validated_date": "2024-06-04T11:46:28+00:00"
+    "last_validated_date": "2024-06-04T16:10:07+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs_query]": {
+    "last_validated_date": "2024-06-04T16:10:09+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_message_size": {
     "last_validated_date": "2024-04-30T13:33:44+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -188,6 +188,9 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_groups_with_dead_letter_queue_and_fifo[sqs_query]": {
     "last_validated_date": "2024-05-21T07:05:53+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
+    "last_validated_date": "2024-06-04T15:21:02+00:00"
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2024-04-30T13:35:47+00:00"
   },
@@ -198,10 +201,10 @@
     "last_validated_date": "2024-04-30T13:34:22+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs]": {
-    "last_validated_date": "2024-04-30T13:34:57+00:00"
+    "last_validated_date": "2024-06-04T11:54:31+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters[sqs_query]": {
-    "last_validated_date": "2024-04-30T13:34:58+00:00"
+    "last_validated_date": "2024-06-04T11:54:34+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_attributes_timestamp_types[sqs]": {
     "last_validated_date": "2024-04-30T13:40:03+00:00"
@@ -214,6 +217,9 @@
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters[sqs_query]": {
     "last_validated_date": "2024-04-30T13:34:55+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_receive_message_message_system_attribute_names_filters[sqs]": {
+    "last_validated_date": "2024-06-04T11:46:28+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_send_batch_message_size": {
     "last_validated_date": "2024-04-30T13:33:44+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -189,7 +189,10 @@
     "last_validated_date": "2024-05-21T07:05:53+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
-    "last_validated_date": "2024-06-04T15:21:02+00:00"
+    "last_validated_date": "2024-06-04T17:43:13+00:00"
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs_query]": {
+    "last_validated_date": "2024-06-04T17:43:14+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2024-04-30T13:35:47+00:00"

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -189,10 +189,10 @@
     "last_validated_date": "2024-05-21T07:05:53+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs]": {
-    "last_validated_date": "2024-06-04T17:43:13+00:00"
+    "last_validated_date": "2024-06-05T07:09:39+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_message_system_attribute_names_with_attribute_names[sqs_query]": {
-    "last_validated_date": "2024-06-04T17:43:14+00:00"
+    "last_validated_date": "2024-06-05T07:09:40+00:00"
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_non_existent_queue": {
     "last_validated_date": "2024-04-30T13:35:47+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
AWS deprecated the `attribute-names` parameter for `receive-message` operation and changed it to `message-system-attribute-names`. This PR addresses this change.
fixes #10908 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- adds the necessary alias handling in LocalStack
- add tests
- add custom entry to query spec. Our sqs-query spec is not updated automatically. Kudos to @bentsku for going through the query spec code with me! For now this PR adds this change manually, if the solution is too hacky we have to reconsider. /cc @alexrashed 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
