### PR TITLE
remove unknown markers in cross accounts test in lambda

### DIFF
--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1832,7 +1832,7 @@ class TestLambdaMultiAccounts:
     def secondary_client(self, secondary_aws_client):
         return secondary_aws_client.lambda_
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
     def test_cross_account_access(
         self, primary_client, secondary_client, create_lambda_function, dummylayer
     ):

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4159,7 +4159,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaMultiAccounts::test_cross_account_access": {
-    "recorded-date": "08-04-2024, 16:59:40",
+    "recorded-date": "10-06-2024, 06:47:50",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaCleanup::test_recreate_function": {

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4158,10 +4158,6 @@
     "recorded-date": "08-04-2024, 16:57:14",
     "recorded-content": {}
   },
-  "tests/aws/services/lambda_/test_lambda.py::TestLambdaMultiAccounts::test_cross_account_access": {
-    "recorded-date": "10-06-2024, 06:47:50",
-    "recorded-content": {}
-  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaCleanup::test_recreate_function": {
     "recorded-date": "15-05-2024, 10:16:45",
     "recorded-content": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As an initiative to remove all `markers.aws.unknown` markers from the tests, this PR handles the ones concerning cross account test in lambda.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
This PR updates the marker to `needs_fixing` for `test_cross_account_access`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
