### PR TITLE
fix S3 image publishing

### DIFF
--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -43,7 +43,7 @@ on:
         description: 'Publish S3-only images on Dockerhub'
         required: false
         type: boolean
-        default: false
+        default: true
       PYTEST_LOGLEVEL:
         type: choice
         description: Loglevel for PyTest

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -194,6 +194,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Download docker-helper.sh
+        run: |
+          curl -o /tmp/docker-helper.sh -L https://raw.githubusercontent.com/localstack/localstack/master/bin/docker-helper.sh -H 'Accept: application/vnd.github.v3.raw'
+          chmod +x /tmp/docker-helper.sh
+
       - name: Download AMD64 image
         uses: actions/download-artifact@v4
         with:
@@ -207,25 +212,25 @@ jobs:
       - name: Load AMD64 image
         env:
           PLATFORM: amd64
-        run: ./bin/docker-helper.sh load
+        run: /tmp/docker-helper.sh load
 
       - name: Push AMD64 image
         env:
           PLATFORM: amd64
-        run: ./bin/docker-helper.sh push
+        run: /tmp/docker-helper.sh push
 
       - name: Load ARM64 image
         env:
           PLATFORM: arm64
-        run: ./bin/docker-helper.sh load
+        run: /tmp/docker-helper.sh load
 
       - name: Push ARM64 image
         env:
           PLATFORM: arm64
-        run: ./bin/docker-helper.sh push
+        run: /tmp/docker-helper.sh push
 
       - name: Create and push manifest
-        run: ./bin/docker-helper.sh push-manifests
+        run: /tmp/docker-helper.sh push-manifests
 
   cleanup:
     name: "Clean up"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -43,7 +43,7 @@ on:
         description: 'Publish S3-only images on Dockerhub'
         required: false
         type: boolean
-        default: true
+        default: false
       PYTEST_LOGLEVEL:
         type: choice
         description: Loglevel for PyTest
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-test-s3
-    if: inputs.publishDockerImage
+    # if: inputs.publishDockerImage
     env:
       IMAGE_NAME: "localstack/localstack"
       DEFAULT_TAG: "s3-latest"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-test-s3
-    # if: inputs.publishDockerImage
+    if: inputs.publishDockerImage
     env:
       IMAGE_NAME: "localstack/localstack"
       DEFAULT_TAG: "s3-latest"

--- a/.github/workflows/tests-s3-image.yml
+++ b/.github/workflows/tests-s3-image.yml
@@ -194,10 +194,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Download docker-helper.sh
-        run: |
-          curl -o /tmp/docker-helper.sh -L https://raw.githubusercontent.com/localstack/localstack/master/bin/docker-helper.sh -H 'Accept: application/vnd.github.v3.raw'
-          chmod +x /tmp/docker-helper.sh
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Download AMD64 image
         uses: actions/download-artifact@v4
@@ -212,25 +210,25 @@ jobs:
       - name: Load AMD64 image
         env:
           PLATFORM: amd64
-        run: /tmp/docker-helper.sh load
+        run: ./bin/docker-helper.sh load
 
       - name: Push AMD64 image
         env:
           PLATFORM: amd64
-        run: /tmp/docker-helper.sh push
+        run: ./bin/docker-helper.sh push
 
       - name: Load ARM64 image
         env:
           PLATFORM: arm64
-        run: /tmp/docker-helper.sh load
+        run: ./bin/docker-helper.sh load
 
       - name: Push ARM64 image
         env:
           PLATFORM: arm64
-        run: /tmp/docker-helper.sh push
+        run: ./bin/docker-helper.sh push
 
       - name: Create and push manifest
-        run: /tmp/docker-helper.sh push-manifests
+        run: ./bin/docker-helper.sh push-manifests
 
   cleanup:
     name: "Clean up"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As seen here with this manual run to publish the S3 image, we did not checkout the repo in the publish job or download the docker helper script, so we did not have access to it.
https://github.com/localstack/localstack/actions/runs/9382410974/job/25834104662

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- ~download the docker helper script in order to be able to execute it~
- checkout the repo in order to have the script available and the git hash

## Testing

Currently running with the `publish` flag set to `true` in order to test the fix, as I need a new image out to contain all the latest changes. 