### PR TITLE
Fix sqs urlencoded parsing

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_sqs.py
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+import pytest
 import requests
 
 from localstack.testing.pytest import markers
@@ -256,3 +257,94 @@ def test_sqs_request_and_response_xml_templates_integration(
     assert re.search("<MessageId>.*</MessageId>", xml_body)
     assert re.search("<MD5OfMessageBody>.*</MD5OfMessageBody>", xml_body)
     assert re.search("<RequestId>.*</RequestId>", xml_body)
+
+
+@pytest.mark.parametrize("message_attribute", ["MessageAttribute", "MessageAttributes"])
+@markers.aws.validated
+def test_sqs_aws_integration_with_message_attribute(
+    create_rest_apigw,
+    sqs_create_queue,
+    aws_client,
+    create_role_with_policy,
+    region_name,
+    account_id,
+    snapshot,
+    message_attribute,
+):
+    # create target SQS stream
+    queue_name = f"queue-{short_uid()}"
+    queue_url = sqs_create_queue(QueueName=queue_name)
+
+    # create invocation role
+    _, role_arn = create_role_with_policy(
+        "Allow", "sqs:SendMessage", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+
+    api_id, _, root = create_rest_apigw(
+        name=f"test-api-${short_uid()}",
+        description="Test Integration with SQS",
+    )
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=root,
+        httpMethod="POST",
+        authorizationType="NONE",
+    )
+
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=root,
+        httpMethod="POST",
+        type="AWS",
+        integrationHttpMethod="POST",
+        uri=f"arn:aws:apigateway:{region_name}:sqs:path/{account_id}/{queue_name}",
+        credentials=role_arn,
+        requestParameters={
+            "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
+        },
+        requestTemplates={
+            "application/json": (
+                "Action=SendMessage&MessageBody=$input.body&"
+                f"{message_attribute}.1.Name=user-agent&"
+                f"{message_attribute}.1.Value.DataType=String&"
+                f"{message_attribute}.1.Value.StringValue=$input.params('HeaderFoo')"
+            )
+        },
+        passthroughBehavior="NEVER",
+    )
+
+    aws_client.apigateway.put_method_response(
+        restApiId=api_id,
+        resourceId=root,
+        httpMethod="POST",
+        statusCode="200",
+        responseModels={"application/json": "Empty"},
+    )
+
+    aws_client.apigateway.put_integration_response(
+        restApiId=api_id,
+        resourceId=root,
+        httpMethod="POST",
+        statusCode="200",
+    )
+
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=TEST_STAGE_NAME)
+    invocation_url = api_invoke_url(api_id=api_id, stage=TEST_STAGE_NAME, path="/")
+
+    def invoke_api(url):
+        _response = requests.post(url, json={"foo": "bar"}, headers={"HeaderFoo": "BAR-Header"})
+        assert _response.ok
+
+    retry(invoke_api, sleep=2, retries=10, url=invocation_url)
+
+    def get_sqs_message():
+        messages = aws_client.sqs.receive_message(
+            QueueUrl=queue_url, MessageAttributeNames=["All"]
+        ).get("Messages", [])
+        assert 1 == len(messages)
+        return messages[0]
+
+    message = retry(get_sqs_message, sleep=2, retries=10)
+    snapshot.match("sqs-message-body", message["Body"])
+    snapshot.match("sqs-message-attributes", message["MessageAttributes"])

--- a/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.snapshot.json
@@ -18,5 +18,33 @@
         "requestId": "<uuid:2>"
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration_with_message_attribute[MessageAttribute]": {
+    "recorded-date": "06-06-2024, 00:38:25",
+    "recorded-content": {
+      "sqs-message-body": {
+        "foo": "bar"
+      },
+      "sqs-message-attributes": {
+        "user-agent": {
+          "DataType": "String",
+          "StringValue": "BAR-Header"
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration_with_message_attribute[MessageAttributes]": {
+    "recorded-date": "06-06-2024, 00:38:34",
+    "recorded-content": {
+      "sqs-message-body": {
+        "foo": "bar"
+      },
+      "sqs-message-attributes": {
+        "user-agent": {
+          "DataType": "String",
+          "StringValue": "BAR-Header"
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_sqs.validation.json
@@ -2,6 +2,12 @@
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration": {
     "last_validated_date": "2024-05-30T17:27:58+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration_with_message_attribute[MessageAttribute]": {
+    "last_validated_date": "2024-06-06T00:38:25+00:00"
+  },
+  "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_aws_integration_with_message_attribute[MessageAttributes]": {
+    "last_validated_date": "2024-06-06T00:38:34+00:00"
+  },
   "tests/aws/services/apigateway/test_apigateway_sqs.py::test_sqs_request_and_response_xml_templates_integration": {
     "last_validated_date": "2023-09-10T08:13:06+00:00"
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fixes #10949 

It appears to be a similar issue to #6091 where sqs accepts both `MessageAttribute.1.Name` and `MessageAttributes.1.Name` when resolving url encoded forms.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

In addition to verifying for the presence of `.1.Key` we also need to look for `.1.Name` when deciding if we use `MessageAttribute` or `MessageAttributes` to build the object.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
