### PR TITLE
remove unknown markers in test_multiregion

### DIFF
--- a/tests/aws/test_multiregion.py
+++ b/tests/aws/test_multiregion.py
@@ -17,7 +17,7 @@ REGION4 = "eu-central-1"
 
 
 class TestMultiRegion:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_multi_region_sns(self, aws_client_factory):
         sns_1 = aws_client_factory(region_name=REGION1).sns
         sns_2 = aws_client_factory(region_name=REGION2).sns
@@ -38,7 +38,7 @@ class TestMultiRegion:
         assert len(result2) == len_2 + 1
         assert REGION2 in result2[0]["TopicArn"]
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_multi_region_api_gateway(self, aws_client_factory, account_id):
         gw_1 = aws_client_factory(region_name=REGION1).apigateway
         gw_2 = aws_client_factory(region_name=REGION2).apigateway

--- a/tests/aws/test_multiregion.validation.json
+++ b/tests/aws/test_multiregion.validation.json
@@ -1,0 +1,5 @@
+{
+  "tests/aws/test_multiregion.py::TestMultiRegion::test_multi_region_sns": {
+    "last_validated_date": "2024-06-10T06:09:20+00:00"
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As an initiative to remove all `markers.aws.unknown` markers from the tests, this PR handles the ones concerning multi region tests.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR: 
- updates the marker to `validated` if it passes against AWS
- updates the marker to `needs_fixing` if it didn't pass against AWS

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
