### PR TITLE
add code to debug monkey patches applied through localstack.utils.patch

### DIFF
--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -190,3 +190,15 @@ def test_get_defining_object():
 
     # static method (= function defined by a class)
     assert get_defining_object(MyEchoer.do_static_echo) == MyEchoer
+
+
+def test_to_string():
+    @patch(MyEchoer.do_echo)
+    def monkey(self, *args):
+        return f"monkey: {args[-1]}"
+
+    applied = [str(p) for p in Patch.applied_patches]
+
+    value = "Patch(function(tests.unit.utils.test_patch:MyEchoer.do_echo) -> function(tests.unit.utils.test_patch:test_to_string.<locals>.monkey), applied=True)"
+    assert value in applied
+    assert str(monkey.patch) == value


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While debugging test failures in #10942, I had a hunch that it had something to do with missing patches, but didn't have the tools to verify. This PR adds these tools.

With the added utilities, I was able to add this simple python snippet after the runtime was ready:

```python
from localstack.utils.patch import Patch

for p in Patch.applied_patches:
    print("- {p}"
```

And compare the outputs when running with the old/new runtime:
```
applied patches:
 - Patch(function(botocore.waiter:Waiter.wait) -> function(localstack.aws.connect:my_patch), applied=True)
 - Patch(function(botocore.parsers:BaseJSONParser._parse_body_as_json) -> function(localstack.aws.client:_patch_botocore_json_parser.<locals>._parse_body_as_json), applied=True)
 - Patch(function(moto.core.utils:convert_to_flask_response.__call__) -> function(localstack.utils.aws.request_context:patch_moto_request_handling.<locals>.convert_to_flask_response_call), applied=True)
 - Patch(function(localstack.utils.threads:FuncThread.__init__) -> function(localstack.utils.aws.request_context:patch_moto_request_handling.<locals>.thread_init), applied=True)
 - Patch(function(localstack.utils.threads:FuncThread.run) -> function(localstack.utils.aws.request_context:patch_moto_request_handling.<locals>.thread_run), applied=True)
 - Patch(method(twisted.python.threadpool:ThreadPool.stop) -> method(localstack.aws.serving.twisted:stop_thread_pool), applied=True)
```
```
applied patches:
 - Patch(function(botocore.waiter:Waiter.wait) -> function(localstack.aws.connect:my_patch), applied=True)
 - Patch(function(botocore.parsers:BaseJSONParser._parse_body_as_json) -> function(localstack.aws.client:_patch_botocore_json_parser.<locals>._parse_body_as_json), applied=True)
 - Patch(method(twisted.python.threadpool:ThreadPool.stop) -> method(localstack.aws.serving.twisted:stop_thread_pool), applied=True)
```

This helped me find where the patches came from

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Patches that use `@patch` or `Patch` are now being tracked in a class-level list `Patch.applied_patches`
* `Patch` can now be printed in a human readable way

<!-- Optional section: How to test these changes? -->

## Testing

See code snippet above

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
