### PR TITLE
Refactor all pytest xfail markers to skip instead

### DIFF
--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -123,7 +123,7 @@ class TestApiGatewayApiRestApi:
         snapshot.match("get-rest-api-after-delete", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(reason="rest apis are case insensitive for now because of custom id tags")
+    @pytest.mark.skip(reason="rest apis are case insensitive for now because of custom id tags")
     def test_get_api_case_insensitive(self, apigw_create_rest_api, snapshot, aws_client):
         api_name1 = f"test-case-sensitive-apis-{short_uid()}"
 

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -608,7 +608,7 @@ class TestAPIGateway:
         response = requests.get(url)
         snapshot.match("mocked-response", response.json())
 
-    @pytest.mark.xfail(reason="Behaviour is not AWS compliant, need to recreate this test")
+    @pytest.mark.skip(reason="Behaviour is not AWS compliant, need to recreate this test")
     @markers.aws.needs_fixing
     # TODO rework or remove this test
     def test_api_gateway_authorizer_crud(self, aws_client):

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -73,7 +73,7 @@ def test_create_change_set_without_parameters(
 
 
 # TODO: implement
-@pytest.mark.xfail(condition=not is_aws_cloud(), reason="Not properly implemented")
+@pytest.mark.skip(condition=not is_aws_cloud(), reason="Not properly implemented")
 @markers.aws.validated
 def test_create_change_set_update_without_parameters(
     cleanup_stacks,

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -73,7 +73,7 @@ def test_create_change_set_without_parameters(
 
 
 # TODO: implement
-@pytest.mark.skip(condition=not is_aws_cloud(), reason="Not properly implemented")
+@pytest.mark.skipif(condition=not is_aws_cloud(), reason="Not properly implemented")
 @markers.aws.validated
 def test_create_change_set_update_without_parameters(
     cleanup_stacks,

--- a/tests/aws/services/cloudformation/resource_providers/opensearch/test_domain.py
+++ b/tests/aws/services/cloudformation/resource_providers/opensearch/test_domain.py
@@ -19,7 +19,7 @@ RESOURCE_GETATT_TARGETS = [
 
 class TestAttributeAccess:
     @pytest.mark.parametrize("attribute", RESOURCE_GETATT_TARGETS)
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="Some tests are expected to fail, since they try to access invalid CFn attributes",
         raises=StackDeployError,
     )

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -324,7 +324,7 @@ def test_lambda_vpc(deploy_cfn_template, aws_client):
     aws_client.lambda_.invoke(FunctionName=fn_name, LogType="Tail", Payload=b"{}")
 
 
-@pytest.mark.xfail(reason="fails/times out with new provider")  # FIXME
+@pytest.mark.skip(reason="fails/times out with new provider")  # FIXME
 @markers.aws.validated
 def test_update_lambda_permissions(deploy_cfn_template, aws_client):
     stack = deploy_cfn_template(

--- a/tests/aws/services/cloudformation/resources/test_legacy.py
+++ b/tests/aws/services/cloudformation/resources/test_legacy.py
@@ -585,7 +585,7 @@ class TestCloudFormation:
         assert len([c for c in certs if c.get("DomainName") == "example.com"]) == 0
 
     # TODO: refactor
-    @pytest.mark.xfail(reason="fails due to / depending on other tests")
+    @pytest.mark.skip(reason="fails due to / depending on other tests")
     @markers.aws.unknown
     def test_deploy_stack_with_sub_select_and_sub_getaz(
         self, deploy_cfn_template, cleanups, aws_client, account_id, region_name

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -439,7 +439,7 @@ class TestSecretsManagerParameters:
 
 
 class TestPreviousValues:
-    @pytest.mark.xfail(reason="outputs don't behave well in combination with conditions")
+    @pytest.mark.skip(reason="outputs don't behave well in combination with conditions")
     @markers.aws.validated
     def test_parameter_usepreviousvalue_behavior(
         self, deploy_cfn_template, is_stack_updated, aws_client

--- a/tests/aws/services/events/test_events_rules.py
+++ b/tests/aws/services/events/test_events_rules.py
@@ -300,7 +300,7 @@ def test_put_event_with_content_base_rule_in_pattern(aws_client, clean_up):
 
 
 @markers.aws.validated
-@pytest.mark.xfail
+@pytest.mark.skip
 def test_verify_rule_event_content(aws_client, clean_up):
     log_group_name = f"/aws/events/testLogGroup-{short_uid()}"
     rule_name = f"rule-{short_uid()}"

--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -186,7 +186,7 @@ class TestScheduleRate:
             "$..storedBytes",
         ]
     )
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="This test is flaky is CI, might be race conditions"  # FIXME: investigate and fix
     )
     def test_scheduled_rule_logs(

--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -484,7 +484,7 @@ class TestIAMIntegrations:
         assert roles["Roles"][0]["RoleName"] == role_name_2
 
     @markers.aws.validated
-    @pytest.mark.xfail
+    @pytest.mark.skip
     @pytest.mark.parametrize(
         "service_name, expected_role",
         [

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -666,7 +666,7 @@ class TestLambdaBehavior:
 
         wait_until(_assert_log_output, strategy="linear")
 
-    @pytest.mark.xfail(reason="Currently flaky in CI")
+    @pytest.mark.skip(reason="Currently flaky in CI")
     @markers.aws.validated
     def test_lambda_invoke_timed_out_environment_reuse(
         self, create_lambda_function, snapshot, aws_client

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -10434,7 +10434,7 @@ class TestS3PresignedPost:
         )
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="failing sporadically with new HTTP gateway (only in CI)",
     )
     def test_post_object_with_files(self, s3_bucket, aws_client):
@@ -10636,7 +10636,7 @@ class TestS3PresignedPost:
         snapshot.match("exception-no-sig-related-fields", exception)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="sporadically failing in CI: presigned-post does not set the body, and then etag is wrong",
     )
     def test_s3_presigned_post_success_action_status_201_response(

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -2968,7 +2968,7 @@ class TestSNSPlatformEndpoint:
         assert e.value.response["Error"]["Message"] == "Endpoint is disabled"
 
     @markers.aws.only_localstack  # needs real credentials for GCM/FCM
-    @pytest.mark.xfail(reason="Need to implement credentials validation when creating platform")
+    @pytest.mark.skip(reason="Need to implement credentials validation when creating platform")
     def test_publish_to_gcm(self, sns_create_platform_application, aws_client):
         key = "mock_server_key"
         token = "mock_token"

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -811,7 +811,7 @@ class TestSqsProvider:
         snapshot.match("get_updated_queue_attributes", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5938")
+    @pytest.mark.skip(reason="see https://github.com/localstack/localstack/issues/5938")
     def test_create_queue_with_default_arguments_works_with_modified_attributes(
         self, sqs_create_queue, aws_sqs_client
     ):
@@ -850,7 +850,7 @@ class TestSqsProvider:
         assert queue_url == sqs_create_queue(QueueName=queue_name)
 
     @markers.aws.validated
-    @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5938")
+    @pytest.mark.skip(reason="see https://github.com/localstack/localstack/issues/5938")
     def test_create_queue_after_modified_attributes(self, sqs_create_queue, aws_sqs_client):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(
@@ -2026,7 +2026,7 @@ class TestSqsProvider:
         assert get_qsize(aws_sqs_client, queue_url) == 1
 
     @markers.aws.validated
-    @pytest.mark.xfail(reason="not implemented in localstack at the moment")
+    @pytest.mark.skip(reason="not implemented in localstack at the moment")
     def test_fifo_delete_message_with_expired_receipt_handle(
         self, sqs_create_queue, aws_sqs_client, snapshot
     ):
@@ -2460,7 +2460,7 @@ class TestSqsProvider:
             sqs_create_queue(QueueName=queue_name)
         e.match("InvalidParameterValue")
 
-    @pytest.mark.xfail
+    @pytest.mark.skip
     @markers.aws.validated
     def test_redrive_policy_attribute_validity(
         self, sqs_create_queue, sqs_get_queue_arn, aws_sqs_client
@@ -2511,7 +2511,7 @@ class TestSqsProvider:
         )
 
     @markers.aws.validated
-    @pytest.mark.xfail(reason="behavior not implemented yet")
+    @pytest.mark.skip(reason="behavior not implemented yet")
     def test_invalid_dead_letter_arn_rejected_before_lookup(self, sqs_create_queue, snapshot):
         dl_dummy_arn = "dummy"
         max_receive_count = 42
@@ -3266,7 +3266,7 @@ class TestSqsProvider:
         snapshot.match("get-dedup-messages", response)
 
     @markers.aws.validated
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="localstack allows queue names with slashes, but this should be deprecated"
     )
     def test_disallow_queue_name_with_slashes(self, sqs_create_queue):
@@ -4150,7 +4150,7 @@ class TestSqsProvider:
         )
         snapshot.match("sse_sqs_attributes", response)
 
-    @pytest.mark.xfail(reason="validation currently not implemented in localstack")
+    @pytest.mark.skip(reason="validation currently not implemented in localstack")
     @markers.aws.validated
     def test_sse_kms_and_sqs_are_mutually_exclusive(
         self, sqs_create_queue, snapshot, aws_sqs_client
@@ -4901,7 +4901,7 @@ class TestSqsQueryApi:
         assert queue1_url.split("/")[-1] not in response.text
         assert queue2_url.split("/")[-1] in response.text
 
-    @pytest.mark.xfail(reason="json serialization not supported yet")
+    @pytest.mark.skip(reason="json serialization not supported yet")
     @markers.aws.validated
     def test_get_list_queues_fails_json_format(self, sqs_create_queue, sqs_http_client):
         queue_url = sqs_create_queue()
@@ -4919,7 +4919,7 @@ class TestSqsQueryApi:
         assert doc["Error"]["Code"] == "InvalidAction"
         assert doc["Error"]["Message"] == "The action ListQueues is not valid for this endpoint."
 
-    @pytest.mark.xfail(reason="json serialization not supported yet")
+    @pytest.mark.skip(reason="json serialization not supported yet")
     @markers.aws.validated
     def test_get_queue_attributes_json_format(self, sqs_create_queue, sqs_http_client):
         queue_url = sqs_create_queue()

--- a/tests/aws/test_terraform.py
+++ b/tests/aws/test_terraform.py
@@ -166,7 +166,7 @@ class TestTerraform:
         assert function_mapping["EventSourceArn"] == queue_arn
 
     @markers.skip_offline
-    @pytest.mark.xfail(reason="flaky")
+    @pytest.mark.skip(reason="flaky")
     @markers.aws.needs_fixing
     def test_apigateway(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()
@@ -214,7 +214,7 @@ class TestTerraform:
         assert len(certs) == 1
 
     @markers.skip_offline
-    @pytest.mark.xfail(reason="flaky")
+    @pytest.mark.skip(reason="flaky")
     @markers.aws.needs_fixing
     def test_apigateway_escaped_policy(self, aws_client):
         rest_apis = aws_client.apigateway.get_rest_apis()

--- a/tests/aws/test_validate.py
+++ b/tests/aws/test_validate.py
@@ -6,7 +6,7 @@ import pytest
 from botocore.auth import SigV4Auth
 
 
-@pytest.mark.xfail(reason="there is no generalized way of server-side request validation yet")
+@pytest.mark.skip(reason="there is no generalized way of server-side request validation yet")
 class TestMissingParameter:
     @markers.aws.validated
     def test_opensearch(self, aws_http_client_factory):

--- a/tests/integration/aws/test_app.py
+++ b/tests/integration/aws/test_app.py
@@ -171,7 +171,7 @@ class TestHttps:
         assert response.ok
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     condition=config.GATEWAY_SERVER not in ["hypercorn"],
     reason=f"websockets not supported with {config.GATEWAY_SERVER}",
 )

--- a/tests/integration/aws/test_app.py
+++ b/tests/integration/aws/test_app.py
@@ -24,7 +24,7 @@ class TestExceptionHandlers:
         }
         assert "Allow" in response.headers
 
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="fails until the service request parser stops detecting custom route requests as s3 requests"
     )
     def test_router_handler_get_http_errors(self, cleanups):
@@ -58,7 +58,7 @@ class TestExceptionHandlers:
             "either read-protected or not readable by the server.",
         }
 
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="fails until the service request parser stops detecting custom route requests as s3 requests"
     )
     def test_router_handler_get_unexpected_errors(self, cleanups):
@@ -171,7 +171,7 @@ class TestHttps:
         assert response.ok
 
 
-@pytest.mark.xfail(
+@pytest.mark.skip(
     condition=config.GATEWAY_SERVER not in ["hypercorn"],
     reason=f"websockets not supported with {config.GATEWAY_SERVER}",
 )

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -365,8 +365,9 @@ class TestDockerClient:
             docker_client.remove_container(container_name)
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.skip(
-        _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
+    @pytest.mark.skipif(
+        condition=_is_podman_test(),
+        reason="Podman get_networks(..) does not return list of networks in CI",
     )
     def test_get_network(self, docker_client: ContainerClient, dummy_container):
         networks = docker_client.get_networks(dummy_container.container_name)
@@ -418,8 +419,9 @@ class TestDockerClient:
         assert ipaddress.IPv4Address(result_custom_network) in ipaddress.IPv4Network(custom_network)
 
     # TODO: currently failing under Podman
-    @pytest.mark.skip(
-        _is_podman_test(), reason="Podman inspect_network does not return `Containers` attribute"
+    @pytest.mark.skipif(
+        condition=_is_podman_test(),
+        reason="Podman inspect_network does not return `Containers` attribute",
     )
     def test_get_container_ip_for_network_wrong_network(
         self, docker_client: ContainerClient, dummy_container, create_network
@@ -439,8 +441,9 @@ class TestDockerClient:
             )
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.skip(
-        _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
+    @pytest.mark.skipif(
+        condition=_is_podman_test(),
+        reason="Podman get_networks(..) does not return list of networks in CI",
     )
     def test_get_container_ip_for_host_network(
         self, docker_client: ContainerClient, create_container
@@ -466,8 +469,9 @@ class TestDockerClient:
             )
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.skip(
-        _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
+    @pytest.mark.skipif(
+        condition=_is_podman_test(),
+        reason="Podman get_networks(..) does not return list of networks in CI",
     )
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):
         info = create_container("alpine", network="host")
@@ -1283,8 +1287,8 @@ class TestDockerClient:
         assert "alpine" in docker_client.inspect_image("alpine")["RepoTags"][0]
 
     # TODO: currently failing under Podman
-    @pytest.mark.skip(
-        _is_podman_test(), reason="Podman inspect_network does not return `Id` attribute"
+    @pytest.mark.skipif(
+        condition=_is_podman_test(), reason="Podman inspect_network does not return `Id` attribute"
     )
     def test_inspect_network(self, docker_client: ContainerClient, create_network):
         network_name = f"ls_test_network_{short_uid()}"

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -365,7 +365,7 @@ class TestDockerClient:
             docker_client.remove_container(container_name)
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
     )
     def test_get_network(self, docker_client: ContainerClient, dummy_container):
@@ -418,7 +418,7 @@ class TestDockerClient:
         assert ipaddress.IPv4Address(result_custom_network) in ipaddress.IPv4Network(custom_network)
 
     # TODO: currently failing under Podman
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         _is_podman_test(), reason="Podman inspect_network does not return `Containers` attribute"
     )
     def test_get_container_ip_for_network_wrong_network(
@@ -439,7 +439,7 @@ class TestDockerClient:
             )
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
     )
     def test_get_container_ip_for_host_network(
@@ -466,7 +466,7 @@ class TestDockerClient:
             )
 
     # TODO: currently failing under Podman in CI (works locally under MacOS)
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         _is_podman_test(), reason="Podman get_networks(..) does not return list of networks in CI"
     )
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):
@@ -1283,7 +1283,7 @@ class TestDockerClient:
         assert "alpine" in docker_client.inspect_image("alpine")["RepoTags"][0]
 
     # TODO: currently failing under Podman
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         _is_podman_test(), reason="Podman inspect_network does not return `Id` attribute"
     )
     def test_inspect_network(self, docker_client: ContainerClient, create_network):

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -73,7 +73,7 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                     service,
                     service.protocol,
                     service.operation_model(operation_name),
-                    marks=pytest.mark.xfail(
+                    marks=pytest.mark.skip(
                         reason=f"{service.service_name} is currently not supported by the service router"
                     ),
                 )


### PR DESCRIPTION
## Motivation

I've noticed we have a lot of tests that are xfailed vs. skipped. I'd argue we actually want to skip all of those, since they can still lead to issues for either the pipeline (e.g. by extending the total duration) or other tests. The whole reason they're xfailed is because there's some issue that we usually don't immediately want to deal with. Often that's issues that lead to timeouts for example where an xfail won't help at all. I'm also not aware that we would've ever actually looked at any XPASS results to "un-xfail" tests.

In favor of simplicity and improving stability of the pipeline, let's fully skip the tests that we know to be flaky/broken.

## Changes

- All previously xfailed tests are now being skipped and thus not executed at all in our tests. This should provide a minor speed up of the pipeline and improve stability a bit.