### PR TITLE
fix flaky new DDB test

### DIFF
--- a/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.snapshot.json
@@ -1267,7 +1267,7 @@
     }
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "recorded-date": "06-06-2024, 09:08:30",
+    "recorded-date": "06-06-2024, 13:02:16",
     "recorded-content": {
       "create-table": {
         "TableDescription": {

--- a/tests/aws/services/dynamodb/test_dynamodb.validation.json
+++ b/tests/aws/services/dynamodb/test_dynamodb.validation.json
@@ -45,7 +45,7 @@
     "last_validated_date": "2023-08-23T14:33:43+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "last_validated_date": "2024-06-06T09:08:30+00:00"
+    "last_validated_date": "2024-06-06T13:02:16+00:00"
   },
   "tests/aws/services/dynamodb/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_stream_view_type": {
     "last_validated_date": "2024-05-31T14:49:56+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As seen [in this run](https://app.circleci.com/pipelines/github/localstack/localstack/25500/workflows/dd484d9d-b92e-4fca-92f1-40298a91e645/jobs/214277), the ARM test failed for `test_dynamodb_stream_records_with_update_item`.
This looks like it can be due to parallel request being processed and not leaving the time to DynamoDB to properly ingest the first item (so it does not return it when looking if the object already exists when "updating" the item with the second call). 

This is a race condition, DynamoDB has a somewhat eventual consistency, so maybe this can happen in AWS, or this could be treated as a race condition/bug in LocalStack, but we do not have a real way of preventing it for now. At least the test is more robust now. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update the test to make sure the first request has been properly processed, before sending the same request again

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
