### PR TITLE
add support for downloading python dependancies using urls

### DIFF
--- a/localstack-core/localstack/packages/core.py
+++ b/localstack-core/localstack/packages/core.py
@@ -247,9 +247,9 @@ class PythonPackageInstaller(PackageInstaller):
     normalized_name: str
     """Normalized package name according to PEP440."""
 
-    def __init__(self, name: str, version: str, *args, **kwargs):
+    def __init__(self, name: str, version: str, package_url: str = None, *args, **kwargs):
         super().__init__(name, version, *args, **kwargs)
-        self.package_url = kwargs.get("package_url")
+        self.package_url = package_url
         self.normalized_name = self._normalize_package_name(name)
 
     def _normalize_package_name(self, name: str):

--- a/localstack-core/localstack/packages/core.py
+++ b/localstack-core/localstack/packages/core.py
@@ -249,6 +249,7 @@ class PythonPackageInstaller(PackageInstaller):
 
     def __init__(self, name: str, version: str, *args, **kwargs):
         super().__init__(name, version, *args, **kwargs)
+        self.package_url = kwargs.get("package_url")
         self.normalized_name = self._normalize_package_name(name)
 
     def _normalize_package_name(self, name: str):
@@ -289,8 +290,15 @@ class PythonPackageInstaller(PackageInstaller):
         venv = self._get_venv(target)
         python_bin = os.path.join(venv.venv_dir, "bin/python")
 
-        # run pip via the python binary of the venv
-        run([python_bin, "-m", "pip", "install", f"{self.name}=={self.version}"], print_error=False)
+        if self.package_url:
+            # install the package from a custom package URL
+            run([python_bin, "-m", "pip", "install", self.package_url], print_error=False)
+        else:
+            # run pip via the python binary of the venv
+            run(
+                [python_bin, "-m", "pip", "install", f"{self.name}=={self.version}"],
+                print_error=False,
+            )
 
     def _setup_existing_installation(self, target: InstallTarget) -> None:
         """If the venv is already present, it just needs to be initialized once."""


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to add support to download python packages using urls like `git+https://github.com/localstack/aws-glue-libs.git@glue-0.9#egg=aws-glue-libs`


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adds support for package url for python installer


## Testing
- Tested manually for installing on of the libraries in spark.


<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
