### PR TITLE
Update dev script to mount community code correctly

### DIFF
--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -124,7 +124,7 @@ class SourceVolumeMountConfigurator:
 
     def __call__(self, cfg: ContainerConfiguration):
         # localstack source code if available
-        source = self.host_paths.localstack_project_dir / "localstack"
+        source = self.host_paths.localstack_project_dir / "localstack-core" / "localstack"
         if source.exists():
             cfg.volumes.add(
                 VolumeBind(str(source), self.container_paths.localstack_source_dir, read_only=True)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When running the `localstack.dev.run` script, the LocalStack community source code is not mounted. This is due to #10800 as it moved the source code locations around. Looks like this particular instance was missed.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Mount the community code from `localstack/localstack-core/localstack` rather than `localstack/localstack`.



<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
