### PR TITLE
replace unknown markers for kinesis-tests

### DIFF
--- a/tests/aws/services/kinesis/test_kinesis.py
+++ b/tests/aws/services/kinesis/test_kinesis.py
@@ -36,13 +36,14 @@ def get_shard_iterator(stream_name, kinesis_client):
 
 
 class TestKinesis:
-    @markers.aws.unknown
+    @markers.aws.validated
     def test_create_stream_without_stream_name_raises(self, aws_client_factory):
         boto_config = BotoConfig(parameter_validation=False)
         kinesis_client = aws_client_factory(config=boto_config).kinesis
         with pytest.raises(ClientError) as e:
             kinesis_client.create_stream()
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+        # TODO snapshotting reveals that the Error.Message is different
 
     @markers.aws.validated
     def test_create_stream_without_shard_count(
@@ -214,7 +215,9 @@ class TestKinesis:
         results.sort(key=lambda k: k.get("Data"))
         snapshot.match("Records", results)
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
+    # this might be a localstack-only test - there doesn't seem to be an endpoint for kinesis on AWS
+    # the test seems to address https://github.com/localstack/localstack/issues/2997 with java AWS SDK usage
     def test_get_records(
         self, kinesis_create_stream, wait_for_stream_ready, aws_client, region_name
     ):
@@ -258,7 +261,9 @@ class TestKinesis:
             == result["Records"][0]["ApproximateArrivalTimestamp"]
         )
 
-    @markers.aws.unknown
+    @markers.aws.needs_fixing
+    # this might be a localstack-only test - there doesn't seem to be an endpoint for kinesis on AWS
+    # the test seems to address https://github.com/localstack/localstack/issues/2997 with java AWS SDK usage
     def test_get_records_empty_stream(
         self,
         kinesis_create_stream,
@@ -434,7 +439,7 @@ class TestKinesis:
 
 class TestKinesisPythonClient:
     @markers.skip_offline
-    @markers.aws.unknown
+    @markers.aws.only_localstack
     def test_run_kcl(self, aws_client, account_id, region_name):
         result = []
 

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {
     "last_validated_date": "2022-08-26T07:30:59+00:00"
   },
+  "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_stream_name_raises": {
+    "last_validated_date": "2024-06-10T09:38:19+00:00"
+  },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_record_lifecycle_data_integrity": {
     "last_validated_date": "2022-08-25T10:39:44+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Following up https://github.com/localstack/localstack/issues/9147 to remove all `unknown` markers, this PR tackles some kinesis-tests.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* added `validated` to `test_create_stream_without_stream_name_raises` which works with AWS, however when attempting to add a snapshot it shows that the error message is still returned in a different format.
* added `needs_fixing` to two tests that use the LocalStack-internal route to retrieve CBOR encoded records. The test likely relates to https://github.com/localstack/localstack/issues/2997 which reported issues with java AWS SDK.
  *  `test_get_records`
  *  `test_get_records_empty_stream`
* added `localstack-only` to `test_run_kcl` which runs some LocalStack specific implementation.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
