### PR TITLE
add codeowners validation to gh actions

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   validate-codeowners:
-    uses: localstack/meta/.github/workflows/validate-codeowners.yml@add-validate-codeowners
-    with:
-      codeowners-file: './CODEOWNERS'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
+      - name: Validate codeowners
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Validate codeowners
         uses: mszostok/codeowners-validator@v0.7.4
         with:
-          checks: "files"
+          checks: "files,duppatterns,syntax"
+          experimental_checks: "avoid-shadowing"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,16 @@
+name: LocalStack - Validate Codeowners
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate-codeowners:
+    uses: localstack/meta/.github/workflows/validate-codeowners.yml@add-validate-codeowners
+    with:
+      codeowners-file: './CODEOWNERS'
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,7 +80,6 @@
 # Snapshot testing
 /localstack-core/localstack/testing/snapshots/ @dominikschubert @steffyP
 /localstack-core/localstack/testing/pytest/ @dominikschubert
-/tests/unit/utils/testing/ @dominikschubert @steffyP
 
 # Scenario testing
 /localstack-core/localstack/testing/scenario/ @dominikschubert @steffyP


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Codeowners can get outdated quickly when refactoring code, or shuffling around modules.
This PR aims to introduce a safety net which warns a user about changes in PRs that would introduce such issues to the Codeowners file 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

This PR adds a small workflow to our suite of actions, which on each PR raised will verify whether the codeowners file is still valid.

<!-- Optional section: How to test these changes? -->
## Testing
In the checks of this PR you should already see the workflow with the name `LocalStack - Validate Codeowners` show up.
It's currently red, as the codeowners file has some issues.

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [x] clean up the CODEOWNERS file, for which I'd need input on from the localstack team

```
    [err] line 83: "/tests/unit/utils/testing/" does not match any files in repository
```

Should we just remove this line?