### PR TITLE
Skip flaky ElasticSearch tests

### DIFF
--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -66,6 +66,8 @@ def try_cluster_health(cluster_url: str):
     ], "expected cluster state to be in a valid state"
 
 
+# flaky run: https://github.com/localstack/localstack/actions/runs/9450891131/job/26030567990
+@pytest.mark.skip("flaky")
 class TestElasticsearchProvider:
     @markers.aws.unknown
     def test_list_versions(self, aws_client):

--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -66,7 +66,6 @@ def try_cluster_health(cluster_url: str):
     ], "expected cluster state to be in a valid state"
 
 
-# flaky run: https://github.com/localstack/localstack/actions/runs/9450891131/job/26030567990
 @pytest.mark.skip("flaky")
 class TestElasticsearchProvider:
     @markers.aws.unknown

--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -66,7 +66,7 @@ def try_cluster_health(cluster_url: str):
     ], "expected cluster state to be in a valid state"
 
 
-@pytest.mark.skip("flaky")
+@pytest.mark.skip(reason="flaky")
 class TestElasticsearchProvider:
     @markers.aws.unknown
     def test_list_versions(self, aws_client):


### PR DESCRIPTION
## Motivation

ElasticSearch tests are very flaky recently in the CI. For example:

Flaky runs:
* Silvio: commented [here](https://localstack-cloud.slack.com/archives/C06PA09NU3U/p1718026531370819?thread_ts=1718026230.448389&cid=C06PA09NU3U) in Slack
* Joel: https://github.com/localstack/localstack/actions/runs/9450891131/job/26030567990


## Changes

Skip flaky tests for ElasticSearch following testing guideline [R01](https://github.com/localstack/localstack/tree/master/docs/testing#r01).

## Discussion

Should we be more selective in skipping the tests? I guess it's all the ones with skip_offline, hence `test_list_versions`, `test_get_compatible_versions`, and `test_update_domain_config` should be fine.

## Logs

Silvio's run:

```
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_domain RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_domain RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_domain FAILED [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_existing_domain_causes_exception RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_existing_domain_causes_exception RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_existing_domain_causes_exception FAILED [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_describe_domains RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_describe_domains RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_describe_domains FAILED [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_domain_version RERUN [ 54%]
../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_domain_version RERUN [ 54%]
```

Joel's run:

```
2024-06-10T15:54:21.7073619Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_list_versions PASSED [ 54%]
2024-06-10T15:54:21.7153165Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_get_compatible_versions PASSED [ 54%]
2024-06-10T15:59:23.4437915Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_get_compatible_version_for_domain RERUN [ 54%]
2024-06-10T16:04:25.0962159Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_get_compatible_version_for_domain RERUN [ 54%]
2024-06-10T16:09:26.8008542Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_get_compatible_version_for_domain ERROR [ 54%]
2024-06-10T16:09:37.4784646Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_domain PASSED [ 54%]
2024-06-10T16:09:48.1380045Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_create_existing_domain_causes_exception PASSED [ 54%]
2024-06-10T16:09:59.3125275Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_describe_domains PASSED [ 54%]
2024-06-10T16:15:00.9744065Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_domain_version RERUN [ 54%]
2024-06-10T16:20:02.5579478Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_domain_version RERUN [ 54%]
2024-06-10T16:25:04.1397855Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_domain_version ERROR [ 54%]
2024-06-10T16:30:06.4153298Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_path_endpoint_strategy RERUN [ 54%]
2024-06-10T16:35:07.9484133Z ../localstack/tests/aws/services/es/test_es.py::TestElasticsearchProvider::test_path_endpoint_strategy RERUN [ 54%]
```

