### PR TITLE
move aws-specific patches into localstack.aws.patches

### DIFF
--- a/localstack-core/localstack/aws/patches.py
+++ b/localstack-core/localstack/aws/patches.py
@@ -1,0 +1,58 @@
+from importlib.util import find_spec
+
+from localstack.runtime import hooks
+from localstack.utils.patch import patch
+
+
+def patch_moto_instance_tracker_meta():
+    """
+    Avoid instance collection for moto dashboard. Introduced in
+    https://github.com/localstack/localstack/pull/3250.
+    """
+    from moto.core.base_backend import InstanceTrackerMeta
+    from moto.core.common_models import BaseModel
+
+    if hasattr(InstanceTrackerMeta, "_ls_patch_applied"):
+        return  # ensure we're not applying the patch multiple times
+
+    @patch(InstanceTrackerMeta.__new__, pass_target=False)
+    def new_instance(meta, name, bases, dct):
+        cls = super(InstanceTrackerMeta, meta).__new__(meta, name, bases, dct)
+        if name == "BaseModel":
+            return cls
+        cls.instances = []
+        return cls
+
+    @patch(BaseModel.__new__, pass_target=False)
+    def new_basemodel(cls, *args, **kwargs):
+        # skip cls.instances.append(..) which is done by the original/upstream constructor
+        instance = super(BaseModel, cls).__new__(cls)
+        return instance
+
+    InstanceTrackerMeta._ls_patch_applied = True
+
+
+def patch_moto_iam_config():
+    """
+    Enable loading AWS IAM managed policies in moto by default.Introduced in
+    https://github.com/localstack/localstack/pull/10112.
+    """
+    from moto.core.config import default_user_config
+
+    default_user_config["iam"]["load_aws_managed_policies"] = True
+
+
+# TODO: this could be improved by introducing a hook specifically for applying global patches that is run
+#  before any other code is imported.
+@hooks.on_infra_start(priority=100)
+def apply_aws_runtime_patches():
+    """
+    Runtime patches specific to the AWS emulator.
+    """
+    if find_spec("moto"):
+        # only load patches when moto is importable
+        from localstack.utils.aws.request_context import patch_moto_request_handling
+
+        patch_moto_request_handling()
+        patch_moto_iam_config()
+        patch_moto_instance_tracker_meta()

--- a/localstack-core/localstack/utils/aws/request_context.py
+++ b/localstack-core/localstack/utils/aws/request_context.py
@@ -166,11 +166,6 @@ def patch_moto_request_handling():
 
     from moto.core import utils as moto_utils
 
-    # enable loading AWS IAM managed policies
-    from moto.core.config import default_user_config
-
-    default_user_config["iam"]["load_aws_managed_policies"] = True
-
     # make sure we properly handle/propagate "not implemented" errors
     @patch(moto_utils.convert_to_flask_response.__call__)
     def convert_to_flask_response_call(fn, *args, **kwargs):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

As part of the effort to reduce coupling of runtime and AWS code #10946, I'm moving some patches that are specific to moto AWS into their own package, and applying them using a hook rather than statically in the infra code. This will also help in #10942.

I left some parts of the `patch_moto_request_handling` because I'd like to separately investigate whether we can simplify or remove it.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* `patch_instance_tracker_meta` is now applied using a hook
* patching the moto config to set `load_aws_managed_policies` is now done in its own patch

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
