### PR TITLE
validate unknown tests - ec2

### DIFF
--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -470,7 +470,7 @@ def pickle_backends():
     return _can_pickle
 
 
-@markers.aws.unknown
+@markers.aws.only_localstack
 def test_pickle_ec2_backend(pickle_backends, aws_client):
     _ = aws_client.ec2.describe_account_attributes()
     pickle_backends(ec2_backends)

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -333,7 +333,8 @@ class TestEc2Integrations:
         gateway = retry(_describe_vpn_gateway, retries=20, sleep=5)
         snapshot.match("attached-gateway", gateway)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
+    # AWS returns 272 elements and a fair bit more information about them than LS
     def test_describe_vpc_endpoints_with_filter(self, aws_client, region_name):
         vpc = aws_client.ec2.create_vpc(CidrBlock="10.0.0.0/16")
         vpc_id = vpc["Vpc"]["VpcId"]

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -156,7 +156,8 @@ class TestEc2Integrations:
         assert vpc["Vpc"]["VpcId"] == vpc_endpoint["VpcEndpoint"]["VpcId"]
         assert len(vpc_endpoint["VpcEndpoint"]["DnsEntries"]) > 0
 
-    @markers.aws.unknown
+    @markers.aws.only_localstack
+    # This test would attempt to purchase Reserved instance.
     def test_reserved_instance_api(self, aws_client):
         rs = aws_client.ec2.describe_reserved_instances_offerings(
             AvailabilityZone="us-east-1a",

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -35,5 +35,147 @@
         }
       ]
     }
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vcp_peering_difference_regions": {
+    "recorded-date": "06-06-2024, 22:40:50",
+    "recorded-content": {
+      "vpc1-id": "<vpc1-id:1>",
+      "vpc2-id": "<vpc2-id:1>",
+      "peering-connection-id": "<peering-connection-id:1>",
+      "pending-acceptance": {
+        "VpcPeeringConnections": [
+          {
+            "AccepterVpcInfo": {
+              "OwnerId": "111111111111",
+              "Region": "ap-southeast-1",
+              "VpcId": "<vpc2-id:1>"
+            },
+            "ExpirationTime": "<datetime>",
+            "RequesterVpcInfo": {
+              "CidrBlock": "192.168.1.0/24",
+              "CidrBlockSet": [
+                {
+                  "CidrBlock": "192.168.1.0/24"
+                }
+              ],
+              "OwnerId": "111111111111",
+              "PeeringOptions": {
+                "AllowDnsResolutionFromRemoteVpc": false,
+                "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+                "AllowEgressFromLocalVpcToRemoteClassicLink": false
+              },
+              "Region": "<region>",
+              "VpcId": "<vpc1-id:1>"
+            },
+            "Status": {
+              "Code": "pending-acceptance",
+              "Message": "Pending Acceptance by 111111111111"
+            },
+            "Tags": [],
+            "VpcPeeringConnectionId": "<peering-connection-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "requester-peer": {
+        "VpcPeeringConnections": [
+          {
+            "AccepterVpcInfo": {
+              "CidrBlock": "192.168.2.0/24",
+              "CidrBlockSet": [
+                {
+                  "CidrBlock": "192.168.2.0/24"
+                }
+              ],
+              "OwnerId": "111111111111",
+              "PeeringOptions": {
+                "AllowDnsResolutionFromRemoteVpc": false,
+                "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+                "AllowEgressFromLocalVpcToRemoteClassicLink": false
+              },
+              "Region": "ap-southeast-1",
+              "VpcId": "<vpc2-id:1>"
+            },
+            "RequesterVpcInfo": {
+              "CidrBlock": "192.168.1.0/24",
+              "CidrBlockSet": [
+                {
+                  "CidrBlock": "192.168.1.0/24"
+                }
+              ],
+              "OwnerId": "111111111111",
+              "PeeringOptions": {
+                "AllowDnsResolutionFromRemoteVpc": false,
+                "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+                "AllowEgressFromLocalVpcToRemoteClassicLink": false
+              },
+              "Region": "<region>",
+              "VpcId": "<vpc1-id:1>"
+            },
+            "Status": {
+              "Code": "active",
+              "Message": "Active"
+            },
+            "Tags": [],
+            "VpcPeeringConnectionId": "<peering-connection-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "accepter-peer": {
+        "VpcPeeringConnections": [
+          {
+            "AccepterVpcInfo": {
+              "CidrBlock": "192.168.2.0/24",
+              "CidrBlockSet": [
+                {
+                  "CidrBlock": "192.168.2.0/24"
+                }
+              ],
+              "OwnerId": "111111111111",
+              "PeeringOptions": {
+                "AllowDnsResolutionFromRemoteVpc": false,
+                "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+                "AllowEgressFromLocalVpcToRemoteClassicLink": false
+              },
+              "Region": "ap-southeast-1",
+              "VpcId": "<vpc2-id:1>"
+            },
+            "RequesterVpcInfo": {
+              "CidrBlock": "192.168.1.0/24",
+              "CidrBlockSet": [
+                {
+                  "CidrBlock": "192.168.1.0/24"
+                }
+              ],
+              "OwnerId": "111111111111",
+              "PeeringOptions": {
+                "AllowDnsResolutionFromRemoteVpc": false,
+                "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+                "AllowEgressFromLocalVpcToRemoteClassicLink": false
+              },
+              "Region": "<region>",
+              "VpcId": "<vpc1-id:1>"
+            },
+            "Status": {
+              "Code": "active",
+              "Message": "Active"
+            },
+            "Tags": [],
+            "VpcPeeringConnectionId": "<peering-connection-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -1,0 +1,39 @@
+{
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
+    "recorded-date": "06-06-2024, 19:21:49",
+    "recorded-content": {
+      "vpc_id": "<vpc_id:1>",
+      "subnet_id": "<subnet_id:1>",
+      "route_table_id": "<route_table_id:1>",
+      "association_id": "<association_id:1>",
+      "route_tables": [
+        {
+          "Associations": [
+            {
+              "Main": false,
+              "RouteTableAssociationId": "<association_id:1>",
+              "RouteTableId": "<route_table_id:1>",
+              "SubnetId": "<subnet_id:1>",
+              "AssociationState": {
+                "State": "associated"
+              }
+            }
+          ],
+          "PropagatingVgws": [],
+          "RouteTableId": "<route_table_id:1>",
+          "Routes": [
+            {
+              "DestinationCidrBlock": "10.0.0.0/16",
+              "GatewayId": "local",
+              "Origin": "CreateRouteTable",
+              "State": "active"
+            }
+          ],
+          "Tags": [],
+          "VpcId": "<vpc_id:1>",
+          "OwnerId": "111111111111"
+        }
+      ]
+    }
+  }
+}

--- a/tests/aws/services/ec2/test_ec2.snapshot.json
+++ b/tests/aws/services/ec2/test_ec2.snapshot.json
@@ -177,5 +177,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_describe_vpn_gateways_filter_by_vpc": {
+    "recorded-date": "06-06-2024, 23:36:39",
+    "recorded-content": {
+      "vpc-id": "<vpc-id:1>",
+      "gateway": {
+        "VpnGateway": {
+          "AmazonSideAsn": 64512,
+          "State": "available",
+          "Type": "ipsec.1",
+          "VpcAttachments": [],
+          "VpnGatewayId": "<vpn-gateway-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "attached-gateway": {
+        "AmazonSideAsn": 64512,
+        "State": "available",
+        "Tags": [],
+        "Type": "ipsec.1",
+        "VpcAttachments": [
+          {
+            "State": "attached",
+            "VpcId": "<vpc-id:1>"
+          }
+        ],
+        "VpnGatewayId": "<vpn-gateway-id:1>"
+      }
+    }
   }
 }

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
     "last_validated_date": "2024-06-06T19:21:49+00:00"
+  },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vcp_peering_difference_regions": {
+    "last_validated_date": "2024-06-06T22:40:50+00:00"
   }
 }

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -2,6 +2,9 @@
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
     "last_validated_date": "2024-06-06T19:21:49+00:00"
   },
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_describe_vpn_gateways_filter_by_vpc": {
+    "last_validated_date": "2024-06-06T23:36:39+00:00"
+  },
   "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_vcp_peering_difference_regions": {
     "last_validated_date": "2024-06-06T22:40:50+00:00"
   }

--- a/tests/aws/services/ec2/test_ec2.validation.json
+++ b/tests/aws/services/ec2/test_ec2.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/services/ec2/test_ec2.py::TestEc2Integrations::test_create_route_table_association": {
+    "last_validated_date": "2024-06-06T19:21:49+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Part of the push to get rid of `unknown` tests.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

I did not create fixtures for the validated tests and used cleanups instead. Vpc resources are really order dependent for deletion and it allowed for a better control.

* test_create_route_table_association => `validated`
* test_create_vpc_endpoint => `needs_fixing`, multiple assumptions are wrong and some moto issues with default values
* test_reserved_instance_api => `only_localstack` I don't want to start $100 bills
* test_vcp_peering_difference_regions => `validated`
* test_describe_vpn_gateways_filter_by_vpc => `validated`
* test_describe_vpc_endpoints_with_filter => `needs_fixing` AWS returns a lot of data. We might want to adapt this test to be more efficient and robust against aws 
* test_pickle_ec2_backend => `only_localstack`


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
