### PR TITLE
Add support for placeholder values in env-file flag for docker flags

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -1212,11 +1212,16 @@ class Util:
                     raise
                 for idx, line in enumerate(env_file_lines):
                     line = line.strip()
-                    if not line or line.startswith("#") or "=" not in line:
+                    if not line or line.startswith("#"):
                         # skip comments or empty lines
                         continue
-                    lhs, _, rhs = line.partition("=")
-                    env_vars[lhs] = rhs
+                    lhs, separator, rhs = line.partition("=")
+                    if rhs or separator:
+                        env_vars[lhs] = rhs
+                    else:
+                        # No "=" in the line, only the name => lookup in local env
+                        if env_value := os.environ.get(lhs):
+                            env_vars[lhs] = env_value
 
         if args.envs:
             env_vars = env_vars if env_vars is not None else {}

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1446,7 +1446,7 @@ class TestRunWithAdditionalArgs:
         assert stdout.decode(config.DEFAULT_ENCODING).strip() == "1024"
 
     def test_run_with_additional_arguments_env_files(
-        self, docker_client: ContainerClient, tmp_path
+        self, docker_client: ContainerClient, tmp_path, monkeypatch
     ):
         env_variable = "TEST1=VAL1"
         env_file = tmp_path / "env1"
@@ -1456,6 +1456,7 @@ class TestRunWithAdditionalArgs:
             TEST2=VAL2
             TEST3=${TEST2}
             TEST4=VAL # end comment
+            TEST5="VAL"
             """)
         env_file.write_text(env_vars)
 
@@ -1472,6 +1473,7 @@ class TestRunWithAdditionalArgs:
         assert "TEST2=VAL2" in env_output
         assert "TEST3=${TEST2}" in env_output
         assert "TEST4=VAL # end comment" in env_output
+        assert 'TEST5="VAL"' in env_output
 
         env_vars = textwrap.dedent("""
             # Some comment
@@ -1487,6 +1489,31 @@ class TestRunWithAdditionalArgs:
         )
         env_output = stdout.decode(config.DEFAULT_ENCODING)
         assert "TEST1" not in env_output
+
+        monkeypatch.setenv("TEST1", "VAL1")
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            remove=True,
+            command=["env"],
+            additional_flags=f"--env-file {env_file}",
+        )
+        env_output = stdout.decode(config.DEFAULT_ENCODING)
+        assert "TEST1=VAL1" in env_output
+
+        env_vars = textwrap.dedent("""
+            # Some comment
+            TEST1=
+            """)
+        env_file.write_text(env_vars)
+
+        stdout, _ = docker_client.run_container(
+            "alpine",
+            remove=True,
+            command=["env"],
+            additional_flags=f"--env-file {env_file}",
+        )
+        env_output = stdout.decode(config.DEFAULT_ENCODING)
+        assert "TEST1=" in env_output.splitlines()
 
 
 class TestDockerImages:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While revisting the features of the `--env-file` parameter for the docker CLI, I noticed we did not include the support for placeholders (variable names without an `=`) in #10880.

To achieve parity with the docker CLI client, I implemented the missing feature + tests.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* An env file like this:

```
TEST
```

with the `TEST` environment variable set inside the container, should correctly be passed (with that value) into the Lambda container (for `LAMBDA_DOCKER_FLAGS`).

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
