### PR TITLE
Fix handling None payload in Lambda Event Source Mapping

### DIFF
--- a/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
@@ -128,9 +128,7 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                 error = None
                 if result.is_error:
                     error = "?"
-                result_payload = (
-                    to_str(json.loads(result.payload)) if result.payload else ""
-                )
+                result_payload = to_str(json.loads(result.payload)) if result.payload else ""
                 callback(
                     result=LegacyInvocationResult(
                         result=result_payload,

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
@@ -128,7 +128,9 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                 error = None
                 if result.is_error:
                     error = "?"
-                result_payload = to_str(json.loads(result.payload)) if result.payload else ""
+                result_payload = (
+                    to_str(json.loads(result.payload)) if result.payload else ""
+                )
                 callback(
                     result=LegacyInvocationResult(
                         result=result_payload,
@@ -183,7 +185,9 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                         error = None
                         if result.is_error:
                             error = "?"
-                        result_payload = to_str(json.loads(result.payload)) if result.payload else ""
+                        result_payload = (
+                            to_str(json.loads(result.payload)) if result.payload else ""
+                        )
                         callback(
                             result=LegacyInvocationResult(
                                 result=result_payload,

--- a/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
+++ b/localstack-core/localstack/services/lambda_/event_source_listeners/adapters.py
@@ -128,9 +128,10 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                 error = None
                 if result.is_error:
                     error = "?"
+                result_payload = to_str(json.loads(result.payload)) if result.payload else ""
                 callback(
                     result=LegacyInvocationResult(
-                        result=to_str(json.loads(result.payload)),
+                        result=result_payload,
                         log_output=result.logs,
                     ),
                     func_arn="doesntmatter",
@@ -182,9 +183,10 @@ class EventSourceAsfAdapter(EventSourceAdapter):
                         error = None
                         if result.is_error:
                             error = "?"
+                        result_payload = to_str(json.loads(result.payload)) if result.payload else ""
                         callback(
                             result=LegacyInvocationResult(
-                                result=to_str(json.loads(result.payload)),
+                                result=result_payload,
                                 log_output=result.logs,
                             ),
                             func_arn="doesntmatter",


### PR DESCRIPTION
Fix for successfully invoked lambdas not deleting source SQS message if the lambda does not have a return value

## Motivation
To resolve the issue I have been having using LocalStack with .net lambdas https://github.com/localstack/localstack/issues/10307

## Changes
It checks if the lambda returned a value before trying to parse it as json

## Testing
Please excuse the lack of tests included with this, I am not a python developer.

To manually test:
* Create a new .net AWS lambda using the `AWS Lambda Project (.NET Core - C#)` template from the Amazon.Lambda.Templates. This will create a function handler without any return value.
* Package and deploy the sample lambda
* Associate with SQS/SNS
* Send a test message

Before this change the message would not be deleted

See the steps to reproduce in https://github.com/localstack/localstack/issues/10307
