### PR TITLE
fix S3 aws-chunked when checksum is provided

### DIFF
--- a/localstack-core/localstack/services/s3/codec.py
+++ b/localstack-core/localstack/services/s3/codec.py
@@ -120,6 +120,7 @@ class AwsChunkedDecoder(io.RawIOBase):
         the provided checksum value by the client in the S3 logic.
         """
         if checksum_algorithm := getattr(self.s3_object, "checksum_algorithm", None):
-            self.s3_object.checksum_value = self._trailing_headers.get(
+            if checksum_value := self._trailing_headers.get(
                 f"x-amz-checksum-{checksum_algorithm.lower()}"
-            )
+            ):
+                self.s3_object.checksum_value = checksum_value

--- a/localstack-core/localstack/services/s3/v3/provider.py
+++ b/localstack-core/localstack/services/s3/v3/provider.py
@@ -669,9 +669,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             "STREAMING-"
         ) or "aws-chunked" in headers.get("content-encoding", "")
         if is_aws_chunked:
-            if checksum_algorithm := get_s3_checksum_algorithm_from_trailing_headers(
-                headers.get("x-amz-trailer", "")
-            ):
+            checksum_algorithm = (
+                checksum_algorithm
+                or get_s3_checksum_algorithm_from_trailing_headers(headers.get("x-amz-trailer", ""))
+            )
+            if checksum_algorithm:
                 s3_object.checksum_algorithm = checksum_algorithm
 
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))
@@ -1955,9 +1957,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         ) or "aws-chunked" in headers.get("content-encoding", "")
         # check if chunked request
         if is_aws_chunked:
-            if checksum_algorithm := get_s3_checksum_algorithm_from_trailing_headers(
-                headers.get("x-amz-trailer", "")
-            ):
+            checksum_algorithm = (
+                checksum_algorithm
+                or get_s3_checksum_algorithm_from_trailing_headers(headers.get("x-amz-trailer", ""))
+            )
+            if checksum_algorithm:
                 s3_part.checksum_algorithm = checksum_algorithm
 
             decoded_content_length = int(headers.get("x-amz-decoded-content-length", 0))


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #10954, a case has not been thought of in this PR, when the checksum would be manually provided as a header and not part of a trailing header with the `aws-chunked` encoding.

This PR fixes this case. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the logic so that if the checksum is provided, do not override it by trying to get the trailing headers that might not be present
- add a test for this use case

_fixes #10914_ (again)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
