### PR TITLE
Fix CloudFormation Fn::Transform replacing unintended values

### DIFF
--- a/tests/aws/services/cloudformation/api/test_transformers.py
+++ b/tests/aws/services/cloudformation/api/test_transformers.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from localstack.testing.pytest import markers
 from localstack.utils.strings import short_uid, to_bytes
 
@@ -58,3 +60,55 @@ def test_duplicate_resources(deploy_cfn_template, s3_bucket, snapshot, aws_clien
 
     resources = aws_client.apigateway.get_resources(restApiId=api_id)
     snapshot.match("api-resources", resources)
+
+
+@markers.aws.validated
+def test_transformer_property_level(deploy_cfn_template, s3_bucket, aws_client, snapshot):
+    api_spec = textwrap.dedent("""
+    Value: from_transformation
+    """)
+    aws_client.s3.put_object(Bucket=s3_bucket, Key="data.yaml", Body=to_bytes(api_spec))
+
+    # deploy template
+    template = textwrap.dedent("""
+        Parameters:
+          BucketName:
+            Type: String
+        Resources:
+          MyParameter:
+            Type: AWS::SSM::Parameter
+            Properties:
+              Description: hello
+              Type: String
+              "Fn::Transform":
+                Name: "AWS::Include"
+                Parameters:
+                  Location: !Sub "s3://${BucketName}/data.yaml"
+        Outputs:
+          ParameterName:
+            Value: !Ref MyParameter
+        """)
+
+    result = deploy_cfn_template(template=template, parameters={"BucketName": s3_bucket})
+    param_name = result.outputs["ParameterName"]
+    param = aws_client.ssm.get_parameter(Name=param_name)
+    assert (
+        param["Parameter"]["Value"] == "from_transformation"
+    )  # value coming from the transformation
+    describe_result = (
+        aws_client.ssm.get_paginator("describe_parameters")
+        .paginate(Filters=[{"Key": "Name", "Values": [param_name]}])
+        .build_full_result()
+    )
+    assert (
+        describe_result["Parameters"][0]["Description"] == "hello"
+    )  # value from a property on the same level as the transformation
+
+    original_template = aws_client.cloudformation.get_template(
+        StackName=result.stack_id, TemplateStage="Original"
+    )
+    snapshot.match("original_template", original_template)
+    processed_template = aws_client.cloudformation.get_template(
+        StackName=result.stack_id, TemplateStage="Processed"
+    )
+    snapshot.match("processed_template", processed_template)

--- a/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
@@ -38,5 +38,55 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_transformers.py::test_transformer_property_level": {
+    "recorded-date": "06-06-2024, 10:37:03",
+    "recorded-content": {
+      "original_template": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "\nParameters:\n  BucketName:\n    Type: String\nResources:\n  MyParameter:\n    Type: AWS::SSM::Parameter\n    Properties:\n      Description: hello\n      Type: String\n      \"Fn::Transform\":\n        Name: \"AWS::Include\"\n        Parameters:\n          Location: !Sub \"s3://${BucketName}/data.yaml\"\nOutputs:\n  ParameterName:\n    Value: !Ref MyParameter\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "processed_template": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": {
+          "Outputs": {
+            "ParameterName": {
+              "Value": {
+                "Ref": "MyParameter"
+              }
+            }
+          },
+          "Parameters": {
+            "BucketName": {
+              "Type": "String"
+            }
+          },
+          "Resources": {
+            "MyParameter": {
+              "Properties": {
+                "Description": "hello",
+                "Type": "String",
+                "Value": "from_transformation"
+              },
+              "Type": "AWS::SSM::Parameter"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.validation.json
@@ -1,5 +1,8 @@
 {
   "tests/aws/services/cloudformation/api/test_transformers.py::test_duplicate_resources": {
     "last_validated_date": "2024-04-15T22:51:13+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_transformers.py::test_transformer_property_level": {
+    "last_validated_date": "2024-06-06T10:38:33+00:00"
   }
 }


### PR DESCRIPTION
## Motivation

Based on a reported issue from a user where they loaded a stepfunction statemachine definition through the `AWS::Include` macro from s3 which lead to the RoleArn missing. 
The issue was that the transformation replaced the whole level of the current object in the iteration and not just the one particular key it's at.


## Changes

- The `Fn::Transform` can now be used with additional keys at the same object level as the intrinsic function.
