### PR TITLE
fix S3 image healthcheck

### DIFF
--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -97,7 +97,7 @@ RUN echo /usr/lib/localstack/python-packages/lib/python3.11/site-packages > loca
 # expose edge service and debugpy
 EXPOSE 4566 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD ./bin/localstack status services --format=json
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD .venv/bin/localstack status services --format=json
 
 # default volume directory
 VOLUME /var/lib/localstack


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported and fixed in #10969, the S3 image health check had not been migrated following the refactoring/move into `localstack-core` (#10800). The fix is the same as #10894, and is now ported to the S3 image as well.

The original PR could not merge quickly due to the CLA, but in order to unblock the S3 image, we can merge this quicker.
Thanks again to @krishanbhasin-px for the fix.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- pick the health check from the regular localstack Dockerfile 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
