### PR TITLE
fix asf update action by avoiding aws cli pin

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -78,18 +78,13 @@ jobs:
           bin/release-helper.sh set-dep-ver boto3 "==$BOTOCORE_VERSION"
           bin/release-helper.sh set-dep-ver boto3-stubs "==$BOTOCORE_VERSION"
 
-          # aws-cli is two minor versions behind botocore
-          AWSCLI_VERSION=$(python -c 'import botocore; from packaging.version import Version; version = Version(botocore.__version__); print(f"{version.major}.{version.minor - 2}.{version.micro}")')
-          echo "Pinning aws-cli to version $AWSCLI_VERSION"
-          bin/release-helper.sh set-dep-ver awscli "==$AWSCLI_VERSION"
-
           # upgrade the requirements files only for the botocore package
           pip install pip-tools
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra dev -o requirements-dev.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --upgrade-package "boto3-stubs==$BOTOCORE_VERSION" --extra typehint -o requirements-typehint.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra runtime -o requirements-runtime.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra test -o requirements-test.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --extra dev -o requirements-dev.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli" --upgrade-package "boto3-stubs==$BOTOCORE_VERSION" --extra typehint -o requirements-typehint.txt pyproject.toml
 
       - name: Read PR markdown template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ base-runtime = [
 runtime = [
     "localstack-core[base-runtime]",
     # pinned / updated by ASF update action
-    "awscli==1.32.117",
+    "awscli>=1.32.117",
     "airspeed-ext>=0.6.3",
     "amazon_kclpy>=2.0.6,!=2.1.0,!=2.1.4",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/10537 extended the pinning of dependencies performed in the `asf-updates.yaml` action - from just `botocore` to also include the transitive pins `boto3`, `boto3-stubs`, as well as `awscli` - in order to reduce the time it takes to perform the backtracking.
However, for the AWS CLI the versioning is not aligned with `botocore`, which is why we introduced a hacky way to determine the AWS CLI version. This hacky approach now broke due to a minor release, as we can see [in the latest scheduled run of the action](https://github.com/localstack/localstack/actions/runs/9442735748):
```
  ERROR: Cannot install awscli==1.32.122 because these package versions have conflicting dependencies.
Traceback (most recent call last):
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 397, in resolve
    self._add_to_criteria(self.state.criteria, r, parent=None)
  File "/home/runner/work/localstack/localstack/.venv/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 174, in _add_to_criteria
    raise RequirementsConflicted(criterion)
pip._vendor.resolvelib.resolvers.RequirementsConflicted: Requirements conflict: SpecifierRequirement('awscli==1.32.122')
```

This PR addresses this fix by just removing this hack. It is currently not necessary because:
- The backtracking currently does not take too long.
- We can now switch to `uv` to address performance issues with the backtracking.

## Changes
- Removes the exact pin of `awscli` (and instead just introduces a lower limit) in the `pyproject.toml`.
- Removes the faulty `awscli` pinning from the ASF update action.

## Testing
#### 💚 Manually:
I tested the commands executed in the ASF action manually and they are successful and the requirements files are updated correctly:
```bash
bin/release-helper.sh set-dep-ver botocore "==1.34.122"
bin/release-helper.sh set-dep-ver boto3 "==1.34.122"
bin/release-helper.sh set-dep-ver boto3-stubs "==1.34.122"
pip-compile --strip-extras --upgrade-package "botocore==1.34.122" --upgrade-package "boto3==1.34.122" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
pip-compile --strip-extras --upgrade-package "botocore==1.34.122" --upgrade-package "boto3==1.34.122" --upgrade-package "awscli" --extra runtime -o requirements-runtime.txt pyproject.toml
pip-compile --strip-extras --upgrade-package "botocore==1.34.122" --upgrade-package "boto3==1.34.122" --upgrade-package "awscli" --extra test -o requirements-test.txt pyproject.toml
pip-compile --strip-extras --upgrade-package "botocore==1.34.122" --upgrade-package "boto3==1.34.122" --upgrade-package "awscli" --extra dev -o requirements-dev.txt pyproject.toml
pip-compile --strip-extras --upgrade-package "botocore==1.34.122" --upgrade-package "boto3==1.34.122" --upgrade-package "awscli" --upgrade-package "boto3-stubs==1.34.122" --extra typehint -o requirements-typehint.txt pyproject.toml
```
#### 💚 Action execution:
I triggered an execution of the affected action from this branch: https://github.com/localstack/localstack/actions/runs/9444259692
Here is the resulting PR: https://github.com/localstack/localstack/pull/10990 (which has the wrong base - namely the branch of this PR - and will therefore be closed again).