### PR TITLE
Fix `Dockerfile.s3` healthcheck

### DIFF
--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -97,7 +97,7 @@ RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > loca
 # expose edge service and debugpy
 EXPOSE 4566 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD ./bin/localstack status services --format=json
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD .venv/bin/localstack status services --format=json
 
 # default volume directory
 VOLUME /var/lib/localstack


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The latest-pushed `latest-s3` image fails to boot properly for me:

```
 localstack-s3 Pulled 
 Container localstack-s3-1  Creating
 Container localstack-s3-1  Created
 Container localstack-s3-1  Starting
 Container localstack-s3-1  Started
 Container localstack-s3-1  Waiting
<after 60s timeout passes>
container localstack-s3-1 is unhealthy
```

Comparing the logs between the old image that worked for us and the new one that doesn't, I can't see any healthcheck calls.

Shelling into the image, manually trying to run the heathcheck command `./bin/localstack status services --format=json` fails with `ModuleNotFoundError: No module named 'localstack'`


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Copied over the healthcheck changes in https://github.com/localstack/localstack/pull/10894/ to the second dockerfile

I manually tested this by running the latest image and running `.venv/bin/localstack status services --format=json`, and got a successful response back

## Request:

It looks like only `latest-*` images are being published to dockerhub; would it be possible to return to publishing tagged/pinned versions?