### PR TITLE
Step Functions: Allow describing ARNs that contain periods (#10976)

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -136,11 +136,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
         visitor.visit(sfn_stores)
 
     _STATE_MACHINE_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:stateMachine:[a-zA-Z0-9-_]+(:\d+)?$"
+        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:stateMachine:[a-zA-Z0-9-_.]+(:\d+)?$"
     )
 
     _STATE_MACHINE_EXECUTION_ARN_REGEX: Final[re.Pattern] = re.compile(
-        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution):[a-zA-Z0-9-_]+(:\d+)?(:[a-zA-Z0-9-_]+)?$"
+        r"^arn:aws:states:[a-z0-9-]+:[0-9]{12}:(stateMachine|execution):[a-zA-Z0-9-_.]+(:\d+)?(:[a-zA-Z0-9-_.]+)?$"
     )
 
     _ACTIVITY_ARN_REGEX: Final[re.Pattern] = re.compile(

--- a/tests/unit/services/stepfunctions/test_validations.py
+++ b/tests/unit/services/stepfunctions/test_validations.py
@@ -1,0 +1,15 @@
+from localstack.services.stepfunctions.provider import StepFunctionsProvider
+
+
+class TestValidations:
+    def test_state_machine_arn_with_periods(self):
+        # will NOT throw an exception if the ARN is valid
+        StepFunctionsProvider._validate_state_machine_arn(
+            "arn:aws:states:us-east-1:000000000000:stateMachine:MyStateMachine.uixsr0hpy"
+        )
+
+    def test_state_machine_execution_arn_with_periods(self):
+        # will NOT throw an exception if the ARN is valid
+        StepFunctionsProvider()._validate_state_machine_execution_arn(
+            "arn:aws:states:us-east-1:000000000000:stateMachine:MyStateMachine.uixsr0hpy:my.execution"
+        )


### PR DESCRIPTION
## Motivation

For Step Functions, we can create a state machine or state machine execution that contains a period (`.`) in the name, but
trying to "describe" that state machine (or execution) incorrectly gives an `InvalidArn` exception.

## Changes

Validation code for state machine ARNs and state machine execution ARNs now allows for periods (`.`) in the name. This matches AWS behaviour.

## Testing

Unit tests were added.